### PR TITLE
fix: audit round 2 — 2 CRIT + 1 WARN from flutter_gemma source review

### DIFF
--- a/apps/mobile/lib/services/slm/slm_download_service.dart
+++ b/apps/mobile/lib/services/slm/slm_download_service.dart
@@ -97,19 +97,23 @@ class SlmDownloadService {
   //  Constants
   // ═══════════════════════════════════════════════════════════════
 
-  /// Model identifier matching flutter_gemma's internal naming.
-  static const String modelId = 'gemma-3n-e4b-it';
+  /// HuggingFace model URL (Gemma 3n E4B IT in .task format).
+  /// In production, configure via remote config.
+  static const String _defaultModelUrl =
+      'https://huggingface.co/litert-community/gemma-3n-E4B-it-litert-preview/resolve/main/gemma3n-E4B-it-multi.task';
+
+  /// Model identifier as registered by flutter_gemma.
+  ///
+  /// flutter_gemma derives this from the URL filename:
+  ///   Uri.parse(url).pathSegments.last → 'gemma3n-E4B-it-multi.task'
+  /// This MUST match the URL filename for isModelInstalled() to work.
+  static const String modelId = 'gemma3n-E4B-it-multi.task';
 
   /// Expected model size (~2.3 GB).
   static const int _expectedSizeBytes = 2400000000;
 
   /// Model version for cache invalidation.
   static const String _modelVersion = '1.0.0';
-
-  /// HuggingFace model URL (Gemma 3n E4B IT in .task format).
-  /// In production, configure via remote config.
-  static const String _defaultModelUrl =
-      'https://huggingface.co/litert-community/gemma-3n-E4B-it-litert-preview/resolve/main/gemma3n-E4B-it-multi.task';
 
   /// SharedPreferences key for model version tracking.
   static const String _prefKeyVersion = 'slm_model_version';
@@ -264,10 +268,19 @@ class SlmDownloadService {
 
   /// Delete the downloaded model to free disk space (~2.3 GB).
   ///
-  /// Note: flutter_gemma manages model files internally.
-  /// We clear our version metadata; the model file is managed
-  /// by the platform's app storage cleanup.
+  /// Uses [FlutterGemma.uninstallModel] to remove both model files
+  /// and flutter_gemma metadata. Also clears our version tracking.
   Future<bool> deleteModel() async {
+    try {
+      // Uninstall via flutter_gemma — deletes files + metadata.
+      await FlutterGemma.uninstallModel(modelId);
+      debugPrint('[SLM] Model uninstalled via flutter_gemma');
+    } catch (e) {
+      // Model might not be registered (e.g., partial download).
+      // Continue to clear our own state regardless.
+      debugPrint('[SLM] flutter_gemma uninstall error (continuing): $e');
+    }
+
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_prefKeyVersion);
@@ -275,10 +288,10 @@ class SlmDownloadService {
       _state = DownloadState.notStarted;
       _progress = 0.0;
       _stateController.add(_state);
-      debugPrint('[SLM] Model state cleared');
+      debugPrint('[SLM] Model deleted — ~${modelSizeFormatted} liberes');
       return true;
     } catch (e) {
-      debugPrint('[SLM] Model deletion failed: $e');
+      debugPrint('[SLM] Model state clear failed: $e');
       return false;
     }
   }

--- a/apps/mobile/lib/services/slm/slm_engine.dart
+++ b/apps/mobile/lib/services/slm/slm_engine.dart
@@ -23,6 +23,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:mint_mobile/services/slm/slm_download_service.dart';
 
 /// Status of the SLM engine.
 enum SlmStatus {
@@ -84,8 +85,9 @@ class SlmEngine {
   /// Whether the engine is ready for inference.
   bool get isAvailable => _status == SlmStatus.running;
 
-  /// Model identifier (used by flutter_gemma internally).
-  static const String modelId = 'gemma-3n-e4b-it';
+  /// Model identifier — delegates to [SlmDownloadService.modelId]
+  /// (derived from the URL filename, e.g. 'gemma3n-E4B-it-multi.task').
+  static String get modelId => SlmDownloadService.modelId;
 
   /// Model display name.
   static const String modelDisplayName = 'Gemma 3n 4B (on-device)';
@@ -188,13 +190,12 @@ class SlmEngine {
         topK: 1,
       );
 
-      // Combine system + user prompt.
-      // flutter_gemma handles <start_of_turn> formatting internally
-      // for ModelType.gemmaIt, so we send a single user message.
-      final combinedPrompt = '$systemPrompt\n\n$userPrompt';
-
+      // Send system prompt via dedicated Message.systemInfo,
+      // then user prompt as Message.text(isUser: true).
+      // flutter_gemma handles <start_of_turn> formatting internally.
+      await chat.addQueryChunk(Message.systemInfo(text: systemPrompt));
       await chat.addQueryChunk(Message.text(
-        text: combinedPrompt,
+        text: userPrompt,
         isUser: true,
       ));
 
@@ -252,9 +253,9 @@ class SlmEngine {
         topK: 1,
       );
 
-      final combinedPrompt = '$systemPrompt\n\n$userPrompt';
+      await chat.addQueryChunk(Message.systemInfo(text: systemPrompt));
       await chat.addQueryChunk(Message.text(
-        text: combinedPrompt,
+        text: userPrompt,
         isUser: true,
       ));
 


### PR DESCRIPTION
CRIT-11: modelId for isModelInstalled() must be the URL filename
  flutter_gemma derives id via Uri.parse(url).pathSegments.last
  Was: 'gemma-3n-e4b-it' (custom, never matches)
  Now: 'gemma3n-E4B-it-multi.task' (matches URL basename)
  Single source of truth in SlmDownloadService.modelId

CRIT-12: deleteModel() now calls FlutterGemma.uninstallModel()
  Was: only clearing SharedPreferences (2.3 GB file stayed on disk)
  Now: uninstallModel() deletes both files + flutter_gemma metadata
  Graceful fallback if model not registered (partial download)

WARN-11: use Message.systemInfo() for system prompt
  Was: concatenating system+user in single Message.text(isUser: true)
  Now: Message.systemInfo(text: systemPrompt) + Message.text(userPrompt)
  Semantically correct, better model behavior

https://claude.ai/code/session_01EUsQdsTBcqBzHrpzCzDWtq