### PR TITLE
fix: enable SLM localhost:3000 web testing

### DIFF
--- a/apps/mobile/lib/screens/slm_settings_screen.dart
+++ b/apps/mobile/lib/screens/slm_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/services/slm/slm_download_service.dart';
@@ -153,18 +154,55 @@ class _SlmSettingsScreenState extends State<SlmSettingsScreen> {
           SliverPadding(
             padding: const EdgeInsets.all(16),
             sliver: SliverList(
-              delegate: SliverChildListDelegate([
-                _buildPrivacyBanner(),
-                const SizedBox(height: 16),
-                _buildModelCard(),
-                const SizedBox(height: 16),
-                _buildStatusCard(),
-                const SizedBox(height: 16),
-                _buildInfoCard(),
-              ]),
+              delegate: SliverChildListDelegate(
+                kIsWeb
+                    ? [_buildWebUnavailableBanner()]
+                    : [
+                        _buildPrivacyBanner(),
+                        const SizedBox(height: 16),
+                        _buildModelCard(),
+                        const SizedBox(height: 16),
+                        _buildStatusCard(),
+                        const SizedBox(height: 16),
+                        _buildInfoCard(),
+                      ],
+              ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildWebUnavailableBanner() {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(Icons.phone_android, size: 48, color: MintColors.primary),
+            const SizedBox(height: 16),
+            Text(
+              'Disponible sur mobile uniquement',
+              style: GoogleFonts.montserrat(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'L\'IA on-device utilise le processeur de ton telephone '
+              'pour generer des reponses 100% privees.\n\n'
+              'Cette fonctionnalite necessite iOS ou Android. '
+              'Le coach utilise des templates statiques en version web.',
+              style: GoogleFonts.inter(fontSize: 14, color: Colors.grey[600]),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -25,9 +25,10 @@ class ApiService {
     const defined = String.fromEnvironment('API_BASE_URL');
     if (defined.isNotEmpty) return defined;
     // Safe fallback: release builds must never point to localhost.
+    // Dev backend runs on port 8000 (uvicorn default).
     return kReleaseMode
         ? 'https://api.mint.ch/api/v1'
-        : 'http://localhost:8888/api/v1';
+        : 'http://localhost:8000/api/v1';
   })();
 
   // Helper method to get auth headers with JWT token

--- a/apps/mobile/lib/services/ios_iap_service.dart
+++ b/apps/mobile/lib/services/ios_iap_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
-import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform, visibleForTesting;
 import 'package:in_app_purchase_platform_interface/in_app_purchase_platform_interface.dart';
 import 'package:mint_mobile/services/api_service.dart';
 
@@ -77,7 +76,7 @@ class IosIapService {
   }
 
   static bool get isSupportedPlatform =>
-      _platformCheckOverride ? _platformCheckOverrideValue : Platform.isIOS;
+      _platformCheckOverride ? _platformCheckOverrideValue : defaultTargetPlatform == TargetPlatform.iOS;
 
   static Future<bool> purchaseCoachMonthly() async {
     if (!isSupportedPlatform) return false;

--- a/apps/mobile/lib/services/slm/gemma_interop.dart
+++ b/apps/mobile/lib/services/slm/gemma_interop.dart
@@ -1,0 +1,13 @@
+/// Conditional export for flutter_gemma.
+///
+/// - On native platforms (dart:io available): re-exports the real package.
+/// - On web (dart:io unavailable): re-exports web-safe stubs.
+///
+/// Usage in SLM files:
+///   import 'package:mint_mobile/services/slm/gemma_interop.dart';
+/// instead of:
+///   import 'package:flutter_gemma/flutter_gemma.dart';
+library;
+
+export 'gemma_stub.dart'
+    if (dart.library.io) 'package:flutter_gemma/flutter_gemma.dart';

--- a/apps/mobile/lib/services/slm/gemma_stub.dart
+++ b/apps/mobile/lib/services/slm/gemma_stub.dart
@@ -1,0 +1,117 @@
+/// Web stub for flutter_gemma — provides type-compatible no-ops.
+///
+/// On native platforms (iOS/Android), the real flutter_gemma package
+/// is used via conditional import in `gemma_interop.dart`.
+/// On web, this stub ensures compilation succeeds and all SLM
+/// operations gracefully return "unsupported".
+library;
+
+// ═══════════════════════════════════════════════════════════════
+//  Enums
+// ═══════════════════════════════════════════════════════════════
+
+enum PreferredBackend { gpu, cpu }
+
+enum ModelType { gemmaIt }
+
+// ═══════════════════════════════════════════════════════════════
+//  Response types
+// ═══════════════════════════════════════════════════════════════
+
+class ModelResponse {
+  @override
+  String toString() => '';
+}
+
+class TextResponse extends ModelResponse {
+  final String token;
+  TextResponse(this.token);
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  Message
+// ═══════════════════════════════════════════════════════════════
+
+class Message {
+  final String text;
+  final bool isUser;
+
+  const Message._({required this.text, this.isUser = false});
+
+  factory Message.systemInfo({required String text}) =>
+      Message._(text: text);
+
+  factory Message.text({required String text, bool isUser = false}) =>
+      Message._(text: text, isUser: isUser);
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  Chat (no-op on web)
+// ═══════════════════════════════════════════════════════════════
+
+class Chat {
+  Future<void> addQueryChunk(Message message) async {}
+  Future<ModelResponse> generateChatResponse() async => ModelResponse();
+  Stream<ModelResponse> generateChatResponseAsync() => const Stream.empty();
+  Future<void> close() async {}
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  InferenceModel (no-op on web)
+// ═══════════════════════════════════════════════════════════════
+
+class InferenceModel {
+  Future<Chat> createChat({
+    double temperature = 0.3,
+    int tokenBuffer = 256,
+    int topK = 1,
+  }) async => Chat();
+
+  Future<void> close() async {}
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  CancelToken
+// ═══════════════════════════════════════════════════════════════
+
+class CancelToken {
+  bool _cancelled = false;
+  bool get isCancelled => _cancelled;
+
+  void cancel([String? reason]) => _cancelled = true;
+
+  static bool isCancel(dynamic error) => false;
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  InstallBuilder (no-op chain)
+// ═══════════════════════════════════════════════════════════════
+
+class _InstallBuilder {
+  _InstallBuilder fromNetwork(String url, {String? token}) => this;
+  _InstallBuilder withProgress(void Function(int) callback) => this;
+  _InstallBuilder withCancelToken(CancelToken token) => this;
+  Future<void> install() async =>
+      throw UnsupportedError('flutter_gemma not available on web');
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  FlutterGemma (web stub — all methods throw/return false)
+// ═══════════════════════════════════════════════════════════════
+
+class FlutterGemma {
+  FlutterGemma._();
+
+  static Future<bool> isModelInstalled(String modelId) async => false;
+
+  static Future<InferenceModel> getActiveModel({
+    int maxTokens = 8192,
+    PreferredBackend preferredBackend = PreferredBackend.gpu,
+  }) async =>
+      throw UnsupportedError('flutter_gemma not available on web');
+
+  static _InstallBuilder installModel({ModelType? modelType}) =>
+      _InstallBuilder();
+
+  static Future<void> uninstallModel(String modelId) async {}
+}

--- a/apps/mobile/lib/services/slm/slm_download_service.dart
+++ b/apps/mobile/lib/services/slm/slm_download_service.dart
@@ -15,7 +15,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:mint_mobile/services/slm/gemma_interop.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Download progress callback.
@@ -145,7 +145,9 @@ class SlmDownloadService {
   /// Check if model is installed via flutter_gemma's native check.
   ///
   /// This is the authoritative source of truth — not SharedPreferences.
+  /// Always returns false on web (native-only feature).
   Future<bool> get isModelReady async {
+    if (kIsWeb) return false;
     try {
       return await FlutterGemma.isModelInstalled(modelId);
     } catch (_) {
@@ -190,6 +192,10 @@ class SlmDownloadService {
     String? modelUrl,
     String? hfToken,
   }) async {
+    if (kIsWeb) {
+      debugPrint('[SLM] Download unavailable on web platform');
+      return false;
+    }
     if (_state == DownloadState.downloading) return false;
 
     _state = DownloadState.downloading;

--- a/apps/mobile/lib/services/slm/slm_engine.dart
+++ b/apps/mobile/lib/services/slm/slm_engine.dart
@@ -22,7 +22,7 @@ library;
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_gemma/flutter_gemma.dart';
+import 'package:mint_mobile/services/slm/gemma_interop.dart';
 import 'package:mint_mobile/services/slm/slm_download_service.dart';
 
 /// Status of the SLM engine.
@@ -114,6 +114,13 @@ class SlmEngine {
   /// then creates an [InferenceModel] with GPU preferred (CPU fallback).
   /// Returns true if initialization succeeded.
   Future<bool> initialize() async {
+    // SLM requires native platform (iOS/Android) — not available on web.
+    if (kIsWeb) {
+      _status = SlmStatus.error;
+      debugPrint('[SLM] Engine unavailable on web platform');
+      return false;
+    }
+
     if (_status == SlmStatus.running && _model != null) return true;
 
     // Use flutter_gemma's native check instead of SharedPreferences path.


### PR DESCRIPTION
- Add flutter_gemma conditional imports (gemma_interop.dart + gemma_stub.dart) so web builds compile without native MediaPipe dependencies
- Add kIsWeb guards in SlmEngine and SlmDownloadService for graceful web fallback
- Add web-specific banner in SlmSettingsScreen ("mobile only" message)
- Fix API base URL: 8888 → 8000 to match uvicorn default
- Replace dart:io Platform with defaultTargetPlatform in IosIapService

https://claude.ai/code/session_01XWA7unsuHijfWtCSx5qg5E