### PR TITLE
[infra] branch-based CI/CD: staging deploy + smoke + prod lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# MINT CI — Run tests on every push & PR
-# Triggers on push to main + any PR
+# MINT CI — Run tests on branch PRs and protected branch pushes
+# Triggers on push to staging/main + PRs targeting dev/staging/main
 # Two parallel jobs: backend (pytest) + flutter (analyze + test)
 # REQUIRED to pass before merge (branch protection rule)
 
@@ -7,9 +7,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [staging, main]
   pull_request:
-    branches: [main]
+    branches: [dev, staging, main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -49,7 +49,7 @@ jobs:
       - name: Changed-lines coverage (PRs only, ≥80%)
         if: github.event_name == 'pull_request'
         working-directory: .
-        run: diff-cover services/backend/coverage.xml --compare-branch=origin/main --fail-under=80
+        run: diff-cover services/backend/coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
       - name: OpenAPI contract check
         env:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,20 +1,30 @@
-# MINT Backend — Deploy to Railway
-# Two environments: staging (on PR) + production (on push to main)
+# MINT Backend — Deploy to Railway by branch
+#
+# Branch strategy:
+#   - push staging -> deploy Railway STAGING + smoke tests
+#   - push main    -> deploy Railway PROD
+#   - PR staging/main -> tests only
 #
 # Required secrets:
-#   RAILWAY_TOKEN          — Railway API token
-#   RAILWAY_SERVICE_ID     — Production service ID
-#   RAILWAY_STAGING_SERVICE_ID — Staging service ID (optional)
+#   RAILWAY_TOKEN
+#   RAILWAY_STAGING_SERVICE_ID
+#   RAILWAY_SERVICE_ID  (prod)
+#
+# Optional secrets (recommended for explicit project/env targeting):
+#   RAILWAY_PROJECT_ID
+#   RAILWAY_STAGING_ENVIRONMENT_ID
+#   RAILWAY_PROD_ENVIRONMENT_ID
+#   STAGING_API_URL (or vars.STAGING_API_URL)
 
 name: Deploy Backend
 
 on:
   push:
-    branches: [main]
+    branches: [staging, main]
     paths:
       - "services/backend/**"
   pull_request:
-    branches: [main]
+    branches: [staging, main]
     paths:
       - "services/backend/**"
   workflow_dispatch:
@@ -49,58 +59,23 @@ jobs:
           DATABASE_URL: "sqlite:///./test.db"
         run: python -m pytest tests/ -q --tb=short -x
 
-  # ─── Deploy to staging (on PR) ─────────────────────────────
+  # ─── Deploy STAGING (push staging only) ─────────────────────
   deploy-staging:
     name: Deploy to Staging
     needs: test
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     environment:
       name: staging
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ vars.STAGING_API_URL }}
     steps:
-      - name: Check Railway config
+      - name: Validate Railway staging secrets
         env:
           HAS_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
+          HAS_STAGING_SERVICE: ${{ secrets.RAILWAY_STAGING_SERVICE_ID != '' }}
         run: |
-          if [ "$HAS_TOKEN" != "true" ]; then
-            echo "::notice::Railway secrets not configured yet — skipping deploy"
-            echo "SKIP_DEPLOY=true" >> "$GITHUB_ENV"
-          fi
-
-      - uses: actions/checkout@v4
-        if: env.SKIP_DEPLOY != 'true'
-
-      - name: Install Railway CLI
-        if: env.SKIP_DEPLOY != 'true'
-        run: npm install -g @railway/cli
-
-      - name: Deploy to staging
-        if: env.SKIP_DEPLOY != 'true'
-        id: deploy
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: |
-          railway up --service ${{ secrets.RAILWAY_STAGING_SERVICE_ID }} --detach
-          echo "Deployed to staging"
-
-  # ─── Deploy to production (on push to main) ────────────────
-  deploy-production:
-    name: Deploy to Production
-    needs: test
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://mint-api.up.railway.app
-    steps:
-      - name: Check Railway config
-        env:
-          HAS_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
-          HAS_SERVICE_ID: ${{ secrets.RAILWAY_SERVICE_ID != '' }}
-        run: |
-          if [ "$HAS_TOKEN" != "true" ] || [ "$HAS_SERVICE_ID" != "true" ]; then
-            echo "::error::Missing Railway secrets (RAILWAY_TOKEN and/or RAILWAY_SERVICE_ID). Aborting production deploy."
+          if [ "$HAS_TOKEN" != "true" ] || [ "$HAS_STAGING_SERVICE" != "true" ]; then
+            echo "::error::Missing Railway staging secrets (RAILWAY_TOKEN and/or RAILWAY_STAGING_SERVICE_ID)."
             exit 1
           fi
 
@@ -109,26 +84,117 @@ jobs:
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
-      - name: Deploy to production
+      - name: Deploy to Railway staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+          RAILWAY_STAGING_ENVIRONMENT_ID: ${{ secrets.RAILWAY_STAGING_ENVIRONMENT_ID }}
         run: |
-          railway up --service ${{ secrets.RAILWAY_SERVICE_ID }} --detach
+          cmd=(railway up --service "${{ secrets.RAILWAY_STAGING_SERVICE_ID }}" --detach)
+          if [ -n "$RAILWAY_PROJECT_ID" ]; then
+            cmd+=(--project "$RAILWAY_PROJECT_ID")
+          fi
+          if [ -n "$RAILWAY_STAGING_ENVIRONMENT_ID" ]; then
+            cmd+=(--environment "$RAILWAY_STAGING_ENVIRONMENT_ID")
+          fi
+
+          echo "Deploy command: ${cmd[*]}"
+          "${cmd[@]}"
+          echo "Deployed to staging"
+
+  # ─── Smoke tests STAGING (after deploy-staging) ─────────────
+  smoke-staging:
+    name: Smoke Staging
+    needs: deploy-staging
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run smoke tests on staging API
+        env:
+          STAGING_API_URL_VAR: ${{ vars.STAGING_API_URL }}
+          STAGING_API_URL_SECRET: ${{ secrets.STAGING_API_URL }}
+        run: |
+          set -euo pipefail
+          URL="${STAGING_API_URL_VAR:-$STAGING_API_URL_SECRET}"
+          if [ -z "$URL" ]; then
+            echo "::error::Missing staging URL. Set vars.STAGING_API_URL or secrets.STAGING_API_URL."
+            exit 1
+          fi
+
+          chmod +x scripts/smoke_staging_api.sh
+          scripts/smoke_staging_api.sh "$URL"
+
+  # ─── Deploy PROD (push main only) ───────────────────────────
+  deploy-production:
+    name: Deploy to Production
+    needs: test
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.PROD_API_URL }}
+    steps:
+      - name: Validate Railway production secrets
+        env:
+          HAS_TOKEN: ${{ secrets.RAILWAY_TOKEN != '' }}
+          HAS_PROD_SERVICE: ${{ secrets.RAILWAY_SERVICE_ID != '' }}
+        run: |
+          if [ "$HAS_TOKEN" != "true" ] || [ "$HAS_PROD_SERVICE" != "true" ]; then
+            echo "::error::Missing Railway production secrets (RAILWAY_TOKEN and/or RAILWAY_SERVICE_ID)."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway production
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+          RAILWAY_PROD_ENVIRONMENT_ID: ${{ secrets.RAILWAY_PROD_ENVIRONMENT_ID }}
+        run: |
+          cmd=(railway up --service "${{ secrets.RAILWAY_SERVICE_ID }}" --detach)
+          if [ -n "$RAILWAY_PROJECT_ID" ]; then
+            cmd+=(--project "$RAILWAY_PROJECT_ID")
+          fi
+          if [ -n "$RAILWAY_PROD_ENVIRONMENT_ID" ]; then
+            cmd+=(--environment "$RAILWAY_PROD_ENVIRONMENT_ID")
+          fi
+
+          echo "Deploy command: ${cmd[*]}"
+          "${cmd[@]}"
           echo "Deployed to production"
 
       - name: Production healthcheck
         env:
-          HEALTHCHECK_URL: ${{ vars.BACKEND_HEALTHCHECK_URL }}
+          PROD_API_URL: ${{ vars.PROD_API_URL }}
+          PROD_API_URL_SECRET: ${{ secrets.PROD_API_URL }}
         run: |
-          url="${HEALTHCHECK_URL:-https://mint-api.up.railway.app/api/v1/health}"
-          echo "Checking backend health on: $url"
+          set -euo pipefail
+          base_url="${PROD_API_URL:-$PROD_API_URL_SECRET}"
+          base_url="${base_url:-https://api.mint.ch/api/v1}"
+          base_url="${base_url%/}"
+          if [[ "$base_url" == */api/v1 ]]; then
+            health_url="${base_url}/health"
+          else
+            health_url="${base_url}/api/v1/health"
+          fi
+
+          echo "Checking backend health on: $health_url"
           for i in 1 2 3 4 5; do
-            if curl -fsS "$url" >/dev/null; then
+            if curl -fsS --connect-timeout 5 --max-time 15 "$health_url" >/dev/null; then
               echo "Backend healthcheck OK"
               exit 0
             fi
             echo "Healthcheck failed (attempt $i/5), retrying in 10s..."
             sleep 10
           done
-          echo "::error::Backend healthcheck failed after deploy: $url"
+
+          echo "::error::Backend healthcheck failed after deploy: $health_url"
           exit 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -11,7 +11,6 @@
 #   APP_STORE_CONNECT_API_KEY_CONTENT  (base64-encoded .p8 file)
 #   MATCH_GIT_URL                      (private repo for certs)
 #   MATCH_PASSWORD                     (decrypt certs)
-#   API_BASE_URL                       (e.g. https://your-api-domain/api/v1)
 # Optional:
 #   HUGGINGFACE_TOKEN                  (required for gated Gemma 3n download)
 #   SLM_MODEL_URL                      (custom model URL override)
@@ -34,10 +33,12 @@ jobs:
   build-and-upload:
     name: Build iOS + Upload TestFlight
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: macos-15
     timeout-minutes: 45
+    env:
+      PROD_API_BASE_URL: "https://api.mint.ch/api/v1"
 
     defaults:
       run:
@@ -79,12 +80,15 @@ jobs:
       - name: Generate l10n
         run: flutter gen-l10n
 
-      - name: Validate backend URL secret
+      - name: Validate production API URL
         env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL: ${{ env.PROD_API_BASE_URL }}
         run: |
-          [[ -n "$API_BASE_URL" ]] || { echo "::error::Missing secret: API_BASE_URL"; exit 1; }
-          echo "API_BASE_URL is configured"
+          if [ "$API_BASE_URL" != "https://api.mint.ch/api/v1" ]; then
+            echo "::error::Unexpected API_BASE_URL for TestFlight main build: $API_BASE_URL"
+            exit 1
+          fi
+          echo "API_BASE_URL is locked to production"
 
       - name: Validate SLM download configuration
         env:
@@ -112,7 +116,7 @@ jobs:
 
       - name: Backend health precheck
         env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL: ${{ env.PROD_API_BASE_URL }}
         run: |
           HEALTH_URL="${API_BASE_URL%/}/health"
           echo "Checking backend health: $HEALTH_URL"
@@ -125,7 +129,7 @@ jobs:
       # ── Pre-build Flutter iOS (generates Xcode project + runs pod install) ──
       - name: Flutter build iOS (no codesign)
         env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL: ${{ env.PROD_API_BASE_URL }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           SLM_MODEL_URL: ${{ secrets.SLM_MODEL_URL }}
         run: |
@@ -140,7 +144,7 @@ jobs:
 
       - name: Prepare DART_DEFINES for Xcode/Fastlane
         env:
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL: ${{ env.PROD_API_BASE_URL }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           SLM_MODEL_URL: ${{ secrets.SLM_MODEL_URL }}
         run: |
@@ -212,7 +216,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL: ${{ env.PROD_API_BASE_URL }}
           DART_DEFINES: ${{ env.DART_DEFINES }}
           CI: "true"
         run: bundle exec fastlane beta

--- a/scripts/smoke_staging_api.sh
+++ b/scripts/smoke_staging_api.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# Smoke tests for MINT staging API.
+# Usage:
+#   scripts/smoke_staging_api.sh https://mint-staging.up.railway.app/api/v1
+#   scripts/smoke_staging_api.sh https://mint-staging.up.railway.app
+#
+# Environment overrides:
+#   MAX_RETRIES=5
+#   SLEEP_SECONDS=5
+#   CONNECT_TIMEOUT=5
+#   MAX_TIME=20
+
+set -Eeuo pipefail
+
+MAX_RETRIES="${MAX_RETRIES:-5}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+CONNECT_TIMEOUT="${CONNECT_TIMEOUT:-5}"
+MAX_TIME="${MAX_TIME:-20}"
+
+timestamp() {
+  date +"%Y-%m-%d %H:%M:%S"
+}
+
+log() {
+  # shellcheck disable=SC2059
+  printf "[%s] %s\n" "$(timestamp)" "$*"
+}
+
+BASE_URL="${1:-${STAGING_API_URL:-}}"
+if [ -z "$BASE_URL" ]; then
+  log "ERROR: Missing staging URL argument."
+  log "Usage: scripts/smoke_staging_api.sh <staging_base_url>"
+  exit 2
+fi
+
+BASE_URL="${BASE_URL%/}"
+if [[ "$BASE_URL" == */api/v1 ]]; then
+  API_BASE="$BASE_URL"
+else
+  API_BASE="$BASE_URL/api/v1"
+fi
+
+call_endpoint() {
+  local name="$1"
+  local method="$2"
+  local url="$3"
+  local payload="$4"
+  local expected_code="$5"
+  local expected_pattern="$6"
+  local attempt
+  local response
+  local code
+  local body
+
+  for ((attempt = 1; attempt <= MAX_RETRIES; attempt++)); do
+    log "[$name] Attempt ${attempt}/${MAX_RETRIES}: ${method} ${url}"
+
+    if [ "$method" = "GET" ]; then
+      response="$(curl -sS -X "$method" \
+        --connect-timeout "$CONNECT_TIMEOUT" \
+        --max-time "$MAX_TIME" \
+        "$url" \
+        -w $'\n%{http_code}' || true)"
+    else
+      response="$(curl -sS -X "$method" \
+        --connect-timeout "$CONNECT_TIMEOUT" \
+        --max-time "$MAX_TIME" \
+        -H "Content-Type: application/json" \
+        --data "$payload" \
+        "$url" \
+        -w $'\n%{http_code}' || true)"
+    fi
+
+    code="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+
+    if [ "$code" = "$expected_code" ] && { [ -z "$expected_pattern" ] || grep -Eiq "$expected_pattern" <<<"$body"; }; then
+      log "[$name] OK (HTTP $code)"
+      return 0
+    fi
+
+    log "[$name] WARN: expected HTTP $expected_code and pattern '$expected_pattern', got HTTP $code"
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      sleep "$SLEEP_SECONDS"
+    fi
+  done
+
+  log "[$name] ERROR after ${MAX_RETRIES} attempts"
+  log "[$name] Last response (truncated):"
+  echo "$body" | head -c 1200
+  echo
+  return 1
+}
+
+ONBOARDING_PAYLOAD="$(cat <<'JSON'
+{
+  "age": 35,
+  "gross_salary": 95000,
+  "canton": "VD",
+  "household_type": "single",
+  "current_savings": 25000,
+  "is_property_owner": false,
+  "existing_3a": 12000,
+  "existing_lpp": 45000
+}
+JSON
+)"
+
+ARBITRAGE_PAYLOAD="$(cat <<'JSON'
+{
+  "capital_lpp_total": 500000,
+  "capital_obligatoire": 320000,
+  "capital_surobligatoire": 180000,
+  "rente_annuelle_proposee": 24000,
+  "canton": "VD",
+  "age_retraite": 65,
+  "horizon": 20
+}
+JSON
+)"
+
+log "Starting staging smoke tests on ${API_BASE}"
+
+failures=0
+
+call_endpoint \
+  "health" \
+  "GET" \
+  "${API_BASE}/health" \
+  "" \
+  "200" \
+  "\"status\"[[:space:]]*:[[:space:]]*\"ok\"" || failures=$((failures + 1))
+
+call_endpoint \
+  "health-ready-status" \
+  "GET" \
+  "${API_BASE}/health/ready" \
+  "" \
+  "200" \
+  "\"status\"[[:space:]]*:[[:space:]]*\"ok\"" || failures=$((failures + 1))
+
+call_endpoint \
+  "health-ready-database" \
+  "GET" \
+  "${API_BASE}/health/ready" \
+  "" \
+  "200" \
+  "\"database\"[[:space:]]*:[[:space:]]*\"ok\"" || failures=$((failures + 1))
+
+call_endpoint \
+  "retirement-checklist" \
+  "GET" \
+  "${API_BASE}/retirement/checklist" \
+  "" \
+  "200" \
+  "\"checklist\"" || failures=$((failures + 1))
+
+call_endpoint \
+  "onboarding-minimal-profile" \
+  "POST" \
+  "${API_BASE}/onboarding/minimal-profile" \
+  "$ONBOARDING_PAYLOAD" \
+  "200" \
+  "\"confidence_score\"" || failures=$((failures + 1))
+
+call_endpoint \
+  "arbitrage-rente-vs-capital" \
+  "POST" \
+  "${API_BASE}/arbitrage/rente-vs-capital" \
+  "$ARBITRAGE_PAYLOAD" \
+  "200" \
+  "\"options\"" || failures=$((failures + 1))
+
+if [ "$failures" -gt 0 ]; then
+  log "Smoke tests FAILED (${failures} check(s) en echec)."
+  exit 1
+fi
+
+log "Smoke tests PASSED."


### PR DESCRIPTION
## Description

- Implement a branch-based CI/CD strategy for MINT without breaking the current Railway production deployment.
- Target Strategy
	•	feature/* → PR into dev
	•	dev → CI only (no deployments)
	•	staging → CI on PRs + on pushes
	•	push to staging → deploy backend to Railway STAGING
	•	after STAGING deploy → blocking job Smoke Staging
	•	main → CI on PRs + on pushes
	•	push to main → deploy backend to Railway PROD
	•	TestFlight (main) → iOS build with production API (https://api.mint.ch/api/v1)