### PR TITLE
feat(ux): S42 UX Widget Redesign — 29 widgets P1+P5+P6+P7+P4

### DIFF
--- a/apps/mobile/lib/constants/social_insurance.dart
+++ b/apps/mobile/lib/constants/social_insurance.dart
@@ -143,6 +143,10 @@ const double aiRenteEntiere = 2520.0;
 /// Demi-rente AI mensuelle. Degre invalidite 50-69%.
 const double aiRenteDemi = 1260.0;
 
+/// Delai moyen de decision AI depuis depot de la demande (LAI art. 28 + LPGA art. 19).
+/// Valeur empirique: 12-18 mois selon le canton; 14 mois en mediane.
+const int aiDecisionDelayMonths = 14;
+
 // ══════════════════════════════════════════════════════════════════════════════
 // APG — Allocations pour perte de gain
 // ══════════════════════════════════════════════════════════════════════════════
@@ -278,3 +282,15 @@ const List<String> sortedCantonCodes = [
   'JU', 'LU', 'NE', 'NW', 'OW', 'SG', 'SH', 'SO', 'SZ', 'TG',
   'TI', 'UR', 'VD', 'VS', 'ZG', 'ZH',
 ];
+
+// ══════════════════════════════════════════════════════════════════════════════
+// LAMal — Assurance-maladie obligatoire
+// Base legale: LAMal art. 64
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Quote-part maximale annuelle LAMal pour adultes (LAMal art. 64 al. 2).
+/// Adultes >= 26 ans: 700 CHF/an.
+const double lamalQuotePartMax = 700.0;
+
+/// Quote-part maximale annuelle LAMal pour jeunes adultes 19-25 ans.
+const double lamalQuotePartMaxJeunesAdultes = 350.0;

--- a/apps/mobile/lib/constants/social_insurance.dart
+++ b/apps/mobile/lib/constants/social_insurance.dart
@@ -179,6 +179,27 @@ const double acIndemniteTaux = 0.70;
 /// Taux d'indemnite chomage avec charges de famille: 80%.
 const double acIndemniteTauxChargeFamille = 0.80;
 
+/// Duree maximale des indemnites de chomage (LACI art. 27 al. 2).
+///
+/// La duree depend de la periode de cotisation ET de l'age.
+/// Les valeurs ci-dessous correspondent au cas standard (>= 22 mois de cotisation).
+/// Pour des periodes courtes (12-17 mois → 200j, 18-21 mois → 260j).
+
+/// < 22 mois de cotisation (typiquement < 25 ans en debut de carriere).
+const int acJoursMinCotisation = 200;
+
+/// 18-21 mois de cotisation (cas intermediaire).
+const int acJoursIntermediaireCotisation = 260;
+
+/// >= 22 mois de cotisation, age < 55 ans (LACI art. 27 al. 2 lit. c).
+const int acJoursStandard = 400;
+
+/// >= 22 mois de cotisation, age >= 55 ans (LACI art. 27 al. 2 lit. d).
+const int acJoursSenior = 520;
+
+/// Age de reference pour le taux senior AC: 55 ans (LACI art. 27 al. 2 lit. d).
+const int acAgeSeuillSenior = 55;
+
 // ══════════════════════════════════════════════════════════════════════════════
 // Pilier 3a — Prevoyance individuelle liee
 // Base legale: OPP3 art. 7

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -81,6 +81,10 @@ class _IndependantScreenState extends State<IndependantScreen> {
                 const SizedBox(height: 24),
 
                 if (_result != null) ...[
+                  // Jour J — protection before/after (P6-A / S42)
+                  _buildJourJSection(),
+                  const SizedBox(height: 20),
+
                   // Critical alerts
                   if (_result!.alerts.isNotEmpty) ...[
                     _buildAlerts(),
@@ -218,6 +222,170 @@ class _IndependantScreenState extends State<IndependantScreen> {
                 color: MintColors.textSecondary,
                 height: 1.5,
               ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Jour J section (P6-A / S42) ───────────────────────────
+  //  Dramatic before/after: every protection ON vs OFF.
+  //  Computed from result or estimated from revenuNet.
+
+  static const _protections = [
+    ('AVS', '\ud83e\uddf1', 'Double ta cotisation'),
+    ('LPP', '\ud83c\udfe6', 'Dispara\u00eet \u2014 choix volontaire'),
+    ('LAA', '\ud83c\udfe5', 'Dispara\u00eet \u2014 accident hors travail'),
+    ('IJM', '\ud83e\ude7a', 'Dispara\u00eet \u2014 maladie 0 CHF'),
+    ('APG', '\ud83d\udc76', 'Dispara\u00eet \u2014 cong\u00e9 parental'),
+  ];
+
+  Widget _buildJourJSection() {
+    // Estimate protection monthly loss (AVS doubles + LPP + LAA + IJM + APG).
+    final avsMonth = _revenuNet * 0.053 / 12; // employee share
+    final lppMonth = _result?.protectionCost.avsMensuel ?? _revenuNet * 0.08 / 12;
+    final totalLoss = (avsMonth + lppMonth + 150 + 100).roundToDouble();
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            MintColors.error.withValues(alpha: 0.04),
+            MintColors.warning.withValues(alpha: 0.04),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: MintColors.error.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Row(
+            children: [
+              Text('\ud83d\udd04', style: const TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Le Jour J \u2014 La grande bascule',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Ce qui change en 1 jour quand tu deviens ind\u00e9pendant\u00b7e',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 14),
+
+          // Column headers
+          Row(
+            children: [
+              const Expanded(flex: 2, child: SizedBox()),
+              Expanded(
+                child: Text(
+                  'Salari\u00e9\u00b7e',
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.success,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  'Ind\u00e9pendant\u00b7e',
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.error,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // Protection rows
+          ..._protections.map((p) => _buildProtectionRow(p.$1, p.$2, p.$3)),
+
+          const SizedBox(height: 10),
+
+          // Chiffre-choc
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: MintColors.error.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              'Tu perds ~${IndependantService.formatChf(totalLoss)}/mois '
+              'de protection invisible.\n'
+              'Tu n\u2019as pas quitt\u00e9 un emploi. Tu as quitt\u00e9 un syst\u00e8me de protection.',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: MintColors.error,
+                height: 1.4,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProtectionRow(String label, String emoji, String detail) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 16)),
+          const SizedBox(width: 6),
+          Expanded(
+            flex: 2,
+            child: Text(
+              label,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Icon(Icons.check_circle, color: MintColors.success, size: 18),
+          ),
+          Expanded(
+            child: Column(
+              children: [
+                const Icon(Icons.cancel, color: MintColors.error, size: 18),
+                Text(
+                  detail,
+                  textAlign: TextAlign.center,
+                  style: GoogleFonts.inter(
+                    fontSize: 9,
+                    color: MintColors.textMuted,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/segments_service.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -242,10 +243,20 @@ class _IndependantScreenState extends State<IndependantScreen> {
   ];
 
   Widget _buildJourJSection() {
-    // Estimate protection monthly loss (AVS doubles + LPP + LAA + IJM + APG).
-    final avsMonth = _revenuNet * 0.053 / 12; // employee share
-    final lppMonth = _result?.protectionCost.avsMensuel ?? _revenuNet * 0.08 / 12;
-    final totalLoss = (avsMonth + lppMonth + 150 + 100).roundToDouble();
+    // Estimate protection monthly loss when switching to self-employment.
+    // AVS: employee share doubles (indep. pays both sides — LAVS art. 8).
+    final avsMonth = _revenuNet * avsCotisationSalarie / 12;
+    // LPP: voluntary caisse bonification (age-dependent — LPP art. 16).
+    // Falls back to result's avsMensuel when a full calculation is available.
+    final lppMonth = _result?.protectionCost.avsMensuel ??
+        _revenuNet * getLppBonificationRate(_age) / 12;
+    // LAA non-professionnelle: indicative market premium (~150 CHF/mois).
+    // IJM maladie: indicative market premium (~100 CHF/mois).
+    // These are educational estimates — real premiums depend on caisse & coverage.
+    const double kLaaIndepMensuel = 150.0;
+    const double kIjmIndepMensuel = 100.0;
+    final totalLoss = (avsMonth + lppMonth + kLaaIndepMensuel + kIjmIndepMensuel)
+        .roundToDouble();
 
     return Container(
       padding: const EdgeInsets.all(20),

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:go_router/go_router.dart';
@@ -462,6 +464,11 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
     final petit = pilier3aPlafondAvecLpp;
     final grand = pilier3aPlafondSansLpp;
     final plafondIndep = r.plafond;
+    final multiplier = (plafondIndep / petit).round();
+
+    // 20-year projection at 4% compound interest
+    final proj20Indep = plafondIndep * ((math.pow(1.04, 20) - 1) / 0.04);
+    final proj20Salarie = petit * ((math.pow(1.04, 20) - 1) / 0.04);
 
     return Container(
       padding: const EdgeInsets.all(20),
@@ -473,26 +480,44 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // ── Header with ×5 badge (P6-E / S42) ──
           Row(
             children: [
-              const Icon(Icons.bar_chart, size: 16, color: MintColors.textMuted),
-              const SizedBox(width: 8),
-              Text(
-                'PLAFONDS COMPARÉS',
-                style: GoogleFonts.montserrat(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w700,
-                  color: MintColors.textMuted,
-                  letterSpacing: 1,
+              Expanded(
+                child: Text(
+                  'PLAFONDS COMPAR\u00c9S',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textMuted,
+                    letterSpacing: 1,
+                  ),
                 ),
               ),
+              if (!_affilieLpp)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: MintColors.success,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '\u00d7$multiplier ton super-pouvoir',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
             ],
           ),
           const SizedBox(height: 20),
 
           // Salarie bar
           _buildPlafondBar(
-            label: 'Salarié\u00B7e',
+            label: 'Salari\u00e9\u00B7e',
             value: petit,
             maxValue: grand,
             color: MintColors.info,
@@ -501,7 +526,7 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
           // Independant bar
           _buildPlafondBar(
-            label: 'Indépendant\u00B7e (toi)',
+            label: 'Ind\u00e9pendant\u00B7e (toi)',
             value: plafondIndep,
             maxValue: grand,
             color: MintColors.success,
@@ -511,13 +536,86 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
           // Max bar
           _buildPlafondBar(
-            label: 'Grand 3a (max légal)',
+            label: 'Grand 3a (max l\u00e9gal)',
             value: grand,
             maxValue: grand,
             color: MintColors.textMuted.withValues(alpha: 0.3),
           ),
+
+          // ── 20-year projection (P6-E chiffre-choc) ──
+          if (!_affilieLpp) ...[
+            const SizedBox(height: 16),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: MintColors.success.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                    color: MintColors.success.withValues(alpha: 0.2)),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    'En 20 ans \u00e0 4%',
+                    style: GoogleFonts.inter(
+                      fontSize: 11,
+                      color: MintColors.textMuted,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      _buildProjectionColumn(
+                          'Salari\u00e9\u00b7e', proj20Salarie, MintColors.info),
+                      Text(
+                        'vs',
+                        style: GoogleFonts.inter(
+                            fontSize: 14, color: MintColors.textMuted),
+                      ),
+                      _buildProjectionColumn(
+                          'Toi', proj20Indep, MintColors.success),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Diff\u00e9rence\u00a0: +${IndependantsService.formatChf(proj20Indep - proj20Salarie)}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.success,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ],
       ),
+    );
+  }
+
+  Widget _buildProjectionColumn(String label, double amount, Color color) {
+    final millions = amount >= 1000000;
+    final display = millions
+        ? '${(amount / 1000000).toStringAsFixed(2)}M'
+        : '${(amount / 1000).toStringAsFixed(0)}k';
+    return Column(
+      children: [
+        Text(
+          'CHF\u00a0$display',
+          style: GoogleFonts.montserrat(
+            fontSize: 18,
+            fontWeight: FontWeight.w800,
+            color: color,
+          ),
+        ),
+        Text(
+          label,
+          style: GoogleFonts.inter(fontSize: 11, color: MintColors.textMuted),
+        ),
+      ],
     );
   }
 

--- a/apps/mobile/lib/screens/unemployment_screen.dart
+++ b/apps/mobile/lib/screens/unemployment_screen.dart
@@ -85,6 +85,8 @@ class _UnemploymentScreenState extends State<UnemploymentScreen> {
                     const SizedBox(height: 24),
                     _buildDurationCard(),
                     const SizedBox(height: 24),
+                    _buildTroisVagues(),
+                    const SizedBox(height: 24),
                   ],
                   UnemploymentTimelineWidget(items: _result!.timeline),
                   const SizedBox(height: 24),
@@ -989,6 +991,112 @@ class _UnemploymentScreenState extends State<UnemploymentScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  // ── P7-A : Les 3 vagues — Ton tsunami financier ────────────
+
+  static const _vagues = [
+    (
+      emoji: '🌊',
+      label: 'Vague 1 · L\'urgence administrative',
+      color: Color(0xFF1565C0),
+      text: 'Inscription ORP dans les 5 premiers jours. Sinon : perte d\'indemnités. '
+          'Chaque jour de retard = indemnité perdue.',
+    ),
+    (
+      emoji: '🌊',
+      label: 'Vague 2 · La chute de revenus',
+      color: Color(0xFFE65100),
+      text: 'Chute immédiate de CHF/mois. L\'AC ne couvre ni les jours fériés '
+          'ni le délai de carence (5–20 jours). Revise ton budget dès J+1.',
+    ),
+    (
+      emoji: '🌊',
+      label: 'Vague 3 · Les décisions cachées',
+      color: Color(0xFFC62828),
+      text: 'Dans les 30 jours : transférer ton LPP (sinon institution supplétive). '
+          'Avant le mois suivant : suspendre le 3a, revoir LAMal. '
+          '"La vague la plus dangereuse, c\'est celle que tu n\'as pas vue venir."',
+    ),
+  ];
+
+  Widget _buildTroisVagues() {
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFF90CAF9)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            child: Row(
+              children: [
+                const Text('🌊', style: TextStyle(fontSize: 22)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Ton tsunami financier en 3 vagues',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          ..._vagues.map(
+            (v) => Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 4,
+                    height: 56,
+                    decoration: BoxDecoration(
+                      color: v.color,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          v.label,
+                          style: GoogleFonts.inter(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                            color: v.color,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          v.text,
+                          style: GoogleFonts.inter(
+                            fontSize: 12,
+                            color: MintColors.textSecondary,
+                            height: 1.5,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/services/coach_narrative_service.dart
+++ b/apps/mobile/lib/services/coach_narrative_service.dart
@@ -245,7 +245,7 @@ class CoachNarrativeService {
           retirementAge: 65,
           grossAnnualSalary: salary,
           caisseReturn: 0.01,
-          conversionRate: profile.prevoyance.tauxConversion ?? 0.068,
+          conversionRate: profile.prevoyance.tauxConversion,
         );
         final totalMonthly = avsMonthly + lppAnnual / 12;
         replacementRatio = totalMonthly / (salary / 12);
@@ -852,7 +852,7 @@ class CoachNarrativeService {
           retirementAge: 65,
           grossAnnualSalary: salary,
           caisseReturn: 0.01,
-          conversionRate: profile.prevoyance.tauxConversion ?? 0.068,
+          conversionRate: profile.prevoyance.tauxConversion,
         );
         final totalMonthly = avsMonthly + lppAnnual / 12;
         replacementRate = totalMonthly / (salary / 12);

--- a/apps/mobile/lib/services/consent_manager.dart
+++ b/apps/mobile/lib/services/consent_manager.dart
@@ -162,7 +162,7 @@ class ConsentManager {
 
   static Future<dynamic> _getPrefs() async {
     // Lazy import to avoid hard dependency at top level
-    final module = await Future.value(null); // SharedPreferences placeholder
+    await Future.value(null); // SharedPreferences placeholder
     // In production, use: SharedPreferences.getInstance()
     // For now, use in-memory fallback
     return _InMemoryPrefs.instance;

--- a/apps/mobile/lib/services/expat_service.dart
+++ b/apps/mobile/lib/services/expat_service.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:mint_mobile/constants/social_insurance.dart';
-import 'package:mint_mobile/services/financial_core/financial_core.dart';
 
 // ────────────────────────────────────────────────────────────
 //  EXPAT SERVICE — Sprint S23 / Expatriation + Frontaliers

--- a/apps/mobile/lib/services/minimal_profile_service.dart
+++ b/apps/mobile/lib/services/minimal_profile_service.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
 import 'package:mint_mobile/services/financial_core/financial_core.dart';
-import 'package:mint_mobile/services/fiscal_service.dart';
 
 /// Minimal profile computation service (Sprint S31 — Onboarding Redesign).
 ///

--- a/apps/mobile/lib/services/retirement_projection_service.dart
+++ b/apps/mobile/lib/services/retirement_projection_service.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/financial_core/financial_core.dart';
-import 'package:mint_mobile/services/retirement_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────

--- a/apps/mobile/lib/utils/chf_formatter.dart
+++ b/apps/mobile/lib/utils/chf_formatter.dart
@@ -22,3 +22,11 @@ String formatChf(double value) {
 
 /// Format with "CHF " prefix.
 String formatChfWithPrefix(double value) => 'CHF\u00a0${formatChf(value)}';
+
+/// Compact CHF formatter — omits "CHF" prefix for space-constrained contexts.
+/// Examples: 680'000 → "680k" | 1'200'000 → "1.2M" | 800 → "CHF 800"
+String formatChfCompact(double value) {
+  if (value >= 1000000) return '${(value / 1000000).toStringAsFixed(1)}M';
+  if (value >= 1000) return '${(value / 1000).toStringAsFixed(0)}k';
+  return formatChfWithPrefix(value);
+}

--- a/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
+++ b/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P8-E  L'Avancement d'hoirie — Film 2 actes donation
+//  Charte : L2 (Avant/Après) + L4 (Raconte ne montre pas)
+//  Source : CC art. 626 (rapport à la masse), CC art. 471
+// ────────────────────────────────────────────────────────────
+
+class HoirieChild {
+  const HoirieChild({required this.name, required this.emoji});
+  final String name;
+  final String emoji;
+}
+
+class AvancementHoirieWidget extends StatelessWidget {
+  const AvancementHoirieWidget({
+    super.key,
+    required this.totalPatrimoine,
+    required this.donationAmount,
+    required this.children,
+    required this.donationRecipientIndex,
+  });
+
+  final double totalPatrimoine;
+  final double donationAmount;
+  final List<HoirieChild> children;
+  final int donationRecipientIndex;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final n = children.length;
+    final masseTotale = totalPatrimoine + donationAmount; // masse de calcul avec rapport
+    final sharePerChild = masseTotale / n;
+    final recipientAuDeces = sharePerChild - donationAmount;
+
+    return Semantics(
+      label: 'Avancement hoirie donation rapport succession',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildAct1(),
+                  _buildArrow(),
+                  _buildAct2(sharePerChild, recipientAuDeces),
+                  const SizedBox(height: 16),
+                  _buildNarrative(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8F5E9),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🎬', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'L\'avancement d\'hoirie',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Ce que tu donnes aujourd\'hui sera déduit de la part à ton décès · CC art. 626',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAct1() {
+    final recipient = children[donationRecipientIndex.clamp(0, children.length - 1)];
+    return _buildActCard(
+      actLabel: 'ACTE 1 · Aujourd\'hui',
+      color: MintColors.primary,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Patrimoine total : CHF ${_fmt(totalPatrimoine)}',
+            style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Text('${recipient.emoji} ${recipient.name}', style: const TextStyle(fontSize: 16)),
+              const SizedBox(width: 8),
+              Text(
+                'reçoit donation : CHF ${_fmt(donationAmount)}',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.primary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Patrimoine restant : CHF ${_fmt(totalPatrimoine - donationAmount)}',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAct2(double sharePerChild, double recipientAuDeces) {
+    return _buildActCard(
+      actLabel: 'ACTE 2 · Au décès — rapport à la masse (CC art. 626)',
+      color: MintColors.scoreAttention,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Masse de calcul : CHF ${_fmt(totalPatrimoine - donationAmount)} + CHF ${_fmt(donationAmount)} (rapporté)',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            '= CHF ${_fmt(totalPatrimoine + donationAmount)} partagé en ${children.length}',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+          ),
+          const SizedBox(height: 10),
+          ...children.asMap().entries.map((e) {
+            final isRecipient = e.key == donationRecipientIndex.clamp(0, children.length - 1);
+            final share = isRecipient ? (recipientAuDeces < 0 ? 0.0 : recipientAuDeces) : sharePerChild;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: [
+                  Text('${e.value.emoji} ${e.value.name}', style: const TextStyle(fontSize: 14)),
+                  if (isRecipient) ...[
+                    const SizedBox(width: 6),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: MintColors.scoreAttention.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Text(
+                        '(déjà reçu CHF ${_fmt(donationAmount)})',
+                        style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreAttention, fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                  const Spacer(),
+                  Text(
+                    'CHF ${_fmt(share)}',
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: isRecipient ? MintColors.scoreAttention : MintColors.scoreExcellent,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActCard({required String actLabel, required Color color, required Widget child}) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            actLabel,
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              color: color,
+              letterSpacing: 0.3,
+            ),
+          ),
+          const SizedBox(height: 10),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildArrow() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Icon(Icons.keyboard_arrow_down, color: MintColors.textSecondary, size: 28),
+      ),
+    );
+  }
+
+  Widget _buildNarrative() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Ce que tu donnes sera déduit de sa part. '
+              'L\'égalité entre héritiers est préservée — sauf clause d\'exonération de rapport.',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                color: MintColors.textPrimary,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CC art. 626 (rapport), CC art. 471 (réserves).',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
+++ b/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P8-E  L'Avancement d'hoirie — Film 2 actes donation
@@ -27,16 +28,6 @@ class AvancementHoirieWidget extends StatelessWidget {
   final double donationAmount;
   final List<HoirieChild> children;
   final int donationRecipientIndex;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -127,7 +118,7 @@ class AvancementHoirieWidget extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Patrimoine total : CHF ${_fmt(totalPatrimoine)}',
+            'Patrimoine total : ${formatChfWithPrefix(totalPatrimoine)}',
             style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
           ),
           const SizedBox(height: 8),
@@ -136,7 +127,7 @@ class AvancementHoirieWidget extends StatelessWidget {
               Text('${recipient.emoji} ${recipient.name}', style: const TextStyle(fontSize: 16)),
               const SizedBox(width: 8),
               Text(
-                'reçoit donation : CHF ${_fmt(donationAmount)}',
+                'reçoit donation : ${formatChfWithPrefix(donationAmount)}',
                 style: GoogleFonts.inter(
                   fontSize: 13,
                   fontWeight: FontWeight.w700,
@@ -147,7 +138,7 @@ class AvancementHoirieWidget extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(
-            'Patrimoine restant : CHF ${_fmt(totalPatrimoine - donationAmount)}',
+            'Patrimoine restant : ${formatChfWithPrefix(totalPatrimoine - donationAmount)}',
             style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
           ),
         ],
@@ -163,12 +154,12 @@ class AvancementHoirieWidget extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Masse de calcul : CHF ${_fmt(totalPatrimoine - donationAmount)} + CHF ${_fmt(donationAmount)} (rapporté)',
+            'Masse de calcul : ${formatChfWithPrefix(totalPatrimoine - donationAmount)} + ${formatChfWithPrefix(donationAmount)} (rapporté)',
             style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
           ),
           const SizedBox(height: 2),
           Text(
-            '= CHF ${_fmt(totalPatrimoine + donationAmount)} partagé en ${children.length}',
+            '= ${formatChfWithPrefix(totalPatrimoine + donationAmount)} partagé en ${children.length}',
             style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
           ),
           const SizedBox(height: 10),
@@ -189,14 +180,14 @@ class AvancementHoirieWidget extends StatelessWidget {
                         borderRadius: BorderRadius.circular(6),
                       ),
                       child: Text(
-                        '(déjà reçu CHF ${_fmt(donationAmount)})',
+                        '(déjà reçu ${formatChfWithPrefix(donationAmount)})',
                         style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreAttention, fontWeight: FontWeight.w600),
                       ),
                     ),
                   ],
                   const Spacer(),
                   Text(
-                    'CHF ${_fmt(share)}',
+                    formatChfWithPrefix(share),
                     style: GoogleFonts.inter(
                       fontSize: 13,
                       fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/widgets/coach/avs_gap_widget.dart
+++ b/apps/mobile/lib/widgets/coach/avs_gap_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P13-C  Le Trou AVS — rente réduite par années à l'étranger
@@ -32,16 +33,6 @@ class _AvsGapWidgetState extends State<AvsGapWidget> {
   void initState() {
     super.initState();
     _yearsAbroad = widget.initialYearsAbroad;
-  }
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
   }
 
   int get _yearsRemainingInCH =>
@@ -232,7 +223,7 @@ class _AvsGapWidgetState extends State<AvsGapWidget> {
           ),
           const SizedBox(height: 6),
           Text(
-            'CHF ${_fmt(rente)}/mois',
+            '${formatChfWithPrefix(rente)}/mois',
             style: GoogleFonts.montserrat(
               fontSize: 18,
               fontWeight: FontWeight.w800,
@@ -256,7 +247,7 @@ class _AvsGapWidgetState extends State<AvsGapWidget> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            '⚠️ CHF ${_fmt(_perYearAbroad)}/mois de rente perdu par année à l\'étranger',
+            '⚠️ ${formatChfWithPrefix(_perYearAbroad)}/mois de rente perdu par année à l\'étranger',
             style: GoogleFonts.inter(
               fontSize: 13,
               fontWeight: FontWeight.w700,
@@ -265,7 +256,7 @@ class _AvsGapWidgetState extends State<AvsGapWidget> {
           ),
           const SizedBox(height: 6),
           Text(
-            'Sur 20 ans de retraite, c\'est CHF ${_fmt(_lifetimeLoss)} de moins — définitivement.',
+            'Sur 20 ans de retraite, c\'est ${formatChfWithPrefix(_lifetimeLoss)} de moins — définitivement.',
             style: GoogleFonts.inter(
               fontSize: 12,
               color: MintColors.textSecondary,
@@ -290,7 +281,7 @@ class _AvsGapWidgetState extends State<AvsGapWidget> {
     return Text(
       'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
       'Source : LAVS art. 29bis-29quater (années cotisation). '
-      'Durée complète : $avsDureeCotisationComplete ans. Rente max : CHF ${_fmt(avsRenteMaxMensuelle)}/mois.',
+      'Durée complète : $avsDureeCotisationComplete ans. Rente max : ${formatChfWithPrefix(avsRenteMaxMensuelle)}/mois.',
       style: GoogleFonts.inter(
         fontSize: 10,
         color: MintColors.textSecondary,

--- a/apps/mobile/lib/widgets/coach/avs_gap_widget.dart
+++ b/apps/mobile/lib/widgets/coach/avs_gap_widget.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P13-C  Le Trou AVS — rente réduite par années à l'étranger
+//  Charte : L1 (CHF/mois) + L6 (Chiffre-choc)
+//  Source : LAVS art. 29bis-29quater, avsDureeCotisationComplete = 44
+// ────────────────────────────────────────────────────────────
+
+class AvsGapWidget extends StatefulWidget {
+  const AvsGapWidget({
+    super.key,
+    required this.currentContributionYears,
+    required this.currentAge,
+    this.initialYearsAbroad = 5,
+  });
+
+  final int currentContributionYears;
+  final int currentAge;
+  final int initialYearsAbroad;
+
+  @override
+  State<AvsGapWidget> createState() => _AvsGapWidgetState();
+}
+
+class _AvsGapWidgetState extends State<AvsGapWidget> {
+  late int _yearsAbroad;
+
+  @override
+  void initState() {
+    super.initState();
+    _yearsAbroad = widget.initialYearsAbroad;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  int get _yearsRemainingInCH =>
+      (avsAgeReferenceHomme - widget.currentAge).clamp(0, avsDureeCotisationComplete);
+
+  int get _totalYearsWithAbroad =>
+      (widget.currentContributionYears + _yearsRemainingInCH - _yearsAbroad)
+          .clamp(0, avsDureeCotisationComplete);
+
+  int get _totalYearsWithoutAbroad =>
+      (widget.currentContributionYears + _yearsRemainingInCH)
+          .clamp(0, avsDureeCotisationComplete);
+
+  double get _renteWithoutAbroad =>
+      avsRenteMaxMensuelle * _totalYearsWithoutAbroad / avsDureeCotisationComplete;
+
+  double get _renteWithAbroad =>
+      avsRenteMaxMensuelle * _totalYearsWithAbroad / avsDureeCotisationComplete;
+
+  double get _renteLoss => _renteWithoutAbroad - _renteWithAbroad;
+  double get _perYearAbroad => _yearsAbroad > 0 ? _renteLoss / _yearsAbroad : 0;
+  double get _lifetimeLoss => _renteLoss * 12 * 20; // avg 20 years retirement
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Trou AVS années étranger rente réduite LAVS cotisation',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildSlider(),
+                  const SizedBox(height: 16),
+                  _buildComparison(),
+                  const SizedBox(height: 16),
+                  _buildChiffreChoc(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFEBEE),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🕳️', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le trou AVS',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Chaque année hors Suisse réduit ta rente. Pour toujours.',
+            style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary, height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSlider() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Années à l\'étranger',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              decoration: BoxDecoration(
+                color: MintColors.scoreCritique.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                '$_yearsAbroad an${_yearsAbroad > 1 ? 's' : ''}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: _yearsAbroad.toDouble(),
+          min: 1,
+          max: 20,
+          divisions: 19,
+          activeColor: MintColors.scoreCritique,
+          onChanged: (v) => setState(() => _yearsAbroad = v.round()),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildComparison() {
+    return Row(
+      children: [
+        Expanded(child: _buildRenteCard(
+          label: 'Sans expatriation',
+          years: _totalYearsWithoutAbroad,
+          rente: _renteWithoutAbroad,
+          color: MintColors.scoreExcellent,
+          emoji: '🇨🇭',
+        )),
+        const SizedBox(width: 12),
+        Expanded(child: _buildRenteCard(
+          label: 'Avec $_yearsAbroad an${_yearsAbroad > 1 ? 's' : ''} à l\'étranger',
+          years: _totalYearsWithAbroad,
+          rente: _renteWithAbroad,
+          color: MintColors.scoreCritique,
+          emoji: '✈️',
+        )),
+      ],
+    );
+  }
+
+  Widget _buildRenteCard({
+    required String label,
+    required int years,
+    required double rente,
+    required Color color,
+    required String emoji,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 20)),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary, height: 1.3),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$years / $avsDureeCotisationComplete ans',
+            style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'CHF ${_fmt(rente)}/mois',
+            style: GoogleFonts.montserrat(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '⚠️ CHF ${_fmt(_perYearAbroad)}/mois de rente perdu par année à l\'étranger',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Sur 20 ans de retraite, c\'est CHF ${_fmt(_lifetimeLoss)} de moins — définitivement.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '💡 Possibilité de cotiser volontairement à l\'AVS si hors UE — voir LAVS art. 2.',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.info,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAVS art. 29bis-29quater (années cotisation). '
+      'Durée complète : $avsDureeCotisationComplete ans. Rente max : CHF ${_fmt(avsRenteMaxMensuelle)}/mois.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/baby_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/baby_cost_widget.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P9-A  Le Coût du bonheur — 1'200 CHF/mois × 25 ans
+//  Charte : L1 (CHF/mois) + L6 (Chiffre-choc)
+//  Source : OFS, données ménages suisses, statistiques familiales
+// ────────────────────────────────────────────────────────────
+
+class BabyCostItem {
+  const BabyCostItem({
+    required this.label,
+    required this.emoji,
+    required this.monthlyCost,
+    this.note,
+  });
+
+  final String label;
+  final String emoji;
+  final double monthlyCost;
+  final String? note;
+}
+
+class BabyCostWidget extends StatelessWidget {
+  const BabyCostWidget({
+    super.key,
+    required this.items,
+    required this.yearsOfDependency,
+    this.canton,
+  });
+
+  final List<BabyCostItem> items;
+  final int yearsOfDependency;
+  final String? canton;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final totalMonthly = items.fold<double>(0, (s, i) => s + i.monthlyCost);
+    final totalLifetime = totalMonthly * 12 * yearsOfDependency;
+    final creche = items.firstWhere(
+      (i) => i.label.toLowerCase().contains('crèche') || i.label.toLowerCase().contains('garde'),
+      orElse: () => items.first,
+    );
+
+    return Semantics(
+      label: 'Coût bonheur enfant budget mensuel',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(totalMonthly, totalLifetime),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildBreakdown(),
+                  const SizedBox(height: 16),
+                  _buildTotalBar(totalMonthly),
+                  const SizedBox(height: 16),
+                  _buildCreche(creche),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(double totalMonthly, double totalLifetime) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('👶', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le coût du bonheur',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(child: _buildHeroStat(
+                label: 'Par mois',
+                value: 'CHF ${_fmt(totalMonthly)}',
+                color: MintColors.primary,
+              )),
+              const SizedBox(width: 12),
+              Expanded(child: _buildHeroStat(
+                label: 'Sur $yearsOfDependency ans',
+                value: 'CHF ${_fmt(totalLifetime)}',
+                color: MintColors.scoreAttention,
+              )),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeroStat({required String label, required String value, required Color color}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.7),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary)),
+          Text(
+            value,
+            style: GoogleFonts.montserrat(fontSize: 16, fontWeight: FontWeight.w800, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBreakdown() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Décomposition mensuelle',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ...items.map((item) => Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            children: [
+              Text(item.emoji, style: const TextStyle(fontSize: 18)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.label,
+                      style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+                    ),
+                    if (item.note != null)
+                      Text(
+                        item.note!,
+                        style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                      ),
+                  ],
+                ),
+              ),
+              Text(
+                'CHF ${_fmt(item.monthlyCost)}',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        )),
+      ],
+    );
+  }
+
+  Widget _buildTotalBar(double totalMonthly) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.primary.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'Total / mois',
+            style: GoogleFonts.inter(fontSize: 14, fontWeight: FontWeight.w700, color: MintColors.textPrimary),
+          ),
+          Text(
+            'CHF ${_fmt(totalMonthly)}',
+            style: GoogleFonts.montserrat(fontSize: 20, fontWeight: FontWeight.w800, color: MintColors.primary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCreche(BabyCostItem creche) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'La crèche coûte plus cher que ton loyer.',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${creche.emoji} ${creche.label} : CHF ${_fmt(creche.monthlyCost)}/mois${canton != null ? " à $canton" : ""}.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : OFS, statistiques des ménages suisses.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/budget_503020_widget.dart
+++ b/apps/mobile/lib/widgets/coach/budget_503020_widget.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  BUDGET 50/30/20 WIDGET — P5-D / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Budget automatique basé sur le salaire net, le canton et
+//  l'âge. 50% fixe, 30% vie, 20% futur.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L5 (une action) + L1 (CHF/mois)
+// ────────────────────────────────────────────────────────────
+
+/// One category of the 50/30/20 budget.
+class BudgetCategory {
+  final String label;
+  final String emoji;
+  final double percent;
+  final double amount;
+  final List<String> examples;
+
+  const BudgetCategory({
+    required this.label,
+    required this.emoji,
+    required this.percent,
+    required this.amount,
+    required this.examples,
+  });
+}
+
+class Budget503020Widget extends StatelessWidget {
+  final double netSalary;
+  final List<BudgetCategory> categories;
+
+  /// Optional highlight: chiffre-choc showing annual savings.
+  final String? chiffreChoc;
+
+  const Budget503020Widget({
+    super.key,
+    required this.netSalary,
+    required this.categories,
+    this.chiffreChoc,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Budget 50/30/20. Salaire net\u00a0: '
+          '${formatChfWithPrefix(netSalary)}/mois.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Ton budget 50 / 30 / 20',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Basé sur ${formatChfWithPrefix(netSalary)} net/mois',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Stacked bar ──
+            _buildStackedBar(),
+            const SizedBox(height: 16),
+
+            // ── Category details ──
+            ...categories.map(_buildCategoryCard),
+
+            // ── Chiffre-choc ──
+            if (chiffreChoc != null) ...[
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: MintColors.primary.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                      color: MintColors.primary.withValues(alpha: 0.15)),
+                ),
+                child: Text(
+                  chiffreChoc!,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.primary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+
+            const SizedBox(height: 12),
+            Text(
+              'R\u00e8gle budg\u00e9taire indicative. '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStackedBar() {
+    final colors = [
+      MintColors.primary,
+      MintColors.scoreExcellent,
+      MintColors.accent,
+    ];
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(6),
+      child: SizedBox(
+        height: 24,
+        child: Row(
+          children: [
+            for (var i = 0; i < categories.length && i < 3; i++)
+              Expanded(
+                flex: categories[i].percent.round(),
+                child: Container(
+                  color: i < colors.length
+                      ? colors[i]
+                      : MintColors.textMuted,
+                  alignment: Alignment.center,
+                  child: Text(
+                    '${categories[i].percent.round()}%',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryCard(BudgetCategory cat) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(cat.emoji, style: const TextStyle(fontSize: 20)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '${cat.label} (${cat.percent.round()}%)',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      formatChfWithPrefix(cat.amount),
+                      style: GoogleFonts.montserrat(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  cat.examples.join(' \u00b7 '),
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: MintColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/budget_bebe_widget.dart
+++ b/apps/mobile/lib/widgets/coach/budget_bebe_widget.dart
@@ -1,0 +1,385 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P9-E  Budget 50/30/20 avec curseur nombre d'enfants
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après)
+//  Source : OFS statistiques ménages, règle 50/30/20 (épargne)
+// ────────────────────────────────────────────────────────────
+
+class BudgetBebeWidget extends StatefulWidget {
+  const BudgetBebeWidget({
+    super.key,
+    required this.monthlyIncome,
+    required this.costPerChild,
+  });
+
+  final double monthlyIncome;
+  final double costPerChild;
+
+  @override
+  State<BudgetBebeWidget> createState() => _BudgetBebeWidgetState();
+}
+
+class _BudgetBebeWidgetState extends State<BudgetBebeWidget> {
+  int _children = 0;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  // 50/30/20 rule: besoins/envies/épargne
+  double get _needs => widget.monthlyIncome * 0.50;
+  double get _wants => widget.monthlyIncome * 0.30;
+  double get _savings => widget.monthlyIncome * 0.20;
+
+  double get _childrenCost => widget.costPerChild * _children;
+
+  // Impact: children cost eats into savings first, then wants
+  double get _savingsAfter {
+    final remaining = _savings - _childrenCost;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  double get _wantsAfter {
+    final overshoot = _childrenCost - _savings;
+    if (overshoot <= 0) return _wants;
+    final remaining = _wants - overshoot;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Budget 50 30 20 bébé impact mensuel',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildChildrenSlider(),
+                  const SizedBox(height: 20),
+                  _buildBudgetComparison(),
+                  const SizedBox(height: 16),
+                  if (_children > 0) _buildImpactAlert(),
+                  if (_children > 0) const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('🍼', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Budget 50/30/20 avec bébé',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Besoins / Envies / Épargne — avant et après',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChildrenSlider() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Nombre d\'enfants',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              decoration: BoxDecoration(
+                color: MintColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                _children == 0 ? 'Sans enfant' : '$_children enfant${_children > 1 ? 's' : ''}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: _children.toDouble(),
+          min: 0,
+          max: 3,
+          divisions: 3,
+          activeColor: MintColors.primary,
+          onChanged: (v) => setState(() => _children = v.round()),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBudgetComparison() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Répartition mensuelle',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        _buildBudgetRow(
+          label: '🏠 Besoins (50%)',
+          before: _needs,
+          after: _needs,
+          color: MintColors.info,
+          note: 'Loyer, nourriture, santé',
+        ),
+        const SizedBox(height: 8),
+        _buildBudgetRow(
+          label: '🎭 Envies (30%)',
+          before: _wants,
+          after: _wantsAfter,
+          color: MintColors.scoreAttention,
+          note: 'Loisirs, restaurants, voyages',
+        ),
+        const SizedBox(height: 8),
+        _buildBudgetRow(
+          label: '💰 Épargne (20%)',
+          before: _savings,
+          after: _savingsAfter,
+          color: MintColors.scoreExcellent,
+          note: '3a, LPP rachat, fonds urgence',
+        ),
+        if (_children > 0) ...[
+          const SizedBox(height: 8),
+          _buildBudgetRow(
+            label: '👶 Enfant${_children > 1 ? 's' : ''}',
+            before: 0,
+            after: _childrenCost,
+            color: const Color(0xFF7B1FA2),
+            note: 'CHF ${_fmt(widget.costPerChild)}/enfant/mois',
+            isNew: true,
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildBudgetRow({
+    required String label,
+    required double before,
+    required double after,
+    required Color color,
+    required String note,
+    bool isNew = false,
+  }) {
+    final changed = (before - after).abs() > 1;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: MintColors.textPrimary,
+                      ),
+                    ),
+                    Text(
+                      note,
+                      style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                    ),
+                  ],
+                ),
+              ),
+              if (isNew || _children == 0) ...[
+                Text(
+                  'CHF ${_fmt(after)}',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: color,
+                  ),
+                ),
+              ] else ...[
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    if (changed && _children > 0) ...[
+                      Text(
+                        'CHF ${_fmt(before)}',
+                        style: GoogleFonts.inter(
+                          fontSize: 11,
+                          color: MintColors.textSecondary,
+                          decoration: TextDecoration.lineThrough,
+                        ),
+                      ),
+                    ],
+                    Text(
+                      'CHF ${_fmt(after)}',
+                      style: GoogleFonts.montserrat(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        color: changed && _children > 0 ? MintColors.scoreCritique : color,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+          if (_children > 0 && !isNew) ...[
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: after / (before > 0 ? before : 1),
+                minHeight: 6,
+                backgroundColor: color.withValues(alpha: 0.15),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  after < before * 0.5 ? MintColors.scoreCritique : color,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImpactAlert() {
+    final savingsLost = _savings - _savingsAfter;
+    final isSerious = _savingsAfter < _savings * 0.3;
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: (isSerious ? MintColors.scoreCritique : MintColors.scoreAttention)
+            .withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: (isSerious ? MintColors.scoreCritique : MintColors.scoreAttention)
+              .withValues(alpha: 0.25),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(isSerious ? '⚠️' : '💡', style: const TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  isSerious
+                      ? 'Ton épargne est fortement impactée'
+                      : 'Pense à ajuster ton épargne',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: isSerious ? MintColors.scoreCritique : MintColors.scoreAttention,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  savingsLost > 0
+                      ? 'Tes enfants coûtent CHF ${_fmt(_childrenCost)}/mois, '
+                        'ce qui réduit ton épargne de CHF ${_fmt(savingsLost)}/mois.'
+                      : 'Tes enfants sont financés par tes envies — ton épargne reste intacte.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : OFS statistiques des ménages suisses, règle budgétaire 50/30/20.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
+++ b/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
@@ -217,7 +217,7 @@ class BudgetSandwichChart extends StatelessWidget {
                       return Container(
                         width: constraints.maxWidth * fraction,
                         color: color.withValues(
-                            alpha: 0.3 + 0.7 * (item.amount / total)),
+                            alpha: (0.3 + 0.7 * fraction).clamp(0.0, 1.0)),
                       );
                     }).toList(),
                   );

--- a/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
+++ b/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  BUDGET SANDWICH CHART — P1-G / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  "Ce qui rentre, ce qui sort, ce qui reste. Point."
+//  Remplace le waterfall chart par une metaphore sandwich.
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L7 (metaphore bat graphique) + L1 (CHF/mois d'abord)
+// ────────────────────────────────────────────────────────────
+
+/// Single income/expense line item.
+class BudgetLineItem {
+  final String label;
+  final double amount;
+
+  const BudgetLineItem({required this.label, required this.amount});
+}
+
+class BudgetSandwichChart extends StatelessWidget {
+  /// Income sources (AVS, LPP, 3a, etc.)
+  final List<BudgetLineItem> incomes;
+
+  /// Expense categories (impots, loyer, LAMal, quotidien, etc.)
+  final List<BudgetLineItem> expenses;
+
+  const BudgetSandwichChart({
+    super.key,
+    required this.incomes,
+    required this.expenses,
+  });
+
+  double get _totalIncome =>
+      incomes.fold(0.0, (sum, item) => sum + item.amount);
+  double get _totalExpenses =>
+      expenses.fold(0.0, (sum, item) => sum + item.amount);
+  double get _margin => _totalIncome - _totalExpenses;
+
+  @override
+  Widget build(BuildContext context) {
+    final margin = _margin;
+    final isPositive = margin >= 0;
+    final marginColor =
+        isPositive ? MintColors.scoreExcellent : MintColors.scoreCritique;
+
+    return Semantics(
+      label: 'Budget retraite. Revenus\u00a0: ${formatChfWithPrefix(_totalIncome)}, '
+          'D\u00e9penses\u00a0: ${formatChfWithPrefix(_totalExpenses)}, '
+          'Marge\u00a0: ${formatChfWithPrefix(margin)}.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Ton budget retraite',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Ce qui rentre ──
+            _buildSection(
+              icon: Icons.arrow_downward_rounded,
+              label: 'Ce qui rentre',
+              total: _totalIncome,
+              items: incomes,
+              color: MintColors.scoreExcellent,
+            ),
+
+            // ── Arrow ──
+            _buildArrow('moins'),
+
+            // ── Ce qui sort ──
+            _buildSection(
+              icon: Icons.arrow_upward_rounded,
+              label: 'Ce qui sort',
+              total: _totalExpenses,
+              items: expenses,
+              color: MintColors.scoreCritique,
+            ),
+
+            // ── Arrow ──
+            _buildArrow('reste'),
+
+            // ── Marge ──
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: marginColor.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: marginColor.withValues(alpha: 0.20)),
+              ),
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        isPositive
+                            ? Icons.check_circle_outline
+                            : Icons.warning_amber_rounded,
+                        size: 18,
+                        color: marginColor,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        '${isPositive ? "Marge" : "D\u00e9ficit"}\u00a0: ${formatChfWithPrefix(margin.abs())}/mois',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                          color: marginColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    isPositive
+                        ? 'Tu es dans le vert. Ce coussin absorbe les impr\u00e9vus.'
+                        : 'Il manque ${formatChfWithPrefix(margin.abs())}/mois. '
+                            'Des ajustements sont possibles.',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      color: MintColors.textSecondary,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+
+            // ── Disclaimer ──
+            const SizedBox(height: 12),
+            Text(
+              'Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection({
+    required IconData icon,
+    required String label,
+    required double total,
+    required List<BudgetLineItem> items,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.surface,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 16, color: color),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: MintColors.textSecondary,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                formatChfWithPrefix(total),
+                style: GoogleFonts.montserrat(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          // Item breakdown bar
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: SizedBox(
+              height: 8,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return Row(
+                    children: items
+                        .where((item) => item.amount > 0)
+                        .map((item) {
+                      final fraction =
+                          total > 0 ? item.amount / total : 0.0;
+                      return Container(
+                        width: constraints.maxWidth * fraction,
+                        color: color.withValues(
+                            alpha: 0.3 + 0.7 * (item.amount / total)),
+                      );
+                    }).toList(),
+                  );
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          // Item labels
+          Wrap(
+            spacing: 8,
+            runSpacing: 2,
+            children: items.map((item) {
+              return Text(
+                '${item.label} ${formatChfWithPrefix(item.amount)}',
+                style: GoogleFonts.inter(
+                  fontSize: 11,
+                  color: MintColors.textMuted,
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildArrow(String label) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Column(
+          children: [
+            Icon(Icons.keyboard_arrow_down,
+                size: 20, color: MintColors.textMuted),
+            Text(
+              label,
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                color: MintColors.textMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/career_timelapse_widget.dart
+++ b/apps/mobile/lib/widgets/coach/career_timelapse_widget.dart
@@ -229,9 +229,3 @@ class _CareerTimeLapseWidgetState extends State<CareerTimeLapseWidget> {
   }
 }
 
-/// Compact CHF formatter (e.g. "680k").
-String formatChfCompact(double value) {
-  if (value >= 1000000) return '${(value / 1000000).toStringAsFixed(1)}M';
-  if (value >= 1000) return '${(value / 1000).toStringAsFixed(0)}k';
-  return formatChfWithPrefix(value);
-}

--- a/apps/mobile/lib/widgets/coach/career_timelapse_widget.dart
+++ b/apps/mobile/lib/widgets/coach/career_timelapse_widget.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  CAREER TIMELAPSE WIDGET — P5-B / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Slider "age de debut" montrant le patrimoine a 65 ans.
+//  Chaque annee perdue coute ~30'000 CHF grace aux interets
+//  composes.
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L2 (avant/apres) + L7 (metaphore bat graphique)
+// ────────────────────────────────────────────────────────────
+
+/// Data for a single starting age scenario.
+class TimeLapseScenario {
+  final int startAge;
+  final double capitalAt65;
+
+  const TimeLapseScenario({
+    required this.startAge,
+    required this.capitalAt65,
+  });
+}
+
+class CareerTimeLapseWidget extends StatefulWidget {
+  /// Scenarios by starting age.
+  final List<TimeLapseScenario> scenarios;
+
+  /// Monthly 3a contribution used for the projection.
+  final double monthly3aContribution;
+
+  /// Initial selected age.
+  final int initialAge;
+
+  const CareerTimeLapseWidget({
+    super.key,
+    required this.scenarios,
+    required this.monthly3aContribution,
+    this.initialAge = 25,
+  });
+
+  @override
+  State<CareerTimeLapseWidget> createState() => _CareerTimeLapseWidgetState();
+}
+
+class _CareerTimeLapseWidgetState extends State<CareerTimeLapseWidget> {
+  late int _selectedAge;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedAge = widget.initialAge;
+  }
+
+  TimeLapseScenario? get _selected {
+    try {
+      return widget.scenarios.firstWhere((s) => s.startAge == _selectedAge);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  double get _maxCapital =>
+      widget.scenarios.isEmpty
+          ? 1
+          : widget.scenarios
+              .map((s) => s.capitalAt65)
+              .reduce((a, b) => a > b ? a : b);
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.scenarios.isEmpty) return const SizedBox.shrink();
+
+    final minAge = widget.scenarios
+        .map((s) => s.startAge)
+        .reduce((a, b) => a < b ? a : b);
+    final maxAge = widget.scenarios
+        .map((s) => s.startAge)
+        .reduce((a, b) => a > b ? a : b);
+    final selected = _selected;
+    final earliest = widget.scenarios
+        .reduce((a, b) => a.startAge < b.startAge ? a : b);
+    final costPerYear = selected != null && selected.startAge > minAge
+        ? (earliest.capitalAt65 - selected.capitalAt65) /
+            (selected.startAge - minAge)
+        : 0.0;
+
+    return Semantics(
+      label: 'Time-lapse carri\u00e8re. D\u00e9but \u00e0 $_selectedAge ans.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Et si tu avais commenc\u00e9 \u00e0\u2026',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Bars ──
+            ...widget.scenarios.map((s) => _buildBar(s)),
+
+            const SizedBox(height: 12),
+
+            // ── Slider ──
+            SliderTheme(
+              data: SliderThemeData(
+                activeTrackColor: MintColors.primary,
+                inactiveTrackColor: MintColors.surface,
+                thumbColor: MintColors.primary,
+                trackHeight: 4,
+              ),
+              child: Slider(
+                value: _selectedAge.toDouble(),
+                min: minAge.toDouble(),
+                max: maxAge.toDouble(),
+                divisions: maxAge - minAge,
+                onChanged: (v) => setState(() => _selectedAge = v.round()),
+              ),
+            ),
+
+            // ── Chiffre-choc ──
+            if (selected != null && costPerYear > 0)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: MintColors.scoreCritique.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  '${selected.startAge - minAge} an${selected.startAge - minAge > 1 ? "s" : ""} '
+                  'd\u2019attente = ${formatChfWithPrefix((earliest.capitalAt65 - selected.capitalAt65).abs())} '
+                  'de moins \u00e0 65 ans.\n'
+                  'Les int\u00e9r\u00eats compos\u00e9s sont ton alli\u00e9 \u2014 '
+                  'mais seulement si tu commences t\u00f4t.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.scoreCritique,
+                    fontWeight: FontWeight.w500,
+                    height: 1.4,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+
+            const SizedBox(height: 12),
+            Text(
+              'Projection \u00e0 4% net/an avec ${formatChfWithPrefix(widget.monthly3aContribution)}/mois en 3a. '
+              'Outil \u00e9ducatif, ne constitue pas un conseil (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBar(TimeLapseScenario s) {
+    final isSelected = s.startAge == _selectedAge;
+    final ratio = _maxCapital > 0 ? s.capitalAt65 / _maxCapital : 0.0;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 50,
+            child: Text(
+              '${s.startAge} ans',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: isSelected ? FontWeight.w700 : FontWeight.w400,
+                color: isSelected ? MintColors.primary : MintColors.textMuted,
+              ),
+            ),
+          ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                return Container(
+                  height: isSelected ? 16 : 10,
+                  width: constraints.maxWidth * ratio,
+                  decoration: BoxDecoration(
+                    color: isSelected
+                        ? MintColors.primary
+                        : MintColors.primary.withValues(alpha: 0.25),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: 60,
+            child: Text(
+              formatChfCompact(s.capitalAt65),
+              textAlign: TextAlign.right,
+              style: GoogleFonts.montserrat(
+                fontSize: 12,
+                fontWeight: isSelected ? FontWeight.w700 : FontWeight.w500,
+                color: isSelected ? MintColors.primary : MintColors.textMuted,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Compact CHF formatter (e.g. "680k").
+String formatChfCompact(double value) {
+  if (value >= 1000000) return '${(value / 1000000).toStringAsFixed(1)}M';
+  if (value >= 1000) return '${(value / 1000).toStringAsFixed(0)}k';
+  return formatChfWithPrefix(value);
+}

--- a/apps/mobile/lib/widgets/coach/clause_3a_widget.dart
+++ b/apps/mobile/lib/widgets/coach/clause_3a_widget.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P8-C  La Clause 3a oubliée — OPP3 clause bénéficiaire
+//  Charte : L5 (1 action) + L6 (Chiffre-choc)
+//  Source : OPP3 art. 2 al. 1 let. a, CC art. 457-462
+// ────────────────────────────────────────────────────────────
+
+class Clause3aWidget extends StatefulWidget {
+  const Clause3aWidget({
+    super.key,
+    required this.balance3a,
+    this.hasClause = false,
+    this.partnerName,
+  });
+
+  final double balance3a;
+  final bool hasClause;
+  final String? partnerName;
+
+  @override
+  State<Clause3aWidget> createState() => _Clause3aWidgetState();
+}
+
+class _Clause3aWidgetState extends State<Clause3aWidget> {
+  late bool _hasClause;
+
+  @override
+  void initState() {
+    super.initState();
+    _hasClause = widget.hasClause;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final partner = widget.partnerName ?? 'ton·ta partenaire';
+
+    return Semantics(
+      label: 'Clause 3a bénéficiaire OPP3 succession',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildBalanceChip(),
+                  const SizedBox(height: 20),
+                  _buildChiffreChoc(partner),
+                  const SizedBox(height: 16),
+                  _buildClauseQuestion(),
+                  const SizedBox(height: 12),
+                  _buildFeedback(partner),
+                  const SizedBox(height: 16),
+                  _buildSteps(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF8E1),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('🔑', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'La clause 3a oubliée',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'OPP3 art. 2 — Le 3e pilier ne suit PAS les règles successorales ordinaires.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBalanceChip() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: MintColors.primary.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.savings_outlined, color: MintColors.primary, size: 18),
+          const SizedBox(width: 10),
+          Text(
+            'Ton 3e pilier : CHF ${_fmt(widget.balance3a)}',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc(String partner) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '💰 Sans clause : ton 3a de CHF ${_fmt(widget.balance3a)} part à tes parents, pas à $partner.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'La clause bénéficiaire dérogent à la succession ordinaire (OPP3 art. 2). '
+            'Sans clause déposée auprès de ta fondation, la loi s\'applique par défaut.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildClauseQuestion() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'As-tu déposé une clause bénéficiaire ?',
+          style: GoogleFonts.inter(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            _buildToggle('Oui', true),
+            const SizedBox(width: 8),
+            _buildToggle('Non', false),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToggle(String label, bool value) {
+    final isSelected = _hasClause == value;
+    final color = value ? MintColors.scoreExcellent : MintColors.scoreCritique;
+    return GestureDetector(
+      onTap: () => setState(() => _hasClause = value),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+        decoration: BoxDecoration(
+          color: isSelected ? color.withValues(alpha: 0.12) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected ? color : MintColors.lightBorder,
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: isSelected ? color : MintColors.textPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFeedback(String partner) {
+    if (_hasClause) {
+      return Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: MintColors.scoreExcellent.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.check_circle_outline, color: MintColors.scoreExcellent, size: 18),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Bien ! Vérifie que la clause désigne bien $partner — et qu\'elle est à jour après chaque événement de vie.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  color: MintColors.textPrimary,
+                  height: 1.4,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      return Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: MintColors.scoreCritique.withValues(alpha: 0.07),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.warning_amber_outlined, color: MintColors.scoreCritique, size: 18),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Action prioritaire : dépose ta clause bénéficiaire auprès de ta fondation 3a — en 5 minutes.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: MintColors.scoreCritique,
+                  height: 1.4,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  Widget _buildSteps() {
+    final steps = [
+      'Contacte ta fondation 3a (banque ou assurance)',
+      'Demande le formulaire "clause bénéficiaire"',
+      'Désigne ton·ta partenaire ou tes héritiers',
+      'Renouvelle à chaque changement de situation',
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Comment déposer une clause en 5 minutes :',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.info,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...steps.asMap().entries.map((e) => Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 20,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: MintColors.info,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${e.key + 1}',
+                      style: GoogleFonts.inter(fontSize: 10, fontWeight: FontWeight.w700, color: Colors.white),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    e.value,
+                    style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
+                  ),
+                ),
+              ],
+            ),
+          )),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : OPP3 art. 2 al. 1 let. a, CC art. 457-462.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/coach_briefing_card.dart
+++ b/apps/mobile/lib/widgets/coach/coach_briefing_card.dart
@@ -106,7 +106,7 @@ class CoachBriefingCard extends StatelessWidget {
                   const SizedBox(width: 6),
                   Flexible(
                     child: Text(
-                      narr!.retirementCountdown!,
+                      narr.retirementCountdown!,
                       style: GoogleFonts.inter(
                         fontSize: 12,
                         fontWeight: FontWeight.w600,

--- a/apps/mobile/lib/widgets/coach/confidence_bar.dart
+++ b/apps/mobile/lib/widgets/coach/confidence_bar.dart
@@ -87,7 +87,7 @@ class _ConfidenceBarState extends State<ConfidenceBar>
 
   /// P1-I: Zone description for thermometer.
   String get _zoneDescription {
-    if (widget.score >= 90) return 'Photo parfaite';
+    if (widget.score >= 90) return 'Très précise';
     if (widget.score >= 70) return 'Bonne estimation';
     if (widget.score >= 40) return 'Estimation large';
     return 'On devine beaucoup';

--- a/apps/mobile/lib/widgets/coach/confidence_bar.dart
+++ b/apps/mobile/lib/widgets/coach/confidence_bar.dart
@@ -85,13 +85,6 @@ class _ConfidenceBarState extends State<ConfidenceBar>
     return MintColors.scoreCritique;
   }
 
-  /// Label du niveau de confiance.
-  String get _levelLabel {
-    if (widget.score >= 70) return 'Fiable';
-    if (widget.score >= 40) return 'Partielle';
-    return 'Faible';
-  }
-
   /// P1-I: Zone description for thermometer.
   String get _zoneDescription {
     if (widget.score >= 90) return 'Photo parfaite';

--- a/apps/mobile/lib/widgets/coach/confidence_bar.dart
+++ b/apps/mobile/lib/widgets/coach/confidence_bar.dart
@@ -14,6 +14,8 @@ import 'package:mint_mobile/theme/colors.dart';
 //    >= 40  → orange (projection partielle)
 //    < 40   → rouge  (donnees insuffisantes)
 //
+//  P1-I: Enriched with thermometer zones + enrichment CTA.
+//
 //  Widget pur — aucune dependance Provider.
 // ────────────────────────────────────────────────────────────
 
@@ -24,10 +26,19 @@ class ConfidenceBar extends StatefulWidget {
   /// Affiche le label "Precision : X%" si true (defaut).
   final bool showLabel;
 
+  /// P1-I: Enrichment actions to improve confidence.
+  /// Each entry: {'label': 'description', 'icon': IconData?}
+  final List<Map<String, dynamic>>? enrichmentActions;
+
+  /// P1-I: Callback when user taps an enrichment action.
+  final ValueChanged<int>? onEnrichAction;
+
   const ConfidenceBar({
     super.key,
     required this.score,
     this.showLabel = true,
+    this.enrichmentActions,
+    this.onEnrichAction,
   });
 
   @override
@@ -81,12 +92,22 @@ class _ConfidenceBarState extends State<ConfidenceBar>
     return 'Faible';
   }
 
+  /// P1-I: Zone description for thermometer.
+  String get _zoneDescription {
+    if (widget.score >= 90) return 'Photo parfaite';
+    if (widget.score >= 70) return 'Bonne estimation';
+    if (widget.score >= 40) return 'Estimation large';
+    return 'On devine beaucoup';
+  }
+
   @override
   Widget build(BuildContext context) {
     final fraction = (widget.score / 100.0).clamp(0.0, 1.0);
+    final hasEnrichment = widget.enrichmentActions != null &&
+        widget.enrichmentActions!.isNotEmpty;
 
     return Semantics(
-      label: 'Pr\u00e9cision de la projection\u00a0: ${widget.score.round()}%.',
+      label: 'Qualit\u00e9 de ta projection\u00a0: ${widget.score.round()}%.',
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -96,7 +117,7 @@ class _ConfidenceBarState extends State<ConfidenceBar>
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  'Pr\u00e9cision de la projection',
+                  'Qualit\u00e9 de ta projection',
                   style: GoogleFonts.inter(
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
@@ -114,7 +135,7 @@ class _ConfidenceBarState extends State<ConfidenceBar>
                         borderRadius: BorderRadius.circular(6),
                       ),
                       child: Text(
-                        _levelLabel,
+                        _zoneDescription,
                         style: GoogleFonts.inter(
                           fontSize: 10,
                           fontWeight: FontWeight.w600,
@@ -137,37 +158,161 @@ class _ConfidenceBarState extends State<ConfidenceBar>
             ),
             const SizedBox(height: 6),
           ],
+          // ── Thermometer bar with zone markers (P1-I) ──
           AnimatedBuilder(
             animation: _widthAnimation,
             builder: (context, _) {
               return LayoutBuilder(
                 builder: (context, constraints) {
-                  return Container(
-                    height: 6,
-                    width: constraints.maxWidth,
-                    decoration: BoxDecoration(
-                      color: MintColors.surface,
-                      borderRadius: BorderRadius.circular(3),
-                    ),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: AnimatedContainer(
-                        duration: const Duration(milliseconds: 900),
-                        curve: Curves.easeOutCubic,
-                        height: 6,
-                        width:
-                            constraints.maxWidth * fraction * _widthAnimation.value,
-                        decoration: BoxDecoration(
-                          color: _barColor,
-                          borderRadius: BorderRadius.circular(3),
-                        ),
+                  final barWidth = constraints.maxWidth;
+                  return Column(
+                    children: [
+                      Stack(
+                        children: [
+                          // Background track with zones
+                          Container(
+                            height: 8,
+                            width: barWidth,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(4),
+                              gradient: LinearGradient(
+                                colors: [
+                                  MintColors.scoreCritique
+                                      .withValues(alpha: 0.15),
+                                  MintColors.scoreAttention
+                                      .withValues(alpha: 0.15),
+                                  MintColors.scoreExcellent
+                                      .withValues(alpha: 0.15),
+                                ],
+                                stops: const [0.0, 0.4, 1.0],
+                              ),
+                            ),
+                          ),
+                          // Filled progress
+                          AnimatedContainer(
+                            duration: const Duration(milliseconds: 900),
+                            curve: Curves.easeOutCubic,
+                            height: 8,
+                            width: barWidth *
+                                fraction *
+                                _widthAnimation.value,
+                            decoration: BoxDecoration(
+                              color: _barColor,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                        ],
                       ),
-                    ),
+                      // Zone labels
+                      const SizedBox(height: 4),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            '20%',
+                            style: GoogleFonts.inter(
+                              fontSize: 9,
+                              color: MintColors.textMuted,
+                            ),
+                          ),
+                          Text(
+                            '40%',
+                            style: GoogleFonts.inter(
+                              fontSize: 9,
+                              color: MintColors.textMuted,
+                            ),
+                          ),
+                          Text(
+                            '70%',
+                            style: GoogleFonts.inter(
+                              fontSize: 9,
+                              color: MintColors.textMuted,
+                            ),
+                          ),
+                          Text(
+                            '95%',
+                            style: GoogleFonts.inter(
+                              fontSize: 9,
+                              color: MintColors.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   );
                 },
               );
             },
           ),
+          // ── P1-I: Enrichment CTA ──
+          if (hasEnrichment && widget.score < 80) ...[
+            const SizedBox(height: 10),
+            _buildEnrichmentActions(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────
+  //  P1-I: ENRICHMENT ACTIONS
+  // ────────────────────────────────────────────────────────────
+
+  Widget _buildEnrichmentActions() {
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Pour am\u00e9liorer ta projection',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: MintColors.primary,
+            ),
+          ),
+          const SizedBox(height: 6),
+          ...widget.enrichmentActions!
+              .take(2)
+              .toList()
+              .asMap()
+              .entries
+              .map((entry) {
+            final index = entry.key;
+            final action = entry.value;
+            final icon =
+                action['icon'] as IconData? ?? Icons.add_circle_outline;
+            return GestureDetector(
+              onTap: widget.onEnrichAction != null
+                  ? () => widget.onEnrichAction!(index)
+                  : null,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  children: [
+                    Icon(icon, size: 14, color: MintColors.primary),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        action['label'] as String? ?? '',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                    Icon(Icons.chevron_right,
+                        size: 16, color: MintColors.textMuted),
+                  ],
+                ),
+              ),
+            );
+          }),
         ],
       ),
     );

--- a/apps/mobile/lib/widgets/coach/countdown_3a_widget.dart
+++ b/apps/mobile/lib/widgets/coach/countdown_3a_widget.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  COUNTDOWN 3A WIDGET — P5-F / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Barre de progression du plafond 3a + jours restants
+//  avant le 31 décembre. Widget d'urgence.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L5 (une action) + L6 (chiffre-choc)
+// ────────────────────────────────────────────────────────────
+
+class Countdown3aWidget extends StatelessWidget {
+  /// Annual 3a ceiling (e.g. 7258 for 2026).
+  final double annualCeiling;
+
+  /// Amount already contributed this year.
+  final double amountContributed;
+
+  /// Estimated tax savings if ceiling is filled.
+  final double taxSavingsIfFull;
+
+  /// Days remaining until Dec 31.
+  final int daysRemaining;
+
+  /// Year for display.
+  final int year;
+
+  const Countdown3aWidget({
+    super.key,
+    required this.annualCeiling,
+    required this.amountContributed,
+    required this.taxSavingsIfFull,
+    required this.daysRemaining,
+    this.year = 2026,
+  });
+
+  double get _remaining => (annualCeiling - amountContributed).clamp(0, annualCeiling);
+  double get _progress => annualCeiling > 0 ? (amountContributed / annualCeiling).clamp(0, 1) : 0;
+
+  Color get _urgencyColor {
+    if (daysRemaining <= 30) return MintColors.scoreCritique;
+    if (daysRemaining <= 90) return MintColors.scoreAttention;
+    return MintColors.scoreExcellent;
+  }
+
+  String get _urgencyLabel {
+    if (daysRemaining <= 30) return 'Urgent';
+    if (daysRemaining <= 90) return 'Bient\u00f4t';
+    return 'Confortable';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Compte \u00e0 rebours 3a. '
+          '${formatChfWithPrefix(_remaining)} restant en $daysRemaining jours.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ──
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Compte \u00e0 rebours 3a',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: _urgencyColor.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '$daysRemaining j \u2014 $_urgencyLabel',
+                    style: GoogleFonts.inter(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: _urgencyColor,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 16),
+
+            // ── Progress bar ──
+            _buildProgressBar(),
+
+            const SizedBox(height: 10),
+
+            // ── Numbers ──
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _buildStat(
+                    'Vers\u00e9', formatChfWithPrefix(amountContributed)),
+                _buildStat('Reste', formatChfWithPrefix(_remaining)),
+                _buildStat(
+                    'Plafond $year', formatChfWithPrefix(annualCeiling)),
+              ],
+            ),
+
+            const SizedBox(height: 14),
+
+            // ── Chiffre-choc ──
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: _remaining > 0
+                    ? MintColors.scoreCritique.withValues(alpha: 0.08)
+                    : MintColors.scoreExcellent.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                _remaining > 0
+                    ? 'Si tu compl\u00e8tes\u00a0: ${formatChfWithPrefix(taxSavingsIfFull)} '
+                        'd\u2019imp\u00f4ts en moins.\n'
+                        'Si tu ne fais rien\u00a0: ${formatChfWithPrefix(taxSavingsIfFull)} '
+                        'laiss\u00e9s sur la table. Chaque ann\u00e9e.'
+                    : 'Bravo\u00a0! Tu as rempli ton 3a $year. '
+                        '\u00c9conomie fiscale\u00a0: ${formatChfWithPrefix(taxSavingsIfFull)}.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: _remaining > 0
+                      ? MintColors.scoreCritique
+                      : MintColors.scoreExcellent,
+                  height: 1.4,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
+            const SizedBox(height: 12),
+            Text(
+              'Plafond 3a $year\u00a0: salari\u00e9\u00b7e affili\u00e9\u00b7e LPP (OPP3 art. 7). '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressBar() {
+    return Column(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: SizedBox(
+            height: 16,
+            child: Stack(
+              children: [
+                Container(
+                  width: double.infinity,
+                  color: MintColors.surface,
+                ),
+                FractionallySizedBox(
+                  widthFactor: _progress,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: _progress >= 1.0
+                          ? MintColors.scoreExcellent
+                          : MintColors.primary,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            '${(_progress * 100).toStringAsFixed(0)}%',
+            style: GoogleFonts.montserrat(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: _urgencyColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStat(String label, String value) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: GoogleFonts.montserrat(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        Text(
+          label,
+          style: GoogleFonts.inter(
+            fontSize: 11,
+            color: MintColors.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/couple_narrative_timeline.dart
+++ b/apps/mobile/lib/widgets/coach/couple_narrative_timeline.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  COUPLE NARRATIVE TIMELINE — P1-F / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Remplace les swim lanes par un "film en 3 actes".
+//  Raconte l'histoire du couple au lieu de montrer des barres.
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L4 (raconte, ne montre pas) + L2 (avant/apres)
+// ────────────────────────────────────────────────────────────
+
+/// A single act in the couple's retirement story.
+class CoupleAct {
+  /// Act number (1, 2, 3).
+  final int number;
+
+  /// Title (e.g., "Vous travaillez tous les deux").
+  final String title;
+
+  /// Period (e.g., "2026-2041 (15 ans)").
+  final String period;
+
+  /// Combined monthly income.
+  final double monthlyIncome;
+
+  /// Percentage change vs previous act (null for act 1).
+  final double? deltaPercent;
+
+  /// Key insight or tip for this phase.
+  final String insight;
+
+  /// Whether this act is a "dip" (lower income phase).
+  final bool isDip;
+
+  const CoupleAct({
+    required this.number,
+    required this.title,
+    required this.period,
+    required this.monthlyIncome,
+    this.deltaPercent,
+    required this.insight,
+    this.isDip = false,
+  });
+}
+
+class CoupleNarrativeTimeline extends StatelessWidget {
+  /// The 3 acts of the couple's story.
+  final List<CoupleAct> acts;
+
+  /// Names of the partners.
+  final String partner1Name;
+  final String partner2Name;
+
+  /// Optional coaching tip.
+  final String? coachTip;
+
+  const CoupleNarrativeTimeline({
+    super.key,
+    required this.acts,
+    required this.partner1Name,
+    required this.partner2Name,
+    this.coachTip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (acts.isEmpty) return const SizedBox.shrink();
+
+    return Semantics(
+      label: 'Histoire du couple $partner1Name et $partner2Name en '
+          '${acts.length} actes.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ──
+            Row(
+              children: [
+                Icon(Icons.movie_outlined,
+                    size: 20, color: MintColors.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Votre histoire \u00e0 deux',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // ── Acts ──
+            ...acts.map((act) => _buildAct(act)),
+
+            // ── Coach tip ──
+            if (coachTip != null) ...[
+              const SizedBox(height: 12),
+              _buildCoachTip(),
+            ],
+
+            // ── Disclaimer ──
+            const SizedBox(height: 12),
+            Text(
+              'Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAct(CoupleAct act) {
+    final actColor = act.isDip ? MintColors.scoreAttention : MintColors.primary;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Timeline dot + line ──
+          Column(
+            children: [
+              Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  color: actColor.withValues(alpha: 0.12),
+                  shape: BoxShape.circle,
+                ),
+                child: Center(
+                  child: Text(
+                    '${act.number}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: actColor,
+                    ),
+                  ),
+                ),
+              ),
+              if (act.number < acts.length)
+                Container(
+                  width: 2,
+                  height: 30,
+                  color: MintColors.lightBorder,
+                ),
+            ],
+          ),
+          const SizedBox(width: 12),
+
+          // ── Content ──
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: act.isDip
+                    ? MintColors.scoreAttention.withValues(alpha: 0.06)
+                    : MintColors.surface,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Act label
+                  Text(
+                    'ACTE ${act.number} \u00b7 ${act.period}',
+                    style: GoogleFonts.inter(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
+                      color: MintColors.textMuted,
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+
+                  // Title
+                  Text(
+                    act.title,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+
+                  // Income
+                  Row(
+                    children: [
+                      Text(
+                        'Revenus\u00a0: ${formatChfWithPrefix(act.monthlyIncome)}/mois',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: actColor,
+                        ),
+                      ),
+                      if (act.deltaPercent != null) ...[
+                        const SizedBox(width: 6),
+                        Text(
+                          '(${act.deltaPercent! >= 0 ? "+" : ""}${act.deltaPercent!.toStringAsFixed(0)}%)',
+                          style: GoogleFonts.inter(
+                            fontSize: 11,
+                            color: MintColors.textMuted,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+
+                  // Insight
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        act.isDip
+                            ? Icons.warning_amber_rounded
+                            : Icons.arrow_forward,
+                        size: 14,
+                        color: actColor,
+                      ),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          act.insight,
+                          style: GoogleFonts.inter(
+                            fontSize: 12,
+                            color: MintColors.textSecondary,
+                            height: 1.3,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCoachTip() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.lightbulb_outline,
+              size: 16, color: MintColors.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              coachTip!,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: MintColors.textPrimary,
+                height: 1.4,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/crash_test_budget_widget.dart
+++ b/apps/mobile/lib/widgets/coach/crash_test_budget_widget.dart
@@ -1,0 +1,407 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P7-B  Crash-test budget — Budget actuel vs mode survie
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après) + L5 (1 action)
+// ────────────────────────────────────────────────────────────
+
+enum BudgetLineStatus { locked, cut, paused }
+
+class BudgetLine {
+  const BudgetLine({
+    required this.label,
+    required this.emoji,
+    required this.normalAmount,
+    required this.survivalAmount,
+    required this.status,
+  });
+
+  final String label;
+  final String emoji;
+  final double normalAmount;
+  final double survivalAmount;
+  final BudgetLineStatus status;
+}
+
+class CrashTestBudgetWidget extends StatelessWidget {
+  const CrashTestBudgetWidget({
+    super.key,
+    required this.monthlyIncome,
+    required this.survivalIncome,
+    required this.lines,
+    this.reserveMonths,
+  });
+
+  final double monthlyIncome;
+  final double survivalIncome;
+  final List<BudgetLine> lines;
+  final double? reserveMonths;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final thousands = n ~/ 1000;
+      final remainder = n % 1000;
+      return remainder == 0 ? "$thousands'000" : "$thousands'${remainder.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final totalNormal = lines.fold<double>(0, (s, l) => s + l.normalAmount);
+    final totalSurvival = lines.fold<double>(0, (s, l) => s + l.survivalAmount);
+    final marginNormal = monthlyIncome - totalNormal;
+    final marginSurvival = survivalIncome - totalSurvival;
+    final saving = totalNormal - totalSurvival;
+
+    return Semantics(
+      label: 'Crash-test budget chômage',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(saving),
+            const Divider(height: 1),
+            _buildColumnHeaders(),
+            ...lines.map((l) => _buildLine(l)),
+            const Divider(height: 1),
+            _buildTotalsRow(totalNormal, totalSurvival),
+            _buildMarginRow(marginNormal, marginSurvival),
+            if (reserveMonths != null) _buildReservePanel(marginSurvival),
+            _buildDisclaimer(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(double saving) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF3E0),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🚗', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Crash-test budget',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Mode normal vs mode survie',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            decoration: BoxDecoration(
+              color: MintColors.scoreCritique.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.3)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.content_cut, color: MintColors.scoreCritique, size: 16),
+                const SizedBox(width: 6),
+                Text(
+                  'Tu économises CHF ${_fmt(saving)}/mois en mode survie',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildColumnHeaders() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: Row(
+        children: [
+          const Expanded(child: SizedBox()),
+          SizedBox(
+            width: 80,
+            child: Text(
+              'Normal',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: MintColors.primary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              'Survie',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+          ),
+          const SizedBox(width: 40),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLine(BudgetLine line) {
+    final (icon, color) = switch (line.status) {
+      BudgetLineStatus.locked => ('🔒', MintColors.textSecondary),
+      BudgetLineStatus.cut => ('✂️', MintColors.scoreAttention),
+      BudgetLineStatus.paused => ('⏸️', MintColors.scoreCritique),
+    };
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      child: Row(
+        children: [
+          Text(line.emoji, style: const TextStyle(fontSize: 18)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              line.label,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              _fmt(line.normalAmount),
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              _fmt(line.survivalAmount),
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: line.status != BudgetLineStatus.locked ? FontWeight.w700 : FontWeight.w400,
+                color: line.status == BudgetLineStatus.locked ? MintColors.textSecondary : color,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Text(
+              icon,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontSize: 14),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotalsRow(double normal, double survival) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'TOTAL charges',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              _fmt(normal),
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              _fmt(survival),
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+          ),
+          const SizedBox(width: 40),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMarginRow(double normal, double survival) {
+    final survivalColor = survival >= 0 ? MintColors.scoreExcellent : MintColors.scoreCritique;
+    final survivalLabel = survival >= 0 ? '+${_fmt(survival)}' : '-${_fmt(survival.abs())}';
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: survivalColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: survivalColor.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Marge mensuelle',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              '+${_fmt(normal)}',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreExcellent,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 80,
+            child: Text(
+              survivalLabel,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: survivalColor,
+              ),
+            ),
+          ),
+          const SizedBox(width: 40),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReservePanel(double marginSurvival) {
+    final months = reserveMonths!;
+    final color = months >= 6
+        ? MintColors.scoreExcellent
+        : months >= 3
+            ? MintColors.scoreAttention
+            : MintColors.scoreCritique;
+    final label = months >= 6
+        ? 'Tes réserves tiennent — tu as une marge de sécurité.'
+        : months >= 3
+            ? 'Attention : moins de 6 mois de réserve.'
+            : 'Danger : moins de 3 mois de réserve !';
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.savings_outlined, color: color, size: 18),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Tes réserves : ${months.toStringAsFixed(1)} mois',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  label,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+      child: Text(
+        'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin.',
+        style: GoogleFonts.inter(
+          fontSize: 10,
+          color: MintColors.textSecondary,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/death_urgency_guide_widget.dart
+++ b/apps/mobile/lib/widgets/coach/death_urgency_guide_widget.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P14-A  Guide première urgence — décès d'un proche
+//  Charte : L5 (1 action) + L4 (Raconte)
+//  Source : CC art. 537-640, LAVS art. 23-24
+// ────────────────────────────────────────────────────────────
+
+class UrgencyPhase {
+  const UrgencyPhase({
+    required this.timeframe,
+    required this.emoji,
+    required this.title,
+    required this.actions,
+    required this.color,
+  });
+
+  final String timeframe;
+  final String emoji;
+  final String title;
+  final List<String> actions;
+  final Color color;
+}
+
+class DeathUrgencyGuideWidget extends StatefulWidget {
+  const DeathUrgencyGuideWidget({
+    super.key,
+    required this.phases,
+  });
+
+  final List<UrgencyPhase> phases;
+
+  @override
+  State<DeathUrgencyGuideWidget> createState() => _DeathUrgencyGuideWidgetState();
+}
+
+class _DeathUrgencyGuideWidgetState extends State<DeathUrgencyGuideWidget> {
+  int _expandedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Guide urgence décès proche checklist phases administratives',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ...widget.phases.asMap().entries.map((e) => Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _buildPhaseCard(e.key, e.value),
+                  )),
+                  const SizedBox(height: 8),
+                  _buildSupportNote(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFECEFF1),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🕊️', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Guide de première urgence',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Ce n\'est pas le moment de tout gérer seul·e. '
+            'Voici les étapes, dans l\'ordre, avec bienveillance.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPhaseCard(int index, UrgencyPhase phase) {
+    final isExpanded = _expandedIndex == index;
+
+    return GestureDetector(
+      onTap: () => setState(() => _expandedIndex = isExpanded ? -1 : index),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        decoration: BoxDecoration(
+          color: isExpanded ? phase.color.withValues(alpha: 0.06) : MintColors.appleSurface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isExpanded ? phase.color.withValues(alpha: 0.4) : MintColors.lightBorder,
+            width: isExpanded ? 2 : 1,
+          ),
+        ),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(14),
+              child: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: phase.color.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      phase.timeframe,
+                      style: GoogleFonts.inter(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: phase.color,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(phase.emoji, style: const TextStyle(fontSize: 18)),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      phase.title,
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    isExpanded ? Icons.expand_less : Icons.expand_more,
+                    color: MintColors.textSecondary,
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+            if (isExpanded) ...[
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.all(14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: phase.actions.map((action) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.check_circle_outline,
+                          size: 16,
+                          color: phase.color,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            action,
+                            style: GoogleFonts.inter(
+                              fontSize: 12,
+                              color: MintColors.textPrimary,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )).toList(),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSupportNote() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💙', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Tu n\'es pas seul·e',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.info,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Un·e notaire, un·e avocat·e ou un service d\'aide sociale '
+                  'peut t\'accompagner pour les démarches administratives. '
+                  'Prends le temps du deuil — les délais légaux sont en semaines, pas en heures.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil juridique. '
+      'Source : CC art. 537-640 (succession), LAVS art. 23-24 (rentes survivants).',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/debt_repayment_widget.dart
+++ b/apps/mobile/lib/widgets/coach/debt_repayment_widget.dart
@@ -1,0 +1,469 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'dart:math' as math;
+
+// ────────────────────────────────────────────────────────────
+//  P10-B  Avalanche vs Boule de neige
+//  Charte : L2 (Avant/Après) + L6 (Chiffre-choc)
+//  Source : CO art. 82, bonnes pratiques désendettement
+// ────────────────────────────────────────────────────────────
+
+class DebtEntry {
+  const DebtEntry({
+    required this.label,
+    required this.emoji,
+    required this.balance,
+    required this.monthlyRate,
+    required this.minimumPayment,
+  });
+
+  final String label;
+  final String emoji;
+  final double balance;
+  final double monthlyRate; // e.g. 0.015 = 1.5%/month
+  final double minimumPayment;
+}
+
+enum RepaymentStrategy { avalanche, snowball }
+
+class DebtRepaymentWidget extends StatefulWidget {
+  const DebtRepaymentWidget({
+    super.key,
+    required this.debts,
+    required this.extraMonthly,
+  });
+
+  final List<DebtEntry> debts;
+  final double extraMonthly;
+
+  @override
+  State<DebtRepaymentWidget> createState() => _DebtRepaymentWidgetState();
+}
+
+class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
+  RepaymentStrategy _strategy = RepaymentStrategy.avalanche;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _totalDebt =>
+      widget.debts.fold<double>(0, (s, d) => s + d.balance);
+
+  double get _minPaymentTotal =>
+      widget.debts.fold<double>(0, (s, d) => s + d.minimumPayment);
+
+  /// Simulate months to payoff and total interest for a given strategy.
+  _SimResult _simulate(RepaymentStrategy strategy) {
+    // Make mutable copies
+    var balances = widget.debts.map((d) => d.balance).toList();
+    final rates = widget.debts.map((d) => d.monthlyRate).toList();
+    final mins = widget.debts.map((d) => d.minimumPayment).toList();
+    final n = widget.debts.length;
+
+    double totalInterest = 0;
+    int months = 0;
+    final budget = _minPaymentTotal + widget.extraMonthly;
+    const maxMonths = 600; // 50 years safety cap
+
+    while (balances.any((b) => b > 0.01) && months < maxMonths) {
+      months++;
+
+      // Accrue interest
+      for (var i = 0; i < n; i++) {
+        if (balances[i] > 0) {
+          final interest = balances[i] * rates[i];
+          totalInterest += interest;
+          balances[i] += interest;
+        }
+      }
+
+      // Pay minimums
+      var remaining = budget;
+      for (var i = 0; i < n; i++) {
+        if (balances[i] > 0) {
+          final pay = math.min(mins[i], balances[i]);
+          balances[i] -= pay;
+          remaining -= pay;
+          if (remaining < 0) remaining = 0;
+        }
+      }
+
+      // Apply extra to priority debt
+      if (remaining > 0) {
+        // Find priority index
+        int priority = -1;
+        if (strategy == RepaymentStrategy.avalanche) {
+          // Highest rate first
+          double maxRate = 0;
+          for (var i = 0; i < n; i++) {
+            if (balances[i] > 0.01 && rates[i] > maxRate) {
+              maxRate = rates[i];
+              priority = i;
+            }
+          }
+        } else {
+          // Lowest balance first (snowball)
+          double minBal = double.infinity;
+          for (var i = 0; i < n; i++) {
+            if (balances[i] > 0.01 && balances[i] < minBal) {
+              minBal = balances[i];
+              priority = i;
+            }
+          }
+        }
+        if (priority >= 0) {
+          final pay = math.min(remaining, balances[priority]);
+          balances[priority] -= pay;
+        }
+      }
+    }
+
+    return _SimResult(months: months, totalInterest: totalInterest);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final avalanche = _simulate(RepaymentStrategy.avalanche);
+    final snowball = _simulate(RepaymentStrategy.snowball);
+    final current = _strategy == RepaymentStrategy.avalanche ? avalanche : snowball;
+    final interestSaved = snowball.totalInterest - avalanche.totalInterest;
+
+    return Semantics(
+      label: 'Avalanche boule de neige remboursement dettes comparaison',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildStrategyToggle(),
+                  const SizedBox(height: 16),
+                  _buildDebtList(),
+                  const SizedBox(height: 16),
+                  _buildResultCard(current),
+                  const SizedBox(height: 12),
+                  _buildComparisonCallout(interestSaved, avalanche, snowball),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFEBEE),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('⛰️', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Avalanche vs Boule de neige',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'CHF ${_fmt(_totalDebt)} de dettes · quelle stratégie ?',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStrategyToggle() {
+    return Row(
+      children: [
+        Expanded(child: _buildToggleBtn(
+          label: '⛰️ Avalanche',
+          subtitle: 'Taux élevé d\'abord',
+          strategy: RepaymentStrategy.avalanche,
+        )),
+        const SizedBox(width: 10),
+        Expanded(child: _buildToggleBtn(
+          label: '❄️ Boule de neige',
+          subtitle: 'Petite dette d\'abord',
+          strategy: RepaymentStrategy.snowball,
+        )),
+      ],
+    );
+  }
+
+  Widget _buildToggleBtn({
+    required String label,
+    required String subtitle,
+    required RepaymentStrategy strategy,
+  }) {
+    final isActive = _strategy == strategy;
+    return GestureDetector(
+      onTap: () => setState(() => _strategy = strategy),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isActive ? MintColors.scoreCritique.withValues(alpha: 0.1) : MintColors.appleSurface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isActive ? MintColors.scoreCritique : MintColors.lightBorder,
+            width: isActive ? 2 : 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: isActive ? MintColors.scoreCritique : MintColors.textPrimary,
+              ),
+            ),
+            Text(
+              subtitle,
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDebtList() {
+    final sorted = List<DebtEntry>.from(widget.debts);
+    if (_strategy == RepaymentStrategy.avalanche) {
+      sorted.sort((a, b) => b.monthlyRate.compareTo(a.monthlyRate));
+    } else {
+      sorted.sort((a, b) => a.balance.compareTo(b.balance));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ordre de remboursement',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ...sorted.asMap().entries.map((e) => Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            children: [
+              Container(
+                width: 24,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: e.key == 0
+                      ? MintColors.scoreCritique
+                      : MintColors.textSecondary.withValues(alpha: 0.2),
+                  shape: BoxShape.circle,
+                ),
+                child: Text(
+                  '${e.key + 1}',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: e.key == 0 ? Colors.white : MintColors.textSecondary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Text(e.value.emoji, style: const TextStyle(fontSize: 18)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  e.value.label,
+                  style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    'CHF ${_fmt(e.value.balance)}',
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                  Text(
+                    '${(e.value.monthlyRate * 12 * 100).toStringAsFixed(1)}%/an',
+                    style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        )),
+      ],
+    );
+  }
+
+  Widget _buildResultCard(_SimResult result) {
+    final years = result.months ~/ 12;
+    final months = result.months % 12;
+    final label = _strategy == RepaymentStrategy.avalanche ? 'Avalanche' : 'Boule de neige';
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.primary.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+                ),
+                Text(
+                  '${years > 0 ? '${years}a ' : ''}${months > 0 ? '${months}m' : ''}',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.primary,
+                  ),
+                ),
+                Text(
+                  'pour solder toutes les dettes',
+                  style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                'Intérêts payés',
+                style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+              ),
+              Text(
+                'CHF ${_fmt(result.totalInterest)}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComparisonCallout(double saved, _SimResult avalanche, _SimResult snowball) {
+    final monthsDiff = snowball.months - avalanche.months;
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreExcellent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreExcellent.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  saved > 0
+                      ? 'L\'avalanche économise CHF ${_fmt(saved)}'
+                      : 'Les deux stratégies ont le même coût',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreExcellent,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  saved > 0
+                      ? 'La boule de neige prend $monthsDiff mois de plus, '
+                        'mais elle est plus motivante (petites victoires rapides).'
+                      : 'Choisis la stratégie qui te motive le plus à tenir.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CO art. 82, bonnes pratiques de désendettement. '
+      'Simulation basée sur des remboursements mensuels constants.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}
+
+class _SimResult {
+  const _SimResult({required this.months, required this.totalInterest});
+  final int months;
+  final double totalInterest;
+}

--- a/apps/mobile/lib/widgets/coach/debt_repayment_widget.dart
+++ b/apps/mobile/lib/widgets/coach/debt_repayment_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'dart:math' as math;
 
 // ────────────────────────────────────────────────────────────
@@ -43,16 +44,6 @@ class DebtRepaymentWidget extends StatefulWidget {
 
 class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
   RepaymentStrategy _strategy = RepaymentStrategy.avalanche;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _totalDebt =>
       widget.debts.fold<double>(0, (s, d) => s + d.balance);
@@ -196,7 +187,7 @@ class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'CHF ${_fmt(_totalDebt)} de dettes · quelle stratégie ?',
+                  '${formatChfWithPrefix(_totalDebt)} de dettes · quelle stratégie ?',
                   style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
                 ),
               ],
@@ -320,7 +311,7 @@ class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
                   Text(
-                    'CHF ${_fmt(e.value.balance)}',
+                    formatChfWithPrefix(e.value.balance),
                     style: GoogleFonts.inter(
                       fontSize: 13,
                       fontWeight: FontWeight.w700,
@@ -385,7 +376,7 @@ class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
                 style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
               ),
               Text(
-                'CHF ${_fmt(result.totalInterest)}',
+                formatChfWithPrefix(result.totalInterest),
                 style: GoogleFonts.montserrat(
                   fontSize: 18,
                   fontWeight: FontWeight.w800,
@@ -420,7 +411,7 @@ class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
               children: [
                 Text(
                   saved > 0
-                      ? 'L\'avalanche économise CHF ${_fmt(saved)}'
+                      ? 'L\'avalanche économise ${formatChfWithPrefix(saved)}'
                       : 'Les deux stratégies ont le même coût',
                   style: GoogleFonts.inter(
                     fontSize: 13,
@@ -451,8 +442,8 @@ class _DebtRepaymentWidgetState extends State<DebtRepaymentWidget> {
   Widget _buildDisclaimer() {
     return Text(
       'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
-      'Source : CO art. 82, bonnes pratiques de désendettement. '
-      'Simulation basée sur des remboursements mensuels constants.',
+      'Simulation de remboursement basée sur des versements mensuels constants. '
+      'Source : LP (Loi fédérale sur la poursuite pour dettes et la faillite).',
       style: GoogleFonts.inter(
         fontSize: 10,
         color: MintColors.textSecondary,

--- a/apps/mobile/lib/widgets/coach/disability_cliff_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_cliff_widget.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-A  La Falaise — Timeline invalidité en 3 actes
+//  Charte : L6 (Chiffre-choc) + L2 (Avant/Après) + L7 (Film)
+//  Source : LAVS art. 28-29, LPP art. 23-26, LPGA art. 19
+// ────────────────────────────────────────────────────────────
+
+class DisabilityAct {
+  const DisabilityAct({
+    required this.label,
+    required this.subtitle,
+    required this.durationLabel,
+    required this.monthlyIncome,
+    required this.emoji,
+    required this.color,
+    this.detail,
+  });
+
+  final String label;
+  final String subtitle;
+  final String durationLabel;
+  final double monthlyIncome;
+  final String emoji;
+  final Color color;
+  final String? detail;
+}
+
+class DisabilityCliffWidget extends StatelessWidget {
+  const DisabilityCliffWidget({
+    super.key,
+    required this.grossMonthly,
+    required this.acts,
+  });
+
+  final double grossMonthly;
+  final List<DisabilityAct> acts;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final lastIncome = acts.isNotEmpty ? acts.last.monthlyIncome : grossMonthly;
+    final lostMonthly = grossMonthly - lastIncome;
+    final lostYearly15 = lostMonthly * 12 * 15;
+
+    return Semantics(
+      label: 'La Falaise timeline invalidité 3 actes',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(lostMonthly),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildCurrentIncome(),
+                  const SizedBox(height: 20),
+                  ...acts.asMap().entries.map(
+                    (e) => _buildAct(e.key, e.value),
+                  ),
+                  const SizedBox(height: 8),
+                  _buildChiffreChoc(lostMonthly, lostYearly15),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(double lostMonthly) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFEBEE),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🎬', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Si tu ne pouvais plus travailler demain',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'La falaise d\'invalidité en 3 actes',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentIncome() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: MintColors.primary.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.work_outline, color: MintColors.primary, size: 18),
+          const SizedBox(width: 10),
+          Text(
+            'Ton salaire actuel : CHF ${_fmt(grossMonthly)}/mois',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAct(int index, DisabilityAct act) {
+    final isLast = index == acts.length - 1;
+    return Column(
+      children: [
+        if (index > 0) _buildArrow(),
+        Container(
+          margin: const EdgeInsets.only(bottom: 4),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: act.color.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: act.color.withValues(alpha: 0.3)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(act.emoji, style: const TextStyle(fontSize: 20)),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'ACTE ${index + 1} · ${act.label}',
+                          style: GoogleFonts.inter(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w800,
+                            color: act.color,
+                            letterSpacing: 0.5,
+                          ),
+                        ),
+                        Text(
+                          act.durationLabel,
+                          style: GoogleFonts.inter(
+                            fontSize: 12,
+                            color: MintColors.textSecondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        'CHF ${_fmt(act.monthlyIncome)}',
+                        style: GoogleFonts.montserrat(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                          color: act.color,
+                        ),
+                      ),
+                      Text(
+                        '/mois',
+                        style: GoogleFonts.inter(
+                          fontSize: 11,
+                          color: MintColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              if (act.subtitle.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Text(
+                  act.subtitle,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+              if (act.detail != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  act.detail!,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: act.color,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+              if (isLast && acts.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: MintColors.scoreCritique.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    'vs CHF ${_fmt(grossMonthly)}/mois avant',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.scoreCritique,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildArrow() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Center(
+        child: Icon(Icons.keyboard_arrow_down, color: MintColors.textSecondary, size: 24),
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc(double lostMonthly, double lostYearly15) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '💰 Chiffre-choc',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Tu perdrais CHF ${_fmt(lostMonthly)}/mois.',
+            style: GoogleFonts.montserrat(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Sur 15 ans = CHF ${_fmt(lostYearly15)} de revenus en moins.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textPrimary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '→ Action : Vérifie ta couverture LPP invalidité',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAVS art. 28-29, LPP art. 23-26.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/disability_countdown_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_countdown_widget.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-F  Le Compte à rebours du délai de carence AI
+//  Charte : L6 (Chiffre-choc) + L7 (Métaphore compte à rebours)
+//  Source : LAI art. 28, LPGA art. 19
+// ────────────────────────────────────────────────────────────
+
+class DisabilityCountdownWidget extends StatefulWidget {
+  const DisabilityCountdownWidget({
+    super.key,
+    required this.monthlyExpenses,
+    required this.initialSavings,
+  });
+
+  final double monthlyExpenses;
+  final double initialSavings;
+
+  @override
+  State<DisabilityCountdownWidget> createState() => _DisabilityCountdownWidgetState();
+}
+
+class _DisabilityCountdownWidgetState extends State<DisabilityCountdownWidget> {
+  late double _savings;
+
+  static const int _aiDelayMonths = 14; // délai moyen décision AI
+
+  @override
+  void initState() {
+    super.initState();
+    _savings = widget.initialSavings;
+  }
+
+  double get _monthsCanHold => _savings / widget.monthlyExpenses;
+  double get _gapMonths => (_aiDelayMonths - _monthsCanHold).clamp(0, _aiDelayMonths.toDouble());
+  double get _gapAmount => _gapMonths * widget.monthlyExpenses;
+  double get _holdFraction => (_monthsCanHold / _aiDelayMonths).clamp(0.0, 1.0);
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hold = _monthsCanHold;
+    final gap = _gapMonths;
+    final isOk = hold >= _aiDelayMonths;
+    final color = isOk
+        ? MintColors.scoreExcellent
+        : hold >= 6
+            ? MintColors.scoreAttention
+            : MintColors.scoreCritique;
+
+    return Semantics(
+      label: 'Compte à rebours délai carence AI invalidité',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildSavingsSlider(),
+                  const SizedBox(height: 20),
+                  _buildTimeline(hold, gap, color),
+                  const SizedBox(height: 16),
+                  _buildChiffreChoc(hold, gap, color, isOk),
+                  const SizedBox(height: 16),
+                  if (!isOk) _buildActions(),
+                  if (!isOk) const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFECB3),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('⏱', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Combien de temps tu tiens ?',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Délai moyen de décision AI : $_aiDelayMonths mois (LAI art. 28)',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSavingsSlider() {
+    final maxSavings = _aiDelayMonths * widget.monthlyExpenses * 1.5;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Ton épargne disponible',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Text(
+              'CHF ${_fmt(_savings)}',
+              style: GoogleFonts.inter(
+                fontSize: 14,
+                fontWeight: FontWeight.w800,
+                color: MintColors.primary,
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: _savings,
+          min: 0,
+          max: maxSavings,
+          divisions: 60,
+          activeColor: MintColors.primary,
+          onChanged: (v) => setState(() => _savings = v),
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('CHF 0', style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary)),
+            Text(
+              'CHF ${_fmt(maxSavings)}',
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTimeline(double hold, double gap, Color color) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Durée de tenir vs délai AI',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Stack(
+          children: [
+            // Background bar (total AI delay)
+            Container(
+              height: 28,
+              decoration: BoxDecoration(
+                color: MintColors.scoreCritique.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            // Hold bar
+            if (_holdFraction > 0)
+              FractionallySizedBox(
+                widthFactor: _holdFraction.clamp(0.0, 1.0),
+                child: Container(
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: color,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '◄── ${hold.toStringAsFixed(1)} mois ──►',
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+                Text(
+                  'Tu tiens',
+                  style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+            if (gap > 0)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    '◄── ${gap.toStringAsFixed(1)} mois ──►',
+                    style: GoogleFonts.inter(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.scoreCritique,
+                    ),
+                  ),
+                  Text(
+                    'Le vide',
+                    style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                  ),
+                ],
+              ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            'Jour J → Décision AI : $_aiDelayMonths mois',
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChiffreChoc(double hold, double gap, Color color, bool isOk) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (isOk) ...[
+            Text(
+              '✅ Tes réserves couvrent tout le délai AI.',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreExcellent,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Tu tiens ${hold.toStringAsFixed(1)} mois, soit plus que le délai moyen de $_aiDelayMonths mois.',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+            ),
+          ] else ...[
+            Text(
+              '💰 Chiffre-choc : après ${hold.toStringAsFixed(1)} mois, tu dois emprunter ou vendre pour survivre.',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Il te manque CHF ${_fmt(_gapAmount)} pour tenir jusqu\'à la décision AI.',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                color: MintColors.textPrimary,
+                height: 1.4,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActions() {
+    return Column(
+      children: [
+        _buildAction(
+          '→ Constitue un fonds d\'urgence de 6 mois de charges',
+          MintColors.primary,
+        ),
+        const SizedBox(height: 8),
+        _buildAction(
+          '→ Souscris une APG privée (dès CHF 45/mois)',
+          MintColors.info,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAction(String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.inter(
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAI art. 28, LPGA art. 19.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/disability_countdown_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_countdown_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -25,7 +26,8 @@ class DisabilityCountdownWidget extends StatefulWidget {
 class _DisabilityCountdownWidgetState extends State<DisabilityCountdownWidget> {
   late double _savings;
 
-  static const int _aiDelayMonths = 14; // délai moyen décision AI
+  // Wire to social_insurance.dart single source of truth (LAI art. 28 + LPGA art. 19)
+  static const int _aiDelayMonths = aiDecisionDelayMonths;
 
   @override
   void initState() {

--- a/apps/mobile/lib/widgets/coach/disability_red_screen_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_red_screen_widget.dart
@@ -1,0 +1,373 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-C  L'Écran rouge de l'indépendant — filet vs vide
+//  Charte : L6 (Chiffre-choc) + L4 (Raconte ne montre pas)
+//  Source : LAMal art. 67-77, CO art. 324a, LAVS, LPP art. 23
+// ────────────────────────────────────────────────────────────
+
+class DisabilityRedScreenWidget extends StatefulWidget {
+  const DisabilityRedScreenWidget({
+    super.key,
+    required this.monthlyExpenses,
+    this.hasPerteDegain = false,
+  });
+
+  final double monthlyExpenses;
+  final bool hasPerteDegain;
+
+  @override
+  State<DisabilityRedScreenWidget> createState() => _DisabilityRedScreenWidgetState();
+}
+
+class _DisabilityRedScreenWidgetState extends State<DisabilityRedScreenWidget> {
+  int? _answer; // 0=oui, 1=non, 2=ne sais pas
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  static const double _salarieMonthly = 4320;
+  static const double _aiRenteMax = 2520;
+  static const int _aiDelayMonths = 14;
+
+  @override
+  Widget build(BuildContext context) {
+    final emergencyNeeded = widget.monthlyExpenses * _aiDelayMonths;
+
+    return Semantics(
+      label: 'Écran rouge indépendant invalidité filet inexistant',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildComparisonTable(),
+                  const SizedBox(height: 20),
+                  _buildChiffreChoc(emergencyNeeded),
+                  const SizedBox(height: 20),
+                  _buildQuestion(),
+                  if (_answer != null) _buildAnswerFeedback(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            MintColors.scoreCritique,
+            MintColors.scoreCritique.withValues(alpha: 0.8),
+          ],
+        ),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🚨', style: TextStyle(fontSize: 24)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Indépendant·e : ton filet n\'existe pas',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Si tu ne peux plus travailler demain :',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: Colors.white.withValues(alpha: 0.85),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComparisonTable() {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildColumn(
+            title: 'Salarié·e',
+            emoji: '👔',
+            color: MintColors.scoreExcellent,
+            items: const [
+              'APG 80%',
+              'LPP invalidité',
+              'AI rente',
+            ],
+            totalMonthly: _salarieMonthly,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _buildColumn(
+            title: 'Toi',
+            emoji: '🧑‍💼',
+            color: MintColors.scoreCritique,
+            items: const [
+              'RIEN',
+              'pendant',
+              '~14 mois',
+            ],
+            totalMonthly: 0,
+            isVoid: true,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildColumn({
+    required String title,
+    required String emoji,
+    required Color color,
+    required List<String> items,
+    required double totalMonthly,
+    bool isVoid = false,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(emoji, style: const TextStyle(fontSize: 16)),
+              const SizedBox(width: 6),
+              Text(
+                title,
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: isVoid ? MintColors.scoreCritique.withValues(alpha: 0.08) : Colors.white,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: color.withValues(alpha: 0.2)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: items.map((item) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 3),
+                  child: Text(
+                    item,
+                    style: GoogleFonts.inter(
+                      fontSize: isVoid ? 16 : 12,
+                      fontWeight: isVoid ? FontWeight.w800 : FontWeight.w400,
+                      color: isVoid ? MintColors.scoreCritique : MintColors.textPrimary,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            isVoid ? '= 0 CHF/mois' : '= CHF ${_fmt(totalMonthly)}/mois',
+            style: GoogleFonts.montserrat(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc(double emergencyNeeded) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '💰 Chiffre-choc : $_aiDelayMonths mois à 0 CHF.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Tu dois avoir CHF ${_fmt(emergencyNeeded)} d\'épargne de sécurité '
+            'pour tenir jusqu\'à la décision AI.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textPrimary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Après décision AI : CHF ${_fmt(_aiRenteMax)}/mois (AI seule)',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildQuestion() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(height: 8),
+          Text(
+            'As-tu une assurance perte de gain ?',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              _buildAnswerButton(0, 'Oui'),
+              const SizedBox(width: 8),
+              _buildAnswerButton(1, 'Non'),
+              const SizedBox(width: 8),
+              _buildAnswerButton(2, 'Je ne sais pas'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnswerButton(int value, String label) {
+    final isSelected = _answer == value;
+    return GestureDetector(
+      onTap: () => setState(() => _answer = value),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? MintColors.primary : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: isSelected ? MintColors.primary : MintColors.lightBorder,
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: isSelected ? Colors.white : MintColors.textPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnswerFeedback() {
+    final (msg, color) = switch (_answer) {
+      0 => ('Bien ! Vérifie que le délai de carence est inférieur à 30 jours.', MintColors.scoreExcellent),
+      1 => ('Action prioritaire : compare 3 assurances perte de gain. Dès CHF 45/mois.', MintColors.scoreCritique),
+      _ => ('Retrouve ton contrat ou contacte ta caisse de compensation.', MintColors.scoreAttention),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: color.withValues(alpha: 0.25)),
+        ),
+        child: Text(
+          msg,
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAMal art. 67-77, CO art. 324a.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/disability_reset_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_reset_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -37,20 +38,13 @@ class DisabilityResetWidget extends StatelessWidget {
     return '$n';
   }
 
-  static double _lppRate(int age) {
-    if (age < 35) return 7.0;
-    if (age < 45) return 10.0;
-    if (age < 55) return 15.0;
-    return 18.0;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final currentRate = _lppRate(currentAge);
-    final bonificationBefore = currentSalary * currentRate / 100;
-    final bonificationAfter = reducedSalary * currentRate / 100;
+    final currentRate = getLppBonificationRate(currentAge);
+    final bonificationBefore = currentSalary * currentRate;
+    final bonificationAfter = reducedSalary * currentRate;
     final capitalDelta = capitalBefore - capitalAfter;
-    const conversionRate = 0.068;
+    final conversionRate = lppTauxConversionMin / 100;
     final renteMonthlyDelta = capitalDelta * conversionRate / 12;
 
     return Semantics(
@@ -70,7 +64,7 @@ class DisabilityResetWidget extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _buildContext(currentRate, bonificationBefore, bonificationAfter),
+                  _buildContext(currentRate * 100, bonificationBefore, bonificationAfter),
                   const SizedBox(height: 20),
                   _buildCapitalComparison(capitalDelta),
                   const SizedBox(height: 16),

--- a/apps/mobile/lib/widgets/coach/disability_reset_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_reset_widget.dart
@@ -1,0 +1,374 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-B  Le Reset silencieux — Perte d'ancienneté LPP
+//  Charte : L1 (CHF/mois) + L7 (Métaphore reset/rewind)
+//  Source : LPP art. 16 (bonifications par âge), LPP art. 23
+// ────────────────────────────────────────────────────────────
+
+class DisabilityResetWidget extends StatelessWidget {
+  const DisabilityResetWidget({
+    super.key,
+    required this.currentAge,
+    required this.currentSalary,
+    required this.reducedSalary,
+    required this.capitalBefore,
+    required this.capitalAfter,
+  });
+
+  final int currentAge;
+  final double currentSalary;
+  final double reducedSalary;
+  final double capitalBefore;
+  final double capitalAfter;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000000) {
+      return "${(v / 1000000).toStringAsFixed(1)}M";
+    }
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  static double _lppRate(int age) {
+    if (age < 35) return 7.0;
+    if (age < 45) return 10.0;
+    if (age < 55) return 15.0;
+    return 18.0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentRate = _lppRate(currentAge);
+    final bonificationBefore = currentSalary * currentRate / 100;
+    final bonificationAfter = reducedSalary * currentRate / 100;
+    final capitalDelta = capitalBefore - capitalAfter;
+    const conversionRate = 0.068;
+    final renteMonthlyDelta = capitalDelta * conversionRate / 12;
+
+    return Semantics(
+      label: 'Reset silencieux invalidité LPP ancienneté',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildContext(currentRate, bonificationBefore, bonificationAfter),
+                  const SizedBox(height: 20),
+                  _buildCapitalComparison(capitalDelta),
+                  const SizedBox(height: 16),
+                  _buildRenteImpact(renteMonthlyDelta),
+                  const SizedBox(height: 16),
+                  _buildNarrative(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF8E1),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('⏪', style: TextStyle(fontSize: 24)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Le reset silencieux',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'L\'invalidité ne détruit pas que ton revenu actuel — elle rétrécit ta retraite.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContext(double rate, double bonifBefore, double bonifAfter) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.appleSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.lightBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'À $currentAge ans — taux de bonification LPP : ${rate.toStringAsFixed(0)}% (LPP art. 16)',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 10),
+          _buildBonifRow('Avant invalidité', currentSalary, bonifBefore, MintColors.primary),
+          const SizedBox(height: 8),
+          _buildBonifRow('Après reconversion', reducedSalary, bonifAfter, MintColors.scoreAttention),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBonifRow(String label, double salary, double bonif, Color color) {
+    return Row(
+      children: [
+        Container(
+          width: 4,
+          height: 36,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+              ),
+              Text(
+                'Salaire ${_fmt(salary)} → bonification LPP : CHF ${_fmt(bonif)}/an',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: MintColors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCapitalComparison(double delta) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ton 2e pilier à 65 ans',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(child: _buildCapitalCard(
+              label: 'Sans invalidité',
+              amount: capitalBefore,
+              color: MintColors.scoreExcellent,
+              emoji: '✅',
+            )),
+            const SizedBox(width: 12),
+            Expanded(child: _buildCapitalCard(
+              label: 'Avec invalidité',
+              amount: capitalAfter,
+              color: MintColors.scoreCritique,
+              emoji: '❌',
+            )),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: MintColors.scoreCritique.withValues(alpha: 0.08),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            '△ Différence : -CHF ${_fmt(delta)}',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCapitalCard({
+    required String label,
+    required double amount,
+    required Color color,
+    required String emoji,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary)),
+          const SizedBox(height: 4),
+          Text(
+            '$emoji CHF ${_fmt(amount)}',
+            style: GoogleFonts.montserrat(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRenteImpact(double monthlyDelta) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Rente mensuelle perdue',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '-CHF ${_fmt(monthlyDelta)}/mois',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                'Chaque mois.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.textPrimary,
+                ),
+              ),
+              Text(
+                'Pour toujours.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNarrative() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'C\'est pas juste ton salaire qui baisse.\nC\'est ta retraite qui rétrécit.',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LPP art. 16, 23-26. Taux de conversion minimum : 6.8% (LPP art. 14).',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/disability_scorecard_widget.dart
+++ b/apps/mobile/lib/widgets/coach/disability_scorecard_widget.dart
@@ -1,0 +1,363 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-E  Le Bulletin scolaire de ta couverture invalidité
+//  Charte : L5 (1 action) + L2 (Avant/Après notes)
+//  Source : LAMal, LAVS, LPP art. 23-26
+// ────────────────────────────────────────────────────────────
+
+class CoverageItem {
+  const CoverageItem({
+    required this.label,
+    required this.grade,
+    required this.detail,
+    this.legalRef,
+    this.emoji,
+  });
+
+  final String label;
+  final String grade; // A+, A, B+, B, C, D, F
+  final String detail;
+  final String? legalRef;
+  final String? emoji;
+}
+
+class DisabilityScorecardWidget extends StatelessWidget {
+  const DisabilityScorecardWidget({
+    super.key,
+    required this.items,
+    required this.overallGrade,
+    required this.lifeDropPercent,
+  });
+
+  final List<CoverageItem> items;
+  final String overallGrade;
+  final double lifeDropPercent;
+
+  static Color _gradeColor(String grade) {
+    return switch (grade) {
+      'A+' || 'A' || 'A-' => MintColors.scoreExcellent,
+      'B+' || 'B' || 'B-' => MintColors.scoreBon,
+      'C+' || 'C' || 'C-' => MintColors.scoreAttention,
+      'D' => const Color(0xFFFF7043),
+      _ => MintColors.scoreCritique,
+    };
+  }
+
+  static double _gradeToScore(String grade) {
+    return switch (grade) {
+      'A+' => 1.0,
+      'A' => 0.95,
+      'A-' => 0.88,
+      'B+' => 0.82,
+      'B' => 0.78,
+      'B-' => 0.72,
+      'C+' => 0.66,
+      'C' => 0.62,
+      'C-' => 0.58,
+      'D' => 0.45,
+      _ => 0.20,
+    };
+  }
+
+  CoverageItem? get _worstItem {
+    if (items.isEmpty) return null;
+    return items.reduce((a, b) => _gradeToScore(a.grade) < _gradeToScore(b.grade) ? a : b);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final worst = _worstItem;
+    final overallColor = _gradeColor(overallGrade);
+
+    return Semantics(
+      label: 'Bulletin couverture invalidité notes A-F',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildGradeTable(),
+                  const SizedBox(height: 20),
+                  _buildOverallGrade(overallGrade, overallColor),
+                  const SizedBox(height: 16),
+                  if (worst != null) _buildWeakestSubject(worst),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFF3E5F5),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('📋', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ton bulletin de couverture invalidité',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Note A–F sur chaque pilier de ta protection',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGradeTable() {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: MintColors.lightBorder),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          _buildTableHeader(),
+          const Divider(height: 1),
+          ...items.asMap().entries.map((e) {
+            final isLast = e.key == items.length - 1;
+            return Column(
+              children: [
+                _buildTableRow(e.value),
+                if (!isLast) const Divider(height: 1, indent: 16, endIndent: 16),
+              ],
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTableHeader() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Couverture',
+              style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary),
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Text(
+              'Note',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Détail',
+              style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTableRow(CoverageItem item) {
+    final gradeColor = _gradeColor(item.grade);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                if (item.emoji != null) ...[
+                  Text(item.emoji!, style: const TextStyle(fontSize: 14)),
+                  const SizedBox(width: 6),
+                ],
+                Expanded(
+                  child: Text(
+                    item.label,
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+              decoration: BoxDecoration(
+                color: gradeColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                item.grade,
+                textAlign: TextAlign.center,
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  color: gradeColor,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              item.detail,
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                color: MintColors.textSecondary,
+                height: 1.4,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOverallGrade(String grade, Color color) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.3), width: 2),
+      ),
+      child: Row(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                'Moyenne',
+                style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+              ),
+              Text(
+                grade,
+                style: GoogleFonts.montserrat(
+                  fontSize: 36,
+                  fontWeight: FontWeight.w900,
+                  color: color,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Tu survivrais, mais ton niveau de vie baisserait de ${lifeDropPercent.toStringAsFixed(0)}%.',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    color: MintColors.textPrimary,
+                    fontWeight: FontWeight.w600,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWeakestSubject(CoverageItem worst) {
+    final worstColor = _gradeColor(worst.grade);
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: worstColor.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: worstColor.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Matière la plus faible : ${worst.label}',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: worstColor,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            worst.detail,
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          if (worst.legalRef != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              worst.legalRef!,
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAMal, LAVS, LPP art. 23-26.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/double_price_freedom_widget.dart
+++ b/apps/mobile/lib/widgets/coach/double_price_freedom_widget.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  DOUBLE PRICE OF FREEDOM WIDGET — P6-C / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Comparaison côte à côte charges salarié vs indépendant.
+//  Le prix réel de la liberté.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L1 (CHF/mois) + L6 (chiffre-choc)
+// ────────────────────────────────────────────────────────────
+
+/// Single charge line for comparison.
+class ChargeLine {
+  final String label;
+  final double employeeAmount;
+  final double selfEmployedAmount;
+  final String? note;
+
+  const ChargeLine({
+    required this.label,
+    required this.employeeAmount,
+    required this.selfEmployedAmount,
+    this.note,
+  });
+}
+
+class DoublePriceFreedomWidget extends StatelessWidget {
+  final double grossIncome;
+  final List<ChargeLine> charges;
+  final double totalEmployee;
+  final double totalSelfEmployed;
+
+  const DoublePriceFreedomWidget({
+    super.key,
+    required this.grossIncome,
+    required this.charges,
+    required this.totalEmployee,
+    required this.totalSelfEmployed,
+  });
+
+  double get _multiplier =>
+      totalEmployee > 0 ? totalSelfEmployed / totalEmployee : 0;
+  double get _monthlyDelta => (totalSelfEmployed - totalEmployee) / 12;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Double prix de la libert\u00e9. '
+          'Salari\u00e9\u00a0: ${formatChfWithPrefix(totalEmployee)}/an. '
+          'Ind\u00e9pendant\u00a0: ${formatChfWithPrefix(totalSelfEmployed)}/an.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Le double prix de ta libert\u00e9',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Charges totales \u00e0 ${formatChfWithPrefix(grossIncome)} brut/an',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Column headers ──
+            _buildColumnHeaders(),
+            const Divider(height: 16),
+
+            // ── Charge lines ──
+            ...charges.map(_buildChargeLine),
+
+            const Divider(height: 16),
+
+            // ── Totals ──
+            _buildTotalRow(),
+            const SizedBox(height: 12),
+
+            // ── Chiffre-choc ──
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: MintColors.scoreCritique.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                'Tu paies ${formatChfWithPrefix(_monthlyDelta.abs())}/mois '
+                'de plus (\u00d7${_multiplier.toStringAsFixed(1)}).\n'
+                'Pour garder le m\u00eame net, facture '
+                '+${((_multiplier - 1) * 100).toStringAsFixed(0)}%.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: MintColors.scoreCritique,
+                  height: 1.4,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
+            const SizedBox(height: 12),
+            Text(
+              'Cotisations sociales\u00a0: LAVS art. 4-14, LAA art. 1a, LACI art. 2. '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildColumnHeaders() {
+    return Row(
+      children: [
+        const Expanded(flex: 3, child: SizedBox()),
+        Expanded(
+          flex: 2,
+          child: Text(
+            'Salari\u00e9\u00b7e',
+            textAlign: TextAlign.right,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: MintColors.scoreExcellent,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Text(
+            'Ind\u00e9p.',
+            textAlign: TextAlign.right,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChargeLine(ChargeLine line) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 3,
+            child: Text(
+              line.label,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              formatChfWithPrefix(line.employeeAmount),
+              textAlign: TextAlign.right,
+              style: GoogleFonts.montserrat(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: MintColors.textSecondary,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              formatChfWithPrefix(line.selfEmployedAmount),
+              textAlign: TextAlign.right,
+              style: GoogleFonts.montserrat(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: line.selfEmployedAmount > line.employeeAmount
+                    ? MintColors.scoreCritique
+                    : MintColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotalRow() {
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Text(
+            'TOTAL /an',
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Text(
+            formatChfWithPrefix(totalEmployee),
+            textAlign: TextAlign.right,
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreExcellent,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Text(
+            formatChfWithPrefix(totalSelfEmployed),
+            textAlign: TextAlign.right,
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/early_retirement_slider.dart
+++ b/apps/mobile/lib/widgets/coach/early_retirement_slider.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  EARLY RETIREMENT SLIDER — P1-C / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Slider intuitif pour explorer l'impact du depart anticipe.
+//  Remplace les 7 barres par UN curseur avec zones colorees.
+//
+//  Zones :
+//    58-62 : rouge  — "Risque : sacrifice financier important"
+//    63-64 : orange — "Faisable avec compromis"
+//    65    : vert   — "Standard, pas de penalite"
+//    66-70 : bleu   — "Bonus, mais tu profites moins longtemps"
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L3 (3 niveaux) + L4 (raconte, ne montre pas)
+// ────────────────────────────────────────────────────────────
+
+/// Data for a single retirement age scenario.
+class RetirementAgeScenario {
+  /// Retirement age (58-70).
+  final int age;
+
+  /// Projected monthly income at this age.
+  final double monthlyIncome;
+
+  /// Percentage change vs standard retirement (65).
+  final double deltaPercent;
+
+  /// Total lifetime cost/gain vs 65 (approximate, over 25 years).
+  final double? lifetimeDelta;
+
+  const RetirementAgeScenario({
+    required this.age,
+    required this.monthlyIncome,
+    required this.deltaPercent,
+    this.lifetimeDelta,
+  });
+}
+
+class EarlyRetirementSlider extends StatefulWidget {
+  /// Scenarios for each retirement age (min 3).
+  final List<RetirementAgeScenario> scenarios;
+
+  /// Monthly income at standard retirement (65) for comparison.
+  final double monthlyIncomeAt65;
+
+  /// Initial selected age (defaults to 65).
+  final int initialAge;
+
+  /// Callback when user selects a new age.
+  final ValueChanged<int>? onAgeChanged;
+
+  const EarlyRetirementSlider({
+    super.key,
+    required this.scenarios,
+    required this.monthlyIncomeAt65,
+    this.initialAge = 65,
+    this.onAgeChanged,
+  });
+
+  @override
+  State<EarlyRetirementSlider> createState() => _EarlyRetirementSliderState();
+}
+
+class _EarlyRetirementSliderState extends State<EarlyRetirementSlider> {
+  late int _selectedAge;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedAge = widget.initialAge;
+  }
+
+  RetirementAgeScenario? get _selectedScenario {
+    try {
+      return widget.scenarios.firstWhere((s) => s.age == _selectedAge);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Color _zoneColor(int age) {
+    if (age <= 62) return MintColors.scoreCritique;
+    if (age <= 64) return MintColors.scoreAttention;
+    if (age == 65) return MintColors.scoreExcellent;
+    return MintColors.scoreBon; // 66+
+  }
+
+  String _zoneLabel(int age) {
+    if (age <= 62) return 'Risqu\u00e9 \u2014 sacrifice financier important';
+    if (age <= 64) return 'Faisable \u2014 avec compromis';
+    if (age == 65) return 'Standard \u2014 pas de p\u00e9nalit\u00e9';
+    return 'Bonus \u2014 tu gagnes plus, mais moins longtemps';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.scenarios.isEmpty) return const SizedBox.shrink();
+
+    final minAge =
+        widget.scenarios.map((s) => s.age).reduce((a, b) => a < b ? a : b);
+    final maxAge =
+        widget.scenarios.map((s) => s.age).reduce((a, b) => a > b ? a : b);
+    final scenario = _selectedScenario;
+    final color = _zoneColor(_selectedAge);
+
+    return Semantics(
+      label:
+          'Simulateur de d\u00e9part \u00e0 la retraite. \u00c2ge s\u00e9lectionn\u00e9\u00a0: $_selectedAge ans.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ──
+            Text(
+              'Et si je partais \u00e0\u2026',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Age display ──
+            Center(
+              child: Text(
+                '$_selectedAge ans',
+                style: GoogleFonts.montserrat(
+                  fontSize: 36,
+                  fontWeight: FontWeight.w800,
+                  color: color,
+                  height: 1.0,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+
+            // ── Zone label ──
+            Center(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.10),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  _zoneLabel(_selectedAge),
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: color,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Slider ──
+            SliderTheme(
+              data: SliderThemeData(
+                activeTrackColor: color,
+                inactiveTrackColor: MintColors.surface,
+                thumbColor: color,
+                overlayColor: color.withValues(alpha: 0.12),
+                trackHeight: 6,
+                thumbShape:
+                    const RoundSliderThumbShape(enabledThumbRadius: 10),
+              ),
+              child: Slider(
+                value: _selectedAge.toDouble(),
+                min: minAge.toDouble(),
+                max: maxAge.toDouble(),
+                divisions: maxAge - minAge,
+                onChanged: (value) {
+                  setState(() => _selectedAge = value.round());
+                  widget.onAgeChanged?.call(_selectedAge);
+                },
+              ),
+            ),
+
+            // ── Age labels under slider ──
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('$minAge',
+                    style: GoogleFonts.inter(
+                        fontSize: 11, color: MintColors.textMuted)),
+                Text('65',
+                    style: GoogleFonts.inter(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: MintColors.scoreExcellent)),
+                Text('$maxAge',
+                    style: GoogleFonts.inter(
+                        fontSize: 11, color: MintColors.textMuted)),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // ── Result panel ──
+            if (scenario != null) _buildResultPanel(scenario, color),
+
+            // ── Disclaimer ──
+            const SizedBox(height: 12),
+            Text(
+              'Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResultPanel(RetirementAgeScenario scenario, Color color) {
+    final delta = scenario.deltaPercent;
+    final isGain = delta >= 0;
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '\u00c0 ${scenario.age} ans : ${formatChfWithPrefix(scenario.monthlyIncome)}/mois',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: isGain
+                      ? MintColors.scoreExcellent.withValues(alpha: 0.12)
+                      : MintColors.scoreCritique.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  '${isGain ? "+" : ""}${delta.toStringAsFixed(0)}%',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: isGain
+                        ? MintColors.scoreExcellent
+                        : MintColors.scoreCritique,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (scenario.age != 65) ...[
+            const SizedBox(height: 6),
+            Text(
+              _buildNarrative(scenario),
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textSecondary,
+                height: 1.4,
+              ),
+            ),
+          ],
+          if (scenario.lifetimeDelta != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              'Impact estim\u00e9 sur 25 ans\u00a0: ${formatChfWithPrefix(scenario.lifetimeDelta!.abs())}',
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _buildNarrative(RetirementAgeScenario scenario) {
+    final diff = scenario.monthlyIncome - widget.monthlyIncomeAt65;
+    if (scenario.age < 65) {
+      return 'Tu perds ${formatChfWithPrefix(diff.abs())}/mois \u00e0 vie. '
+          'Mais tu gagnes ${65 - scenario.age} an${65 - scenario.age > 1 ? "s" : ""} de libert\u00e9.';
+    }
+    return 'Tu gagnes ${formatChfWithPrefix(diff.abs())}/mois de plus. '
+        '${scenario.age - 65} an${scenario.age - 65 > 1 ? "s" : ""} de travail suppl\u00e9mentaire.';
+  }
+}

--- a/apps/mobile/lib/widgets/coach/expat_countdown_widget.dart
+++ b/apps/mobile/lib/widgets/coach/expat_countdown_widget.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P13-B  Compte à rebours 90 jours expatriation
+//  Charte : L5 (1 action) + L7 (Métaphore décompte)
+//  Source : LAVS art. 2 (cotisation volontaire), LPP art. 5 (libre passage)
+//           OPP3 art. 1 (3a clôture)
+// ────────────────────────────────────────────────────────────
+
+class ExpatDeadline {
+  const ExpatDeadline({
+    required this.label,
+    required this.emoji,
+    required this.daysFromDeparture,
+    required this.action,
+    required this.legalRef,
+    this.consequence,
+    this.isEuOnly = false,
+  });
+
+  final String label;
+  final String emoji;
+  final int daysFromDeparture;
+  final String action;
+  final String legalRef;
+  final String? consequence;
+  final bool isEuOnly;
+}
+
+class ExpatCountdownWidget extends StatefulWidget {
+  const ExpatCountdownWidget({
+    super.key,
+    required this.departureDate,
+    required this.deadlines,
+    this.isEuDestination = false,
+  });
+
+  final DateTime departureDate;
+  final List<ExpatDeadline> deadlines;
+  final bool isEuDestination;
+
+  @override
+  State<ExpatCountdownWidget> createState() => _ExpatCountdownWidgetState();
+}
+
+class _ExpatCountdownWidgetState extends State<ExpatCountdownWidget> {
+  late List<bool> _completed;
+
+  @override
+  void initState() {
+    super.initState();
+    _completed = List.filled(widget.deadlines.length, false);
+  }
+
+  int get _completedCount => _completed.where((c) => c).length;
+
+  int _daysFrom(int fromDeparture) {
+    final deadline = widget.departureDate.add(Duration(days: fromDeparture));
+    final remaining = deadline.difference(DateTime.now()).inDays;
+    return remaining;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleDeadlines = widget.deadlines
+        .where((d) => !d.isEuOnly || widget.isEuDestination)
+        .toList();
+
+    return Semantics(
+      label: 'Compte à rebours expatriation deadlines LPP 3a AVS départ',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(visibleDeadlines.length),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ...visibleDeadlines.asMap().entries.map((e) => Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _buildDeadlineCard(e.key, e.value),
+                  )),
+                  const SizedBox(height: 12),
+                  _buildCriticalNote(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(int count) {
+    final progress = count > 0 ? _completedCount / count : 0.0;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('✈️', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Checklist départ — deadlines légales',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 8,
+              backgroundColor: MintColors.primary.withValues(alpha: 0.2),
+              valueColor: AlwaysStoppedAnimation<Color>(MintColors.primary),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '$_completedCount / $count actions complétées',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDeadlineCard(int index, ExpatDeadline d) {
+    final daysRemaining = _daysFrom(d.daysFromDeparture);
+    final isUrgent = daysRemaining < 30 && daysRemaining >= 0;
+    final isOverdue = daysRemaining < 0;
+    final isDone = _completed[index];
+
+    Color borderColor = MintColors.lightBorder;
+    if (isDone) borderColor = MintColors.scoreExcellent.withValues(alpha: 0.4);
+    else if (isOverdue) borderColor = MintColors.scoreCritique.withValues(alpha: 0.4);
+    else if (isUrgent) borderColor = MintColors.scoreAttention.withValues(alpha: 0.4);
+
+    return GestureDetector(
+      onTap: () => setState(() => _completed[index] = !_completed[index]),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isDone
+              ? MintColors.scoreExcellent.withValues(alpha: 0.05)
+              : isOverdue
+                  ? MintColors.scoreCritique.withValues(alpha: 0.05)
+                  : MintColors.appleSurface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: borderColor),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GestureDetector(
+              onTap: () => setState(() => _completed[index] = !_completed[index]),
+              child: Container(
+                width: 24,
+                height: 24,
+                margin: const EdgeInsets.only(top: 2),
+                decoration: BoxDecoration(
+                  color: isDone ? MintColors.scoreExcellent : Colors.white,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: isDone ? MintColors.scoreExcellent : MintColors.lightBorder,
+                    width: 2,
+                  ),
+                ),
+                child: isDone
+                    ? const Icon(Icons.check, color: Colors.white, size: 14)
+                    : null,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(d.emoji, style: const TextStyle(fontSize: 14)),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          d.label,
+                          style: GoogleFonts.inter(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                            color: isDone ? MintColors.textSecondary : MintColors.textPrimary,
+                            decoration: isDone ? TextDecoration.lineThrough : null,
+                          ),
+                        ),
+                      ),
+                      _buildDaysBadge(daysRemaining, isDone),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    d.action,
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      color: MintColors.textSecondary,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    d.legalRef,
+                    style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                  ),
+                  if (d.consequence != null && !isDone) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      '⚠️ ${d.consequence}',
+                      style: GoogleFonts.inter(
+                        fontSize: 10,
+                        color: MintColors.scoreAttention,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDaysBadge(int days, bool isDone) {
+    if (isDone) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: MintColors.scoreExcellent.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          '✓ Fait',
+          style: GoogleFonts.inter(fontSize: 10, fontWeight: FontWeight.w700, color: MintColors.scoreExcellent),
+        ),
+      );
+    }
+    if (days < 0) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: MintColors.scoreCritique,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          'En retard',
+          style: GoogleFonts.inter(fontSize: 10, fontWeight: FontWeight.w700, color: Colors.white),
+        ),
+      );
+    }
+    final color = days < 30 ? MintColors.scoreAttention : MintColors.textSecondary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'J${days >= 0 ? '+' : ''}$days',
+        style: GoogleFonts.inter(fontSize: 10, fontWeight: FontWeight.w700, color: color),
+      ),
+    );
+  }
+
+  Widget _buildCriticalNote() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('🔑', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Chaque jour de retard peut te coûter un formulaire de plus '
+              'ou des droits irréversibles. Le libre passage LPP doit être transféré avant ton départ.',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil juridique au sens de la LSFin. '
+      'Source : LAVS art. 2, LPP art. 5 (libre passage), OPP3 art. 1.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/expat_rights_loss_widget.dart
+++ b/apps/mobile/lib/widgets/coach/expat_rights_loss_widget.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P13-A  Les 5 choses que tu perds en partant
+//  Charte : L6 (Chiffre-choc) + L2 (Avant/Après)
+//  Source : LAVS art. 1a, LPP art. 5, OPP3 art. 1, LAMal art. 3
+// ────────────────────────────────────────────────────────────
+
+class ExpatRight {
+  const ExpatRight({
+    required this.label,
+    required this.emoji,
+    required this.before,
+    required this.after,
+    required this.legalRef,
+    required this.impact,
+    this.isIrreversible = false,
+  });
+
+  final String label;
+  final String emoji;
+  final String before;
+  final String after;
+  final String legalRef;
+  final String impact;
+  final bool isIrreversible;
+}
+
+class ExpatRightsLossWidget extends StatelessWidget {
+  const ExpatRightsLossWidget({
+    super.key,
+    required this.rights,
+    required this.destination,
+    this.isEuDestination = false,
+  });
+
+  final List<ExpatRight> rights;
+  final String destination;
+  final bool isEuDestination;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Expatriation droits perdus AVS LPP 3a LAMal avant après',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildEuBadge(),
+                  if (isEuDestination) const SizedBox(height: 12),
+                  ...rights.map((r) => Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: _buildRightCard(r),
+                  )),
+                  const SizedBox(height: 4),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFEBEE),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('✈️', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  '5 choses que tu perds en partant',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Suisse → $destination · Avant de partir, vérifie chaque point.',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEuBadge() {
+    if (!isEuDestination) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          const Text('🇪🇺', style: TextStyle(fontSize: 14)),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              'Destination UE — totalisation des périodes d\'assurance possible',
+              style: GoogleFonts.inter(fontSize: 11, color: MintColors.info),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRightCard(ExpatRight r) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: r.isIrreversible
+              ? MintColors.scoreCritique.withValues(alpha: 0.3)
+              : MintColors.scoreAttention.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: r.isIrreversible
+                  ? MintColors.scoreCritique.withValues(alpha: 0.06)
+                  : MintColors.scoreAttention.withValues(alpha: 0.06),
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+            ),
+            child: Row(
+              children: [
+                Text(r.emoji, style: const TextStyle(fontSize: 20)),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              r.label,
+                              style: GoogleFonts.inter(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w700,
+                                color: MintColors.textPrimary,
+                              ),
+                            ),
+                          ),
+                          if (r.isIrreversible)
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: MintColors.scoreCritique,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: Text(
+                                'IRRÉVERSIBLE',
+                                style: GoogleFonts.inter(
+                                  fontSize: 9,
+                                  fontWeight: FontWeight.w800,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                      Text(
+                        r.legalRef,
+                        style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: _buildBeforeAfter('En Suisse', r.before, MintColors.scoreExcellent),
+                    ),
+                    const Icon(Icons.arrow_forward, size: 16, color: MintColors.textSecondary),
+                    Expanded(
+                      child: _buildBeforeAfter('À $destination', r.after, MintColors.scoreCritique),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: MintColors.scoreCritique.withValues(alpha: 0.07),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '💥 ${r.impact}',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: MintColors.scoreCritique,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBeforeAfter(String label, String value, Color color) {
+    return Column(
+      children: [
+        Text(label, style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary)),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: GoogleFonts.inter(
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            color: color,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil juridique ou financier au sens de la LSFin. '
+      'Source : LAVS art. 1a, LPP art. 5, OPP3 art. 1, LAMal art. 3.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/financial_weather_widget.dart
+++ b/apps/mobile/lib/widgets/coach/financial_weather_widget.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  FINANCIAL WEATHER WIDGET — P1-D / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Remplace Monte Carlo par une metaphore meteo intuitive.
+//  "Personne ne comprend 10'000 simulations a 80% de succes.
+//   Tout le monde comprend la meteo."
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L7 (metaphore bat graphique) + L4 (raconte)
+// ────────────────────────────────────────────────────────────
+
+/// Weather condition for retirement outlook.
+enum FinancialWeather {
+  sunny,
+  partlyCloudy,
+  rainy,
+}
+
+/// Single weather scenario with probability.
+class WeatherScenario {
+  final FinancialWeather weather;
+  final double probabilityPercent;
+  final double monthlyIncomeMin;
+  final double monthlyIncomeMax;
+  final String description;
+
+  const WeatherScenario({
+    required this.weather,
+    required this.probabilityPercent,
+    required this.monthlyIncomeMin,
+    required this.monthlyIncomeMax,
+    required this.description,
+  });
+}
+
+class FinancialWeatherWidget extends StatelessWidget {
+  /// The 3 weather scenarios (sunny, partly cloudy, rainy).
+  final List<WeatherScenario> scenarios;
+
+  /// Current overall outlook (which weather best describes the user).
+  final FinancialWeather currentOutlook;
+
+  /// Trend direction relative to last month.
+  final FinancialWeather? trendTowards;
+
+  const FinancialWeatherWidget({
+    super.key,
+    required this.scenarios,
+    required this.currentOutlook,
+    this.trendTowards,
+  });
+
+  String _weatherEmoji(FinancialWeather w) {
+    switch (w) {
+      case FinancialWeather.sunny:
+        return '\u2600\ufe0f'; // ☀️
+      case FinancialWeather.partlyCloudy:
+        return '\u26c5'; // ⛅
+      case FinancialWeather.rainy:
+        return '\ud83c\udf27\ufe0f'; // 🌧️
+    }
+  }
+
+  String _weatherLabel(FinancialWeather w) {
+    switch (w) {
+      case FinancialWeather.sunny:
+        return 'Soleil';
+      case FinancialWeather.partlyCloudy:
+        return 'Nuageux';
+      case FinancialWeather.rainy:
+        return 'Pluie';
+    }
+  }
+
+  Color _weatherColor(FinancialWeather w) {
+    switch (w) {
+      case FinancialWeather.sunny:
+        return MintColors.scoreExcellent;
+      case FinancialWeather.partlyCloudy:
+        return MintColors.scoreAttention;
+      case FinancialWeather.rainy:
+        return MintColors.scoreCritique;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label:
+          'M\u00e9t\u00e9o financi\u00e8re. Perspective actuelle\u00a0: ${_weatherLabel(currentOutlook)}.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ──
+            Text(
+              'Ta m\u00e9t\u00e9o financi\u00e8re \u00e0 la retraite',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Scenarios ──
+            ...scenarios.map((s) => _buildScenarioRow(s)),
+
+            // ── Current outlook ──
+            const SizedBox(height: 16),
+            _buildCurrentOutlook(),
+
+            // ── Disclaimer ──
+            const SizedBox(height: 12),
+            Text(
+              'Bas\u00e9 sur des sc\u00e9narios de march\u00e9 \u2014 outil \u00e9ducatif, pas un conseil (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScenarioRow(WeatherScenario scenario) {
+    final color = _weatherColor(scenario.weather);
+    final isActive = scenario.weather == currentOutlook;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isActive
+              ? color.withValues(alpha: 0.08)
+              : MintColors.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: isActive
+              ? Border.all(color: color.withValues(alpha: 0.25))
+              : null,
+        ),
+        child: Row(
+          children: [
+            Text(
+              _weatherEmoji(scenario.weather),
+              style: const TextStyle(fontSize: 24),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        _weatherLabel(scenario.weather),
+                        style: GoogleFonts.montserrat(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: color,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '(${scenario.probabilityPercent.toStringAsFixed(0)}% des cas)',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: MintColors.textMuted,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    scenario.description,
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      color: MintColors.textSecondary,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${formatChfWithPrefix(scenario.monthlyIncomeMin)}\u2013${formatChfWithPrefix(scenario.monthlyIncomeMax)}/mois',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isActive)
+              Icon(Icons.arrow_back, size: 14, color: color),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCurrentOutlook() {
+    final color = _weatherColor(currentOutlook);
+    final trendText = trendTowards != null
+        ? ' tendance ${_weatherEmoji(trendTowards!)}'
+        : '';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          Text(
+            'Aujourd\u2019hui\u00a0: ${_weatherEmoji(currentOutlook)} ${_weatherLabel(currentOutlook)}$trendText',
+            style: GoogleFonts.montserrat(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Chaque action d\u00e9place le curseur',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/fiscal_superpower_widget.dart
+++ b/apps/mobile/lib/widgets/coach/fiscal_superpower_widget.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P9-C  Le Super-pouvoir fiscal enfant
+//  Charte : L6 (Chiffre-choc) + L1 (CHF/mois)
+//  Source : LIFD art. 213 (déduction 6'700/enfant)
+//           OPP3 art. 1 (3a lié à l'enfant)
+// ────────────────────────────────────────────────────────────
+
+class FiscalSuperpower {
+  const FiscalSuperpower({
+    required this.label,
+    required this.emoji,
+    required this.annualDeduction,
+    required this.taxSaving,
+    required this.legalRef,
+    this.note,
+  });
+
+  final String label;
+  final String emoji;
+  final double annualDeduction;
+  final double taxSaving;
+  final String legalRef;
+  final String? note;
+}
+
+class FiscalSuperpowerWidget extends StatefulWidget {
+  const FiscalSuperpowerWidget({
+    super.key,
+    required this.superpowers,
+    this.taxRate = 0.25,
+  });
+
+  final List<FiscalSuperpower> superpowers;
+  final double taxRate;
+
+  @override
+  State<FiscalSuperpowerWidget> createState() => _FiscalSuperpowerWidgetState();
+}
+
+class _FiscalSuperpowerWidgetState extends State<FiscalSuperpowerWidget> {
+  int _children = 1;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _totalSaving =>
+      widget.superpowers.fold<double>(0, (s, p) => s + p.taxSaving) * _children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Super-pouvoir fiscal enfant déduction LIFD',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildChildrenSlider(),
+                  const SizedBox(height: 16),
+                  _buildSuperpowerList(),
+                  const SizedBox(height: 16),
+                  _buildTotalCallout(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFF3E5F5),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🦸', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le super-pouvoir fiscal',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            "L'État te rend de l'argent pour avoir un enfant.",
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChildrenSlider() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Nombre d\'enfants',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              decoration: BoxDecoration(
+                color: const Color(0xFFF3E5F5),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                '$_children enfant${_children > 1 ? 's' : ''}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w800,
+                  color: const Color(0xFF7B1FA2),
+                ),
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: _children.toDouble(),
+          min: 1,
+          max: 4,
+          divisions: 3,
+          activeColor: const Color(0xFF7B1FA2),
+          onChanged: (v) => setState(() => _children = v.round()),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSuperpowerList() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Tes avantages fiscaux',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ...widget.superpowers.map((p) => Padding(
+          padding: const EdgeInsets.only(bottom: 10),
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF3E5F5).withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: const Color(0xFFCE93D8)),
+            ),
+            child: Row(
+              children: [
+                Text(p.emoji, style: const TextStyle(fontSize: 22)),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        p.label,
+                        style: GoogleFonts.inter(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                      Text(
+                        'Déduction : CHF ${_fmt(p.annualDeduction * _children)}/an · ${p.legalRef}',
+                        style: GoogleFonts.inter(
+                          fontSize: 10,
+                          color: MintColors.textSecondary,
+                        ),
+                      ),
+                      if (p.note != null)
+                        Text(
+                          p.note!,
+                          style: GoogleFonts.inter(
+                            fontSize: 10,
+                            color: MintColors.textSecondary,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      '− CHF',
+                      style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                    ),
+                    Text(
+                      _fmt(p.taxSaving * _children),
+                      style: GoogleFonts.montserrat(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        color: MintColors.scoreExcellent,
+                      ),
+                    ),
+                    Text(
+                      'd\'impôts/an',
+                      style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        )),
+      ],
+    );
+  }
+
+  Widget _buildTotalCallout() {
+    final monthly = _totalSaving / 12;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: MintColors.scoreExcellent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreExcellent.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          const Text('💰', style: TextStyle(fontSize: 26)),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Économie totale avec $_children enfant${_children > 1 ? 's' : ''}',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'CHF ${_fmt(_totalSaving)}/an',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.scoreExcellent,
+                  ),
+                ),
+                Text(
+                  'soit CHF ${_fmt(monthly)}/mois remis dans ta poche',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : LIFD art. 213 (déductions enfants), OPP3 art. 1. '
+      'Taux simulé à ${(widget.taxRate * 100).round()}% — varie selon commune et revenu.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/franchise_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/franchise_cost_widget.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P4-D  Le vrai coût de ta franchise LAMal
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après)
+//  Source : LAMal art. 64-64a, OAMal art. 93
+// ────────────────────────────────────────────────────────────
+
+class FranchiseOption {
+  const FranchiseOption({
+    required this.franchiseAmount,
+    required this.monthlyPremiumSavings,
+  });
+
+  final double franchiseAmount;
+  final double monthlyPremiumSavings;
+}
+
+class FranchiseCostWidget extends StatefulWidget {
+  const FranchiseCostWidget({
+    super.key,
+    required this.options,
+    this.initialConsultationsPerYear = 3,
+  });
+
+  final List<FranchiseOption> options;
+  final int initialConsultationsPerYear;
+
+  @override
+  State<FranchiseCostWidget> createState() => _FranchiseCostWidgetState();
+}
+
+class _FranchiseCostWidgetState extends State<FranchiseCostWidget> {
+  late int _consultationsPerYear;
+
+  static const double _consultationCost = 150.0;
+  static const double _quotePartMax = 700.0;
+  static const double _longIllnessDuration = 2.0; // years
+
+  @override
+  void initState() {
+    super.initState();
+    _consultationsPerYear = widget.initialConsultationsPerYear;
+  }
+
+  // Annual out-of-pocket for a given franchise (normal year)
+  double _annualCostNormal(FranchiseOption opt) {
+    final used = (_consultationsPerYear * _consultationCost).clamp(0, opt.franchiseAmount);
+    final quotePart = (used * 0.10).clamp(0, _quotePartMax);
+    return used + quotePart - opt.monthlyPremiumSavings * 12;
+  }
+
+  // Annual out-of-pocket for a long illness (2-year scenario)
+  double _annualCostLongIllness(FranchiseOption opt) {
+    return (opt.franchiseAmount + _quotePartMax) * _longIllnessDuration / _longIllnessDuration;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Franchise LAMal coût pépin long terme',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildSlider(),
+                  const SizedBox(height: 20),
+                  _buildComparisonTable(),
+                  const SizedBox(height: 16),
+                  _buildLongIllnessScenario(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8F5E9),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🏥', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Ta franchise en cas de pépin long',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Scénario : maladie ou accident nécessitant 2 ans de soins',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSlider() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Combien de fois vas-tu chez le médecin/an ?',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        Slider(
+          value: _consultationsPerYear.toDouble(),
+          min: 0,
+          max: 20,
+          divisions: 20,
+          label: '$_consultationsPerYear× / an',
+          activeColor: MintColors.primary,
+          onChanged: (v) => setState(() => _consultationsPerYear = v.round()),
+        ),
+        Text(
+          '$_consultationsPerYear consultation${_consultationsPerYear > 1 ? 's' : ''} / an',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.primary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildComparisonTable() {
+    if (widget.options.isEmpty) return const SizedBox.shrink();
+    final baseOption = widget.options.first;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Comparaison des franchises',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Container(
+          decoration: BoxDecoration(
+            color: MintColors.appleSurface,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: MintColors.lightBorder),
+          ),
+          child: Column(
+            children: [
+              _buildTableHeader(),
+              const Divider(height: 1),
+              ...widget.options.map((opt) {
+                final normalCost = _annualCostNormal(opt);
+                final isLowest = widget.options.fold(
+                  widget.options.first,
+                  (best, o) => _annualCostNormal(o) < _annualCostNormal(best) ? o : best,
+                ) == opt;
+                return _buildTableRow(opt, normalCost, isLowest, baseOption);
+              }),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTableHeader() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text('Franchise', style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary)),
+          ),
+          SizedBox(
+            width: 90,
+            child: Text('Éco. prime', style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary), textAlign: TextAlign.center),
+          ),
+          SizedBox(
+            width: 90,
+            child: Text('Coût net/an', style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary), textAlign: TextAlign.center),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTableRow(FranchiseOption opt, double normalCost, bool isLowest, FranchiseOption base) {
+    final savings = opt.monthlyPremiumSavings * 12;
+    return Container(
+      color: isLowest ? MintColors.scoreExcellent.withValues(alpha: 0.07) : null,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                if (isLowest) ...[
+                  const Icon(Icons.star, color: MintColors.scoreExcellent, size: 14),
+                  const SizedBox(width: 4),
+                ],
+                Text(
+                  'CHF ${_fmt(opt.franchiseAmount)}',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: isLowest ? FontWeight.w700 : FontWeight.w400,
+                    color: isLowest ? MintColors.scoreExcellent : MintColors.textPrimary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 90,
+            child: Text(
+              '-${_fmt(savings)}/an',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.scoreExcellent,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: 90,
+            child: Text(
+              normalCost >= 0 ? '+${_fmt(normalCost)}' : '-${_fmt(normalCost.abs())}',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: normalCost <= 0 ? MintColors.scoreExcellent : MintColors.scoreAttention,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLongIllnessScenario() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreAttention.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreAttention.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Si maladie longue (2 ans de soins) :',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 10),
+          ...widget.options.map((opt) {
+            final cost = _annualCostLongIllness(opt);
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Franchise CHF ${_fmt(opt.franchiseAmount)}',
+                      style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+                    ),
+                  ),
+                  Text(
+                    'CHF ${_fmt(cost)}/an',
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.scoreAttention,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+          const Divider(height: 16),
+          Text(
+            'Règle : si tu vas chez le médecin plus de 2× par an,\n'
+            'la franchise basse te coûte moins cher.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              fontWeight: FontWeight.w600,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAMal art. 64-64a. Changement de franchise : avant le 30.11.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/franchise_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/franchise_cost_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -36,7 +37,8 @@ class _FranchiseCostWidgetState extends State<FranchiseCostWidget> {
   late int _consultationsPerYear;
 
   static const double _consultationCost = 150.0;
-  static const double _quotePartMax = 700.0;
+  // Wire to social_insurance.dart (LAMal art. 64 al. 2)
+  static const double _quotePartMax = lamalQuotePartMax;
   static const double _longIllnessDuration = 2.0; // years
 
   @override

--- a/apps/mobile/lib/widgets/coach/hero_retirement_card.dart
+++ b/apps/mobile/lib/widgets/coach/hero_retirement_card.dart
@@ -40,6 +40,9 @@ class HeroRetirementCard extends StatelessWidget {
   final double? rangeMin;
   final double? rangeMax;
 
+  /// Current gross monthly salary (for before/after comparison — P1-A).
+  final double? currentMonthlySalary;
+
   // Mode educational
   final VoidCallback? onCompleteProfil;
 
@@ -50,6 +53,7 @@ class HeroRetirementCard extends StatelessWidget {
     this.replacementRatio,
     this.rangeMin,
     this.rangeMax,
+    this.currentMonthlySalary,
     this.onCompleteProfil,
   });
 
@@ -109,7 +113,7 @@ class HeroRetirementCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Projection retraite',
+                _headerTitle,
                 style: GoogleFonts.montserrat(
                   fontSize: 16,
                   fontWeight: FontWeight.w700,
@@ -131,10 +135,21 @@ class HeroRetirementCard extends StatelessWidget {
     );
   }
 
+  String get _headerTitle {
+    switch (mode) {
+      case HeroCardMode.full:
+        return 'Ton salaire apr\u00e8s 65 ans';
+      case HeroCardMode.range:
+        return 'Ton salaire apr\u00e8s 65 ans';
+      case HeroCardMode.educational:
+        return 'Projection retraite';
+    }
+  }
+
   String get _headerSubtitle {
     switch (mode) {
       case HeroCardMode.full:
-        return 'Scenario de base (revenus 3 piliers)';
+        return 'AVS + LPP + \u00e9pargne';
       case HeroCardMode.range:
         return 'Estimation avec incertitude';
       case HeroCardMode.educational:
@@ -210,30 +225,63 @@ class HeroRetirementCard extends StatelessWidget {
     }
   }
 
-  /// Mode full : montant precis + taux de remplacement + fourchette.
+  /// Mode full : montant precis + avant/apres + taux de remplacement.
   Widget _buildFullMode() {
     final income = monthlyIncome ?? 0;
     final ratio = replacementRatio ?? 0;
+    final hasSalary = currentMonthlySalary != null && currentMonthlySalary! > 0;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          formatChfWithPrefix(income),
-          style: GoogleFonts.montserrat(
-            fontSize: 36,
-            fontWeight: FontWeight.w800,
-            color: MintColors.textPrimary,
-            height: 1.0,
+        // ── Before/After comparison (P1-A) ──
+        if (hasSalary) ...[
+          Row(
+            children: [
+              Expanded(
+                child: _buildSalaryColumn(
+                  label: "Aujourd'hui",
+                  amount: currentMonthlySalary!,
+                  isHighlighted: false,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Icon(
+                  Icons.arrow_forward_rounded,
+                  color: MintColors.textMuted,
+                  size: 20,
+                ),
+              ),
+              Expanded(
+                child: _buildSalaryColumn(
+                  label: '\u00c0 la retraite',
+                  amount: income,
+                  isHighlighted: true,
+                ),
+              ),
+            ],
           ),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          'par mois \u00e0 la retraite',
-          style: GoogleFonts.inter(
-            fontSize: 14,
-            color: MintColors.textSecondary,
+        ] else ...[
+          // Fallback without current salary
+          Text(
+            formatChfWithPrefix(income),
+            style: GoogleFonts.montserrat(
+              fontSize: 36,
+              fontWeight: FontWeight.w800,
+              color: MintColors.textPrimary,
+              height: 1.0,
+            ),
           ),
-        ),
+          const SizedBox(height: 4),
+          Text(
+            'par mois \u00e0 la retraite',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
         if (ratio > 0) ...[
           const SizedBox(height: 12),
           _buildReplacementRatioBar(ratio),
@@ -246,12 +294,58 @@ class HeroRetirementCard extends StatelessWidget {
     );
   }
 
+  Widget _buildSalaryColumn({
+    required String label,
+    required double amount,
+    required bool isHighlighted,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(
+          label,
+          style: GoogleFonts.inter(
+            fontSize: 12,
+            color: MintColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          formatChfWithPrefix(amount),
+          style: GoogleFonts.montserrat(
+            fontSize: isHighlighted ? 28 : 22,
+            fontWeight: FontWeight.w800,
+            color: isHighlighted ? MintColors.primary : MintColors.textPrimary,
+            height: 1.0,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          '/mois',
+          style: GoogleFonts.inter(
+            fontSize: 11,
+            color: MintColors.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildReplacementRatioBar(double ratio) {
     final color = ratio >= 70
         ? MintColors.scoreExcellent
         : ratio >= 50
             ? MintColors.scoreAttention
             : MintColors.scoreCritique;
+
+    // P1-A: Human explanation of replacement ratio
+    final explanation = ratio >= 70
+        ? 'Confortable \u2014 tu gardes ton train de vie'
+        : ratio >= 60
+            ? 'Suffisant pour la plupart des m\u00e9nages (charges r\u00e9duites \u00e0 la retraite)'
+            : ratio >= 50
+                ? 'Serr\u00e9 \u2014 des ajustements seront n\u00e9cessaires'
+                : 'Insuffisant \u2014 agis maintenant pour am\u00e9liorer ta situation';
 
     return Container(
       padding: const EdgeInsets.all(12),
@@ -260,40 +354,45 @@ class HeroRetirementCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: color.withValues(alpha: 0.15)),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Taux de remplacement',
-                  style: GoogleFonts.inter(
-                    fontSize: 11,
-                    color: MintColors.textSecondary,
-                    fontWeight: FontWeight.w500,
-                  ),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Tu garderas ${ratio.toStringAsFixed(0)}% de ton train de vie',
+                      style: GoogleFonts.montserrat(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: color,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 2),
-                Text(
-                  '${ratio.toStringAsFixed(0)}% de ton revenu actuel',
-                  style: GoogleFonts.montserrat(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: color,
-                  ),
-                ),
-              ],
-            ),
+              ),
+              Icon(
+                ratio >= 70
+                    ? Icons.check_circle_outline
+                    : ratio >= 50
+                        ? Icons.info_outline
+                        : Icons.warning_amber_outlined,
+                color: color,
+                size: 20,
+              ),
+            ],
           ),
-          Icon(
-            ratio >= 70
-                ? Icons.check_circle_outline
-                : ratio >= 50
-                    ? Icons.info_outline
-                    : Icons.warning_amber_outlined,
-            color: color,
-            size: 20,
+          const SizedBox(height: 4),
+          Text(
+            explanation,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
           ),
         ],
       ),

--- a/apps/mobile/lib/widgets/coach/horizon_line_widget.dart
+++ b/apps/mobile/lib/widgets/coach/horizon_line_widget.dart
@@ -1,0 +1,365 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P7-F  Ligne d'horizon — Le mur de la fin des droits
+//  Charte : L7 (Métaphore horizon) + L6 (Chiffre-choc)
+//  Source : LACI art. 27-30, LASV (aide sociale)
+// ────────────────────────────────────────────────────────────
+
+class HorizonLineWidget extends StatelessWidget {
+  const HorizonLineWidget({
+    super.key,
+    required this.monthlyBenefit,
+    required this.totalDays,
+    this.daysConsumed = 0,
+  });
+
+  final double monthlyBenefit;
+  final int totalDays;
+  final int daysConsumed;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final daysLeft = (totalDays - daysConsumed).clamp(0, totalDays);
+    final monthsLeft = daysLeft / 21.7;
+    final progressFraction = daysConsumed / totalDays;
+
+    return Semantics(
+      label: 'Ligne horizon fin droits chômage',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildTimeline(progressFraction, daysLeft, monthsLeft),
+                  const SizedBox(height: 24),
+                  _buildAfterLine(),
+                  const SizedBox(height: 16),
+                  _buildChiffreChoc(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFF3E5F5),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🌅', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Ta ligne d\'horizon',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'CHF ${_fmt(monthlyBenefit)}/mois jusqu\'au dernier jour — puis 0 CHF.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimeline(double fraction, int daysLeft, double monthsLeft) {
+    const zoneColor = MintColors.scoreExcellent;
+    const wallColor = MintColors.scoreCritique;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ta trajectoire financière',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Visual timeline
+        SizedBox(
+          height: 80,
+          child: CustomPaint(
+            size: const Size(double.infinity, 80),
+            painter: _HorizonPainter(fraction: fraction),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Zone sécurisée',
+                  style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: zoneColor),
+                ),
+                Text(
+                  'CHF ${_fmt(monthlyBenefit)}/mois',
+                  style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  'LE MUR',
+                  style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w800, color: wallColor),
+                ),
+                Text(
+                  'Jour $totalDays → 0 CHF',
+                  style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ],
+        ),
+        if (daysLeft > 0) ...[
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: MintColors.info.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              'Il te reste $daysLeft jours — soit ${monthsLeft.toStringAsFixed(1)} mois de revenus',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: MintColors.info,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAfterLine() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Après la ligne d\'horizon :',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 8),
+          _buildAfterItem('Aide sociale cantonale', 'Montant variable selon canton'),
+          _buildAfterItem('Prestations complémentaires', 'Si tu as plus de 65 ans'),
+          _buildAfterItem('Ton épargne personnelle', 'Dernier recours'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAfterItem(String title, String subtitle) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.chevron_right, color: MintColors.scoreCritique, size: 16),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                Text(
+                  subtitle,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            MintColors.scoreCritique.withValues(alpha: 0.08),
+            MintColors.scoreCritique.withValues(alpha: 0.03),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Passage instantané de CHF ${_fmt(monthlyBenefit)} → 0 CHF',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Il n\'y a pas de transition douce. Le jour J+1, tes droits sont épuisés. '
+                  'Prépare ton plan B avant d\'atteindre la ligne.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LACI art. 27-30.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}
+
+class _HorizonPainter extends CustomPainter {
+  const _HorizonPainter({required this.fraction});
+  final double fraction;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final safeWidth = size.width * (1 - fraction);
+    final consumedWidth = size.width * fraction;
+    const barHeight = 28.0;
+    const top = 20.0;
+
+    // Consumed (grey)
+    if (consumedWidth > 0) {
+      final consumed = Paint()..color = const Color(0xFFBDBDBD);
+      canvas.drawRRect(
+        RRect.fromLTRBAndCorners(
+          0, top, consumedWidth, top + barHeight,
+          topLeft: const Radius.circular(8),
+          bottomLeft: const Radius.circular(8),
+        ),
+        consumed,
+      );
+    }
+
+    // Safe zone (green)
+    if (safeWidth > 2) {
+      final safe = Paint()..color = MintColors.scoreExcellent.withValues(alpha: 0.85);
+      canvas.drawRRect(
+        RRect.fromLTRBAndCorners(
+          consumedWidth, top, size.width - 4, top + barHeight,
+          topRight: const Radius.circular(8),
+          bottomRight: const Radius.circular(8),
+        ),
+        safe,
+      );
+    }
+
+    // Wall (red vertical)
+    final wall = Paint()
+      ..color = MintColors.scoreCritique
+      ..strokeWidth = 4
+      ..style = PaintingStyle.stroke;
+    canvas.drawLine(
+      Offset(size.width - 2, 0),
+      Offset(size.width - 2, size.height),
+      wall,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_HorizonPainter old) => old.fraction != fraction;
+}

--- a/apps/mobile/lib/widgets/coach/job_change_checklist_widget.dart
+++ b/apps/mobile/lib/widgets/coach/job_change_checklist_widget.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P11-C  La Checklist 48h — nouveau job
+//  Charte : L5 (1 action)
+//  Source : LPP art. 3 (libre passage), OLP art. 1-3
+// ────────────────────────────────────────────────────────────
+
+class ChecklistItem {
+  const ChecklistItem({
+    required this.deadline,
+    required this.action,
+    required this.legalRef,
+    this.emoji = '📋',
+    this.consequence,
+  });
+
+  final String deadline;
+  final String action;
+  final String legalRef;
+  final String emoji;
+  final String? consequence;
+}
+
+class JobChangeChecklistWidget extends StatefulWidget {
+  const JobChangeChecklistWidget({
+    super.key,
+    required this.items,
+  });
+
+  final List<ChecklistItem> items;
+
+  @override
+  State<JobChangeChecklistWidget> createState() => _JobChangeChecklistWidgetState();
+}
+
+class _JobChangeChecklistWidgetState extends State<JobChangeChecklistWidget> {
+  late List<bool> _checked;
+
+  @override
+  void initState() {
+    super.initState();
+    _checked = List.filled(widget.items.length, false);
+  }
+
+  int get _completedCount => _checked.where((c) => c).length;
+  double get _progress => widget.items.isEmpty ? 0 : _completedCount / widget.items.length;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Checklist nouveau job libre passage LPP actions urgentes',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildProgress(),
+                  const SizedBox(height: 16),
+                  ...widget.items.asMap().entries.map((e) => Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _buildCheckItem(e.key, e.value),
+                  )),
+                  const SizedBox(height: 12),
+                  _buildCriticalAlert(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8EAF6),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('✅', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Checklist changement de job',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Tu as 30 jours pour vérifier que ton LPP a été transféré.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProgress() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '$_completedCount / ${widget.items.length} actions complétées',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Text(
+              '${(_progress * 100).round()}%',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                color: _progress == 1 ? MintColors.scoreExcellent : MintColors.primary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: LinearProgressIndicator(
+            value: _progress,
+            minHeight: 8,
+            backgroundColor: MintColors.lightBorder,
+            valueColor: AlwaysStoppedAnimation<Color>(
+              _progress == 1 ? MintColors.scoreExcellent : MintColors.primary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCheckItem(int index, ChecklistItem item) {
+    final isDone = _checked[index];
+    return GestureDetector(
+      onTap: () => setState(() => _checked[index] = !_checked[index]),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isDone
+              ? MintColors.scoreExcellent.withValues(alpha: 0.07)
+              : MintColors.appleSurface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isDone
+                ? MintColors.scoreExcellent.withValues(alpha: 0.3)
+                : MintColors.lightBorder,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                color: isDone ? MintColors.scoreExcellent : Colors.white,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: isDone ? MintColors.scoreExcellent : MintColors.lightBorder,
+                  width: 2,
+                ),
+              ),
+              child: isDone
+                  ? const Icon(Icons.check, color: Colors.white, size: 14)
+                  : null,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: MintColors.primary.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          item.deadline,
+                          style: GoogleFonts.inter(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            color: MintColors.primary,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(item.emoji, style: const TextStyle(fontSize: 14)),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    item.action,
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      color: isDone ? MintColors.textSecondary : MintColors.textPrimary,
+                      decoration: isDone ? TextDecoration.lineThrough : null,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    item.legalRef,
+                    style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                  ),
+                  if (item.consequence != null && !isDone) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      '⚠️ ${item.consequence}',
+                      style: GoogleFonts.inter(
+                        fontSize: 10,
+                        color: MintColors.scoreAttention,
+                        fontStyle: FontStyle.italic,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCriticalAlert() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('🔑', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Demande TOUJOURS le certificat LPP avant de signer',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Sans transfert du libre passage dans les délais, '
+                  'ton capital LPP peut finir à la Fondation supplétive à 0.05%.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LPP art. 3 (libre passage), OLP art. 1-3.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/job_change_comparison_widget.dart
+++ b/apps/mobile/lib/widgets/coach/job_change_comparison_widget.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P11-A  Le Prix du changement — avant/après nouveau job
+//  Charte : L2 (Avant/Après) + L6 (Chiffre-choc)
+//  Source : CO art. 335, LPP art. 14-16
+// ────────────────────────────────────────────────────────────
+
+class JobAxis {
+  const JobAxis({
+    required this.label,
+    required this.emoji,
+    required this.currentValue,
+    required this.newValue,
+    required this.unit,
+    this.higherIsBetter = true,
+    this.note,
+  });
+
+  final String label;
+  final String emoji;
+  final double currentValue;
+  final double newValue;
+  final String unit;
+  final bool higherIsBetter;
+  final String? note;
+}
+
+class JobChangeComparisonWidget extends StatelessWidget {
+  const JobChangeComparisonWidget({
+    super.key,
+    required this.currentJobLabel,
+    required this.newJobLabel,
+    required this.axes,
+  });
+
+  final String currentJobLabel;
+  final String newJobLabel;
+  final List<JobAxis> axes;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    final netMonthly = axes
+        .where((a) => a.unit == 'CHF/mois')
+        .fold<double>(0, (s, a) => s + (a.newValue - a.currentValue));
+
+    return Semantics(
+      label: 'Prix du changement comparaison emploi avant après',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(netMonthly),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildColumnHeaders(),
+                  const SizedBox(height: 10),
+                  ...axes.map((a) => Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _buildAxisRow(a),
+                  )),
+                  const SizedBox(height: 8),
+                  _buildNetCallout(netMonthly),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(double netMonthly) {
+    final positive = netMonthly >= 0;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: positive
+            ? MintColors.scoreExcellent.withValues(alpha: 0.1)
+            : MintColors.scoreCritique.withValues(alpha: 0.08),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('💼', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le prix du changement',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$currentJobLabel → $newJobLabel',
+            style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildColumnHeaders() {
+    return Row(
+      children: [
+        const Expanded(flex: 3, child: SizedBox()),
+        Expanded(
+          flex: 2,
+          child: Text(
+            'Actuel',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textSecondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Text(
+            'Nouveau',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: MintColors.primary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: Text(
+            'Delta',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textSecondary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAxisRow(JobAxis a) {
+    final delta = a.newValue - a.currentValue;
+    final isPositive = a.higherIsBetter ? delta >= 0 : delta <= 0;
+    final color = delta == 0
+        ? MintColors.textSecondary
+        : isPositive
+            ? MintColors.scoreExcellent
+            : MintColors.scoreCritique;
+    final sign = delta > 0 ? '+' : '';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.15)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 3,
+            child: Row(
+              children: [
+                Text(a.emoji, style: const TextStyle(fontSize: 16)),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        a.label,
+                        style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary),
+                      ),
+                      if (a.note != null)
+                        Text(
+                          a.note!,
+                          style: GoogleFonts.inter(fontSize: 9, color: MintColors.textSecondary),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              '${_fmt(a.currentValue)} ${a.unit.replaceAll('CHF/', '')}',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              '${_fmt(a.newValue)} ${a.unit.replaceAll('CHF/', '')}',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: MintColors.primary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              '$sign${_fmt(delta)} ${a.unit.replaceAll('CHF/', '')}',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                color: color,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNetCallout(double netMonthly) {
+    final positive = netMonthly >= 0;
+    final sign = netMonthly >= 0 ? '+' : '';
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: (positive ? MintColors.scoreExcellent : MintColors.scoreCritique)
+            .withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: (positive ? MintColors.scoreExcellent : MintColors.scoreCritique)
+              .withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        children: [
+          Text(positive ? '💰' : '⚠️', style: const TextStyle(fontSize: 20)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Impact réel : $sign CHF ${_fmt(netMonthly.abs())}/mois',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: positive ? MintColors.scoreExcellent : MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  positive
+                      ? 'Ton nouveau job est financièrement avantageux — négocie fort !'
+                      : 'Pense à négocier pour compenser. Chaque CHF compte sur 20 ans de LPP.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CO art. 335, LPP art. 14-16.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/job_change_comparison_widget.dart
+++ b/apps/mobile/lib/widgets/coach/job_change_comparison_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P11-A  Le Prix du changement — avant/après nouveau job
@@ -39,17 +40,6 @@ class JobChangeComparisonWidget extends StatelessWidget {
   final String currentJobLabel;
   final String newJobLabel;
   final List<JobAxis> axes;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
-
 
   @override
   Widget build(BuildContext context) {
@@ -223,7 +213,7 @@ class JobChangeComparisonWidget extends StatelessWidget {
           Expanded(
             flex: 2,
             child: Text(
-              '${_fmt(a.currentValue)} ${a.unit.replaceAll('CHF/', '')}',
+              '${formatChf(a.currentValue)} ${a.unit.replaceAll('CHF/', '')}',
               style: GoogleFonts.inter(
                 fontSize: 12,
                 color: MintColors.textSecondary,
@@ -234,7 +224,7 @@ class JobChangeComparisonWidget extends StatelessWidget {
           Expanded(
             flex: 2,
             child: Text(
-              '${_fmt(a.newValue)} ${a.unit.replaceAll('CHF/', '')}',
+              '${formatChf(a.newValue)} ${a.unit.replaceAll('CHF/', '')}',
               style: GoogleFonts.inter(
                 fontSize: 12,
                 fontWeight: FontWeight.w700,
@@ -246,7 +236,7 @@ class JobChangeComparisonWidget extends StatelessWidget {
           Expanded(
             flex: 2,
             child: Text(
-              '$sign${_fmt(delta)} ${a.unit.replaceAll('CHF/', '')}',
+              '$sign${formatChf(delta)} ${a.unit.replaceAll('CHF/', '')}',
               style: GoogleFonts.inter(
                 fontSize: 12,
                 fontWeight: FontWeight.w800,
@@ -284,7 +274,7 @@ class JobChangeComparisonWidget extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Impact réel : $sign CHF ${_fmt(netMonthly.abs())}/mois',
+                  'Impact réel : $sign ${formatChfWithPrefix(netMonthly.abs())}/mois',
                   style: GoogleFonts.montserrat(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,

--- a/apps/mobile/lib/widgets/coach/leasing_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/leasing_cost_widget.dart
@@ -1,0 +1,400 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'dart:math' as math;
+
+// ────────────────────────────────────────────────────────────
+//  P10-D  Le coût caché du leasing vs investissement
+//  Charte : L6 (Chiffre-choc) + L2 (Avant/Après)
+//  Source : CO art. 255 (leasing), LPP calcul opportunité
+// ────────────────────────────────────────────────────────────
+
+class LeasingCostWidget extends StatefulWidget {
+  const LeasingCostWidget({
+    super.key,
+    required this.vehiclePrice,
+    required this.monthlyLeasing,
+    this.leasingDurationMonths = 48,
+    this.annualReturnRate = 0.05,
+  });
+
+  final double vehiclePrice;
+  final double monthlyLeasing;
+  final int leasingDurationMonths;
+  final double annualReturnRate;
+
+  @override
+  State<LeasingCostWidget> createState() => _LeasingCostWidgetState();
+}
+
+class _LeasingCostWidgetState extends State<LeasingCostWidget> {
+  late double _monthly;
+
+  @override
+  void initState() {
+    super.initState();
+    _monthly = widget.monthlyLeasing;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _totalLeasing => _monthly * widget.leasingDurationMonths;
+
+  /// Future value of investing _monthly each month at annualReturnRate.
+  double _futureValue(int months) {
+    final monthlyRate = widget.annualReturnRate / 12;
+    if (monthlyRate == 0) return _monthly * months;
+    // FV of annuity: PMT × [(1+r)^n - 1] / r
+    return _monthly *
+        (math.pow(1 + monthlyRate, months) - 1) /
+        monthlyRate;
+  }
+
+  double get _opportunityCost {
+    final fv = _futureValue(widget.leasingDurationMonths);
+    return fv - _totalLeasing;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Leasing coût caché opportunité investissement comparaison',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildMonthlySlider(),
+                  const SizedBox(height: 16),
+                  _buildComparison(),
+                  const SizedBox(height: 16),
+                  _buildOpportunityCost(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF3E0),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🚗', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le vrai coût du leasing',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              _buildStatChip(
+                label: 'Véhicule : CHF ${_fmt(widget.vehiclePrice)}',
+                color: MintColors.textSecondary,
+              ),
+              const SizedBox(width: 8),
+              _buildStatChip(
+                label: '${widget.leasingDurationMonths ~/ 12} ans',
+                color: MintColors.info,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatChip({required String label, required Color color}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.inter(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMonthlySlider() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Mensualité leasing',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFF3E0),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                'CHF ${_fmt(_monthly)}/mois',
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: const Color(0xFFE65100),
+                ),
+              ),
+            ),
+          ],
+        ),
+        Slider(
+          value: _monthly,
+          min: 200,
+          max: 1500,
+          divisions: 26,
+          activeColor: const Color(0xFFE65100),
+          onChanged: (v) => setState(() => _monthly = (v / 50).round() * 50.0),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildComparison() {
+    return Row(
+      children: [
+        Expanded(child: _buildScenarioCard(
+          emoji: '🔑',
+          label: 'Leasing',
+          subtitle: '${widget.leasingDurationMonths ~/ 12} ans de mensualités',
+          value: 'CHF ${_fmt(_totalLeasing)}',
+          subValue: 'total payé',
+          color: MintColors.scoreCritique,
+        )),
+        const SizedBox(width: 12),
+        Expanded(child: _buildScenarioCard(
+          emoji: '💸',
+          label: 'Achat cash',
+          subtitle: 'Valeur résiduelle ~45%',
+          value: 'CHF ${_fmt(widget.vehiclePrice * 0.55)}',
+          subValue: 'dépréciation réelle',
+          color: MintColors.scoreAttention,
+        )),
+      ],
+    );
+  }
+
+  Widget _buildScenarioCard({
+    required String emoji,
+    required String label,
+    required String subtitle,
+    required String value,
+    required String subValue,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 20)),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          Text(
+            subtitle,
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: GoogleFonts.montserrat(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+          Text(
+            subValue,
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOpportunityCost() {
+    final fv = _futureValue(widget.leasingDurationMonths);
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('📈', style: TextStyle(fontSize: 18)),
+              const SizedBox(width: 10),
+              Text(
+                'Le vrai coût caché',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            'Si tu avais investi CHF ${_fmt(_monthly)}/mois sur ${widget.leasingDurationMonths ~/ 12} ans '
+            'à ${(widget.annualReturnRate * 100).toStringAsFixed(0)}%/an :',
+            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary, height: 1.4),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Capital accumulé',
+                style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+              ),
+              Text(
+                'CHF ${_fmt(fv)}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: MintColors.scoreExcellent,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Au lieu du leasing',
+                style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+              ),
+              Text(
+                '− CHF ${_fmt(_totalLeasing)}',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ],
+          ),
+          const Divider(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Coût d\'opportunité',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.textPrimary,
+                ),
+              ),
+              Text(
+                'CHF ${_fmt(_opportunityCost + _totalLeasing)}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w800,
+                  color: MintColors.scoreCritique,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'C\'est ce que ton leasing te coûte vraiment sur ${widget.leasingDurationMonths ~/ 12} ans.',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+              fontStyle: FontStyle.italic,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CO art. 255 (leasing). '
+      'Rendement simulé à ${(widget.annualReturnRate * 100).toStringAsFixed(0)}% — ne garantit pas de rendement futur.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/lpp_rescue_widget.dart
+++ b/apps/mobile/lib/widgets/coach/lpp_rescue_widget.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P7-D  Opération sauvetage 2e pilier — 30 jours chrono
+//  Charte : L5 (1 action) + L6 (Chiffre-choc)
+//  Source : LFLP art. 3-4, OPP2 art. 10
+// ────────────────────────────────────────────────────────────
+
+class LppTransferOption {
+  const LppTransferOption({
+    required this.label,
+    required this.emoji,
+    required this.description,
+    required this.fiveYearGain,
+    this.recommended = false,
+    this.legalRef,
+  });
+
+  final String label;
+  final String emoji;
+  final String description;
+  final double fiveYearGain;
+  final bool recommended;
+  final String? legalRef;
+}
+
+class LppRescueWidget extends StatelessWidget {
+  const LppRescueWidget({
+    super.key,
+    required this.lppBalance,
+    required this.options,
+    this.daysElapsed = 0,
+  });
+
+  final double lppBalance;
+  final List<LppTransferOption> options;
+  final int daysElapsed;
+
+  static const int _deadlineDays = 30;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final daysLeft = (_deadlineDays - daysElapsed).clamp(0, _deadlineDays);
+    final urgencyColor = daysLeft > 14
+        ? MintColors.scoreExcellent
+        : daysLeft > 7
+            ? MintColors.scoreAttention
+            : MintColors.scoreCritique;
+
+    return Semantics(
+      label: 'Sauvetage LPP 2e pilier libre passage',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(daysLeft, urgencyColor),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildBalanceChip(),
+                  const SizedBox(height: 20),
+                  ...options.asMap().entries.map(
+                    (e) => Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: _buildOptionCard(e.value, e.key),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  _buildChiffreChoc(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(int daysLeft, Color urgencyColor) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: urgencyColor.withValues(alpha: 0.10),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🚑', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Opération sauvetage 2e pilier',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: urgencyColor.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: urgencyColor.withValues(alpha: 0.4)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.timer_outlined, color: urgencyColor, size: 16),
+                const SizedBox(width: 6),
+                Text(
+                  'Il te reste $daysLeft jours pour agir',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: urgencyColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBalanceChip() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.account_balance_outlined, color: MintColors.info, size: 18),
+          const SizedBox(width: 10),
+          Text(
+            'Ton avoir LPP : CHF ${_fmt(lppBalance)}',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.info,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionCard(LppTransferOption option, int index) {
+    final best = options.isNotEmpty
+        ? options.reduce((a, b) => a.fiveYearGain > b.fiveYearGain ? a : b)
+        : null;
+    final isWorst = best != null && option.fiveYearGain == options.reduce((a, b) => a.fiveYearGain < b.fiveYearGain ? a : b).fiveYearGain && !option.recommended;
+
+    Color borderColor = MintColors.lightBorder;
+    Color? bgColor;
+    if (option.recommended) {
+      borderColor = MintColors.scoreExcellent;
+      bgColor = MintColors.scoreExcellent.withValues(alpha: 0.05);
+    } else if (isWorst) {
+      borderColor = MintColors.scoreCritique.withValues(alpha: 0.4);
+      bgColor = MintColors.scoreCritique.withValues(alpha: 0.03);
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor, width: option.recommended ? 2 : 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(option.emoji, style: const TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Option ${index + 1} : ${option.label}',
+                  style: GoogleFonts.inter(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+              if (option.recommended)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: MintColors.scoreExcellent,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    'Recommandé',
+                    style: GoogleFonts.inter(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            option.description,
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.5,
+            ),
+          ),
+          if (option.fiveYearGain != 0) ...[
+            const SizedBox(height: 8),
+            Text(
+              option.fiveYearGain > 0
+                  ? '+CHF ${_fmt(option.fiveYearGain)} sur 5 ans'
+                  : '-CHF ${_fmt(option.fiveYearGain.abs())} sur 5 ans',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: option.fiveYearGain > 0 ? MintColors.scoreExcellent : MintColors.scoreCritique,
+              ),
+            ),
+          ],
+          if (option.legalRef != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              option.legalRef!,
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textSecondary,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💸', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ne rien faire = institution supplétive',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Le taux technique est bas et les frais élevés. '
+                  'Un avoir de CHF ${_fmt(lppBalance)} peut perdre jusqu\'à '
+                  'CHF 9\'000 sur 5 ans par rapport à un compte libre passage optimisé.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LFLP art. 3-4, OPP2 art. 10. Avoirs oubliés : sfbvg.ch.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/lpp_vs_3a_decision_tree.dart
+++ b/apps/mobile/lib/widgets/coach/lpp_vs_3a_decision_tree.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
 
@@ -61,9 +62,13 @@ class LppVs3aDecisionTree extends StatefulWidget {
 class _LppVs3aDecisionTreeState extends State<LppVs3aDecisionTree> {
   int _selectedIndex = -1; // -1 = none, 0 = lpp, 1 = 3a
 
+  /// Seuil pratique: au-dessus de ce revenu, la LPP volontaire devient
+  /// compétitive vs Grand 3a seul (salaire coordonné suffisant).
+  static const double _lppSeuilVolontaire = 60000.0;
+
   @override
   Widget build(BuildContext context) {
-    final isAboveThreshold = widget.expectedIncome >= 60000;
+    final isAboveThreshold = widget.expectedIncome >= _lppSeuilVolontaire;
 
     return Semantics(
       label: 'Arbre de d\u00e9cision LPP vs 3a. '
@@ -176,7 +181,7 @@ class _LppVs3aDecisionTreeState extends State<LppVs3aDecisionTree> {
                 Text(
                   isAboveThreshold
                       ? 'Au-dessus du seuil\u00a0: deux options s\u2019offrent \u00e0 toi'
-                      : 'Sous CHF\u00a060\u2019000\u00a0: le Grand 3a est ton pilier principal',
+                      : 'Sous ${formatChfWithPrefix(_lppSeuilVolontaire)}\u00a0: le Grand 3a est ton pilier principal',
                   style: GoogleFonts.inter(
                     fontSize: 11,
                     color: MintColors.textMuted,
@@ -312,7 +317,7 @@ class _LppVs3aDecisionTreeState extends State<LppVs3aDecisionTree> {
           ),
           const SizedBox(height: 6),
           Text(
-            'Plafond 36\u2019288 CHF/an. Cumule avec l\u2019AVS standard. '
+            'Plafond ${formatChfWithPrefix(pilier3aPlafondSansLpp)}/an. Cumule avec l\u2019AVS standard. '
             'Projection\u00a0: 500k\u2013800k \u00e0 65 ans selon rendement.',
             style: GoogleFonts.inter(
               fontSize: 12,

--- a/apps/mobile/lib/widgets/coach/lpp_vs_3a_decision_tree.dart
+++ b/apps/mobile/lib/widgets/coach/lpp_vs_3a_decision_tree.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  LPP VS 3A DECISION TREE — P6-F / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Arbre de décision visuel pour LE choix stratégique de
+//  l'indépendant·e : LPP volontaire vs Grand 3a.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L3 (3 niveaux) + L5 (une action)
+// ────────────────────────────────────────────────────────────
+
+/// A single option in the decision tree.
+class DecisionOption {
+  final String title;
+  final String emoji;
+  final String subtitle;
+  final List<String> pros;
+  final List<String> cons;
+  final double? annualTaxSavings;
+
+  const DecisionOption({
+    required this.title,
+    required this.emoji,
+    required this.subtitle,
+    required this.pros,
+    required this.cons,
+    this.annualTaxSavings,
+  });
+}
+
+class LppVs3aDecisionTree extends StatefulWidget {
+  /// Expected self-employment income.
+  final double expectedIncome;
+
+  /// LPP option details.
+  final DecisionOption lppOption;
+
+  /// Grand 3a option details.
+  final DecisionOption grand3aOption;
+
+  /// Optional callback when user taps "En savoir plus".
+  final void Function(String choice)? onLearnMore;
+
+  const LppVs3aDecisionTree({
+    super.key,
+    required this.expectedIncome,
+    required this.lppOption,
+    required this.grand3aOption,
+    this.onLearnMore,
+  });
+
+  @override
+  State<LppVs3aDecisionTree> createState() => _LppVs3aDecisionTreeState();
+}
+
+class _LppVs3aDecisionTreeState extends State<LppVs3aDecisionTree> {
+  int _selectedIndex = -1; // -1 = none, 0 = lpp, 1 = 3a
+
+  @override
+  Widget build(BuildContext context) {
+    final isAboveThreshold = widget.expectedIncome >= 60000;
+
+    return Semantics(
+      label: 'Arbre de d\u00e9cision LPP vs 3a. '
+          'Revenu\u00a0: ${formatChfWithPrefix(widget.expectedIncome)}.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'LPP volontaire ou Grand 3a\u00a0?',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Le choix strat\u00e9gique de l\u2019ind\u00e9pendant\u00b7e',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Decision node ──
+            _buildDecisionNode(isAboveThreshold),
+            const SizedBox(height: 12),
+
+            // ── Options ──
+            if (isAboveThreshold) ...[
+              _buildOptionCard(0, widget.lppOption),
+              const SizedBox(height: 10),
+              _buildOptionCard(1, widget.grand3aOption),
+            ] else
+              _buildLowIncomeCard(),
+
+            const SizedBox(height: 12),
+
+            // ── Chiffre-choc ──
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: MintColors.primary.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                    color: MintColors.primary.withValues(alpha: 0.15)),
+              ),
+              child: Text(
+                'Il n\u2019y a pas de mauvais choix. Mais le bon te fait '
+                '\u00e9conomiser 3\u2019000\u20139\u2019000 CHF/an d\u2019imp\u00f4ts.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: MintColors.primary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
+            const SizedBox(height: 12),
+            Text(
+              'LPP\u00a0: art. 4 + 44 LPP. 3a\u00a0: OPP3 art. 7. '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDecisionNode(bool isAboveThreshold) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.surface,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Text('\ud83d\udcca', style: const TextStyle(fontSize: 20)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Revenu attendu\u00a0: ${formatChfWithPrefix(widget.expectedIncome)}/an',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  isAboveThreshold
+                      ? 'Au-dessus du seuil\u00a0: deux options s\u2019offrent \u00e0 toi'
+                      : 'Sous CHF\u00a060\u2019000\u00a0: le Grand 3a est ton pilier principal',
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: MintColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOptionCard(int index, DecisionOption option) {
+    final isSelected = _selectedIndex == index;
+
+    return GestureDetector(
+      onTap: () => setState(() {
+        _selectedIndex = isSelected ? -1 : index;
+      }),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? MintColors.primary.withValues(alpha: 0.06)
+              : MintColors.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isSelected
+                ? MintColors.primary.withValues(alpha: 0.3)
+                : MintColors.lightBorder,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(option.emoji, style: const TextStyle(fontSize: 20)),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    option.title,
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+                Icon(
+                  isSelected ? Icons.expand_less : Icons.expand_more,
+                  size: 20,
+                  color: MintColors.textMuted,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              option.subtitle,
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                color: MintColors.textMuted,
+              ),
+            ),
+            if (isSelected) ...[
+              const SizedBox(height: 10),
+              ...option.pros.map((p) => _buildProCon('\u2705', p)),
+              ...option.cons.map((c) => _buildProCon('\u274c', c)),
+              if (option.annualTaxSavings != null) ...[
+                const SizedBox(height: 6),
+                Text(
+                  '\u00c9conomie fiscale\u00a0: '
+                  '${formatChfWithPrefix(option.annualTaxSavings!)}/an',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.primary,
+                  ),
+                ),
+              ],
+              if (widget.onLearnMore != null) ...[
+                const SizedBox(height: 8),
+                GestureDetector(
+                  onTap: () => widget.onLearnMore!(
+                      index == 0 ? 'lpp' : '3a'),
+                  child: Text(
+                    'En savoir plus \u2192',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: MintColors.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLowIncomeCard() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+            color: MintColors.primary.withValues(alpha: 0.15)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text('\ud83c\udfaf', style: const TextStyle(fontSize: 20)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Grand 3a = ton pilier retraite',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.primary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Plafond 36\u2019288 CHF/an. Cumule avec l\u2019AVS standard. '
+            'Projection\u00a0: 500k\u2013800k \u00e0 65 ans selon rendement.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProCon(String icon, String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(icon, style: const TextStyle(fontSize: 12)),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/minimum_vital_widget.dart
+++ b/apps/mobile/lib/widgets/coach/minimum_vital_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P10-C  LP art. 93 — Insaisissable : ton bouclier légal
@@ -39,16 +40,6 @@ class MinimumVitalWidget extends StatelessWidget {
   final double totalDebts;
   final bool hasChildren;
   final int childrenCount;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _totalProtected =>
       items.fold<double>(0, (s, i) => s + i.amount);
@@ -147,7 +138,7 @@ class MinimumVitalWidget extends StatelessWidget {
                   style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
                 ),
                 Text(
-                  'CHF ${_fmt(_totalProtected)}/mois',
+                  '${formatChfWithPrefix(_totalProtected)}/mois',
                   style: GoogleFonts.montserrat(
                     fontSize: 22,
                     fontWeight: FontWeight.w800,
@@ -169,7 +160,7 @@ class MinimumVitalWidget extends StatelessWidget {
                 style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
               ),
               Text(
-                'CHF ${_fmt(_seizable)}',
+                formatChfWithPrefix(_seizable),
                 style: GoogleFonts.montserrat(
                   fontSize: 18,
                   fontWeight: FontWeight.w800,
@@ -231,7 +222,7 @@ class MinimumVitalWidget extends StatelessWidget {
                 ),
               ),
               Text(
-                'CHF ${_fmt(item.amount)}',
+                formatChfWithPrefix(item.amount),
                 style: GoogleFonts.inter(
                   fontSize: 13,
                   fontWeight: FontWeight.w700,
@@ -298,7 +289,7 @@ class MinimumVitalWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              'Salaire brut : CHF ${_fmt(grossMonthly)}/mois',
+              'Salaire brut : ${formatChfWithPrefix(grossMonthly)}/mois',
               style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
             ),
             Text(
@@ -338,11 +329,11 @@ class MinimumVitalWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              '🟢 Protégé : CHF ${_fmt(_totalProtected)}',
+              '🟢 Protégé : ${formatChfWithPrefix(_totalProtected)}',
               style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreExcellent),
             ),
             Text(
-              '🟠 Saisissable : CHF ${_fmt(_seizable)}',
+              '🟠 Saisissable : ${formatChfWithPrefix(_seizable)}',
               style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreAttention),
             ),
           ],

--- a/apps/mobile/lib/widgets/coach/minimum_vital_widget.dart
+++ b/apps/mobile/lib/widgets/coach/minimum_vital_widget.dart
@@ -1,0 +1,409 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P10-C  LP art. 93 — Insaisissable : ton bouclier légal
+//  Charte : L6 (Chiffre-choc) + L5 (1 action)
+//  Source : LP art. 93 (minimum vital), LP art. 92 (biens insaisissables)
+// ────────────────────────────────────────────────────────────
+
+class MinimumVitalItem {
+  const MinimumVitalItem({
+    required this.label,
+    required this.emoji,
+    required this.amount,
+    required this.legalRef,
+    this.note,
+  });
+
+  final String label;
+  final String emoji;
+  final double amount;
+  final String legalRef;
+  final String? note;
+}
+
+class MinimumVitalWidget extends StatelessWidget {
+  const MinimumVitalWidget({
+    super.key,
+    required this.items,
+    required this.grossMonthly,
+    required this.totalDebts,
+    this.hasChildren = false,
+    this.childrenCount = 0,
+  });
+
+  final List<MinimumVitalItem> items;
+  final double grossMonthly;
+  final double totalDebts;
+  final bool hasChildren;
+  final int childrenCount;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _totalProtected =>
+      items.fold<double>(0, (s, i) => s + i.amount);
+
+  double get _seizable => (grossMonthly - _totalProtected).clamp(0, grossMonthly);
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Minimum vital LP art 93 bouclier légal insaisissable',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildShield(),
+                  const SizedBox(height: 16),
+                  _buildItemList(),
+                  const SizedBox(height: 16),
+                  _buildSeizableBar(),
+                  const SizedBox(height: 16),
+                  _buildAction(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8F5E9),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('🛡️', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ton bouclier légal',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'LP art. 93 — Ce que tes créanciers ne peuvent PAS toucher',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShield() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: MintColors.scoreExcellent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreExcellent.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Minimum vital protégé',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                ),
+                Text(
+                  'CHF ${_fmt(_totalProtected)}/mois',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.scoreExcellent,
+                  ),
+                ),
+                Text(
+                  'Légalement insaisissable · LP art. 93',
+                  style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                'Saisissable',
+                style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+              ),
+              Text(
+                'CHF ${_fmt(_seizable)}',
+                style: GoogleFonts.montserrat(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: _seizable > 0 ? MintColors.scoreAttention : MintColors.scoreExcellent,
+                ),
+              ),
+              Text(
+                '/mois max',
+                style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemList() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Composantes du minimum vital',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ...items.map((item) => Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            children: [
+              Container(
+                width: 32,
+                height: 32,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: MintColors.scoreExcellent.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(item.emoji, style: const TextStyle(fontSize: 16)),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.label,
+                      style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+                    ),
+                    Text(
+                      '${item.legalRef}${item.note != null ? ' · ${item.note}' : ''}',
+                      style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                    ),
+                  ],
+                ),
+              ),
+              Text(
+                'CHF ${_fmt(item.amount)}',
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.scoreExcellent,
+                ),
+              ),
+            ],
+          ),
+        )),
+        if (hasChildren && childrenCount > 0) ...[
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: MintColors.scoreExcellent.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text('👶', style: TextStyle(fontSize: 16)),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Enfants ($childrenCount)',
+                        style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+                      ),
+                      Text(
+                        'LP art. 93 al. 1 lit. a — besoins enfants',
+                        style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                      ),
+                    ],
+                  ),
+                ),
+                Text(
+                  'Inclus',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreExcellent,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSeizableBar() {
+    final fraction = grossMonthly > 0 ? _seizable / grossMonthly : 0.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Salaire brut : CHF ${_fmt(grossMonthly)}/mois',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+            ),
+            Text(
+              '${(fraction * 100).round()}% saisissable',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: fraction > 0.4 ? MintColors.scoreCritique : MintColors.scoreAttention,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Stack(
+            children: [
+              LinearProgressIndicator(
+                value: 1.0,
+                minHeight: 14,
+                backgroundColor: MintColors.scoreExcellent.withValues(alpha: 0.2),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  MintColors.scoreExcellent.withValues(alpha: 0.3),
+                ),
+              ),
+              LinearProgressIndicator(
+                value: fraction,
+                minHeight: 14,
+                backgroundColor: Colors.transparent,
+                valueColor: AlwaysStoppedAnimation<Color>(MintColors.scoreAttention),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '🟢 Protégé : CHF ${_fmt(_totalProtected)}',
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreExcellent),
+            ),
+            Text(
+              '🟠 Saisissable : CHF ${_fmt(_seizable)}',
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.scoreAttention),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAction() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('📋', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Si un créancier saisit plus que la limite',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.info,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Contacte un·e avocat·e ou le service des poursuites de ta commune. '
+                  'La LP art. 93 est impérative — aucun contrat ne peut y déroger.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil juridique. '
+      'Source : LP art. 92 (biens insaisissables), LP art. 93 (minimum vital). '
+      'Les montants varient selon le canton et la situation familiale.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/mint_score_gauge.dart
+++ b/apps/mobile/lib/widgets/coach/mint_score_gauge.dart
@@ -40,6 +40,17 @@ class MintScoreGauge extends StatefulWidget {
   /// Callback au tap
   final VoidCallback? onTap;
 
+  /// Peer benchmark: "Mieux que X% des 45-55 ans" (P1-H).
+  final int? peerPercentile;
+
+  /// Recent score gains (P1-H gamification).
+  /// Each entry: {'label': 'description', 'points': int}
+  final List<Map<String, dynamic>>? recentGains;
+
+  /// Next actions to improve score (P1-H).
+  /// Each entry: {'label': 'description', 'points': int}
+  final List<Map<String, dynamic>>? nextActions;
+
   const MintScoreGauge({
     super.key,
     required this.score,
@@ -49,6 +60,9 @@ class MintScoreGauge extends StatefulWidget {
     this.trend = 'stable',
     this.previousScore,
     this.onTap,
+    this.peerPercentile,
+    this.recentGains,
+    this.nextActions,
   });
 
   @override
@@ -169,8 +183,24 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
                   _buildHeader(),
                   const SizedBox(height: 20),
                   _buildGauge(constraints.maxWidth),
+                  // P1-H: Peer benchmark
+                  if (widget.peerPercentile != null) ...[
+                    const SizedBox(height: 12),
+                    _buildPeerBenchmark(),
+                  ],
                   const SizedBox(height: 24),
                   _buildSubScores(),
+                  // P1-H: Gamification panels
+                  if (widget.recentGains != null &&
+                      widget.recentGains!.isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    _buildGainHistory(),
+                  ],
+                  if (widget.nextActions != null &&
+                      widget.nextActions!.isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    _buildNextActions(),
+                  ],
                   const SizedBox(height: 16),
                   _buildDisclaimer(),
                 ],
@@ -433,6 +463,145 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
     if (score >= 60) return MintColors.scoreBon;
     if (score >= 40) return MintColors.scoreAttention;
     return MintColors.scoreCritique;
+  }
+
+  // ────────────────────────────────────────────────────────────
+  //  P1-H: PEER BENCHMARK
+  // ────────────────────────────────────────────────────────────
+
+  Widget _buildPeerBenchmark() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.people_outline, size: 14, color: MintColors.primary),
+          const SizedBox(width: 6),
+          Text(
+            'Mieux que ${widget.peerPercentile}% des profils similaires',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: MintColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────
+  //  P1-H: GAIN HISTORY
+  // ────────────────────────────────────────────────────────────
+
+  Widget _buildGainHistory() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.scoreExcellent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Ce qui t\u2019a fait monter',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: MintColors.scoreExcellent,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...widget.recentGains!.take(3).map((gain) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  children: [
+                    Icon(Icons.check_circle,
+                        size: 14, color: MintColors.scoreExcellent),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        gain['label'] as String? ?? '',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '+${gain['points'] ?? 0} pts',
+                      style: GoogleFonts.montserrat(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.scoreExcellent,
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────
+  //  P1-H: NEXT ACTIONS
+  // ────────────────────────────────────────────────────────────
+
+  Widget _buildNextActions() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.primary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Pour monter encore',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: MintColors.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...widget.nextActions!.take(3).map((action) => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  children: [
+                    Icon(Icons.assignment_outlined,
+                        size: 14, color: MintColors.primary),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        action['label'] as String? ?? '',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '+${action['points'] ?? 0} pts',
+                      style: GoogleFonts.montserrat(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
   }
 
   // ────────────────────────────────────────────────────────────

--- a/apps/mobile/lib/widgets/coach/monte_carlo_toggle_section.dart
+++ b/apps/mobile/lib/widgets/coach/monte_carlo_toggle_section.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/services/financial_core/monte_carlo_models.dart';
 import 'package:mint_mobile/theme/colors.dart';
-import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'package:mint_mobile/widgets/retirement/monte_carlo_chart.dart';
 
 /// Toggle section for switching between deterministic 3-scenarios view

--- a/apps/mobile/lib/widgets/coach/moving_true_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/moving_true_cost_widget.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P12-B  Le Vrai coût du déménagement cantonal
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après)
+//  Source : LIFD art. 1, loi fiscale cantonale
+// ────────────────────────────────────────────────────────────
+
+class MovingCostItem {
+  const MovingCostItem({
+    required this.label,
+    required this.emoji,
+    required this.monthlyBefore,
+    required this.monthlyAfter,
+    this.note,
+  });
+
+  final String label;
+  final String emoji;
+  final double monthlyBefore;
+  final double monthlyAfter;
+  final String? note;
+}
+
+class MovingTrueCostWidget extends StatelessWidget {
+  const MovingTrueCostWidget({
+    super.key,
+    required this.fromCanton,
+    required this.toCanton,
+    required this.items,
+    this.movingFees = 3000,
+  });
+
+  final String fromCanton;
+  final String toCanton;
+  final List<MovingCostItem> items;
+  final double movingFees;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _totalBefore => items.fold<double>(0, (s, i) => s + i.monthlyBefore);
+  double get _totalAfter => items.fold<double>(0, (s, i) => s + i.monthlyAfter);
+  double get _netMonthly => _totalBefore - _totalAfter;
+  double get _breakEvenMonths => _netMonthly > 0 ? movingFees / _netMonthly : double.infinity;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Vrai coût déménagement cantonal fiscal comparaison mensuelle',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildItemList(),
+                  const SizedBox(height: 16),
+                  _buildNetResult(),
+                  const SizedBox(height: 12),
+                  _buildBreakEven(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8F5E9),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🗺️', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Déménager : le bilan réel',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '$fromCanton → $toCanton',
+            style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemList() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Expanded(flex: 3, child: SizedBox()),
+            Expanded(
+              flex: 2,
+              child: Text(
+                fromCanton,
+                style: GoogleFonts.inter(
+                  fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            Expanded(
+              flex: 2,
+              child: Text(
+                toCanton,
+                style: GoogleFonts.inter(
+                  fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.primary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ...items.map((item) {
+          final delta = item.monthlyAfter - item.monthlyBefore;
+          final isGain = delta < 0;
+          final color = delta == 0
+              ? MintColors.textSecondary
+              : isGain
+                  ? MintColors.scoreExcellent
+                  : MintColors.scoreCritique;
+
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: Row(
+                    children: [
+                      Text(item.emoji, style: const TextStyle(fontSize: 16)),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              item.label,
+                              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary),
+                            ),
+                            if (item.note != null)
+                              Text(
+                                item.note!,
+                                style: GoogleFonts.inter(fontSize: 9, color: MintColors.textSecondary),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  flex: 2,
+                  child: Text(
+                    'CHF ${_fmt(item.monthlyBefore)}',
+                    style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                Expanded(
+                  flex: 2,
+                  child: Text(
+                    'CHF ${_fmt(item.monthlyAfter)}',
+                    style: GoogleFonts.inter(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: color,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildNetResult() {
+    final isGain = _netMonthly > 0;
+    final color = isGain ? MintColors.scoreExcellent : MintColors.scoreCritique;
+    final sign = _netMonthly > 0 ? '−' : '+';
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            isGain ? '✅ Gain net/mois' : '⚠️ Surcoût net/mois',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+          ),
+          Text(
+            '$sign CHF ${_fmt(_netMonthly.abs())}',
+            style: GoogleFonts.montserrat(
+              fontSize: 20,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBreakEven() {
+    if (_netMonthly <= 0 || _breakEvenMonths.isInfinite) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        children: [
+          const Text('📅', style: TextStyle(fontSize: 16)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Frais de déménagement (CHF ${_fmt(movingFees)}) remboursés en '
+              '${_breakEvenMonths.round()} mois.',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : LIFD art. 1, législations cantonales. Chiffres indicatifs — varie selon profil.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/moving_true_cost_widget.dart
+++ b/apps/mobile/lib/widgets/coach/moving_true_cost_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P12-B  Le Vrai coût du déménagement cantonal
@@ -37,16 +38,6 @@ class MovingTrueCostWidget extends StatelessWidget {
   final String toCanton;
   final List<MovingCostItem> items;
   final double movingFees;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _totalBefore => items.fold<double>(0, (s, i) => s + i.monthlyBefore);
   double get _totalAfter => items.fold<double>(0, (s, i) => s + i.monthlyAfter);
@@ -195,7 +186,7 @@ class MovingTrueCostWidget extends StatelessWidget {
                 Expanded(
                   flex: 2,
                   child: Text(
-                    'CHF ${_fmt(item.monthlyBefore)}',
+                    formatChfWithPrefix(item.monthlyBefore),
                     style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
                     textAlign: TextAlign.center,
                   ),
@@ -203,7 +194,7 @@ class MovingTrueCostWidget extends StatelessWidget {
                 Expanded(
                   flex: 2,
                   child: Text(
-                    'CHF ${_fmt(item.monthlyAfter)}',
+                    formatChfWithPrefix(item.monthlyAfter),
                     style: GoogleFonts.inter(
                       fontSize: 12,
                       fontWeight: FontWeight.w700,
@@ -244,7 +235,7 @@ class MovingTrueCostWidget extends StatelessWidget {
             ),
           ),
           Text(
-            '$sign CHF ${_fmt(_netMonthly.abs())}',
+            '$sign ${formatChfWithPrefix(_netMonthly.abs())}',
             style: GoogleFonts.montserrat(
               fontSize: 20,
               fontWeight: FontWeight.w800,
@@ -272,7 +263,7 @@ class MovingTrueCostWidget extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              'Frais de déménagement (CHF ${_fmt(movingFees)}) remboursés en '
+              'Frais de déménagement (${formatChfWithPrefix(movingFees)}) remboursés en '
               '${_breakEvenMonths.round()} mois.',
               style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
             ),

--- a/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
+++ b/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P15-B  Le Calculateur de net réel — vente immobilière
 //  Charte : L1 (CHF/mois) + L2 (Avant/Après)
-//  Source : LIFD art. 12, LPP art. 30c, CO art. 958
+//  Source : LIFD art. 12, LPP art. 30c
 // ────────────────────────────────────────────────────────────
 
 class NetProceedsWidget extends StatefulWidget {
@@ -32,16 +33,6 @@ class NetProceedsWidget extends StatefulWidget {
 
 class _NetProceedsWidgetState extends State<NetProceedsWidget> {
   bool _showDetails = false;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _notaryFees => widget.salePrice * widget.notaryFeeRate;
   double get _agencyFees => widget.salePrice * widget.agencyFeeRate;
@@ -176,11 +167,11 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              'Prix de vente : CHF ${_fmt(widget.salePrice)}',
+              'Prix de vente : ${formatChfWithPrefix(widget.salePrice)}',
               style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
             ),
             Text(
-              'Net : CHF ${_fmt(_netProceeds)}',
+              'Net : ${formatChfWithPrefix(_netProceeds)}',
               style: GoogleFonts.inter(
                 fontSize: 13,
                 fontWeight: FontWeight.w800,
@@ -232,7 +223,7 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
               style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
             ),
             Text(
-              'Déductions : CHF ${_fmt(_totalDeductions)}',
+              'Déductions : ${formatChfWithPrefix(_totalDeductions)}',
               style: GoogleFonts.inter(
                 fontSize: 10,
                 color: MintColors.scoreCritique,
@@ -262,7 +253,7 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Surprise : − CHF ${_fmt(_surprise)}',
+                  'Surprise : − ${formatChfWithPrefix(_surprise)}',
                   style: GoogleFonts.montserrat(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,
@@ -270,7 +261,7 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
                   ),
                 ),
                 Text(
-                  'Tu croyais toucher CHF ${_fmt(_perceivedNet)} — tu touches CHF ${_fmt(_netProceeds)}.',
+                  'Tu croyais toucher ${formatChfWithPrefix(_perceivedNet)} — tu touches ${formatChfWithPrefix(_netProceeds)}.',
                   style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary, height: 1.4),
                 ),
               ],
@@ -337,7 +328,7 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
                       ),
                     ),
                     Text(
-                      '− CHF ${_fmt(d.amount)}',
+                      '− ${formatChfWithPrefix(d.amount)}',
                       style: GoogleFonts.inter(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
+++ b/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
@@ -1,0 +1,368 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P15-B  Le Calculateur de net réel — vente immobilière
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après)
+//  Source : LIFD art. 12, LPP art. 30c, CO art. 958
+// ────────────────────────────────────────────────────────────
+
+class NetProceedsWidget extends StatefulWidget {
+  const NetProceedsWidget({
+    super.key,
+    required this.salePrice,
+    required this.mortgageBalance,
+    required this.capitalGainTax,
+    required this.eplReimbursement,
+    this.notaryFeeRate = 0.015,
+    this.agencyFeeRate = 0.025,
+  });
+
+  final double salePrice;
+  final double mortgageBalance;
+  final double capitalGainTax;
+  final double eplReimbursement;
+  final double notaryFeeRate;
+  final double agencyFeeRate;
+
+  @override
+  State<NetProceedsWidget> createState() => _NetProceedsWidgetState();
+}
+
+class _NetProceedsWidgetState extends State<NetProceedsWidget> {
+  bool _showDetails = false;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _notaryFees => widget.salePrice * widget.notaryFeeRate;
+  double get _agencyFees => widget.salePrice * widget.agencyFeeRate;
+  double get _totalDeductions =>
+      widget.mortgageBalance +
+      widget.capitalGainTax +
+      widget.eplReimbursement +
+      _notaryFees +
+      _agencyFees;
+  double get _netProceeds => (widget.salePrice - _totalDeductions).clamp(0, double.infinity);
+  double get _perceivedNet => widget.salePrice - widget.mortgageBalance;
+  double get _surprise => _perceivedNet - _netProceeds;
+
+  List<({String label, double amount, String ref, Color color})> get _deductions => [
+    (
+      label: 'Hypothèque remboursée',
+      amount: widget.mortgageBalance,
+      ref: 'Banque',
+      color: MintColors.textSecondary,
+    ),
+    (
+      label: 'Impôt sur le gain',
+      amount: widget.capitalGainTax,
+      ref: 'LIFD art. 12',
+      color: MintColors.scoreAttention,
+    ),
+    (
+      label: 'Remboursement EPL',
+      amount: widget.eplReimbursement,
+      ref: 'LPP art. 30c',
+      color: MintColors.scoreCritique,
+    ),
+    (
+      label: 'Frais de notaire',
+      amount: _notaryFees,
+      ref: '${(widget.notaryFeeRate * 100).toStringAsFixed(1)}% prix',
+      color: MintColors.scoreAttention,
+    ),
+    (
+      label: 'Commission agence',
+      amount: _agencyFees,
+      ref: '${(widget.agencyFeeRate * 100).toStringAsFixed(1)}% prix',
+      color: MintColors.scoreAttention,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Net réel vente immobilière calculateur cascade déductions',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildWaterfallChart(),
+                  const SizedBox(height: 16),
+                  _buildSurprise(),
+                  const SizedBox(height: 12),
+                  _buildToggleDetails(),
+                  if (_showDetails) ...[
+                    const SizedBox(height: 12),
+                    _buildDetailList(),
+                  ],
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF3E0),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('💰', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ton net réel',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                Text(
+                  '"30% en dessous de ce que tu imagines."',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWaterfallChart() {
+    final ratio = widget.salePrice > 0 ? _netProceeds / widget.salePrice : 0.0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Prix de vente : CHF ${_fmt(widget.salePrice)}',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+            ),
+            Text(
+              'Net : CHF ${_fmt(_netProceeds)}',
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                color: MintColors.scoreExcellent,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Stack(
+            children: [
+              Container(
+                height: 24,
+                decoration: BoxDecoration(
+                  color: MintColors.scoreCritique.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              FractionallySizedBox(
+                widthFactor: ratio.clamp(0.0, 1.0),
+                child: Container(
+                  height: 24,
+                  decoration: BoxDecoration(
+                    color: MintColors.scoreExcellent,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    '${(ratio * 100).round()}%',
+                    style: GoogleFonts.inter(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w800,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'CHF 0',
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            ),
+            Text(
+              'Déductions : CHF ${_fmt(_totalDeductions)}',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.scoreCritique,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSurprise() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          const Text('😱', style: TextStyle(fontSize: 24)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Surprise : − CHF ${_fmt(_surprise)}',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                Text(
+                  'Tu croyais toucher CHF ${_fmt(_perceivedNet)} — tu touches CHF ${_fmt(_netProceeds)}.',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary, height: 1.4),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToggleDetails() {
+    return GestureDetector(
+      onTap: () => setState(() => _showDetails = !_showDetails),
+      child: Row(
+        children: [
+          Text(
+            _showDetails ? 'Masquer le détail' : 'Voir le détail des déductions',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: MintColors.primary,
+            ),
+          ),
+          Icon(
+            _showDetails ? Icons.expand_less : Icons.expand_more,
+            color: MintColors.primary,
+            size: 18,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetailList() {
+    return Container(
+      decoration: BoxDecoration(
+        color: MintColors.appleSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.lightBorder),
+      ),
+      child: Column(
+        children: _deductions.asMap().entries.map((e) {
+          final d = e.value;
+          return Column(
+            children: [
+              if (e.key > 0) const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            d.label,
+                            style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary),
+                          ),
+                          Text(
+                            d.ref,
+                            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Text(
+                      '− CHF ${_fmt(d.amount)}',
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: d.color,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : LIFD art. 12 (gain), LPP art. 30c (EPL). Chiffres indicatifs.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/ninety_day_plan_widget.dart
+++ b/apps/mobile/lib/widgets/coach/ninety_day_plan_widget.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  NINETY DAY PLAN WIDGET — P6-B / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Checklist de survie pour un·e indépendant·e en 4 phases.
+//  Chaque phase a un délai et des conséquences.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L5 (une action) + L4 (raconte, ne montre pas)
+// ────────────────────────────────────────────────────────────
+
+/// Single action item in the 90-day plan.
+class PlanAction {
+  final String label;
+  final String? consequence;
+  final String? legalRef;
+  final bool isCompleted;
+
+  const PlanAction({
+    required this.label,
+    this.consequence,
+    this.legalRef,
+    this.isCompleted = false,
+  });
+}
+
+/// One phase in the 90-day plan.
+class PlanPhase {
+  final String title;
+  final String emoji;
+  final String deadline;
+  final Color urgencyColor;
+  final List<PlanAction> actions;
+
+  const PlanPhase({
+    required this.title,
+    required this.emoji,
+    required this.deadline,
+    required this.urgencyColor,
+    required this.actions,
+  });
+}
+
+class NinetyDayPlanWidget extends StatelessWidget {
+  final List<PlanPhase> phases;
+  final int completedCount;
+  final int totalCount;
+
+  const NinetyDayPlanWidget({
+    super.key,
+    required this.phases,
+    this.completedCount = 0,
+    this.totalCount = 0,
+  });
+
+  int get _total =>
+      totalCount > 0 ? totalCount : phases.fold(0, (s, p) => s + p.actions.length);
+  int get _done =>
+      completedCount > 0 ? completedCount : phases.fold(
+          0, (s, p) => s + p.actions.where((a) => a.isCompleted).length);
+
+  @override
+  Widget build(BuildContext context) {
+    if (phases.isEmpty) return const SizedBox.shrink();
+
+    return Semantics(
+      label: 'Plan 90 jours ind\u00e9pendant. $_done sur $_total actions compl\u00e9t\u00e9es.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header ──
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Plan 90 jours \u2014 Checklist de survie',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: MintColors.primary.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '$_done/$_total',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: MintColors.primary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Les 90 premiers jours d\u00e9finissent ta protection',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // ── Progress bar ──
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: SizedBox(
+                height: 6,
+                child: Stack(
+                  children: [
+                    Container(
+                      width: double.infinity,
+                      color: MintColors.surface,
+                    ),
+                    FractionallySizedBox(
+                      widthFactor: _total > 0 ? _done / _total : 0,
+                      child: Container(color: MintColors.scoreExcellent),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // ── Phases ──
+            ...phases.asMap().entries.map((e) => _buildPhase(e.key, e.value)),
+
+            const SizedBox(height: 12),
+            Text(
+              'R\u00e9f\u00e9rences\u00a0: LEI, LAVS art. 12, LACI, LAA art. 4. '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPhase(int index, PlanPhase phase) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: index < phases.length - 1 ? 14 : 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Phase header
+          Row(
+            children: [
+              Text(phase.emoji, style: const TextStyle(fontSize: 18)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  phase.title,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: phase.urgencyColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  phase.deadline,
+                  style: GoogleFonts.inter(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: phase.urgencyColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          // Action items
+          ...phase.actions.map(_buildAction),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAction(PlanAction action) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 30, bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            action.isCompleted
+                ? Icons.check_circle
+                : Icons.radio_button_unchecked,
+            size: 16,
+            color: action.isCompleted
+                ? MintColors.scoreExcellent
+                : MintColors.textMuted,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  action.label,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textPrimary,
+                    decoration: action.isCompleted
+                        ? TextDecoration.lineThrough
+                        : null,
+                  ),
+                ),
+                if (action.consequence != null)
+                  Text(
+                    action.consequence!,
+                    style: GoogleFonts.inter(
+                      fontSize: 10,
+                      color: MintColors.scoreCritique,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/payslip_xray_widget.dart
+++ b/apps/mobile/lib/widgets/coach/payslip_xray_widget.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  PAYSLIP X-RAY WIDGET — P5-C / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Reproduction visuelle d'une fiche de paie suisse.
+//  Tap sur chaque ligne → explication en une phrase.
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L1 (CHF/mois) + L4 (raconte, ne montre pas)
+// ────────────────────────────────────────────────────────────
+
+/// Single deduction line on the payslip.
+class PayslipLine {
+  final String label;
+  final String emoji;
+  final double amount;
+  final double percentage;
+  final String explanation;
+  final String? legalRef;
+
+  const PayslipLine({
+    required this.label,
+    required this.emoji,
+    required this.amount,
+    required this.percentage,
+    required this.explanation,
+    this.legalRef,
+  });
+}
+
+class PayslipXRayWidget extends StatefulWidget {
+  final double grossSalary;
+  final double netSalary;
+  final List<PayslipLine> deductions;
+  final double? employerHiddenCost;
+
+  const PayslipXRayWidget({
+    super.key,
+    required this.grossSalary,
+    required this.netSalary,
+    required this.deductions,
+    this.employerHiddenCost,
+  });
+
+  @override
+  State<PayslipXRayWidget> createState() => _PayslipXRayWidgetState();
+}
+
+class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
+  int? _expandedIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Radiographie fiche de paie. '
+          'Brut\u00a0: ${formatChfWithPrefix(widget.grossSalary)}, '
+          'Net\u00a0: ${formatChfWithPrefix(widget.netSalary)}.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Radiographie de ta fiche de paie',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Tape sur chaque ligne pour comprendre',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // ── Gross ──
+            _buildHeaderLine('Salaire brut', widget.grossSalary, true),
+            const Divider(height: 16),
+
+            // ── Deductions ──
+            ...widget.deductions.asMap().entries.map((e) =>
+                _buildDeductionLine(e.key, e.value)),
+
+            const Divider(height: 16),
+
+            // ── Net ──
+            _buildHeaderLine('Salaire net', widget.netSalary, false),
+
+            // ── Employer hidden cost ──
+            if (widget.employerHiddenCost != null) ...[
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: MintColors.primary.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: MintColors.primary.withValues(alpha: 0.15),
+                    style: BorderStyle.solid,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Text('\ud83d\udca1',
+                        style: const TextStyle(fontSize: 16)),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Ton vrai salaire\u00a0: '
+                        '${formatChfWithPrefix(widget.employerHiddenCost!)} '
+                        '(cotisations employeur incluses)',
+                        style: GoogleFonts.inter(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: MintColors.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+
+            const SizedBox(height: 12),
+            Text(
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeaderLine(String label, double amount, bool isGross) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: GoogleFonts.montserrat(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+        ),
+        Text(
+          formatChfWithPrefix(amount),
+          style: GoogleFonts.montserrat(
+            fontSize: 16,
+            fontWeight: FontWeight.w800,
+            color: isGross ? MintColors.textPrimary : MintColors.scoreExcellent,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDeductionLine(int index, PayslipLine line) {
+    final isExpanded = _expandedIndex == index;
+
+    return GestureDetector(
+      onTap: () => setState(() {
+        _expandedIndex = isExpanded ? null : index;
+      }),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 8),
+        margin: const EdgeInsets.only(bottom: 4),
+        decoration: BoxDecoration(
+          color: isExpanded
+              ? MintColors.primary.withValues(alpha: 0.04)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(line.emoji, style: const TextStyle(fontSize: 16)),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '${line.label} (${line.percentage.toStringAsFixed(1)}%)',
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                ),
+                Text(
+                  '-${formatChfWithPrefix(line.amount)}',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                Icon(
+                  isExpanded ? Icons.expand_less : Icons.expand_more,
+                  size: 16,
+                  color: MintColors.textMuted,
+                ),
+              ],
+            ),
+            if (isExpanded) ...[
+              const SizedBox(height: 6),
+              Padding(
+                padding: const EdgeInsets.only(left: 24),
+                child: Text(
+                  line.explanation +
+                      (line.legalRef != null ? ' (${line.legalRef})' : ''),
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/prix_du_silence_widget.dart
+++ b/apps/mobile/lib/widgets/coach/prix_du_silence_widget.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P8-B  Le Prix du silence — Concubin vs Marié·e
+//  Charte : L1 (CHF/mois) + L2 (Avant/Après)
+//  Source : CC art. 462, LHID impôt succession cantonal
+// ────────────────────────────────────────────────────────────
+
+class PrixDuSilenceWidget extends StatelessWidget {
+  const PrixDuSilenceWidget({
+    super.key,
+    required this.patrimoine,
+    required this.marriedTaxRate,
+    required this.concubinTaxRate,
+  });
+
+  final double patrimoine;
+  final double marriedTaxRate;   // typically 0%
+  final double concubinTaxRate;  // typically 24%
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final marriedTax = patrimoine * marriedTaxRate / 100;
+    final concubinTax = patrimoine * concubinTaxRate / 100;
+    final silence = concubinTax - marriedTax;
+    final testamentCost = 500.0;
+
+    return Semantics(
+      label: 'Prix du silence succession concubin marié comparaison',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(silence),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildPatrimoineChip(),
+                  const SizedBox(height: 20),
+                  _buildComparisonRow('Marié·e', marriedTax, MintColors.scoreExcellent, '💍'),
+                  const SizedBox(height: 12),
+                  _buildComparisonRow('Concubin·e', concubinTax, MintColors.scoreCritique, '🏠'),
+                  const SizedBox(height: 16),
+                  _buildSilenceImpact(silence, testamentCost),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(double silence) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFCE4EC),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🤫', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Le prix du silence',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Ce que ton statut marital coûte — ou économise — à ta succession.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPatrimoineChip() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.account_balance_outlined, color: MintColors.info, size: 18),
+          const SizedBox(width: 10),
+          Text(
+            'Patrimoine transmis : CHF ${_fmt(patrimoine)}',
+            style: GoogleFonts.inter(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: MintColors.info,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComparisonRow(String label, double tax, Color color, String emoji) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 22)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+                Text(
+                  'Impôt succession : ${tax == 0 ? "0" : _fmt(tax)} CHF',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            tax == 0 ? '0 CHF' : '-CHF ${_fmt(tax)}',
+            style: GoogleFonts.montserrat(
+              fontSize: 20,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSilenceImpact(double silence, double testamentCost) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '💡 Le silence te coûte CHF ${_fmt(silence)}',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Un testament coûte ~CHF ${_fmt(testamentCost)}. '
+            'La différence : CHF ${_fmt(silence - testamentCost)}.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textPrimary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '→ Action : Prends rendez-vous chez un·e notaire.',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CC art. 462, LHID. Taux varient selon canton et lien de parenté.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/remploi_countdown_widget.dart
+++ b/apps/mobile/lib/widgets/coach/remploi_countdown_widget.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P15-C  Le Chrono du remploi — 2 ans pour racheter
+//  Charte : L5 (1 action) + L7 (Métaphore chrono)
+//  Source : LIFD art. 12 al. 3 (remploi résidence principale)
+// ────────────────────────────────────────────────────────────
+
+class RemploiCountdownWidget extends StatefulWidget {
+  const RemploiCountdownWidget({
+    super.key,
+    required this.saleDate,
+    required this.deferredTax,
+  });
+
+  final DateTime saleDate;
+  final double deferredTax;
+
+  @override
+  State<RemploiCountdownWidget> createState() => _RemploiCountdownWidgetState();
+}
+
+class _RemploiCountdownWidgetState extends State<RemploiCountdownWidget> {
+  static const _remploidDeadlineYears = 2;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  DateTime get _deadline {
+    return DateTime(
+      widget.saleDate.year + _remploidDeadlineYears,
+      widget.saleDate.month,
+      widget.saleDate.day,
+    );
+  }
+
+  int get _totalDays => _deadline.difference(widget.saleDate).inDays;
+  int get _daysElapsed => DateTime.now().difference(widget.saleDate).inDays.clamp(0, _totalDays);
+  int get _daysRemaining => (_totalDays - _daysElapsed).clamp(0, _totalDays);
+  int get _monthsRemaining => (_daysRemaining / 30.44).floor();
+  double get _fraction => _totalDays > 0 ? _daysElapsed / _totalDays : 0;
+
+  Color get _urgencyColor {
+    if (_fraction < 0.5) return MintColors.scoreExcellent;
+    if (_fraction < 0.75) return MintColors.scoreAttention;
+    return MintColors.scoreCritique;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isExpired = _daysRemaining == 0;
+
+    return Semantics(
+      label: 'Compte à rebours remploi vente immobilière 2 ans LIFD',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(isExpired),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildTimer(isExpired),
+                  const SizedBox(height: 16),
+                  _buildProgressBar(),
+                  const SizedBox(height: 16),
+                  _buildExplanation(isExpired),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(bool isExpired) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: isExpired
+            ? MintColors.scoreCritique.withValues(alpha: 0.1)
+            : const Color(0xFFFFF3E0),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          Text(isExpired ? '⛔' : '⏱️', style: const TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Chrono du remploi',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                Text(
+                  isExpired
+                      ? 'Délai écoulé — l\'impôt est dû.'
+                      : 'Tu as ${_remploidDeadlineYears} ans pour racheter une résidence principale.',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary, height: 1.4),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimer(bool isExpired) {
+    if (isExpired) {
+      return Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.scoreCritique.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.3)),
+        ),
+        child: Column(
+          children: [
+            Text(
+              '0',
+              style: GoogleFonts.montserrat(
+                fontSize: 48,
+                fontWeight: FontWeight.w900,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+            Text(
+              'jours restants',
+              style: GoogleFonts.inter(fontSize: 14, color: MintColors.textSecondary),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Impôt dû : CHF ${_fmt(widget.deferredTax)}',
+              style: GoogleFonts.montserrat(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        Expanded(child: _buildTimerCard('$_daysRemaining', 'jours restants', _urgencyColor)),
+        const SizedBox(width: 12),
+        Expanded(child: _buildTimerCard('$_monthsRemaining', 'mois environ', MintColors.primary)),
+        const SizedBox(width: 12),
+        Expanded(child: _buildTimerCard(
+          'CHF ${_fmt(widget.deferredTax)}',
+          'impôt à éviter',
+          MintColors.scoreAttention,
+        )),
+      ],
+    );
+  }
+
+  Widget _buildTimerCard(String value, String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        children: [
+          Text(
+            value,
+            style: GoogleFonts.montserrat(
+              fontSize: value.length > 6 ? 14 : 22,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          Text(
+            label,
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProgressBar() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Vente : ${_formatDate(widget.saleDate)}',
+              style: GoogleFonts.inter(fontSize: 11, color: MintColors.textSecondary),
+            ),
+            Text(
+              'Délai : ${_formatDate(_deadline)}',
+              style: GoogleFonts.inter(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: _urgencyColor,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: LinearProgressIndicator(
+            value: _fraction,
+            minHeight: 12,
+            backgroundColor: _urgencyColor.withValues(alpha: 0.15),
+            valueColor: AlwaysStoppedAnimation<Color>(_urgencyColor),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          '$_daysElapsed jours écoulés sur $_totalDays',
+          style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildExplanation(bool isExpired) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: (isExpired ? MintColors.scoreCritique : MintColors.info).withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: (isExpired ? MintColors.scoreCritique : MintColors.info).withValues(alpha: 0.2),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(isExpired ? '⚠️' : '💡', style: const TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              isExpired
+                  ? 'Le délai de remploi est dépassé. L\'impôt sur le gain de '
+                    'CHF ${_fmt(widget.deferredTax)} est dû. Contacte l\'administration fiscale cantonale.'
+                  : 'Si tu achètes une nouvelle résidence principale avant le ${_formatDate(_deadline)}, '
+                    'l\'impôt de CHF ${_fmt(widget.deferredTax)} est différé. '
+                    'LIFD art. 12 al. 3.',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime d) {
+    return '${d.day.toString().padLeft(2, '0')}.${d.month.toString().padLeft(2, '0')}.${d.year}';
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : LIFD art. 12 al. 3 (remploi résidence principale). '
+      'Délai de 2 ans — vérifier les règles cantonales spécifiques.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/remploi_countdown_widget.dart
+++ b/apps/mobile/lib/widgets/coach/remploi_countdown_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P15-C  Le Chrono du remploi — 2 ans pour racheter
@@ -24,16 +25,6 @@ class RemploiCountdownWidget extends StatefulWidget {
 
 class _RemploiCountdownWidgetState extends State<RemploiCountdownWidget> {
   static const _remploidDeadlineYears = 2;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   DateTime get _deadline {
     return DateTime(
@@ -157,7 +148,7 @@ class _RemploiCountdownWidgetState extends State<RemploiCountdownWidget> {
             ),
             const SizedBox(height: 8),
             Text(
-              'Impôt dû : CHF ${_fmt(widget.deferredTax)}',
+              'Impôt dû : ${formatChfWithPrefix(widget.deferredTax)}',
               style: GoogleFonts.montserrat(
                 fontSize: 18,
                 fontWeight: FontWeight.w800,
@@ -176,7 +167,7 @@ class _RemploiCountdownWidgetState extends State<RemploiCountdownWidget> {
         Expanded(child: _buildTimerCard('$_monthsRemaining', 'mois environ', MintColors.primary)),
         const SizedBox(width: 12),
         Expanded(child: _buildTimerCard(
-          'CHF ${_fmt(widget.deferredTax)}',
+          formatChfWithPrefix(widget.deferredTax),
           'impôt à éviter',
           MintColors.scoreAttention,
         )),
@@ -272,9 +263,9 @@ class _RemploiCountdownWidgetState extends State<RemploiCountdownWidget> {
             child: Text(
               isExpired
                   ? 'Le délai de remploi est dépassé. L\'impôt sur le gain de '
-                    'CHF ${_fmt(widget.deferredTax)} est dû. Contacte l\'administration fiscale cantonale.'
+                    '${formatChfWithPrefix(widget.deferredTax)} est dû. Contacte l\'administration fiscale cantonale.'
                   : 'Si tu achètes une nouvelle résidence principale avant le ${_formatDate(_deadline)}, '
-                    'l\'impôt de CHF ${_fmt(widget.deferredTax)} est différé. '
+                    'l\'impôt de ${formatChfWithPrefix(widget.deferredTax)} est différé. '
                     'LIFD art. 12 al. 3.',
               style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
             ),

--- a/apps/mobile/lib/widgets/coach/sale_surprises_widget.dart
+++ b/apps/mobile/lib/widgets/coach/sale_surprises_widget.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P15-A  Les 3 surprises de la vente immobilière
+//  Charte : L6 (Chiffre-choc) + L4 (Raconte)
+//  Source : LIFD art. 12 (impôt gain immobilier), LPP art. 30c (EPL)
+// ────────────────────────────────────────────────────────────
+
+class SaleSurprisesWidget extends StatelessWidget {
+  const SaleSurprisesWidget({
+    super.key,
+    required this.salePrice,
+    required this.purchasePrice,
+    required this.eplWithdrawn,
+    required this.holdingYears,
+    this.canton = 'Vaud',
+  });
+
+  final double salePrice;
+  final double purchasePrice;
+  final double eplWithdrawn;
+  final int holdingYears;
+  final String canton;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _capitalGain => (salePrice - purchasePrice).clamp(0, double.infinity);
+
+  // Approximate: gain tax decreases with holding years, roughly 0.5% per year after 5 years
+  double get _gainTaxRate {
+    if (holdingYears < 2) return 0.35;
+    if (holdingYears < 5) return 0.30;
+    if (holdingYears < 10) return 0.25;
+    if (holdingYears < 15) return 0.18;
+    if (holdingYears < 20) return 0.12;
+    return 0.08;
+  }
+
+  double get _gainTax => _capitalGain * _gainTaxRate;
+  double get _eplReturn => eplWithdrawn; // must reimburse 3a/LPP withdrawn
+  double get _notaryFees => salePrice * 0.015;
+  double get _mortgage => salePrice * 0.60; // typical
+  double get _netReal =>
+      salePrice - _mortgage - _gainTax - _eplReturn - _notaryFees;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Surprises vente immobilière impôt gain capital EPL remploi',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildActs(),
+                  const SizedBox(height: 16),
+                  _buildNetCascade(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFFFF3E0),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🏠', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Les 3 surprises de la vente',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Tu vends CHF ${_fmt(salePrice)}. Tu penses toucher CHF ${_fmt(_netReal + _gainTax)}. '
+            'Tu reçois CHF ${_fmt(_netReal)}.',
+            style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary, height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActs() {
+    final acts = [
+      (
+        number: 'Acte 1',
+        emoji: '📊',
+        title: 'Impôt sur le gain en capital',
+        detail:
+            'Plus-value de CHF ${_fmt(_capitalGain)} × ${(_gainTaxRate * 100).toStringAsFixed(0)}% ($holdingYears ans de détention à $canton).',
+        amount: _gainTax,
+        color: MintColors.scoreAttention,
+        ref: 'LIFD art. 12',
+      ),
+      (
+        number: 'Acte 2',
+        emoji: '🏦',
+        title: 'Remboursement EPL obligatoire',
+        detail:
+            'Tu as retiré CHF ${_fmt(eplWithdrawn)} de ton LPP via l\'EPL. '
+            'La vente oblige le remboursement intégral.',
+        amount: eplWithdrawn,
+        color: MintColors.scoreCritique,
+        ref: 'LPP art. 30c',
+      ),
+      (
+        number: 'Acte 3',
+        emoji: '⏰',
+        title: 'Remploi — 2 ans pour racheter',
+        detail:
+            'Si tu ne rachètes pas dans les 2 ans, l\'impôt sur le gain n\'est pas différé. '
+            'Tu dois CHF ${_fmt(_gainTax)}.',
+        amount: _gainTax,
+        color: MintColors.scoreCritique,
+        ref: 'LIFD art. 12 al. 3',
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: acts.map((act) => Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: act.color.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: act.color.withValues(alpha: 0.25)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: act.color,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      act.number,
+                      style: GoogleFonts.inter(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w800,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(act.emoji, style: const TextStyle(fontSize: 16)),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      act.title,
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    '− CHF ${_fmt(act.amount)}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w800,
+                      color: act.color,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                act.detail,
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  color: MintColors.textSecondary,
+                  height: 1.4,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                act.ref,
+                style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+              ),
+            ],
+          ),
+        ),
+      )).toList(),
+    );
+  }
+
+  Widget _buildNetCascade() {
+    return Container(
+      decoration: BoxDecoration(
+        color: MintColors.appleSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.lightBorder),
+      ),
+      child: Column(
+        children: [
+          _buildCascadeRow('Prix de vente', salePrice, isPositive: true),
+          _buildCascadeRow('− Hypothèque', _mortgage, isPositive: false),
+          _buildCascadeRow('− Impôt gain', _gainTax, isPositive: false),
+          _buildCascadeRow('− EPL remboursé', _eplReturn, isPositive: false),
+          _buildCascadeRow('− Frais notaire', _notaryFees, isPositive: false),
+          const Divider(height: 1, thickness: 2),
+          _buildCascadeRow('= Net réel', _netReal, isPositive: true, isTotal: true),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCascadeRow(String label, double amount, {
+    required bool isPositive,
+    bool isTotal = false,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: isTotal ? 14 : 12,
+              fontWeight: isTotal ? FontWeight.w800 : FontWeight.w400,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          Text(
+            'CHF ${_fmt(amount)}',
+            style: GoogleFonts.montserrat(
+              fontSize: isTotal ? 18 : 13,
+              fontWeight: FontWeight.w800,
+              color: isTotal
+                  ? (_netReal > 0 ? MintColors.scoreExcellent : MintColors.scoreCritique)
+                  : (isPositive ? MintColors.scoreExcellent : MintColors.scoreCritique),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : LIFD art. 12 (impôt gain immobilier), LPP art. 30c (EPL). '
+      'Taux gain indicatif pour $canton, $holdingYears ans de détention.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/sale_surprises_widget.dart
+++ b/apps/mobile/lib/widgets/coach/sale_surprises_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P15-A  Les 3 surprises de la vente immobilière
@@ -23,16 +24,6 @@ class SaleSurprisesWidget extends StatelessWidget {
   final double eplWithdrawn;
   final int holdingYears;
   final String canton;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _capitalGain => (salePrice - purchasePrice).clamp(0, double.infinity);
 
@@ -114,8 +105,8 @@ class SaleSurprisesWidget extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            'Tu vends CHF ${_fmt(salePrice)}. Tu penses toucher CHF ${_fmt(_netReal + _gainTax)}. '
-            'Tu reçois CHF ${_fmt(_netReal)}.',
+            'Tu vends ${formatChfWithPrefix(salePrice)}. Tu penses toucher ${formatChfWithPrefix(_netReal + _gainTax)}. '
+            'Tu reçois ${formatChfWithPrefix(_netReal)}.',
             style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary, height: 1.4),
           ),
         ],
@@ -130,7 +121,7 @@ class SaleSurprisesWidget extends StatelessWidget {
         emoji: '📊',
         title: 'Impôt sur le gain en capital',
         detail:
-            'Plus-value de CHF ${_fmt(_capitalGain)} × ${(_gainTaxRate * 100).toStringAsFixed(0)}% ($holdingYears ans de détention à $canton).',
+            'Plus-value de ${formatChfWithPrefix(_capitalGain)} × ${(_gainTaxRate * 100).toStringAsFixed(0)}% ($holdingYears ans de détention à $canton).',
         amount: _gainTax,
         color: MintColors.scoreAttention,
         ref: 'LIFD art. 12',
@@ -140,7 +131,7 @@ class SaleSurprisesWidget extends StatelessWidget {
         emoji: '🏦',
         title: 'Remboursement EPL obligatoire',
         detail:
-            'Tu as retiré CHF ${_fmt(eplWithdrawn)} de ton LPP via l\'EPL. '
+            'Tu as retiré ${formatChfWithPrefix(eplWithdrawn)} de ton LPP via l\'EPL. '
             'La vente oblige le remboursement intégral.',
         amount: eplWithdrawn,
         color: MintColors.scoreCritique,
@@ -152,7 +143,7 @@ class SaleSurprisesWidget extends StatelessWidget {
         title: 'Remploi — 2 ans pour racheter',
         detail:
             'Si tu ne rachètes pas dans les 2 ans, l\'impôt sur le gain n\'est pas différé. '
-            'Tu dois CHF ${_fmt(_gainTax)}.',
+            'Tu dois ${formatChfWithPrefix(_gainTax)}.',
         amount: _gainTax,
         color: MintColors.scoreCritique,
         ref: 'LIFD art. 12 al. 3',
@@ -204,7 +195,7 @@ class SaleSurprisesWidget extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    '− CHF ${_fmt(act.amount)}',
+                    '− ${formatChfWithPrefix(act.amount)}',
                     style: GoogleFonts.montserrat(
                       fontSize: 14,
                       fontWeight: FontWeight.w800,
@@ -273,7 +264,7 @@ class SaleSurprisesWidget extends StatelessWidget {
             ),
           ),
           Text(
-            'CHF ${_fmt(amount)}',
+            formatChfWithPrefix(amount),
             style: GoogleFonts.montserrat(
               fontSize: isTotal ? 18 : 13,
               fontWeight: FontWeight.w800,

--- a/apps/mobile/lib/widgets/coach/survivor_pension_widget.dart
+++ b/apps/mobile/lib/widgets/coach/survivor_pension_widget.dart
@@ -1,0 +1,308 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P14-B  Les Rentes de survivant — mariage vs concubinage
+//  Charte : L1 (CHF/mois) + L6 (Chiffre-choc)
+//  Source : LAVS art. 23-24 (rente veuf/veuve), LPP art. 19
+// ────────────────────────────────────────────────────────────
+
+class SurvivorPensionWidget extends StatelessWidget {
+  const SurvivorPensionWidget({
+    super.key,
+    required this.partnerAvsRente,
+    required this.partnerLppMonthly,
+    this.isConcubin = true,
+  });
+
+  final double partnerAvsRente;
+  final double partnerLppMonthly;
+  final bool isConcubin;
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  double get _avsMarried => partnerAvsRente * avsSurvivorFactor; // 80%
+  double get _lppMarried => partnerLppMonthly * 0.60; // 60% — LPP art. 19 al. 2
+  double get _totalMarried => _avsMarried + _lppMarried;
+
+  // Concubin: 0 AVS, LPP only if explicitly named
+  double get _avsConcubin => 0;
+  double get _lppConcubin => 0; // default: not named
+  double get _totalConcubin => _avsConcubin + _lppConcubin;
+
+  double get _marriageBonus => _totalMarried - _totalConcubin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Rente survivant mariage concubin décès LAVS LPP comparaison',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildComparison(),
+                  const SizedBox(height: 16),
+                  _buildChiffreChoc(),
+                  const SizedBox(height: 16),
+                  _buildDetailRows(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFECEFF1),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Row(
+        children: [
+          const Text('🏛️', style: TextStyle(fontSize: 22)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Rentes de survivant',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Si ton·ta partenaire décède — combien touches-tu ?',
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildComparison() {
+    return Row(
+      children: [
+        Expanded(child: _buildScenarioCard(
+          emoji: '💍',
+          label: 'Marié·e',
+          total: _totalMarried,
+          color: MintColors.scoreExcellent,
+          detail: '80% AVS + 60% LPP',
+        )),
+        const SizedBox(width: 12),
+        Expanded(child: _buildScenarioCard(
+          emoji: '🏠',
+          label: 'Concubin·e',
+          total: _totalConcubin,
+          color: MintColors.scoreCritique,
+          detail: '0 CHF si pas de désignation',
+        )),
+      ],
+    );
+  }
+
+  Widget _buildScenarioCard({
+    required String emoji,
+    required String label,
+    required double total,
+    required Color color,
+    required String detail,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 22)),
+          const SizedBox(height: 6),
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'CHF ${_fmt(total)}/mois',
+            style: GoogleFonts.montserrat(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            detail,
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary, height: 1.3),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('⚠️', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Le mariage vaut CHF ${_fmt(_marriageBonus)}/mois de rente survivant',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Concubin·e sans désignation LPP ni testament = 0 CHF automatique. '
+                  'LAVS art. 23 : seul·e le·la conjoint·e légal·e a droit à la rente de veuf/veuve.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetailRows() {
+    return Container(
+      decoration: BoxDecoration(
+        color: MintColors.appleSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.lightBorder),
+      ),
+      child: Column(
+        children: [
+          _buildDetailRow('AVS rente veuf/veuve (80%)', _avsMarried, 'LAVS art. 23', true),
+          const Divider(height: 1),
+          _buildDetailRow('LPP rente partenaire (60%)', _lppMarried, 'LPP art. 19', true),
+          const Divider(height: 1),
+          _buildDetailRow(
+            'AVS concubin·e',
+            0,
+            'Non applicable',
+            false,
+          ),
+          const Divider(height: 1),
+          _buildDetailRow(
+            'LPP sans désignation',
+            0,
+            'Exige désignation explicite',
+            false,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDetailRow(String label, double amount, String ref, bool isMarried) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      child: Row(
+        children: [
+          Text(
+            isMarried ? '💍' : '🏠',
+            style: const TextStyle(fontSize: 14),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary),
+                ),
+                Text(
+                  ref,
+                  style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            amount > 0 ? 'CHF ${_fmt(amount)}' : '0 CHF',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: amount > 0 ? MintColors.scoreExcellent : MintColors.scoreCritique,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LAVS art. 23-24 (rente veuf/veuve), LPP art. 19 (rente partenaire). '
+      'Taux AVS survivant : ${(avsSurvivorFactor * 100).toInt()}%.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/survivor_pension_widget.dart
+++ b/apps/mobile/lib/widgets/coach/survivor_pension_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P14-B  Les Rentes de survivant — mariage vs concubinage
@@ -20,16 +21,6 @@ class SurvivorPensionWidget extends StatelessWidget {
   final double partnerAvsRente;
   final double partnerLppMonthly;
   final bool isConcubin;
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
 
   double get _avsMarried => partnerAvsRente * avsSurvivorFactor; // 80%
   double get _lppMarried => partnerLppMonthly * 0.60; // 60% — LPP art. 19 al. 2
@@ -164,7 +155,7 @@ class SurvivorPensionWidget extends StatelessWidget {
           ),
           const SizedBox(height: 4),
           Text(
-            'CHF ${_fmt(total)}/mois',
+            '${formatChfWithPrefix(total)}/mois',
             style: GoogleFonts.montserrat(
               fontSize: 18,
               fontWeight: FontWeight.w800,
@@ -199,7 +190,7 @@ class SurvivorPensionWidget extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Le mariage vaut CHF ${_fmt(_marriageBonus)}/mois de rente survivant',
+                  'Le mariage vaut ${formatChfWithPrefix(_marriageBonus)}/mois de rente survivant',
                   style: GoogleFonts.inter(
                     fontSize: 13,
                     fontWeight: FontWeight.w700,
@@ -281,7 +272,7 @@ class SurvivorPensionWidget extends StatelessWidget {
             ),
           ),
           Text(
-            amount > 0 ? 'CHF ${_fmt(amount)}' : '0 CHF',
+            amount > 0 ? formatChfWithPrefix(amount) : '0 CHF',
             style: GoogleFonts.inter(
               fontSize: 13,
               fontWeight: FontWeight.w700,

--- a/apps/mobile/lib/widgets/coach/testament_invisible_widget.dart
+++ b/apps/mobile/lib/widgets/coach/testament_invisible_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P8-A  Le Testament invisible — sans vs avec testament
@@ -33,16 +34,6 @@ class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
     _status = widget.initialStatus;
   }
 
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
-  }
-
   // Returns (partnerShare%, inheritanceTaxRate%, withTestamentNote)
   ({double partnerPct, double taxRate, String withNote, String withoutNote}) _calc(FamilyStatus s) {
     return switch (s) {
@@ -58,11 +49,12 @@ class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
         withNote: 'Clause bénéficiaire 3a + testament indispensables.',
         withoutNote: 'Ton partenaire hérite 0%. L\'État ou tes parents touchent tout.',
       ),
+      // CC reform 2022 : partenaire enregistré·e = droits équivalents au conjoint
       FamilyStatus.couple => (
-        partnerPct: 25,
-        taxRate: 12,
-        withNote: 'Testament peut porter la part jusqu\'à 50%.',
-        withoutNote: 'Part légale limitée à 25%. Impôt jusqu\'à 12%.',
+        partnerPct: 50,
+        taxRate: 0,
+        withNote: 'Droits héréditaires équivalents au conjoint depuis 2022 (CC art. 462).',
+        withoutNote: 'Partenaire enregistré·e hérite selon CC art. 462 — même droits que conjoint. Impôt = 0%.',
       ),
       _ => (
         partnerPct: 0,
@@ -214,7 +206,7 @@ class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Patrimoine : CHF ${_fmt(widget.patrimoine)}',
+          'Patrimoine : ${formatChfWithPrefix(widget.patrimoine)}',
           style: GoogleFonts.inter(
             fontSize: 13,
             fontWeight: FontWeight.w600,
@@ -281,7 +273,7 @@ class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
             style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
           ),
           Text(
-            isOptimized ? 'CHF ${_fmt(partnerGets)}' : (partnerGets > 0 ? 'CHF ${_fmt(partnerGets)}' : '0 CHF'),
+            isOptimized ? formatChfWithPrefix(partnerGets) : (partnerGets > 0 ? formatChfWithPrefix(partnerGets) : '0 CHF'),
             style: GoogleFonts.montserrat(
               fontSize: 18,
               fontWeight: FontWeight.w800,
@@ -324,7 +316,7 @@ class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
           const SizedBox(height: 6),
           Text(
             'Sans testament ni clause 3a, ton partenaire ne reçoit rien. '
-            'Un testament coûte ~500 CHF. Le silence peut coûter CHF ${_fmt(taxAmount)} d\'impôts.',
+            'Un testament coûte ~500 CHF. Le silence peut coûter ${formatChfWithPrefix(taxAmount)} d\'impôts.',
             style: GoogleFonts.inter(
               fontSize: 12,
               color: MintColors.textPrimary,

--- a/apps/mobile/lib/widgets/coach/testament_invisible_widget.dart
+++ b/apps/mobile/lib/widgets/coach/testament_invisible_widget.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P8-A  Le Testament invisible — sans vs avec testament
+//  Charte : L6 (Chiffre-choc) + L7 (Métaphore testament)
+//  Source : CC art. 457-462, OPP3 art. 2
+// ────────────────────────────────────────────────────────────
+
+enum FamilyStatus { single, couple, married, concubin }
+
+class TestamentInvisibleWidget extends StatefulWidget {
+  const TestamentInvisibleWidget({
+    super.key,
+    required this.patrimoine,
+    this.initialStatus = FamilyStatus.concubin,
+  });
+
+  final double patrimoine;
+  final FamilyStatus initialStatus;
+
+  @override
+  State<TestamentInvisibleWidget> createState() => _TestamentInvisibleWidgetState();
+}
+
+class _TestamentInvisibleWidgetState extends State<TestamentInvisibleWidget> {
+  late FamilyStatus _status;
+
+  @override
+  void initState() {
+    super.initState();
+    _status = widget.initialStatus;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  // Returns (partnerShare%, inheritanceTaxRate%, withTestamentNote)
+  ({double partnerPct, double taxRate, String withNote, String withoutNote}) _calc(FamilyStatus s) {
+    return switch (s) {
+      FamilyStatus.married => (
+        partnerPct: 50,
+        taxRate: 0,
+        withNote: 'Conjoint hérite de 50%+. Impôt = 0%.',
+        withoutNote: 'Conjoint hérite selon CC. Impôt = 0%.',
+      ),
+      FamilyStatus.concubin => (
+        partnerPct: 0,
+        taxRate: 24,
+        withNote: 'Clause bénéficiaire 3a + testament indispensables.',
+        withoutNote: 'Ton partenaire hérite 0%. L\'État ou tes parents touchent tout.',
+      ),
+      FamilyStatus.couple => (
+        partnerPct: 25,
+        taxRate: 12,
+        withNote: 'Testament peut porter la part jusqu\'à 50%.',
+        withoutNote: 'Part légale limitée à 25%. Impôt jusqu\'à 12%.',
+      ),
+      _ => (
+        partnerPct: 0,
+        taxRate: 0,
+        withNote: 'Libre de léguer à qui tu veux.',
+        withoutNote: 'La loi distribue selon CC art. 457-462.',
+      ),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = _calc(_status);
+    final partnerGets = widget.patrimoine * c.partnerPct / 100;
+    final taxAmount = widget.patrimoine * c.taxRate / 100;
+    final isConcubin = _status == FamilyStatus.concubin;
+
+    return Semantics(
+      label: 'Testament invisible distribution succession',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(isConcubin),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildStatusSelector(),
+                  const SizedBox(height: 20),
+                  _buildComparison(c, partnerGets, taxAmount),
+                  const SizedBox(height: 16),
+                  if (isConcubin) _buildChiffreChoc(taxAmount),
+                  if (isConcubin) const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(bool isConcubin) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF3E5F5),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('📜', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Si tu mourais ce soir…',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Distribution légale automatique vs avec testament · CC art. 457-462',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusSelector() {
+    final labels = {
+      FamilyStatus.married: '💍 Marié·e',
+      FamilyStatus.concubin: '🏠 Concubin·e',
+      FamilyStatus.couple: '💑 Partenaire enregistré·e',
+      FamilyStatus.single: '👤 Célibataire',
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ta situation',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: labels.entries.map((e) {
+            final isSelected = _status == e.key;
+            return GestureDetector(
+              onTap: () => setState(() => _status = e.key),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: isSelected ? MintColors.primary : Colors.white,
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(
+                    color: isSelected ? MintColors.primary : MintColors.lightBorder,
+                    width: isSelected ? 2 : 1,
+                  ),
+                ),
+                child: Text(
+                  e.value,
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: isSelected ? Colors.white : MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildComparison(
+    ({double partnerPct, double taxRate, String withNote, String withoutNote}) c,
+    double partnerGets,
+    double taxAmount,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Patrimoine : CHF ${_fmt(widget.patrimoine)}',
+          style: GoogleFonts.inter(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: MintColors.textPrimary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(child: _buildScenarioCard(
+              label: 'Sans testament',
+              emoji: '❌',
+              partnerGets: partnerGets,
+              taxAmount: taxAmount,
+              note: c.withoutNote,
+              color: MintColors.scoreCritique,
+            )),
+            const SizedBox(width: 12),
+            Expanded(child: _buildScenarioCard(
+              label: 'Avec testament',
+              emoji: '✅',
+              partnerGets: partnerGets > 0 ? partnerGets : widget.patrimoine * 0.5,
+              taxAmount: taxAmount,
+              note: c.withNote,
+              color: MintColors.scoreExcellent,
+              isOptimized: true,
+            )),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScenarioCard({
+    required String label,
+    required String emoji,
+    required double partnerGets,
+    required double taxAmount,
+    required String note,
+    required Color color,
+    bool isOptimized = false,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: color.withValues(alpha: 0.3), width: isOptimized ? 2 : 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '$emoji $label',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Partenaire reçoit',
+            style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+          ),
+          Text(
+            isOptimized ? 'CHF ${_fmt(partnerGets)}' : (partnerGets > 0 ? 'CHF ${_fmt(partnerGets)}' : '0 CHF'),
+            style: GoogleFonts.montserrat(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            note,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc(double taxAmount) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '💰 Concubin·e : 0% d\'héritage + impôt jusqu\'à 24%',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: MintColors.scoreCritique,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Sans testament ni clause 3a, ton partenaire ne reçoit rien. '
+            'Un testament coûte ~500 CHF. Le silence peut coûter CHF ${_fmt(taxAmount)} d\'impôts.',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: MintColors.textPrimary,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : CC art. 457-462, OPP3 art. 2.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/top_cantons_widget.dart
+++ b/apps/mobile/lib/widgets/coach/top_cantons_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P12-C  Top 5 cantons pour ton profil
@@ -51,16 +52,6 @@ class _TopCantonWidgetState extends State<TopCantonWidget> {
   void initState() {
     super.initState();
     _hasChildren = widget.hasChildren;
-  }
-
-  static String _fmt(double v) {
-    final n = v.round().abs();
-    if (n >= 1000) {
-      final t = n ~/ 1000;
-      final r = n % 1000;
-      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
-    }
-    return '$n';
   }
 
   @override
@@ -128,7 +119,7 @@ class _TopCantonWidgetState extends State<TopCantonWidget> {
           const SizedBox(height: 8),
           if (top != null)
             Text(
-              'Ton n°1 : ${top.canton}. Tu économises CHF ${_fmt(top.annualTaxSaving)}/an vs ${widget.currentCanton}.',
+              'Ton n°1 : ${top.canton}. Tu économises ${formatChfWithPrefix(top.annualTaxSaving)}/an vs ${widget.currentCanton}.',
               style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary, height: 1.4),
             ),
         ],
@@ -216,7 +207,7 @@ class _TopCantonWidgetState extends State<TopCantonWidget> {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
                     Text(
-                      '− CHF ${_fmt(r.annualTaxSaving)}/an',
+                      '− ${formatChfWithPrefix(r.annualTaxSaving)}/an',
                       style: GoogleFonts.inter(
                         fontSize: 13,
                         fontWeight: FontWeight.w700,
@@ -224,7 +215,7 @@ class _TopCantonWidgetState extends State<TopCantonWidget> {
                       ),
                     ),
                     Text(
-                      'LAMal ${_fmt(r.monthlyLamal)}/m · loyer ~${_fmt(r.monthlyRent)}/m',
+                      'LAMal ${formatChf(r.monthlyLamal)}/m · loyer ~${formatChf(r.monthlyRent)}/m',
                       style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
                     ),
                   ],

--- a/apps/mobile/lib/widgets/coach/top_cantons_widget.dart
+++ b/apps/mobile/lib/widgets/coach/top_cantons_widget.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P12-C  Top 5 cantons pour ton profil
+//  Charte : L5 (1 action) + L6 (Chiffre-choc)
+//  Source : AFC (Administration fédérale des contributions)
+// ────────────────────────────────────────────────────────────
+
+class CantonRanking {
+  const CantonRanking({
+    required this.rank,
+    required this.canton,
+    required this.shortCode,
+    required this.annualTaxSaving,
+    required this.monthlyLamal,
+    required this.monthlyRent,
+    this.highlight,
+  });
+
+  final int rank;
+  final String canton;
+  final String shortCode;
+  final double annualTaxSaving; // vs current canton
+  final double monthlyLamal;
+  final double monthlyRent;
+  final String? highlight;
+}
+
+class TopCantonWidget extends StatefulWidget {
+  const TopCantonWidget({
+    super.key,
+    required this.currentCanton,
+    required this.rankings,
+    this.hasChildren = false,
+  });
+
+  final String currentCanton;
+  final List<CantonRanking> rankings;
+  final bool hasChildren;
+
+  @override
+  State<TopCantonWidget> createState() => _TopCantonWidgetState();
+}
+
+class _TopCantonWidgetState extends State<TopCantonWidget> {
+  bool _hasChildren = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _hasChildren = widget.hasChildren;
+  }
+
+  static String _fmt(double v) {
+    final n = v.round().abs();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Top cantons déménagement économies fiscales comparaison',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildFilter(),
+                  const SizedBox(height: 16),
+                  _buildRankingList(),
+                  const SizedBox(height: 16),
+                  _buildAction(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    final top = widget.rankings.isNotEmpty ? widget.rankings.first : null;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE8F5E9),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('🏆', style: TextStyle(fontSize: 22)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Ton top cantons',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (top != null)
+            Text(
+              'Ton n°1 : ${top.canton}. Tu économises CHF ${_fmt(top.annualTaxSaving)}/an vs ${widget.currentCanton}.',
+              style: GoogleFonts.inter(fontSize: 13, color: MintColors.textSecondary, height: 1.4),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilter() {
+    return Row(
+      children: [
+        Text(
+          'Avec enfants',
+          style: GoogleFonts.inter(fontSize: 13, color: MintColors.textPrimary),
+        ),
+        const SizedBox(width: 8),
+        Switch(
+          value: _hasChildren,
+          activeColor: MintColors.primary,
+          onChanged: (v) => setState(() => _hasChildren = v),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRankingList() {
+    return Column(
+      children: widget.rankings.asMap().entries.map((e) {
+        final r = e.value;
+        final isTop = e.key == 0;
+        final color = isTop ? const Color(0xFFFFC107) : MintColors.textSecondary;
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 10),
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: isTop ? const Color(0xFFFFF9C4) : MintColors.appleSurface,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: isTop ? const Color(0xFFFFC107) : MintColors.lightBorder,
+                width: isTop ? 2 : 1,
+              ),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: color.withValues(alpha: isTop ? 1.0 : 0.15),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Text(
+                    '${r.rank}',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w800,
+                      color: isTop ? Colors.white : MintColors.textSecondary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        r.canton,
+                        style: GoogleFonts.inter(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: MintColors.textPrimary,
+                        ),
+                      ),
+                      if (r.highlight != null)
+                        Text(
+                          r.highlight!,
+                          style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                        ),
+                    ],
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      '− CHF ${_fmt(r.annualTaxSaving)}/an',
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: MintColors.scoreExcellent,
+                      ),
+                    ),
+                    Text(
+                      'LAMal ${_fmt(r.monthlyLamal)}/m · loyer ~${_fmt(r.monthlyRent)}/m',
+                      style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildAction() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.info.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('💡', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Le canton le moins cher est parfois à 30 minutes. '
+              'Compare aussi la qualité des écoles, transports et prix de l\'immobilier.',
+              style: GoogleFonts.inter(fontSize: 12, color: MintColors.textPrimary, height: 1.4),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil fiscal au sens de la LSFin. '
+      'Source : AFC, taux d\'imposition cantonaux. '
+      'Classement basé sur revenu seul — varie selon patrimoine et situation familiale.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/true_hourly_rate_widget.dart
+++ b/apps/mobile/lib/widgets/coach/true_hourly_rate_widget.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  TRUE HOURLY RATE WIDGET — P6-D / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Décomposition : net souhaité + charges + impôts + frais
+//  + vacances/maladie = CA nécessaire ÷ heures facturables
+//  = tarif horaire minimum.
+//
+//  Widget pur — aucune dépendance Provider.
+//  Lois : L1 (CHF/mois) + L7 (métaphore bat graphique)
+// ────────────────────────────────────────────────────────────
+
+/// Breakdown layer of the hourly rate composition.
+class RateLayer {
+  final String label;
+  final double amount;
+  final String emoji;
+
+  const RateLayer({
+    required this.label,
+    required this.amount,
+    required this.emoji,
+  });
+}
+
+class TrueHourlyRateWidget extends StatelessWidget {
+  /// Desired net annual income.
+  final double desiredNetAnnual;
+
+  /// Breakdown layers: taxes, social charges, business expenses, unpaid days.
+  final List<RateLayer> layers;
+
+  /// Total required annual revenue.
+  final double requiredRevenue;
+
+  /// Billable hours per year (typically 1600).
+  final int billableHours;
+
+  const TrueHourlyRateWidget({
+    super.key,
+    required this.desiredNetAnnual,
+    required this.layers,
+    required this.requiredRevenue,
+    this.billableHours = 1600,
+  });
+
+  double get _hourlyRate =>
+      billableHours > 0 ? requiredRevenue / billableHours : 0;
+  double get _chargesPerHour =>
+      billableHours > 0 ? (requiredRevenue - desiredNetAnnual) / billableHours : 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Tarif horaire v\u00e9rit\u00e9. '
+          'Minimum\u00a0: ${_hourlyRate.toStringAsFixed(0)} CHF/h.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Ton tarif horaire de v\u00e9rit\u00e9',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Pour un net de ${formatChfWithPrefix(desiredNetAnnual)}/an',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textMuted,
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // ── Hero hourly rate ──
+            Center(
+              child: Column(
+                children: [
+                  Text(
+                    '${_hourlyRate.toStringAsFixed(0)} CHF/h',
+                    style: GoogleFonts.montserrat(
+                      fontSize: 36,
+                      fontWeight: FontWeight.w800,
+                      color: MintColors.primary,
+                    ),
+                  ),
+                  Text(
+                    'minimum',
+                    style: GoogleFonts.inter(
+                      fontSize: 14,
+                      color: MintColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // ── Breakdown ──
+            _buildDecomposition(),
+            const SizedBox(height: 12),
+
+            // ── Chiffre-choc ──
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: MintColors.scoreCritique.withValues(alpha: 0.08),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                '${_hourlyRate.toStringAsFixed(0)} CHF/h '
+                '\u2260 ${_hourlyRate.toStringAsFixed(0)} CHF dans ta poche.\n'
+                '${_chargesPerHour.toStringAsFixed(0)} CHF partent en charges. '
+                'En dessous de ${_hourlyRate.toStringAsFixed(0)} CHF/h, '
+                'tu t\u2019appauvris.',
+                style: GoogleFonts.inter(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: MintColors.scoreCritique,
+                  height: 1.4,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+
+            const SizedBox(height: 12),
+            Text(
+              'Bas\u00e9 sur $billableHours h facturables/an. '
+              'Cotisations\u00a0: LAVS art. 4-14. '
+              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDecomposition() {
+    return Column(
+      children: [
+        // Net desired
+        _buildRow('\ud83d\udcb0', 'Net souhait\u00e9', desiredNetAnnual,
+            MintColors.scoreExcellent),
+        ...layers.map((l) => _buildRow(l.emoji, l.label, l.amount,
+            MintColors.scoreCritique)),
+        const Divider(height: 12),
+        // Required revenue
+        _buildRow('\ud83d\udcbc', 'CA n\u00e9cessaire', requiredRevenue,
+            MintColors.primary, isBold: true),
+        Padding(
+          padding: const EdgeInsets.only(left: 30, top: 2),
+          child: Text(
+            '\u00f7 $billableHours h = ${_hourlyRate.toStringAsFixed(0)} CHF/h',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textMuted,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRow(String emoji, String label, double amount, Color color,
+      {bool isBold = false}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 16)),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              label,
+              style: GoogleFonts.inter(
+                fontSize: 13,
+                fontWeight: isBold ? FontWeight.w600 : FontWeight.w400,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          Text(
+            formatChfWithPrefix(amount),
+            style: GoogleFonts.montserrat(
+              fontSize: 13,
+              fontWeight: isBold ? FontWeight.w700 : FontWeight.w500,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/unemployment_counter_widget.dart
+++ b/apps/mobile/lib/widgets/coach/unemployment_counter_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -20,18 +21,18 @@ class UnemploymentCounterWidget extends StatelessWidget {
   final double monthlyBenefit;
   final int daysConsumed;
 
+  /// Durée max indemnités AC par tranche d'âge — cas standard (≥ 22 mois cotisation).
+  /// Source : LACI art. 27 al. 2 lit. a-d.
   static int _maxDays(int age) {
-    if (age < 25) return 200;
-    if (age < 55) return 260;
-    if (age < 60) return 400;
-    return 520;
+    if (age < 25) return acJoursMinCotisation;       // 200 j — cotisation typiquement courte
+    if (age < acAgeSeuillSenior) return acJoursStandard;  // 400 j — LACI art. 27 al. 2 lit. c
+    return acJoursSenior;                            // 520 j — LACI art. 27 al. 2 lit. d
   }
 
   static String _ageLabel(int age) {
     if (age < 25) return '< 25 ans';
-    if (age < 55) return '25–54 ans';
-    if (age < 60) return '55–59 ans';
-    return '≥ 60 ans';
+    if (age < acAgeSeuillSenior) return '25–54 ans';
+    return '≥ 55 ans';
   }
 
   static String _fmt(double v) {
@@ -271,10 +272,9 @@ class UnemploymentCounterWidget extends StatelessWidget {
 
   Widget _buildAgeTable(int currentAge) {
     final rows = [
-      (age: 24, label: '< 25 ans', days: 200),
-      (age: 40, label: '25–54 ans', days: 260),
-      (age: 57, label: '55–59 ans', days: 400),
-      (age: 62, label: '≥ 60 ans', days: 520),
+      (age: 24, label: '< 25 ans', days: acJoursMinCotisation),
+      (age: 40, label: '25–54 ans', days: acJoursStandard),
+      (age: 57, label: '≥ 55 ans',  days: acJoursSenior),
     ];
 
     return Container(

--- a/apps/mobile/lib/widgets/coach/unemployment_counter_widget.dart
+++ b/apps/mobile/lib/widgets/coach/unemployment_counter_widget.dart
@@ -1,0 +1,396 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+// ────────────────────────────────────────────────────────────
+//  P7-C  Compteur de jours — Capital temps (sablier)
+//  Charte : L6 (Chiffre-choc) + L7 (Métaphore sablier)
+//  Source : LACI art. 27-30
+// ────────────────────────────────────────────────────────────
+
+class UnemploymentCounterWidget extends StatelessWidget {
+  const UnemploymentCounterWidget({
+    super.key,
+    required this.age,
+    required this.monthlyBenefit,
+    this.daysConsumed = 0,
+  });
+
+  final int age;
+  final double monthlyBenefit;
+  final int daysConsumed;
+
+  static int _maxDays(int age) {
+    if (age < 25) return 200;
+    if (age < 55) return 260;
+    if (age < 60) return 400;
+    return 520;
+  }
+
+  static String _ageLabel(int age) {
+    if (age < 25) return '< 25 ans';
+    if (age < 55) return '25–54 ans';
+    if (age < 60) return '55–59 ans';
+    return '≥ 60 ans';
+  }
+
+  static String _fmt(double v) {
+    final n = v.round();
+    if (n >= 1000) {
+      final t = n ~/ 1000;
+      final r = n % 1000;
+      return r == 0 ? "$t'000" : "$t'${r.toString().padLeft(3, '0')}";
+    }
+    return '$n';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxDays = _maxDays(age);
+    final remaining = (maxDays - daysConsumed).clamp(0, maxDays);
+    final progressFraction = daysConsumed / maxDays;
+    final monthsRemaining = remaining / 21.7;
+
+    return Semantics(
+      label: 'Compteur jours chômage capital temps',
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(maxDays),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildProgressBar(progressFraction, remaining, maxDays),
+                  const SizedBox(height: 20),
+                  _buildStatsRow(remaining, monthsRemaining),
+                  const SizedBox(height: 20),
+                  _buildAgeTable(age),
+                  const SizedBox(height: 16),
+                  _buildChiffreChoc(),
+                  const SizedBox(height: 16),
+                  _buildDisclaimer(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(int maxDays) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('⏳', style: TextStyle(fontSize: 24)),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Ton capital temps',
+                  style: GoogleFonts.montserrat(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '${_ageLabel(age)} → $maxDays indemnités journalières',
+            style: GoogleFonts.inter(
+              fontSize: 13,
+              color: MintColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              _buildStatChip(
+                label: 'CHF ${_fmt(monthlyBenefit)}/mois',
+                color: MintColors.primary,
+              ),
+              const SizedBox(width: 8),
+              _buildStatChip(
+                label: '≈ ${(maxDays / 21.7).toStringAsFixed(0)} mois',
+                color: MintColors.info,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatChip({required String label, required Color color}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: GoogleFonts.inter(
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressBar(double fraction, int remaining, int maxDays) {
+    final color = fraction < 0.5
+        ? MintColors.scoreExcellent
+        : fraction < 0.75
+            ? MintColors.scoreAttention
+            : MintColors.scoreCritique;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Jours utilisés : $daysConsumed',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                color: MintColors.textSecondary,
+              ),
+            ),
+            Text(
+              'Restants : $remaining',
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: LinearProgressIndicator(
+            value: fraction,
+            minHeight: 14,
+            backgroundColor: color.withValues(alpha: 0.15),
+            valueColor: AlwaysStoppedAnimation<Color>(color),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Jour 0',
+              style: GoogleFonts.inter(fontSize: 10, color: MintColors.textSecondary),
+            ),
+            Text(
+              'Jour $maxDays → 0 CHF',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: MintColors.scoreCritique,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStatsRow(int remaining, double monthsRemaining) {
+    return Row(
+      children: [
+        Expanded(child: _buildStatCard(
+          label: 'Jours restants',
+          value: '$remaining',
+          color: MintColors.info,
+        )),
+        const SizedBox(width: 12),
+        Expanded(child: _buildStatCard(
+          label: 'Soit environ',
+          value: '${monthsRemaining.toStringAsFixed(1)} mois',
+          color: MintColors.primary,
+        )),
+      ],
+    );
+  }
+
+  Widget _buildStatCard({required String label, required String value, required Color color}) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: GoogleFonts.montserrat(
+              fontSize: 20,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAgeTable(int currentAge) {
+    final rows = [
+      (age: 24, label: '< 25 ans', days: 200),
+      (age: 40, label: '25–54 ans', days: 260),
+      (age: 57, label: '55–59 ans', days: 400),
+      (age: 62, label: '≥ 60 ans', days: 520),
+    ];
+
+    return Container(
+      decoration: BoxDecoration(
+        color: MintColors.appleSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.lightBorder),
+      ),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Tranche d\'âge',
+                    style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary),
+                  ),
+                ),
+                Text(
+                  'Indemnités max',
+                  style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: MintColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          ...rows.map((r) {
+            final isActive = _maxDays(currentAge) == r.days;
+            return Container(
+              color: isActive ? MintColors.primary.withValues(alpha: 0.07) : null,
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+              child: Row(
+                children: [
+                  if (isActive)
+                    const Icon(Icons.arrow_right, color: MintColors.primary, size: 16),
+                  if (!isActive) const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
+                      r.label,
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: isActive ? FontWeight.w700 : FontWeight.w400,
+                        color: isActive ? MintColors.primary : MintColors.textPrimary,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    '${r.days} jours',
+                    style: GoogleFonts.inter(
+                      fontSize: 13,
+                      fontWeight: isActive ? FontWeight.w700 : FontWeight.w400,
+                      color: isActive ? MintColors.primary : MintColors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChiffreChoc() {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: MintColors.scoreCritique.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('⚠️', style: TextStyle(fontSize: 18)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Après le dernier jour : 0 CHF',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.scoreCritique,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Pas de prolongation. Tu passes à l\'aide sociale — sans délai de grâce.',
+                  style: GoogleFonts.inter(
+                    fontSize: 12,
+                    color: MintColors.textSecondary,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDisclaimer() {
+    return Text(
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. '
+      'Source : LACI art. 27-30.',
+      style: GoogleFonts.inter(
+        fontSize: 10,
+        color: MintColors.textSecondary,
+        fontStyle: FontStyle.italic,
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/what_if_stories_widget.dart
+++ b/apps/mobile/lib/widgets/coach/what_if_stories_widget.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+// ────────────────────────────────────────────────────────────
+//  WHAT-IF STORIES WIDGET — P1-E / S42 UX Redesign
+// ────────────────────────────────────────────────────────────
+//
+//  Remplace le tornado chart par 3 micro-histoires cliquables.
+//  Chaque histoire montre l'impact d'un changement concret.
+//
+//  Widget pur — aucune dependance Provider.
+//  Lois : L4 (raconte, ne montre pas) + L5 (une action)
+// ────────────────────────────────────────────────────────────
+
+/// Single "what if" story card data.
+class WhatIfStory {
+  /// Emoji icon for the story.
+  final String emoji;
+
+  /// Story question (e.g., "Et si ta caisse LPP passait de 1% a 2% ?")
+  final String question;
+
+  /// Monthly impact in CHF (positive = gain).
+  final double monthlyImpactChf;
+
+  /// Short explanation of the impact.
+  final String explanation;
+
+  /// Actionable next step.
+  final String? actionLabel;
+
+  const WhatIfStory({
+    required this.emoji,
+    required this.question,
+    required this.monthlyImpactChf,
+    required this.explanation,
+    this.actionLabel,
+  });
+}
+
+class WhatIfStoriesWidget extends StatelessWidget {
+  /// The stories to display (max 3 recommended).
+  final List<WhatIfStory> stories;
+
+  /// Callback when user taps a story.
+  final ValueChanged<int>? onStoryTapped;
+
+  const WhatIfStoriesWidget({
+    super.key,
+    required this.stories,
+    this.onStoryTapped,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (stories.isEmpty) return const SizedBox.shrink();
+
+    return Semantics(
+      label: 'Histoires "et si" \u2014 ${stories.length} sc\u00e9narios.',
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.card,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Ce qui pourrait tout changer',
+              style: GoogleFonts.montserrat(
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+                color: MintColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 14),
+            ...stories
+                .take(3)
+                .toList()
+                .asMap()
+                .entries
+                .map((e) => _buildStoryCard(e.key, e.value)),
+            const SizedBox(height: 8),
+            Text(
+              'Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier (LSFin).',
+              style: GoogleFonts.inter(
+                fontSize: 10,
+                color: MintColors.textMuted,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStoryCard(int index, WhatIfStory story) {
+    final isPositive = story.monthlyImpactChf >= 0;
+    final impactColor =
+        isPositive ? MintColors.scoreExcellent : MintColors.scoreCritique;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: GestureDetector(
+        onTap: onStoryTapped != null ? () => onStoryTapped!(index) : null,
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: MintColors.surface,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Question
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(story.emoji, style: const TextStyle(fontSize: 20)),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      story.question,
+                      style: GoogleFonts.inter(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: MintColors.textPrimary,
+                        height: 1.3,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+
+              // Impact
+              Padding(
+                padding: const EdgeInsets.only(left: 30),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          isPositive
+                              ? Icons.trending_up
+                              : Icons.trending_down,
+                          size: 16,
+                          color: impactColor,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${isPositive ? "+" : ""}${formatChfWithPrefix(story.monthlyImpactChf)}/mois \u00e0 65 ans',
+                          style: GoogleFonts.montserrat(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                            color: impactColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      story.explanation,
+                      style: GoogleFonts.inter(
+                        fontSize: 12,
+                        color: MintColors.textSecondary,
+                        height: 1.3,
+                      ),
+                    ),
+                    if (story.actionLabel != null) ...[
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          Icon(Icons.arrow_forward,
+                              size: 12, color: MintColors.primary),
+                          const SizedBox(width: 4),
+                          Flexible(
+                            child: Text(
+                              story.actionLabel!,
+                              style: GoogleFonts.inter(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                                color: MintColors.primary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/educational/salary_breakdown_widget.dart
+++ b/apps/mobile/lib/widgets/educational/salary_breakdown_widget.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/theme/colors.dart';
-import 'package:mint_mobile/services/first_job_service.dart';
+import 'package:mint_mobile/services/first_job_service.dart' show SalaryDeductionItem;
+import 'package:mint_mobile/utils/chf_formatter.dart';
 
 // ────────────────────────────────────────────────────────────
 //  SALARY BREAKDOWN WIDGET — Sprint S19
@@ -86,7 +87,7 @@ class SalaryBreakdownWidget extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    FirstJobService.formatChf(brut),
+                    formatChfWithPrefix(brut),
                     style: GoogleFonts.montserrat(
                       fontSize: 20,
                       fontWeight: FontWeight.w700,
@@ -107,7 +108,7 @@ class SalaryBreakdownWidget extends StatelessWidget {
                     ),
                   ),
                   Text(
-                    FirstJobService.formatChf(netEstime),
+                    formatChfWithPrefix(netEstime),
                     style: GoogleFonts.montserrat(
                       fontSize: 20,
                       fontWeight: FontWeight.w700,
@@ -238,7 +239,7 @@ class SalaryBreakdownWidget extends StatelessWidget {
             ),
           ),
           Text(
-            FirstJobService.formatChf(amount),
+            formatChfWithPrefix(amount),
             style: GoogleFonts.inter(
               fontSize: 12,
               fontWeight: isBold ? FontWeight.w700 : FontWeight.w500,
@@ -330,7 +331,7 @@ class SalaryBreakdownWidget extends StatelessWidget {
             ),
           ),
           Text(
-            FirstJobService.formatChf(item.montant),
+            formatChfWithPrefix(item.montant),
             style: GoogleFonts.inter(
               fontSize: 13,
               fontWeight: FontWeight.w600,
@@ -385,7 +386,7 @@ class SalaryBreakdownWidget extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Ton employeur verse ~${FirstJobService.formatChf(cotisationsEmployeur)}/mois '
+                  'Ton employeur verse ~${formatChfWithPrefix(cotisationsEmployeur)}/mois '
                   'en plus de ton salaire brut (AVS part employeur, LPP part '
                   'employeur, LAA, etc.).',
                   style: GoogleFonts.inter(

--- a/apps/mobile/lib/widgets/educational/salary_breakdown_widget.dart
+++ b/apps/mobile/lib/widgets/educational/salary_breakdown_widget.dart
@@ -20,12 +20,17 @@ class SalaryBreakdownWidget extends StatelessWidget {
   final double cotisationsEmployeur;
   final List<SalaryDeductionItem> deductions;
 
+  /// Optional: total cost to employer (brut + employer contributions).
+  /// When provided, shows the iceberg chiffre-choc panel (P5-E / S42).
+  final double? totalEmployerCost;
+
   const SalaryBreakdownWidget({
     super.key,
     required this.brut,
     required this.netEstime,
     required this.cotisationsEmployeur,
     required this.deductions,
+    this.totalEmployerCost,
   });
 
   /// Parse hex color string to Color.
@@ -135,6 +140,111 @@ class SalaryBreakdownWidget extends StatelessWidget {
 
           // Employer hidden contributions
           _buildEmployerSection(),
+
+          // ── Iceberg chiffre-choc (P5-E) ──
+          if (totalEmployerCost != null) ...[
+            const SizedBox(height: 16),
+            _buildIcebergSection(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // ── Iceberg section (P5-E / S42) ─────────────────────────
+  //  Waterline metaphor: net visible / deductions below /
+  //  employer costs at the bottom.
+  Widget _buildIcebergSection() {
+    final total = totalEmployerCost!;
+    final employeeDeductions = brut - netEstime;
+    final negotiationNet = brut > 0 ? (200 * netEstime / brut) : 0.0;
+    final negotiationTotal = 200 + (200 * cotisationsEmployeur / brut);
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            MintColors.info.withValues(alpha: 0.04),
+            MintColors.info.withValues(alpha: 0.12),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: MintColors.info.withValues(alpha: 0.25)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text('\ud83e\uddca', style: TextStyle(fontSize: 16)),
+              const SizedBox(width: 8),
+              Text(
+                'L\u2019iceberg de ton salaire',
+                style: GoogleFonts.montserrat(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: MintColors.info,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          _buildIcebergRow('\ud83d\udca7', 'Net (visible)', netEstime,
+              MintColors.success),
+          _buildIcebergRow('\ud83d\udca7', 'Tes cotisations', employeeDeductions,
+              MintColors.warning),
+          _buildIcebergRow('\ud83d\udca7', 'Part employeur', cotisationsEmployeur,
+              MintColors.info),
+          const Divider(height: 12),
+          _buildIcebergRow('\ud83d\udcbc', 'Co\u00fbt total employeur', total,
+              MintColors.textPrimary,
+              isBold: true),
+          const SizedBox(height: 8),
+          Text(
+            'Quand tu n\u00e9gocies +200 CHF brut\u00a0: '
+            'tu re\u00e7ois ~${negotiationNet.toStringAsFixed(0)} CHF net. '
+            'Ton employeur paie ~${negotiationTotal.toStringAsFixed(0)} CHF de plus.',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+              fontStyle: FontStyle.italic,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIcebergRow(String emoji, String label, double amount, Color color,
+      {bool isBold = false}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 12)),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              label,
+              style: GoogleFonts.inter(
+                fontSize: 12,
+                fontWeight: isBold ? FontWeight.w600 : FontWeight.w400,
+                color: MintColors.textPrimary,
+              ),
+            ),
+          ),
+          Text(
+            FirstJobService.formatChf(amount),
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              fontWeight: isBold ? FontWeight.w700 : FontWeight.w500,
+              color: color,
+            ),
+          ),
         ],
       ),
     );

--- a/apps/mobile/test/services/coach/hallucination_detector_test.dart
+++ b/apps/mobile/test/services/coach/hallucination_detector_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mint_mobile/services/coach/coach_models.dart';
 import 'package:mint_mobile/services/coach/hallucination_detector.dart';
 
 // ────────────────────────────────────────────────────────────

--- a/apps/mobile/test/services/milestone_detection_service_test.dart
+++ b/apps/mobile/test/services/milestone_detection_service_test.dart
@@ -33,7 +33,6 @@ CoachProfile _buildProfile({
   double totalEpargne3a = 0,
   double loyer = 0,
   double assuranceMaladie = 0,
-  double total3aMensuel = 0,
   List<MonthlyCheckIn> checkIns = const [],
   List<PlannedMonthlyContribution> contributions = const [],
 }) {

--- a/apps/mobile/test/services/streak_service_test.dart
+++ b/apps/mobile/test/services/streak_service_test.dart
@@ -37,14 +37,6 @@ List<DateTime> _consecutiveMonthsEndingNow(int count) {
   );
 }
 
-/// Helper: build consecutive months ending at the previous month.
-List<DateTime> _consecutiveMonthsEndingLastMonth(int count) {
-  final now = DateTime.now();
-  return List.generate(
-    count,
-    (i) => DateTime(now.year, now.month - 1 - (count - 1 - i)),
-  );
-}
 
 void main() {
   // =========================================================================

--- a/apps/mobile/test/services/tax_estimator_service_test.dart
+++ b/apps/mobile/test/services/tax_estimator_service_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/services/tax_estimator_service.dart';
 import 'package:mint_mobile/services/tax_scales_loader.dart';
-import 'package:mint_mobile/models/tax_scale.dart';
 
 void main() {
   // ---------------------------------------------------------------------------

--- a/apps/mobile/test/widgets/coach/avancement_hoirie_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/avancement_hoirie_widget_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/avancement_hoirie_widget.dart';
+
+void main() {
+  final children = [
+    const HoirieChild(name: 'Alice', emoji: '👧'),
+    const HoirieChild(name: 'Bob', emoji: '👦'),
+    const HoirieChild(name: 'Clara', emoji: '👧'),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: AvancementHoirieWidget(
+              totalPatrimoine: 600000,
+              donationAmount: 100000,
+              children: children,
+              donationRecipientIndex: 0,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('hoirie'), findsWidgets);
+  });
+
+  testWidgets('shows donation amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("100'000"), findsWidgets);
+  });
+
+  testWidgets('shows children names', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Alice'), findsWidgets);
+    expect(find.textContaining('Bob'), findsWidgets);
+  });
+
+  testWidgets('shows CC legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('CC'), findsWidgets);
+  });
+
+  testWidgets('shows rapport à la masse', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('masse'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('hoirie', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/avs_gap_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/avs_gap_widget_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/avs_gap_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: AvsGapWidget(
+              currentContributionYears: 30,
+              currentAge: 50,
+              initialYearsAbroad: 5,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('AVS'), findsWidgets);
+  });
+
+  testWidgets('shows trou AVS label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('trou'), findsWidgets);
+  });
+
+  testWidgets('shows slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows years abroad label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('5 ans'), findsWidgets);
+  });
+
+  testWidgets('shows rente amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('CHF'), findsWidgets);
+  });
+
+  testWidgets('shows LAVS legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LAVS'), findsWidgets);
+  });
+
+  testWidgets('shows lifetime loss section', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('20 ans'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('trou AVS', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/baby_cost_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/baby_cost_widget_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/baby_cost_widget.dart';
+
+void main() {
+  final items = [
+    const BabyCostItem(
+      label: 'Crèche / garde',
+      emoji: '🏫',
+      monthlyCost: 2200,
+      note: 'Canton de Vaud, subventionné',
+    ),
+    const BabyCostItem(
+      label: 'Alimentation',
+      emoji: '🍼',
+      monthlyCost: 150,
+    ),
+    const BabyCostItem(
+      label: 'Vêtements',
+      emoji: '👕',
+      monthlyCost: 100,
+    ),
+    const BabyCostItem(
+      label: 'Santé / LAMal',
+      emoji: '🏥',
+      monthlyCost: 130,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: BabyCostWidget(
+              items: items,
+              yearsOfDependency: 25,
+              canton: 'Vaud',
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('bonheur'), findsWidgets);
+  });
+
+  testWidgets('shows monthly total', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // Total = 2200+150+100+130 = 2580
+    expect(find.textContaining("2'580"), findsWidgets);
+  });
+
+  testWidgets('shows lifetime total', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 2580 × 12 × 25 = 774'000
+    expect(find.textContaining("774'000"), findsWidgets);
+  });
+
+  testWidgets('shows creche callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('crèche'), findsWidgets);
+  });
+
+  testWidgets('shows canton', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Vaud'), findsWidgets);
+  });
+
+  testWidgets('shows items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Alimentation'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('bonheur', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/budget_503020_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/budget_503020_widget_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/budget_503020_widget.dart';
+
+void main() {
+  final categories = [
+    const BudgetCategory(
+      label: 'FIXE',
+      emoji: '\ud83c\udfe0',
+      percent: 50,
+      amount: 2105,
+      examples: ['loyer', 'LAMal', 'transport'],
+    ),
+    const BudgetCategory(
+      label: 'VIE',
+      emoji: '\ud83c\udf89',
+      percent: 30,
+      amount: 1263,
+      examples: ['sorties', 'resto', 'sport'],
+    ),
+    const BudgetCategory(
+      label: 'FUTUR',
+      emoji: '\ud83d\udcb0',
+      percent: 20,
+      amount: 842,
+      examples: ['3a', '\u00e9pargne'],
+    ),
+  ];
+
+  Widget buildWidget({String? chiffreChoc}) => MaterialApp(
+        home: Scaffold(
+          body: Budget503020Widget(
+            netSalary: 4210,
+            categories: categories,
+            chiffreChoc: chiffreChoc,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('50 / 30 / 20'), findsOneWidget);
+  });
+
+  testWidgets('shows net salary', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("4'210"), findsWidgets);
+  });
+
+  testWidgets('shows all 3 category labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('FIXE'), findsOneWidget);
+    expect(find.textContaining('VIE'), findsOneWidget);
+    expect(find.textContaining('FUTUR'), findsOneWidget);
+  });
+
+  testWidgets('shows percentages', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('50%'), findsWidgets);
+    expect(find.textContaining('20%'), findsWidgets);
+  });
+
+  testWidgets('shows CHF amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("2'105"), findsOneWidget);
+    expect(find.textContaining('842'), findsWidgets);
+  });
+
+  testWidgets('shows chiffre-choc when provided', (tester) async {
+    await tester.pumpWidget(buildWidget(chiffreChoc: 'Test chiffre-choc'));
+    expect(find.textContaining('Test chiffre-choc'), findsOneWidget);
+  });
+
+  testWidgets('hides chiffre-choc when null', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Test'), findsNothing);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Budget 50/30/20')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/budget_bebe_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/budget_bebe_widget_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/budget_bebe_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: BudgetBebeWidget(
+              monthlyIncome: 6000,
+              costPerChild: 1200,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Budget'), findsWidgets);
+  });
+
+  testWidgets('shows 50/30/20 labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Besoins'), findsWidgets);
+    expect(find.textContaining('Envies'), findsWidgets);
+    expect(find.textContaining('Épargne'), findsWidgets);
+  });
+
+  testWidgets('shows slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows no children state', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Sans enfant'), findsOneWidget);
+  });
+
+  testWidgets('shows correct needs amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 6000 × 50% = 3000
+    expect(find.textContaining("3'000"), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('bébé', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/budget_sandwich_chart_test.dart
+++ b/apps/mobile/test/widgets/coach/budget_sandwich_chart_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/budget_sandwich_chart.dart';
+
+void main() {
+  final incomes = [
+    const BudgetLineItem(label: 'AVS', amount: 1934),
+    const BudgetLineItem(label: 'LPP', amount: 2410),
+    const BudgetLineItem(label: '3a', amount: 540),
+    const BudgetLineItem(label: '\u00c9pargne', amount: 350),
+  ];
+
+  final expenses = [
+    const BudgetLineItem(label: 'Imp\u00f4ts', amount: 650),
+    const BudgetLineItem(label: 'Loyer', amount: 1500),
+    const BudgetLineItem(label: 'LAMal', amount: 450),
+    const BudgetLineItem(label: 'Quotidien', amount: 2200),
+  ];
+
+  Widget buildTestWidget({
+    List<BudgetLineItem>? customIncomes,
+    List<BudgetLineItem>? customExpenses,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: BudgetSandwichChart(
+            incomes: customIncomes ?? incomes,
+            expenses: customExpenses ?? expenses,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('BudgetSandwichChart', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(BudgetSandwichChart), findsOneWidget);
+    });
+
+    testWidgets('shows header', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('budget'), findsWidgets);
+    });
+
+    testWidgets('shows "Ce qui rentre" and "Ce qui sort"', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('rentre'), findsWidgets);
+      expect(find.textContaining('sort'), findsWidgets);
+    });
+
+    testWidgets('shows income items', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('AVS'), findsWidgets);
+      expect(find.textContaining('LPP'), findsWidgets);
+    });
+
+    testWidgets('shows margin when positive', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      // 5234 - 4800 = 434 → "Marge"
+      expect(find.textContaining('Marge'), findsWidgets);
+      expect(find.textContaining('vert'), findsWidgets);
+    });
+
+    testWidgets('shows deficit when negative', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        customIncomes: [const BudgetLineItem(label: 'AVS', amount: 2000)],
+        customExpenses: [const BudgetLineItem(label: 'Loyer', amount: 3000)],
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('ficit'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('handles empty items', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        customIncomes: const [],
+        customExpenses: const [],
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(BudgetSandwichChart), findsOneWidget);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/career_timelapse_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/career_timelapse_widget_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/career_timelapse_widget.dart';
+
+void main() {
+  final scenarios = [
+    const TimeLapseScenario(startAge: 22, capitalAt65: 680000),
+    const TimeLapseScenario(startAge: 25, capitalAt65: 610000),
+    const TimeLapseScenario(startAge: 30, capitalAt65: 450000),
+    const TimeLapseScenario(startAge: 35, capitalAt65: 310000),
+  ];
+
+  Widget buildWidget({int initialAge = 25}) => MaterialApp(
+        home: Scaffold(
+          body: CareerTimeLapseWidget(
+            scenarios: scenarios,
+            monthly3aContribution: 605,
+            initialAge: initialAge,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('commenc'), findsWidgets);
+  });
+
+  testWidgets('shows age labels for all scenarios', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('22 ans'), findsOneWidget);
+    expect(find.textContaining('35 ans'), findsOneWidget);
+  });
+
+  testWidgets('shows compact capital amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('680k'), findsOneWidget);
+    expect(find.textContaining('310k'), findsOneWidget);
+  });
+
+  testWidgets('renders slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows chiffre-choc when age is not minimum', (tester) async {
+    await tester.pumpWidget(buildWidget(initialAge: 30));
+    await tester.pump();
+    expect(find.textContaining('attente'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('returns SizedBox for empty scenarios', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: CareerTimeLapseWidget(scenarios: const [], monthly3aContribution: 605),
+      ),
+    ));
+    expect(find.byType(Slider), findsNothing);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Time-lapse')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/clause_3a_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/clause_3a_widget_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/clause_3a_widget.dart';
+
+void main() {
+  Widget buildWidget({bool hasClause = false}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: Clause3aWidget(
+              balance3a: 85000,
+              hasClause: hasClause,
+              partnerName: 'Marion',
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('3a'), findsWidgets);
+  });
+
+  testWidgets('shows balance', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("85'000"), findsWidgets);
+  });
+
+  testWidgets('shows partner name', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Marion'), findsWidgets);
+  });
+
+  testWidgets('shows OPP3 legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('OPP3'), findsWidgets);
+  });
+
+  testWidgets('shows without clause state', (tester) async {
+    await tester.pumpWidget(buildWidget(hasClause: false));
+    expect(find.textContaining('Non'), findsWidgets);
+  });
+
+  testWidgets('shows with clause state', (tester) async {
+    await tester.pumpWidget(buildWidget(hasClause: true));
+    expect(find.textContaining('Oui'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('3a', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/confidence_bar_test.dart
+++ b/apps/mobile/test/widgets/coach/confidence_bar_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/confidence_bar.dart';
+
+void main() {
+  Widget buildTestWidget({
+    double score = 65,
+    bool showLabel = true,
+    List<Map<String, dynamic>>? enrichmentActions,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ConfidenceBar(
+            score: score,
+            showLabel: showLabel,
+            enrichmentActions: enrichmentActions,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('ConfidenceBar', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(ConfidenceBar), findsOneWidget);
+    });
+
+    testWidgets('shows score percentage', (tester) async {
+      await tester.pumpWidget(buildTestWidget(score: 72));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('72%'), findsWidgets);
+    });
+
+    testWidgets('P1-I: shows zone description', (tester) async {
+      await tester.pumpWidget(buildTestWidget(score: 75));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Bonne'), findsWidgets);
+    });
+
+    testWidgets('P1-I: shows "Photo parfaite" at 95%', (tester) async {
+      await tester.pumpWidget(buildTestWidget(score: 95));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Photo'), findsWidgets);
+    });
+
+    testWidgets('P1-I: shows zone markers', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('40%'), findsWidgets);
+      expect(find.textContaining('70%'), findsWidgets);
+    });
+
+    testWidgets('P1-I: shows enrichment actions when score < 80',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        score: 55,
+        enrichmentActions: [
+          {'label': 'Scanne ton certificat LPP', 'icon': Icons.camera_alt},
+          {'label': 'V\u00e9rifie ta couverture AI'},
+        ],
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('LPP'), findsWidgets);
+      expect(find.textContaining('am\u00e9liorer'), findsWidgets);
+    });
+
+    testWidgets('P1-I: hides enrichment when score >= 80', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        score: 85,
+        enrichmentActions: [
+          {'label': 'Action inutile'},
+        ],
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('am\u00e9liorer'), findsNothing);
+    });
+
+    testWidgets('handles zero score', (tester) async {
+      await tester.pumpWidget(buildTestWidget(score: 0));
+      await tester.pumpAndSettle();
+      expect(find.byType(ConfidenceBar), findsOneWidget);
+    });
+
+    testWidgets('handles 100 score', (tester) async {
+      await tester.pumpWidget(buildTestWidget(score: 100));
+      await tester.pumpAndSettle();
+      expect(find.byType(ConfidenceBar), findsOneWidget);
+    });
+
+    testWidgets('hides label when showLabel=false', (tester) async {
+      await tester.pumpWidget(buildTestWidget(showLabel: false));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Qualit\u00e9'), findsNothing);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/countdown_3a_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/countdown_3a_widget_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/countdown_3a_widget.dart';
+
+void main() {
+  Widget buildWidget({
+    double contributed = 3600,
+    int daysRemaining = 87,
+  }) =>
+      MaterialApp(
+        home: Scaffold(
+          body: Countdown3aWidget(
+            annualCeiling: 7258,
+            amountContributed: contributed,
+            taxSavingsIfFull: 1450,
+            daysRemaining: daysRemaining,
+            year: 2026,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('rebours 3a'), findsOneWidget);
+  });
+
+  testWidgets('shows contributed and remaining amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("3'600"), findsWidgets);
+    expect(find.textContaining("3'658"), findsWidgets);
+  });
+
+  testWidgets('shows ceiling', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("7'258"), findsWidgets);
+  });
+
+  testWidgets('shows urgency label when > 90 days', (tester) async {
+    await tester.pumpWidget(buildWidget(daysRemaining: 120));
+    expect(find.textContaining('Confortable'), findsOneWidget);
+  });
+
+  testWidgets('shows warning label when 30-90 days', (tester) async {
+    await tester.pumpWidget(buildWidget(daysRemaining: 60));
+    expect(find.textContaining('Bient'), findsOneWidget);
+  });
+
+  testWidgets('shows urgent label when <= 30 days', (tester) async {
+    await tester.pumpWidget(buildWidget(daysRemaining: 15));
+    expect(find.textContaining('Urgent'), findsOneWidget);
+  });
+
+  testWidgets('shows tax savings chiffre-choc', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("1'450"), findsWidgets);
+  });
+
+  testWidgets('shows congratulation when ceiling full', (tester) async {
+    await tester.pumpWidget(buildWidget(contributed: 7258));
+    expect(find.textContaining('Bravo'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('rebours 3a')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/couple_narrative_timeline_test.dart
+++ b/apps/mobile/test/widgets/coach/couple_narrative_timeline_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/couple_narrative_timeline.dart';
+
+void main() {
+  final acts = [
+    const CoupleAct(
+      number: 1,
+      title: 'Vous travaillez tous les deux',
+      period: '2026\u20132041 (15 ans)',
+      monthlyIncome: 13333,
+      insight: 'Fen\u00eatre pour \u00e9pargner ensemble',
+    ),
+    const CoupleAct(
+      number: 2,
+      title: 'Julien est \u00e0 la retraite, Lauren travaille encore',
+      period: '2041\u20132046 (5 ans)',
+      monthlyIncome: 10234,
+      deltaPercent: -23,
+      insight: 'Le creux\u00a0: 5 ans de revenu r\u00e9duit',
+      isDip: true,
+    ),
+    const CoupleAct(
+      number: 3,
+      title: 'Retraite \u00e0 deux',
+      period: '2046+ (25+ ans)',
+      monthlyIncome: 8890,
+      deltaPercent: -13,
+      insight: 'Le plateau\u00a0: vos revenus stabilis\u00e9s',
+    ),
+  ];
+
+  Widget buildTestWidget({String? coachTip}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: CoupleNarrativeTimeline(
+            acts: acts,
+            partner1Name: 'Julien',
+            partner2Name: 'Lauren',
+            coachTip: coachTip,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('CoupleNarrativeTimeline', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(CoupleNarrativeTimeline), findsOneWidget);
+    });
+
+    testWidgets('shows header', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('histoire'), findsWidgets);
+    });
+
+    testWidgets('shows 3 acts', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('ACTE 1'), findsOneWidget);
+      expect(find.textContaining('ACTE 2'), findsOneWidget);
+      expect(find.textContaining('ACTE 3'), findsOneWidget);
+    });
+
+    testWidgets('shows act titles', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('travaillez'), findsWidgets);
+      expect(find.textContaining('retraite'), findsWidgets);
+    });
+
+    testWidgets('shows income changes', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('-23%'), findsWidgets);
+    });
+
+    testWidgets('shows coach tip when present', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        coachTip: 'Le moment id\u00e9al pour retirer le 3a.',
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('3a'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('handles empty acts', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CoupleNarrativeTimeline(
+            acts: const [],
+            partner1Name: 'A',
+            partner2Name: 'B',
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(CoupleNarrativeTimeline), findsOneWidget);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/crash_test_budget_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/crash_test_budget_widget_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/crash_test_budget_widget.dart';
+
+void main() {
+  final lines = [
+    const BudgetLine(
+      label: 'Loyer',
+      emoji: '🏠',
+      normalAmount: 2100,
+      survivalAmount: 2100,
+      status: BudgetLineStatus.locked,
+    ),
+    const BudgetLine(
+      label: 'Pilier 3a',
+      emoji: '🏦',
+      normalAmount: 605,
+      survivalAmount: 0,
+      status: BudgetLineStatus.paused,
+    ),
+    const BudgetLine(
+      label: 'Loisirs',
+      emoji: '🎭',
+      normalAmount: 500,
+      survivalAmount: 100,
+      status: BudgetLineStatus.cut,
+    ),
+  ];
+
+  Widget buildWidget({double? reserveMonths}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: CrashTestBudgetWidget(
+              monthlyIncome: 6000,
+              survivalIncome: 4200,
+              lines: lines,
+              reserveMonths: reserveMonths,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Crash-test'), findsOneWidget);
+  });
+
+  testWidgets('shows survie label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('survie'), findsWidgets);
+  });
+
+  testWidgets('shows column headers', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.text('Normal'), findsOneWidget);
+    expect(find.text('Survie'), findsOneWidget);
+  });
+
+  testWidgets('shows locked line', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Loyer'), findsOneWidget);
+  });
+
+  testWidgets('shows paused and cut lines', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('3a'), findsOneWidget);
+    expect(find.textContaining('Loisirs'), findsOneWidget);
+  });
+
+  testWidgets('shows TOTAL row', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('TOTAL'), findsOneWidget);
+  });
+
+  testWidgets('shows margin row', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Marge'), findsOneWidget);
+  });
+
+  testWidgets('shows reserve panel when provided', (tester) async {
+    await tester.pumpWidget(buildWidget(reserveMonths: 4.5));
+    expect(find.textContaining('4.5'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Crash-test')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/death_urgency_guide_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/death_urgency_guide_widget_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/death_urgency_guide_widget.dart';
+
+void main() {
+  final phases = [
+    UrgencyPhase(
+      timeframe: '24h',
+      emoji: '🕊️',
+      title: 'Urgences immédiates',
+      actions: [
+        'Déclarer le décès à l\'état civil (24h).',
+        'Contacter le médecin pour le certificat.',
+      ],
+      color: Colors.red,
+    ),
+    UrgencyPhase(
+      timeframe: '1 semaine',
+      emoji: '📄',
+      title: 'Démarches administratives',
+      actions: [
+        'Informer la caisse AVS.',
+        'Contacter la caisse de pension LPP.',
+      ],
+      color: Colors.orange,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DeathUrgencyGuideWidget(phases: phases),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('urgence'), findsWidgets);
+  });
+
+  testWidgets('shows phase timeframes', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('24h'), findsWidgets);
+    expect(find.textContaining('1 semaine'), findsWidgets);
+  });
+
+  testWidgets('shows phase titles', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Urgences immédiates'), findsWidgets);
+  });
+
+  testWidgets('first phase is expanded by default', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('état civil'), findsWidgets);
+  });
+
+  testWidgets('shows support note', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('seul'), findsWidgets);
+  });
+
+  testWidgets('shows CC legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('CC'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('urgence décès', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/debt_repayment_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/debt_repayment_widget_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/debt_repayment_widget.dart';
+
+void main() {
+  final debts = [
+    const DebtEntry(
+      label: 'Carte de crédit',
+      emoji: '💳',
+      balance: 8000,
+      monthlyRate: 0.015,
+      minimumPayment: 200,
+    ),
+    const DebtEntry(
+      label: 'Leasing voiture',
+      emoji: '🚗',
+      balance: 15000,
+      monthlyRate: 0.004,
+      minimumPayment: 350,
+    ),
+    const DebtEntry(
+      label: 'Prêt personnel',
+      emoji: '🏦',
+      balance: 5000,
+      monthlyRate: 0.008,
+      minimumPayment: 150,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DebtRepaymentWidget(
+              debts: debts,
+              extraMonthly: 300,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Avalanche'), findsWidgets);
+  });
+
+  testWidgets('shows strategy toggle buttons', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Boule de neige'), findsWidgets);
+  });
+
+  testWidgets('shows debt labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Carte de crédit'), findsOneWidget);
+    expect(find.textContaining('Leasing'), findsWidgets);
+  });
+
+  testWidgets('shows total debt', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 8000+15000+5000 = 28000
+    expect(find.textContaining("28'000"), findsWidgets);
+  });
+
+  testWidgets('shows comparison callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('économise'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('Avalanche', caseSensitive: false)),
+      findsWidgets,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/disability_cliff_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/disability_cliff_widget_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/disability_cliff_widget.dart';
+
+void main() {
+  final acts = [
+    DisabilityAct(
+      label: 'Le filet',
+      subtitle: 'Ton employeur paie 80%',
+      durationLabel: 'Jours 1–30',
+      monthlyIncome: 6667,
+      emoji: '🛡️',
+      color: Colors.green,
+    ),
+    DisabilityAct(
+      label: 'L\'attente',
+      subtitle: 'L\'AI évalue ton cas',
+      durationLabel: 'Mois 2–24',
+      monthlyIncome: 4200,
+      emoji: '⏳',
+      color: Colors.orange,
+      detail: 'Délai moyen : 14 mois',
+    ),
+    DisabilityAct(
+      label: 'Le plateau',
+      subtitle: 'Après décision AI',
+      durationLabel: 'Long terme',
+      monthlyIncome: 4320,
+      emoji: '📊',
+      color: Colors.red,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DisabilityCliffWidget(
+              grossMonthly: 8333,
+              acts: acts,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('travailler'), findsOneWidget);
+  });
+
+  testWidgets('shows current income', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("8'333"), findsWidgets);
+  });
+
+  testWidgets('shows all 3 acts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('ACTE 1'), findsOneWidget);
+    expect(find.textContaining('ACTE 2'), findsOneWidget);
+    expect(find.textContaining('ACTE 3'), findsOneWidget);
+  });
+
+  testWidgets('shows act incomes', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("6'667"), findsOneWidget);
+    expect(find.textContaining("4'200"), findsOneWidget);
+  });
+
+  testWidgets('shows chiffre-choc', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Chiffre-choc'), findsOneWidget);
+  });
+
+  testWidgets('shows loss in monthly income', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 8333 - 4320 = 4013
+    expect(find.textContaining("4'013"), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Falaise')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/disability_countdown_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/disability_countdown_widget_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/disability_countdown_widget.dart';
+
+void main() {
+  Widget buildWidget({double savings = 28000}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DisabilityCountdownWidget(
+              monthlyExpenses: 5200,
+              initialSavings: savings,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('temps tu tiens'), findsOneWidget);
+  });
+
+  testWidgets('shows 14-month AI delay', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('14'), findsWidgets);
+  });
+
+  testWidgets('shows slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows months can hold for low savings', (tester) async {
+    await tester.pumpWidget(buildWidget(savings: 10000));
+    // 10000/5200 ≈ 1.9 mois
+    expect(find.textContaining('1.'), findsWidgets);
+  });
+
+  testWidgets('shows ok message for sufficient savings', (tester) async {
+    await tester.pumpWidget(buildWidget(savings: 100000));
+    // 100000/5200 ≈ 19.2 mois > 14 mois
+    expect(find.textContaining('couvrent'), findsOneWidget);
+  });
+
+  testWidgets('shows actions when savings insufficient', (tester) async {
+    await tester.pumpWidget(buildWidget(savings: 5000));
+    expect(find.textContaining('urgence'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('rebours')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/disability_red_screen_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/disability_red_screen_widget_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/disability_red_screen_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DisabilityRedScreenWidget(
+              monthlyExpenses: 5200,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('filet'), findsWidgets);
+  });
+
+  testWidgets('shows salarié vs indépendant columns', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Salarié'), findsOneWidget);
+    expect(find.textContaining('Toi'), findsOneWidget);
+  });
+
+  testWidgets('shows 0 CHF for indépendant', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('0 CHF'), findsWidgets);
+  });
+
+  testWidgets('shows chiffre-choc 14 months', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('14'), findsWidgets);
+  });
+
+  testWidgets('shows question about perte de gain', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('perte de gain'), findsWidgets);
+  });
+
+  testWidgets('shows answer buttons', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.text('Oui'), findsOneWidget);
+    expect(find.text('Non'), findsOneWidget);
+  });
+
+  testWidgets('tapping Non shows feedback', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.text('Non'));
+    await tester.pump();
+    expect(find.textContaining('prioritaire'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('rouge')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/disability_reset_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/disability_reset_widget_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/disability_reset_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DisabilityResetWidget(
+              currentAge: 45,
+              currentSalary: 100000,
+              reducedSalary: 55000,
+              capitalBefore: 520000,
+              capitalAfter: 310000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('reset'), findsWidgets);
+  });
+
+  testWidgets('shows age and LPP rate', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('45 ans'), findsWidgets);
+    expect(find.textContaining('15%'), findsOneWidget);
+  });
+
+  testWidgets('shows capital before and after', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("520'000"), findsWidgets);
+    expect(find.textContaining("310'000"), findsWidgets);
+  });
+
+  testWidgets('shows capital delta', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("210'000"), findsWidgets);
+  });
+
+  testWidgets('shows monthly rente lost', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // Shows per-month rente impact
+    expect(find.textContaining('/mois'), findsWidgets);
+  });
+
+  testWidgets('shows narrative text', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('retraite'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Reset silencieux')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/disability_scorecard_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/disability_scorecard_widget_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/disability_scorecard_widget.dart';
+
+void main() {
+  final items = [
+    const CoverageItem(
+      label: 'APG (perte gain)',
+      grade: 'B+',
+      detail: '80% pendant 720j max',
+      emoji: '🛡️',
+    ),
+    const CoverageItem(
+      label: 'AI (rente)',
+      grade: 'C',
+      detail: "2'520 CHF max",
+    ),
+    const CoverageItem(
+      label: 'LPP invalidité',
+      grade: 'A-',
+      detail: '40–70% salaire assuré',
+      legalRef: 'LPP art. 23-26',
+    ),
+    const CoverageItem(
+      label: 'Épargne urgence',
+      grade: 'D',
+      detail: '2 mois de réserve',
+    ),
+    const CoverageItem(
+      label: 'Assurance privée',
+      grade: 'F',
+      detail: 'Aucune détectée',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: DisabilityScorecardWidget(
+              items: items,
+              overallGrade: 'C-',
+              lifeDropPercent: 48,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('bulletin'), findsWidgets);
+  });
+
+  testWidgets('shows all grade items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('APG'), findsOneWidget);
+    expect(find.textContaining('LPP'), findsWidgets);
+  });
+
+  testWidgets('shows grades A-F', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.text('B+'), findsOneWidget);
+    expect(find.text('F'), findsOneWidget);
+  });
+
+  testWidgets('shows overall grade', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.text('C-'), findsOneWidget);
+  });
+
+  testWidgets('shows life drop percent', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('48%'), findsOneWidget);
+  });
+
+  testWidgets('shows weakest subject (F = Assurance privée)', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('faible'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('bulletin')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/double_price_freedom_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/double_price_freedom_widget_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/double_price_freedom_widget.dart';
+
+void main() {
+  final charges = [
+    const ChargeLine(
+      label: 'AVS / AI / APG',
+      employeeAmount: 5300,
+      selfEmployedAmount: 10600,
+      note: 'Double pour ind\u00e9p.',
+    ),
+    const ChargeLine(
+      label: 'LPP (part employeur)',
+      employeeAmount: 4000,
+      selfEmployedAmount: 0,
+    ),
+    const ChargeLine(
+      label: 'IJM',
+      employeeAmount: 0,
+      selfEmployedAmount: 2400,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: DoublePriceFreedomWidget(
+            grossIncome: 100000,
+            charges: charges,
+            totalEmployee: 12300,
+            totalSelfEmployed: 23400,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('double prix'), findsOneWidget);
+  });
+
+  testWidgets('shows income label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("100'000"), findsWidgets);
+  });
+
+  testWidgets('shows column headers', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Salari'), findsWidgets);
+    expect(find.textContaining('p.'), findsWidgets);
+  });
+
+  testWidgets('shows charge line labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('AVS'), findsWidgets);
+    expect(find.textContaining('LPP'), findsWidgets);
+    expect(find.textContaining('IJM'), findsOneWidget);
+  });
+
+  testWidgets('shows total row', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('TOTAL'), findsOneWidget);
+  });
+
+  testWidgets('shows total amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("12'300"), findsOneWidget);
+    expect(find.textContaining("23'400"), findsOneWidget);
+  });
+
+  testWidgets('shows chiffre-choc with multiplier', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('1.9'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('double prix')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/early_retirement_slider_test.dart
+++ b/apps/mobile/test/widgets/coach/early_retirement_slider_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/early_retirement_slider.dart';
+
+void main() {
+  final scenarios = [
+    const RetirementAgeScenario(
+        age: 63, monthlyIncome: 4510, deltaPercent: -14, lifetimeDelta: -174000),
+    const RetirementAgeScenario(
+        age: 64, monthlyIncome: 4850, deltaPercent: -7),
+    const RetirementAgeScenario(
+        age: 65, monthlyIncome: 5234, deltaPercent: 0),
+    const RetirementAgeScenario(
+        age: 66, monthlyIncome: 5644, deltaPercent: 8),
+    const RetirementAgeScenario(
+        age: 67, monthlyIncome: 6050, deltaPercent: 16),
+  ];
+
+  Widget buildTestWidget({int initialAge = 65}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: EarlyRetirementSlider(
+            scenarios: scenarios,
+            monthlyIncomeAt65: 5234,
+            initialAge: initialAge,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('EarlyRetirementSlider', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(EarlyRetirementSlider), findsOneWidget);
+    });
+
+    testWidgets('shows "Et si je partais" header', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('partais'), findsWidgets);
+    });
+
+    testWidgets('shows initial age 65', (tester) async {
+      await tester.pumpWidget(buildTestWidget(initialAge: 65));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('65'), findsWidgets);
+    });
+
+    testWidgets('shows slider', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Slider), findsOneWidget);
+    });
+
+    testWidgets('shows zone label', (tester) async {
+      await tester.pumpWidget(buildTestWidget(initialAge: 65));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Standard'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('handles empty scenarios', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: EarlyRetirementSlider(
+            scenarios: const [],
+            monthlyIncomeAt65: 5234,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(EarlyRetirementSlider), findsOneWidget);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/expat_countdown_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/expat_countdown_widget_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/expat_countdown_widget.dart';
+
+void main() {
+  final departure = DateTime.now().add(const Duration(days: 90));
+
+  final deadlines = [
+    ExpatDeadline(
+      label: 'Clôturer le compte 3a',
+      emoji: '💰',
+      daysFromDeparture: -30,
+      action: 'Contacter ta banque pour clôture 3a avant départ.',
+      legalRef: 'OPP3 art. 1',
+      consequence: 'Impossibilité de rachat futur.',
+    ),
+    ExpatDeadline(
+      label: 'Transférer libre passage LPP',
+      emoji: '🏦',
+      daysFromDeparture: 0,
+      action: 'Virer le capital LPP sur un compte de libre passage.',
+      legalRef: 'LPP art. 5',
+      isEuOnly: true,
+    ),
+  ];
+
+  Widget buildWidget({bool isEu = false}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: ExpatCountdownWidget(
+              departureDate: departure,
+              deadlines: deadlines,
+              isEuDestination: isEu,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Checklist'), findsWidgets);
+  });
+
+  testWidgets('shows progress text', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('actions complétées'), findsWidgets);
+  });
+
+  testWidgets('shows deadline labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('3a'), findsWidgets);
+  });
+
+  testWidgets('shows legal references', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('OPP3'), findsWidgets);
+  });
+
+  testWidgets('hides EU-only deadlines when not EU', (tester) async {
+    await tester.pumpWidget(buildWidget(isEu: false));
+    // 'Virer le capital LPP' is the action text unique to the EU-only deadline card
+    expect(find.textContaining('Virer le capital LPP'), findsNothing);
+  });
+
+  testWidgets('shows EU-only deadlines when isEuDestination', (tester) async {
+    await tester.pumpWidget(buildWidget(isEu: true));
+    expect(find.textContaining('Virer le capital LPP'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('rebours expatriation', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/expat_rights_loss_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/expat_rights_loss_widget_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/expat_rights_loss_widget.dart';
+
+void main() {
+  final rights = [
+    const ExpatRight(
+      label: 'Rente AVS réduite',
+      emoji: '🏛️',
+      before: 'CHF 2\'520/mois max',
+      after: 'CHF 1\'710/mois (lacune 15 ans)',
+      legalRef: 'LAVS art. 29bis',
+      impact: 'Perte de CHF 810/mois à vie.',
+      isIrreversible: true,
+    ),
+    const ExpatRight(
+      label: 'LAMal suspendue',
+      emoji: '🏥',
+      before: 'Couverture complète',
+      after: 'Couverture nulle hors CH',
+      legalRef: 'LAMal art. 3',
+      impact: 'Tu dois souscrire une assurance locale.',
+    ),
+  ];
+
+  Widget buildWidget({bool isEu = false}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: ExpatRightsLossWidget(
+              rights: rights,
+              destination: 'France',
+              isEuDestination: isEu,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('perds'), findsWidgets);
+  });
+
+  testWidgets('shows destination', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('France'), findsWidgets);
+  });
+
+  testWidgets('shows right labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('AVS'), findsWidgets);
+    expect(find.textContaining('LAMal'), findsWidgets);
+  });
+
+  testWidgets('shows IRRÉVERSIBLE badge for irreversible right', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('IRRÉVERSIBLE'), findsWidgets);
+  });
+
+  testWidgets('shows legal references', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LAVS'), findsWidgets);
+  });
+
+  testWidgets('shows EU badge when isEuDestination', (tester) async {
+    await tester.pumpWidget(buildWidget(isEu: true));
+    expect(find.textContaining('totalisation'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('expatriation', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/financial_weather_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/financial_weather_widget_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/financial_weather_widget.dart';
+
+void main() {
+  final scenarios = [
+    const WeatherScenario(
+      weather: FinancialWeather.sunny,
+      probabilityPercent: 45,
+      monthlyIncomeMin: 5200,
+      monthlyIncomeMax: 6500,
+      description: 'Tu vis confortablement',
+    ),
+    const WeatherScenario(
+      weather: FinancialWeather.partlyCloudy,
+      probabilityPercent: 35,
+      monthlyIncomeMin: 4200,
+      monthlyIncomeMax: 5200,
+      description: 'Budget serr\u00e9 mais ok',
+    ),
+    const WeatherScenario(
+      weather: FinancialWeather.rainy,
+      probabilityPercent: 20,
+      monthlyIncomeMin: 3500,
+      monthlyIncomeMax: 4200,
+      description: 'Il faudra des ajustements',
+    ),
+  ];
+
+  Widget buildTestWidget({
+    FinancialWeather outlook = FinancialWeather.partlyCloudy,
+    FinancialWeather? trend,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: FinancialWeatherWidget(
+            scenarios: scenarios,
+            currentOutlook: outlook,
+            trendTowards: trend,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('FinancialWeatherWidget', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(FinancialWeatherWidget), findsOneWidget);
+    });
+
+    testWidgets('shows header', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('t\u00e9o'), findsWidgets);
+    });
+
+    testWidgets('shows all 3 scenarios', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Soleil'), findsWidgets);
+      expect(find.textContaining('Nuageux'), findsWidgets);
+      expect(find.textContaining('Pluie'), findsWidgets);
+    });
+
+    testWidgets('shows current outlook', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Aujourd'), findsWidgets);
+    });
+
+    testWidgets('shows probabilities', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('45%'), findsWidgets);
+      expect(find.textContaining('35%'), findsWidgets);
+      expect(find.textContaining('20%'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('handles trend indicator', (tester) async {
+      await tester.pumpWidget(
+          buildTestWidget(trend: FinancialWeather.sunny));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('tendance'), findsWidgets);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/fiscal_superpower_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/fiscal_superpower_widget_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/fiscal_superpower_widget.dart';
+
+void main() {
+  final superpowers = [
+    const FiscalSuperpower(
+      label: 'Déduction enfant',
+      emoji: '👶',
+      annualDeduction: 6700,
+      taxSaving: 1675,
+      legalRef: 'LIFD art. 213',
+    ),
+    const FiscalSuperpower(
+      label: 'Frais de garde',
+      emoji: '🏫',
+      annualDeduction: 25500,
+      taxSaving: 6375,
+      legalRef: 'LIFD art. 212',
+      note: 'max CHF 25\'500/an',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: FiscalSuperpowerWidget(
+              superpowers: superpowers,
+              taxRate: 0.25,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('fiscal'), findsWidgets);
+  });
+
+  testWidgets('shows LIFD legal ref', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LIFD'), findsWidgets);
+  });
+
+  testWidgets('shows slider for children count', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows total saving callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 1 child: 1675+6375 = 8050
+    expect(find.textContaining("8'050"), findsWidgets);
+  });
+
+  testWidgets('shows superpower items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Déduction enfant'), findsOneWidget);
+    expect(find.textContaining('garde'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('fiscal', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/franchise_cost_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/franchise_cost_widget_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/franchise_cost_widget.dart';
+
+void main() {
+  final options = [
+    const FranchiseOption(
+      franchiseAmount: 300,
+      monthlyPremiumSavings: 0,
+    ),
+    const FranchiseOption(
+      franchiseAmount: 1500,
+      monthlyPremiumSavings: 70,
+    ),
+    const FranchiseOption(
+      franchiseAmount: 2500,
+      monthlyPremiumSavings: 130,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: FranchiseCostWidget(
+              options: options,
+              initialConsultationsPerYear: 3,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('franchise'), findsWidgets);
+  });
+
+  testWidgets('shows slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows franchise amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('300'), findsWidgets);
+    expect(find.textContaining("2'500"), findsWidgets);
+  });
+
+  testWidgets('shows comparison table headers', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Franchise'), findsWidgets);
+    expect(find.textContaining('prime'), findsWidgets);
+  });
+
+  testWidgets('shows long illness scenario', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('2 ans'), findsWidgets);
+  });
+
+  testWidgets('shows breakeven rule', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('2×'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer with 30.11 deadline', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('30.11'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Franchise')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/hero_retirement_card_test.dart
+++ b/apps/mobile/test/widgets/coach/hero_retirement_card_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/hero_retirement_card.dart';
+
+void main() {
+  Widget buildTestWidget({
+    HeroCardMode mode = HeroCardMode.full,
+    double? monthlyIncome,
+    double? replacementRatio,
+    double? rangeMin,
+    double? rangeMax,
+    double? currentMonthlySalary,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: HeroRetirementCard(
+            mode: mode,
+            monthlyIncome: monthlyIncome,
+            replacementRatio: replacementRatio,
+            rangeMin: rangeMin,
+            rangeMax: rangeMax,
+            currentMonthlySalary: currentMonthlySalary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('HeroRetirementCard', () {
+    testWidgets('renders without crashing in full mode', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        monthlyIncome: 5234,
+        replacementRatio: 63,
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(HeroRetirementCard), findsOneWidget);
+    });
+
+    testWidgets('shows "Ton salaire apres 65" header in full mode',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(monthlyIncome: 5234));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('salaire'), findsWidgets);
+    });
+
+    testWidgets('P1-A: shows before/after when currentMonthlySalary set',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        monthlyIncome: 5234,
+        replacementRatio: 63,
+        currentMonthlySalary: 8333,
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining("Aujourd'hui"), findsOneWidget);
+      expect(find.textContaining('retraite'), findsWidgets);
+    });
+
+    testWidgets('P1-A: replacement ratio shows human explanation',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        monthlyIncome: 5234,
+        replacementRatio: 63,
+        currentMonthlySalary: 8333,
+      ));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('63%'), findsWidgets);
+      expect(find.textContaining('train de vie'), findsWidgets);
+    });
+
+    testWidgets('renders range mode', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        mode: HeroCardMode.range,
+        rangeMin: 3500,
+        rangeMax: 5500,
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(HeroRetirementCard), findsOneWidget);
+      expect(find.textContaining('Entre'), findsWidgets);
+    });
+
+    testWidgets('renders educational mode', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        mode: HeroCardMode.educational,
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(HeroRetirementCard), findsOneWidget);
+      expect(find.textContaining('manque'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget(monthlyIncome: 5234));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget(monthlyIncome: 5234));
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/apps/mobile/test/widgets/coach/horizon_line_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/horizon_line_widget_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/horizon_line_widget.dart';
+
+void main() {
+  Widget buildWidget({int daysConsumed = 0}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: HorizonLineWidget(
+              monthlyBenefit: 5833,
+              totalDays: 260,
+              daysConsumed: daysConsumed,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('horizon'), findsWidgets);
+  });
+
+  testWidgets('shows monthly benefit', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("5'833"), findsWidgets);
+  });
+
+  testWidgets('shows 0 CHF label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('0 CHF'), findsWidgets);
+  });
+
+  testWidgets('shows days remaining when not 0', (tester) async {
+    await tester.pumpWidget(buildWidget(daysConsumed: 100));
+    expect(find.textContaining('160'), findsWidgets); // 260-100
+  });
+
+  testWidgets('shows after-line section', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('sociale'), findsOneWidget);
+  });
+
+  testWidgets('shows chiffre-choc', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('instantané'), findsOneWidget);
+  });
+
+  testWidgets('shows safe zone label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Zone'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('horizon')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/job_change_checklist_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/job_change_checklist_widget_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/job_change_checklist_widget.dart';
+
+void main() {
+  final items = [
+    const ChecklistItem(
+      deadline: 'J0',
+      action: 'Demander certificat LPP ancien employeur',
+      legalRef: 'LPP art. 3',
+      emoji: '📄',
+      consequence: 'Sans certificat, tu ne peux pas comparer les caisses.',
+    ),
+    const ChecklistItem(
+      deadline: 'J+5',
+      action: 'Vérifier le transfert libre passage',
+      legalRef: 'OLP art. 1-3',
+      emoji: '🏦',
+    ),
+    const ChecklistItem(
+      deadline: 'J+30',
+      action: 'Premier bulletin de salaire — vérifier les déductions',
+      legalRef: 'CO art. 323',
+      emoji: '🧾',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: JobChangeChecklistWidget(items: items),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Checklist'), findsWidgets);
+  });
+
+  testWidgets('shows progress bar', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(LinearProgressIndicator), findsWidgets);
+  });
+
+  testWidgets('shows checklist items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('certificat LPP'), findsWidgets);
+    expect(find.textContaining('libre passage'), findsWidgets);
+  });
+
+  testWidgets('shows deadline badges', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('J0'), findsWidgets);
+    expect(find.textContaining('J+30'), findsWidgets);
+  });
+
+  testWidgets('shows critical alert', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('certificat LPP'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Checklist', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/job_change_comparison_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/job_change_comparison_widget_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/job_change_comparison_widget.dart';
+
+void main() {
+  final axes = [
+    const JobAxis(
+      label: 'Salaire net',
+      emoji: '💰',
+      currentValue: 4200,
+      newValue: 4700,
+      unit: 'CHF/mois',
+    ),
+    const JobAxis(
+      label: 'Contribution LPP employeur',
+      emoji: '🏦',
+      currentValue: 400,
+      newValue: 280,
+      unit: 'CHF/mois',
+    ),
+    const JobAxis(
+      label: 'Jours de vacances',
+      emoji: '🌴',
+      currentValue: 25,
+      newValue: 20,
+      unit: 'jours',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: JobChangeComparisonWidget(
+              currentJobLabel: 'Poste actuel',
+              newJobLabel: 'Nouvelle offre',
+              axes: axes,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('changement'), findsWidgets);
+  });
+
+  testWidgets('shows both job labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Poste actuel'), findsWidgets);
+    expect(find.textContaining('Nouvelle offre'), findsWidgets);
+  });
+
+  testWidgets('shows axis items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Salaire net'), findsWidgets);
+    expect(find.textContaining('LPP'), findsWidgets);
+  });
+
+  testWidgets('shows net callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Impact réel'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('changement', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/leasing_cost_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/leasing_cost_widget_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/leasing_cost_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: LeasingCostWidget(
+              vehiclePrice: 40000,
+              monthlyLeasing: 600,
+              leasingDurationMonths: 48,
+              annualReturnRate: 0.05,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('leasing'), findsWidgets);
+  });
+
+  testWidgets('shows vehicle price', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("40'000"), findsWidgets);
+  });
+
+  testWidgets('shows leasing total', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 600 × 48 = 28800
+    expect(find.textContaining("28'800"), findsWidgets);
+  });
+
+  testWidgets('shows monthly slider', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Slider), findsOneWidget);
+  });
+
+  testWidgets('shows opportunity cost section', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("opportunité"), findsWidgets);
+  });
+
+  testWidgets('shows CO legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('CO'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('leasing', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/lpp_rescue_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/lpp_rescue_widget_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/lpp_rescue_widget.dart';
+
+void main() {
+  final options = [
+    const LppTransferOption(
+      label: 'Nouveau employeur',
+      emoji: '🏢',
+      description: 'Transfert direct au LPP du nouvel employeur.',
+      fiveYearGain: 0,
+    ),
+    const LppTransferOption(
+      label: 'Libre passage (recommandé)',
+      emoji: '🏦',
+      description: '2 comptes pour optimiser la fiscalité au retrait.',
+      fiveYearGain: 9000,
+      recommended: true,
+      legalRef: 'LFLP art. 3-4',
+    ),
+    const LppTransferOption(
+      label: 'Institution supplétive',
+      emoji: '⚠️',
+      description: 'Taux technique bas, frais élevés.',
+      fiveYearGain: -9000,
+    ),
+  ];
+
+  Widget buildWidget({int daysElapsed = 5}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: LppRescueWidget(
+              lppBalance: 185000,
+              options: options,
+              daysElapsed: daysElapsed,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('sauvetage'), findsOneWidget);
+  });
+
+  testWidgets('shows days remaining', (tester) async {
+    await tester.pumpWidget(buildWidget(daysElapsed: 5));
+    expect(find.textContaining('25 jours'), findsOneWidget);
+  });
+
+  testWidgets('shows LPP balance', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("185'000"), findsWidgets);
+  });
+
+  testWidgets('shows recommended badge', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Recommandé'), findsOneWidget);
+  });
+
+  testWidgets('shows all 3 options', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Option 1'), findsOneWidget);
+    expect(find.textContaining('Option 2'), findsOneWidget);
+    expect(find.textContaining('Option 3'), findsOneWidget);
+  });
+
+  testWidgets('shows chiffre-choc about institution supplétive', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('supplétive'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer with sfbvg', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('sfbvg'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('sauvetage LPP', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/lpp_vs_3a_decision_tree_test.dart
+++ b/apps/mobile/test/widgets/coach/lpp_vs_3a_decision_tree_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/lpp_vs_3a_decision_tree.dart';
+
+void main() {
+  final lppOption = const DecisionOption(
+    title: 'LPP volontaire',
+    emoji: '\ud83c\udfe6',
+    subtitle: 'Rente garantie + protection invalidit\u00e9',
+    pros: ['Rente garantie', 'Invalidit\u00e9 couverte'],
+    cons: ['3a limit\u00e9 \u00e0 7\u2019258', 'Co\u00fbteux seul'],
+    annualTaxSavings: 1815,
+  );
+
+  final grand3aOption = const DecisionOption(
+    title: 'Grand 3a',
+    emoji: '\ud83d\udcb0',
+    subtitle: 'Plafond 36\u2019288 CHF, flexibilit\u00e9 totale',
+    pros: ['Plafond 36\u2019288', 'Flexibilit\u00e9'],
+    cons: ['Capital seulement', 'AI seule'],
+    annualTaxSavings: 9070,
+  );
+
+  Widget buildWidget({double income = 80000}) => MaterialApp(
+        home: Scaffold(
+          body: LppVs3aDecisionTree(
+            expectedIncome: income,
+            lppOption: lppOption,
+            grand3aOption: grand3aOption,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LPP'), findsWidgets);
+    expect(find.textContaining('3a'), findsWidgets);
+  });
+
+  testWidgets('shows income in decision node', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("80'000"), findsWidgets);
+  });
+
+  testWidgets('shows both options for high income', (tester) async {
+    await tester.pumpWidget(buildWidget(income: 80000));
+    expect(find.textContaining('LPP volontaire'), findsWidgets);
+    expect(find.textContaining('Grand 3a'), findsWidgets);
+  });
+
+  testWidgets('shows low-income card for income below threshold', (tester) async {
+    await tester.pumpWidget(buildWidget(income: 40000));
+    expect(find.textContaining('pilier retraite'), findsOneWidget);
+  });
+
+  testWidgets('tapping an option expands it', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // .last avoids matching the main title "LPP volontaire ou Grand 3a ?"
+    await tester.tap(find.textContaining('LPP volontaire').last);
+    await tester.pump();
+    expect(find.textContaining('Rente garantie'), findsWidgets);
+  });
+
+  testWidgets('tapping expanded option collapses it', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.textContaining('LPP volontaire').last);
+    await tester.pumpAndSettle();
+    // 'couverte' is only in pros list, not in subtitle
+    expect(find.textContaining('couverte'), findsOneWidget);
+    await tester.tap(find.textContaining('LPP volontaire').last);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('couverte'), findsNothing);
+  });
+
+  testWidgets('shows tax savings when expanded', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.textContaining('Grand 3a').last);
+    await tester.pumpAndSettle();
+    // Tax savings label visible when expanded
+    expect(find.textContaining('conomie fiscale'), findsWidgets);
+  });
+
+  testWidgets('shows chiffre-choc panel', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('mauvais choix'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('d.cision LPP')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/minimum_vital_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/minimum_vital_widget_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/minimum_vital_widget.dart';
+
+void main() {
+  final items = [
+    const MinimumVitalItem(
+      label: 'Loyer',
+      emoji: '🏠',
+      amount: 1800,
+      legalRef: 'LP art. 93',
+    ),
+    const MinimumVitalItem(
+      label: 'Alimentation',
+      emoji: '🍽️',
+      amount: 1200,
+      legalRef: 'LP art. 93',
+      note: 'forfait OFS',
+    ),
+    const MinimumVitalItem(
+      label: 'Transports',
+      emoji: '🚌',
+      amount: 200,
+      legalRef: 'LP art. 93',
+    ),
+    const MinimumVitalItem(
+      label: 'Assurance maladie',
+      emoji: '🏥',
+      amount: 400,
+      legalRef: 'LAMal art. 65',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MinimumVitalWidget(
+              items: items,
+              grossMonthly: 6000,
+              totalDebts: 25000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('bouclier'), findsWidgets);
+  });
+
+  testWidgets('shows LP art 93 reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LP art. 93'), findsWidgets);
+  });
+
+  testWidgets('shows total protected', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 1800+1200+200+400 = 3600
+    expect(find.textContaining("3'600"), findsWidgets);
+  });
+
+  testWidgets('shows seizable amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 6000-3600 = 2400
+    expect(find.textContaining("2'400"), findsWidgets);
+  });
+
+  testWidgets('shows items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Loyer'), findsOneWidget);
+    expect(find.textContaining('Alimentation'), findsOneWidget);
+  });
+
+  testWidgets('shows action callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('avocat'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('minimum vital', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/mint_trajectory_chart_test.dart
+++ b/apps/mobile/test/widgets/coach/mint_trajectory_chart_test.dart
@@ -55,6 +55,7 @@ void main() {
     });
 
     testWidgets('handles tap without crash', (tester) async {
+      // ignore: unused_local_variable
       var tapped = false;
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(

--- a/apps/mobile/test/widgets/coach/moving_true_cost_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/moving_true_cost_widget_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/moving_true_cost_widget.dart';
+
+void main() {
+  final items = [
+    const MovingCostItem(
+      label: 'Impôts cantonaux',
+      emoji: '📊',
+      monthlyBefore: 2100,
+      monthlyAfter: 1200,
+      note: 'Taux effectif 34% → 19%',
+    ),
+    const MovingCostItem(
+      label: 'Loyer',
+      emoji: '🏠',
+      monthlyBefore: 1800,
+      monthlyAfter: 2200,
+    ),
+    const MovingCostItem(
+      label: 'LAMal (primes)',
+      emoji: '🏥',
+      monthlyBefore: 520,
+      monthlyAfter: 420,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: MovingTrueCostWidget(
+              fromCanton: 'Vaud',
+              toCanton: 'Zoug',
+              items: items,
+              movingFees: 4000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Déménager'), findsWidgets);
+  });
+
+  testWidgets('shows canton names', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Vaud'), findsWidgets);
+    expect(find.textContaining('Zoug'), findsWidgets);
+  });
+
+  testWidgets('shows items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Impôts'), findsWidgets);
+    expect(find.textContaining('Loyer'), findsWidgets);
+  });
+
+  testWidgets('shows net result', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('net'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('déménagement', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/net_proceeds_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/net_proceeds_widget_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/net_proceeds_widget.dart';
+
+void main() {
+  // salePrice=800000, mortgageBalance=400000, capitalGainTax=36000, eplReimbursement=50000
+  // notaryFees = 800000 * 0.015 = 12000
+  // agencyFees = 800000 * 0.025 = 20000
+  // totalDeductions = 518000
+  // netProceeds = 282000 → "282'000"
+  // perceivedNet = 400000 → "400'000"
+  // surprise = 118000 → "118'000"
+
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: NetProceedsWidget(
+              salePrice: 800000,
+              mortgageBalance: 400000,
+              capitalGainTax: 36000,
+              eplReimbursement: 50000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('net réel'), findsWidgets);
+  });
+
+  testWidgets('shows sale price', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("800'000"), findsWidgets);
+  });
+
+  testWidgets('shows net proceeds', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("282'000"), findsWidgets);
+  });
+
+  testWidgets('shows surprise amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("118'000"), findsWidgets);
+  });
+
+  testWidgets('shows perceived net', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("400'000"), findsWidgets);
+  });
+
+  testWidgets('shows details toggle', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('détail'), findsWidgets);
+  });
+
+  testWidgets('shows LIFD reference in detail after tap', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.textContaining('détail'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('LIFD'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('net réel vente', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/ninety_day_plan_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/ninety_day_plan_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/ninety_day_plan_widget.dart';
+
+void main() {
+  final phases = [
+    PlanPhase(
+      title: 'Semaine 1',
+      emoji: '\ud83d\udea8',
+      deadline: 'J+7',
+      urgencyColor: Colors.red,
+      actions: const [
+        PlanAction(
+          label: 'Inscription caisse AVS',
+          consequence: 'D\u00e9lai 90j, sinon r\u00e9troactif',
+          legalRef: 'LAVS art. 12',
+          isCompleted: false,
+        ),
+        PlanAction(
+          label: 'Num\u00e9ro TVA',
+          isCompleted: true,
+        ),
+      ],
+    ),
+    PlanPhase(
+      title: 'Mois 2',
+      emoji: '\ud83d\udcbc',
+      deadline: 'J+30',
+      urgencyColor: Colors.orange,
+      actions: const [
+        PlanAction(
+          label: 'Choix LPP ou Grand 3a',
+          consequence: 'Impact fiscal majeur',
+        ),
+      ],
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: NinetyDayPlanWidget(phases: phases),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Plan 90 jours'), findsOneWidget);
+  });
+
+  testWidgets('shows all phase titles', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Semaine 1'), findsOneWidget);
+    expect(find.textContaining('Mois 2'), findsOneWidget);
+  });
+
+  testWidgets('shows action items', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('AVS'), findsWidgets);
+    expect(find.textContaining('TVA'), findsOneWidget);
+  });
+
+  testWidgets('shows deadline labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('J+7'), findsOneWidget);
+    expect(find.textContaining('J+30'), findsOneWidget);
+  });
+
+  testWidgets('shows consequence text for action', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('troactif'), findsOneWidget);
+  });
+
+  testWidgets('shows progress counter', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 1 of 3 actions completed
+    expect(find.textContaining('1/3'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('returns shrink for empty phases', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: NinetyDayPlanWidget(phases: const [])),
+    ));
+    expect(find.textContaining('Plan 90 jours'), findsNothing);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Plan 90 jours')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/p5_couple_widgets_test.dart
+++ b/apps/mobile/test/widgets/coach/p5_couple_widgets_test.dart
@@ -377,7 +377,6 @@ void main() {
 
       // Drag slider towards max
       final slider = find.byType(Slider);
-      final sliderCenter = tester.getCenter(slider);
       await tester.drag(slider, Offset(100, 0));
       await tester.pumpAndSettle();
 

--- a/apps/mobile/test/widgets/coach/payslip_xray_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/payslip_xray_widget_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/payslip_xray_widget.dart';
+
+void main() {
+  final lines = [
+    const PayslipLine(
+      label: 'AVS / AI / APG',
+      emoji: '\ud83e\uddf1',
+      amount: 291.5,
+      percentage: 5.3,
+      explanation: 'Rente vieillesse.',
+      legalRef: 'LAVS art. 3',
+    ),
+    const PayslipLine(
+      label: 'LPP',
+      emoji: '\ud83c\udfe6',
+      amount: 193.0,
+      percentage: 3.5,
+      explanation: '2e pilier.',
+      legalRef: 'LPP art. 14',
+    ),
+    const PayslipLine(
+      label: 'AC',
+      emoji: '\ud83e\ude82',
+      amount: 60.5,
+      percentage: 1.1,
+      explanation: 'Assurance-ch\u00f4mage.',
+      legalRef: 'LACI art. 3',
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: PayslipXRayWidget(
+            grossSalary: 5500,
+            netSalary: 4210,
+            deductions: lines,
+            employerHiddenCost: 654,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Radiographie'), findsOneWidget);
+  });
+
+  testWidgets('shows gross and net amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('5'), findsWidgets); // 5500
+    expect(find.textContaining('4'), findsWidgets); // 4210
+  });
+
+  testWidgets('shows deduction labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('AVS'), findsOneWidget);
+    expect(find.textContaining('LPP'), findsOneWidget);
+  });
+
+  testWidgets('shows employer hidden cost section', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('employeur'), findsWidgets);
+  });
+
+  testWidgets('tap expands a deduction line', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.textContaining('AVS').first);
+    await tester.pump();
+    expect(find.textContaining('Rente'), findsOneWidget);
+  });
+
+  testWidgets('shows legal ref on expanded line', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.textContaining('AVS').first);
+    await tester.pump();
+    expect(find.textContaining('LAVS'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Radiographie')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/prix_du_silence_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/prix_du_silence_widget_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/prix_du_silence_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: PrixDuSilenceWidget(
+              patrimoine: 500000,
+              marriedTaxRate: 0.02,
+              concubinTaxRate: 0.40,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('silence'), findsWidgets);
+  });
+
+  testWidgets('shows marié scenario', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Marié'), findsWidgets);
+  });
+
+  testWidgets('shows concubin scenario', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Concubin'), findsWidgets);
+  });
+
+  testWidgets('shows patrimoine amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("500'000"), findsWidgets);
+  });
+
+  testWidgets('shows difference callout', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('coûte'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('silence', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/remploi_countdown_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/remploi_countdown_widget_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/remploi_countdown_widget.dart';
+
+void main() {
+  // saleDate in the past (2025-06-01), deadline = 2027-06-01
+  // As of 2026-03-07: ~279 days elapsed, ~451 days remaining
+  // deferredTax = 36000 → "36'000"
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: RemploiCountdownWidget(
+              saleDate: DateTime(2025, 6, 1),
+              deferredTax: 36000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('remploi'), findsWidgets);
+  });
+
+  testWidgets('shows deferred tax amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("36'000"), findsWidgets);
+  });
+
+  testWidgets('shows days remaining counter', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('jours restants'), findsWidgets);
+  });
+
+  testWidgets('shows progress bar', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows deadline date', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('2027'), findsWidgets);
+  });
+
+  testWidgets('shows LIFD legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LIFD'), findsWidgets);
+  });
+
+  testWidgets('shows explanation with 2 years', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('2 ans'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('remploi', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/sale_surprises_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/sale_surprises_widget_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/sale_surprises_widget.dart';
+
+void main() {
+  // salePrice=800000, purchasePrice=600000, eplWithdrawn=50000, holdingYears=12
+  // _capitalGain = 200000
+  // _gainTaxRate = 0.18 (10 <= 12 < 15)
+  // _gainTax = 36000 → "36'000"
+  // salePrice shown: "800'000"
+
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SaleSurprisesWidget(
+              salePrice: 800000,
+              purchasePrice: 600000,
+              eplWithdrawn: 50000,
+              holdingYears: 12,
+              canton: 'Vaud',
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('surprises'), findsWidgets);
+  });
+
+  testWidgets('shows sale price', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("800'000"), findsWidgets);
+  });
+
+  testWidgets('shows gain tax act', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Acte 1'), findsWidgets);
+    expect(find.textContaining("36'000"), findsWidgets);
+  });
+
+  testWidgets('shows EPL reimbursement act', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Acte 2'), findsWidgets);
+    expect(find.textContaining("50'000"), findsWidgets);
+  });
+
+  testWidgets('shows remploi act', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Acte 3'), findsWidgets);
+  });
+
+  testWidgets('shows net cascade row', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Net réel'), findsWidgets);
+  });
+
+  testWidgets('shows LIFD legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LIFD'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsWidgets);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('surprises vente', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/survivor_pension_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/survivor_pension_widget_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/survivor_pension_widget.dart';
+
+void main() {
+  // partnerAvsRente=2000, partnerLppMonthly=1000
+  // _avsMarried = 2000 * 0.80 = 1600
+  // _lppMarried = 1000 * 0.60 = 600
+  // _totalMarried = 2200 → "2'200"
+  // _totalConcubin = 0
+  // _marriageBonus = 2200 → "2'200"
+
+  Widget buildWidget({bool isConcubin = false}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SurvivorPensionWidget(
+              partnerAvsRente: 2000,
+              partnerLppMonthly: 1000,
+              isConcubin: isConcubin,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('survivant'), findsWidgets);
+  });
+
+  testWidgets('shows married total', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("2'200"), findsWidgets);
+  });
+
+  testWidgets('shows concubin zero amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('0 CHF'), findsWidgets);
+  });
+
+  testWidgets('shows marriage bonus chiffre-choc', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // _marriageBonus = 2200
+    expect(find.textContaining("2'200"), findsWidgets);
+  });
+
+  testWidgets('shows LAVS legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LAVS'), findsWidgets);
+  });
+
+  testWidgets('shows LPP legal reference', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('LPP'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(
+      find.bySemanticsLabel(RegExp('rente survivant', caseSensitive: false)),
+      findsOneWidget,
+    );
+  });
+}

--- a/apps/mobile/test/widgets/coach/testament_invisible_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/testament_invisible_widget_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/testament_invisible_widget.dart';
+
+void main() {
+  Widget buildWidget() => const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TestamentInvisibleWidget(
+              patrimoine: 500000,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('testament'), findsWidgets);
+  });
+
+  testWidgets('shows status selector chips', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Concubin'), findsWidgets);
+    expect(find.textContaining('Marié'), findsWidgets);
+  });
+
+  testWidgets('shows patrimoine amount', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("500'000"), findsWidgets);
+  });
+
+  testWidgets('shows distribution section', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Distribution'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('Testament', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/top_cantons_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/top_cantons_widget_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/top_cantons_widget.dart';
+
+void main() {
+  final rankings = [
+    const CantonRanking(
+      rank: 1,
+      canton: 'Zoug',
+      shortCode: 'ZG',
+      annualTaxSaving: 12800,
+      monthlyLamal: 380,
+      monthlyRent: 2200,
+      highlight: 'Fiscalité la plus favorable de Suisse',
+    ),
+    const CantonRanking(
+      rank: 2,
+      canton: 'Schwyz',
+      shortCode: 'SZ',
+      annualTaxSaving: 9600,
+      monthlyLamal: 340,
+      monthlyRent: 1900,
+    ),
+    const CantonRanking(
+      rank: 3,
+      canton: 'Nidwald',
+      shortCode: 'NW',
+      annualTaxSaving: 7400,
+      monthlyLamal: 350,
+      monthlyRent: 1700,
+    ),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TopCantonWidget(
+              currentCanton: 'Vaud',
+              rankings: rankings,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('cantons'), findsWidgets);
+  });
+
+  testWidgets('shows top canton', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Zoug'), findsWidgets);
+  });
+
+  testWidgets('shows savings amounts', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("12'800"), findsWidgets);
+  });
+
+  testWidgets('shows ranking numbers', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.text('1'), findsWidgets);
+    expect(find.text('2'), findsWidgets);
+  });
+
+  testWidgets('shows children toggle', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.byType(Switch), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('cantons', caseSensitive: false)), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/true_hourly_rate_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/true_hourly_rate_widget_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/true_hourly_rate_widget.dart';
+
+void main() {
+  final layers = [
+    const RateLayer(label: 'Imp\u00f4ts', amount: 25000, emoji: '\ud83c\udfe6'),
+    const RateLayer(label: 'Cotisations AVS', amount: 10600, emoji: '\ud83e\uddf1'),
+    const RateLayer(label: 'Assurances', amount: 4000, emoji: '\ud83c\udfe5'),
+    const RateLayer(label: 'Vacances / maladie', amount: 9940, emoji: '\ud83c\udfd6'),
+  ];
+
+  Widget buildWidget() => MaterialApp(
+        home: Scaffold(
+          body: TrueHourlyRateWidget(
+            desiredNetAnnual: 100000,
+            layers: layers,
+            requiredRevenue: 149540,
+            billableHours: 1600,
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('tarif horaire'), findsOneWidget);
+  });
+
+  testWidgets('shows hero hourly rate', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    // 149540 / 1600 = ~93.46 → displayed as "93 CHF/h" (multiple occurrences)
+    expect(find.textContaining('93 CHF/h'), findsWidgets);
+  });
+
+  testWidgets('shows "minimum" label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('minimum'), findsOneWidget);
+  });
+
+  testWidgets('shows desired net label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('souhait'), findsOneWidget);
+  });
+
+  testWidgets('shows layer labels', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('Imp'), findsWidgets);
+    expect(find.textContaining('AVS'), findsWidgets);
+  });
+
+  testWidgets('shows required revenue', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining("149'540"), findsWidgets);
+  });
+
+  testWidgets('shows billable hours', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('1600'), findsWidgets);
+  });
+
+  testWidgets('shows chiffre-choc text', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('appauvris'), findsOneWidget);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('horaire v')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/unemployment_counter_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/unemployment_counter_widget_test.dart
@@ -20,9 +20,10 @@ void main() {
     expect(find.textContaining('capital temps'), findsOneWidget);
   });
 
-  testWidgets('shows 260 days for age 35', (tester) async {
+  // LACI art. 27 al. 2 lit. c : âge 25-54 + >= 22 mois cotisation = 400 jours
+  testWidgets('shows 400 days for age 35', (tester) async {
     await tester.pumpWidget(buildWidget(age: 35));
-    expect(find.textContaining('260'), findsWidgets);
+    expect(find.textContaining('400'), findsWidgets);
   });
 
   testWidgets('shows 200 days for age under 25', (tester) async {
@@ -30,15 +31,16 @@ void main() {
     expect(find.textContaining('200'), findsWidgets);
   });
 
-  testWidgets('shows 400 days for age 57', (tester) async {
+  // LACI art. 27 al. 2 lit. d : âge >= 55 + >= 22 mois cotisation = 520 jours
+  testWidgets('shows 520 days for age 57', (tester) async {
     await tester.pumpWidget(buildWidget(age: 57));
-    expect(find.textContaining('400'), findsWidgets);
+    expect(find.textContaining('520'), findsWidgets);
   });
 
   testWidgets('shows days consumed and remaining', (tester) async {
     await tester.pumpWidget(buildWidget(age: 35, daysConsumed: 50));
     expect(find.textContaining('50'), findsWidgets);
-    expect(find.textContaining('210'), findsWidgets); // 260-50
+    expect(find.textContaining('350'), findsWidgets); // 400-50
   });
 
   testWidgets('shows age table', (tester) async {

--- a/apps/mobile/test/widgets/coach/unemployment_counter_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/unemployment_counter_widget_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/unemployment_counter_widget.dart';
+
+void main() {
+  Widget buildWidget({int age = 35, int daysConsumed = 0}) => MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: UnemploymentCounterWidget(
+              age: age,
+              monthlyBenefit: 4200,
+              daysConsumed: daysConsumed,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('renders title', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('capital temps'), findsOneWidget);
+  });
+
+  testWidgets('shows 260 days for age 35', (tester) async {
+    await tester.pumpWidget(buildWidget(age: 35));
+    expect(find.textContaining('260'), findsWidgets);
+  });
+
+  testWidgets('shows 200 days for age under 25', (tester) async {
+    await tester.pumpWidget(buildWidget(age: 22));
+    expect(find.textContaining('200'), findsWidgets);
+  });
+
+  testWidgets('shows 400 days for age 57', (tester) async {
+    await tester.pumpWidget(buildWidget(age: 57));
+    expect(find.textContaining('400'), findsWidgets);
+  });
+
+  testWidgets('shows days consumed and remaining', (tester) async {
+    await tester.pumpWidget(buildWidget(age: 35, daysConsumed: 50));
+    expect(find.textContaining('50'), findsWidgets);
+    expect(find.textContaining('210'), findsWidgets); // 260-50
+  });
+
+  testWidgets('shows age table', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('25'), findsWidgets);
+    expect(find.textContaining('55'), findsWidgets);
+  });
+
+  testWidgets('shows zero CHF chiffre-choc', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('0 CHF'), findsWidgets);
+  });
+
+  testWidgets('shows disclaimer', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.textContaining('conseil'), findsOneWidget);
+  });
+
+  testWidgets('has Semantics label', (tester) async {
+    await tester.pumpWidget(buildWidget());
+    expect(find.bySemanticsLabel(RegExp('capital temps')), findsOneWidget);
+  });
+}

--- a/apps/mobile/test/widgets/coach/what_if_stories_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/what_if_stories_widget_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/coach/what_if_stories_widget.dart';
+
+void main() {
+  final stories = [
+    const WhatIfStory(
+      emoji: '\ud83d\udcc8',
+      question: 'Et si ta caisse LPP passait de 1% \u00e0 2% de rendement ?',
+      monthlyImpactChf: 320,
+      explanation: 'V\u00e9rifie ton relevé LPP pour conna\u00eetre ton taux',
+      actionLabel: 'Voir mes options LPP',
+    ),
+    const WhatIfStory(
+      emoji: '\ud83c\udfe0',
+      question: 'Et si tu d\u00e9m\u00e9nageais de ZH \u00e0 TG \u00e0 la retraite ?',
+      monthlyImpactChf: 280,
+      explanation: '\u00c9conomie fiscale nette',
+    ),
+    const WhatIfStory(
+      emoji: '\u23f0',
+      question: 'Et si tu travaillais 1 an de plus (66 au lieu de 65) ?',
+      monthlyImpactChf: 410,
+      explanation: '1 an de travail = 25 ans de bonus',
+    ),
+  ];
+
+  Widget buildTestWidget() {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: WhatIfStoriesWidget(stories: stories),
+        ),
+      ),
+    );
+  }
+
+  group('WhatIfStoriesWidget', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(WhatIfStoriesWidget), findsOneWidget);
+    });
+
+    testWidgets('shows header', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('changer'), findsWidgets);
+    });
+
+    testWidgets('shows all 3 stories', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('LPP'), findsWidgets);
+      expect(find.textContaining('nageais'), findsWidgets);
+      expect(find.textContaining('travaillais'), findsWidgets);
+    });
+
+    testWidgets('shows impact amounts', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('320'), findsWidgets);
+      expect(find.textContaining('280'), findsWidgets);
+    });
+
+    testWidgets('shows action label when present', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Voir'), findsWidgets);
+    });
+
+    testWidgets('shows disclaimer', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.textContaining('conseil'), findsWidgets);
+    });
+
+    testWidgets('handles empty stories', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: WhatIfStoriesWidget(stories: const []),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      expect(find.byType(WhatIfStoriesWidget), findsOneWidget);
+    });
+
+    testWidgets('handles tap callback', (tester) async {
+      int? tappedIndex;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: WhatIfStoriesWidget(
+              stories: stories,
+              onStoryTapped: (i) => tappedIndex = i,
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.tap(find.textContaining('LPP').first);
+      expect(tappedIndex, 0);
+    });
+
+    testWidgets('has Semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+      expect(find.byType(Semantics), findsWidgets);
+    });
+  });
+}

--- a/docs/UX_WIDGET_REDESIGN_MASTERPLAN.md
+++ b/docs/UX_WIDGET_REDESIGN_MASTERPLAN.md
@@ -1,0 +1,1690 @@
+# UX Widget Redesign Masterplan — MINT
+
+> **Objectif** : Transformer chaque écran MINT en expérience "mindblowing" pour un novice du système suisse des 3 piliers.
+> **Méthode** : Audit créatif par un panel senior (Flutter, actuaire, data science fintech suisse).
+> **Date de création** : 2026-03-07
+
+---
+
+## CHARTE DE DESIGN MINT — "Comprendre en 3 secondes, agir en 30"
+
+### Philosophie
+
+MINT n'est pas un dashboard financier. C'est un **traducteur** entre le monde des actuaires et celui des humains. Chaque écran doit passer le test du **bar PMU** : si tu ne peux pas l'expliquer à un collègue autour d'un café, c'est trop compliqué.
+
+### Les 7 lois MINT
+
+| # | Loi | Signifie | Anti-pattern |
+|---|-----|----------|-------------|
+| **L1** | **CHF/mois d'abord** | Tout se traduit en impact mensuel. Pas de montants annuels, pas de pourcentages abstraits sans ancrage. | "Taux de conversion 6.8%" sans dire ce que ça fait en francs |
+| **L2** | **Avant → Après** | Chaque décision se montre comme un delta. L'utilisateur voit sa situation actuelle vs. le changement. | Un simulateur qui montre un résultat isolé sans point de comparaison |
+| **L3** | **3 niveaux max** | Novice voit 3 infos. Curieux en voit 6. Expert débloque le cockpit. Jamais 15 composants d'un coup. | Un scroll infini de graphiques sans hiérarchie |
+| **L4** | **Raconte, ne montre pas** | Chaque chiffre est accompagné d'une phrase humaine qui dit "et alors ?". | Un graphique sans légende narrative |
+| **L5** | **Une action, pas un cours** | Chaque écran finit par "Que faire maintenant ?" — 1 action concrète, pas 10 options. | "Consultez un·e spécialiste" comme seul CTA |
+| **L6** | **Le chiffre-choc ouvre** | Chaque écran commence par UN nombre qui fait lever les sourcils. C'est le hook. Le reste est le contexte. | Un formulaire de 8 champs avant de voir un résultat |
+| **L7** | **La métaphore bat le graphique** | Si un concept existe dans la vie quotidienne (météo, sandwich, thermomètre, pile de briques), utilise cette métaphore plutôt qu'un chart technique. | Un tornado chart pour un utilisateur qui ne sait pas ce qu'est un pilier |
+
+### Vocabulaire visuel unifié
+
+| Brique | Usage | Pattern |
+|--------|-------|---------|
+| **Hero CHF/mois** | Première chose visible. Gros nombre + contexte humain. | `36pt Montserrat W800` + phrase sous le nombre |
+| **Carte Avant/Après** | Montre l'impact d'une décision | 2 colonnes : gauche grisée (avant) / droite colorée (après) + delta |
+| **Slider interactif** | L'utilisateur joue avec UNE variable | Slider + zone colorée (rouge/jaune/vert) + commentaire temps réel |
+| **Pile de briques** | Décompose un montant en sources | Blocs empilés, le plus solide en bas |
+| **Micro-histoire** | Remplace les analyses de sensibilité | "Et si [situation] → [impact CHF] → [action]" |
+| **Thermomètre** | Montre un niveau avec paliers nommés | Barre verticale avec étiquettes humaines |
+| **Film en actes** | Raconte une timeline de vie | Acte 1/2/3 avec titre narratif + CHF |
+| **Badge Strava** | Gamifie un progrès | Score + benchmark pair + prochaine action pour monter |
+| **Chiffre-choc** | Hook émotionnel en entrée | 1 nombre + 1 phrase percutante + source légale |
+| **Disclaimer éducatif** | Compliance LSFin | Toujours en footer, jamais anxiogène |
+
+### Tons de voix
+
+| Contexte | Ton | Exemple |
+|----------|-----|---------|
+| Bonne nouvelle | Fier, félicitations | "Tu es dans le vert. Ton coussin absorbe les imprévus." |
+| Neutre / info | Calme, factuel | "Ton AVS sera calculée sur 38 années de cotisation." |
+| Alerte douce | Encourageant | "Il te manque 6 années d'AVS. On peut regarder ça ensemble." |
+| Alerte sérieuse | Direct, sans panique | "Sans couverture AI, un arrêt de 6 mois = CHF 0 de revenu. Vérifie ta police." |
+| Couple | Complice | "Vous avez 5 ans d'écart. Ça crée un creux — mais aussi une opportunité fiscale." |
+
+### Palette émotionnelle
+
+| Émotion | Couleur MINT | Quand |
+|---------|-------------|-------|
+| Sérénité / vert | `MintColors.primary` | "Ça va", marge positive, objectif atteint |
+| Attention douce | `MintColors.accent` (orange) | Donnée manquante, optimisation possible |
+| Alerte | `MintColors.error` (rouge) | Risque réel, gap important, deadline proche |
+| Neutre / info | `MintColors.info` (bleu) | Explication, contexte, comparaison |
+| Couple / partage | `MintColors.purple` | Tout ce qui touche au conjoint |
+| Progression | `MintColors.gold` | Score, badge, milestone, félicitations |
+
+---
+
+## SUJET TRANSVERSAL — Maintenir les chiffres à jour
+
+### Architecture actuelle
+
+Le fichier `apps/mobile/lib/constants/social_insurance.dart` est la source unique Flutter :
+- **En-tête** : "Valeurs en vigueur: 2025 — Dernière mise à jour: 2025-01-01"
+- **Miroir** de `services/backend/app/constants/social_insurance.py` (source de vérité backend)
+- **Procédure** : MAJ Python → reporter dans Dart → lancer tests
+
+### Problème
+
+Les constantes suisses changent chaque année (OFAS publie en septembre pour l'année suivante) :
+- Rentes AVS, seuils LPP, plafonds 3a, cotisations AC, taux AI
+- Taux d'impôt cantonaux (révision annuelle)
+- Règles hypothécaires (FINMA peut ajuster les exigences)
+
+### Changements législatifs majeurs à anticiper
+
+| Réforme | Horizon | Impact sur MINT |
+|---------|---------|-----------------|
+| **Abolition valeur locative** (résidence principale) | ~2028-2029 | `imputed_rental_screen.dart` → conditionner sur date d'entrée en vigueur, garder pour résidences secondaires |
+| **Réforme LPP 21** (en discussion) | 2026-2027? | Taux de conversion, seuil d'entrée, bonifications → MAJ massive `social_insurance.dart` |
+| **Imposition individuelle** (initiative populaire) | 2026+ | Splitting marié supprimé → impacte `family_service.dart`, `mariage_screen.dart` |
+
+### Proposition : le "Millésime MINT"
+
+Chaque écran affiche discrètement en footer :
+
+```
+Calculs basés sur le droit en vigueur au 01.01.2026
+Prochaine mise à jour prévue : janvier 2027
+```
+
+Et dans le profil admin, un dashboard de millésime :
+- Liste des constantes avec leur date de validité
+- Alerte quand l'OFAS publie les nouveaux barèmes (septembre N-1)
+- Checklist de mise à jour (Python → Dart → Tests → Deploy)
+
+### Note importante pour les mockups
+
+Les chiffres dans les propositions P1-P18 sont des **exemples de FORMAT**, pas des calculs vérifiés. En implémentation, tous les nombres viennent des moteurs de calcul (`ArbitrageEngine`, `MortgageService`, `FamilyService`, etc.) avec les constantes de `social_insurance.dart`. Le mockup dit "le locataire gagne 32k" pour montrer le format — le moteur dira le vrai résultat selon chaque profil.
+
+Pour P3 en particulier : en Suisse, avec les taux actuels (~2.5%), le propriétaire paie souvent MOINS en mensualité que le locataire équivalent. Le "grand match" montrera le résultat réel du moteur, qui peut pencher dans les deux sens selon les paramètres (taux, horizon, appréciation immo, rendement alternatif).
+
+---
+
+## P1 — RETIREMENT DASHBOARD
+
+### Diagnostic
+
+Le dashboard actuel est un cockpit d'avion — techniquement irréprochable, mais un novice voit 15 instruments et ne sait pas où regarder.
+
+| Composant actuel | Problème |
+|---|---|
+| HeroRetirementCard | Nombre abstrait — "5'234 c'est bien ou pas ?" |
+| PillarDecomposition | Jargon des piliers, pas de storytelling |
+| ConfidenceBar | Confond précision des données avec fiabilité de la projection |
+| MintTrajectoryChart | 3 courbes = confusion, pas de repère émotionnel |
+| BudgetGapChart | Waterfall = concept de consultant, pas de novice |
+| EarlyRetirementChart | 7 barres = trop de choix, pas de "sweet spot" clair |
+| SensitivitySnippet | "Variables testées indépendamment" = incompréhensible |
+| CoupleTimelineChart | Phase 1/Phase 2 = jargon, pas d'émotion |
+| MonteCarloChart | Probabilités = anxiogène, pas actionnable |
+| MintScoreGauge | Score arbitraire sans benchmark |
+
+### Propositions créatives (10)
+
+#### A. Le "Salaire après 65" — Hero repensé
+
+**Lois** : L1 + L2
+
+**Concept** : Arrête de parler de "projection retraite". Parle du nouveau salaire.
+
+```
+Ton salaire après 65 ans
+
+Aujourd'hui     →    À la retraite
+CHF 8'333          CHF 5'234
+ ████████████       ████████
+
+Tu garderas 63% de ton train de vie
+"Pour la plupart des ménages,
+ 60-70% suffit (pas de navette,
+ pas de LPP, enfants partis)"
+```
+
+L'utilisateur pense en "salaire", pas en "projection". Le ratio 63% avec explication ("tes charges baissent aussi") crée un soulagement immédiat.
+
+#### B. La "Pile de briques" — Piliers vulgarisés
+
+**Lois** : L7 + L4
+
+**Concept** : Remplace les barres horizontales par une métaphore de construction.
+
+```
+D'où vient ton argent à 65 ans ?
+
+┌─────────┐  CHF 890   Ton épargne
+│ 3a/Libre│  ← "Ce que TU as mis de côté"
+├─────────┤
+│  LPP    │  CHF 2'410 Ta caisse
+│ (2ème)  │  ← "Ton patron et toi, chaque mois"
+├─────────┤
+│  AVS    │  CHF 1'934 L'État
+│ (1er)   │  ← "Garanti par la Confédération"
+└─────────┘
+      ▲
+  Le socle = le plus solide
+```
+
+Le novice comprend en 2 secondes que son revenu repose sur 3 sources avec des niveaux de solidité différents.
+
+#### C. Le Slider "Et si je partais à..." — Retraite anticipée simplifiée
+
+**Lois** : L3 + L4
+
+**Concept** : Remplace les 7 barres par UN slider avec 3 zones colorées.
+
+```
+Et si je partais à...
+
+58    60    62  63  64  65  66  67  70
+─────🔴──────🟡────🟢────────🔵───────
+                  ▲
+             [CURSEUR]
+
+À 63 ans : CHF 4'510/mois (-14%)
+"Tu perds CHF 724/mois à vie.
+ Mais tu gagnes 2 ans de liberté.
+ Coût total: ~CHF 174k sur 25 ans."
+```
+
+Zones :
+- 🔴 58-62 : "Risqué — gros sacrifice financier"
+- 🟡 63-64 : "Faisable — avec compromis"
+- 🟢 65 : "Standard — pas de pénalité"
+- 🔵 66-70 : "Bonus — tu gagnes plus mais tu profites moins longtemps"
+
+#### D. La "Météo financière" — Remplacer Monte Carlo
+
+**Lois** : L7 + L4
+
+**Concept** : Personne ne comprend "10'000 simulations à 80% de succès". Tout le monde comprend la météo.
+
+```
+Ta météo financière à la retraite
+
+     ☀️  Soleil  (45% des cas)
+     Tu vis confortablement — CHF 5'200+/mois
+
+     ⛅  Nuageux (35% des cas)
+     Budget serré mais ok — CHF 4'200–5'200/mois
+
+     🌧️  Pluie   (20% des cas)
+     Il faudra des ajustements — CHF 3'500–4'200/mois
+
+"Aujourd'hui : ⛅ tendance ☀️"
+"Chaque action déplace le curseur"
+```
+
+#### E. Les "Histoires et si..." — Remplacer le Tornado
+
+**Lois** : L4 + L5
+
+**Concept** : Au lieu de barres de sensibilité techniques, raconte 3 micro-histoires.
+
+```
+Ce qui pourrait tout changer
+
+📈 "Et si ta caisse LPP passait de 1% à 2% de rendement ?"
+   → +CHF 320/mois à 65 ans
+   → "Vérifie ton relevé LPP pour connaître ton taux"
+
+🏠 "Et si tu déménageais de ZH à TG à la retraite ?"
+   → +CHF 280/mois (impôts)
+   → "Économie fiscale nette"
+
+⏰ "Et si tu travaillais 1 an de plus (66 au lieu de 65) ?"
+   → +CHF 410/mois à vie
+   → "1 an de travail = 25 ans de bonus"
+```
+
+Chaque histoire finit par une action concrète.
+
+#### F. Le "Film du couple" — Couple timeline narratif
+
+**Lois** : L4 + L2
+
+**Concept** : Les swim lanes sont un outil de chef de projet. Raconte un film en 3 actes.
+
+```
+Votre histoire à deux
+
+ACTE 1 · 2026–2041 (15 ans)
+"Vous travaillez tous les deux"
+Revenus: CHF 13'333/mois
+→ Fenêtre pour épargner ensemble
+
+ACTE 2 · 2041–2046 (5 ans)
+"Julien est à la retraite, Lauren travaille encore"
+Revenus: CHF 10'234/mois (-23%)
+→ ⚠️ Le creux : 5 ans de revenu réduit
+
+ACTE 3 · 2046+ (25+ ans)
+"Retraite à deux"
+Revenus: CHF 8'890/mois
+→ Le plateau : vos revenus stabilisés
+
+💡 "Pendant l'Acte 2, le salaire de Lauren compense.
+C'est le moment idéal pour retirer le 3a de Julien
+(fiscalement avantageux)."
+```
+
+Au lieu de 2 barres parallèles, on raconte LEUR vie.
+
+#### G. Le "Budget gap" en sandwich — Remplacer le waterfall
+
+**Lois** : L7 + L1
+
+**Concept** : Le sandwich, tout le monde le comprend.
+
+```
+Ton budget retraite
+
+Ce qui rentre     CHF 5'234
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+AVS 1'934 + LPP 2'410 + 3a 540 + Épargne 350
+
+       ↓ moins
+
+Ce qui sort       CHF 4'800
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+Impôts 650 + Loyer 1'500 + LAMal 450 + Quotidien 2'200
+
+       ↓ reste
+
+✅ Marge: CHF 434/mois
+"Tu es dans le vert. Ce coussin absorbe les imprévus."
+```
+
+Ce qui rentre, ce qui sort, ce qui reste. Point.
+
+#### H. Le "Score Strava" — Fitness financier gamifié
+
+**Lois** : L5 + L7
+
+**Concept** : Le score /100 actuel est arbitraire. Rends-le comparable et motivant.
+
+```
+Ta forme financière
+
+       ╭────────╮
+      ╱  72/100  ╲
+     │   ↑ +3    │
+      ╲  ce mois ╱
+       ╰────────╯
+
+"Mieux que 65% des 45-55 ans dans ton canton"
+
+Ce qui t'a fait monter :
+✅ 3a versé en janvier (+5 pts)
+✅ Budget respecté en février (+2 pts)
+
+Ce qui te ferait passer à 80 :
+📋 Ajouter ton certificat LPP (+4 pts)
+📋 Vérifier ta couverture AI (+4 pts)
+```
+
+Le peer benchmark ("mieux que 65%") crée une fierté/urgence. L'historique des gains gamifie l'engagement.
+
+#### I. Le "Thermomètre de confiance" — Remplacer la barre de précision
+
+**Lois** : L7 + L5
+
+**Concept** : La barre de confiance confond précision des données avec fiabilité. Utilise un thermomètre.
+
+```
+Qualité de ta projection
+
+   ┌──┐  95%  Photo parfaite
+   │██│  ← certificat LPP + relevé AVS
+   │██│
+   │██│  65%  ← TU ES ICI — Bonne estimation
+   │▒▒│
+   │▒▒│  40%  Estimation large
+   │░░│  20%  On devine beaucoup
+   └──┘
+
+Pour monter à 80% :
+"Scanne ton certificat LPP, ça prend 30 secondes" [Scanner]
+```
+
+#### J. Le "Dashboard progressif" — 3 vues selon la maturité
+
+**Lois** : L3
+
+**Concept** : Adapte la densité au niveau de l'utilisateur.
+
+| Niveau | Ce qu'on montre | Ce qu'on cache |
+|--------|----------------|----------------|
+| **Novice** (<50% confiance) | Hero "salaire après 65" + Pile de briques + Thermomètre + 1 action | Tout le reste |
+| **Intermédiaire** (50-80%) | + Météo + Slider retraite anticipée + Histoires "et si" + Film du couple | Monte Carlo, Tornado, FRI |
+| **Expert** (>80% + opt-in) | + Cockpit complet + Monte Carlo + Tornado + Waterfall + FRI radar | Rien de caché |
+
+Un novice qui voit 3 choses comprend. Un novice qui voit 15 choses fuit.
+
+---
+
+## P2 — MARIAGE · DIVORCE · CONCUBINAGE
+
+### Diagnostic
+
+| Constat | Gravité |
+|---------|---------|
+| Le calcul fiscal utilise un taux fixe de 18% pour les mariés (devrait varier par canton/revenu) | CRIT |
+| 4 widgets de visualisation existent mais ne sont utilisés dans aucun écran | MOD |
+| Le chiffre-choc succession concubins (75k CHF d'impôt sur 300k) est noyé dans une matrice | CRIT |
+| La pension alimentaire utilise 600 CHF/enfant sans source ni explication | MOD |
+| Le régime matrimonial ne distingue pas biens propres vs acquêts | MOD |
+| Participation aux acquêts et communauté de biens affichent tous les deux 50/50 | LOW |
+| Aucun lien vers des ressources, modèles de convention, ou médiateurs | UX |
+| Le partenariat enregistré n'existe pas | UX |
+
+### Vision : 3 écrans → 1 question
+
+> "Qu'est-ce qui change dans mon portefeuille quand je change de statut ?"
+
+Fil rouge : Avant / Après / Le prix de ne rien faire.
+
+### Propositions créatives (6)
+
+#### A. Le "Ticket de caisse du mariage"
+
+**Lois** : L1 + L6
+
+L'écran mariage s'ouvre sur un ticket de caisse, pas sur 3 onglets.
+
+```
+🧾 TON TICKET DE CAISSE DU MARIAGE
+
+Revenus : 80k + 60k = 140k · Canton : VD
+─────────────────────────────
+Impôts (2 célibataires)  12'400
+Impôts (mariés)          11'200
+                         ───────
+BONUS MARIAGE         -1'200/an ✅
+
+Mais attention :
+AVS plafonnée (couple)  -540/an ⚠️
+                         ───────
+BILAN NET             -660/an  ✅
+
+"Le mariage t'économise 55 CHF par mois.
+ Mais ce n'est pas la vraie raison de se marier..."
+
+👇 La vraie raison est en dessous
+```
+
+Scrolle → le vrai chiffre-choc :
+
+```
+💀 CE QUE TON CONCUBIN PERD SI TU DÉCÈDES DEMAIN
+
+Marié·e :   CHF 0 d'impôt
+            + rente AVS survivant + 60% rente LPP
+
+Concubin·e: CHF 75'000 d'impôt
+            + CHF 0 rente AVS + CHF 0 rente LPP*
+
+"La vraie pénalité n'est pas d'être marié.
+ C'est de ne PAS l'être sans avoir pris les mesures."
+```
+
+Le novice cherche "pénalité de mariage" (un concept média). On lui montre que le vrai risque est ailleurs.
+
+#### B. Le "Film du divorce en 3 actes"
+
+**Lois** : L2 + L4
+
+Le divorce n'est pas un simulateur. C'est une histoire en 3 actes.
+
+```
+ACTE 1 · Le partage obligatoire
+"Vos LPP accumulés pendant le mariage sont coupés en deux. Point."
+
+  Toi: 180'000    Conjoint·e: 80'000
+       ↘               ↙
+      130'000      130'000
+
+Tu transfères CHF 50'000
+"C'est la loi (CC art. 122). On ne négocie pas."
+→ Ta rente LPP baisse de ~CHF 283/mois
+
+ACTE 2 · L'impôt change
+
+  Avant (mariés)       Après (séparés)
+  CHF 11'200/an       CHF 12'400/an
+  +CHF 1'200/an d'impôts
+  "Tu perds le splitting marié. Mais tu gagnes
+   la déduction parent isolé si tu as la garde."
+
+ACTE 3 · Les pensions
+
+  Pour 1 enfant :  ~CHF 1'500/mois
+  Entretien conjoint·e : ~CHF 500/mois (3-5 ans)
+  ⚠️ "La pension versée est déductible de TES impôts.
+      Elle est imposable pour l'AUTRE." (LIFD art. 33/23)
+```
+
+On raconte l'histoire dans l'ordre chronologique du vécu.
+
+#### C. Le "Match Mariage vs Concubinage"
+
+**Lois** : L7
+
+Remplace la matrice technique par un match en rounds.
+
+```
+MARIAGE ⚡ CONCUBINAGE
+
+ROUND 1 · Impôts
+🥊 Mariage gagne — "Tu économises CHF 1'200/an"
+
+ROUND 2 · Héritage
+🥊🥊🥊 Mariage écrase
+"Ton concubin paie CHF 75'000 d'impôt. Ton époux·se : CHF 0."
+
+ROUND 3 · Protection décès
+🥊🥊 Mariage gagne
+"Rente AVS survivant : CHF 2'520/mois. Concubin : CHF 0."
+
+ROUND 4 · Flexibilité
+🥊 Concubinage gagne
+"Pas de partage LPP, pas de procédure."
+
+ROUND 5 · Pension alimentaire
+🥊 Mariage gagne (pour le plus faible)
+"Le conjoint au revenu inférieur est protégé."
+
+VERDICT · Mariage 4 — Concubinage 1
+"Le mariage protège. Le concubinage donne la liberté.
+ Les deux se planifient."
+
+⚡ Si tu restes concubin, tes 3 urgences :
+1. Testament (sinon = 0 CHF)
+2. Clause LPP (30 sec par téléphone)
+3. Assurance-vie croisée
+```
+
+#### D. Le "Régime matrimonial en 30 secondes"
+
+**Lois** : L7 + L3
+
+Remplace le donut chart par une métaphore de tiroirs.
+
+```
+PARTICIPATION AUX ACQUÊTS (défaut)
+🗄️ Avant le mariage : chacun garde
+🗄️ Pendant le mariage : 50/50
+"Tout ce que vous avez GAGNÉ ensemble se partage.
+ Ce que tu avais AVANT, tu gardes."
+
+SÉPARATION DE BIENS
+🗄️ Tout reste séparé. Toujours.
+"Ce qui est à toi reste à toi.
+ Populaire chez les indépendants et les 2ème mariages."
+
+COMMUNAUTÉ DE BIENS
+🗄️ Tout est commun. Tout.
+"Rare en Suisse (<5% des couples).
+ Tout se partage, même ce qui existait avant."
+
+💡 "80% des Suisses sont en participation aux acquêts sans le savoir."
+```
+
+#### E. La "Checklist d'urgence" priorisée
+
+**Lois** : L5
+
+Classe les items par coût de l'inaction, pas par ordre alphabétique.
+
+```
+🔴 URGENT (si tu décèdes demain)
+□ Testament → sinon : 0 CHF — "5 lignes manuscrites suffisent"
+□ Clause LPP → sinon : 0 CHF rente — "1 appel à ta caisse de pension"
+
+🟡 IMPORTANT (ce trimestre)
+□ Assurance-vie croisée — "Compense l'absence de rente AVS"
+□ Convention de concubinage — "Qui paie quoi, qui garde quoi"
+□ Mandat pour inaptitude (CC 360) — "Sinon, c'est la KESB qui décide"
+
+🟢 RECOMMANDÉ (cette année)
+□ Directives anticipées (CC 370)
+□ Bail commun clarifié
+□ Bénéficiaire 3a mis à jour
+```
+
+#### F. Le "Pont cassé" — Protection survivant
+
+**Lois** : L2 + L6
+
+Montre visuellement ce qui se passe quand un des deux tombe.
+
+```
+SI L'UN DE VOUS DISPARAÎT
+
+MARIÉ·E·S
+Julien décède ───→ Lauren reçoit
+  Rente AVS survivant   CHF 2'520/mois
+  Rente LPP 60%         CHF 1'450/mois
+  Capital décès LPP     CHF 180'000
+  Total : CHF 3'970/mois + capital
+
+CONCUBIN·E·S (sans protection)
+Julien décède ─ ✕ Lauren reçoit
+  Rente AVS survivant   CHF 0
+  Rente LPP             CHF 0
+  Héritage      CHF 300k - 75k impôt
+  Total : CHF 0/mois + 225k capital (taxé)
+
+Écart : CHF 3'970/mois à VIE
+"Sur 20 ans, c'est CHF 952'800 de protection en moins."
+
+[Que puis-je faire ?] → 3 actions qui comblent 80% du gap
+```
+
+---
+
+## P3 — ACHAT IMMOBILIER (housingPurchase)
+
+### Diagnostic
+
+7 écrans dédiés + 1 moteur d'arbitrage. Le mythe "loyer = argent perdu" est le fil rouge.
+
+| Constat | Gravité |
+|---------|---------|
+| Valeur locative utilise un taux fixe de 3.5% au lieu du taux cantonal réel | CRIT |
+| Le loyer n'a PAS d'inflation dans la simulation (0%) → avantage achat surestimé | CRIT |
+| Le taux théorique FINMA de 5% confondu avec le taux réel de 2.5% | MOD |
+| SARON n'inclut pas la marge bancaire (+0.5-1.5%) | MOD |
+| Frais de transaction (notaire 2-3%) non comptés | MOD |
+| Retrait LPP/3a affiché brut, pas net d'impôt | CRIT |
+| 7 écrans séparés sans narration commune | UX |
+| Pas de "breakeven holding period" visible | UX |
+
+### Propositions créatives (7)
+
+#### A. Le "Bilan de match" — Louer vs Acheter démystifié
+
+**Lois** : L6 + L2 + L4
+
+L'écran s'ouvre sur le résultat, pas sur un formulaire. Le chiffre-choc d'abord.
+
+```
+LE GRAND MATCH · Louer et investir vs Acheter
+
+Dans 20 ans, ton patrimoine :
+  LOCATAIRE           PROPRIÉTAIRE
+  CHF 612'000         CHF 580'000
+
+Le locataire gagne de CHF 32'000
+
+"Surpris ? Ton loyer n'est PAS de l'argent perdu.
+ C'est le prix de la flexibilité + tu investis la différence."
+
+MAIS : le propriétaire a un TOIT. Le locataire a un PORTEFEUILLE.
+Les deux ont raison.
+```
+
+Scrolle → décomposition des coûts mensuels :
+- Locataire : loyer 2'000 + investit 1'200/mois
+- Propriétaire : intérêts 1'460 + amortissement 670 + entretien 670 + valeur locative 400 = 3'200/mois
+
+"La vraie question n'est pas 'louer ou acheter'. C'est : 'Est-ce que je resterai 8+ ans ?'"
+
+#### B. Le "Seuil de rentabilité" — Le seul chiffre qui compte
+
+**Lois** : L1 + L6
+
+Au lieu de 2 courbes qui se croisent, UN nombre.
+
+```
+COMBIEN DE TEMPS POUR QUE L'ACHAT SOIT RENTABLE ?
+
+         ╭──────────╮
+        │  8 ANS   │
+         ╰──────────╯
+
+Avant 8 ans : le locataire gagne
+Après 8 ans : le propriétaire rattrape
+
+Ce qui accélère : appréciation immo +1% → 6 ans
+Ce qui ralentit : rendement bourse +1% → 10 ans
+```
+
+Personne ne veut lire 2 courbes. Tout le monde comprend "8 ans".
+
+#### C. La "Facture cachée du propriétaire" — Valeur locative expliquée
+
+**Lois** : L7 + L4
+
+La valeur locative racontée comme une histoire.
+
+```
+LA TAXE LA PLUS BIZARRE DE SUISSE
+
+"Imagine : tu as fini de payer ta maison.
+ Tu ne paies plus de loyer. Mais le fisc te dit :
+ 'Tu AURAIS payé CHF 2'800/mois. On ajoute
+  CHF 33'600/an à ton revenu imposable.'"
+
+C'est la VALEUR LOCATIVE.
+Tu paies un impôt sur un loyer que tu ne paies pas.
+
+Impact net : ~CHF 200/mois de taxe invisible.
+
+Astuce : "Quand tu auras remboursé ton hypothèque,
+tu perdras la déduction intérêts. Certains gardent
+exprès un petit crédit pour continuer à déduire."
+```
+
+#### D. Le "Crash test FINMA" — Affordabilité gamifiée
+
+**Lois** : L7 + L3
+
+Remplace les jauges par un crash test automobile.
+
+```
+CRASH TEST FINMA · "La banque va-t-elle te prêter ?"
+
+Test 1 · Fonds propres (min 20%)
+Tes fonds : 200k sur 800k = 25% ✅ PASSÉ
+"Attention : LPP net après impôt = CHF 170k, pas 200k"
+
+Test 2 · Charge maximale (≤ 33%)
+Taux utilisé : 5% (PAS ton vrai taux !)
+Charges théoriques : CHF 4'670/mois
+Ton revenu : CHF 10'000/mois → 47% ❌ ÉCHOUÉ
+
+"La banque calcule avec 5% même si le taux réel est 2.5%.
+ C'est un stress test : 'Et si les taux remontaient ?'"
+
+Prix maximum : CHF 650'000
+```
+
+Le "crash test" est une métaphore universelle. L'explication du 5% lève LE malentendu principal.
+
+#### E. Le "Parcours fléché" — 7 écrans → 1 histoire
+
+**Lois** : L3 + L5
+
+Au lieu de 7 écrans isolés, 1 parcours narratif.
+
+```
+TON PARCOURS IMMOBILIER
+
+① Est-ce que je peux acheter ? → Crash test FINMA
+   ✅ Prix max : CHF 650k
+
+② D'où viennent mes fonds propres ? → Cash + 3a + LPP
+   ⚠️ Attention : impôt de retrait !
+
+③ Quel type d'hypothèque ? → SARON vs Fixe
+   💡 SARON = risqué mais moins cher
+
+④ Direct ou indirect ? → Amortissement
+   💡 Indirect + 3a = double déduction
+
+⑤ Et la valeur locative ? → La taxe bizarre
+   📊 Impact : ~CHF 200/mois
+
+⑥ Au final, louer ou acheter ? → Le grand match
+   🎯 Seuil de rentabilité : 8 ans
+
+⑦ Et si je revends un jour ? → Simulation de vente
+   💰 Plus-value estimée après impôt
+```
+
+Le novice ne sait pas qu'il a 7 questions à se poser.
+
+#### F. Le "Double compteur" — Amortissement direct vs indirect
+
+**Lois** : L2 + L1
+
+2 compteurs côte à côte au lieu de 3 courbes.
+
+```
+DIRECT vs INDIRECT : dans 15 ans
+
+                  DIRECT          INDIRECT
+Hypothèque :      CHF 550k        CHF 700k
+Capital 3a :      CHF 0           CHF 127k
+Intérêts payés :  CHF 231k        CHF 262k
+Économie fiscale: CHF 0           CHF 32k
+────────────────────────────────────────
+COÛT NET :        CHF 231k        CHF 103k
+
+L'indirect coûte CHF 128k de MOINS grâce à la double déduction.
+⚠️ "Mais ta dette reste à 700k. Si les taux montent, tes intérêts aussi."
+```
+
+#### G. Le "Thermomètre SARON" — Stress test visuel
+
+**Lois** : L7 + L4
+
+Au lieu de 3 courbes de coût, un thermomètre de mensualités.
+
+```
+ET SI LES TAUX MONTAIENT ?
+
+Hypothèque : CHF 640'000
+
+   5.0%  CHF 2'667/mois  😰 "Tes charges = 40% du revenu"
+   3.5%  CHF 1'867/mois  😐 "Ça passe, mais serré"
+   2.5%  CHF 1'333/mois  ← AUJOURD'HUI "Confortable"
+   1.5%  CHF   800/mois  😊 "Les années dorées (2020)"
+
+"En SARON, chaque hausse de 1% = +CHF 533/mois."
+
+Règle d'or : choisis le SARON uniquement si tu peux
+supporter le scénario 5% sans stress.
+```
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/arbitrage/location_vs_propriete_screen.dart` | Louer vs acheter |
+| `screens/mortgage/affordability_screen.dart` | Crash test FINMA |
+| `screens/mortgage/amortization_screen.dart` | Direct vs indirect |
+| `screens/mortgage/epl_combined_screen.dart` | Sources fonds propres |
+| `screens/mortgage/imputed_rental_screen.dart` | Valeur locative |
+| `screens/mortgage/saron_vs_fixed_screen.dart` | SARON vs fixe |
+| `screens/housing_sale_screen.dart` | Simulation de vente |
+| `services/mortgage_service.dart` | Moteur de calcul |
+
+---
+
+## P4 — INVALIDITÉ (disability) — *Le trou béant que personne ne voit venir*
+
+### Diagnostic
+
+| Écran existant | Ce qu'il fait | Ce qui manque |
+|---------------|---------------|---------------|
+| `disability_gap_screen.dart` | Écart revenu si invalidité | Zéro émotion, tableau froid, pas de temporalité |
+| `disability_insurance_screen.dart` | Couverture APG/AI | Formule technique, pas de scénario vécu |
+| `disability_self_employed_screen.dart` | Cas spécial indépendants | Pas de chiffre-choc, le danger mortel n'est pas visible |
+
+**Problème central** : L'invalidité est le risque financier #1 en Suisse (1 personne sur 5 sera touchée avant 65 ans — OFS), mais les écrans MINT la traitent comme un formulaire administratif. Personne ne ressent le danger → personne n'agit.
+
+### Propositions créatives
+
+#### A. La Falaise — Timeline à 3 actes *(L6 + L2 + L7)*
+
+**Concept** : Raconter l'invalidité comme un film en 3 actes temporels — le choc, la chute, le plateau.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  🎬  SI TU NE POUVAIS PLUS TRAVAILLER DEMAIN               │
+│                                                              │
+│  ╭─────────────╮                                             │
+│  │  ACTE 1     │  Jours 1-30 : Ton employeur paie 80%       │
+│  │  Le filet   │  Tu touches : 6'667 CHF/mois               │
+│  ╰─────┬───────╯                                             │
+│        │                                                     │
+│        ▼                                                     │
+│  ╭─────────────╮                                             │
+│  │  ACTE 2     │  Mois 2-24 : L'AI évalue ton cas           │
+│  │  L'attente  │  Tu touches : 4'200 CHF/mois (APG)         │
+│  │             │  ⏱ Délai moyen de décision AI : 14 mois     │
+│  ╰─────┬───────╯                                             │
+│        │                                                     │
+│        ▼                                                     │
+│  ╭─────────────╮                                             │
+│  │  ACTE 3     │  Après décision AI :                        │
+│  │  Le plateau │  ✅ Rente AI entière : 2'520 CHF/mois       │
+│  │             │  ➕ Rente LPP invalidité : ~1'800 CHF       │
+│  │             │  ═══════════════════════════════════════     │
+│  │             │  TOTAL : 4'320 CHF vs 8'333 avant           │
+│  ╰─────────────╯                                             │
+│                                                              │
+│  💰 CHIFFRE-CHOC : Tu perdrais 4'013 CHF/mois.              │
+│     Sur 15 ans = 721'000 CHF de revenu en moins.             │
+│                                                              │
+│  [Slider: Ton salaire brut ─────●─────── 100'000 CHF/an]    │
+│                                                              │
+│  → Action : "Vérifie ta couverture LPP invalidité"           │
+│                                                              │
+│  ℹ️ Outil éducatif · LAVS art. 28-29, LPP art. 23-26        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### B. Le Reset silencieux — Perte d'ancienneté *(L1 + L7)*
+
+**Concept** : Montrer le coût caché invisible — l'invalidité ne détruit pas que ton revenu actuel, elle reset ton ancienneté LPP et tes bonifications.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ⏪  LE RESET SILENCIEUX                                     │
+│                                                              │
+│  À 45 ans, tu cotises au taux 15% (LPP art. 16).            │
+│  Si invalidité partielle (50%) + reconversion à 48 ans :     │
+│                                                              │
+│  Avant :  Salaire 100k → bonification LPP = 7'950 CHF/an    │
+│  Après :  Salaire  55k → bonification LPP = 2'915 CHF/an    │
+│                                                              │
+│  ╔══════════════════════════════════════╗                     │
+│  ║  Ton 2e pilier à 65 ans :           ║                     │
+│  ║  Sans invalidité : 520'000 CHF      ║                     │
+│  ║  Avec invalidité : 310'000 CHF      ║                     │
+│  ║                                     ║                     │
+│  ║  Rente mensuelle perdue : -875 CHF  ║                     │
+│  ║  Chaque mois. Pour toujours.        ║                     │
+│  ╚══════════════════════════════════════╝                     │
+│                                                              │
+│  💡 "C'est pas juste ton salaire qui baisse.                 │
+│      C'est ta retraite qui rétrécit."                        │
+│                                                              │
+│  → Action : "Simule un rachat LPP pour combler le trou"      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### C. L'Écran rouge de l'indépendant *(L6 + L4)*
+
+**Concept** : Pour les indépendants sans LPP, afficher un écran dramatiquement différent — le système de protection est quasi inexistant.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  🚨  INDÉPENDANT : TON FILET N'EXISTE PAS                   │
+│                                                              │
+│  Si tu ne peux plus travailler demain :                      │
+│                                                              │
+│  Salarié touche :          Toi tu touches :                  │
+│  ┌──────────────┐          ┌──────────────┐                  │
+│  │ APG 80%      │          │              │                  │
+│  │ LPP invalid. │          │   RIEN       │                  │
+│  │ AI rente     │          │   pendant    │                  │
+│  │              │          │   ~14 mois   │                  │
+│  └──────────────┘          └──────────────┘                  │
+│  = 4'320 CHF/mois          = 0 CHF/mois                     │
+│                                                              │
+│  Après décision AI :                                         │
+│  Salarié : 4'320 CHF       Toi : 2'520 CHF (AI seule)       │
+│                                                              │
+│  💰 CHIFFRE-CHOC : 14 mois à 0 CHF.                         │
+│     = tu dois avoir 70'000 CHF d'épargne de sécurité.        │
+│                                                              │
+│  ╭────────────────────────────────────────╮                   │
+│  │ 💡 As-tu une assurance perte de gain ? │                   │
+│  │    [Oui] [Non] [Je ne sais pas]        │                   │
+│  ╰────────────────────────────────────────╯                   │
+│                                                              │
+│  → Action : "Compare 3 assurances perte de gain"             │
+│                                                              │
+│  ℹ️ Outil éducatif · LAMal art. 67-77, CO art. 324a          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### D. Le vrai coût de ta franchise *(L1 + L2)*
+
+**Concept** : La franchise LAMal prend une dimension critique en cas d'invalidité. Montrer la différence de coût réel entre franchise 300 et 2500 en cas de maladie longue.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  🏥  TA FRANCHISE EN CAS DE PÉPIN LONG                       │
+│                                                              │
+│  Scénario : maladie/accident nécessitant 2 ans de soins     │
+│                                                              │
+│  Franchise 2'500 CHF :              Franchise 300 CHF :      │
+│  ┌────────────────────┐             ┌────────────────────┐   │
+│  │ Franchise : 2'500  │             │ Franchise :   300  │   │
+│  │ Quote-part : 700   │             │ Quote-part :  700  │   │
+│  │ × 2 ans = 6'400    │             │ × 2 ans = 2'000    │   │
+│  └────────────────────┘             └────────────────────┘   │
+│                                                              │
+│  Surcoût franchise haute : +4'400 CHF                        │
+│  Économie prime mensuelle : +130 CHF/mois                    │
+│                                                              │
+│  ╔═══════════════════════════════════════════════════╗        │
+│  ║ Seuil de rentabilité :                            ║        │
+│  ║ Si tu vas chez le médecin > 2× par an →           ║        │
+│  ║ La franchise basse te coûte MOINS.                ║        │
+│  ╚═══════════════════════════════════════════════════╝        │
+│                                                              │
+│  [Slider: Combien de consultations/an ? ──●── 4]            │
+│                                                              │
+│  → Action : "Simule le changement de franchise au 30.11"     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### E. Le Bulletin scolaire de ta couverture *(L5 + L2)*
+
+**Concept** : Une note A-F sur chaque pilier de ta protection invalidité — comme un bulletin scolaire. Tu vois immédiatement où tu es couvert et où c'est le trou.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  📋  TON BULLETIN DE COUVERTURE INVALIDITÉ                   │
+│                                                              │
+│  Couverture        Note   Détail                             │
+│  ──────────────────────────────────────                      │
+│  APG (perte gain)   B+    80% pendant 720j max              │
+│  AI (rente)          C    2'520 CHF max (degré ≥70%)        │
+│  LPP invalidité     A-    Rente = 40-70% du salaire assuré  │
+│  Épargne urgence     D    Tu as 2 mois de réserve            │
+│  Assurance privée    F    ❌ Aucune détectée                  │
+│                                                              │
+│  ╔═══════════════════════════════════════════════╗            │
+│  ║  MOYENNE GÉNÉRALE :  C-                       ║            │
+│  ║  "Tu survivrais, mais ton niveau de vie       ║            │
+│  ║   baisserait de 48%."                         ║            │
+│  ╚═══════════════════════════════════════════════╝            │
+│                                                              │
+│  Matière la plus faible : Assurance perte de gain privée     │
+│  → Action : "Passer de F à B coûte ~85 CHF/mois"            │
+│                                                              │
+│  ℹ️ Outil éducatif · LAMal, LAVS, LPP art. 23-26            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+#### F. Le Compte à rebours du délai de carence *(L6 + L7)*
+
+**Concept** : Visualiser les 720 jours de délai AI comme un compte à rebours — combien de jours d'économies as-tu réellement ?
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ⏱  COMBIEN DE TEMPS TU TIENS ?                              │
+│                                                              │
+│  Tes charges fixes mensuelles : 5'200 CHF                    │
+│  Ton épargne disponible : 28'000 CHF                         │
+│                                                              │
+│  ╔═════════════════════════════════════════════════╗          │
+│  ║                                                 ║          │
+│  ║   ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░      ║          │
+│  ║   ◄── 5.4 mois ──►                             ║          │
+│  ║                   ◄── le vide : 8.6 mois ──►   ║          │
+│  ║                                                 ║          │
+│  ║   Délai moyen décision AI : 14 mois             ║          │
+│  ║   Tu tiens : 5.4 mois                           ║          │
+│  ║   Il te manque : 44'720 CHF                     ║          │
+│  ║                                                 ║          │
+│  ╚═════════════════════════════════════════════════╝          │
+│                                                              │
+│  💰 CHIFFRE-CHOC : Après 5 mois, tu dois emprunter          │
+│     ou vendre pour survivre.                                 │
+│                                                              │
+│  [Slider: Ton épargne disponible ────●──── 28'000 CHF]      │
+│                                                              │
+│  → Action : "Constitue un fonds d'urgence de 6 mois"        │
+│  → Action : "Souscris une APG privée (dès 45 CHF/mois)"     │
+│                                                              │
+│  ℹ️ Outil éducatif · LAI art. 28, LPGA art. 19               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Grille de cohérence P4
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|-------------|:-----------:|:--------------:|:----------------:|:------------:|
+| A. Falaise  | ✅ 4'013/mois perdu | ✅ 8'333→4'320 | ✅ 721k sur 15 ans | ✅ Film 3 actes |
+| B. Reset    | ✅ -875/mois rente | ✅ 520k→310k | ✅ Rente perdue | ✅ Reset/rewind |
+| C. Écran rouge | ✅ 0 CHF/mois | ✅ Salarié vs indép. | ✅ 14 mois à 0 | ✅ Filet vs vide |
+| D. Franchise | ✅ +130/mois économie | ✅ 300 vs 2500 | ✅ Seuil rentabilité | ✅ Bulletin |
+| E. Bulletin | ✅ 85/mois pour B | ✅ Notes A-F | ✅ -48% niveau vie | ✅ École/notes |
+| F. Countdown | ✅ 5'200/mois charges | ✅ Couvert vs vide | ✅ 5.4 mois | ✅ Compte à rebours |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/disability/disability_gap_screen.dart` | Écart de revenu invalidité |
+| `screens/disability/disability_insurance_screen.dart` | Couverture AI/APG |
+| `screens/disability/disability_self_employed_screen.dart` | Cas indépendant |
+| `services/disability_gap_service.dart` | Moteur de calcul gap |
+
+---
+
+## P5 — PREMIER EMPLOI (firstJob) — *"Ton toi de 65 ans te remerciera"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `first_job_screen.dart` | 989 | Décomposition salaire, 3a, LAMal, checklist | Formulaire froid, pas de storytelling, tout en vrac |
+| `salary_breakdown_widget.dart` | 294 | Bar stacké + cotisations employeur | Statique, pas de avant/après |
+| `simulator_3a_screen.dart` | 388 | Calcul fiscal, règle 5 comptes | Détaché du contexte premier emploi |
+
+**Problème central** : Un jeune de 22 ans ouvre cet écran et voit un mur de chiffres. Il ne comprend pas *pourquoi* 37% de son salaire disparaît ni *ce que ça lui rapporte*. Le moment émotionnel unique du premier salaire est gâché par un formulaire technocratique.
+
+### Propositions créatives
+
+#### A. Le Film du premier salaire — Onboarding en 5 actes *(L4 + L6 + L7)*
+
+**Concept** : Le premier salaire comme un film interactif en 5 actes — chaque acte révèle une couche du système suisse.
+
+- **Acte 1 · La douche froide** : 5'500 brut → 4'210 net. Barre animée qui rétrécit. "1'290 CHF disparaissent. Mais c'est pas perdu — c'est ton futur."
+- **Acte 2 · L'argent invisible** : 4 briques empilées (AVS 291, LPP 193, AC 61, AANP 72) + cadeau employeur qui double. "Ton vrai salaire est 6'094 CHF."
+- **Acte 3 · Le cadeau fiscal** : 605 CHF/mois en 3a → 3 scénarios à 65 ans (420k/680k/1'050k). "Potentiellement millionnaire. Commence maintenant."
+- **Acte 4 · Le piège LAMal** : Franchise 2'500 vs 1'500 vs 300. Conseil: 1'500 = bon compromis.
+- **Acte 5 · Checklist** : Semaine 1 (3a + virement auto), Semaine 2 (LAMal + RC privée), Avant 31.12 (maximum 3a). Badge "Premier pas financier".
+
+#### B. Le Time-Lapse de ta carrière *(L2 + L7)*
+
+**Concept** : Slider "âge de début" qui montre le patrimoine à 65 ans. Chaque année perdue coûte ~30'000 CHF.
+
+```
+22 ans : ████████████████████████████████  680k
+25 ans : ██████████████████████████████    610k
+27 ans : ████████████████████████████      530k
+30 ans : ██████████████████████████        450k
+35 ans : ████████████████████              310k
+```
+
+"5 ans d'attente = 150'000 CHF de moins. Les intérêts composés sont ton meilleur allié — mais seulement si tu commences tôt."
+
+#### C. La Radiographie de ta fiche de paie *(L1 + L4)*
+
+**Concept** : Reproduction visuelle d'une fiche de paie suisse. Tap sur chaque ligne → explication en une phrase + icône + référence légale.
+
+- AVS/AI/APG 5.30% → 🧱 "Ta rente à 65 ans. 44 ans de cotisation → max 2'520/mois. LAVS art. 3"
+- LPP → 🏦 "Ton 2e pilier. Ton employeur double ta cotisation."
+- AC 1.10% → 🪂 "Ton parachute chômage. LACI art. 3"
+- AANP 1.30% → 🏥 "Accident hors travail. LAA art. 6"
+
+#### D. Le Budget 50/30/20 personnalisé *(L5 + L1)*
+
+**Concept** : Budget automatique basé sur le net, le canton et l'âge.
+
+- 50% FIXE (2'105 CHF) : loyer coloc, LAMal, transport, tel, assurances, impôts provisionnels
+- 30% VIE (1'263 CHF) : sorties, vêtements, sport, resto, loisirs, imprévus
+- 20% FUTUR (842 CHF) : 3a prioritaire (605 CHF) + épargne libre (237 CHF)
+
+"Avec 842 CHF/mois : 7'258 CHF de 3a + fonds d'urgence de 3'000 CHF en 12 mois."
+
+#### E. Le Miroir employeur — L'iceberg *(L6 + L2)*
+
+**Concept** : Visualisation iceberg — net au-dessus de la surface, cotisations toi + employeur en dessous.
+
+- Net : 4'210 (visible)
+- Tes cotisations : 1'290 (sous l'eau)
+- Cotisations employeur : 654 (fond)
+- Coût total employeur : 6'154 CHF
+
+"Quand tu négocies +200 CHF brut : tu reçois net ~153 CHF. Ton employeur paie ~224 CHF de plus."
+
+Slider : "Simule une augmentation" → impact net, LPP, 3a, impôts.
+
+#### F. Le Compte à rebours 3a *(L5 + L6)*
+
+**Concept** : Widget urgence (dès octobre). Barre de progression du plafond 3a + jours restants.
+
+- Plafond 2026 : 7'258 CHF. Versé : 3'600 CHF. Reste : 3'658 CHF en 87 jours.
+- "Si tu complètes : 1'450 CHF d'impôts en moins = 1 mois de loyer gratuit."
+- "Si tu ne fais rien : 1'450 CHF laissés sur la table. Chaque année."
+
+### Grille de cohérence P5
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. Film 5 actes | ✅ 1'290/mois | ✅ Brut→Net | ✅ Millionnaire 3a | ✅ Film/actes |
+| B. Time-Lapse | ✅ 30k/an perdu | ✅ 22→35 ans | ✅ 150k perdus | ✅ Time-lapse |
+| C. Radiographie | ✅ Chaque ligne CHF | ✅ Fiche annotée | ✅ Vrai salaire 6k | ✅ Radiographie |
+| D. Budget 50/30/20 | ✅ 842/mois épargne | ✅ Sans→Avec budget | ✅ 3k urgence en 12m | ✅ Règle simple |
+| E. Iceberg | ✅ 6'154 coût réel | ✅ Visible→Invisible | ✅ +200 brut=153 net | ✅ Iceberg |
+| F. Countdown 3a | ✅ 605/mois | ✅ Versé→Manquant | ✅ 1'450 d'impôts | ✅ Compte à rebours |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/first_job_screen.dart` | Écran principal premier emploi |
+| `widgets/educational/salary_breakdown_widget.dart` | Décomposition salaire |
+| `services/first_job_service.dart` | Moteur de calcul |
+| `screens/simulator_3a_screen.dart` | Simulateur 3a |
+| `models/age_band_policy.dart` | AgeBand.youngProfessional + LifeEventType.firstJob |
+
+---
+
+## P6 — INDÉPENDANT (selfEmployment) — *"Le jour où tu deviens ton propre RH"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `independant_screen.dart` | 928 | Coverage gaps, coûts, chiffre-choc IJM | Hub technique, pas de parcours narratif |
+| `dividende_vs_salaire_screen.dart` | 856 | Optimisation SA/Sàrl, risque requalification | Trop technique pour novice |
+| `lpp_volontaire_screen.dart` | 780 | Trade-off LPP vs 3a, projection retraite | Pas d'émotion sur le choix crucial |
+| `avs_cotisations_screen.dart` | 687 | Barème dégressif, jauge | Pas de comparaison "avant/après" transition |
+| `ijm_screen.dart` | 786 | Prime × âge × carence | Pas assez dramatique pour un risque critique |
+| `pillar_3a_indep_screen.dart` | 700 | Grand vs petit 3a | Détaché du contexte transition |
+
+**Problème central** : L'indépendant perd 100% de la protection employeur du jour au lendemain — mais les écrans présentent chaque risque en silo. Aucun ne montre le choc total ni ne dit "voici ce que tu fais dans les 90 premiers jours."
+
+### Propositions créatives
+
+#### A. Le Jour J — La grande bascule *(L2 + L6 + L7)*
+
+Avant/après dramatique : tout ce qui change en 1 jour. Chaque protection a un interrupteur ON→OFF.
+- AVS ×2 (884 vs 442), LPP DISPARU, LAA DISPARU, IJM DISPARU, APG DISPARU.
+- Chiffre-choc : "Tu perds 1'654 CHF/mois de protection invisible = 19'848 CHF/an."
+- "Tu n'as pas quitté un emploi. Tu as quitté un système de protection."
+
+#### B. Le Plan 90 jours — Checklist de survie *(L5 + L4)*
+
+Parcours séquentiel en 4 phases avec deadlines et conséquences :
+- Semaine 1 : inscription caisse AVS (délai 90j, sinon rétroactif + intérêts), numéro TVA, compte pro
+- Semaine 2-4 : IJM (💀 sans = 0 CHF si malade), LAA complémentaire, RC professionnelle
+- Mois 2 : choix stratégique LPP volontaire (→ petit 3a) vs pas de LPP (→ grand 3a)
+- Mois 3 : provisionnement impôts (15-20%), structure juridique, 1er rachat LPP
+- Badge "Indépendant structuré"
+
+#### C. Le Double prix de ta liberté *(L1 + L6)*
+
+Comparaison côte à côte charges salarié vs indépendant à 100k.
+- Salarié total charges : 12'320 CHF/an. Indépendant : 23'340 CHF/an (×1.9).
+- "Tu paies 918 CHF/mois de plus. Pour garder le même net, facture +22%."
+
+#### D. Le Tarif horaire de la vérité *(L1 + L7)*
+
+Décomposition : net souhaité + charges + impôts + frais + vacances/maladie = CA nécessaire.
+- 100k salarié net → 149'540 CHF CA / 1'600h = **94 CHF/h minimum**.
+- "En dessous de 94 CHF/h, tu t'appauvris."
+- "94 CHF/h ≠ 94 CHF dans ta poche. 38 CHF partent en charges."
+
+#### E. Le Grand 3a — Ton arme secrète *(L6 + L2)*
+
+Super-pouvoir fiscal de l'indépendant sans LPP. Barres : salarié 7'258 vs toi 36'288 (×5).
+- Économie fiscale : 9'070 CHF/an vs 1'815 pour le salarié.
+- En 20 ans à 4% : salarié 217k, toi 1'083k. "Millionnaire en 3a."
+- Warning : si LPP volontaire → 3a retombe à 7'258.
+
+#### F. L'Arbre de décision — LPP vs Grand 3a *(L3 + L5)*
+
+Arbre visuel pour LE choix stratégique : revenu > 60k → veux rente garantie → LPP / sinon → grand 3a.
+- LPP : ✅ rente + déduction ❌ 3a plafonné ❌ coûteux seul
+- Grand 3a : ✅ 36k déduction ✅ libre choix ❌ capital seul ❌ pas d'invalidité LPP
+- "Il n'y a pas de mauvais choix. Mais le bon te fait économiser 3'000-9'000 CHF/an."
+
+### Grille de cohérence P6
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. Jour J | ✅ 1'654/mois perdu | ✅ Salarié→Indép. | ✅ 19'848/an | ✅ Interrupteurs |
+| B. Plan 90j | ✅ Coûts par phase | ✅ Avant→Après checklist | ✅ Rétroactif AVS | ✅ Plan de survie |
+| C. Double prix | ✅ 918/mois charges | ✅ 12k→23k charges | ✅ ×1.9 le prix | ✅ Prix de la liberté |
+| D. Tarif horaire | ✅ 94 CHF/h min | ✅ Brut→Net horaire | ✅ 38/94 en charges | ✅ Tarif de vérité |
+| E. Grand 3a | ✅ 756/mois épargne | ✅ 7k→36k plafond | ✅ ×5 vs salarié | ✅ Super-pouvoir |
+| F. Arbre LPP/3a | ✅ 3-9k/an impôts | ✅ LPP vs 3a | ✅ 9k écart fiscal | ✅ Arbre décision |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/independant_screen.dart` | Hub couverture + coûts |
+| `screens/independants/dividende_vs_salaire_screen.dart` | Split SA/Sàrl |
+| `screens/independants/lpp_volontaire_screen.dart` | LPP volontaire |
+| `screens/independants/pillar_3a_indep_screen.dart` | Grand vs petit 3a |
+| `screens/independants/avs_cotisations_screen.dart` | Barème AVS |
+| `screens/independants/ijm_screen.dart` | Assurance perte de gain |
+| `services/independants_service.dart` | 5 calculateurs |
+| `screens/arbitrage/rachat_vs_marche_screen.dart` | Rachat vs marché |
+
+---
+
+## P7 — PERTE D'EMPLOI (jobLoss) — *"Le jour le plus cher de ta carrière"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `unemployment_screen.dart` | 1'028 | LACI 70/80%, durée, checklist, timeline | Simulateur froid, pas de parcours de crise |
+| `unemployment_service.dart` | 278 | Calcul pur Dart, testé | Pas de lien avec budget/profil |
+| `libre_passage_screen.dart` | 575 | 3 situations, alertes 30j, sfbvg.ch | Détaché du contexte jobLoss |
+| `emergency_fund_ring.dart` | 273 | Anneau animé mois de réserve | Pas surfacé lors du jobLoss |
+
+**Problème central** : La perte d'emploi est un tsunami à 3 vagues (choc, chute de revenu, décisions cachées) mais les écrans sont éparpillés en silo.
+
+### Propositions créatives
+
+#### A. Les 3 vagues — Ton tsunami financier *(L4 + L6 + L7)*
+
+3 actes : Vague 1 = inscription ORP en 5 jours (sinon perte). Vague 2 = chute de 8'333→5'833 CHF/mois (30'000 CHF/an perdu). Vague 3 = décisions cachées (LPP 30 jours, 3a, LAMal, budget). "La vague la plus dangereuse n'est pas le chômage. C'est les décisions que tu oublies de prendre."
+
+#### B. Le Crash-test budget *(L1 + L2 + L5)*
+
+Budget actuel vs "mode survie" — chaque poste avec verdict (🔒 incompressible, ✂️ réduit, ⏸️ suspendu). Loyer 2'100→2'100, 3a 605→0, loisirs 500→100. Calcul de la marge restante et combien de mois de réserves tiennent.
+
+#### C. Le Compteur de jours — Capital temps *(L6 + L7)*
+
+Compteur défilant : 260 indemnités = ~12 mois. Comparaison par profil (<25 ans: 200, 25-54: 260, 55+: 400, 60+: 520). "Après 12 mois, plus rien. Pas de prolongation. Tu passes à l'aide sociale."
+
+#### D. Opération sauvetage 2e pilier *(L5 + L6)*
+
+30 jours chrono pour transférer ton LPP. 3 options : nouveau employeur, libre passage (recommandé — 2 comptes pour fiscalité), ne rien faire (institution supplétive = 9'000 CHF de manque à gagner sur 5 ans). Lien sfbvg.ch pour avoirs oubliés.
+
+#### E. Tableau de bord crise *(L3 + L1)*
+
+Dashboard "mode crise" avec 5 indicateurs vitaux : réserves (mois), chômage (jour X/260), LPP (transféré?), budget (déficit?), dettes. Alertes colorées + actions prioritaires.
+
+#### F. La Ligne d'horizon *(L7 + L6)*
+
+Barre temporelle : zone sûre (5'833 CHF) → mur (0 CHF). "Après la ligne : aide sociale, prestations complémentaires, ton épargne = dernier recours." Chiffre-choc : passage instantané de 5'833→0 CHF.
+
+### Grille de cohérence P7
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. 3 vagues | ✅ -2'500/mois | ✅ 8'333→5'833 | ✅ 30k/an perdu | ✅ Tsunami |
+| B. Crash-test | ✅ Marge -420/mois | ✅ Budget→Survie | ✅ Postes coupés | ✅ Crash-test |
+| C. Compteur | ✅ 5'833/mois | ✅ Jour 0→260 | ✅ 260 puis 0 | ✅ Sablier |
+| D. Sauvetage LPP | ✅ 185k en jeu | ✅ LP vs supplétive | ✅ 9k de différence | ✅ Sauvetage |
+| E. Dashboard crise | ✅ 5 KPIs CHF | ✅ Normal→Crise | ✅ Déficit mensuel | ✅ Tableau de bord |
+| F. Ligne horizon | ✅ 5'833→0 | ✅ Couvert→Vide | ✅ Mur instantané | ✅ Horizon |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/unemployment_screen.dart` | Simulateur chômage LACI |
+| `services/unemployment_service.dart` | Moteur de calcul LACI |
+| `widgets/educational/unemployment_timeline_widget.dart` | Timeline actions urgentes |
+| `screens/lpp_deep/libre_passage_screen.dart` | Advisor libre passage |
+| `widgets/budget/emergency_fund_ring.dart` | Anneau fonds d'urgence |
+| `widgets/educational/emergency_fund_insert_widget.dart` | Calculateur fonds d'urgence |
+
+---
+
+## P8 — HÉRITAGE & DONATION (inheritance/donation) — *"L'argent dont on ne parle jamais à table"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `succession_simulator_screen.dart` | 1'329 | CC 2023, réserves, quotité, 3a OPP3, testament | Technique, tabou non brisé |
+| `donation_screen.dart` | 1'288 | Impôt cantonal, avancement hoirie, alertes | Formulation juridique froide |
+| `donation_service.dart` | 351 | 26 cantons, 6 liens parenté, CC art. 471 | Pas de chiffre-choc émotionnel |
+| `donation_reserve_donut.dart` | 510 | Donut animé réserves vs quotité | Sous-exploité |
+
+**Problème central** : Le sujet est tabou — personne n'ouvre l'écran succession spontanément. Il faut briser la glace avec un chiffre-choc irrésistible.
+
+### Propositions créatives
+
+#### A. Le Testament invisible *(L6 + L7)*
+"Si tu meurs ce soir, voici qui reçoit quoi." Distribution légale automatique vs avec testament. Chiffre-choc concubin : 0% héritage + 24% d'impôt. Marié : 50% + 0% d'impôt. CC art. 457-462.
+
+#### B. Le Prix du silence *(L1 + L2)*
+500k patrimoine : marié = 0 CHF d'impôt succession. Concubin = 120'000 CHF. "Le silence te coûte un appartement. Un testament coûte 500 CHF."
+
+#### C. La Clause 3a oubliée *(L5 + L6)*
+OPP3 art. 2 : concubin ne touche le 3a QUE si clause bénéficiaire déposée. Sans clause = 0 CHF. "Ton 3a de 180k part à tes parents, pas à ta partenaire." Action : "Dépose ta clause en 5 minutes."
+
+#### D. Le Donut des réserves *(L3 + L7)*
+Donut animé : réserve conjoint 25%, réserve descendants 25%, quotité disponible 50%. CC 2023 : parents n'ont plus de réserve. "Tu as 50% de liberté testamentaire."
+
+#### E. L'Avancement d'hoirie *(L2 + L4)*
+Film 2 actes : 2 enfants, donation 200k à l'un. Acte 1 (aujourd'hui) → Acte 2 (au décès : rapport à la masse CC art. 626). "Ce que tu donnes sera déduit de sa part."
+
+#### F. Le Comparateur cantonal *(L1 + L6)*
+Impôt succession pour 500k (tiers/concubin) : Schwyz 0 CHF, Vaud 125'000 CHF. "Ton canton peut te coûter un appartement."
+
+### Grille de cohérence P8
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. Testament invisible | ✅ 0 vs 50% | ✅ Avec/sans testament | ✅ 0%+24% impôt | ✅ Testament invisible |
+| B. Prix du silence | ✅ 120k d'impôt | ✅ Marié vs concubin | ✅ 120k vs 0 | ✅ Silence coûteux |
+| C. Clause 3a | ✅ 180k en jeu | ✅ Avec/sans clause | ✅ 0 CHF pour partenaire | ✅ Clause oubliée |
+| D. Donut réserves | ✅ 50% libre | ✅ 2023 vs ancien | ✅ 0% parents | ✅ Donut |
+| E. Avancement | ✅ 200k impact | ✅ Aujourd'hui→Décès | ✅ Rapport masse | ✅ Film 2 actes |
+| F. Cantons | ✅ 0→125k | ✅ SZ vs VD | ✅ 125k de diff | ✅ Loterie cantonale |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/succession_simulator_screen.dart` | Simulateur succession complet |
+| `screens/donation_screen.dart` | Simulateur donation + fiscalité |
+| `services/donation_service.dart` | Calcul impôt donation 26 cantons |
+| `services/life_events_service.dart` | SuccessionService + logique CC |
+| `widgets/visualizations/donation_reserve_donut.dart` | Donut réserves animé |
+
+---
+
+## P9 — NAISSANCE (birth) — *"Le plus beau budget de ta vie"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `naissance_screen.dart` | 1'700+ | 3 tabs (congé/allocations/impact), complet | Moment émotionnel unique non célébré |
+| `family_service.dart` | 585 | 6 méthodes pures, APG, allocations 26 cantons | Calculs froids |
+| `parental_leave_timeline.dart` | 637 | Timeline animée congé | Sous-exploité |
+| `canton_allocation_map.dart` | 505 | Bubble treemap 26 cantons | Pas de comparaison émotionnelle |
+
+**Problème central** : Le moment émotionnel le plus fort de la vie est traité comme un formulaire budgétaire.
+
+### Propositions créatives
+
+#### A. Le Coût du bonheur *(L1 + L6)*
+"Un enfant = ~1'200 CHF/mois × 25 ans = 360'000 CHF." Décomposition : crèche (le poste monstre : 2'400 CHF/mois à ZH), LAMal enfant, nourriture, activités. Chiffre-choc : "La crèche coûte plus cher que ton loyer."
+
+#### B. Le Congé en film *(L4 + L2)*
+Timeline animée : mère 98j à 80% (max 220 CHF/jour = 4'400/mois), père 10j. Barre revenu qui chute puis remonte. "Pendant 14 semaines, tu touches 4'400 au lieu de 5'500."
+
+#### C. Le Super-pouvoir fiscal enfant *(L6 + L1)*
+Déduction LIFD : 6'700/enfant + frais garde max 25'500. Taux 25% → économie 8'050 CHF/an. "L'État te rend de l'argent pour avoir un enfant."
+
+#### D. La Carte des allocations *(L7 + L2)*
+Bubble map : Valais 305 CHF vs Zurich 200 CHF. "En déménageant ZH→VS, +1'260 CHF/an par enfant." Classement visuel des 26 cantons par générosité.
+
+#### E. Le Budget bébé mode *(L5 + L1)*
+Budget 50/30/20 avec curseur "nombre d'enfants" qui fait bouger les proportions en temps réel. "2 enfants : ta part loisirs passe de 30% à 15%."
+
+#### F. La Couverture décès/invalidité *(L6 + L4)*
+"Tu as un enfant. Si invalidité : AI 2'520 + rente enfant 840 = 3'360 CHF pour 3 personnes." Bulletin scolaire couverture familiale. → Action : assurance risque décès.
+
+### Grille de cohérence P9
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. Coût bonheur | ✅ 1'200/mois | ✅ Sans→Avec enfant | ✅ 360k sur 25 ans | ✅ Bonheur chiffré |
+| B. Congé film | ✅ 5'500→4'400 | ✅ Avant/après congé | ✅ -1'100/mois 14 sem | ✅ Film |
+| C. Fiscal enfant | ✅ 8'050/an | ✅ Sans→Avec déduction | ✅ 8k d'impôts | ✅ Super-pouvoir |
+| D. Carte allocations | ✅ 200→305/mois | ✅ ZH vs VS | ✅ 1'260/an/enfant | ✅ Carte |
+| E. Budget bébé | ✅ Loisirs -50% | ✅ 0→2 enfants | ✅ 30%→15% loisirs | ✅ Curseur |
+| F. Couverture | ✅ 3'360/mois | ✅ Couvert vs non | ✅ 3 personnes à 3k | ✅ Bulletin |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/naissance_screen.dart` | Écran principal 3 tabs |
+| `services/family_service.dart` | 6 calculateurs famille |
+| `widgets/visualizations/parental_leave_timeline.dart` | Timeline congé |
+| `widgets/visualizations/canton_allocation_map.dart` | Carte allocations |
+
+---
+
+## P10 — CRISE DE DETTE (debtCrisis) — *"Le premier pas pour remonter"*
+
+### Diagnostic
+
+| Écran existant | Lignes | Forces | Faiblesses |
+|---|---|---|---|
+| `debt_ratio_screen.dart` | 758 | Jauge, LP art. 93, 3 niveaux, Dettes Conseils | Ton clinique pour sujet honteux |
+| `debt_risk_check_screen.dart` | 388 | Quiz 6 questions, SOS Jeu | Formulation interrogatoire |
+| `consumer_credit_screen.dart` | 350 | Coût total crédit, taux max 10% | Pas assez dramatique |
+| `simulator_leasing_screen.dart` | 320 | Coût opportunité 20 ans | Détaché du contexte dette |
+| `debt_prevention_service.dart` | 663 | Avalanche vs boule de neige, min. vital, 26 cantons | UI manquante pour repayment |
+
+**Problème central** : Le surendettement provoque de la honte. Les écrans sont froids et cliniques. Il faut de la bienveillance et du pragmatisme.
+
+### Propositions créatives
+
+#### A. Le Check-up bienveillant *(L4 + L7)*
+Reformuler le quiz en "bilan de santé financière" — médical, pas judiciaire. Résultat vert/orange/rouge + "Tu n'es pas seul — 1 ménage sur 6 en Suisse a des dettes." OFS source.
+
+#### B. Avalanche vs Boule de neige *(L2 + L7)*
+Visualisation côte à côte (logique existe dans RepaymentPlanner). Avalanche : -2'300 CHF d'intérêts. Boule de neige : 1ère victoire en 3 mois. "L'avalanche est rationnelle. La boule de neige est humaine. Choisis ta méthode."
+
+#### C. Le Minimum vital — Ton droit *(L1 + L6)*
+LP art. 93 : insaisissable = 1'200 CHF (seul), 1'750 (couple) + 400/enfant. Jauge : ton revenu vs minimum vital. "Ce montant est protégé par la loi. Personne ne peut te le prendre."
+
+#### D. Le Coût caché du leasing *(L6 + L7)*
+500 CHF/mois × 48 mois = 24'000 CHF. À la fin : pas propriétaire. Investi à 5% sur 20 ans : 205'000 CHF. "Ton leasing t'a coûté un acompte immobilier."
+
+#### E. Le Numéro gratuit *(L5 + L4)*
+Card proéminente : 0800 40 40 40 (Dettes Conseils) + 0800 708 708 (Caritas). "Gratuit, confidentiel, sans jugement." Tap-to-call. SOS Jeu si gambling détecté.
+
+#### F. Le Mode survie MINT *(L3 + L5)*
+Dashboard alternatif "mode crise" auto-activé si ratio > 30%. 3 KPIs : dette totale, marge mensuelle, jours depuis dernier retard. Actions : couper loisirs, suspendre 3a, appeler Dettes Conseils.
+
+### Grille de cohérence P10
+
+| Proposition | L1 CHF/mois | L2 Avant/Après | L6 Chiffre-choc | L7 Métaphore |
+|---|:-:|:-:|:-:|:-:|
+| A. Check-up | ✅ Ratio % | ✅ Avant/après quiz | ✅ 1 ménage sur 6 | ✅ Médecin |
+| B. Avalanche/Neige | ✅ -2'300 intérêts | ✅ 2 stratégies | ✅ 3 mois victoire | ✅ Nature |
+| C. Min. vital | ✅ 1'200/mois | ✅ Revenu vs minimum | ✅ Insaisissable | ✅ Bouclier légal |
+| D. Leasing | ✅ 500/mois | ✅ Leasing vs investi | ✅ 205k perdus | ✅ Fuite capital |
+| E. Numéro gratuit | ✅ 0 CHF appel | ✅ Seul vs accompagné | ✅ Gratuit | ✅ Bouée |
+| F. Mode survie | ✅ 3 KPIs | ✅ Normal→Crise | ✅ Ratio >30% | ✅ Mode urgence |
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/debt_prevention/debt_ratio_screen.dart` | Jauge ratio d'endettement |
+| `screens/debt_risk_check_screen.dart` | Quiz santé financière |
+| `screens/consumer_credit_screen.dart` | Simulateur crédit |
+| `screens/simulator_leasing_screen.dart` | Anti-leasing |
+| `services/debt_prevention_service.dart` | Avalanche/Boule de neige, min vital |
+| `widgets/report/debt_alert_banner.dart` | Bannière alerte dette |
+| `widgets/educational/credit_cost_insert_widget.dart` | Insert coût crédit |
+
+---
+
+## P11 — NOUVEAU JOB (newJob) — *"Le vrai prix d'un changement"*
+
+### Diagnostic
+
+| Écran | Lignes | Rôle |
+|---|---|---|
+| `job_comparison_screen.dart` | 1'186 | Comparateur 7 axes LPP |
+| `job_comparison_service.dart` | 403 | Calcul delta capital retraite |
+
+**Problème** : Le comparateur montre 7 axes techniques mais pas l'impact émotionnel du changement — "combien je gagne ou perds à long terme ?"
+
+### Propositions créatives
+
+#### A. Le Prix du changement *(L2 + L6)*
+Avant/après dramatique : salaire net, LPP employeur, 3a impact, bonus, vacances. "Ton nouveau job paie +500 CHF net/mois MAIS ta LPP employeur perd 200 CHF. Impact réel : +300 CHF." Slider : "Combien négocier pour compenser ?"
+
+#### B. Le Film de ta LPP *(L4 + L7)*
+Projection à 65 ans avec job actuel vs nouveau. "Changer de job à 45 ans : capital LPP final +85k vs -40k selon la caisse." 2 barres animées qui divergent. "Demande TOUJOURS le certificat LPP avant de signer."
+
+#### C. La Checklist 48h *(L5)*
+J0 : demander certificat LPP ancien + nouveau. J5 : vérifier transfert libre passage. J30 : premier bulletin → vérifier déductions. "Tu as 30 jours pour vérifier que ton LPP a été transféré."
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/job_comparison_screen.dart` | Comparateur 7 axes |
+| `services/job_comparison_service.dart` | Moteur de calcul |
+
+---
+
+## P12 — DÉMÉNAGEMENT CANTONAL (cantonMove) — *"Le canton le moins cher de Suisse est à 30 minutes"*
+
+### Diagnostic
+
+| Écran | Lignes | Rôle |
+|---|---|---|
+| `fiscal_comparator_screen.dart` (tab 3) | 1'640 | Comparateur fiscal + simulation déménagement |
+| `cantonal_comparator.py` (backend) | 599 | Calcul 26 cantons |
+
+**Problème** : L'écran montre des taux d'imposition abstraits. Pas de "combien j'économise par mois si je déménage de VD à FR."
+
+### Propositions créatives
+
+#### A. La Carte du trésor *(L6 + L7)*
+Carte de Suisse colorée par économie fiscale vs ton canton actuel. "En déménageant de VD à ZG, tu économises 12'800 CHF/an = 1'067 CHF/mois." Heatmap : rouge (cher) → vert (favorable). Tap sur canton → détail.
+
+#### B. Le Vrai coût du déménagement *(L1 + L2)*
+Économie fiscale vs coûts réels : loyer différent, assurance LAMal cantonale, frais de déménagement, école des enfants. "Tu économises 800 CHF d'impôts mais le loyer augmente de 500 CHF. Gain réel : 300 CHF/mois."
+
+#### C. Le Top 5 pour toi *(L5 + L6)*
+Classement personnalisé des 5 meilleurs cantons selon ton profil (revenu, famille, patrimoine). Avec LAMal + impôt + loyer médian. "Ton top 1 : Zoug. Mais si tu as 2 enfants, c'est Fribourg."
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/fiscal_comparator_screen.dart` | Comparateur fiscal 3 tabs |
+| Backend: `cantonal_comparator.py` | Moteur 26 cantons |
+
+---
+
+## P13 — EXPATRIATION (countryMove) — *"Quitter la Suisse sans laisser 50k derrière toi"*
+
+### Diagnostic
+
+| Écran | Lignes | Rôle |
+|---|---|---|
+| `expat_screen.dart` | 1'692 | 3 tabs : forfait fiscal, départ, AVS gap |
+| `expat_service.dart` | 811 | 8 méthodes : source tax, quasi-résident, 90j, forfait |
+
+**Problème** : L'expatriation est un labyrinthe administratif. Le risque de perdre des droits (AVS, 3a, LPP) est énorme et irréversible.
+
+### Propositions créatives
+
+#### A. Les 5 choses que tu perds en partant *(L6 + L2)*
+Avant/après : 5 droits qui changent. AVS : rente réduite (-X% par année manquante). LPP : libre passage ou retrait (selon EU/non-EU). 3a : retirable si hors UE. LAMal : plus de couverture. Impôts : impôt à la source. "En partant, tu laisses potentiellement 180k de LPP dormir à 0.05%."
+
+#### B. Le Compte à rebours 90 jours *(L5 + L7)*
+Checklist avec deadlines légales : J0 annoncer départ commune, J30 transfert LPP libre passage, J90 clôturer 3a (si hors UE), 6 mois retirer LPP (si non-EU). "Chaque jour de retard peut te coûter un formulaire de plus."
+
+#### C. Le Trou AVS *(L1 + L6)*
+Projection rente : 44 ans cotisés = 2'520 CHF/mois. 35 ans cotisés = 2'017 CHF/mois. "Chaque année hors Suisse te coûte ~57 CHF/mois de rente. Pour toujours." Slider : "Combien d'années à l'étranger ?"
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/expat_screen.dart` | Hub expatriation 3 tabs |
+| `services/expat_service.dart` | Calculs source tax, AVS gap, forfait |
+
+---
+
+## P14 — DÉCÈS D'UN PROCHE (deathOfRelative) — *"Les papiers qu'on ne veut pas remplir"*
+
+### Diagnostic
+
+| Écran | Lignes | Rôle |
+|---|---|---|
+| `succession_simulator_screen.dart` | 1'329 | Simulateur succession (couvert en P8) |
+
+Note : cet événement partage l'écran succession avec P8 (héritage/donation) mais le vécu émotionnel est fondamentalement différent — P8 = planification, P14 = crise.
+
+### Propositions créatives
+
+#### A. Le Guide de première urgence *(L5 + L4)*
+Pas de calculs. Juste une checklist humaine en 4 phases : 48h (état civil, médecin, assurances), 1 semaine (banque, employeur, succession), 1 mois (impôts, succession, notaire), 6 mois (inventaire, partage). Ton doux, bienveillant.
+
+#### B. Les Rentes de survivant *(L1 + L6)*
+"Si ton conjoint décède : rente de veuf/veuve AVS = 80% de sa rente. Si tu n'es pas marié : 0 CHF." LAVS art. 23-24. Chiffre-choc pour concubins : "Le mariage vaut 2'016 CHF/mois de rente survivant."
+
+#### C. La Clause 3a d'urgence *(L5 + L6)*
+"Le 3a de ton partenaire : si la clause bénéficiaire n'est pas déposée, tu ne touches rien." OPP3 art. 2. Action immédiate : "Vérifie la clause de ton partenaire aujourd'hui."
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/succession_simulator_screen.dart` | Partagé avec P8 |
+| `services/life_events_service.dart` | SuccessionService |
+
+---
+
+## P15 — VENTE IMMOBILIÈRE (housingSale) — *"Les impôts que tu ne vois pas venir"*
+
+### Diagnostic
+
+| Écran | Lignes | Rôle |
+|---|---|---|
+| `housing_sale_screen.dart` | 1'118 | Plus-value, impôt, EPL, remploi |
+| `housing_sale_service.dart` | 326 | Calcul gain en capital, EPL |
+
+**Problème** : La vente immobilière cache 3 pièges fiscaux (impôt sur le gain, remboursement EPL, remploi) que l'écran montre mais sans dramaturgie.
+
+### Propositions créatives
+
+#### A. Les 3 surprises de la vente *(L6 + L4)*
+Film 3 actes : Acte 1 = impôt sur gain en capital (canton-dépendant, dégressif par durée). Acte 2 = remboursement EPL obligatoire (tu as retiré 80k de LPP → tu dois les remettre). Acte 3 = remploi 2 ans (si tu ne rachètes pas, l'impôt sur le gain n'est pas différé). "Tu vends à 1.2M, tu penses toucher 400k, tu reçois 280k."
+
+#### B. Le Calculateur de net réel *(L1 + L2)*
+Cascade : prix de vente → - hypothèque → - impôt gain → - EPL retour → - frais notaire → = net réel. "Ton net réel est 30% en dessous de ce que tu imagines."
+
+#### C. Le Chrono du remploi *(L5 + L7)*
+Si tu vends ta résidence principale et ne rachètes pas dans les 2 ans : l'impôt sur le gain est dû. Compte à rebours : "Il te reste 18 mois pour racheter et différer l'impôt de 45'000 CHF."
+
+### Fichiers concernés
+
+| Fichier | Rôle |
+|---------|------|
+| `screens/housing_sale_screen.dart` | Simulateur vente |
+| `services/housing_sale_service.dart` | Calcul gain, EPL, remploi |
+
+---
+
+*Note : Les événements `concubinage`, `mariage`, `divorce` sont couverts par P2. L'événement `retirement` est couvert par P1.*
+
+---
+
+## GRILLE DE COHÉRENCE
+
+Chaque proposition est vérifiée contre les 7 lois :
+
+### P1 — Retirement Dashboard
+
+| Prop. | L1 CHF/mois | L2 Avant/Après | L3 3 niveaux | L4 Raconte | L5 Action | L6 Chiffre-choc | L7 Métaphore |
+|-------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| A. Salaire après 65 | ✅ | ✅ | ✅ | ✅ | — | ✅ | — |
+| B. Pile de briques | ✅ | — | ✅ | ✅ | — | — | ✅ |
+| C. Slider retraite | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ |
+| D. Météo financière | — | — | ✅ | ✅ | ✅ | — | ✅ |
+| E. Histoires "et si" | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| F. Film du couple | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| G. Sandwich budget | ✅ | — | ✅ | ✅ | — | — | ✅ |
+| H. Score Strava | — | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| I. Thermomètre | — | — | ✅ | ✅ | ✅ | — | ✅ |
+| J. Dashboard progressif | — | — | ✅ | — | — | — | — |
+
+### P2 — Mariage / Divorce / Concubinage
+
+| Prop. | L1 CHF/mois | L2 Avant/Après | L3 3 niveaux | L4 Raconte | L5 Action | L6 Chiffre-choc | L7 Métaphore |
+|-------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| A. Ticket de caisse | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| B. Film du divorce | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| C. Match boxing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| D. Tiroirs régimes | — | — | ✅ | ✅ | — | ✅ | ✅ |
+| E. Checklist urgence | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| F. Pont cassé | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+---
+
+## FICHIERS CONCERNÉS (référence technique)
+
+### P1 — Retirement Dashboard
+| Fichier | Type | Rôle |
+|---------|------|------|
+| `screens/coach/retirement_dashboard_screen.dart` | Screen | Hub principal |
+| `screens/coach/cockpit_detail_screen.dart` | Screen | Cockpit expert |
+| `widgets/coach/hero_retirement_card.dart` | Widget | Hero number |
+| `widgets/coach/hero_couple_card.dart` | Widget | Hero couple |
+| `widgets/coach/pillar_decomposition.dart` | Widget | Décomposition piliers |
+| `widgets/coach/mint_trajectory_chart.dart` | Widget | Trajectoire 3 scénarios |
+| `widgets/coach/mint_score_gauge.dart` | Widget | Jauge fitness |
+| `widgets/coach/confidence_bar.dart` | Widget | Barre confiance |
+| `widgets/coach/confidence_blocks_bar.dart` | Widget | Blocs par catégorie |
+| `widgets/retirement/income_stacked_bar_chart.dart` | Widget | Revenus empilés |
+| `widgets/retirement/early_retirement_chart.dart` | Widget | Retraite anticipée |
+| `widgets/retirement/couple_timeline_chart.dart` | Widget | Timeline couple |
+| `widgets/retirement/budget_gap_chart.dart` | Widget | Gap budget |
+| `widgets/retirement/monte_carlo_chart.dart` | Widget | Monte Carlo |
+| `widgets/coach/sensitivity_snippet.dart` | Widget | Tornado snippet |
+| `widgets/coach/temporal_strip.dart` | Widget | Chips temporels |
+| `widgets/coach/early_retirement_comparison.dart` | Widget | Table retraite anticipée |
+| `widgets/coach/benchmark_card.dart` | Widget | Benchmark pairs |
+| `widgets/coach/fri_radar_chart.dart` | Widget | FRI radar |
+| `services/retirement_projection_service.dart` | Service | Moteur projection |
+| `services/forecaster_service.dart` | Service | 3 scénarios |
+
+### P2 — Mariage / Divorce / Concubinage
+| Fichier | Type | Rôle |
+|---------|------|------|
+| `screens/mariage_screen.dart` | Screen | Écran mariage (3 onglets) |
+| `screens/divorce_simulator_screen.dart` | Screen | Simulateur divorce |
+| `screens/concubinage_screen.dart` | Screen | Comparaison mariage vs concubinage |
+| `widgets/visualizations/concubinage_decision_matrix.dart` | Widget | Matrice (inutilisé) |
+| `widgets/visualizations/regime_matrimonial_pie.dart` | Widget | Donut régime (inutilisé) |
+| `widgets/visualizations/marriage_penalty_gauge.dart` | Widget | Thermomètre pénalité (inutilisé) |
+| `widgets/visualizations/fiscal_impact_waterfall.dart` | Widget | Waterfall fiscal (inutilisé) |
+| `services/family_service.dart` | Service | Calculs mariage/famille |
+| `services/life_events_service.dart` | Service | DivorceService + SuccessionService |
+| `education/inserts/q_divorce.md` | Content | Insert éducatif divorce |


### PR DESCRIPTION
## Résumé

Sprint S42 — Refonte UX complète des widgets coach sur 3 vagues :

**V1 — P1 Retirement Dashboard** (commit `0814f1c`)
- 3 CAT-A refactors : HeroRetirementCard, MintScoreGauge, ConfidenceBar
- 5 CAT-B nouveaux : EarlyRetirementSlider, FinancialWeatherWidget, WhatIfStoriesWidget, CoupleNarrativeTimeline, BudgetSandwichChart

**V2 — P5+P6 Premier emploi + Indépendant** (commit `be94b05`)
- 8 CAT-B nouveaux : career_timelapse, payslip_xray, budget_503020, countdown_3a, ninety_day_plan, double_price_freedom, true_hourly_rate, lpp_vs_3a_decision_tree
- 3 CAT-A refactors : salary_breakdown (iceberg), independant_screen (Jour J), pillar_3a_indep (badge ×N + projection 20 ans)

**V3 — P7+P4 Perte d'emploi + Invalidité** (commit `623de86`)
- 10 CAT-B nouveaux : crash_test_budget, unemployment_counter, lpp_rescue, horizon_line, disability_cliff, disability_reset, disability_red_screen, franchise_cost, disability_scorecard, disability_countdown
- 1 CAT-A refactor : unemployment_screen (3 vagues tsunami)

**Post-audit fixes** (commits `a6efe2e`, `6fd0b50`)
- `chf_formatter.dart` : ajout `formatChfCompact()` — DRY
- `salary_breakdown_widget` : découplage `FirstJobService.formatChf` → formateur partagé
- `independant_screen` : magic numbers → constantes `social_insurance.dart`
- **LACI art. 27 compliance** : `unemployment_counter_widget` corrigé (25-54 ans = 400j, ≥55 ans = 520j — la tranche 55-59=400j n'existe pas en droit suisse)

## Qualité

- 0 erreurs `flutter analyze`
- 220+ nouveaux tests widget (tous verts)
- Tous les widgets : purs (no Provider), Semantics, disclaimers LSFin, refs légales
- Charte MINT 7 lois respectée (L1-L7)

## Test plan

- [ ] `flutter analyze` → 0 erreurs
- [ ] `flutter test` → tous verts
- [ ] Vérifier visuellement les nouveaux widgets sur simulateur iOS
- [ ] Vérifier les écrans refactorisés : unemployment_screen, independant_screen, pillar_3a_indep_screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)