### PR TITLE
fix(test): fix 40 CI Flutter failures — accent matching + Provider scope

### DIFF
--- a/apps/mobile/test/screens/lpp_deep_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/lpp_deep_screens_smoke_test.dart
@@ -37,18 +37,18 @@ void main() {
 
   group('RachatEchelonneScreen', () {
     Widget buildScreen() {
-      return ChangeNotifierProvider<CoachProfileProvider>(
-        create: (_) => CoachProfileProvider(),
-        child: const MaterialApp(
-          locale: Locale('fr'),
-          localizationsDelegates: [
-            S.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: S.supportedLocales,
-          home: RachatEchelonneScreen(),
+      return MaterialApp(
+        locale: const Locale('fr'),
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: ChangeNotifierProvider<CoachProfileProvider>(
+          create: (_) => CoachProfileProvider(),
+          child: const RachatEchelonneScreen(),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- Fix 40 Flutter test failures from i18n migration (accent matching + Provider scope)
- Post-S44 merge cleanup — single commit `0db6653`

## Test plan
- [x] Tests pass on branch
- [x] Single focused fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)