### PR TITLE
Production: Docker cache bust

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install deps from pyproject.toml (single source of truth)
+# Cache bust: S56 added anthropic SDK (2026-03-20)
 COPY pyproject.toml .
 COPY app/ app/
 RUN pip install --no-cache-dir .


### PR DESCRIPTION
Force pip reinstall with anthropic SDK.