### PR TITLE
fix: lazy init + env var fallback

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -31,7 +31,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_service = ClaudeCoachService()
+_service: ClaudeCoachService | None = None
+
+
+def _get_service() -> ClaudeCoachService:
+    """Lazy init — ensures env vars are loaded before reading API key."""
+    global _service
+    if _service is None:
+        _service = ClaudeCoachService()
+    return _service
 
 # Simple in-memory quota tracking (per-user per-day).
 # In production, replace with Redis or DB.
@@ -67,7 +75,8 @@ def coach_chat(request: CoachChatRequest) -> CoachChatResponse:
     Rate limited to COACH_DAILY_QUOTA messages per user per day.
     All output filtered by ComplianceGuard.
     """
-    if not _service.is_available:
+    service = _get_service()
+    if not service.is_available:
         return CoachChatResponse(
             reply=(
                 "Le coach IA n'est pas disponible pour le moment. "
@@ -120,7 +129,7 @@ def coach_chat(request: CoachChatRequest) -> CoachChatResponse:
         for m in request.conversation_history[-20:]
     ]
 
-    result = _service.chat(
+    result = service.chat(
         message=request.message,
         conversation_history=history,
         system_prompt=system_prompt,

--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -192,11 +192,21 @@ class ClaudeCoachService:
             logger.warning("anthropic SDK not installed — coach chat disabled")
             self._client = None
             return
+
+        # Try settings first, then direct env var as fallback
         api_key = settings.ANTHROPIC_API_KEY
         if not api_key:
-            logger.warning("ANTHROPIC_API_KEY not set — coach chat disabled")
+            import os
+            api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+            if api_key:
+                logger.info("ANTHROPIC_API_KEY found via os.environ (not pydantic settings)")
+
+        if not api_key:
+            logger.warning("ANTHROPIC_API_KEY not set — coach chat disabled (checked settings + os.environ)")
             self._client = None
         else:
+            key_preview = f"{api_key[:8]}...{api_key[-4:]}" if len(api_key) > 12 else "***"
+            logger.info("Claude coach initialized with key %s", key_preview)
             self._client = Anthropic(api_key=api_key)
 
     @property


### PR DESCRIPTION
Init service on first request, not at import time. Fallback to os.environ.