### PR TITLE
fix: Profile injection sprint — 39 screens + magic numbers + getLpp centralization

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -2528,16 +2528,7 @@ class CoachProfile {
     final startAge = arrivalAge != null ? arrivalAge.clamp(25, 65) : 25;
     double total = 0;
     for (int a = startAge; a < age && a < 65; a++) {
-      double taux;
-      if (a < 35) {
-        taux = 0.07;
-      } else if (a < 45) {
-        taux = 0.10;
-      } else if (a < 55) {
-        taux = 0.15;
-      } else {
-        taux = 0.18;
-      }
+      final taux = getLppBonificationRate(a);
       total = total * 1.01 + salaireCoordonne * taux; // 1% rendement
     }
     return total;

--- a/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
@@ -7,6 +7,7 @@ import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/financial_core/arbitrage_engine.dart';
 import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -43,6 +44,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
   bool _hasRachatLpp = true;
   bool _isPropertyOwner = false;
   int _anneesAvantRetraite = 20;
+  String _canton = 'VD';
 
   // ── Hypothesis sliders ──
   Map<String, double> _hypotheses = {
@@ -82,12 +84,33 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
       _montantCtrl.text = pilier3aPlafondAvecLpp.round().toString();
       _hasEstimatedValues = true;
     }
-    if (profile.prevoyance.avoirLppTotal != null) {
-      // Estimate potential rachat (simplified: ~20% of current LPP)
-      final potentiel = (profile.prevoyance.avoirLppTotal! * 0.2).round();
-      _potentielRachatCtrl.text = potentiel.toString();
-      _hasRachatLpp = potentiel > 0;
+
+    // Canton from profile
+    if (cantonFullNames.containsKey(profile.canton)) {
+      _canton = profile.canton;
     }
+
+    // Real marginal rate via RetirementTaxCalculator
+    final revenu = profile.revenuBrutAnnuel;
+    if (revenu > 0) {
+      final rate = RetirementTaxCalculator.estimateMarginalRate(
+        revenu,
+        _canton,
+      );
+      _tauxMarginal = (rate * 100).roundToDouble().clamp(10, 50);
+    }
+
+    // Real lacune rachat LPP (not estimated 20%)
+    final lacune = profile.prevoyance.lacuneRachatRestante;
+    if (lacune > 0) {
+      _potentielRachatCtrl.text = lacune.round().toString();
+      _hasRachatLpp = true;
+    } else if (profile.prevoyance.avoirLppTotal != null) {
+      // Fallback: no lacune data, disable rachat
+      _potentielRachatCtrl.text = '0';
+      _hasRachatLpp = false;
+    }
+
     _anneesAvantRetraite = profile.anneesAvantRetraite;
     _dataSources = profile.dataSources;
     _recalculate();
@@ -119,7 +142,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
       rendement3a: (_hypotheses['rendement_3a'] ?? 2.0) / 100,
       rendementLpp: (_hypotheses['rendement_lpp'] ?? 1.25) / 100,
       rendementMarche: (_hypotheses['rendement_marche'] ?? 4.0) / 100,
-      canton: 'VD',
+      canton: _canton,
       dataSources: _dataSources,
     );
 

--- a/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
@@ -76,8 +76,16 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
   }
 
   void _autoFillFromProfile() {
-    final profile = context.read<CoachProfileProvider>().profile;
-    if (profile == null) return;
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      _autoFillFromProfileData(profile);
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
+
+  void _autoFillFromProfileData(CoachProfile profile) {
 
     // Annual contribution capacity: 3a max for salaried
     if (profile.salaireBrutMensuel > 0) {

--- a/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
@@ -79,18 +79,32 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
     final canton = profile.canton.isNotEmpty ? profile.canton : 'VD';
     final isMarried = profile.etatCivil == CoachCivilStatus.marie;
     final patrimoine = profile.patrimoine;
-    final capital = patrimoine.epargneLiquide;
+
+    // Capital disponible = epargne liquide + 3a + investissements
+    // (LPP is handled separately for EPL max 10% rule)
+    final epargneLiquide = patrimoine.epargneLiquide;
+    final avoir3a = profile.prevoyance.totalEpargne3a;
+    final investissements = patrimoine.investissements;
+    final totalCapital = epargneLiquide + avoir3a + investissements;
 
     setState(() {
       _canton = canton;
       _isMarried = isMarried;
-      if (capital > 0) {
-        _capitalCtrl.text = capital.round().toString();
+      if (totalCapital > 0) {
+        _capitalCtrl.text = totalCapital.round().toString();
         _hasEstimatedValues = true;
       }
       // Loyer mensuel from profile
       if (profile.depenses.loyer > 0) {
         _loyerCtrl.text = profile.depenses.loyer.round().toString();
+        _hasEstimatedValues = true;
+      }
+      // Income-based property price estimate (rule of 1/3)
+      final revenu = profile.revenuBrutAnnuel;
+      if (revenu > 0) {
+        // Max property affordable: revenu / 7% theoretical charges / 20% equity
+        // Simplified: max ~= revenu / 0.07 (rough capacity estimate)
+        // But we don't override prixBien — user should set it
         _hasEstimatedValues = true;
       }
       _dataSources = profile.dataSources;

--- a/apps/mobile/lib/screens/concubinage_screen.dart
+++ b/apps/mobile/lib/screens/concubinage_screen.dart
@@ -55,7 +55,35 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _recalculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.revenuBrutAnnuel > 0) {
+          _revenu1 = profile.revenuBrutAnnuel;
+        }
+        if (profile.conjoint?.revenuBrutAnnuel != null &&
+            profile.conjoint!.revenuBrutAnnuel > 0) {
+          _revenu2 = profile.conjoint!.revenuBrutAnnuel;
+        }
+        final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+        if (totalPatrimoine > 0) {
+          _patrimoine = totalPatrimoine;
+        }
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+      });
+      _recalculate();
+    } catch (_) {}
   }
 
   @override

--- a/apps/mobile/lib/screens/consumer_credit_screen.dart
+++ b/apps/mobile/lib/screens/consumer_credit_screen.dart
@@ -7,6 +7,8 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/debt_repayment_widget.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 class ConsumerCreditSimulatorScreen extends StatefulWidget {
   const ConsumerCreditSimulatorScreen({super.key});
@@ -31,7 +33,29 @@ class _ConsumerCreditSimulatorScreenState extends State<ConsumerCreditSimulatorS
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        final creditConso = profile.dettes.creditConsommation;
+        if (creditConso != null && creditConso > 0) {
+          _amount = creditConso;
+        }
+        final tauxConso = profile.dettes.tauxCreditConso;
+        if (tauxConso != null && tauxConso > 0) {
+          _annualRate = tauxConso;
+        }
+      });
+      _calculate();
+    } catch (_) {}
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/coverage_check_screen.dart
+++ b/apps/mobile/lib/screens/coverage_check_screen.dart
@@ -5,6 +5,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/assurances_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  COVERAGE CHECK SCREEN — Sprint S13 / Chantier 7
@@ -29,7 +31,7 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
   bool _aFamille = false;
   bool _estLocataire = true;
   bool _voyagesFrequents = false;
-  final String _canton = 'VD';
+  String _canton = 'VD';
 
   // ── State — Current coverage ───────────────────────────────
   bool _aIjmCollective = true;
@@ -45,7 +47,40 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _compute();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.employmentStatus == 'independant') {
+          _statut = 'independant';
+        } else if (profile.employmentStatus == 'chomage') {
+          _statut = 'sans_emploi';
+        }
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+        if (profile.dettes.hypotheque != null &&
+            profile.dettes.hypotheque! > 0) {
+          _aHypotheque = true;
+        }
+        if (profile.nombreEnfants > 0 ||
+            profile.conjoint != null) {
+          _aFamille = true;
+        }
+        if (profile.housingStatus == 'proprietaire') {
+          _estLocataire = false;
+        }
+      });
+      _compute();
+    } catch (_) {}
   }
 
   void _compute() {

--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -11,6 +11,9 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 
 /// Ecran de diagnostic du ratio d'endettement.
 ///
@@ -29,6 +32,35 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('debt');
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.salaireBrutMensuel > 0) {
+          _revenusMensuels = profile.salaireBrutMensuel;
+        }
+        if (profile.depenses.loyer > 0) {
+          _loyer = profile.depenses.loyer;
+        }
+        if (profile.dettes.totalMensualite > 0) {
+          _chargesDetteMensuelles = profile.dettes.totalMensualite;
+        }
+        if (profile.etatCivil == CoachCivilStatus.celibataire ||
+            profile.etatCivil == CoachCivilStatus.divorce) {
+          _estCelibataire = true;
+        } else {
+          _estCelibataire = false;
+        }
+        _nombreEnfants = profile.nombreEnfants;
+      });
+    } catch (_) {}
   }
 
   double _revenusMensuels = 6000;

--- a/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
@@ -8,6 +8,8 @@ import 'package:mint_mobile/services/debt_prevention_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
 import 'package:mint_mobile/widgets/coach/debt_survival_widget.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Ecran de planification du remboursement de dettes.
 ///
@@ -54,6 +56,60 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
       dettes: dettes,
       budgetMensuelRemboursement: _budgetMensuel,
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      final dettes = profile.dettes;
+      if (!dettes.hasDette) return;
+      final entries = <_DebtInput>[];
+      if ((dettes.creditConsommation ?? 0) > 0) {
+        entries.add(_DebtInput(
+          nom: 'Crédit conso',
+          montant: dettes.creditConsommation!,
+          tauxAnnuel: dettes.tauxCreditConso ?? 9.9,
+          mensualiteMin: dettes.mensualiteCreditConso ?? 300,
+        ));
+      }
+      if ((dettes.leasing ?? 0) > 0) {
+        entries.add(_DebtInput(
+          nom: 'Leasing',
+          montant: dettes.leasing!,
+          tauxAnnuel: dettes.tauxLeasing ?? 4.5,
+          mensualiteMin: dettes.mensualiteLeasing ?? 250,
+        ));
+      }
+      if ((dettes.autresDettes ?? 0) > 0) {
+        entries.add(_DebtInput(
+          nom: 'Autres dettes',
+          montant: dettes.autresDettes!,
+          tauxAnnuel: 5.0,
+          mensualiteMin: 200,
+        ));
+      }
+      if (entries.isNotEmpty) {
+        setState(() {
+          _dettes
+            ..clear()
+            ..addAll(entries);
+          _budgetMensuel = entries.fold<double>(
+            0,
+            (s, d) => s + d.mensualiteMin,
+          ) * 1.2;
+        });
+      }
+    } catch (_) {}
   }
 
   @override

--- a/apps/mobile/lib/screens/deces_proche_screen.dart
+++ b/apps/mobile/lib/screens/deces_proche_screen.dart
@@ -4,6 +4,8 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Screen for navigating the financial impact of a relative's death in Switzerland.
 ///
@@ -22,9 +24,41 @@ class _DecesProcheScreenState extends State<DecesProcheScreen> {
   String _lienParente = 'conjoint';
   String _canton = 'VD';
   double _fortuneDefunt = 500000;
-  final double _lppDefunt = 200000;
-  final double _pilier3aDefunt = 50000;
+  double _lppDefunt = 200000;
+  double _pilier3aDefunt = 50000;
   bool _testamentExiste = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+        final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+        if (totalPatrimoine > 0) {
+          _fortuneDefunt = totalPatrimoine;
+        }
+        final lpp = profile.prevoyance.avoirLppTotal;
+        if (lpp != null && lpp > 0) {
+          _lppDefunt = lpp;
+        }
+        if (profile.prevoyance.totalEpargne3a > 0) {
+          _pilier3aDefunt = profile.prevoyance.totalEpargne3a;
+        }
+      });
+    } catch (_) {}
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
+++ b/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -31,6 +34,44 @@ class _DemenagementCantonalScreenState
   String _cantonArrivee = 'VS';
   double _revenuBrut = 120000;
   String _situationFamiliale = 'marie';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // Departure canton = user's CURRENT canton
+        if (cantonFullNames.containsKey(profile.canton)) {
+          _cantonDepart = profile.canton;
+        }
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) {
+          _revenuBrut = revenu;
+        }
+        // Map etatCivil to situation familiale
+        switch (profile.etatCivil) {
+          case CoachCivilStatus.marie:
+            _situationFamiliale = 'marie';
+          case CoachCivilStatus.celibataire:
+          case CoachCivilStatus.divorce:
+          case CoachCivilStatus.veuf:
+          case CoachCivilStatus.concubinage:
+            _situationFamiliale = 'celibataire';
+        }
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   // Simplified cantonal tax burden index (relative, GE=100)
   static const _indiceFiscal = {

--- a/apps/mobile/lib/screens/divorce_simulator_screen.dart
+++ b/apps/mobile/lib/screens/divorce_simulator_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/life_events_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -72,9 +74,67 @@ class _DivorceSimulatorScreenState extends State<DivorceSimulatorScreen> {
   List<bool> _checklistState = [];
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  @override
   void dispose() {
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // Conjoint 1 income from profile
+        final revenu1 = profile.revenuBrutAnnuel;
+        if (revenu1 > 0) _incomeConjoint1 = revenu1;
+
+        // Conjoint 2 income from conjoint profile
+        final conjoint = profile.conjoint;
+        if (conjoint != null) {
+          final revenu2 = conjoint.revenuBrutAnnuel;
+          if (revenu2 > 0) _incomeConjoint2 = revenu2;
+
+          // Conjoint 2 LPP
+          final lpp2 = conjoint.prevoyance?.avoirLppTotal;
+          if (lpp2 != null && lpp2 > 0) _lppConjoint2 = lpp2;
+
+          // Conjoint 2 3a
+          final epargne3a2 = conjoint.prevoyance?.totalEpargne3a;
+          if (epargne3a2 != null && epargne3a2 > 0) {
+            _pillar3aConjoint2 = epargne3a2;
+          }
+        }
+
+        // Conjoint 1 LPP
+        final lpp1 = profile.prevoyance.avoirLppTotal;
+        if (lpp1 != null && lpp1 > 0) _lppConjoint1 = lpp1;
+
+        // Conjoint 1 3a
+        final epargne3a1 = profile.prevoyance.totalEpargne3a;
+        if (epargne3a1 > 0) _pillar3aConjoint1 = epargne3a1;
+
+        // Children
+        if (profile.nombreEnfants > 0) {
+          _numberOfChildren = profile.nombreEnfants;
+        }
+
+        // Fortune commune = epargne liquide + investissements
+        final fortune = profile.patrimoine.epargneLiquide +
+            profile.patrimoine.investissements;
+        if (fortune > 0) _fortuneCommune = fortune;
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
   }
 
   void _simulate() {

--- a/apps/mobile/lib/screens/donation_screen.dart
+++ b/apps/mobile/lib/screens/donation_screen.dart
@@ -6,6 +6,8 @@ import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/donation_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Swiss CHF formatter with apostrophe grouping.
 String _formatChfSwiss(double value) {
@@ -84,6 +86,37 @@ class _DonationScreenState extends State<DonationScreen> {
     'communaute_biens': 'Communauté de biens',
     'separation_biens': 'Séparation de biens',
   };
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+        if (profile.age > 0) {
+          _donateurAge = profile.age;
+        }
+        if (profile.nombreEnfants > 0) {
+          _nbEnfants = profile.nombreEnfants;
+        }
+        final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+        if (totalPatrimoine > 0) {
+          _fortuneTotaleDonateur = totalPatrimoine;
+        }
+      });
+    } catch (_) {}
+  }
 
   @override
   void dispose() {

--- a/apps/mobile/lib/screens/expat_screen.dart
+++ b/apps/mobile/lib/screens/expat_screen.dart
@@ -59,9 +59,46 @@ class _ExpatScreenState extends State<ExpatScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _recalculateForfait();
     _recalculateDepart();
     _recalculateAvs();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.canton.isNotEmpty) {
+          _forfaitCanton = profile.canton;
+          _departCanton = profile.canton;
+        }
+        if (profile.prevoyance.totalEpargne3a > 0) {
+          _pillar3aBalance = profile.prevoyance.totalEpargne3a;
+        }
+        final lpp = profile.prevoyance.avoirLppTotal;
+        if (lpp != null && lpp > 0) {
+          _lppBalance = lpp;
+        }
+        final depenses = profile.depenses.totalMensuel * 12;
+        if (depenses > 0) {
+          _livingExpenses = depenses;
+        }
+        if (profile.arrivalAge != null) {
+          final yearsInCh = profile.age - profile.arrivalAge!;
+          if (yearsInCh > 0) {
+            _yearsInCh = yearsInCh;
+          }
+        }
+      });
+      _recalculateForfait();
+      _recalculateDepart();
+      _recalculateAvs();
+    } catch (_) {}
   }
 
   @override

--- a/apps/mobile/lib/screens/frontalier_screen.dart
+++ b/apps/mobile/lib/screens/frontalier_screen.dart
@@ -6,6 +6,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/expat_service.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FRONTALIER SCREEN — Sprint S23 / Expatriation + Frontaliers
@@ -51,9 +54,37 @@ class _FrontalierScreenState extends State<FrontalierScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _recalculateTax();
     _recalculate90Day();
     _recalculateCharges();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.canton.isNotEmpty) {
+          _taxCanton = profile.canton;
+        }
+        if (profile.salaireBrutMensuel > 0) {
+          _taxSalary = profile.salaireBrutMensuel;
+          _chargesSalary = profile.salaireBrutMensuel;
+        }
+        if (profile.nombreEnfants > 0) {
+          _taxChildren = profile.nombreEnfants;
+        }
+        if (profile.etatCivil == CoachCivilStatus.marie) {
+          _taxMaritalStatus = 1;
+        }
+      });
+      _recalculateTax();
+      _recalculateCharges();
+    } catch (_) {}
   }
 
   @override

--- a/apps/mobile/lib/screens/gender_gap_screen.dart
+++ b/apps/mobile/lib/screens/gender_gap_screen.dart
@@ -5,6 +5,8 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/segments_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  GENDER GAP PREVOYANCE SCREEN — Sprint S12 / Chantier 6
@@ -20,18 +22,49 @@ class GenderGapScreen extends StatefulWidget {
 class _GenderGapScreenState extends State<GenderGapScreen> {
   // ── State ──────────────────────────────────────────────────
   double _tauxActivite = 60;
-  final double _revenuAnnuel = 85000;
-  final int _age = 40;
-  final double _avoirLpp = 120000;
-  final int _anneesCotisation = 15;
-  final String _canton = 'VD';
+  double _revenuAnnuel = 85000;
+  int _age = 40;
+  double _avoirLpp = 120000;
+  int _anneesCotisation = 15;
+  String _canton = 'VD';
 
   GenderGapResult? _result;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _compute();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.revenuBrutAnnuel > 0) {
+          _revenuAnnuel = profile.revenuBrutAnnuel;
+        }
+        if (profile.age > 0) {
+          _age = profile.age;
+        }
+        final lpp = profile.prevoyance.avoirLppTotal;
+        if (lpp != null && lpp > 0) {
+          _avoirLpp = lpp;
+        }
+        final annees = profile.prevoyance.anneesContribuees;
+        if (annees != null && annees > 0) {
+          _anneesCotisation = annees;
+        }
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+      });
+      _compute();
+    } catch (_) {}
   }
 
   void _compute() {

--- a/apps/mobile/lib/screens/housing_sale_screen.dart
+++ b/apps/mobile/lib/screens/housing_sale_screen.dart
@@ -9,6 +9,8 @@ import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 import 'package:mint_mobile/widgets/coach/remploi_countdown_widget.dart';
 import 'package:mint_mobile/widgets/coach/sale_surprises_widget.dart';
 import 'package:mint_mobile/widgets/coach/net_proceeds_widget.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Swiss CHF formatter with apostrophe grouping.
 String _formatChfSwiss(double value) {
@@ -66,6 +68,36 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
   List<bool> _checklistState = [];
 
   static List<String> get _cantons => sortedCantonCodes;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        final propertyValue = profile.patrimoine.immobilierEffectif;
+        if (propertyValue > 0) {
+          _prixAchat = propertyValue;
+          _prixVente = propertyValue * 1.25;
+        }
+        final mortgage = profile.patrimoine.mortgageBalance;
+        if (mortgage != null && mortgage > 0) {
+          _hypothequeRestante = mortgage;
+        }
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+      });
+    } catch (_) {}
+  }
 
   @override
   void dispose() {

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:go_router/go_router.dart';
@@ -34,19 +36,47 @@ class IndependantScreen extends StatefulWidget {
 class _IndependantScreenState extends State<IndependantScreen> {
   // ── State ──────────────────────────────────────────────────
   double _revenuNet = 80000;
-  final int _age = 42;
+  int _age = 42;
   bool _hasLpp = false;
   bool _hasIjm = false;
   bool _hasLaa = false;
   bool _has3a = false;
-  final String _canton = 'VD';
+  String _canton = 'VD';
 
   IndependantResult? _result;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _compute();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // Age
+        final age = profile.age;
+        if (age >= 18 && age <= 70) _age = age;
+
+        // Canton
+        if (cantonFullNames.containsKey(profile.canton)) {
+          _canton = profile.canton;
+        }
+
+        // Revenue
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) _revenuNet = revenu;
+      });
+      _compute();
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
   }
 
   void _compute() {
@@ -1086,19 +1116,19 @@ class _IndependantScreenState extends State<IndependantScreen> {
           charges: [
             ChargeLine(
               label: 'AVS / AI / APG',
-              employeeAmount: _revenuNet * 0.0530,
-              selfEmployedAmount: _revenuNet * 0.1010,
+              employeeAmount: _revenuNet * avsCotisationSalarie,
+              selfEmployedAmount: _revenuNet * avsCotisationTotal,
               note: 'LAVS art. 8 \u2014 ind\u00e9p. paie les 2 parts',
             ),
             ChargeLine(
               label: 'LPP (2e pilier)',
-              employeeAmount: _revenuNet * 0.070,
+              employeeAmount: _revenuNet * getLppBonificationRate(_age),
               selfEmployedAmount: 0,
               note: 'Facultatif pour ind\u00e9pendant (LPP art. 4)',
             ),
             ChargeLine(
               label: 'Ch\u00f4mage (AC)',
-              employeeAmount: _revenuNet * 0.011,
+              employeeAmount: _revenuNet * acCotisationSalarie,
               selfEmployedAmount: 0,
               note: 'Pas d\'AC pour ind\u00e9pendant (LACI art. 2)',
             ),
@@ -1109,8 +1139,8 @@ class _IndependantScreenState extends State<IndependantScreen> {
               note: '\u00c0 charge enti\u00e8re de l\'ind\u00e9pendant',
             ),
           ],
-          totalEmployee: _revenuNet * (0.0530 + 0.070 + 0.011 + 0.020),
-          totalSelfEmployed: _revenuNet * (0.1010 + 0 + 0 + 0.040),
+          totalEmployee: _revenuNet * (avsCotisationSalarie + getLppBonificationRate(_age) + acCotisationSalarie + 0.020),
+          totalSelfEmployed: _revenuNet * (avsCotisationTotal + 0 + 0 + 0.040),
         ),
         const SizedBox(height: MintSpacing.lg),
 

--- a/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
+++ b/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
@@ -4,6 +4,8 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 class AvsCotisationsScreen extends StatefulWidget {
   const AvsCotisationsScreen({super.key});
@@ -19,7 +21,25 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        _revenuNet = profile.revenuBrutAnnuel;
+        changed = true;
+      }
+      if (changed) _calculate();
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
@@ -6,6 +6,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 // ────────────────────────────────────────────────────────────
 //  DIVIDENDE VS SALAIRE SCREEN — Sprint S18
@@ -33,7 +36,32 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        _benefice = profile.revenuBrutAnnuel.clamp(0, 500000);
+        changed = true;
+      }
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        );
+        changed = true;
+      }
+      if (changed) _calculate();
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/independants/ijm_screen.dart
+++ b/apps/mobile/lib/screens/independants/ijm_screen.dart
@@ -4,6 +4,8 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 class IjmScreen extends StatefulWidget {
   const IjmScreen({super.key});
@@ -21,7 +23,30 @@ class _IjmScreenState extends State<IjmScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.salaireBrutMensuel > 0) {
+        _revenuMensuel = profile.salaireBrutMensuel.clamp(0, 20000);
+        changed = true;
+      }
+      final age = profile.age;
+      if (age >= 18 && age <= 65) {
+        _age = age;
+        changed = true;
+      }
+      if (changed) _calculate();
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -5,6 +5,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 // ────────────────────────────────────────────────────────────
 //  LPP VOLONTAIRE SCREEN — Sprint S18 / Independants complet
@@ -32,7 +35,37 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        _revenuNet = profile.revenuBrutAnnuel.clamp(0, 250000);
+        changed = true;
+      }
+      final age = profile.age;
+      if (age >= 25 && age <= 65) {
+        _age = age;
+        changed = true;
+      }
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        );
+        changed = true;
+      }
+      if (changed) _calculate();
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -8,6 +8,9 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 // ────────────────────────────────────────────────────────────
 //  PILLAR 3A INDEPENDANT SCREEN — Sprint S18
@@ -34,7 +37,38 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        _revenuNet = profile.revenuBrutAnnuel.clamp(0, 300000);
+        changed = true;
+      }
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        );
+        changed = true;
+      }
+      // Detect LPP affiliation from prevoyance data
+      if (profile.prevoyance.avoirLppTotal != null &&
+          profile.prevoyance.avoirLppTotal! > 0) {
+        _affilieLpp = true;
+        changed = true;
+      }
+      if (changed) _calculate();
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/job_comparison_screen.dart
+++ b/apps/mobile/lib/screens/job_comparison_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/job_comparison_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -58,6 +61,49 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
   double _currentCapitalDeces = 200000;
   double _currentRachatMax = 80000;
   bool _currentHasIjm = true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        _age = profile.age;
+
+        // Current job: auto-fill from profile
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) {
+          _currentSalaireBrut = revenu;
+        }
+        final lpp = profile.prevoyance.avoirLppTotal;
+        if (lpp != null && lpp > 0) {
+          _currentAvoirVieillesse = lpp;
+        }
+        // Conversion rate from profile or legal minimum
+        final tc = profile.prevoyance.tauxConversion;
+        if (tc > 0 && tc < 1) {
+          _currentTauxConversion = tc * 100;
+        } else {
+          _currentTauxConversion = lppTauxConversionMin;
+        }
+        // Rachat maximum from profile
+        final rachat = profile.prevoyance.lacuneRachatRestante;
+        if (rachat > 0) {
+          _currentRachatMax = rachat;
+        }
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   // New job inputs
   double _newSalaireBrut = 95000;

--- a/apps/mobile/lib/screens/lamal_franchise_screen.dart
+++ b/apps/mobile/lib/screens/lamal_franchise_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -35,7 +37,30 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('lamal');
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _compute();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // Monthly health insurance premium
+        final prime = profile.depenses.assuranceMaladie;
+        if (prime > 0) _primeMensuelle = prime;
+
+        // Annual medical expenses
+        final frais = profile.depenses.fraisMedicaux;
+        if (frais != null && frais > 0) _depensesSante = frais;
+      });
+      _compute();
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
   }
 
   void _compute() {

--- a/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -27,11 +29,13 @@ class _EplScreenState extends State<EplScreen> {
   bool _aRachete = false;
   int _anneesSDepuisRachat = 0;
   String _canton = 'ZH';
+  double _obligRatio = 0.6;
+  double _grossAnnualSalary = 100000;
 
   EplResult get _result {
-    // Repartition simplifiee oblig / suroblig
-    final oblig = _avoirTotal * 0.6;
-    final suroblig = _avoirTotal * 0.4;
+    // Repartition oblig / suroblig from profile or default ratio
+    final oblig = _avoirTotal * _obligRatio;
+    final suroblig = _avoirTotal * (1 - _obligRatio);
 
     return EplSimulator.simulate(
       avoirTotal: _avoirTotal,
@@ -43,6 +47,49 @@ class _EplScreenState extends State<EplScreen> {
       anneesSDepuisRachat: _anneesSDepuisRachat,
       canton: _canton,
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // LPP total balance
+        final lppTotal = profile.prevoyance.avoirLppTotal;
+        if (lppTotal != null && lppTotal > 0) _avoirTotal = lppTotal;
+
+        // Age
+        final age = profile.age;
+        if (age >= 25 && age <= 65) _age = age;
+
+        // Canton
+        if (cantonFullNames.containsKey(profile.canton)) {
+          _canton = profile.canton;
+        }
+
+        // Oblig / surob split from profile if available
+        final oblig = profile.prevoyance.avoirLppObligatoire;
+        final surob = profile.prevoyance.avoirLppSurobligatoire;
+        if (oblig != null && surob != null && (oblig + surob) > 0) {
+          _obligRatio = oblig / (oblig + surob);
+        }
+
+        // Gross annual salary
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) _grossAnnualSalary = revenu;
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
   }
 
   @override
@@ -443,7 +490,7 @@ class _EplScreenState extends State<EplScreen> {
       eplRepaid: 0,
       currentAge: _age,
       retirementAge: 65,
-      grossAnnualSalary: 100000,
+      grossAnnualSalary: _grossAnnualSalary,
       caisseReturn: 0.02,
       conversionRate: 0.068,
     );

--- a/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
@@ -491,8 +491,8 @@ class _EplScreenState extends State<EplScreen> {
       currentAge: _age,
       retirementAge: 65,
       grossAnnualSalary: _grossAnnualSalary,
-      caisseReturn: 0.02,
-      conversionRate: 0.068,
+      caisseReturn: lppTauxInteretMin / 100,
+      conversionRate: lppTauxConversionMinDecimal,
     );
 
     final renteWithout = eplImpact.renteWithoutEpl / 12;

--- a/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -26,6 +28,37 @@ class _LibrePassageScreenState extends State<LibrePassageScreen> {
   bool _hasNewEmployer = true;
   double _avoir = 150000;
   int _age = 35;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        _age = profile.age;
+        // Prefer libre passage total if available, otherwise fall back to LPP total
+        final librePassage = profile.prevoyance.totalLibrePassage;
+        if (librePassage > 0) {
+          _avoir = librePassage;
+        } else {
+          final lpp = profile.prevoyance.avoirLppTotal;
+          if (lpp != null && lpp > 0) {
+            _avoir = lpp;
+          }
+        }
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   LibrePassageResult get _result => LibrePassageAdvisor.analyze(
         statut: _statut,

--- a/apps/mobile/lib/screens/mariage_screen.dart
+++ b/apps/mobile/lib/screens/mariage_screen.dart
@@ -68,7 +68,37 @@ class _MariageScreenState extends State<MariageScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _recalculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.revenuBrutAnnuel > 0) {
+          _revenu1 = profile.revenuBrutAnnuel;
+        }
+        if (profile.conjoint?.revenuBrutAnnuel != null &&
+            profile.conjoint!.revenuBrutAnnuel > 0) {
+          _revenu2 = profile.conjoint!.revenuBrutAnnuel;
+        }
+        if (profile.canton.isNotEmpty) {
+          _canton = profile.canton;
+        }
+        _nbEnfants = profile.nombreEnfants;
+        final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+        if (totalPatrimoine > 0) {
+          _patrimoine1 = totalPatrimoine * 0.6;
+          _patrimoine2 = totalPatrimoine * 0.4;
+        }
+      });
+      _recalculate();
+    } catch (_) {}
   }
 
   @override

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -1,7 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -37,6 +40,9 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('mortgage');
     _emitScreenReturn();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
   }
 
   void _emitScreenReturn() {
@@ -60,11 +66,36 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   String _canton = 'VD';
   bool _showAdvancedParams = false;
 
-  static const _cantons = [
-    'AG', 'AI', 'AR', 'BE', 'BL', 'BS', 'FR', 'GE', 'GL', 'GR',
-    'JU', 'LU', 'NE', 'NW', 'OW', 'SG', 'SH', 'SO', 'SZ', 'TG',
-    'TI', 'UR', 'VD', 'VS', 'ZG', 'ZH',
-  ];
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        final revenuAnnuel = profile.revenuBrutAnnuel;
+        if (revenuAnnuel > 0) {
+          _revenuBrut = revenuAnnuel;
+        }
+        final epargne = profile.patrimoine.epargneLiquide;
+        if (epargne > 0) {
+          _epargneDispo = epargne;
+        }
+        final avoir3a = profile.prevoyance.totalEpargne3a;
+        if (avoir3a > 0) {
+          _avoir3a = avoir3a;
+        }
+        final lpp = profile.prevoyance.avoirLppTotal;
+        if (lpp != null && lpp > 0) {
+          _avoirLpp = lpp;
+        }
+        if (cantonFullNames.containsKey(profile.canton)) {
+          _canton = profile.canton;
+        }
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   AffordabilityResult get _result => AffordabilityCalculator.calculate(
         revenuBrutAnnuel: _revenuBrut,
@@ -229,7 +260,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                               child: DropdownButtonHideUnderline(
                                 child: DropdownButton<String>(
                                   value: _canton,
-                                  items: _cantons
+                                  items: sortedCantonCodes
                                       .map((c) => DropdownMenuItem(
                                             value: c,
                                             child: Text(c,

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -80,10 +80,8 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
         if (epargne > 0) {
           _epargneDispo = epargne;
         }
-        final avoir3a = profile.prevoyance.totalEpargne3a;
-        if (avoir3a > 0) {
-          _avoir3a = avoir3a;
-        }
+        // Always use profile's 3a value (even 0 = no savings is valid data)
+        _avoir3a = profile.prevoyance.totalEpargne3a;
         final lpp = profile.prevoyance.avoirLppTotal;
         if (lpp != null && lpp > 0) {
           _avoirLpp = lpp;

--- a/apps/mobile/lib/screens/mortgage/amortization_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/amortization_screen.dart
@@ -7,6 +7,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/mortgage_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 /// Ecran de comparaison amortissement direct vs indirect.
 ///
@@ -31,6 +34,42 @@ class _AmortizationScreenState extends State<AmortizationScreen> {
         dureeAns: _dureeAns,
         tauxMarginal: _tauxMarginal,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      final mortgage = profile.patrimoine.mortgageBalance;
+      if (mortgage != null && mortgage > 0) {
+        _montantHypothecaire = mortgage.clamp(200000, 2000000);
+        changed = true;
+      }
+      final rate = profile.patrimoine.mortgageRate;
+      if (rate != null && rate > 0) {
+        _tauxInteret = (rate / 100).clamp(0.01, 0.05);
+        changed = true;
+      }
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        ).clamp(0.15, 0.45);
+        changed = true;
+      }
+      if (changed) setState(() {});
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/mortgage/epl_combined_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/epl_combined_screen.dart
@@ -7,6 +7,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/mortgage_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Ecran de financement EPL multi-sources.
 ///
@@ -34,6 +36,47 @@ class _EplCombinedScreenState extends State<EplCombinedScreen> {
         prixCible: _prixCible,
         canton: _canton,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.patrimoine.epargneLiquide > 0) {
+        _epargneCash = profile.patrimoine.epargneLiquide.clamp(0, 500000);
+        changed = true;
+      }
+      if (profile.prevoyance.totalEpargne3a > 0) {
+        _avoir3a = profile.prevoyance.totalEpargne3a.clamp(0, 300000);
+        changed = true;
+      }
+      final lpp = profile.prevoyance.avoirLppTotal;
+      if (lpp != null && lpp > 0) {
+        _avoirLpp = lpp.clamp(0, 500000);
+        changed = true;
+      }
+      final propertyValue = profile.patrimoine.propertyMarketValue;
+      if (propertyValue != null && propertyValue > 0) {
+        _prixCible = propertyValue.clamp(200000, 3000000);
+        changed = true;
+      }
+      if (profile.canton.isNotEmpty) {
+        _canton = profile.canton.toUpperCase();
+        changed = true;
+      }
+      if (changed) setState(() {});
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
@@ -5,6 +5,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/mortgage_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 /// Ecran de calcul de la valeur locative et de son impact fiscal.
 ///
@@ -33,6 +36,48 @@ class _ImputedRentalScreenState extends State<ImputedRentalScreen> {
         bienAncien: _bienAncien,
         tauxMarginal: _tauxMarginal,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      final propertyValue = profile.patrimoine.propertyMarketValue;
+      if (propertyValue != null && propertyValue > 0) {
+        _valeurVenale = propertyValue.clamp(200000, 3000000);
+        changed = true;
+      }
+      if (profile.canton.isNotEmpty) {
+        _canton = profile.canton.toUpperCase();
+        changed = true;
+      }
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        ).clamp(0.15, 0.45);
+        changed = true;
+      }
+      // Estimate annual interest from mortgage balance and rate
+      final mortgage = profile.patrimoine.mortgageBalance;
+      final rate = profile.patrimoine.mortgageRate;
+      if (mortgage != null && mortgage > 0 && rate != null && rate > 0) {
+        _interetsAnnuels = (mortgage * rate / 100).clamp(0, 80000);
+        changed = true;
+      }
+      if (changed) setState(() {});
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/mortgage/saron_vs_fixed_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/saron_vs_fixed_screen.dart
@@ -7,6 +7,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/mortgage_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 /// Ecran comparateur SARON vs Taux fixe.
 ///
@@ -30,6 +32,29 @@ class _SaronVsFixedScreenState extends State<SaronVsFixedScreen> {
         montantHypothecaire: _montantHypothecaire,
         dureeAns: _dureeAns,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      final mortgage = profile.patrimoine.mortgageBalance;
+      if (mortgage != null && mortgage > 0) {
+        setState(() {
+          _montantHypothecaire = mortgage.clamp(200000, 2000000);
+        });
+      }
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/naissance_screen.dart
+++ b/apps/mobile/lib/screens/naissance_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -64,6 +66,9 @@ class _NaissanceScreenState extends State<NaissanceScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _recalculateAll();
   }
 
@@ -71,6 +76,39 @@ class _NaissanceScreenState extends State<NaissanceScreen>
   void dispose() {
     _tabController.dispose();
     super.dispose();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        // Tab 1: Conge — monthly salary
+        if (profile.salaireBrutMensuel > 0) {
+          _salaireMensuel = profile.salaireBrutMensuel;
+        }
+
+        // Tab 2: Allocations — canton and children
+        final canton = profile.canton;
+        if (FamilyService.cantonNames.containsKey(canton)) {
+          _cantonAlloc = canton;
+        }
+        if (profile.nombreEnfants > 0) {
+          _nbEnfantsAlloc = profile.nombreEnfants;
+        }
+
+        // Tab 3: Impact — annual income and children
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) _revenuImpact = revenu;
+        if (profile.nombreEnfants > 0) {
+          _nbEnfantsImpact = profile.nombreEnfants;
+        }
+      });
+      _recalculateAll();
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
   }
 
   void _recalculateAll() {

--- a/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -25,6 +27,43 @@ class _ProviderComparatorScreenState extends State<ProviderComparatorScreen> {
   double _versementAnnuel = pilier3aPlafondAvecLpp;
   int _duree = 35;
   ProfilRisque _profilRisque = ProfilRisque.dynamique;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        _age = profile.age;
+        _duree = profile.anneesAvantRetraite.clamp(5, 45);
+        // Map riskTolerance string to ProfilRisque enum
+        final risk = profile.riskTolerance;
+        if (risk != null) {
+          switch (risk.toLowerCase()) {
+            case 'prudent':
+            case 'conservateur':
+              _profilRisque = ProfilRisque.prudent;
+            case 'equilibre':
+            case 'modere':
+              _profilRisque = ProfilRisque.equilibre;
+            case 'dynamique':
+            case 'agressif':
+              _profilRisque = ProfilRisque.dynamique;
+          }
+        }
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   ProviderComparisonResult get _result => ProviderComparator.compare(
         age: _age,

--- a/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
@@ -6,6 +6,9 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/pillar_3a_deep_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 /// Ecran de simulation du rendement reel 3a avec economie fiscale.
 ///
@@ -33,6 +36,37 @@ class _RealReturnScreenState extends State<RealReturnScreen> {
         fraisGestion: _fraisGestion,
         dureeAnnees: _dureeAnnees,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        _tauxMarginal = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        ).clamp(0.0, 0.50);
+        changed = true;
+      }
+      final yearsToRetirement = profile.anneesAvantRetraite;
+      if (yearsToRetirement >= 5 && yearsToRetirement <= 40) {
+        _dureeAnnees = yearsToRetirement;
+        changed = true;
+      }
+      if (changed) setState(() {});
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
@@ -8,6 +8,9 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/retroactive_3a_calculator.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 /// Simulateur de rattrapage 3a retroactif (nouveaute 2026).
 ///
@@ -40,6 +43,45 @@ class _Retroactive3aScreenState extends State<Retroactive3aScreen> {
         tauxMarginal: _tauxMarginal,
         hasLpp: _hasLpp,
       );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      bool changed = false;
+      if (profile.revenuBrutAnnuel > 0) {
+        final rate = RetirementTaxCalculator.estimateMarginalRate(
+          profile.revenuBrutAnnuel,
+          profile.canton,
+        );
+        // Snap to nearest available rate in the dropdown
+        final closest = _taxRates.reduce((a, b) =>
+            (a - rate).abs() < (b - rate).abs() ? a : b);
+        _tauxMarginal = closest;
+        changed = true;
+      }
+      // Detect LPP affiliation from prevoyance data
+      if (profile.prevoyance.avoirLppTotal != null &&
+          profile.prevoyance.avoirLppTotal! > 0) {
+        _hasLpp = true;
+        changed = true;
+      } else if (profile.employmentStatus == 'independant') {
+        _hasLpp = false;
+        changed = true;
+      }
+      if (changed) setState(() {});
+    } catch (_) {
+      // Provider not available
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -28,6 +31,46 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
   double _revenuImposable = 120000;
   int _ageRetraitDebut = 60;
   int _ageRetraitFin = 64;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        final avoir3a = profile.prevoyance.totalEpargne3a;
+        if (avoir3a > 0) {
+          _avoirTotal = avoir3a;
+        }
+        final nb3a = profile.prevoyance.nombre3a;
+        if (nb3a > 0 && nb3a <= 5) {
+          _nbComptes = nb3a;
+        }
+        if (cantonFullNames.containsKey(profile.canton)) {
+          _canton = profile.canton;
+        }
+        final revenu = profile.revenuBrutAnnuel;
+        if (revenu > 0) {
+          _revenuImposable = revenu;
+        }
+        final targetAge = profile.targetRetirementAge ?? 65;
+        // Withdrawal typically starts 5 years before retirement
+        final computedDebut = (targetAge - 5).clamp(60, 65);
+        _ageRetraitDebut = computedDebut;
+        _ageRetraitFin = targetAge.clamp(computedDebut, 65);
+      });
+    } catch (_) {
+      // Provider not in tree (tests) — keep defaults
+    }
+  }
 
   StaggeredWithdrawalResult get _result =>
       StaggeredWithdrawalSimulator.simulate(

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -35,6 +35,7 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
   @override
   void initState() {
     super.initState();
+    _emitScreenReturn();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeFromProfile();
     });
@@ -82,11 +83,8 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
         ageRetraitFin: _ageRetraitFin,
       );
 
-  @override
-  void initState() {
-    super.initState();
-    _emitScreenReturn();
-  }
+  // _emitScreenReturn is called from primary initState above
+  // (merged with profile initialization)
 
   void _emitScreenReturn() {
     final plan = '${_nbComptes}x_$_ageRetraitDebut-$_ageRetraitFin';

--- a/apps/mobile/lib/screens/simulator_compound_screen.dart
+++ b/apps/mobile/lib/screens/simulator_compound_screen.dart
@@ -6,6 +6,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/info_tooltip.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 class SimulatorCompoundScreen extends StatefulWidget {
   const SimulatorCompoundScreen({super.key});
@@ -27,7 +29,31 @@ class _SimulatorCompoundScreenState extends State<SimulatorCompoundScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final provider = context.read<CoachProfileProvider>();
+      if (!provider.hasProfile) return;
+      final profile = provider.profile!;
+      setState(() {
+        if (profile.salaireBrutMensuel > 0) {
+          _monthlyContribution =
+              (profile.salaireBrutMensuel * 0.1).roundToDouble();
+        }
+        if (profile.patrimoine.epargneLiquide > 0) {
+          _principal = profile.patrimoine.epargneLiquide;
+        }
+        if (profile.age > 0) {
+          _years = (65 - profile.age).clamp(5, 45);
+        }
+      });
+      _calculate();
+    } catch (_) {}
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/simulator_leasing_screen.dart
+++ b/apps/mobile/lib/screens/simulator_leasing_screen.dart
@@ -6,6 +6,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/leasing_cost_widget.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
 class SimulatorLeasingScreen extends StatefulWidget {
   const SimulatorLeasingScreen({super.key});
@@ -26,7 +28,26 @@ class _SimulatorLeasingScreenState extends State<SimulatorLeasingScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeFromProfile();
+    });
     _calculate();
+  }
+
+  void _initializeFromProfile() {
+    try {
+      final profile = context.read<CoachProfileProvider>().profile;
+      if (profile == null) return;
+      // Leasing is a generic calculator — check if dettes.leasing informs
+      // a better monthly payment default
+      final leasingDebt = profile.dettes.mensualiteLeasing;
+      if (leasingDebt != null && leasingDebt > 0) {
+        _monthlyPayment = leasingDebt.clamp(100, 1500);
+        _calculate();
+      }
+    } catch (_) {
+      // Provider not available
+    }
   }
 
   void _calculate() {

--- a/apps/mobile/lib/screens/unemployment_screen.dart
+++ b/apps/mobile/lib/screens/unemployment_screen.dart
@@ -60,6 +60,13 @@ class _UnemploymentScreenState extends State<UnemploymentScreen>
       setState(() {
         _gainAssure = salaireMensuel.roundToDouble();
         _age = age;
+        if (p.nombreEnfants > 0) {
+          _hasChildren = true;
+        }
+        final annees = p.prevoyance.anneesContribuees;
+        if (annees != null && annees > 0) {
+          _moisCotisation = (annees * 12).clamp(0, 480);
+        }
       });
       _calculate();
     });

--- a/apps/mobile/lib/services/coaching_service.dart
+++ b/apps/mobile/lib/services/coaching_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/services/rag_service.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -136,36 +137,10 @@ class CoachingService {
   /// Swiss legal retirement age (post-AVS21 reform, unified at 65).
   static const int _ageRetraite = 65;
 
-  /// Simplified cantonal marginal tax rates for fiscal impact estimation.
-  /// These are rough averages (fed + cantonal + communal) at ~80 kCHF income.
-  static const Map<String, double> _tauxMarginalCantonal = {
-    'ZH': 0.34,
-    'BE': 0.38,
-    'LU': 0.30,
-    'UR': 0.25,
-    'SZ': 0.24,
-    'OW': 0.25,
-    'NW': 0.25,
-    'GL': 0.29,
-    'ZG': 0.22,
-    'FR': 0.35,
-    'SO': 0.35,
-    'BS': 0.37,
-    'BL': 0.35,
-    'SH': 0.33,
-    'AR': 0.30,
-    'AI': 0.27,
-    'SG': 0.33,
-    'GR': 0.32,
-    'AG': 0.33,
-    'TG': 0.31,
-    'TI': 0.35,
-    'VD': 0.37,
-    'VS': 0.32,
-    'NE': 0.38,
-    'GE': 0.37,
-    'JU': 0.38,
-  };
+  // Cantonal marginal tax rates removed — replaced by
+  // RetirementTaxCalculator.estimateMarginalRate(income, canton)
+  // from financial_core/tax_calculator.dart, which accounts for
+  // both income level and canton grouping (high/low tax cantons).
 
   /// Age milestones with coaching relevance.
   static const List<int> _ageMilestones = [25, 35, 45, 50, 55, 58, 63];
@@ -383,7 +358,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     final restant = plafond - profile.montant3a;
     if (restant <= 0) return;
 
-    final tauxMarginal = _getTauxMarginal(profile.canton);
+    final tauxMarginal = _getTauxMarginal(profile.canton, revenuAnnuel: profile.revenuAnnuel);
     final impact = restant * tauxMarginal;
 
     tips.add(CoachingTip(
@@ -417,7 +392,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     final plafond = profile.employmentStatus == EmploymentStatus.independant
         ? _plafond3aIndependant
         : _plafond3aSalarie;
-    final tauxMarginal = _getTauxMarginal(profile.canton);
+    final tauxMarginal = _getTauxMarginal(profile.canton, revenuAnnuel: profile.revenuAnnuel);
     final impact = plafond * tauxMarginal;
 
     tips.add(CoachingTip(
@@ -445,7 +420,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     if (!profile.hasLpp) return;
     if (profile.lacuneLpp <= 0) return;
 
-    final tauxMarginal = _getTauxMarginal(profile.canton);
+    final tauxMarginal = _getTauxMarginal(profile.canton, revenuAnnuel: profile.revenuAnnuel);
     // Recommend max 20% of income or available lacune, whichever is smaller
     final double rachatRecommande =
         (profile.lacuneLpp).clamp(0.0, profile.revenuAnnuel * 0.2);
@@ -642,13 +617,14 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     final tauxPct = profile.tauxActivite.toStringAsFixed(0);
     final reductionPct = (100 - profile.tauxActivite).toStringAsFixed(0);
 
-    // Rough estimate: LPP contribution gap
+    // Rough estimate: LPP contribution gap using age-based bonification (LPP art. 16)
+    final lppRate = getLppBonificationRate(profile.age);
     final salaireCoordonne = (profile.revenuAnnuel - lppDeductionCoordination).clamp(0, lppSalaireCoordMax.toDouble());
-    final cotisLppAnnuelle = salaireCoordonne * 0.15; // ~15% average
+    final cotisLppAnnuelle = salaireCoordonne * lppRate;
     final cotisPleinTemps =
         (profile.revenuAnnuel / (profile.tauxActivite / 100) - lppDeductionCoordination)
                 .clamp(0, lppSalaireCoordMax.toDouble()) *
-            0.15;
+            lppRate;
     final gap = cotisPleinTemps - cotisLppAnnuelle;
 
     tips.add(CoachingTip(
@@ -679,7 +655,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     if (profile.employmentStatus != EmploymentStatus.independant) return;
 
     const plafond3a = _plafond3aIndependant;
-    final tauxMarginal = _getTauxMarginal(profile.canton);
+    final tauxMarginal = _getTauxMarginal(profile.canton, revenuAnnuel: profile.revenuAnnuel);
     final impact = plafond3a * tauxMarginal;
 
     tips.add(CoachingTip(
@@ -740,7 +716,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     final restant = plafond - profile.montant3a;
     if (restant <= 0) return;
 
-    final tauxMarginal = _getTauxMarginal(profile.canton);
+    final tauxMarginal = _getTauxMarginal(profile.canton, revenuAnnuel: profile.revenuAnnuel);
     final impact = restant * tauxMarginal;
 
     tips.add(CoachingTip(
@@ -909,9 +885,11 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
     return tips.where((t) => categories.contains(t.category)).toList();
   }
 
-  /// Get the estimated marginal tax rate for a canton.
-  static double _getTauxMarginal(String canton) {
-    return _tauxMarginalCantonal[canton.toUpperCase()] ?? 0.33;
+  /// Get the estimated marginal tax rate for a given income and canton.
+  /// Delegates to RetirementTaxCalculator.estimateMarginalRate (financial_core).
+  static double _getTauxMarginal(String canton, {double revenuAnnuel = 80000}) {
+    return RetirementTaxCalculator.estimateMarginalRate(
+        revenuAnnuel, canton);
   }
 
   /// Format a CHF amount with Swiss apostrophe separator.

--- a/apps/mobile/lib/services/financial_report_service.dart
+++ b/apps/mobile/lib/services/financial_report_service.dart
@@ -234,8 +234,10 @@ class FinancialReportService {
     final effectiveRate = _estimateEffectiveRate(
         taxableIncome, profile.canton, profile.isMarried);
     final totalTax = taxableIncome * effectiveRate;
-    final cantonalTax = totalTax * 0.75; // ~75% cantonal+communal
-    final federalTax = totalTax * 0.25; // ~25% fédéral
+    // Approximation: ~75% of Swiss income tax is cantonal+communal, ~25% federal.
+    // A precise split requires FiscalService per canton; acceptable for report overview.
+    final cantonalTax = totalTax * 0.75;
+    final federalTax = totalTax * 0.25;
 
     // Simulation avec rachat LPP (si montant disponible)
     final lppBuybackAvailable =
@@ -621,13 +623,13 @@ class FinancialReportService {
 
   double _estimateEffectiveRate(
       double taxableIncome, String canton, bool isMarried) {
-    // TODO(P8-Phase2): migrate to FiscalService.estimateTax() for canton-aware rates
-    final baseRate = isMarried ? 0.12 : 0.15;
-
-    if (taxableIncome > 150000) return baseRate + 0.10;
-    if (taxableIncome > 100000) return baseRate + 0.05;
-    if (taxableIncome > 60000) return baseRate + 0.02;
-    return baseRate;
+    // Delegate to centralized marginal rate estimator (financial_core).
+    // RetirementTaxCalculator.estimateMarginalRate accounts for canton grouping
+    // and income-level brackets (AFC taux marginaux 2025).
+    final marginalRate =
+        RetirementTaxCalculator.estimateMarginalRate(taxableIncome, canton);
+    // Married couples benefit from splitting (~15% reduction, cf. LIFD art. 36).
+    return isMarried ? marginalRate * 0.85 : marginalRate;
   }
 
   double _estimateAvsRent(UserProfile profile) {

--- a/apps/mobile/lib/services/first_job_service.dart
+++ b/apps/mobile/lib/services/first_job_service.dart
@@ -168,7 +168,7 @@ class FirstJobService {
       double coordinated = annuel - lppDeductionCoordination;
       coordinated = max(coordinated, lppSalaireCoordMin);
       coordinated = min(coordinated, _lppMaxCoordinated);
-      final lppRate = _getLppRate(age);
+      final lppRate = getLppBonificationRate(age);
       lppEmploye = (coordinated * lppRate) / 12 / 2; // employee half
     }
 
@@ -248,14 +248,8 @@ class FirstJobService {
     );
   }
 
-  /// Get LPP bonification rate by age.
-  static double _getLppRate(int age) {
-    if (age < 25) return 0.0;
-    if (age <= 34) return 0.07;
-    if (age <= 44) return 0.10;
-    if (age <= 54) return 0.15;
-    return 0.18;
-  }
+  // _getLppRate removed — use centralized getLppBonificationRate(age)
+  // from social_insurance.dart (LPP art. 16).
 
   /// Calculate LAMal franchise options.
   /// Returns (options, recommended franchise, annual savings vs 300).

--- a/apps/mobile/lib/services/independants_service.dart
+++ b/apps/mobile/lib/services/independants_service.dart
@@ -588,22 +588,11 @@ class IndependantsService {
     final renteAvsMax = AvsCalculator.annualRente(avsRenteMaxMensuelle); // 32760 CHF (13 rentes)
     final projectionSansLpp = renteAvsMax;
 
-    // With LPP: project capital at retirement
+    // With LPP: project capital at retirement using centralized bonification rates
     double capitalLpp = 0;
     for (int i = 0; i < anneesRestantes; i++) {
       final ageYear = age + i;
-      double taux;
-      if (ageYear >= 55) {
-        taux = 0.18;
-      } else if (ageYear >= 45) {
-        taux = 0.15;
-      } else if (ageYear >= 35) {
-        taux = 0.10;
-      } else if (ageYear >= 25) {
-        taux = 0.07;
-      } else {
-        taux = 0;
-      }
+      final taux = getLppBonificationRate(ageYear);
       capitalLpp =
           capitalLpp * (1 + _projectedReturn) + salaireCoordonne * taux;
     }

--- a/apps/mobile/lib/services/life_events_service.dart
+++ b/apps/mobile/lib/services/life_events_service.dart
@@ -1,3 +1,5 @@
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+
 // ────────────────────────────────────────────────────────────
 //  DIVORCE SERVICE
 // ────────────────────────────────────────────────────────────
@@ -284,15 +286,21 @@ class DivorceService {
   }
 
   /// Simplified individual tax estimation (Swiss progressive).
+  ///
+  /// Delegates to RetirementTaxCalculator.estimateMarginalRate for the
+  /// income-based marginal rate, then applies it as an effective rate.
+  /// Canton defaults to 'ZH' (median tax burden) since the divorce
+  /// service does not have canton in scope here.
+  /// TODO(profile-injection): Pass canton from DivorceInput when available.
   static double _estimateIndividualTax(double income) {
     if (income <= 0) return 0;
-    // Simplified progressive brackets (federal + cantonal average)
-    if (income <= 30000) return income * 0.05;
-    if (income <= 60000) return 1500 + (income - 30000) * 0.12;
-    if (income <= 100000) return 5100 + (income - 60000) * 0.18;
-    if (income <= 150000) return 12300 + (income - 100000) * 0.22;
-    if (income <= 250000) return 23300 + (income - 150000) * 0.28;
-    return 51300 + (income - 250000) * 0.33;
+    // Use centralized marginal rate (AFC taux marginaux 2025).
+    // 'ZH' is used as a median proxy — not exact, but avoids fabricated brackets.
+    final marginalRate =
+        RetirementTaxCalculator.estimateMarginalRate(income, 'ZH');
+    // Effective tax ≈ ~60-70% of marginal rate for progressive systems.
+    // This approximation aligns with the old bracket-based approach.
+    return income * marginalRate * 0.65;
   }
 
   /// Format CHF with Swiss apostrophe.

--- a/apps/mobile/lib/services/life_events_service.dart
+++ b/apps/mobile/lib/services/life_events_service.dart
@@ -173,8 +173,11 @@ class DivorceService {
     // Married couples benefit from ~15-25% effective discount (splitting).
     // After divorce, each is taxed individually.
     final combinedIncome = input.incomeConjoint1 + input.incomeConjoint2;
-    // Simplified progressive rate: ~20% effective for married on combined income
-    final taxMarried = combinedIncome * 0.18;
+    // Married rate via centralized calculator (splitting + canton-average)
+    final marriedRate = RetirementTaxCalculator.estimateMarginalRate(
+      combinedIncome, 'ZH', isMarried: true,
+    );
+    final taxMarried = combinedIncome * marriedRate;
     // Individual rates slightly higher per person
     final taxC1 = _estimateIndividualTax(input.incomeConjoint1);
     final taxC2 = _estimateIndividualTax(input.incomeConjoint2);

--- a/apps/mobile/lib/services/minimal_profile_service.dart
+++ b/apps/mobile/lib/services/minimal_profile_service.dart
@@ -185,8 +185,12 @@ class MinimalProfileService {
     bool isPropertyOwner,
   ) {
     // Expense base ≈ 75% of gross — intentionally different from NetIncomeBreakdown
-    // (which computes actual net payslip). Here 0.75 approximates disposable spending
-    // capacity for the minimal profile expense estimator, not salary net.
+    // (which computes actual net payslip and requires canton + age).
+    // Here 0.75 approximates disposable spending capacity as a quick proxy
+    // for the minimal profile context where canton may not be reliable yet.
+    // Swiss average: social charges ~6.4%, LPP ~5-9%, taxes ~10-15% → net ~70-78%.
+    // 0.75 is a reasonable median. For canton-aware precision, use
+    // NetIncomeBreakdown.compute() when canton and age are confirmed.
     final netMonthly = grossAnnualSalary * 0.75 / 12;
 
     // Expense ratio depends on household type

--- a/apps/mobile/lib/services/precision/precision_service.dart
+++ b/apps/mobile/lib/services/precision/precision_service.dart
@@ -411,7 +411,7 @@ class PrecisionService {
         (annualSalary - lppDeductionCoordination).clamp(lppSalaireCoordMin, annualSalary * 0.8);
     double lppEstimate = 0;
     for (int a = (age - yearsContrib).round(); a < age; a++) {
-      lppEstimate += salaireCoord * _bonificationRate(a);
+      lppEstimate += salaireCoord * getLppBonificationRate(a);
     }
     // Add ~2% annual return compounding
     lppEstimate *= 1.0 + (yearsContrib * 0.015);
@@ -439,7 +439,7 @@ class PrecisionService {
       final coordMin = (annualSalary - lppDeductionCoordination).clamp(lppSalaireCoordMin, lppSalaireCoordMax);
       double obligEstimate = 0;
       for (int a = (age - yearsContrib).round(); a < age; a++) {
-        obligEstimate += coordMin * _bonificationRate(a);
+        obligEstimate += coordMin * getLppBonificationRate(a);
       }
       obligEstimate *= 1.0 + (yearsContrib * 0.01);
 
@@ -710,14 +710,8 @@ class PrecisionService {
     }
   }
 
-  /// LPP bonification rate by age (LPP art. 16).
-  static double _bonificationRate(int age) {
-    if (age < 25) return 0;
-    if (age < 35) return 0.07;
-    if (age < 45) return 0.10;
-    if (age < 55) return 0.15;
-    return 0.18;
-  }
+  // _bonificationRate removed — use centralized getLppBonificationRate(age)
+  // from social_insurance.dart (LPP art. 16).
 
   /// Approximate net/gross ratio by canton.
   static double _netRatio(String canton) {

--- a/apps/mobile/test/services/coaching_service_test.dart
+++ b/apps/mobile/test/services/coaching_service_test.dart
@@ -711,7 +711,7 @@ void main() {
       expect(CoachingService.formatChf(1000000), 'CHF\u00A01\'000\'000');
     });
 
-    test('unknown canton uses default marginal rate of 33%', () {
+    test('unknown canton uses Swiss-average marginal rate from TaxCalculator', () {
       final tips = CoachingService.generateTips(
         profile: const CoachingProfile(
           age: 30,
@@ -724,10 +724,11 @@ void main() {
         ),
       );
 
-      // missing_3a tip should be generated with default rate
+      // missing_3a tip should be generated with calculator rate
       final missing3a = tips.firstWhere((t) => t.id == 'missing_3a');
-      // Impact = 7258 (plafond 3a 2025) * 0.33 (default taux) = 2395.14
-      expect(missing3a.estimatedImpactChf, closeTo(7258 * 0.33, 0.01));
+      // Uses RetirementTaxCalculator.estimateMarginalRate(80000, 'XX')
+      // fallback=13% effective × 0.90 income adj × 1.3 marginal ≈ 15.21%
+      expect(missing3a.estimatedImpactChf, closeTo(1103.94, 5));
     });
   });
 

--- a/apps/mobile/test/services/life_events_service_test.dart
+++ b/apps/mobile/test/services/life_events_service_test.dart
@@ -232,7 +232,9 @@ void main() {
         ),
       );
 
-      expect(result.taxImpact.estimatedTaxMarried, closeTo(180000 * 0.18, 0.01));
+      // Uses RetirementTaxCalculator.estimateMarginalRate(180000, 'ZH', isMarried: true)
+      // Effective: 12.9% * 1.15 income adj * 0.85 married * 1.3 marginal ≈ 16.36%
+      expect(result.taxImpact.estimatedTaxMarried, closeTo(29455.50, 50));
     });
 
     test('individual taxes sum is different from married tax', () {

--- a/services/backend/tests/test_minimal_profile.py
+++ b/services/backend/tests/test_minimal_profile.py
@@ -244,6 +244,25 @@ class TestAvsProjection:
         assert partial < full
         assert abs(partial - full * 0.5) < 1.0  # ~50% of full
 
+    def test_avs_ramd_lauren_67k_full_years(self):
+        """Golden couple: Lauren (67k, full 44 years) uses RAMD interpolation.
+
+        RAMD = 67'000: ratio = (67000-14700)/(88200-14700) ≈ 0.7116
+        full_rente = 1260 + 0.7116 * 1260 ≈ 2156.6 CHF/mois (full years).
+        With 40 contribution years: 2156.6 * 40/44 ≈ 1960.5 CHF/mois.
+        This verifies RAMD interpolation works, NOT flat max.
+        """
+        full_rente = _estimate_avs_monthly(67_000.0, 44)
+        # RAMD interpolation: must be between min and max
+        assert AVS_RENTE_MIN_MENSUELLE < full_rente < AVS_RENTE_MAX_MENSUELLE
+        # Expected: ~2156.6 CHF for full years (linear interpolation)
+        assert abs(full_rente - 2156.6) < 5.0, f"Expected ~2156.6, got {full_rente}"
+
+        # With 40 contribution years (~expat with partial gap)
+        partial_rente = _estimate_avs_monthly(67_000.0, 40)
+        expected_partial = full_rente * (40 / 44)
+        assert abs(partial_rente - expected_partial) < 1.0
+
 
 # ===========================================================================
 # TestLppProjection — 3 tests


### PR DESCRIPTION
## Summary
- **39 simulator screens** now pre-fill from CoachProfile instead of hardcoded defaults
- **8 services** cleaned: magic numbers replaced with centralized calculators
- **4 getLppBonificationRate copies** eliminated → single import from social_insurance.dart
- **6 post-merge bugs** caught and fixed (missing try/catch, orphan brace, magic conversion rates, hardcoded tax rates)
- **Backend**: AVS RAMD test added for Lauren (67k → ~2156 CHF/mois)

## Wave breakdown
| Wave | Screens | Scope |
|------|---------|-------|
| 1 - Agent 1 | 8 | affordability, staggered_withdrawal, job_comparison, allocation_annuelle, demenagement, libre_passage, location_vs_propriete, provider_comparator |
| 1 - Agent 2 | 5 | divorce, naissance, epl, independant, lamal_franchise |
| 1 - Agent 3 | 8 services | coaching_service, financial_report, life_events, minimal_profile, first_job, independants, precision, coach_profile |
| 2A | 14 | mariage, concubinage, expat, gender_gap, housing_sale, frontalier, deces_proche, donation, coverage_check, unemployment, consumer_credit, debt_ratio, repayment, compound |
| 2B | 12 | avs_cotisations, dividende_vs_salaire, ijm, lpp_volontaire, pillar_3a_indep, amortization, epl_combined, imputed_rental, saron_vs_fixed, real_return, retroactive_3a, leasing |

## Metrics
- **50 files changed**, +1438 / -152 lines
- **flutter analyze**: 0 issues
- **flutter test**: 8134 passed, 0 failures

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed
- [x] grep validation: 0 screens without CoachProfileProvider
- [x] Deep audit of each agent's work (field names, null safety, try/catch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)