### PR TITLE
feat(ux): MintSurface wave 2 — 5 more legacy screens (#127)

### DIFF
--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -21,6 +21,7 @@ import 'package:mint_mobile/widgets/coach/indicatif_banner.dart';
 import 'package:mint_mobile/widgets/precision/smart_default_indicator.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/screen_return.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 
 /// Rente vs Capital arbitrage screen — the "a-ha" moment.
@@ -622,13 +623,9 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
   // ═══════════════════════════════════════════════════════════════
 
   Widget _buildInputSection() {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.card,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1024,19 +1021,10 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
         ? S.of(context)!.renteVsCapitalSyntheseCapitalHigher(formatChf(delta))
         : S.of(context)!.renteVsCapitalSyntheseRenteHigher(formatChf(delta));
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.card,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-        boxShadow: [
-          BoxShadow(
-            color: MintColors.primary.withAlpha(8),
-            blurRadius: 20, offset: const Offset(0, 6),
-          ),
-        ],
-      ),
+      elevated: true,
       child: Column(
         children: [
           Row(
@@ -1199,13 +1187,9 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
   // ═══════════════════════════════════════════════════════════════
 
   Widget _buildExplorerBloc(List<TrajectoireOption> chartOptions) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.card,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1443,13 +1427,10 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
     required String rightDetail,
     required String bottomText,
   }) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.card,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1642,13 +1623,10 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
     final lowDelta = v.lowValue - v.baseValue;
     final highDelta = v.highValue - v.baseValue;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: MintColors.card,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+      radius: 12,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1761,13 +1739,10 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
 
   Widget _buildDisclaimerCard() {
     if (_result == null) return const SizedBox.shrink();
-    return Container(
-      width: double.infinity,
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.surface,
-        borderRadius: BorderRadius.circular(16),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
@@ -19,6 +19,7 @@ import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/widgets/coach/coach_helpers.dart';
 import 'package:mint_mobile/widgets/coach/milestone_celebration_sheet.dart';
 import 'package:mint_mobile/widgets/coach/micro_action_card.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/services/monthly_briefing_service.dart';
 import 'package:mint_mobile/services/notification_service.dart';
 import 'package:mint_mobile/services/fri_computation_service.dart';
@@ -623,30 +624,24 @@ Reponds uniquement avec le texte final.
       button: true,
       child: GestureDetector(
         onTap: _showAddContributionSheet,
-        child: Container(
+        child: MintSurface(
+          tone: MintSurfaceTone.blanc,
           padding: const EdgeInsets.symmetric(vertical: 14),
-        decoration: BoxDecoration(
-          color: MintColors.surface,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: MintColors.coachAccent.withValues(alpha: 0.3),
-            style: BorderStyle.solid,
+          radius: 16,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.add_circle_outline,
+                  color: MintColors.coachAccent, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                s.checkinAddContribution,
+                style: MintTextStyles.bodyMedium(color: MintColors.coachAccent).copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
           ),
         ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.add_circle_outline,
-                color: MintColors.coachAccent, size: 20),
-            const SizedBox(width: 8),
-            Text(
-              s.checkinAddContribution,
-              style: MintTextStyles.bodyMedium(color: MintColors.coachAccent).copyWith(fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
       ),
-    ),
     );
   }
 
@@ -953,13 +948,10 @@ Reponds uniquement avec le texte final.
     required IconData icon,
     required Color color,
   }) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: MintColors.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1445,13 +1437,10 @@ Reponds uniquement avec le texte final.
   // ── Disclaimer ─────────────────────────────────────────────
   Widget _buildDisclaimer() {
     final s = S.of(context)!;
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: MintColors.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+      radius: 16,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1496,20 +1485,11 @@ class _ContributionRow extends StatelessWidget {
 
     return Stack(
       children: [
-        Container(
+        MintSurface(
+          tone: MintSurfaceTone.blanc,
           padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: MintColors.white,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: MintColors.lightBorder),
-            boxShadow: [
-              BoxShadow(
-                color: MintColors.primary.withValues(alpha: 0.04),
-                blurRadius: 12,
-                offset: const Offset(0, 4),
-              ),
-            ],
-          ),
+          radius: 16,
+          elevated: true,
           child: Row(
             children: [
               // Category icon

--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 /// Ecran de diagnostic du ratio d'endettement.
 ///
@@ -164,13 +165,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
       DebtRiskLevel.rouge => S.of(context)!.debtRatioLevelCritique,
     };
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+      radius: 16,
       child: Column(
         children: [
           // Semi-circle gauge
@@ -289,14 +287,11 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
         // ── Affiner le diagnostic ──
         GestureDetector(
           onTap: () => setState(() => _showDetails = !_showDetails),
-          child: Container(
+          child: MintSurface(
+            tone: MintSurfaceTone.blanc,
             padding: const EdgeInsets.symmetric(
                 horizontal: MintSpacing.md, vertical: MintSpacing.sm + 4),
-            decoration: BoxDecoration(
-              color: MintColors.white,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: MintColors.border),
-            ),
+            radius: 12,
             child: Row(
               children: [
                 Icon(
@@ -418,17 +413,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
   }) {
     final color = accentColor ?? MintColors.primary;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: accentColor != null
-              ? accentColor.withValues(alpha: 0.3)
-              : MintColors.border,
-        ),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -524,13 +512,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
     required int selectedIndex,
     required ValueChanged<int> onChanged,
   }) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -588,13 +573,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
     required List<int> options,
     required ValueChanged<int> onChanged,
   }) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -841,13 +823,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
   }
 
   Widget _buildRecommandationsSection(DebtRatioResult result) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+      radius: 16,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1001,13 +980,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
       child: InkWell(
       onTap: () => _launchUrl(url),
       borderRadius: BorderRadius.circular(12),
-      child: Container(
+      child: MintSurface(
+        tone: MintSurfaceTone.blanc,
         padding: const EdgeInsets.all(MintSpacing.sm + 6),
-        decoration: BoxDecoration(
-          color: MintColors.white,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: MintColors.border),
-        ),
+        radius: 12,
         child: Row(
           children: [
             Expanded(

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -16,6 +16,7 @@ import 'package:mint_mobile/widgets/coach/payslip_xray_widget.dart';
 import 'package:mint_mobile/widgets/coach/job_change_checklist_widget.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FIRST JOB SCREEN — Sprint S19 / Premier emploi
@@ -231,13 +232,10 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
   // ── Header ─────────────────────────────────────────────────
 
   Widget _buildHeader() {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
-      ),
+      radius: 16,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -303,14 +301,9 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     required int divisions,
     required ValueChanged<double> onChanged,
   }) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: MintPremiumSlider(
         label: title,
         value: value,
@@ -326,14 +319,9 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
   // ── Canton + Activity Rate ─────────────────────────────────
 
   Widget _buildCantonAndActivity() {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -429,13 +417,9 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
 
   Widget _build3aRecommendation() {
     final r = _result!;
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -566,13 +550,9 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
 
   Widget _buildLamalComparison() {
     final r = _result!;
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -701,13 +681,9 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
 
   Widget _buildChecklist() {
     final items = _result?.checklist ?? [];
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -15,6 +15,7 @@ import 'package:mint_mobile/widgets/fiscal/canton_ranking_bar.dart';
 import 'package:mint_mobile/widgets/fiscal/move_savings_card.dart';
 import 'package:mint_mobile/widgets/coach/moving_true_cost_widget.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FISCAL COMPARATOR SCREEN — Sprint S20 / 26 cantons
@@ -260,14 +261,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
   Widget _buildInputsCard() {
     final sortedCodes = FiscalService.sortedCantonCodes;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -542,13 +538,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
     );
     final isBelow = tauxEffectif < avgAdjusted;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Row(
         children: [
           // Rate circle
@@ -619,13 +611,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
     final chargeTotaleAvecExtras =
         (tax['chargeTotale'] as double) + wealthTax + churchTax;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -879,13 +867,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
         const SizedBox(height: 12),
 
         // Ranking list
-        Container(
+        MintSurface(
+          tone: MintSurfaceTone.blanc,
           padding: const EdgeInsets.symmetric(vertical: 8),
-          decoration: BoxDecoration(
-            color: MintColors.white,
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: MintColors.lightBorder),
-          ),
           child: Column(
             children: _allCantons.map((c) {
               return CantonRankingBar(
@@ -941,14 +925,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
         const SizedBox(height: 20),
 
         // Canton pickers
-        Container(
+        MintSurface(
+          tone: MintSurfaceTone.blanc,
           padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: MintColors.white,
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-                color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-          ),
           child: Column(
             children: [
               // From
@@ -1078,13 +1057,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
     final difference = impotDepart - impotArrivee;
     final isSaving = difference > 0;
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1222,13 +1197,9 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
       S.of(context)!.fiscalChecklist6,
     ];
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
## Summary
30 Container+BoxDecoration replaced with MintSurface across 5 screens:
- coach_checkin (4), fiscal_comparator (7), debt_ratio (7), first_job (6), rente_vs_capital (6)
- Net: +93 / -215 lines

Combined Sprint 1B total: **67 MintSurface replacements** across 10 legacy screens.

## Test plan
- [x] flutter analyze: 0 issues
- [x] flutter test: 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)