### PR TITLE
feat(a11y): Semantics on 43 screens (#128)

### DIFF
--- a/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
+++ b/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
@@ -259,10 +259,13 @@ class FinancialReportScreenV2 extends StatelessWidget {
       message = S.of(context)!.reportStatusLow;
       emoji = '\ud83d\udd34'; // red circle
     }
-    return Text(
-      '$emoji $message',
-      style: MintTextStyles.bodyLarge(color: MintColors.white).copyWith(fontWeight: FontWeight.w600),
-      textAlign: TextAlign.center,
+    return Semantics(
+      label: message,
+      child: Text(
+        '$emoji $message',
+        style: MintTextStyles.bodyLarge(color: MintColors.white).copyWith(fontWeight: FontWeight.w600),
+        textAlign: TextAlign.center,
+      ),
     );
   }
 

--- a/apps/mobile/lib/screens/advisor/score_reveal_screen.dart
+++ b/apps/mobile/lib/screens/advisor/score_reveal_screen.dart
@@ -675,9 +675,12 @@ class _ScoreRevealScreenState extends State<ScoreRevealScreen>
       opacity: _ctaOpacity.value,
       child: Column(
         children: [
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
+          Semantics(
+            button: true,
+            label: S.of(context)!.scoreRevealCtaDashboard,
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton(
               onPressed: _ctaOpacity.value > 0.5
                   ? () => context.go('/home')
                   : null,
@@ -697,6 +700,7 @@ class _ScoreRevealScreenState extends State<ScoreRevealScreen>
                 ).copyWith(fontWeight: FontWeight.w700),
               ),
             ),
+          ),
           ),
           const SizedBox(height: MintSpacing.md - 4),
           // Secondary action

--- a/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
@@ -426,21 +426,25 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
             ],
           ),
           const SizedBox(height: 12),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: _recalculate,
-              style: FilledButton.styleFrom(
-                backgroundColor: MintColors.primary,
-                foregroundColor: MintColors.white,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(14),
+          Semantics(
+            button: true,
+            label: S.of(context)!.locationComparer,
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _recalculate,
+                style: FilledButton.styleFrom(
+                  backgroundColor: MintColors.primary,
+                  foregroundColor: MintColors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
                 ),
-              ),
-              child: Text(
-                S.of(context)!.locationComparer,
-                style: MintTextStyles.titleMedium(color: MintColors.white),
+                child: Text(
+                  S.of(context)!.locationComparer,
+                  style: MintTextStyles.titleMedium(color: MintColors.white),
+                ),
               ),
             ),
           ),

--- a/apps/mobile/lib/screens/bank_import_screen.dart
+++ b/apps/mobile/lib/screens/bank_import_screen.dart
@@ -210,10 +210,13 @@ class _BankImportScreenState extends State<BankImportScreen> {
             ),
           ),
           const SizedBox(height: 20),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton.icon(
-              onPressed: _isUploading ? null : () => _pickAndUpload(),
+          Semantics(
+            button: true,
+            label: s.bankImportUploadButton,
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _isUploading ? null : () => _pickAndUpload(),
               style: FilledButton.styleFrom(
                 backgroundColor: MintColors.white,
                 foregroundColor: MintColors.info,
@@ -229,6 +232,7 @@ class _BankImportScreenState extends State<BankImportScreen> {
                 style: const TextStyle(fontWeight: FontWeight.w600),
               ),
             ),
+          ),
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/coach/cockpit_detail_screen.dart
+++ b/apps/mobile/lib/screens/coach/cockpit_detail_screen.dart
@@ -536,16 +536,20 @@ class _CockpitDetailScreenState extends State<CockpitDetailScreen> {
                       style: MintTextStyles.bodyMedium(),
                     ),
                     const SizedBox(height: 20),
-                    FilledButton.icon(
-                      onPressed: () => context.push('/scan'),
-                      icon: const Icon(Icons.edit_outlined, size: 18),
-                      label: Text(
-                        S.of(context)!.cockpitDetailEnrichProfile,
+                    Semantics(
+                      button: true,
+                      label: S.of(context)!.cockpitDetailEnrichProfile,
+                      child: FilledButton.icon(
+                        onPressed: () => context.push('/scan'),
+                        icon: const Icon(Icons.edit_outlined, size: 18),
+                        label: Text(
+                          S.of(context)!.cockpitDetailEnrichProfile,
                         style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.w600),
                       ),
                       style: FilledButton.styleFrom(
                         backgroundColor: MintColors.primary,
                       ),
+                    ),
                     ),
                   ],
                 ),

--- a/apps/mobile/lib/screens/coach/conversation_history_screen.dart
+++ b/apps/mobile/lib/screens/coach/conversation_history_screen.dart
@@ -191,11 +191,14 @@ class _EmptyState extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: MintSpacing.lg),
-            FilledButton.icon(
-              onPressed: onNewConversation,
-              icon: const Icon(Icons.add),
-              label: Text(
-                l10n.conversationStartFirst,
+            Semantics(
+              button: true,
+              label: l10n.conversationStartFirst,
+              child: FilledButton.icon(
+                onPressed: onNewConversation,
+                icon: const Icon(Icons.add),
+                label: Text(
+                  l10n.conversationStartFirst,
                 style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.w600),
               ),
               style: FilledButton.styleFrom(
@@ -206,6 +209,7 @@ class _EmptyState extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
+            ),
             ),
           ],
         ),

--- a/apps/mobile/lib/screens/consumer_credit_screen.dart
+++ b/apps/mobile/lib/screens/consumer_credit_screen.dart
@@ -287,9 +287,12 @@ class _ConsumerCreditSimulatorScreenState extends State<ConsumerCreditSimulatorS
         children: [
           Text(S.of(context)!.creditTaMensualite, style: MintTextStyles.bodyMedium()),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            _currencyFormat.format(monthlyPayment),
-            style: MintTextStyles.displayMedium(),
+          Semantics(
+            label: '${S.of(context)!.creditTaMensualite}: ${_currencyFormat.format(monthlyPayment)}',
+            child: Text(
+              _currencyFormat.format(monthlyPayment),
+              style: MintTextStyles.displayMedium(),
+            ),
           ),
           const SizedBox(height: MintSpacing.lg),
           const Divider(color: MintColors.border),

--- a/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
@@ -223,9 +223,12 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
                 .copyWith(fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            '${strategiePrioritaire.moisJusquaLiberation} mois',
-            style: MintTextStyles.displayMedium(color: color),
+          Semantics(
+            label: '${S.of(context)!.repaymentLibereDans}: ${strategiePrioritaire.moisJusquaLiberation} mois',
+            child: Text(
+              '${strategiePrioritaire.moisJusquaLiberation} mois',
+              style: MintTextStyles.displayMedium(color: color),
+            ),
           ),
           const SizedBox(height: 4),
           if (result.economieInterets > 0)
@@ -407,9 +410,12 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
     required String display,
     required VoidCallback onTap,
   }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
+    return Semantics(
+      button: true,
+      label: '$label: $display',
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
         padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 10),
         decoration: BoxDecoration(
           color: MintColors.white,
@@ -437,6 +443,7 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
           ],
         ),
       ),
+    ),
     );
   }
 
@@ -585,8 +592,11 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
   }
 
   Widget _buildBudgetSection() {
-    return GestureDetector(
-      onTap: () => _showValueEditor(
+    return Semantics(
+      button: true,
+      label: S.of(context)!.repaymentBudgetLabel,
+      child: GestureDetector(
+        onTap: () => _showValueEditor(
         label: S.of(context)!.repaymentBudgetEditorLabel,
         currentValue: _budgetMensuel,
         min: 200,
@@ -634,6 +644,7 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
           ],
         ),
       ),
+    ),
     );
   }
 

--- a/apps/mobile/lib/screens/deces_proche_screen.dart
+++ b/apps/mobile/lib/screens/deces_proche_screen.dart
@@ -128,9 +128,12 @@ class _DecesProcheScreenState extends State<DecesProcheScreen> {
       ),
       child: Column(
         children: [
-          Text(
-            '$delaiRepudiation',
-            style: MintTextStyles.displayLarge(color: MintColors.white),
+          Semantics(
+            label: '$delaiRepudiation ${s.decesProcheMoisRepudiation}',
+            child: Text(
+              '$delaiRepudiation',
+              style: MintTextStyles.displayLarge(color: MintColors.white),
+            ),
           ),
           Text(
             s.decesProcheMoisRepudiation,

--- a/apps/mobile/lib/screens/disability/disability_gap_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_gap_screen.dart
@@ -426,11 +426,15 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
   }
 
   Widget _buildSectionCta(String label, String route) {
-    return SizedBox(
-      width: double.infinity,
-      child: OutlinedButton(
-        onPressed: () => context.push(route),
-        child: Text(label),
+    return Semantics(
+      button: true,
+      label: label,
+      child: SizedBox(
+        width: double.infinity,
+        child: OutlinedButton(
+          onPressed: () => context.push(route),
+          child: Text(label),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
@@ -240,9 +240,12 @@ class _DisabilityInsuranceScreenState extends State<DisabilityInsuranceScreen> {
           ),
         ),
       ),
-      title: Text(
-        S.of(context)!.disabilityInsAppBarTitle,
-        style: MintTextStyles.titleMedium(color: MintColors.white).copyWith(fontWeight: FontWeight.w700),
+      title: Semantics(
+        header: true,
+        child: Text(
+          S.of(context)!.disabilityInsAppBarTitle,
+          style: MintTextStyles.titleMedium(color: MintColors.white).copyWith(fontWeight: FontWeight.w700),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/screens/document_detail_screen.dart
+++ b/apps/mobile/lib/screens/document_detail_screen.dart
@@ -265,11 +265,14 @@ class DocumentDetailScreen extends StatelessWidget {
         ],
 
         // Action buttons
-        SizedBox(
-          width: double.infinity,
-          child: FilledButton(
-            onPressed: () {
-              ScaffoldMessenger.of(context).showSnackBar(
+        Semantics(
+          button: true,
+          label: s.documentsConfirmButton,
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () {
+                ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(s.documentDetailProfileUpdated),
                   backgroundColor: MintColors.success,
@@ -284,6 +287,7 @@ class DocumentDetailScreen extends StatelessWidget {
               s.documentsConfirmButton,
             ),
           ),
+        ),
         ),
         const SizedBox(height: MintSpacing.sm + 4),
         Center(

--- a/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
@@ -264,11 +264,14 @@ class _AvsGuideScreenState extends State<AvsGuideScreen> {
   // ── Open ahv-iv.ch button ──────────────────────────────────
 
   Widget _buildOpenAhvButton(S l) {
-    return SizedBox(
-      width: double.infinity,
-      height: 56,
-      child: FilledButton.icon(
-        onPressed: _onOpenAhv,
+    return Semantics(
+      button: true,
+      label: l.avsGuideOpenAhvButton,
+      child: SizedBox(
+        width: double.infinity,
+        height: 56,
+        child: FilledButton.icon(
+          onPressed: _onOpenAhv,
         icon: const Icon(Icons.open_in_new, size: 20),
         label: Text(
           l.avsGuideOpenAhvButton,
@@ -282,17 +285,21 @@ class _AvsGuideScreenState extends State<AvsGuideScreen> {
           ),
         ),
       ),
+    ),
     );
   }
 
   // ── Scan button ────────────────────────────────────────────
 
   Widget _buildScanButton(S l) {
-    return SizedBox(
-      width: double.infinity,
-      height: 56,
-      child: OutlinedButton.icon(
-        onPressed: _isProcessing ? null : _onScanExtract,
+    return Semantics(
+      button: true,
+      label: l.avsGuideScanButton,
+      child: SizedBox(
+        width: double.infinity,
+        height: 56,
+        child: OutlinedButton.icon(
+          onPressed: _isProcessing ? null : _onScanExtract,
         icon: const Icon(Icons.document_scanner_outlined, size: 22),
         label: Text(
           l.avsGuideScanButton,
@@ -306,6 +313,7 @@ class _AvsGuideScreenState extends State<AvsGuideScreen> {
           ),
         ),
       ),
+    ),
     );
   }
 

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -452,11 +452,14 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
   Widget _buildCtaButton(BuildContext context) {
     return Opacity(
       opacity: _ctaFadeIn.value,
-      child: SizedBox(
-        width: double.infinity,
-        height: 56,
-        child: FilledButton.icon(
-          onPressed: () {
+      child: Semantics(
+        button: true,
+        label: S.of(context)!.docImpactReturnDashboard,
+        child: SizedBox(
+          width: double.infinity,
+          height: 56,
+          child: FilledButton.icon(
+            onPressed: () {
             // Navigate back to root dashboard via GoRouter
             context.go('/home');
           },
@@ -473,6 +476,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
             ),
           ),
         ),
+      ),
       ),
     );
   }

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -235,11 +235,14 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
   Widget _buildCaptureButtons() {
     return Column(
       children: [
-        SizedBox(
-          width: double.infinity,
-          height: 56,
-          child: FilledButton.icon(
-            onPressed: _isProcessing ? null : _onCameraPressed,
+        Semantics(
+          button: true,
+          label: S.of(context)!.documentScanTakePhoto,
+          child: SizedBox(
+            width: double.infinity,
+            height: 56,
+            child: FilledButton.icon(
+              onPressed: _isProcessing ? null : _onCameraPressed,
             icon: const Icon(
               kIsWeb ? Icons.upload_file_outlined : Icons.camera_alt_outlined,
               size: 22,
@@ -261,12 +264,16 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
             ),
           ),
         ),
+        ),
         const SizedBox(height: 12),
-        SizedBox(
-          width: double.infinity,
-          height: 56,
-          child: OutlinedButton.icon(
-            onPressed: _isProcessing ? null : _onGalleryPressed,
+        Semantics(
+          button: true,
+          label: S.of(context)!.docScanFromGallery,
+          child: SizedBox(
+            width: double.infinity,
+            height: 56,
+            child: OutlinedButton.icon(
+              onPressed: _isProcessing ? null : _onGalleryPressed,
             icon: const Icon(Icons.photo_library_outlined, size: 22),
             label: Text(
               S.of(context)!.docScanFromGallery,
@@ -280,6 +287,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
               ),
             ),
           ),
+        ),
         ),
       ],
     );

--- a/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
@@ -304,11 +304,14 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
   // ── Confirm button ───────────────────────────────────────
 
   Widget _buildConfirmButton() {
-    return SizedBox(
-      width: double.infinity,
-      height: 56,
-      child: FilledButton.icon(
-        onPressed: _onConfirmAll,
+    return Semantics(
+      button: true,
+      label: S.of(context)!.extractionReviewConfirmAll,
+      child: SizedBox(
+        width: double.infinity,
+        height: 56,
+        child: FilledButton.icon(
+          onPressed: _onConfirmAll,
         icon: const Icon(Icons.check_circle_outline, size: 22),
         label: Text(
           S.of(context)!.extractionReviewConfirmAll,
@@ -322,6 +325,7 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
           ),
         ),
       ),
+    ),
     );
   }
 

--- a/apps/mobile/lib/screens/expert/expert_tier_screen.dart
+++ b/apps/mobile/lib/screens/expert/expert_tier_screen.dart
@@ -351,21 +351,25 @@ class _SpecialistCard extends StatelessWidget {
             style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
           ),
           const SizedBox(height: MintSpacing.md),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: onTap,
-              style: FilledButton.styleFrom(
-                backgroundColor: MintColors.primary,
-                foregroundColor: MintColors.white,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(14),
+          Semantics(
+            button: true,
+            label: ctaLabel,
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onTap,
+                style: FilledButton.styleFrom(
+                  backgroundColor: MintColors.primary,
+                  foregroundColor: MintColors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
                 ),
-                padding: const EdgeInsets.symmetric(vertical: 14),
-              ),
-              child: Text(
-                ctaLabel,
-                style: MintTextStyles.bodySmall(color: MintColors.white),
+                child: Text(
+                  ctaLabel,
+                  style: MintTextStyles.bodySmall(color: MintColors.white),
+                ),
               ),
             ),
           ),
@@ -752,10 +756,13 @@ class _BottomCtaBar extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: onRequest,
+          Semantics(
+            button: true,
+            label: requestLabel,
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onRequest,
               style: FilledButton.styleFrom(
                 backgroundColor: MintColors.primary,
                 foregroundColor: MintColors.white,
@@ -769,6 +776,7 @@ class _BottomCtaBar extends StatelessWidget {
                 style: MintTextStyles.bodySmall(color: MintColors.white),
               ),
             ),
+          ),
           ),
           const SizedBox(height: MintSpacing.sm),
           TextButton(

--- a/apps/mobile/lib/screens/explore/famille_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/famille_hub_screen.dart
@@ -108,51 +108,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/fiscalite_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/fiscalite_hub_screen.dart
@@ -108,51 +108,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/logement_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/logement_hub_screen.dart
@@ -120,51 +120,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/patrimoine_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/patrimoine_hub_screen.dart
@@ -108,51 +108,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/retraite_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/retraite_hub_screen.dart
@@ -146,51 +146,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/sante_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/sante_hub_screen.dart
@@ -108,51 +108,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/explore/travail_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/travail_hub_screen.dart
@@ -150,51 +150,55 @@ class _HubItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: MintSurface(
-        tone: tone,
-        padding: EdgeInsets.symmetric(
-          horizontal: MintSpacing.lg,
-          vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
-        ),
-        child: Row(
-          children: [
-            if (icon != null) ...[
-              Icon(icon, color: MintColors.textSecondary, size: 22),
-              const SizedBox(width: MintSpacing.md),
-            ],
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: subtitle != null
-                        ? MintTextStyles.titleMedium()
-                        : MintTextStyles.bodyMedium(),
-                  ),
-                  if (subtitle != null) ...[
-                    const SizedBox(height: MintSpacing.xs),
+    return Semantics(
+      button: true,
+      label: title,
+      child: GestureDetector(
+        onTap: onTap,
+        child: MintSurface(
+          tone: tone,
+          padding: EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: subtitle != null ? MintSpacing.lg : MintSpacing.md,
+          ),
+          child: Row(
+            children: [
+              if (icon != null) ...[
+                Icon(icon, color: MintColors.textSecondary, size: 22),
+                const SizedBox(width: MintSpacing.md),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle!,
-                      style: MintTextStyles.bodySmall(
-                        color: MintColors.textSecondary,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                      title,
+                      style: subtitle != null
+                          ? MintTextStyles.titleMedium()
+                          : MintTextStyles.bodyMedium(),
                     ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: MintSpacing.xs),
+                      Text(
+                        subtitle!,
+                        style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            const SizedBox(width: MintSpacing.sm),
-            Icon(
-              Icons.chevron_right_rounded,
-              color: MintColors.textMuted.withValues(alpha: 0.5),
-              size: 20,
-            ),
-          ],
+              const SizedBox(width: MintSpacing.sm),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: MintColors.textMuted.withValues(alpha: 0.5),
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/screens/household/accept_invitation_screen.dart
+++ b/apps/mobile/lib/screens/household/accept_invitation_screen.dart
@@ -112,10 +112,13 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
           ),
         ],
         const SizedBox(height: 24),
-        FilledButton(
-          onPressed: household.isLoading
-              ? null
-              : () async {
+        Semantics(
+          button: true,
+          label: 'Rejoindre le menage',
+          child: FilledButton(
+            onPressed: household.isLoading
+                ? null
+                : () async {
                   final code = _codeController.text.trim();
                   if (code.isEmpty) return;
                   household.clearError();
@@ -140,6 +143,7 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
                   'Rejoindre le menage',
                   style: MintTextStyles.titleMedium(color: MintColors.white),
                 ),
+        ),
         ),
       ],
     );

--- a/apps/mobile/lib/screens/household/household_screen.dart
+++ b/apps/mobile/lib/screens/household/household_screen.dart
@@ -204,10 +204,14 @@ class _HouseholdScreenState extends State<HouseholdScreen> {
               style: MintTextStyles.bodyMedium(),
             ),
             const SizedBox(height: 20),
-            FilledButton.icon(
-              onPressed: () => setState(() => _showInviteForm = true),
-              icon: const Icon(Icons.person_add),
-              label: Text(S.of(context)!.householdInvitePartner),
+            Semantics(
+              button: true,
+              label: S.of(context)!.householdInvitePartner,
+              child: FilledButton.icon(
+                onPressed: () => setState(() => _showInviteForm = true),
+                icon: const Icon(Icons.person_add),
+                label: Text(S.of(context)!.householdInvitePartner),
+              ),
             ),
             if (_showInviteForm) ...[
               const SizedBox(height: 16),

--- a/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
@@ -277,9 +277,12 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
       ),
       child: Column(
         children: [
-          Text(
-            IndependantsService.formatChf(saving),
-            style: MintTextStyles.displayMedium(color: saving > 0 ? MintColors.white : MintColors.primary),
+          Semantics(
+            label: IndependantsService.formatChf(saving),
+            child: Text(
+              IndependantsService.formatChf(saving),
+              style: MintTextStyles.displayMedium(color: saving > 0 ? MintColors.white : MintColors.primary),
+            ),
           ),
           const SizedBox(height: MintSpacing.sm),
           Text(

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -270,9 +270,12 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
       ),
       child: Column(
         children: [
-          Text(
-            IndependantsService.formatChf(r.capitalisationAnnuelle),
-            style: MintTextStyles.displayMedium(color: MintColors.white),
+          Semantics(
+            label: IndependantsService.formatChf(r.capitalisationAnnuelle),
+            child: Text(
+              IndependantsService.formatChf(r.capitalisationAnnuelle),
+              style: MintTextStyles.displayMedium(color: MintColors.white),
+            ),
           ),
           const SizedBox(height: MintSpacing.sm),
           Text(

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -270,9 +270,12 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         ),
         child: Column(
           children: [
-            Text(
-              IndependantsService.formatChf(r.economieFiscale),
-              style: MintTextStyles.displayMedium(color: MintColors.primary),
+            Semantics(
+              label: IndependantsService.formatChf(r.economieFiscale),
+              child: Text(
+                IndependantsService.formatChf(r.economieFiscale),
+                style: MintTextStyles.displayMedium(color: MintColors.primary),
+              ),
             ),
             const SizedBox(height: MintSpacing.sm),
             Text(
@@ -293,9 +296,12 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
       ),
       child: Column(
         children: [
-          Text(
-            IndependantsService.formatChf(r.avantageSurSalarie),
-            style: MintTextStyles.displayMedium(color: MintColors.white),
+          Semantics(
+            label: IndependantsService.formatChf(r.avantageSurSalarie),
+            child: Text(
+              IndependantsService.formatChf(r.avantageSurSalarie),
+              style: MintTextStyles.displayMedium(color: MintColors.white),
+            ),
           ),
           const SizedBox(height: MintSpacing.sm),
           Text(

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
@@ -187,11 +187,15 @@ class _SmartOnboardingScreenState extends State<SmartOnboardingScreen> {
                   style: MintTextStyles.bodyMedium(),
                 ),
                 const SizedBox(height: MintSpacing.md),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: () => Navigator.of(ctx).pop(true),
-                    child: Text(l.onboardingConsentAllow),
+                Semantics(
+                  button: true,
+                  label: l.onboardingConsentAllow,
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () => Navigator.of(ctx).pop(true),
+                      child: Text(l.onboardingConsentAllow),
+                    ),
                   ),
                 ),
                 const SizedBox(height: MintSpacing.sm),

--- a/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
@@ -600,11 +600,14 @@ class _LiteracyChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(16),
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
         decoration: BoxDecoration(
           color: selected ? MintColors.primary.withAlpha(24) : MintColors.white,
           borderRadius: BorderRadius.circular(16),
@@ -622,6 +625,7 @@ class _LiteracyChip extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 }

--- a/apps/mobile/lib/screens/onboarding/steps/step_jit_explanation.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_jit_explanation.dart
@@ -149,10 +149,13 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
               const SizedBox(height: 16),
 
               // ── NAVIGATION ──────────────────────────────────────────
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  onPressed: widget.onNext,
+              Semantics(
+                button: true,
+                label: 'Que puis-je faire ?',
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: widget.onNext,
                   style: FilledButton.styleFrom(
                     backgroundColor: MintColors.primary,
                     foregroundColor: MintColors.white,
@@ -169,6 +172,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
                     ),
                   ),
                 ),
+              ),
               ),
               const SizedBox(height: 8),
               Center(

--- a/apps/mobile/lib/screens/onboarding/steps/step_next_step.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_next_step.dart
@@ -84,10 +84,13 @@ class StepNextStep extends StatelessWidget {
               const Spacer(flex: 3),
 
               // ── PRIMARY CTA — enrich ────────────────────────────────
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  onPressed: () {
+              Semantics(
+                button: true,
+                label: 'Affiner mon profil',
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () {
                     AnalyticsService().trackEvent(
                       kEventEnrichmentStarted,
                       category: 'conversion',
@@ -111,6 +114,7 @@ class StepNextStep extends StatelessWidget {
                     ),
                   ),
                 ),
+              ),
               ),
               const SizedBox(height: 12),
 

--- a/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
@@ -292,26 +292,30 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                   ),
                 ),
                 const SizedBox(height: 20),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: () => Navigator.of(ctx).pop(true),
-                    style: FilledButton.styleFrom(
-                      backgroundColor: MintColors.primary,
-                      foregroundColor: MintColors.background,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(14),
+                Semantics(
+                  button: true,
+                  label: 'Scanner ce document',
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () => Navigator.of(ctx).pop(true),
+                      style: FilledButton.styleFrom(
+                        backgroundColor: MintColors.primary,
+                        foregroundColor: MintColors.background,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                        ),
                       ),
-                    ),
-                    child: Text(
-                      'Scanner ce document',
+                      child: Text(
+                        'Scanner ce document',
                       style: GoogleFonts.inter(
                         fontSize: 15,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
+                ),
                 ),
                 const SizedBox(height: 10),
                 SizedBox(

--- a/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
@@ -367,10 +367,13 @@ class _StepQuestionsState extends State<StepQuestions> {
                   const SizedBox(height: 48),
 
                   // ── CTA ───────────────────────────────────────────────────
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton(
-                      onPressed: widget.viewModel.canCompute ? _onSubmit : null,
+                  Semantics(
+                    button: true,
+                    label: l.onboardingSmartSeeResult,
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: widget.viewModel.canCompute ? _onSubmit : null,
                       style: FilledButton.styleFrom(
                         backgroundColor: MintColors.primary,
                         foregroundColor: MintColors.background,
@@ -388,6 +391,7 @@ class _StepQuestionsState extends State<StepQuestions> {
                         ),
                       ),
                     ),
+                  ),
                   ),
                   const SizedBox(height: 24),
 

--- a/apps/mobile/lib/screens/onboarding/steps/step_stress_selector.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_stress_selector.dart
@@ -180,10 +180,13 @@ class _StressCard extends StatelessWidget {
           ? MintColors.primary.withAlpha(20)
           : MintColors.surface,
       borderRadius: BorderRadius.circular(16),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(16),
-        onTap: onTap,
-        child: Container(
+      child: Semantics(
+        button: true,
+        label: option.label,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: onTap,
+          child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(16),
@@ -245,6 +248,7 @@ class _StressCard extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/apps/mobile/lib/screens/onboarding/steps/step_top_actions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_top_actions.dart
@@ -178,17 +178,20 @@ class _ActionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = _priorityColor(tip.priority);
 
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(16),
-      child: Container(
-        padding: const EdgeInsets.all(20),
-        decoration: BoxDecoration(
-          color: MintColors.card,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: MintColors.lightBorder),
-        ),
-        child: Row(
+    return Semantics(
+      button: true,
+      label: tip.title,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: MintColors.card,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: MintColors.lightBorder),
+          ),
+          child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Index badge
@@ -253,6 +256,7 @@ class _ActionCard extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
@@ -336,9 +336,12 @@ class _Retroactive3aScreenState extends State<Retroactive3aScreen> {
                 .copyWith(fontWeight: FontWeight.w700, letterSpacing: 1.0),
           ),
           const SizedBox(height: MintSpacing.sm + 4),
-          Text(
-            'CHF\u00a0${formatChf(result.economiesFiscales)}',
-            style: MintTextStyles.displayMedium(color: MintColors.white),
+          Semantics(
+            label: 'CHF ${formatChf(result.economiesFiscales)}',
+            child: Text(
+              'CHF\u00a0${formatChf(result.economiesFiscales)}',
+              style: MintTextStyles.displayMedium(color: MintColors.white),
+            ),
           ),
           const SizedBox(height: MintSpacing.sm + 4),
           Text(

--- a/apps/mobile/lib/screens/portfolio_screen.dart
+++ b/apps/mobile/lib/screens/portfolio_screen.dart
@@ -145,9 +145,12 @@ class PortfolioScreen extends StatelessWidget {
             style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.w500),
           ),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            'CHF 102\'678.64',
-            style: MintTextStyles.displayMedium(),
+          Semantics(
+            label: 'CHF 102\'678.64',
+            child: Text(
+              'CHF 102\'678.64',
+              style: MintTextStyles.displayMedium(),
+            ),
           ),
           const SizedBox(height: 16),
           Row(

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -90,10 +90,14 @@ class FinancialSummaryScreen extends StatelessWidget {
               style: MintTextStyles.bodyLarge(),
             ),
             const SizedBox(height: 12),
-            FilledButton(
-              onPressed: () => context.push('/onboarding/quick'),
-              child:
-                  Text(S.of(context)!.financialSummaryStartDiagnostic),
+            Semantics(
+              button: true,
+              label: S.of(context)!.financialSummaryStartDiagnostic,
+              child: FilledButton(
+                onPressed: () => context.push('/onboarding/quick'),
+                child:
+                    Text(S.of(context)!.financialSummaryStartDiagnostic),
+              ),
             ),
           ],
         ),

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -446,9 +446,12 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
         children: [
           Text(l.sim3aAnnualTaxSaved, style: MintTextStyles.bodyMedium()),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            _currencyFormat.format(_result!['annualTaxSaved']!),
-            style: MintTextStyles.displayMedium(color: MintColors.primary),
+          Semantics(
+            label: '${l.sim3aAnnualTaxSaved}: ${_currencyFormat.format(_result!['annualTaxSaved']!)}',
+            child: Text(
+              _currencyFormat.format(_result!['annualTaxSaved']!),
+              style: MintTextStyles.displayMedium(color: MintColors.primary),
+            ),
           ),
           const SizedBox(height: MintSpacing.lg),
           const Divider(color: MintColors.border),

--- a/apps/mobile/lib/screens/simulator_compound_screen.dart
+++ b/apps/mobile/lib/screens/simulator_compound_screen.dart
@@ -219,9 +219,12 @@ class _SimulatorCompoundScreenState extends State<SimulatorCompoundScreen> {
         children: [
           Text(S.of(context)!.compoundValeurFinale, style: MintTextStyles.bodyMedium()),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            _currencyFormat.format(finalValue),
-            style: MintTextStyles.displayMedium(),
+          Semantics(
+            label: '${S.of(context)!.compoundValeurFinale}: ${_currencyFormat.format(finalValue)}',
+            child: Text(
+              _currencyFormat.format(finalValue),
+              style: MintTextStyles.displayMedium(),
+            ),
           ),
           const SizedBox(height: MintSpacing.lg),
           Row(

--- a/apps/mobile/lib/screens/simulator_leasing_screen.dart
+++ b/apps/mobile/lib/screens/simulator_leasing_screen.dart
@@ -241,9 +241,12 @@ class _SimulatorLeasingScreenState extends State<SimulatorLeasingScreen> {
         children: [
           Text(S.of(context)!.leasingCoutOpportunite20, style: MintTextStyles.bodyMedium()),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            _currencyFormat.format(opportunityCost20),
-            style: MintTextStyles.displayMedium(color: MintColors.error),
+          Semantics(
+            label: '${S.of(context)!.leasingCoutOpportunite20}: ${_currencyFormat.format(opportunityCost20)}',
+            child: Text(
+              _currencyFormat.format(opportunityCost20),
+              style: MintTextStyles.displayMedium(color: MintColors.error),
+            ),
           ),
           const SizedBox(height: MintSpacing.lg),
           Text(


### PR DESCRIPTION
## Summary
43 screens received Semantics wrappers on interactive elements and key values:
- 7 explore hubs, 12 simulators, 5 document screens, 7 onboarding steps, 12 misc
- 5 files correctly skipped (containers, viewmodels, display-only)

## Test plan
- [x] flutter analyze: 0 issues
- [x] flutter test: 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)