### PR TITLE
feat(orchestration): ReturnContract on 6 screens — coach receives simulation results

### DIFF
--- a/apps/mobile/lib/screens/disability/disability_gap_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_gap_screen.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/widgets/coach/edu_shared_widgets.dart';
 import 'package:mint_mobile/widgets/collapsible_section.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P4 — ÉCRAN PRINCIPAL INVALIDITÉ
@@ -39,17 +40,28 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
     super.didChangeDependencies();
     if (_seededFromProfile) return;
     _seededFromProfile = true;
-    ScreenCompletionTracker.markCompleted('disability_gap');
     final profile = context.read<CoachProfileProvider>().profile;
-    if (profile == null) return;
-    setState(() {
-      final salary = profile.salaireBrutMensuel;
-      if (salary > 0) _grossMonthly = salary.clamp(2000.0, 25000.0);
-      final age = DateTime.now().year - profile.birthYear;
-      _age = age.clamp(18, 64);
-      final savings = profile.patrimoine.epargneLiquide;
-      if (savings > 0) _savings = savings.clamp(0.0, 500000.0);
-    });
+    if (profile != null) {
+      setState(() {
+        final salary = profile.salaireBrutMensuel;
+        if (salary > 0) _grossMonthly = salary.clamp(2000.0, 25000.0);
+        final age = DateTime.now().year - profile.birthYear;
+        _age = age.clamp(18, 64);
+        final savings = profile.patrimoine.epargneLiquide;
+        if (savings > 0) _savings = savings.clamp(0.0, 500000.0);
+      });
+    }
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'disability_gap',
+      ScreenReturn.completed(
+        route: '/disability-gap',
+        updatedFields: {
+          'disabilityGapMensuel': _grossMonthly - _acts.last.monthlyIncome,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: 'assurance_invalidite',
+      ),
+    );
   }
 
   // ── Calcul des actes (La Falaise) ─────────────────────────

--- a/apps/mobile/lib/screens/divorce_simulator_screen.dart
+++ b/apps/mobile/lib/screens/divorce_simulator_screen.dart
@@ -15,6 +15,7 @@ import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_signal_row.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 
 /// Swiss CHF formatter with apostrophe grouping.
 String _formatChfSwiss(double value) {
@@ -157,7 +158,18 @@ class _DivorceSimulatorScreenState extends State<DivorceSimulatorScreen> {
       _result = DivorceService.simulate(input: input);
       _checklistState = List.filled(_result!.checklist.length, false);
     });
-    ScreenCompletionTracker.markCompleted('divorce_simulator');
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'divorce_simulator',
+      ScreenReturn.completed(
+        route: '/divorce',
+        updatedFields: {
+          'divorceLppSplit': _result!.lppSplit.transferAmount,
+          'divorcePensionAlimentaire': _result!.pensionAlimentaireMonthly,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: 'budget_post_divorce',
+      ),
+    );
 
     // Smooth scroll to results
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -15,6 +15,7 @@ import 'package:mint_mobile/widgets/fiscal/canton_ranking_bar.dart';
 import 'package:mint_mobile/widgets/fiscal/move_savings_card.dart';
 import 'package:mint_mobile/widgets/coach/moving_true_cost_widget.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -170,7 +171,25 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
         communeMultiplier: communeMultiplier,
       );
     });
-    ScreenCompletionTracker.markCompleted('fiscal_comparator');
+    final bestCanton = _allCantons.isNotEmpty
+        ? _allCantons.first['canton'] as String?
+        : null;
+    final maxSavings = _allCantons.isNotEmpty
+        ? (_allCantons.last['chargeTotale'] as double) -
+            (_allCantons.first['chargeTotale'] as double)
+        : 0.0;
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'fiscal_comparator',
+      ScreenReturn.completed(
+        route: '/fiscal-comparator',
+        updatedFields: {
+          'fiscalBestCanton': bestCanton,
+          'fiscalMaxSavings': maxSavings,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: maxSavings > 5000 ? 'demenagement' : null,
+      ),
+    );
   }
 
   // ════════════════════════════════════════════════════════════

--- a/apps/mobile/lib/screens/job_comparison_screen.dart
+++ b/apps/mobile/lib/screens/job_comparison_screen.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 import 'package:mint_mobile/widgets/coach/job_change_comparison_widget.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 /// Swiss CHF formatter with apostrophe grouping.
@@ -163,7 +164,20 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
       );
       _checklistState = List.filled(_result!.checklist.length, false);
     });
-    ScreenCompletionTracker.markCompleted('job_comparison');
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'job_comparison',
+      ScreenReturn.completed(
+        route: '/job-comparison',
+        updatedFields: {
+          'jobComparisonDeltaNet': _result!.axes.isNotEmpty
+              ? _result!.axes.first.delta
+              : 0.0,
+          'jobComparisonLppDelta': _result!.annualPensionDelta,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: 'lpp_rachat',
+      ),
+    );
 
     // Smooth scroll to results
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/apps/mobile/lib/screens/lamal_franchise_screen.dart
+++ b/apps/mobile/lib/screens/lamal_franchise_screen.dart
@@ -9,6 +9,7 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/assurances_service.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -72,7 +73,22 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
         isChild: _isChild,
       );
     });
-    ScreenCompletionTracker.markCompleted('lamal_franchise');
+    final optimalEconomie = _result?.comparaison
+            .where((c) => c.isOptimal)
+            .map((c) => c.economieVs300)
+            .firstOrNull ??
+        0.0;
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'lamal_franchise',
+      ScreenReturn.completed(
+        route: '/lamal-franchise',
+        updatedFields: {
+          'lamalFranchiseOptimale': _result?.franchiseOptimale ?? 300,
+          'lamalEconomie': optimalEconomie,
+        },
+        confidenceDelta: 0.02,
+      ),
+    );
   }
 
   // ── Build ──────────────────────────────────────────────────

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -12,6 +12,7 @@ import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'package:mint_mobile/widgets/coach/early_retirement_slider.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 /// Ecran de simulation du rachat LPP echelonne vs bloc.
@@ -83,7 +84,18 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('lpp_deep');
-    ScreenCompletionTracker.markCompleted('rachat_echelonne');
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'rachat_echelonne',
+      ScreenReturn.completed(
+        route: '/lpp-deep/rachat-echelonne',
+        updatedFields: {
+          'rachatOptimalAnnuel': _rachatMax / _horizon,
+          'rachatEconomieFiscale': _result.delta,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: 'pilier_3a',
+      ),
+    );
     _heroController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 800),


### PR DESCRIPTION
## Summary
6 screens upgraded from basic `markCompleted()` to full `markCompletedWithReturn()` with real `ScreenReturn` data:

| Screen | updatedFields | nextCapSuggestion |
|--------|--------------|-------------------|
| rachat_echelonne | rachatOptimalAnnuel, economieFiscale | pilier_3a |
| divorce_simulator | lppSplit, pensionAlimentaire | budget_post_divorce |
| lamal_franchise | franchiseOptimale, economie | null |
| job_comparison | deltaNet, lppDelta | lpp_rachat |
| fiscal_comparator | bestCanton, maxSavings | demenagement (if >5k) |
| disability_gap | gapMensuel | assurance_invalidite |

**Total screens with ReturnContract: 10/10** (4 existing + 6 new)

The coach can now say "Tu as simulé X, voici ce que ca change" after any of these 10 simulations.

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)