### PR TITLE
feat(orchestration): Realtime ReturnContract — coach reacts immediately

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -47,6 +47,8 @@ import 'package:mint_mobile/services/voice/platform_voice_backend.dart';
 import 'package:mint_mobile/services/llm/provider_health_service.dart';
 import 'package:mint_mobile/services/coach/data_driven_opener_service.dart';
 import 'package:mint_mobile/services/coach/precomputed_insights_service.dart';
+import 'package:mint_mobile/services/screen_completion_tracker.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/services/coach/proactive_trigger_service.dart';
 import 'package:mint_mobile/services/nudge/nudge_engine.dart';
 import 'package:mint_mobile/services/nudge/nudge_persistence.dart';
@@ -199,6 +201,14 @@ class _CoachChatScreenState extends State<CoachChatScreen>
   AnimationController? _milestonePulseController;
   bool _milestonePulsing = false;
 
+  /// Realtime subscription to ScreenReturn events from simulators.
+  StreamSubscription<ScreenReturn>? _screenReturnSub;
+
+  /// Debounce timer for realtime screen returns — prevents LLM spam when
+  /// sliders emit on every change (e.g. affordability, staggered_withdrawal).
+  Timer? _screenReturnDebounce;
+  ScreenReturn? _lastPendingReturn;
+
   @override
   void initState() {
     super.initState();
@@ -307,10 +317,17 @@ class _CoachChatScreenState extends State<CoachChatScreen>
         }
       }
     }
+
+    // Realtime ReturnContract: listen for simulation results.
+    _screenReturnSub = ScreenCompletionTracker.stream.listen(
+      _onRealtimeScreenReturn,
+    );
   }
 
   @override
   void dispose() {
+    _screenReturnSub?.cancel();
+    _screenReturnDebounce?.cancel();
     _autoSaveConversation();
     _controller.dispose();
     _scrollController.dispose();
@@ -1739,6 +1756,45 @@ class _CoachChatScreenState extends State<CoachChatScreen>
     }
 
     _scrollToBottom();
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  //  REALTIME RETURN CONTRACT — immediate coach reaction
+  // ════════════════════════════════════════════════════════════════
+
+  /// Called via stream when ANY screen emits a ScreenReturn — even if the user
+  /// navigated there without coach suggestion (direct explore, deep link).
+  ///
+  /// Builds a context-rich system message from the real simulation data and
+  /// sends it to the LLM so the coach can react immediately.
+  void _onRealtimeScreenReturn(ScreenReturn ret) {
+    if (!mounted) return;
+
+    // Debounce: screens like affordability emit on every slider change.
+    // We only react to the LAST event after 2 seconds of quiet.
+    _lastPendingReturn = ret;
+    _screenReturnDebounce?.cancel();
+    _screenReturnDebounce = Timer(const Duration(seconds: 2), () {
+      if (!mounted) return;
+      if (_isBusy) return; // Don't interrupt an ongoing LLM call.
+      final pending = _lastPendingReturn;
+      if (pending == null) return;
+      _lastPendingReturn = null;
+
+      // Build a context-rich summary from the real simulation data.
+      final buf = StringBuffer();
+      buf.write('Je viens de simuler ${pending.route}');
+      if (pending.updatedFields != null && pending.updatedFields!.isNotEmpty) {
+        final highlights = pending.updatedFields!.entries
+            .take(3)
+            .map((e) => '${e.key}: ${e.value}')
+            .join(', ');
+        buf.write(' ($highlights)');
+      }
+      buf.write('.');
+
+      _sendMessage(buf.toString());
+    });
   }
 
   /// Prepend a visible memory reference phrase to a coach response.

--- a/apps/mobile/lib/services/screen_completion_tracker.dart
+++ b/apps/mobile/lib/services/screen_completion_tracker.dart
@@ -15,6 +15,7 @@
 /// See: docs/CHAT_TO_SCREEN_ORCHESTRATION_STRATEGY.md §7
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -31,6 +32,18 @@ const _kPrefix = 'screen_return_';
 /// disk state.
 class ScreenCompletionTracker {
   ScreenCompletionTracker._();
+
+  // ════════════════════════════════════════════════════════════════
+  //  REALTIME STREAM — coach listens for immediate reaction
+  // ════════════════════════════════════════════════════════════════
+
+  static final _controller = StreamController<ScreenReturn>.broadcast();
+
+  /// Realtime stream of ScreenReturn events.
+  ///
+  /// CoachChatScreen subscribes to this so the LLM can react immediately
+  /// when a user completes a simulation — no polling needed.
+  static Stream<ScreenReturn> get stream => _controller.stream;
 
   // ════════════════════════════════════════════════════════════════
   //  WRITE
@@ -56,8 +69,13 @@ class ScreenCompletionTracker {
     ScreenReturn screenReturn, {
     SharedPreferences? prefs,
     DateTime? now,
-  }) =>
-      _writeReturn(screenId, screenReturn, prefs: prefs, now: now);
+  }) {
+    // Emit on realtime stream FIRST — coach reacts immediately.
+    if (!_controller.isClosed) {
+      _controller.add(screenReturn);
+    }
+    return _writeReturn(screenId, screenReturn, prefs: prefs, now: now);
+  }
 
   /// Persist a [ScreenOutcome.abandoned] entry for [screenId].
   ///


### PR DESCRIPTION
## Summary
Architecture upgrade: the coach now reacts **immediately** when a user finishes a simulation.

**Before**: Screen → SharedPreferences → coach reads on next greeting (poll)
**After**: Screen → StreamController → coach receives event in realtime → auto-sends contextual LLM message

### Changes
- `ScreenCompletionTracker`: added broadcast `StreamController<ScreenReturn>`
- `CoachChatScreen`: subscribes to stream, debounces (2s), sends contextual message with real simulation data

### Safety
- 2-second debounce prevents spam from slider-heavy screens (affordability, staggered_withdrawal)
- `mounted` + `_isBusy` guards prevent crashes and concurrent LLM calls
- Subscription cancelled on dispose
- Broadcast stream: events dropped if no listener (safe)

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)