### PR TITLE
fix(ux): Zero bare Slider — 21 migrated + test fix

### DIFF
--- a/apps/mobile/lib/screens/consumer_credit_screen.dart
+++ b/apps/mobile/lib/screens/consumer_credit_screen.dart
@@ -6,6 +6,7 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/debt_repayment_widget.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
@@ -232,40 +233,15 @@ class _ConsumerCreditSimulatorScreenState extends State<ConsumerCreditSimulatorS
     required void Function(double) onChanged,
     bool isWarning = false,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)),
-            Text(
-              format(value),
-              style: MintTextStyles.bodyMedium(
-                color: isWarning ? MintColors.error : MintColors.primary,
-              ).copyWith(fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
-        const SizedBox(height: MintSpacing.sm),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 4,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
-            overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
-            activeTrackColor: isWarning ? MintColors.error : MintColors.primary,
-            inactiveTrackColor: MintColors.border,
-            thumbColor: isWarning ? MintColors.error : MintColors.primary,
-          ),
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: format,
+      activeColor: isWarning ? MintColors.error : null,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/disability/disability_gap_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_gap_screen.dart
@@ -12,6 +12,7 @@ import 'package:mint_mobile/widgets/coach/disability_scorecard_widget.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/widgets/coach/edu_shared_widgets.dart';
 import 'package:mint_mobile/widgets/collapsible_section.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/models/screen_return.dart';
 
@@ -460,41 +461,14 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
     required String Function(double) format,
     required void Function(double) onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Flexible(
-              child: Text(
-                label,
-                style: MintTextStyles.labelSmall(color: MintColors.textSecondary),
-              ),
-            ),
-            Text(
-              format(value),
-              style: MintTextStyles.bodySmall(color: MintColors.primary).copyWith(fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 3,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
-            activeTrackColor: MintColors.primary,
-            inactiveTrackColor: MintColors.border,
-            thumbColor: MintColors.primary,
-          ),
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: format,
+      onChanged: onChanged,
     );
   }
 }

--- a/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/widgets/coach/disability_scorecard_widget.dart';
 import 'package:mint_mobile/widgets/coach/franchise_cost_widget.dart';
 import 'package:mint_mobile/widgets/coach/edu_shared_widgets.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P4 — COUVERTURE INVALIDITÉ
@@ -311,39 +312,14 @@ class _DisabilityInsuranceScreenState extends State<DisabilityInsuranceScreen> {
     required String Function(double) format,
     required void Function(double) onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Flexible(
-              child: Text(label,
-                  style: MintTextStyles.labelSmall(color: MintColors.textSecondary)),
-            ),
-            Text(
-              format(value),
-              style: MintTextStyles.bodySmall(color: MintColors.primary).copyWith(fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 3,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
-            activeTrackColor: MintColors.primary,
-            inactiveTrackColor: MintColors.border,
-            thumbColor: MintColors.primary,
-          ),
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/disability_red_screen_widget.dart';
 import 'package:mint_mobile/widgets/coach/disability_countdown_widget.dart';
 import 'package:mint_mobile/widgets/coach/edu_shared_widgets.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  P4 — INVALIDITÉ INDÉPENDANT
@@ -159,34 +160,15 @@ class _DisabilitySelfEmployedScreenState
             style: MintTextStyles.labelSmall(),
           ),
           const SizedBox(height: 12),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                S.of(context)!.disabilitySelfEmployedRevenueLabel,
-                style: MintTextStyles.labelSmall(),
-              ),
-              Text(
-                "CHF ${_fmtChf(_monthlyRevenue)}",
-                style: MintTextStyles.bodyMedium(color: MintColors.critical).copyWith(fontWeight: FontWeight.w700),
-              ),
-            ],
-          ),
-          SliderTheme(
-            data: SliderTheme.of(context).copyWith(
-              trackHeight: 3,
-              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
-              activeTrackColor: MintColors.critical,
-              inactiveTrackColor: MintColors.border,
-              thumbColor: MintColors.critical,
-            ),
-            child: Slider(
-              value: _monthlyRevenue,
-              min: 2000,
-              max: 25000,
-              divisions: 46,
-              onChanged: (v) => setState(() => _monthlyRevenue = v),
-            ),
+          MintPremiumSlider(
+            label: S.of(context)!.disabilitySelfEmployedRevenueLabel,
+            value: _monthlyRevenue,
+            min: 2000,
+            max: 25000,
+            divisions: 46,
+            formatValue: (v) => "CHF ${_fmtChf(v)}",
+            activeColor: MintColors.critical,
+            onChanged: (v) => setState(() => _monthlyRevenue = v),
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/services/wealth_tax_service.dart';
 import 'package:mint_mobile/widgets/fiscal/canton_ranking_bar.dart';
 import 'package:mint_mobile/widgets/fiscal/move_savings_card.dart';
 import 'package:mint_mobile/widgets/coach/moving_true_cost_widget.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
@@ -287,49 +288,17 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Revenue slider
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Text(
-                  S.of(context)!.fiscalGrossAnnualIncome,
-                  style: MintTextStyles.titleMedium(),
-                ),
-              ),
-              Text(
-                FiscalService.formatChf(_revenuBrut),
-                style: MintTextStyles.headlineMedium(color: MintColors.primary),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          SliderTheme(
-            data: SliderTheme.of(context).copyWith(
-              activeTrackColor: MintColors.primary,
-              inactiveTrackColor: MintColors.border,
-              thumbColor: MintColors.primary,
-              overlayColor: MintColors.primary.withValues(alpha: 0.1),
-              trackHeight: 6,
-            ),
-            child: Slider(
-              value: _revenuBrut,
-              min: 30000,
-              max: 500000,
-              divisions: 94,
-              onChanged: (v) {
-                _revenuBrut = (v / 5000).round() * 5000.0;
-                _recalculate();
-              },
-            ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text("CHF\u00A030'000",
-                  style: MintTextStyles.labelSmall()),
-              Text("CHF\u00A0500'000",
-                  style: MintTextStyles.labelSmall()),
-            ],
+          MintPremiumSlider(
+            label: S.of(context)!.fiscalGrossAnnualIncome,
+            value: _revenuBrut,
+            min: 30000,
+            max: 500000,
+            divisions: 94,
+            formatValue: (v) => FiscalService.formatChf(v),
+            onChanged: (v) {
+              _revenuBrut = (v / 5000).round() * 5000.0;
+              _recalculate();
+            },
           ),
           const SizedBox(height: 20),
 

--- a/apps/mobile/lib/screens/gender_gap_screen.dart
+++ b/apps/mobile/lib/screens/gender_gap_screen.dart
@@ -5,6 +5,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/segments_service.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
@@ -225,65 +226,22 @@ class _GenderGapScreenState extends State<GenderGapScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                s.genderGapTauxActivite,
-                style: MintTextStyles.titleMedium(),
-              ),
-              Semantics(
-                label: '${_tauxActivite.round()}%',
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: _tauxActivite < 60
-                        ? MintColors.error.withValues(alpha: 0.1)
-                        : _tauxActivite < 80
-                            ? MintColors.warning.withValues(alpha: 0.1)
-                            : MintColors.success.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    '${_tauxActivite.round()}%',
-                    style: MintTextStyles.headlineMedium(
-                      color: _tauxActivite < 60
-                          ? MintColors.error
-                          : _tauxActivite < 80
-                              ? MintColors.warning
-                              : MintColors.success,
-                    ).copyWith(fontSize: 18),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: MintSpacing.sm),
-          SliderTheme(
-            data: SliderTheme.of(context).copyWith(
-              activeTrackColor: MintColors.primary,
-              inactiveTrackColor: MintColors.border,
-              thumbColor: MintColors.primary,
-              overlayColor: MintColors.primary.withValues(alpha: 0.1),
-              trackHeight: 6,
-            ),
-            child: Slider(
-              value: _tauxActivite,
-              min: 10,
-              max: 100,
-              divisions: 18,
-              onChanged: (value) {
-                _tauxActivite = value;
-                _compute();
-              },
-            ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('10%', style: MintTextStyles.labelSmall()),
-              Text('100%', style: MintTextStyles.labelSmall()),
-            ],
+          MintPremiumSlider(
+            label: s.genderGapTauxActivite,
+            value: _tauxActivite,
+            min: 10,
+            max: 100,
+            divisions: 18,
+            formatValue: (v) => '${v.round()}%',
+            activeColor: _tauxActivite < 60
+                ? MintColors.error
+                : _tauxActivite < 80
+                    ? MintColors.warning
+                    : MintColors.success,
+            onChanged: (value) {
+              _tauxActivite = value;
+              _compute();
+            },
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/widgets/coach/lpp_vs_3a_decision_tree.dart';
 import 'package:mint_mobile/widgets/coach/fiscal_superpower_widget.dart';
 import 'package:mint_mobile/widgets/coach/double_price_freedom_widget.dart';
 import 'package:mint_mobile/widgets/coach/lpp_rescue_widget.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  INDEPENDANT SCREEN — Sprint S12 / Chantier 6
@@ -455,52 +456,23 @@ class _IndependantScreenState extends State<IndependantScreen> {
             style: MintTextStyles.titleMedium(),
           ),
           const SizedBox(height: MintSpacing.sm),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                IndependantService.formatChf(_revenuNet),
-                style: MintTextStyles.headlineMedium(),
-              ),
-              Text(
-                S.of(context)!.independantAgeLabel(_age),
-                style: MintTextStyles.bodySmall(
-                    color: MintColors.textSecondary),
-              ),
-            ],
+          Text(
+            S.of(context)!.independantAgeLabel(_age),
+            style: MintTextStyles.bodySmall(
+                color: MintColors.textSecondary),
           ),
           const SizedBox(height: MintSpacing.sm),
-          Semantics(
+          MintPremiumSlider(
             label: S.of(context)!.independantRevenueTitle,
-            value: IndependantService.formatChf(_revenuNet),
-            child: SliderTheme(
-              data: SliderTheme.of(context).copyWith(
-                activeTrackColor: MintColors.primary,
-                inactiveTrackColor: MintColors.border,
-                thumbColor: MintColors.primary,
-                overlayColor: MintColors.primary.withValues(alpha: 0.1),
-                trackHeight: 4,
-              ),
-              child: Slider(
-                value: _revenuNet,
-                min: 20000,
-                max: 200000,
-                divisions: 36,
-                onChanged: (value) {
-                  _revenuNet = value;
-                  _compute();
-                },
-              ),
-            ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('CHF\u00A020k',
-                  style: MintTextStyles.labelSmall()),
-              Text('CHF\u00A0200k',
-                  style: MintTextStyles.labelSmall()),
-            ],
+            value: _revenuNet,
+            min: 20000,
+            max: 200000,
+            divisions: 36,
+            formatValue: (v) => IndependantService.formatChf(v),
+            onChanged: (value) {
+              _revenuNet = value;
+              _compute();
+            },
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
+++ b/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
@@ -4,6 +4,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
@@ -118,47 +119,17 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(s.avsCotisationsRevenuLabel, style: MintTextStyles.titleMedium()),
-          const SizedBox(height: MintSpacing.sm + 4),
-          Text(
-            IndependantsService.formatChf(_revenuNet),
-            style: MintTextStyles.headlineMedium(color: MintColors.primary),
-          ),
-          const SizedBox(height: MintSpacing.sm + 4),
-          Semantics(
-            label: s.avsCotisationsRevenuLabel,
-            value: IndependantsService.formatChf(_revenuNet),
-            child: SliderTheme(
-              data: SliderTheme.of(context).copyWith(
-                activeTrackColor: MintColors.primary,
-                inactiveTrackColor: MintColors.border,
-                thumbColor: MintColors.primary,
-                overlayColor: MintColors.primary.withValues(alpha: 0.1),
-                trackHeight: 4,
-              ),
-              child: Slider(
-                value: _revenuNet,
-                min: 0,
-                max: 250000,
-                divisions: 250,
-                onChanged: (value) {
-                  _revenuNet = value;
-                  _calculate();
-                },
-              ),
-            ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(s.avsCotisationsSliderMin, style: MintTextStyles.labelSmall()),
-              Text(s.avsCotisationsSliderMax250k, style: MintTextStyles.labelSmall()),
-            ],
-          ),
-        ],
+      child: MintPremiumSlider(
+        label: s.avsCotisationsRevenuLabel,
+        value: _revenuNet,
+        min: 0,
+        max: 250000,
+        divisions: 250,
+        formatValue: (v) => IndependantsService.formatChf(v),
+        onChanged: (value) {
+          _revenuNet = value;
+          _calculate();
+        },
       ),
     );
   }

--- a/apps/mobile/lib/screens/independants/ijm_screen.dart
+++ b/apps/mobile/lib/screens/independants/ijm_screen.dart
@@ -4,6 +4,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/independants_service.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 
@@ -129,30 +130,14 @@ class _IjmScreenState extends State<IjmScreen> {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(title, style: MintTextStyles.titleMedium()),
-              Text(valueLabel, style: MintTextStyles.headlineMedium(color: MintColors.primary).copyWith(fontSize: 20)),
-            ],
-          ),
-          const SizedBox(height: MintSpacing.sm + 4),
-          Semantics(
-            label: title,
-            value: valueLabel,
-            child: SliderTheme(
-              data: SliderTheme.of(context).copyWith(activeTrackColor: MintColors.primary, inactiveTrackColor: MintColors.border, thumbColor: MintColors.primary, overlayColor: MintColors.primary.withValues(alpha: 0.1), trackHeight: 4),
-              child: Slider(value: value, min: min, max: max, divisions: divisions, onChanged: onChanged),
-            ),
-          ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [Text(minLabel, style: MintTextStyles.labelSmall()), Text(maxLabel, style: MintTextStyles.labelSmall())],
-          ),
-        ],
+      child: MintPremiumSlider(
+        label: title,
+        value: value,
+        min: min,
+        max: max,
+        divisions: divisions,
+        formatValue: (_) => valueLabel,
+        onChanged: onChanged,
       ),
     );
   }

--- a/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/financial_core/financial_core.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 
 /// Ecran de simulation du retrait EPL (Encouragement a la Propriete du Logement).
@@ -335,29 +336,14 @@ class _EplScreenState extends State<EplScreen> {
     required String format,
     required ValueChanged<double> onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-            Text(format, style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-          ],
-        ),
-        Semantics(
-          label: label,
-          value: format,
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            activeColor: MintColors.primary,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: (_) => format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart';
 import 'package:mint_mobile/widgets/coach/lpp_rescue_widget.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 
 /// Ecran de conseil en libre passage.
@@ -265,44 +266,25 @@ class _LibrePassageScreenState extends State<LibrePassageScreen> {
           ),
           const SizedBox(height: MintSpacing.md),
           // Age slider
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(l.librePassageLabelAge, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-              Text(l.librePassageLabelAgeFormat(_age), style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-            ],
-          ),
-          Semantics(
+          MintPremiumSlider(
             label: l.librePassageLabelAge,
-            value: l.librePassageLabelAgeFormat(_age),
-            child: Slider(
-              value: _age.toDouble(),
-              min: 18,
-              max: 65,
-              divisions: 47,
-              activeColor: MintColors.primary,
-              onChanged: (v) => setState(() => _age = v.round()),
-            ),
+            value: _age.toDouble(),
+            min: 18,
+            max: 65,
+            divisions: 47,
+            formatValue: (v) => l.librePassageLabelAgeFormat(v.round()),
+            onChanged: (v) => setState(() => _age = v.round()),
           ),
           const SizedBox(height: MintSpacing.sm),
           // Avoir slider
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(l.librePassageLabelAvoir, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-              Text('CHF ${(_avoir / 1000).toStringAsFixed(0)}k', style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-            ],
-          ),
-          Semantics(
+          MintPremiumSlider(
             label: l.librePassageLabelAvoir,
-            child: Slider(
-              value: _avoir,
-              min: 0,
-              max: 500000,
-              divisions: 100,
-              activeColor: MintColors.primary,
-              onChanged: (v) => setState(() => _avoir = v),
-            ),
+            value: _avoir,
+            min: 0,
+            max: 500000,
+            divisions: 100,
+            formatValue: (v) => 'CHF ${(v / 1000).toStringAsFixed(0)}k',
+            onChanged: (v) => setState(() => _avoir = v),
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -13,6 +13,7 @@ import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'package:mint_mobile/widgets/coach/early_retirement_slider.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/models/screen_return.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 /// Ecran de simulation du rachat LPP echelonne vs bloc.
@@ -438,7 +439,7 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
                   const SizedBox(height: MintSpacing.sm),
                   Row(
                     children: [
-                      Expanded(child: Slider(value: _manualTaux, min: 0.10, max: 0.45, divisions: 35, activeColor: MintColors.primary, onChanged: (v) { _manualTaux = v; _onInputChanged(); })),
+                      Expanded(child: MintCompactSlider(value: _manualTaux, min: 0.10, max: 0.45, divisions: 35, onChanged: (v) { _manualTaux = v; _onInputChanged(); })),
                       Semantics(
                         button: true,
                         label: l.rachatEchelonneAuto,
@@ -545,22 +546,14 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   }
 
   Widget _buildSliderRow({required String label, required double value, required double min, required double max, required int divisions, required String format, required ValueChanged<double> onChanged}) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-            Text(format, style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-          ],
-        ),
-        Semantics(
-          label: label,
-          value: format,
-          child: Slider(value: value, min: min, max: max, divisions: divisions, activeColor: MintColors.primary, onChanged: onChanged),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: (_) => format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
+++ b/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
@@ -19,6 +19,7 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'package:mint_mobile/services/financial_core/confidence_scorer.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 /// SharedPreferences key for the last time the user visited the Dossier tab.
@@ -1532,40 +1533,15 @@ class _CoachingPreferenceSheetState extends State<_CoachingPreferenceSheet> {
             ),
             const SizedBox(height: MintSpacing.lg),
 
-            // Intensity label
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  _intensityLabel(_pref.intensity),
-                  style: MintTextStyles.titleMedium(),
-                ),
-                Text(
-                  '${_pref.intensity}/5',
-                  style: MintTextStyles.bodyMedium(
-                    color: MintColors.textSecondary,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: MintSpacing.sm),
-
-            // Slider
-            SliderTheme(
-              data: SliderThemeData(
-                activeTrackColor: MintColors.primary,
-                inactiveTrackColor: MintColors.lightBorder,
-                thumbColor: MintColors.primary,
-                overlayColor: MintColors.primary.withValues(alpha: 0.1),
-                trackHeight: 3,
-              ),
-              child: Slider(
-                value: _pref.intensity.toDouble(),
-                min: 1,
-                max: 5,
-                divisions: 4,
-                onChanged: (v) => _save(v.round()),
-              ),
+            // Intensity slider
+            MintPremiumSlider(
+              label: _intensityLabel(_pref.intensity),
+              value: _pref.intensity.toDouble(),
+              min: 1,
+              max: 5,
+              divisions: 4,
+              formatValue: (v) => '${v.round()}/5',
+              onChanged: (v) => _save(v.round()),
             ),
 
             // Labels under slider

--- a/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
@@ -11,6 +11,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 
 /// Quick Start — single-screen onboarding that gets the user to the dashboard
 /// in under 30 seconds.
@@ -259,53 +260,30 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
                     const SizedBox(height: 22),
 
                     // ── Age slider ──
-                    _buildSliderLabel(
-                      l.quickStartAge,
-                      l.quickStartAgeValue(_age.round().toString()),
-                    ),
-                    Semantics(
+                    MintPremiumSlider(
                       label: l.quickStartAge,
-                      slider: true,
-                      value:
-                          l.quickStartAgeValue(_age.round().toString()),
-                      child: SliderTheme(
-                        data: _sliderTheme(),
-                        child: Slider(
-                          value: _age,
-                          min: 18,
-                          max: 75,
-                          divisions: 57,
-                          onChanged: (v) => setState(() => _age = v),
-                        ),
-                      ),
+                      value: _age,
+                      min: 18,
+                      max: 75,
+                      divisions: 57,
+                      formatValue: (v) =>
+                          l.quickStartAgeValue(v.round().toString()),
+                      onChanged: (v) => setState(() => _age = v),
                     ),
                     const SizedBox(height: MintSpacing.md),
 
                     // ── Revenu brut annuel slider ──
-                    _buildSliderLabel(
-                      l.quickStartSalary,
-                      _salary == 0
-                          ? l.quickStartNoIncome
-                          : l.quickStartSalaryValue(
-                              formatChfWithPrefix(_salary)),
-                    ),
-                    Semantics(
+                    MintPremiumSlider(
                       label: l.quickStartSalary,
-                      slider: true,
-                      value: _salary == 0
+                      value: _salary,
+                      min: 0,
+                      max: 500000,
+                      divisions: 100,
+                      formatValue: (v) => v == 0
                           ? l.quickStartNoIncome
                           : l.quickStartSalaryValue(
-                              formatChfWithPrefix(_salary)),
-                      child: SliderTheme(
-                        data: _sliderTheme(),
-                        child: Slider(
-                          value: _salary,
-                          min: 0,
-                          max: 500000,
-                          divisions: 100,
-                          onChanged: (v) => setState(() => _salary = v),
-                        ),
-                      ),
+                              formatChfWithPrefix(v)),
+                      onChanged: (v) => setState(() => _salary = v),
                     ),
                     const SizedBox(height: MintSpacing.md),
 
@@ -567,14 +545,4 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
     );
   }
 
-  SliderThemeData _sliderTheme() {
-    return SliderThemeData(
-      activeTrackColor: MintColors.primary,
-      inactiveTrackColor: MintColors.border,
-      thumbColor: MintColors.primary,
-      overlayColor: MintColors.primary.withValues(alpha: 0.12),
-      trackHeight: 4,
-      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
-    );
-  }
 }

--- a/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/pillar_3a_deep_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 
 /// Ecran comparateur de providers 3a (fintech / banque / assurance).
@@ -281,29 +282,14 @@ class _ProviderComparatorScreenState extends State<ProviderComparatorScreen> {
     required String format,
     required ValueChanged<double> onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-            Text(format, style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-          ],
-        ),
-        Semantics(
-          label: label,
-          value: format,
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            activeColor: MintColors.primary,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: (_) => format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
@@ -6,6 +6,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/pillar_3a_deep_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
@@ -254,41 +255,14 @@ class _RealReturnScreenState extends State<RealReturnScreen> {
     required String format,
     required ValueChanged<double> onChanged,
   }) {
-    return Semantics(
-      label: '$label: $format',
-      slider: true,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Flexible(
-                child: Text(label, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-              ),
-              Text(format, style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-            ],
-          ),
-          const SizedBox(height: MintSpacing.xs),
-          SliderTheme(
-            data: SliderTheme.of(context).copyWith(
-              activeTrackColor: MintColors.primary,
-              inactiveTrackColor: MintColors.border,
-              thumbColor: MintColors.primary,
-              overlayColor: MintColors.primary.withValues(alpha: 0.1),
-              trackHeight: 4,
-              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
-            ),
-            child: Slider(
-              value: value,
-              min: min,
-              max: max,
-              divisions: divisions,
-              onChanged: onChanged,
-            ),
-          ),
-        ],
-      ),
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: (_) => format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/pillar_3a_deep_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 
@@ -309,22 +310,14 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
     required String format,
     required ValueChanged<double> onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodySmall(color: MintColors.textPrimary)),
-            Text(format, style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700)),
-          ],
-        ),
-        Semantics(
-          label: label,
-          value: format,
-          child: Slider(value: value, min: min, max: max, divisions: divisions, activeColor: MintColors.primary, onChanged: onChanged),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: (_) => format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/lib/screens/simulator_leasing_screen.dart
+++ b/apps/mobile/lib/screens/simulator_leasing_screen.dart
@@ -5,6 +5,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/leasing_cost_widget.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
@@ -193,37 +194,14 @@ class _SimulatorLeasingScreenState extends State<SimulatorLeasingScreen> {
     required String Function(double) format,
     required void Function(double) onChanged,
   }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(label, style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)),
-            Text(
-              format(value),
-              style: MintTextStyles.bodyMedium(color: MintColors.primary).copyWith(fontWeight: FontWeight.w600),
-            ),
-          ],
-        ),
-        const SizedBox(height: MintSpacing.sm),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 4,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
-            activeTrackColor: MintColors.primary,
-            inactiveTrackColor: MintColors.border,
-            thumbColor: MintColors.primary,
-          ),
-          child: Slider(
-            value: value,
-            min: min,
-            max: max,
-            divisions: divisions,
-            onChanged: onChanged,
-          ),
-        ),
-      ],
+    return MintPremiumSlider(
+      label: label,
+      value: value,
+      min: min,
+      max: max,
+      divisions: divisions,
+      formatValue: format,
+      onChanged: onChanged,
     );
   }
 

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 
 // Screens under test
@@ -143,8 +144,8 @@ void main() {
       await tester.pumpWidget(buildTestable(const IndependantScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(find.text('Revenu net annuel'), findsOneWidget);
-      expect(find.byType(Slider), findsOneWidget);
+      expect(find.text('Revenu net annuel'), findsWidgets);
+      expect(find.byType(MintPremiumSlider), findsOneWidget);
     });
 
     testWidgets('shows PARCOURS INDEPENDANT in app bar', (tester) async {


### PR DESCRIPTION
## Summary
- **21 bare Slider()** across 18 files migrated to MintPremiumSlider
- **1 test** updated (IndependantScreen → checks MintPremiumSlider)
- **0 bare Colors.*** confirmed (epl_combined already used MintColors)
- Net -401 lines (SliderTheme boilerplate removed)

## Verification
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed
- [x] `grep " Slider(" screens/ | grep -v MintPremiumSlider` → 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)