### PR TITLE
feat(responsive): ConstrainedBox on 97 screens + 15 overflow fixes

### DIFF
--- a/apps/mobile/lib/screens/achievements_screen.dart
+++ b/apps/mobile/lib/screens/achievements_screen.dart
@@ -103,13 +103,13 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             style: MintTextStyles.headlineMedium(),
           ),
         ),
-        body: Center(
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
           child: Text(
             s.achievementsEmptyProfile,
             style: MintTextStyles.bodyMedium(),
             textAlign: TextAlign.center,
           ),
-        ),
+        ))),
       );
     }
 
@@ -132,7 +132,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -183,7 +183,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             ],
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/admin_analytics_screen.dart
+++ b/apps/mobile/lib/screens/admin_analytics_screen.dart
@@ -91,7 +91,7 @@ class _AdminAnalyticsScreenState extends State<AdminAnalyticsScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: _loading
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
           ? const Center(
               child: Padding(
                 padding: EdgeInsets.only(top: 60),
@@ -103,7 +103,7 @@ class _AdminAnalyticsScreenState extends State<AdminAnalyticsScreen> {
               : SingleChildScrollView(
                   padding: const EdgeInsets.all(MintSpacing.lg - 4),
                   child: _buildContent(l10n),
-                ),
+                ))),
     );
   }
 

--- a/apps/mobile/lib/screens/admin_observability_screen.dart
+++ b/apps/mobile/lib/screens/admin_observability_screen.dart
@@ -127,7 +127,7 @@ class _AdminObservabilityScreenState extends State<AdminObservabilityScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: _loading
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
           ? const Center(child: CircularProgressIndicator())
           : _error != null
               ? _buildError(l10n)
@@ -155,7 +155,7 @@ class _AdminObservabilityScreenState extends State<AdminObservabilityScreen> {
                       )),
                     ],
                   ),
-                ),
+                ))),
     );
   }
 

--- a/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
+++ b/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
@@ -75,7 +75,7 @@ class FinancialReportScreenV2 extends StatelessWidget {
           ),
         ],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -202,7 +202,7 @@ class FinancialReportScreenV2 extends StatelessWidget {
             const SizedBox(height: MintSpacing.xxl),
           ],
         ),
-      ),
+      ))),
     );
   }
 
@@ -840,10 +840,11 @@ class FinancialReportScreenV2 extends StatelessWidget {
               children: [
                 const Icon(Icons.verified_outlined, size: 20, color: MintColors.info),
                 const SizedBox(width: 8),
-                Text(
+                Flexible(child: Text(
                   S.of(context)!.reportSoaTitle,
                   style: MintTextStyles.headlineMedium(),
-                ),
+                  overflow: TextOverflow.ellipsis,
+                )),
               ],
             ),
             const SizedBox(height: 20),

--- a/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
@@ -165,7 +165,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── AppBar: white standard (Design System §4.5) ──
           SliverAppBar(
@@ -312,7 +312,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/arbitrage/arbitrage_bilan_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/arbitrage_bilan_screen.dart
@@ -34,7 +34,7 @@ class ArbitrageBilanScreen extends StatelessWidget {
     if (profile == null) {
       return Scaffold(
         appBar: AppBar(title: Text(S.of(context)!.arbitrageBilanTitle)),
-        body: Center(
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
           child: Padding(
             padding: const EdgeInsets.all(32),
             child: Column(
@@ -56,7 +56,7 @@ class ArbitrageBilanScreen extends StatelessWidget {
               ],
             ),
           ),
-        ),
+        ))),
       );
     }
 
@@ -64,7 +64,7 @@ class ArbitrageBilanScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── AppBar ──
           SliverAppBar(
@@ -155,7 +155,7 @@ class ArbitrageBilanScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
@@ -150,7 +150,7 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── SliverAppBar ──
           SliverAppBar(
@@ -323,7 +323,7 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -398,7 +398,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
         : _optionsAsAgeTrajectories(_result!.options);
 
     return Scaffold(
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── SliverAppBar (white standard — Simulator screen) ──
           SliverAppBar(
@@ -505,7 +505,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/ask_mint_screen.dart
+++ b/apps/mobile/lib/screens/ask_mint_screen.dart
@@ -88,9 +88,9 @@ class _AskMintScreenState extends State<AskMintScreen> {
           const SizedBox(width: 8),
         ],
       ),
-      body: byok.isConfigured
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: byok.isConfigured
           ? _buildChatInterface(s, byok)
-          : _buildConfigureCTA(s),
+          : _buildConfigureCTA(s))),
     );
   }
 
@@ -149,13 +149,14 @@ class _AskMintScreenState extends State<AskMintScreen> {
                 const Icon(Icons.lock_outline,
                     size: 14, color: MintColors.textMuted),
                 const SizedBox(width: 6),
-                Text(
+                Flexible(child: Text(
                   s.byokPrivacyShort,
                   style: const TextStyle(
                     fontSize: 12,
                     color: MintColors.textMuted,
                   ),
-                ),
+                  overflow: TextOverflow.ellipsis,
+                )),
               ],
             )),
           ],

--- a/apps/mobile/lib/screens/auth/forgot_password_screen.dart
+++ b/apps/mobile/lib/screens/auth/forgot_password_screen.dart
@@ -93,7 +93,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Form(
@@ -242,7 +242,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
             ),
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -55,7 +55,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Form(
@@ -250,10 +250,11 @@ class _LoginScreenState extends State<LoginScreen> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text(
+                    Flexible(child: Text(
                       l10n.authNoAccount,
                       style: MintTextStyles.bodyMedium(),
-                    ),
+                      overflow: TextOverflow.ellipsis,
+                    )),
                     const SizedBox(width: MintSpacing.sm),
                     TextButton(
                       onPressed: () {
@@ -285,7 +286,7 @@ class _LoginScreenState extends State<LoginScreen> {
             ),
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -102,7 +102,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Form(
@@ -610,7 +610,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
             ),
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/auth/verify_email_screen.dart
+++ b/apps/mobile/lib/screens/auth/verify_email_screen.dart
@@ -91,7 +91,7 @@ class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Column(
@@ -167,7 +167,7 @@ class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/bank_import_screen.dart
+++ b/apps/mobile/lib/screens/bank_import_screen.dart
@@ -54,7 +54,7 @@ class _BankImportScreenState extends State<BankImportScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(s),
           SliverToBoxAdapter(
@@ -133,7 +133,7 @@ class _BankImportScreenState extends State<BankImportScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/budget/budget_container_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_container_screen.dart
@@ -26,7 +26,7 @@ class BudgetContainerScreen extends StatelessWidget {
   Widget _buildEmptyState(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(S.of(context)!.budgetTitle)),
-      body: Center(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
         child: Padding(
           padding: const EdgeInsets.all(32.0),
           child: Column(
@@ -69,7 +69,7 @@ class BudgetContainerScreen extends StatelessWidget {
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -160,7 +160,7 @@ class _BudgetScreenState extends State<BudgetScreen>
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: Consumer<BudgetProvider>(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Consumer<BudgetProvider>(
         builder: (context, provider, child) {
           if (_hasError) {
             return Center(
@@ -420,7 +420,7 @@ class _BudgetScreenState extends State<BudgetScreen>
             ),
           );
         },
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/byok_settings_screen.dart
+++ b/apps/mobile/lib/screens/byok_settings_screen.dart
@@ -59,7 +59,7 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -114,7 +114,7 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
             const SizedBox(height: MintSpacing.xxl - 8),
           ],
         ),
-      ),
+      ))),
     );
   }
 
@@ -289,7 +289,7 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
         children: [
           const Icon(Icons.open_in_new, size: 14, color: MintColors.info),
           const SizedBox(width: 6),
-          Text(
+          Flexible(child: Text(
             s.byokGetKeyOn(label),
             style: MintTextStyles.bodySmall(
               color: MintColors.info,
@@ -297,7 +297,8 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
               decoration: TextDecoration.underline,
               decorationColor: MintColors.info,
             ),
-          ),
+            overflow: TextOverflow.ellipsis,
+          )),
         ],
       ),
     ),

--- a/apps/mobile/lib/screens/cantonal_benchmark_screen.dart
+++ b/apps/mobile/lib/screens/cantonal_benchmark_screen.dart
@@ -69,7 +69,7 @@ class _CantonalBenchmarkScreenState extends State<CantonalBenchmarkScreen> {
         : null;
 
     return Scaffold(
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -132,7 +132,7 @@ class _CantonalBenchmarkScreenState extends State<CantonalBenchmarkScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/annual_refresh_screen.dart
+++ b/apps/mobile/lib/screens/coach/annual_refresh_screen.dart
@@ -242,7 +242,7 @@ class _AnnualRefreshScreenState extends State<AnnualRefreshScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -283,7 +283,7 @@ class _AnnualRefreshScreenState extends State<AnnualRefreshScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 
@@ -667,7 +667,7 @@ class _AnnualRefreshScreenState extends State<AnnualRefreshScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -788,7 +788,7 @@ class _AnnualRefreshScreenState extends State<AnnualRefreshScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -2077,7 +2077,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: Column(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Column(
         children: [
           _buildAppBar(context),
           MintEntrance(child: _buildDisclaimer()),
@@ -2098,7 +2098,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
           if (_isLoading) _buildLoadingIndicator(),
           MintEntrance(delay: const Duration(milliseconds: 200), child: _buildInputBar()),
         ],
-      ),
+      ))),
     );
   }
 
@@ -2115,7 +2115,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
         backgroundColor: MintColors.primary,
         foregroundColor: MintColors.white,
       ),
-      body: Center(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: MintSpacing.xl),
           child: Column(
@@ -2146,7 +2146,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
@@ -454,7 +454,7 @@ Reponds uniquement avec le texte final.
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -466,7 +466,7 @@ Reponds uniquement avec le texte final.
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/cockpit_detail_screen.dart
+++ b/apps/mobile/lib/screens/coach/cockpit_detail_screen.dart
@@ -311,7 +311,7 @@ class _CockpitDetailScreenState extends State<CockpitDetailScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -483,7 +483,7 @@ class _CockpitDetailScreenState extends State<CockpitDetailScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 
@@ -515,7 +515,7 @@ class _CockpitDetailScreenState extends State<CockpitDetailScreen> {
   Widget _buildEmptyState() {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverFillRemaining(
@@ -558,7 +558,7 @@ class _CockpitDetailScreenState extends State<CockpitDetailScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/conversation_history_screen.dart
+++ b/apps/mobile/lib/screens/coach/conversation_history_screen.dart
@@ -77,7 +77,7 @@ class _ConversationHistoryScreenState extends State<ConversationHistoryScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── App Bar ──
           SliverAppBar(
@@ -137,7 +137,7 @@ class _ConversationHistoryScreenState extends State<ConversationHistoryScreen> {
               ),
             ),
         ],
-      ),
+      ))),
 
       // ── FAB: New conversation ──
       floatingActionButton: (!_isLoading && _error == null)

--- a/apps/mobile/lib/screens/coach/optimisation_decaissement_screen.dart
+++ b/apps/mobile/lib/screens/coach/optimisation_decaissement_screen.dart
@@ -25,7 +25,7 @@ class OptimisationDecaissementScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── AppBar white standard ──────────────────────────────
           SliverAppBar(
@@ -129,7 +129,7 @@ class OptimisationDecaissementScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart
+++ b/apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart
@@ -357,7 +357,7 @@ class _RetirementDashboardScreenState extends State<RetirementDashboardScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(profile.firstName),
           SliverPadding(
@@ -489,7 +489,7 @@ class _RetirementDashboardScreenState extends State<RetirementDashboardScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 
@@ -500,7 +500,7 @@ class _RetirementDashboardScreenState extends State<RetirementDashboardScreen> {
   Widget _buildStateC() {
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(null),
           SliverPadding(
@@ -520,7 +520,7 @@ class _RetirementDashboardScreenState extends State<RetirementDashboardScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/succession_patrimoine_screen.dart
+++ b/apps/mobile/lib/screens/coach/succession_patrimoine_screen.dart
@@ -28,7 +28,7 @@ class SuccessionPatrimoineScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── AppBar white standard ──────────────────────────────
           SliverAppBar(
@@ -207,7 +207,7 @@ class SuccessionPatrimoineScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/coach/weekly_recap_screen.dart
+++ b/apps/mobile/lib/screens/coach/weekly_recap_screen.dart
@@ -105,11 +105,11 @@ class _WeeklyRecapScreenState extends State<WeeklyRecapScreen> {
         ),
         centerTitle: false,
       ),
-      body: _loading
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
           ? const Center(child: CircularProgressIndicator())
           : _errorKey != null
               ? _buildEmpty(l)
-              : _buildContent(l),
+              : _buildContent(l))),
     );
   }
 

--- a/apps/mobile/lib/screens/confidence/confidence_dashboard_screen.dart
+++ b/apps/mobile/lib/screens/confidence/confidence_dashboard_screen.dart
@@ -103,7 +103,7 @@ class _ConfidenceDashboardScreenState extends State<ConfidenceDashboardScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -127,7 +127,7 @@ class _ConfidenceDashboardScreenState extends State<ConfidenceDashboardScreen>
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/consent_dashboard_screen.dart
+++ b/apps/mobile/lib/screens/consent_dashboard_screen.dart
@@ -137,7 +137,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
             style: MintTextStyles.headlineMedium(),
           ),
         ),
-        body: const Center(child: CircularProgressIndicator()),
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const Center(child: CircularProgressIndicator()))),
       );
     }
 
@@ -153,7 +153,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
             style: MintTextStyles.headlineMedium(),
           ),
         ),
-        body: Center(
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
           child: Container(
             padding: const EdgeInsets.all(MintSpacing.md),
             margin: const EdgeInsets.all(MintSpacing.lg),
@@ -175,7 +175,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
               ],
             ),
           ),
-        ),
+        ))),
       );
     }
 
@@ -194,7 +194,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -228,7 +228,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
             _buildSources(l10n),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/consumer_credit_screen.dart
+++ b/apps/mobile/lib/screens/consumer_credit_screen.dart
@@ -83,7 +83,7 @@ class _ConsumerCreditSimulatorScreenState extends State<ConsumerCreditSimulatorS
         // PDF export hidden — stub not yet implemented
         actions: const [],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -130,7 +130,7 @@ class _ConsumerCreditSimulatorScreenState extends State<ConsumerCreditSimulatorS
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/coverage_check_screen.dart
+++ b/apps/mobile/lib/screens/coverage_check_screen.dart
@@ -111,7 +111,7 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -152,7 +152,7 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -87,7 +87,7 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -149,7 +149,7 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/debt_prevention/help_resources_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/help_resources_screen.dart
@@ -29,7 +29,7 @@ class _HelpResourcesScreenState extends State<HelpResourcesScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.surface,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -92,7 +92,7 @@ class _HelpResourcesScreenState extends State<HelpResourcesScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/debt_risk_check_screen.dart
+++ b/apps/mobile/lib/screens/debt_risk_check_screen.dart
@@ -54,10 +54,10 @@ class _DebtRiskCheckScreenState extends State<DebtRiskCheckScreen> {
         title: Text(S.of(context)!.debtCheckTitle, style: MintTextStyles.headlineMedium()),
         actions: const [],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: _showResults ? _buildResults() : _buildQuestionnaire(),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/deces_proche_screen.dart
+++ b/apps/mobile/lib/screens/deces_proche_screen.dart
@@ -75,7 +75,7 @@ class _DecesProcheScreenState extends State<DecesProcheScreen> {
         elevation: 0,
         scrolledUnderElevation: 0,
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(20),
           child: Column(
@@ -114,7 +114,7 @@ class _DecesProcheScreenState extends State<DecesProcheScreen> {
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
+++ b/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
@@ -110,7 +110,7 @@ class _DemenagementCantonalScreenState
         foregroundColor: MintColors.textPrimary,
         elevation: 0,
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Column(
@@ -182,7 +182,7 @@ class _DemenagementCantonalScreenState
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/disability/disability_gap_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_gap_screen.dart
@@ -253,7 +253,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -303,7 +303,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_insurance_screen.dart
@@ -171,7 +171,7 @@ class _DisabilityInsuranceScreenState extends State<DisabilityInsuranceScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -203,7 +203,7 @@ class _DisabilityInsuranceScreenState extends State<DisabilityInsuranceScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
@@ -49,7 +49,7 @@ class _DisabilitySelfEmployedScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.redBgLight, // fond rouge très pale
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(),
           SliverPadding(
@@ -82,7 +82,7 @@ class _DisabilitySelfEmployedScreenState
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/divorce_simulator_screen.dart
+++ b/apps/mobile/lib/screens/divorce_simulator_screen.dart
@@ -196,7 +196,7 @@ class _DivorceSimulatorScreenState extends State<DivorceSimulatorScreen> {
           style: MintTextStyles.headlineMedium(color: MintColors.textPrimary),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         controller: _scrollController,
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
@@ -254,7 +254,7 @@ class _DivorceSimulatorScreenState extends State<DivorceSimulatorScreen> {
             const SizedBox(height: MintSpacing.xl + MintSpacing.sm),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/document_detail_screen.dart
+++ b/apps/mobile/lib/screens/document_detail_screen.dart
@@ -31,7 +31,7 @@ class DocumentDetailScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context, s),
           SliverToBoxAdapter(
@@ -43,7 +43,7 @@ class DocumentDetailScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
@@ -53,7 +53,7 @@ class _AvsGuideScreenState extends State<AvsGuideScreen> {
     final l = S.of(context)!;
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context, l),
           SliverPadding(
@@ -83,7 +83,7 @@ class _AvsGuideScreenState extends State<AvsGuideScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -143,7 +143,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: AnimatedBuilder(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: AnimatedBuilder(
         animation: Listenable.merge([_masterController, _pulseController]),
         builder: (context, _) {
           return SafeArea(
@@ -174,7 +174,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
             ),
           );
         },
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -78,7 +78,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -106,7 +106,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
@@ -49,7 +49,7 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -78,7 +78,7 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/documents_screen.dart
+++ b/apps/mobile/lib/screens/documents_screen.dart
@@ -96,7 +96,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
           const SizedBox(width: MintSpacing.sm),
         ],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -149,7 +149,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/donation_screen.dart
+++ b/apps/mobile/lib/screens/donation_screen.dart
@@ -163,7 +163,7 @@ class _DonationScreenState extends State<DonationScreen> {
       appBar: AppBar(
         title: Text(S.of(context)!.donationAppBarTitle),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         controller: _scrollController,
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
@@ -202,7 +202,7 @@ class _DonationScreenState extends State<DonationScreen> {
             const SizedBox(height: 40),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/education/comprendre_hub_screen.dart
+++ b/apps/mobile/lib/screens/education/comprendre_hub_screen.dart
@@ -27,7 +27,7 @@ class ComprendreHubScreen extends StatelessWidget {
         scrolledUnderElevation: 0,
         leading: const BackButton(color: MintColors.textPrimary),
       ),
-      body: ListView.builder(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView.builder(
         padding: const EdgeInsets.all(MintSpacing.lg),
         itemCount: EducationData.themes.length + 1, // +1 for header
         itemBuilder: (context, index) {
@@ -46,7 +46,7 @@ class ComprendreHubScreen extends StatelessWidget {
             child: _ThemeCard(theme: theme),
           );
         },
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/education/theme_detail_screen.dart
+++ b/apps/mobile/lib/screens/education/theme_detail_screen.dart
@@ -61,9 +61,9 @@ class _ThemeDetailScreenState extends State<ThemeDetailScreen>
       return Scaffold(
         backgroundColor: MintColors.background,
         appBar: AppBar(title: Text(S.of(context)!.themeInconnu)),
-        body: Center(
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Center(
           child: Text(S.of(context)!.themeInconnuBody),
-        ),
+        ))),
       );
     }
     final theme = rawTheme.localized(S.of(context));
@@ -71,7 +71,7 @@ class _ThemeDetailScreenState extends State<ThemeDetailScreen>
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── Compact colored header ──
           SliverAppBar(
@@ -138,17 +138,21 @@ class _ThemeDetailScreenState extends State<ThemeDetailScreen>
                                   color: MintColors.white, size: 28),
                             )),
                             const SizedBox(height: 12),
-                            MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
+                            Flexible(child: MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
                               theme.title,
                               style: MintTextStyles.headlineLarge(color: MintColors.white),
-                            )),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ))),
                             const SizedBox(height: MintSpacing.xs),
-                            MintEntrance(delay: const Duration(milliseconds: 200), child: Text(
+                            Flexible(child: MintEntrance(delay: const Duration(milliseconds: 200), child: Text(
                               theme.question,
                               style: MintTextStyles.bodyMedium(
                                 color: MintColors.white.withValues(alpha: 0.85),
                               ),
-                            )),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ))),
                           ],
                         ),
                       ),
@@ -218,7 +222,7 @@ class _ThemeDetailScreenState extends State<ThemeDetailScreen>
               ),
             ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/expert/expert_tier_screen.dart
+++ b/apps/mobile/lib/screens/expert/expert_tier_screen.dart
@@ -190,7 +190,7 @@ class _ExpertTierScreenState extends State<ExpertTierScreen> {
         ),
         centerTitle: true,
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: Column(
           children: [
             // Disclaimer banner — always visible (compliance).
@@ -215,7 +215,7 @@ class _ExpertTierScreenState extends State<ExpertTierScreen> {
             )),
           ],
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/famille_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/famille_hub_screen.dart
@@ -21,7 +21,7 @@ class FamilleHubScreen extends StatelessWidget {
         title: Text(l.exploreHubFamilleTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -87,7 +87,7 @@ class FamilleHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/fiscalite_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/fiscalite_hub_screen.dart
@@ -21,7 +21,7 @@ class FiscaliteHubScreen extends StatelessWidget {
         title: Text(l.exploreHubFiscaliteTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -87,7 +87,7 @@ class FiscaliteHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/logement_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/logement_hub_screen.dart
@@ -21,7 +21,7 @@ class LogementHubScreen extends StatelessWidget {
         title: Text(l.exploreHubLogementTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -99,7 +99,7 @@ class LogementHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/patrimoine_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/patrimoine_hub_screen.dart
@@ -21,7 +21,7 @@ class PatrimoineHubScreen extends StatelessWidget {
         title: Text(l.exploreHubPatrimoineTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -87,7 +87,7 @@ class PatrimoineHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/retraite_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/retraite_hub_screen.dart
@@ -21,7 +21,7 @@ class RetraiteHubScreen extends StatelessWidget {
         title: Text(l.exploreHubRetraiteTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -123,7 +123,7 @@ class RetraiteHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/sante_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/sante_hub_screen.dart
@@ -21,7 +21,7 @@ class SanteHubScreen extends StatelessWidget {
         title: Text(l.exploreHubSanteTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -87,7 +87,7 @@ class SanteHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/explore/travail_hub_screen.dart
+++ b/apps/mobile/lib/screens/explore/travail_hub_screen.dart
@@ -21,7 +21,7 @@ class TravailHubScreen extends StatelessWidget {
         title: Text(l.exploreHubTravailTitle, style: MintTextStyles.headlineMedium()),
         centerTitle: false,
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
           vertical: MintSpacing.md,
@@ -129,7 +129,7 @@ class TravailHubScreen extends StatelessWidget {
           ),
           const SizedBox(height: MintSpacing.xxl),
         ],
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -90,7 +90,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -203,7 +203,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/gender_gap_screen.dart
+++ b/apps/mobile/lib/screens/gender_gap_screen.dart
@@ -105,7 +105,7 @@ class _GenderGapScreenState extends State<GenderGapScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(MintSpacing.lg, MintSpacing.sm, MintSpacing.lg, MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -144,7 +144,7 @@ class _GenderGapScreenState extends State<GenderGapScreen> {
             const SizedBox(height: MintSpacing.xxl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/household/accept_invitation_screen.dart
+++ b/apps/mobile/lib/screens/household/accept_invitation_screen.dart
@@ -55,12 +55,12 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
         foregroundColor: MintColors.textPrimary,
         elevation: 0,
       ),
-      body: Padding(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Padding(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: _accepted
             ? _buildSuccess(context)
             : _buildForm(context, household),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/household/household_screen.dart
+++ b/apps/mobile/lib/screens/household/household_screen.dart
@@ -60,13 +60,13 @@ class _HouseholdScreenState extends State<HouseholdScreen> {
         elevation: 0,
         scrolledUnderElevation: 0,
       ),
-      body: !auth.isLoggedIn
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: !auth.isLoggedIn
           ? _buildLoginPrompt(context)
           : !sub.isPaid
               ? _buildUpsellCard(context)
               : household.isLoading && !household.hasHousehold
                   ? const Center(child: CircularProgressIndicator())
-                  : _buildContent(context, household),
+                  : _buildContent(context, household))),
     );
   }
 

--- a/apps/mobile/lib/screens/housing_sale_screen.dart
+++ b/apps/mobile/lib/screens/housing_sale_screen.dart
@@ -147,7 +147,7 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
       appBar: AppBar(
         title: Text(S.of(context)!.housingSaleAppBarTitle),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         controller: _scrollController,
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
@@ -228,7 +228,7 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
             const SizedBox(height: 40),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -103,7 +103,7 @@ class _IndependantScreenState extends State<IndependantScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -205,7 +205,7 @@ class _IndependantScreenState extends State<IndependantScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
+++ b/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
@@ -63,7 +63,7 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
         scrolledUnderElevation: 0,
         title: Text(s.avsCotisationsTitle, style: MintTextStyles.headlineMedium()),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.md),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,7 +88,7 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
             const SizedBox(height: MintSpacing.xxl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
@@ -81,7 +81,7 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -120,7 +120,7 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independants/ijm_screen.dart
+++ b/apps/mobile/lib/screens/independants/ijm_screen.dart
@@ -70,7 +70,7 @@ class _IjmScreenState extends State<IjmScreen> {
         scrolledUnderElevation: 0,
         title: Text(s.ijmTitle, style: MintTextStyles.headlineMedium()),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.md),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -101,7 +101,7 @@ class _IjmScreenState extends State<IjmScreen> {
             const SizedBox(height: 100),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -85,7 +85,7 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -118,7 +118,7 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -88,7 +88,7 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -119,7 +119,7 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/job_comparison_screen.dart
+++ b/apps/mobile/lib/screens/job_comparison_screen.dart
@@ -207,7 +207,7 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         controller: _scrollController,
         padding: const EdgeInsets.symmetric(
           horizontal: MintSpacing.lg,
@@ -354,7 +354,7 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/lamal_franchise_screen.dart
+++ b/apps/mobile/lib/screens/lamal_franchise_screen.dart
@@ -99,7 +99,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -149,7 +149,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
@@ -102,7 +102,7 @@ class _EplScreenState extends State<EplScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -165,7 +165,7 @@ class _EplScreenState extends State<EplScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/libre_passage_screen.dart
@@ -80,7 +80,7 @@ class _LibrePassageScreenState extends State<LibrePassageScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -180,7 +180,7 @@ class _LibrePassageScreenState extends State<LibrePassageScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -112,7 +112,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // ── White standard AppBar (Design System §4.5) ──
           SliverAppBar(
@@ -409,7 +409,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/mortgage/amortization_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/amortization_screen.dart
@@ -90,7 +90,7 @@ class _AmortizationScreenState extends State<AmortizationScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.all(MintSpacing.md),
         children: [
           // Intro pedagogique
@@ -124,7 +124,7 @@ class _AmortizationScreenState extends State<AmortizationScreen> {
           ),
           const SizedBox(height: MintSpacing.xl),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
@@ -98,7 +98,7 @@ class _ImputedRentalScreenState extends State<ImputedRentalScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.all(MintSpacing.md),
         children: [
           // Intro
@@ -128,7 +128,7 @@ class _ImputedRentalScreenState extends State<ImputedRentalScreen> {
           ),
           const SizedBox(height: MintSpacing.xl),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/mortgage/saron_vs_fixed_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/saron_vs_fixed_screen.dart
@@ -75,7 +75,7 @@ class _SaronVsFixedScreenState extends State<SaronVsFixedScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.all(MintSpacing.md),
         children: [
           // Chiffre choc
@@ -105,7 +105,7 @@ class _SaronVsFixedScreenState extends State<SaronVsFixedScreen> {
           ),
           const SizedBox(height: MintSpacing.xl),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/onboarding/chiffre_choc_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/chiffre_choc_screen.dart
@@ -192,8 +192,8 @@ class _ChiffreChocScreenState extends State<ChiffreChocScreen>
     final l10n = S.of(context)!;
 
     if (choc == null || profile == null) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const Center(child: CircularProgressIndicator()))),
       );
     }
 
@@ -203,7 +203,7 @@ class _ChiffreChocScreenState extends State<ChiffreChocScreen>
 
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg),
           child: Column(
@@ -396,7 +396,7 @@ class _ChiffreChocScreenState extends State<ChiffreChocScreen>
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 }

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -93,7 +93,7 @@ class _DataBlockEnrichmentScreenState
           style: MintTextStyles.titleMedium(color: MintColors.textPrimary).copyWith(fontSize: 18, fontWeight: FontWeight.w700),
         ),
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 24),
           child: Column(
@@ -181,7 +181,7 @@ class _DataBlockEnrichmentScreenState
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
@@ -190,7 +190,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
           },
         ),
       ),
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         top: false,
         child: Column(
           children: [
@@ -379,7 +379,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
             )),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/open_banking/consent_screen.dart
+++ b/apps/mobile/lib/screens/open_banking/consent_screen.dart
@@ -74,7 +74,7 @@ class _ConsentScreenState extends State<ConsentScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -119,7 +119,7 @@ class _ConsentScreenState extends State<ConsentScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/open_banking/open_banking_hub_screen.dart
+++ b/apps/mobile/lib/screens/open_banking/open_banking_hub_screen.dart
@@ -32,7 +32,7 @@ class OpenBankingHubScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -97,7 +97,7 @@ class OpenBankingHubScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/open_banking/transaction_list_screen.dart
+++ b/apps/mobile/lib/screens/open_banking/transaction_list_screen.dart
@@ -79,7 +79,7 @@ class _TransactionListScreenState extends State<TransactionListScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverPadding(
@@ -126,7 +126,7 @@ class _TransactionListScreenState extends State<TransactionListScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
@@ -82,7 +82,7 @@ class _ProviderComparatorScreenState extends State<ProviderComparatorScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -124,7 +124,7 @@ class _ProviderComparatorScreenState extends State<ProviderComparatorScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/real_return_screen.dart
@@ -83,7 +83,7 @@ class _RealReturnScreenState extends State<RealReturnScreen> {
         foregroundColor: MintColors.textPrimary,
         title: Text(l.realReturnTitle, style: MintTextStyles.headlineMedium()),
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.all(MintSpacing.md),
         children: [
           // Chiffre choc
@@ -114,7 +114,7 @@ class _RealReturnScreenState extends State<RealReturnScreen> {
           _buildDisclaimer(result.disclaimer),
           const SizedBox(height: MintSpacing.xl),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/retroactive_3a_screen.dart
@@ -91,7 +91,7 @@ class _Retroactive3aScreenState extends State<Retroactive3aScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             pinned: true,
@@ -144,7 +144,7 @@ class _Retroactive3aScreenState extends State<Retroactive3aScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -109,7 +109,7 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.surface,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           SliverAppBar(
             expandedHeight: 100,
@@ -155,7 +155,7 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/portfolio_screen.dart
+++ b/apps/mobile/lib/screens/portfolio_screen.dart
@@ -30,7 +30,7 @@ class PortfolioScreen extends StatelessWidget {
         backgroundColor: MintColors.white,
         surfaceTintColor: MintColors.white,
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -60,7 +60,7 @@ class PortfolioScreen extends StatelessWidget {
             const SizedBox(height: 100),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -38,7 +38,7 @@ class FinancialSummaryScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           if (profile == null)
@@ -46,7 +46,7 @@ class FinancialSummaryScreen extends StatelessWidget {
           else
             _buildContent(context, profile),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/profile_screen.dart
+++ b/apps/mobile/lib/screens/profile_screen.dart
@@ -44,7 +44,7 @@ class ProfileScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverToBoxAdapter(
@@ -120,7 +120,7 @@ class ProfileScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/pulse/pulse_screen.dart
+++ b/apps/mobile/lib/screens/pulse/pulse_screen.dart
@@ -823,7 +823,7 @@ class _PulseScreenState extends State<PulseScreen> {
     final l = S.of(context)!;
     return Scaffold(
       backgroundColor: MintColors.white,
-      body: SafeArea(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(MintSpacing.lg),
           child: Column(
@@ -870,7 +870,7 @@ class _PulseScreenState extends State<PulseScreen> {
             ],
           ),
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -175,7 +175,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
         title: Text(l.sim3aTitle, style: MintTextStyles.headlineMedium()),
         actions: const [],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -207,7 +207,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/simulator_compound_screen.dart
+++ b/apps/mobile/lib/screens/simulator_compound_screen.dart
@@ -80,7 +80,7 @@ class _SimulatorCompoundScreenState extends State<SimulatorCompoundScreen> {
         title: Text(S.of(context)!.compoundTitle, style: MintTextStyles.headlineMedium()),
         actions: const [],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -97,7 +97,7 @@ class _SimulatorCompoundScreenState extends State<SimulatorCompoundScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/simulator_leasing_screen.dart
+++ b/apps/mobile/lib/screens/simulator_leasing_screen.dart
@@ -73,7 +73,7 @@ class _SimulatorLeasingScreenState extends State<SimulatorLeasingScreen> {
         title: Text(S.of(context)!.leasingTitle, style: MintTextStyles.headlineMedium()),
         actions: const [],
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -98,7 +98,7 @@ class _SimulatorLeasingScreenState extends State<SimulatorLeasingScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/slm_settings_screen.dart
+++ b/apps/mobile/lib/screens/slm_settings_screen.dart
@@ -39,7 +39,7 @@ class SlmSettingsScreen extends StatelessWidget {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: ListView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: ListView(
         padding: const EdgeInsets.all(MintSpacing.md),
         children: [
           MintEntrance(child: _buildPrivacyBanner(context, l10n)),
@@ -52,7 +52,7 @@ class SlmSettingsScreen extends StatelessWidget {
           const SizedBox(height: MintSpacing.md),
           MintEntrance(delay: const Duration(milliseconds: 400), child: _buildInfoCard(context, slm, l10n)),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/timeline_screen.dart
+++ b/apps/mobile/lib/screens/timeline_screen.dart
@@ -290,7 +290,7 @@ class TimelineScreen extends StatelessWidget {
     final categories = _buildCategories(context);
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           _buildAppBar(context),
           SliverToBoxAdapter(child: _buildTimelineHeader(context)),
@@ -324,7 +324,7 @@ class TimelineScreen extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/tools_library_screen.dart
+++ b/apps/mobile/lib/screens/tools_library_screen.dart
@@ -524,7 +524,7 @@ class _ToolsLibraryScreenState extends State<ToolsLibraryScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.background,
-      body: CustomScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
         slivers: [
           // App Bar
           SliverAppBar(
@@ -630,7 +630,7 @@ class _ToolsLibraryScreenState extends State<ToolsLibraryScreen> {
             child: SizedBox(height: 100),
           ),
         ],
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/screens/unemployment_screen.dart
+++ b/apps/mobile/lib/screens/unemployment_screen.dart
@@ -108,7 +108,7 @@ class _UnemploymentScreenState extends State<UnemploymentScreen>
           style: MintTextStyles.headlineMedium(color: MintColors.textPrimary),
         ),
       ),
-      body: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.md, MintSpacing.lg, MintSpacing.lg,
         ),
@@ -163,7 +163,7 @@ class _UnemploymentScreenState extends State<UnemploymentScreen>
             const SizedBox(height: MintSpacing.xxl + MintSpacing.xl),
           ],
         ),
-      ),
+      ))),
     );
   }
 

--- a/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
+++ b/apps/mobile/lib/widgets/coach/avancement_hoirie_widget.dart
@@ -122,10 +122,11 @@ class AvancementHoirieWidget extends StatelessWidget {
             children: [
               Text('${recipient.emoji} ${recipient.name}', style: const TextStyle(fontSize: 16)),
               const SizedBox(width: 8),
-              Text(
+              Flexible(child: Text(
                 'reçoit donation : ${formatChfWithPrefix(donationAmount)}',
                 style: MintTextStyles.bodySmall(color: MintColors.primary).copyWith(fontWeight: FontWeight.w700),
-              ),
+                overflow: TextOverflow.ellipsis,
+              )),
             ],
           ),
           const SizedBox(height: 6),
@@ -162,10 +163,10 @@ class AvancementHoirieWidget extends StatelessWidget {
               padding: const EdgeInsets.only(bottom: 6),
               child: Row(
                 children: [
-                  Text('${e.value.emoji} ${e.value.name}', style: const TextStyle(fontSize: 14)),
+                  Flexible(child: Text('${e.value.emoji} ${e.value.name}', style: const TextStyle(fontSize: 14), overflow: TextOverflow.ellipsis)),
                   if (isRecipient) ...[
                     const SizedBox(width: 6),
-                    Container(
+                    Flexible(child: Container(
                       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                       decoration: BoxDecoration(
                         color: MintColors.scoreAttention.withValues(alpha: 0.15),
@@ -174,8 +175,9 @@ class AvancementHoirieWidget extends StatelessWidget {
                       child: Text(
                         '(déjà reçu ${formatChfWithPrefix(donationAmount)})',
                         style: MintTextStyles.micro(color: MintColors.scoreAttention).copyWith(fontWeight: FontWeight.w600),
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
+                    )),
                   ],
                   const Spacer(),
                   Text(

--- a/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
+++ b/apps/mobile/lib/widgets/coach/budget_sandwich_chart.dart
@@ -115,10 +115,11 @@ class BudgetSandwichChart extends StatelessWidget {
                         color: marginColor,
                       ),
                       const SizedBox(width: 6),
-                      Text(
+                      Flexible(child: Text(
                         '${isPositive ? "Marge" : "D\u00e9ficit"}\u00a0: ${formatChfWithPrefix(margin.abs())}/mois',
                         style: MintTextStyles.titleMedium(color: marginColor).copyWith(fontSize: 18, fontWeight: FontWeight.w800),
-                      ),
+                        overflow: TextOverflow.ellipsis,
+                      )),
                     ],
                   ),
                   const SizedBox(height: 4),

--- a/apps/mobile/lib/widgets/coach/crash_test_budget_widget.dart
+++ b/apps/mobile/lib/widgets/coach/crash_test_budget_widget.dart
@@ -119,14 +119,14 @@ class CrashTestBudgetWidget extends StatelessWidget {
               border: Border.all(color: MintColors.scoreCritique.withValues(alpha: 0.3)),
             ),
             child: Row(
-              mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(Icons.content_cut, color: MintColors.scoreCritique, size: 16),
                 const SizedBox(width: 6),
-                Text(
+                Flexible(child: Text(
                   'Tu économises CHF ${_fmt(saving)}/mois en mode survie',
                   style: MintTextStyles.bodySmall(color: MintColors.scoreCritique).copyWith(fontWeight: FontWeight.w700),
-                ),
+                  overflow: TextOverflow.ellipsis,
+                )),
               ],
             ),
           ),

--- a/apps/mobile/lib/widgets/coach/divorce_film_widget.dart
+++ b/apps/mobile/lib/widgets/coach/divorce_film_widget.dart
@@ -365,7 +365,8 @@ class DivorceFilmWidget extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(label, style: MintTextStyles.labelSmall(color: MintColors.textPrimary).copyWith(fontSize: 12)),
+          Flexible(child: Text(label, style: MintTextStyles.labelSmall(color: MintColors.textPrimary).copyWith(fontSize: 12), overflow: TextOverflow.ellipsis)),
+          const SizedBox(width: 8),
           Text(
             'CHF ${_fmt(amount)}/mois',
             style: MintTextStyles.labelSmall(color: MintColors.info).copyWith(fontSize: 12, fontWeight: FontWeight.w700),

--- a/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
+++ b/apps/mobile/lib/widgets/coach/net_proceeds_widget.dart
@@ -158,10 +158,12 @@ class _NetProceedsWidgetState extends State<NetProceedsWidget> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
+            Flexible(child: Text(
               'Prix de vente : ${formatChfWithPrefix(widget.salePrice)}',
               style: MintTextStyles.labelSmall(color: MintColors.textSecondary).copyWith(fontSize: 12),
-            ),
+              overflow: TextOverflow.ellipsis,
+            )),
+            const SizedBox(width: 8),
             Text(
               'Net : ${formatChfWithPrefix(_netProceeds)}',
               style: MintTextStyles.bodySmall(color: MintColors.scoreExcellent).copyWith(fontWeight: FontWeight.w800),

--- a/apps/mobile/lib/widgets/coach/prix_du_silence_widget.dart
+++ b/apps/mobile/lib/widgets/coach/prix_du_silence_widget.dart
@@ -116,10 +116,11 @@ class PrixDuSilenceWidget extends StatelessWidget {
         children: [
           const Icon(Icons.account_balance_outlined, color: MintColors.info, size: 18),
           const SizedBox(width: 10),
-          Text(
+          Flexible(child: Text(
             'Patrimoine transmis : CHF ${_fmt(patrimoine)}',
             style: MintTextStyles.bodyMedium(color: MintColors.info).copyWith(fontWeight: FontWeight.w700),
-          ),
+            overflow: TextOverflow.ellipsis,
+          )),
         ],
       ),
     );

--- a/apps/mobile/lib/widgets/premium/mint_premium_slider.dart
+++ b/apps/mobile/lib/widgets/premium/mint_premium_slider.dart
@@ -42,10 +42,12 @@ class MintPremiumSlider extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
+            Flexible(child: Text(
               label,
               style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
-            ),
+              overflow: TextOverflow.ellipsis,
+            )),
+            const SizedBox(width: 8),
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
               decoration: BoxDecoration(

--- a/apps/mobile/lib/widgets/premium/mint_signal_row.dart
+++ b/apps/mobile/lib/widgets/premium/mint_signal_row.dart
@@ -34,12 +34,16 @@ class MintSignalRow extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                label,
-                style: MintTextStyles.bodyMedium(
-                  color: MintColors.textSecondary,
+              Flexible(
+                child: Text(
+                  label,
+                  style: MintTextStyles.bodyMedium(
+                    color: MintColors.textSecondary,
+                  ),
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
+              const SizedBox(width: MintSpacing.sm),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/apps/mobile/lib/widgets/profile/hero_gap_card.dart
+++ b/apps/mobile/lib/widgets/profile/hero_gap_card.dart
@@ -112,12 +112,12 @@ class HeroGapCard extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _miniCard(s, s.heroGapToday, formatChf(currentMonthlyNet)),
+        Flexible(child: _miniCard(s, s.heroGapToday, formatChf(currentMonthlyNet))),
         const Padding(
           padding: EdgeInsets.symmetric(horizontal: 12),
           child: Icon(Icons.arrow_forward, color: MintColors.white70, size: 20),
         ),
-        _miniCard(s, s.heroGapRetirement, formatChf(projectedMonthlyRetirement)),
+        Flexible(child: _miniCard(s, s.heroGapRetirement, formatChf(projectedMonthlyRetirement))),
       ],
     );
   }
@@ -187,10 +187,11 @@ class HeroGapCard extends StatelessWidget {
         children: [
           const Icon(Icons.document_scanner, color: MintColors.white, size: 18),
           const SizedBox(width: 8),
-          Text(
+          Flexible(child: Text(
             s.heroGapScanCta,
             style: MintTextStyles.bodySmall(color: MintColors.white).copyWith(fontSize: 13, fontWeight: FontWeight.w500, decoration: TextDecoration.underline, decorationColor: MintColors.white70),
-          ),
+            overflow: TextOverflow.ellipsis,
+          )),
           if (confidenceBoostPercent != null) ...[
             const SizedBox(width: 8),
             Container(

--- a/apps/mobile/lib/widgets/report/retirement_projection_card.dart
+++ b/apps/mobile/lib/widgets/report/retirement_projection_card.dart
@@ -42,10 +42,11 @@ class RetirementProjectionCard extends StatelessWidget {
         // Replacement rate
         Row(
           children: [
-            Text(
+            Flexible(child: Text(
               'Taux de remplacement : ',
               style: MintTextStyles.bodySmall(color: MintColors.textSecondary).copyWith(fontSize: 12),
-            ),
+              overflow: TextOverflow.ellipsis,
+            )),
             Text(
               '${replacementRate.toStringAsFixed(0)}%',
               style: MintTextStyles.bodySmall(color: rateColor).copyWith(fontSize: 12, fontWeight: FontWeight.w700),

--- a/apps/mobile/lib/widgets/retirement/budget_gauge_widget.dart
+++ b/apps/mobile/lib/widgets/retirement/budget_gauge_widget.dart
@@ -185,10 +185,12 @@ class _BudgetGaugeWidgetState extends State<BudgetGaugeWidget>
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
+              Flexible(child: Text(
                 isSurplus ? 'Excedent mensuel' : 'Deficit mensuel',
                 style: MintTextStyles.bodyLarge(color: MintColors.textPrimary).copyWith(fontSize: 15, fontWeight: FontWeight.w700),
-              ),
+                overflow: TextOverflow.ellipsis,
+              )),
+              const SizedBox(width: 8),
               AnimatedBuilder(
                 animation: _fillAnimation,
                 builder: (context, _) {

--- a/apps/mobile/test/screens/document_scan_screen_test.dart
+++ b/apps/mobile/test/screens/document_scan_screen_test.dart
@@ -27,6 +27,13 @@ void main() {
     await tester.pumpWidget(_wrap(const DocumentScanScreen()));
     await tester.pumpAndSettle();
 
+    // Scroll down to reveal capture buttons (ConstrainedBox narrows content)
+    final scrollable = find.byType(Scrollable);
+    if (scrollable.evaluate().isNotEmpty) {
+      await tester.scrollUntilVisible(find.text('Prendre une photo'), 200, scrollable: scrollable.first);
+      await tester.pumpAndSettle();
+    }
+
     expect(find.text('Prendre une photo'), findsOneWidget);
     expect(find.text('Depuis la galerie'), findsOneWidget);
     expect(find.textContaining('MODE PROTOTYPE'), findsNothing);

--- a/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
@@ -104,7 +104,7 @@ void main() {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
-      await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -600));
       await tester.pump();
 
       // i18n: affordabilityParameters = "Tes hypotheses"


### PR DESCRIPTION
## Summary
- **97 screens** wrapped with `Center(child: ConstrainedBox(maxWidth: 600))` for tablet/web
- **15 widgets** fixed for Row overflow (Flexible + TextOverflow.ellipsis)
- **2 tests** adjusted for narrower layout (scroll offsets)

## Overflow fixes
crash_test_budget, mint_premium_slider, retirement_projection_card, financial_report_v2, ask_mint, login, byok_settings, avancement_hoirie, divorce_film, net_proceeds, prix_du_silence, budget_sandwich_chart, budget_gauge, hero_gap_card, theme_detail

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed (matches baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)