### PR TITLE
chore: Sprint 4 Governance — colors cleanup + docs sync

### DIFF
--- a/apps/mobile/lib/theme/colors.dart
+++ b/apps/mobile/lib/theme/colors.dart
@@ -9,8 +9,7 @@ class MintColors {
 
   
   // Selection / Highlight - Neutral & Premium
-  static const Color selectionBg = Color(0xFFF5F5F7); 
-  static const Color selectionBorder = Color(0xFF1D1D1F);
+  static const Color selectionBg = Color(0xFFF5F5F7);
   
   // Transparent
   static const Color transparent = Color(0x00000000);
@@ -19,8 +18,7 @@ class MintColors {
   static const Color background = Color(0xFFFFFFFF);
   static const Color appleSurface = Color(0xFFF5F5F7); 
   static const Color surface = Color(0xFFF5F5F7); 
-  static const Color cardGround = Color(0xFFFBFBFD);  static const Color glassBackground = Color(0xB3FFFFFF);
-  static const Color glassBorder = Color(0x33FFFFFF); 
+  static const Color cardGround = Color(0xFFFBFBFD);
   static const Color card = Color(0xFFFFFFFF);
   
   // Text
@@ -125,14 +123,10 @@ class MintColors {
   static const Color successionDark = Color(0xFF37474F); // Legal/succession header
   static const Color withdrawalOptim = Color(0xFF00695C); // Decaissement teal
   static const Color charcoal = Color(0xFF2D2D30); // Premium dark gradients
-  static const Color darkSurface = Color(0xFF2C2C2E); // Dark UI variant
 
   // Additional chart & visualization colors
-  static const Color emeraldDark = Color(0xFF059669); // alias categoryGreen
-  static const Color greenMaterial = Color(0xFF4CAF50); // alias centralScenario
   static const Color greenLight = Color(0xFFA5D6A7); // Light green segments
   static const Color blueDark = Color(0xFF1565C0); // Dark blue charts
-  static const Color blueLight = Color(0xFF0EA5E9); // Sky blue
   static const Color violetDeep = Color(0xFF9333EA); // Deep purple
   static const Color purpleDark = Color(0xFF6A1B9A); // Dark purple
   static const Color indigoDeep = Color(0xFF4338CA); // Deep indigo
@@ -140,12 +134,9 @@ class MintColors {
   static const Color roseDeep = Color(0xFFE91E63); // Rose/pink
   static const Color orangeMaterial = Color(0xFFF97316); // Orange-400
   static const Color amberLight = Color(0xFFFBBF24); // Amber-400
-  static const Color redMaterial = Color(0xFFF44336); // Material red
   static const Color redDark = Color(0xFFC62828); // Dark red
   static const Color redDeep = Color(0xFFE53935); // Deep red
   static const Color greenApple = Color(0xFF34C759); // iOS green
-  static const Color blueGoogle = Color(0xFF1A73E8); // Google blue
-  static const Color slateDark = Color(0xFF263238); // Blue-grey 900
 
   // Misc single-use (bank import, open banking, etc.)
   static const Color greyMedium = Color(0xFF9E9E9E); // Grey-500
@@ -156,7 +147,6 @@ class MintColors {
   static const Color ecruBg = Color(0xFFECEFF1); // Blue-grey 50
   static const Color indigoBg = Color(0xFFE8EAF6); // Indigo-50
   static const Color redBg = Color(0xFFFFCDD2); // Red-100
-  static const Color yellowLight = Color(0xFFFFEB3B); // Yellow-400
   static const Color yellowGold = Color(0xFFFFE082); // Amber-200
   static const Color amberWarm = Color(0xFFFFECB3); // Amber-100
   static const Color amberDark = Color(0xFF856404); // Dark amber text
@@ -177,18 +167,14 @@ class MintColors {
   static const Color purpleIos = Color(0xFF5856D6); // iOS purple
   static const Color darkNight = Color(0xFF1A1A2E); // Night dark
   static const Color darkDeep = Color(0xFF0D1117); // GitHub dark
-  static const Color darkApple = Color(0xFF1C1C1E); // Apple dark
   static const Color orangeFlat = Color(0xFFE67E22); // Orange flat-ui
   static const Color orangeNeon = Color(0xFFEE5A24); // Neon orange
-  static const Color orangeRetro = Color(0xFFFF6B35); // Retro orange
   static const Color pinkHot = Color(0xFFFF6482); // Hot pink
   static const Color redApple = Color(0xFFFF2D55); // Apple red
   static const Color greenDirect = Color(0xFF22C55E); // Green-500
   static const Color greenDark = Color(0xFF388E3C); // Green-700
-  static const Color greenBright2 = Color(0xFF34D058); // GitHub green
   static const Color greenMint = Color(0xFF32D74B); // iOS green mint
   static const Color greenClassic = Color(0xFF27AE60); // Flat green
-  static const Color greenForestMid = Color(0xFF2E7D5E); // Forest mid
   static const Color blueClassic = Color(0xFF2196F3); // Blue-500
   static const Color blueBright = Color(0xFF3B82F6); // Blue-500 tailwind
   static const Color tealDark = Color(0xFF004D40); // Teal-900
@@ -198,7 +184,6 @@ class MintColors {
   static const Color orangeSpice = Color(0xFFFFBE76); // Spice orange
   static const Color warningText = Color(0xFFF57F17); // Amber-900
   static const Color greyApple = Color(0xFF8E8E93); // Apple grey
-  static const Color greyNeutral = Color(0xFF9CA3AF); // Grey-400 cool
   static const Color redBgLight = Color(0xFFFFF1F1); // Very light red bg
   static const Color warningBgLight = Color(0xFFFFF3CD); // Warning banner bg
   static const Color warningBgWarm = Color(0xFFFEF3C7); // Warm warning bg
@@ -210,7 +195,6 @@ class MintColors {
   static const Color redWine = Color(0xFFCC3333); // Wine red
   static const Color redMedium = Color(0xFFD32F2F); // Material red-700
   static const Color greenPastel = Color(0xFF66BB6A); // Green-400
-  static const Color orangeFF = Color(0xFFFF9800); // Orange-500
   static const Color nearBlack = Color(0xFF0A0A0F); // Near-black overlay
   static const Color blueMaterial900 = Color(0xFF0D47A1); // Blue-900
 
@@ -220,17 +204,7 @@ class MintColors {
   static const Color white70 = Color(0xB3FFFFFF); // 70% white
   static const Color white60 = Color(0x99FFFFFF); // 60% white
   static const Color white54 = Color(0x8AFFFFFF); // 54% white
-  static const Color white38 = Color(0x61FFFFFF); // 38% white
   static const Color white30 = Color(0x4DFFFFFF); // 30% white
   static const Color white24 = Color(0x3DFFFFFF); // 24% white
-  static const Color black87 = Color(0xDD000000); // 87% black
-  static const Color black54 = Color(0x8A000000); // 54% black
-  static const Color black45 = Color(0x73000000); // 45% black
-  static const Color black26 = Color(0x42000000); // 26% black
-  static const Color black12 = Color(0x1F000000); // 12% black
 
-  // Landing / branding gradient
-  static const Color brandGreen = Color(0xFF1DB954); // Spotify-style green
-  static const Color brandGreenDark = Color(0xFF0A8F6C); // Dark brand green
-  static const Color landingSurface = Color(0xFFF5F6F7); // Landing page background
 }

--- a/docs/DOC_STATUS_MATRIX.md
+++ b/docs/DOC_STATUS_MATRIX.md
@@ -1,6 +1,6 @@
 # MINT Documentation Status Matrix
 
-> Created: 2026-03-21
+> Created: 2026-03-21 | Last reviewed: 2026-03-25
 > Purpose: Single-glance status of every doc — last update, accuracy vs code, what's drifted.
 > Update this file whenever a doc is significantly modified or when codebase diverges.
 
@@ -39,7 +39,7 @@
 
 | Document | Last Updated | Status | Sync with Code | Notes |
 |----------|-------------|--------|----------------|-------|
-| `docs/ROADMAP_V2.md` | 2026-03-21 | `current` | `synced` | Status column added; S51-S68 deliverables corrected vs actual code |
+| `docs/ROADMAP_V2.md` | 2026-03-25 | `current` | `synced` | Status column added; S51-S68 deliverables corrected vs actual code. Re-verified 2026-03-25. |
 | `docs/SPRINT_TRACKER.md` | 2026-03-17 | `partially outdated` | `minor drift` | Covers S0-S50 accurately; S51-S56 not listed (covered by ROADMAP_V2) |
 | `docs/P8_EXECUTION.md` | unknown | `not checked` | `not checked` | Billing invariants — not reviewed this session |
 | `docs/P6_BILLING_INVARIANTS.md` | unknown | `not checked` | `not checked` | Not reviewed this session |
@@ -50,7 +50,7 @@
 
 | Document | Last Updated | Status | Sync with Code | Notes |
 |----------|-------------|--------|----------------|-------|
-| `docs/NAVIGATION_GRAAL_V10.md` | 2026-03-21 | `current` | `synced` | §8, §9 routes verified against app.dart; destinations updated to DONE |
+| `docs/NAVIGATION_GRAAL_V10.md` | 2026-03-25 | `current` | `synced` | §8, §9 routes verified against app.dart; destinations updated to DONE. ScreenRegistry confirmed at 111 entries (2026-03-25). |
 | `docs/CHAT_TO_SCREEN_ORCHESTRATION_STRATEGY.md` | unknown | `partially outdated` | `minor drift` | ScreenRegistry and RoutePlanner exist in code; ReturnContract/ScreenReturn not confirmed in code |
 | `docs/APP_WEB_LONG_TERM_ARCHITECTURE.md` | unknown | `not checked` | `not checked` | Not reviewed this session |
 
@@ -60,9 +60,9 @@
 
 | Document | Last Updated | Status | Sync with Code | Notes |
 |----------|-------------|--------|----------------|-------|
-| `docs/DESIGN_SYSTEM.md` | unknown | `current` | `synced` | MintColors, MintTextStyles, MintSpacing, MintMotion all implemented. Outfit deprecated, MintGlassCard deprecated. |
+| `docs/DESIGN_SYSTEM.md` | 2026-03-25 | `partially outdated` | `minor drift` | MintColors, MintTextStyles, MintSpacing, MintMotion all implemented. MintSurface and MintLoadingSkeleton documented. MintEntrance and MintTextField exist in code (`widgets/premium/`) but are NOT documented in DESIGN_SYSTEM.md. Outfit deprecated, MintGlassCard deprecated. |
 | `docs/VOICE_SYSTEM.md` | unknown | `current` | `N/A` | Editorial guidelines — not code-dependent |
-| `docs/MINT_SCREEN_BOARD_101.md` | unknown | `partially outdated` | `minor drift` | Screen count may have changed. Not verified screen-by-screen this session |
+| `docs/MINT_SCREEN_BOARD_101.md` | 2026-03-25 | `current` | `synced` | 113 active surfaces verified against `find screens/ -name "*.dart"` (121 files, 8 helpers excluded). 3 screens added: weekly_recap, expert_tier, smart_onboarding. ScreenRegistry: 111 entries. |
 | `docs/UX_WIDGET_REDESIGN_MASTERPLAN.md` | unknown | `partially outdated` | `not checked` | 75 proposals — some implemented, status per-widget not tracked here |
 | `docs/UX_V2_COACH_CONVERSATIONNEL.md` | unknown | `significantly outdated` | `major drift` | Describes old 3-tab coach-centric UI. App moved to 4-tab shell with coach as one tab |
 | `docs/AUDIT_REPORT_2026-03-13.md` | 2026-03-13 | `partially outdated` | `minor drift` | Point-in-time audit. S52 closed many findings. |
@@ -75,7 +75,7 @@
 
 | Document | Last Updated | Status | Sync with Code | Notes |
 |----------|-------------|--------|----------------|-------|
-| `docs/BLUEPRINT_COACH_AI_LAYER.md` | 2026-03-21 (modified) | `partially outdated` | `minor drift` | References `coach_dashboard_screen.dart` (replaced by `CoachChatScreen`). Core architecture accurate. `route_to_screen` tool in `coach_tools.py` not verified. |
+| `docs/BLUEPRINT_COACH_AI_LAYER.md` | 2026-03-25 | `partially outdated` | `minor drift` | References `coach_dashboard_screen.dart` (replaced by `CoachChatScreen`). Agent loop (tool_use -> execute -> re-call LLM) implemented in `coach_chat.py` + `coach_tools.py` but not explicitly documented in blueprint. `structured_reasoning.py` with `ReasoningOutput` exists in code. `ReturnContract` listed as S58 task (§Tx) — not confirmed shipped. Core architecture accurate. |
 | `docs/MINT_CAP_ENGINE_SPEC.md` | unknown | `current` | `synced` | CapEngine + CapMemoryStore both implemented per spec |
 | `docs/CAPENGINE_IMPLEMENTATION_CHECKLIST.md` | unknown | `current` | `synced` | Phases 0-4 complete |
 

--- a/docs/MINT_SCREEN_BOARD_101.md
+++ b/docs/MINT_SCREEN_BOARD_101.md
@@ -1,12 +1,13 @@
-# MINT Screen Board 109
+# MINT Screen Board 113
 
 > Statut: board de référence pour la migration UX des surfaces MINT
 > Source: codebase actuel + `MINT_UX_GRAAL_MASTERPLAN.md`
 > Usage: savoir quel template appliquer à chaque écran et dans quel ordre le migrer
-> Périmètre: `109` surfaces actives (`105 *_screen.dart` + `4` shell/tabs)
+> Périmètre: `113` surfaces actives (`108 *_screen.dart` + `1 *_screen_v2.dart` + `4` shell/tabs)
 > Note: le label historique `101` reste un nom de chantier dans certains échanges, pas un décompte exact
 > Source de vérité: oui, pour le mapping `surface -> template -> priorité`
 > Ne couvre pas: logique métier détaillée, copy, navigation complète, contrats techniques
+> Dernière synchronisation: 2026-03-25 (121 fichiers .dart dans screens/, 8 helpers exclus)
 
 ---
 
@@ -122,6 +123,7 @@ Les templates maîtres et les behaviors d'orchestration sont deux axes orthogona
 | Aujourd'hui / Pulse | `pulse/pulse_screen.dart` | HP | T1-T5 | 8/10 | A | réponse inline — score, cap du jour |
 | Quick Start | `onboarding/quick_start_screen.dart` | RF | T1-T5 | 10/10 | — | onboarding, non routable depuis chat |
 | Chiffre-Choc | `onboarding/chiffre_choc_screen.dart` | HP | T1-T5 | 10/10 | — | non routable depuis chat |
+| Smart Onboarding | `onboarding/smart_onboarding_screen.dart` | RF | T6-B | — | — | 7-step value-first onboarding flow (Lot 2 + P8-2), non routable depuis chat |
 | Data Block Enrichment | `onboarding/data_block_enrichment_screen.dart` | RF | T6-A | — | D | capture, déclenché par readiness bloquante |
 | Score Reveal | `advisor/score_reveal_screen.dart` | HP | T6-A | — | — | non routable depuis chat |
 | Financial Report V2 | `advisor/financial_report_screen_v2.dart` | HP | T6-B | — | — | synthèse premium, billing-gated, doit rester un `Hero Plan` et jamais devenir un dump de données |
@@ -136,6 +138,7 @@ Les templates maîtres et les behaviors d'orchestration sont deux axes orthogona
 | Coach Check-in | `coach/coach_checkin_screen.dart` | RF | T6-B | — | D | mini-flow data, déclenché par coach |
 | Annual Refresh | `coach/annual_refresh_screen.dart` | RF | T6-B | — | D | refresh annuel, déclenché par coach |
 | Cockpit Detail | `coach/cockpit_detail_screen.dart` | HP | T6-B | — | A | réponse inline enrichie |
+| Weekly Recap | `coach/weekly_recap_screen.dart` | HP | T6-B | — | B | intent: `weekly_recap` — ajouté S59, uses MintSurface+MintEntrance |
 
 ## 3.4 Retraite / prévoyance
 
@@ -308,11 +311,11 @@ Le tableau de transactions reste accessible comme couche de preuve, jamais comme
 | Admin Observability | `admin_observability_screen.dart` | QU | T6-C | — | — | non routable depuis chat |
 | Admin Analytics | `admin_analytics_screen.dart` | QU | T6-C | — | — | non routable depuis chat |
 
-## 3.19 Futur / roadmap hors codebase
+## 3.19 Expert tier
 
 | Écran | Fichier | Template | Priorité | Score S52 | Behavior | Notes |
 |---|---|---:|---:|---:|---:|---|
-| Weekly Recap | `future` | HP | T-future | — | B | intent: `weekly_recap` — prévu en phase 2 roadmap, pas encore implémenté dans le codebase |
+| Expert Tier | `expert/expert_tier_screen.dart` | DC | T6-B | — | B | intent: `expert_tier` — 3 specialist types, dossier prep, Phase 3 feature |
 
 ---
 
@@ -379,4 +382,4 @@ Settings, admin, open banking, portfolio, timeline, tools legacy.
 4. Nettoyer les fuites i18n des écrans déjà refondus
 5. Migrer le long tail `T6-B`
 6. Fermer les utilitaires `T6-C`
-7. Screenshot board final des 109 surfaces actives
+7. Screenshot board final des 113 surfaces actives

--- a/docs/ROADMAP_V2.md
+++ b/docs/ROADMAP_V2.md
@@ -3,7 +3,7 @@
 > Date: March 2026 | Version: 2.1 | Production: v0.9.1
 > Based on: `visions/MINT_Analyse_Strategique_Benchmark.md` (40+ apps, 18 research themes)
 > Execution method: Autoresearch Dev Agents (`visions/MINT_Autoresearch_Dev_Agents.md`)
-> Last sync: 2026-03-21 — status column added, deliverables corrected against code
+> Last sync: 2026-03-25 — status column added, deliverables corrected against code
 
 ---
 
@@ -51,7 +51,7 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 | S53 | Gate Closer | `shipped` | Honesty clause enforcement, disability gap fixes, AVS couple caps (LAVS art. 35 applied correctly), all 18 life events coverage, LPP split logic | 13e rente AVS not found in codebase — not yet implemented |
 | S54 | Financial Health Score v1 | `shipped` | `FinancialHealthScoreService` (4-axis composite), `ScoreRevealScreen`, `StreakService` (with badges and milestones), `MilestoneV2Service`, achievements screen | FHS service exists and is functional; UI wiring to daily widget is partial |
 | S55 | North Star screens | `shipped` | `QuickStartScreen` V2, `RetirementDashboardScreen` V2, `LandingScreen` V10, `ScoreRevealScreen`, 12 screens redesigned to Hero Plan / Decision Canvas templates | Sprint label was "Streaks + 10 Milestones" in old roadmap — actual S55 was visual premium |
-| S56 | Chat Central | `shipped` | Claude API live (tool calling), `CoachOrchestrator`, `ContextInjectorService`, lightning menu wiring, `ProactiveTriggerService` (7 triggers), `RegionalVoiceService` (26 cantons), `RagRetrievalService` (FAQ fallback + cantonal context), `VoiceService` (stub backend + config), `WeeklyRecapService` (service layer), Dossier tab reorganization | RAG v2 file-based retrieval wired; vector store embedding pipeline not yet implemented. Voice service exists with stub backend — real STT/TTS not integrated |
+| S56 | Chat Central | `shipped` | Claude API live (tool calling), `CoachOrchestrator`, `ContextInjectorService`, lightning menu wiring, `ProactiveTriggerService` (7 triggers), `RegionalVoiceService` (26 cantons), `RagRetrievalService` (FAQ fallback + cantonal context), `VoiceService` (stub backend + config), `WeeklyRecapService` (service layer), `StructuredReasoningService` (reasoning/humanization split), Dossier tab reorganization, agent loop (tool_use -> execute -> re-call LLM) in `coach_chat.py`, 5 internal tools (`retrieve_memories`, `get_budget_status`, `get_retirement_projection`, `get_cross_pillar_analysis`, `get_cap_status`) | RAG v2 file-based retrieval wired; vector store embedding pipeline not yet implemented. Voice service exists with stub backend — real STT/TTS not integrated. Agent loop runs up to 5 iterations with 8K token budget |
 
 **KPIs Phase 1**: DAU/MAU > 25%, Retention J7 > 35%, Chat used by > 40% active users
 
@@ -70,7 +70,7 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 | Sprint | Objective | Status | What actually shipped | Notes |
 |--------|-----------|--------|-----------------------|-------|
 | S57 | Lifecycle Engine + ScreenRegistry + ReadinessGate | `shipped` | `LifecyclePhase` (7-phase enum), `LifecycleDetector`, `LifecycleContentService`, `LifecycleAdaptation`, `ScreenRegistry` (109 surfaces with intentTag/behavior/requiredFields), `ReadinessGate` (3 levels) | Lifecycle engine pure functions; content adaptation wiring to coach system prompt is partial |
-| S58 | AI Memory + RoutePlanner + ReturnContract | `foundation` | `RoutePlanner` service exists, `ScreenRegistry` complete, `GoalTrackerService` exists | `ReturnContract` / `ScreenReturn` model not found in codebase. `route_to_screen` tool in `coach_tools.py` not verified. Cross-session vector store not implemented |
+| S58 | AI Memory + RoutePlanner + ReturnContract | `shipped` | `ScreenReturn` model (V2 with completed/abandoned/changedInputs), `ScreenCompletionTracker` (realtime broadcast stream + SharedPreferences persistence), `ReturnContract` on 11 screens (rente_vs_capital, simulator_3a, staggered_withdrawal, affordability, rachat_echelonne, divorce, lamal_franchise, job_comparison, fiscal_comparator, disability_gap, budget), `CoachMemoryService` (cross-session insights), `MemoryReferenceService`, `RoutePlanner`, `route_to_screen` tool in coach_tools.py | Fully implemented. Realtime stream feeds coach chat immediately after simulation. Vector store memory not yet implemented |
 | S59 | Weekly Recap AI | `foundation` | `WeeklyRecapService` (service layer complete), `WeeklyRecapScreen` (screen exists at `/coach/weekly-recap`) | Screen is implemented but route in app.dart shows it as live; quality of generated content depends on BYOK |
 | S60 | Cantonal benchmarks | `shipped` | `CantonalBenchmarkService` (full 26-canton data), `CantonalBenchmarkScreen` at `/cantonal-benchmark`, no social comparison language | Service and screen fully implemented with compliance-safe language |
 | S61 | JITAI Proactive nudges | `shipped` | `JitaiNudgeService` (trigger engine), `ProactiveTriggerService` (7 triggers: lifecycle change, weekly recap, goal milestone, seasonal, inactivity, confidence improvement, new cap) | Nudge delivery to UI is partial — trigger logic complete, notification wiring depends on `NotificationService` |
@@ -92,12 +92,12 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 
 | Sprint | Objective | Status | What actually shipped | Notes |
 |--------|-----------|--------|-----------------------|-------|
-| S63 | Voice AI (STT+TTS) | `foundation` | `VoiceService` (class with stub backend), `VoiceConfig`, `VoiceChatIntegration`, `RegionalVoiceService` (26-canton flavor for system prompt) | Stub backend only — no real STT/TTS provider integrated. Regional voice flavor is for text coaching, not audio |
-| S64 | Multi-LLM redundancy | `foundation` | `MultiLlmService` (class with provider health tracking, Claude primary + GPT-4o fallback) | Service layer exists; production failover not verified. Local model for sensitive calcs not implemented |
-| S65 | Expert tier (human advisors) | `planned` | — | No advisor matching, dossier prep for human sessions, or scheduling implemented |
-| S66 | Advanced gamification | `planned` | — | Community challenge service exists as skeleton; cantonal leagues not implemented |
-| S67 | RAG v2 (comprehensive) | `foundation` | `RagRetrievalService` (3 document pools: concepts, cantons, FAQ; keyword-based scoring; source citations) | File-based keyword retrieval implemented. Vector embeddings not implemented. Document count: 45+ concepts, 26 cantonal docs (pending), 10 FAQ docs (pending) |
-| S68 | Agent autonome v1 | `planned` | — | No form pre-fill, letter generation, or fiscal dossier prep implemented |
+| S63 | Voice AI (STT+TTS) | `foundation` | `VoiceService` (class with stub backend), `VoiceConfig`, `VoiceChatIntegration`, `VoiceInputButton`, `VoiceOutputButton`, `VoiceStateMachine`, `PlatformVoiceBackend`, `RegionalVoiceService` (26-canton flavor for system prompt) | Stub backend only — no real STT/TTS provider integrated. Full UI widget layer (input/output buttons, state machine, platform backend) exists but wired to stub. Regional voice flavor is for text coaching, not audio |
+| S64 | Multi-LLM redundancy | `shipped` | `MultiLlmService` (Claude primary + GPT-4o fallback), `LlmFailoverService` (automatic failover with retry logic), `ProviderHealthService` (health tracking + circuit breaker), `ResponseQualityMonitor` (quality scoring + anomaly detection) — all with unit tests | Full failover stack implemented and tested. Local model for sensitive calcs not implemented |
+| S65 | Expert tier (human advisors) | `foundation` | `ExpertTierScreen` (UI), `AdvisorSpecialization` (enum), `AdvisorMatchingService`, `DossierPreparationService` (AI pre-filled dossier with compliance disclaimer), `SessionSchedulerService` — all with unit tests | Service layer complete. No real advisor marketplace or payment integration. Dossier generation is functional but untested with real specialist workflows |
+| S66 | Advanced gamification | `foundation` | `CommunityChallengeService` (community challenges by archetype), `SeasonalEventService` (time-based event triggers), `MilestoneV2Service` (achievement tracking with badges) | Service layer complete. Challenge completion UI wiring partial; cantonal leagues not implemented |
+| S67 | RAG v2 (comprehensive) | `foundation` | `RagRetrievalService` (3 document pools: concepts, cantons, FAQ; keyword-based scoring; source citations), backend: `HybridSearchService` (pgvector + PostgreSQL FTS, 0.7/0.3 score fusion), `KnowledgeCatalog` (full corpus registry), `FaqService` (FAQ retrieval), `CantonalKnowledge` (26-canton knowledge base), `KnowledgeUpdatePipeline` (freshness checks), `/knowledge/status` API endpoint — all with backend tests | Keyword retrieval live in production. pgvector hybrid search implemented but requires production PostgreSQL with pgvector extension. Backend RAG stack fully tested; vector embeddings pipeline ready but not activated in prod |
+| S68 | Agent autonome v1 | `foundation` | `AutonomousAgentService` (task generation with mandatory user validation, safe mode, audit log), `AgentValidationGate` (validation enforcement before any action), `FormPrefillService` (form pre-fill from profile), `LetterGenerationService` (letter drafts with placeholder fields) — validation gate, form prefill, and letter generation have unit tests | Service layer complete with compliance-safe design (all tasks require user validation). No end-to-end wiring to coach chat yet. AutonomousAgentService lacks dedicated test file |
 
 **KPIs Phase 3**: Retention M12 > 25%, NPS > 50, Revenue MRR > CHF 50K
 
@@ -162,7 +162,7 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 
 ---
 
-## ACTUAL CODEBASE STATE (2026-03-21)
+## ACTUAL CODEBASE STATE (2026-03-25)
 
 ### What is fully shipped and production-ready
 
@@ -170,27 +170,34 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 - 7 Explorer hubs with 60+ flows reachable
 - `CapEngine` (12-rule heuristic scoring) + `CapMemoryStore`
 - `CoachChatScreen` with Claude API + tool calling + compliance guard
+- Agent loop (tool_use -> execute -> re-call LLM, max 5 iterations, 8K token budget)
+- `StructuredReasoningService` (reasoning/humanization split)
+- 5 internal tools: `retrieve_memories`, `get_budget_status`, `get_retirement_projection`, `get_cross_pillar_analysis`, `get_cap_status`
 - `ConversationMemoryService` (cross-session persistence)
 - `FinancialHealthScoreService` (4-axis composite)
 - `StreakService` + `MilestoneV2Service` + `AchievementsScreen`
 - `LifecyclePhase` (7-phase enum) + `LifecycleDetector` + `LifecycleContentService`
 - `ScreenRegistry` (109 surfaces) + `ReadinessGate` + `RoutePlanner`
+- `ScreenReturn` model (V2) + `ScreenCompletionTracker` (realtime stream) on 11 screens
+- `CoachMemoryService` + `MemoryReferenceService`
 - `CantonalBenchmarkService` + `CantonalBenchmarkScreen`
 - `JitaiNudgeService` + `ProactiveTriggerService` (7 triggers)
 - `AdaptiveChallengeService` + `SeasonalEventService`
 - `RegionalVoiceService` (26 cantons — text prompt flavor, not audio)
 - `RagRetrievalService` (keyword-based, 3 doc pools)
-- `MultiLlmService` (Claude primary + fallback config)
+- `MultiLlmService` + `LlmFailoverService` + `ProviderHealthService` + `ResponseQualityMonitor`
 - `WeeklyRecapService` + `WeeklyRecapScreen`
 - `Retroactive3aCalculator` + `Retroactive3aScreen`
 - Financial core: 11 calculators (AVS, LPP, Tax, FRI, Monte Carlo, Arbitrage, Confidence, Withdrawal Sequencing, Tornado Sensitivity, Housing Cost, Coach Reasoner)
-- 110+ screens, 6428+ tests green, flutter analyze 0 errors
+- 110+ screens, 8101+ Flutter tests + 4787 backend tests green, flutter analyze 0 errors
 
 ### What is foundation / partial
 
-- Voice AI: `VoiceService` exists with stub backend — no real STT/TTS provider integrated
-- `ReturnContract` / `ScreenReturn` model: referenced in docs, not confirmed in code
-- RAG v2: keyword retrieval works; vector embeddings not implemented
+- Voice AI: `VoiceService`, `VoiceInputButton`, `VoiceOutputButton`, `VoiceStateMachine`, `PlatformVoiceBackend`, `VoiceChatIntegration` — full widget layer exists with stub backend, no real STT/TTS provider integrated
+- RAG v2 backend: `HybridSearchService` (pgvector + FTS), `KnowledgeCatalog`, `FaqService`, `CantonalKnowledge`, `KnowledgeUpdatePipeline` — all tested, pgvector not activated in production
+- Expert tier: `ExpertTierScreen`, `AdvisorMatchingService`, `DossierPreparationService`, `SessionSchedulerService` — service layer tested, no real advisor marketplace
+- Agent autonome: `AutonomousAgentService`, `AgentValidationGate`, `FormPrefillService`, `LetterGenerationService` — service layer exists, not wired to coach chat
+- Advanced gamification: `CommunityChallengeService`, `SeasonalEventService`, `MilestoneV2Service` — service layer complete, UI wiring partial
 - AI Memory vector store: `ConversationMemoryService` handles conversation history, not semantic cross-session recall
 - Weekly Recap content quality: depends on BYOK configuration
 - Notification delivery: `NotificationService` exists; full JITAI delivery pipeline not verified
@@ -198,12 +205,14 @@ Each agent follows the Karpathy loop: modify code, execute tests, measure metric
 ### What is planned (not started)
 
 - 13e rente AVS in calculator
-- Expert tier (human advisor matching)
-- Form pre-fill / autonomous agent (S68)
+- Real STT/TTS provider integration (S63 — widget layer ready, backend stub)
+- Local LLM for sensitive calculations (S64)
+- Real advisor marketplace + payment integration (S65)
+- Cantonal leagues (S66)
+- pgvector activation in production (S67 — code ready, infra pending)
+- Agent autonome wired to coach chat (S68)
 - Institutional API connections (S69+)
 - B2B white-label (S71+)
-- Real STT/TTS integration (S63)
-- Cantonal leagues and community features (S66)
 
 ---
 
@@ -264,4 +273,4 @@ Each phase activates specific agents. Agents run nightly (8h sessions) on dedica
 
 ---
 
-*This document is the strategic roadmap for MINT V2. Updated 2026-03-21 with status column reflecting actual code state. All sprint execution uses autoresearch dev agents as defined in `visions/MINT_Autoresearch_Dev_Agents.md`.*
+*This document is the strategic roadmap for MINT V2. Updated 2026-03-25 with status column reflecting actual code state. All sprint execution uses autoresearch dev agents as defined in `visions/MINT_Autoresearch_Dev_Agents.md`.*


### PR DESCRIPTION
## Summary
- **26 orphan color constants** removed from colors.dart (153 remaining, all actively used)
- **ROADMAP_V2.md** synced with actual code state — 8 sprint statuses corrected
- **MINT_SCREEN_BOARD_101.md** updated to 113 surfaces, 3 missing screens added
- **DOC_STATUS_MATRIX.md** refreshed — flagged DESIGN_SYSTEM.md and BLUEPRINT as minor drift

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)