### PR TITLE
fix: Zero debt round 2 — 10 MEDIUM findings closed

### DIFF
--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -6612,7 +6612,7 @@
   "affordabilityRelatedCalculate": "Calculate",
   "affordabilityAdvancedParams": "More assumptions",
   "demenagementTitreV2": "Moving cantons — how much do you save?",
-  "demenagementCtaOptimal": "Find the best canton for you",
+  "demenagementCtaOptimal": "Find the right canton for you",
   "demenagementInsightPositif": "This move boosts your purchasing power. The savings cover about {mois} months of average rent.",
   "@demenagementInsightPositif": {
     "placeholders": {
@@ -7062,7 +7062,7 @@
   "lamalFranchiseAppBarTitle": "LAMal Deductible",
   "lamalFranchiseDemoMode": "DEMO MODE",
   "lamalFranchiseHeaderTitle": "Your LAMal deductible",
-  "lamalFranchiseHeaderSubtitle": "Find the best deductible for your health costs",
+  "lamalFranchiseHeaderSubtitle": "Find the right deductible for your health costs",
   "lamalFranchiseIntro": "A higher deductible lowers your monthly premium but increases your out-of-pocket costs when you see a doctor. Adjust the sliders to find the right balance.",
   "lamalFranchiseToggleAdulte": "Adult",
   "lamalFranchiseToggleEnfant": "Child",
@@ -7510,7 +7510,7 @@
   "pillar3aIndepEduInvestirBody": "For a long horizon (>10 years), a 3a invested in equities can offer much higher returns than a classic 3a savings account.",
   "pillar3aIndepDisclaimer": "Tax savings are calculated based on the indicated marginal rate. The actual rate depends on your canton, municipality, and family situation. Consult a specialist for a personalized calculation.",
   "dividendeVsSalaireTitle": "Dividend vs Salary",
-  "dividendeVsSalaireHeaderInfo": "If you own an SA or Sàrl, you can pay yourself a combination of salary and dividends. Dividends are taxed at 50% (qualifying participation) and escape AVS contributions. Find the best-adapted split.",
+  "dividendeVsSalaireHeaderInfo": "If you own an SA or Sàrl, you can pay yourself a combination of salary and dividends. Dividends are taxed at 50% (qualifying participation) and escape AVS contributions. Find the right split for your situation.",
   "dividendeVsSalaireBenefice": "Total profit",
   "dividendeVsSalaireSliderMax500k": "CHF 500,000",
   "dividendeVsSalairePartSalaire": "Salary share",
@@ -7743,7 +7743,7 @@
       }
     }
   },
-  "providerComparatorChiffreChocSubtitle": "between the best and worst performing provider",
+  "providerComparatorChiffreChocSubtitle": "between the highest and lowest performing provider",
   "providerComparatorSectionParametres": "Parameters",
   "providerComparatorLabelAge": "Age",
   "providerComparatorLabelAgeFormat": "{age} yrs",
@@ -10824,7 +10824,7 @@
   "reportActionTitleAvsCheck": "Check your AVS account",
   "reportActionDescAvsCheck": "Avoid losing up to CHF\u00a038\u2019000 of lifetime pension.",
   "reportActionTitleDette": "Pay off your consumer debts",
-  "reportActionDescDette": "It\u2019s the best investment: you save 6-10\u00a0% per year on interest.",
+  "reportActionDescDette": "It\u2019s a highly effective step: you save 6-10\u00a0% per year on interest.",
   "reportActionTitleUrgence": "Build your emergency fund",
   "reportActionDescUrgence": "Aim for 3\u00a0months of expenses in a separate savings account.",
   "reportRoadmapPhaseImmediat": "Immediate",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -10542,7 +10542,7 @@
   "capCoverageCheckSeniorWhyNow": "Dopo i 50, il divario tra reddito e prestazioni AI\u00a0+\u00a0LPP pu\u00f2 superare il 40\u00a0%. Il tuo IJM copre il resto\u00a0?",
   "capCoverageCheckWhyNow": "IJM, AI, LPP invalidit\u00e0 \u2014 verifica che la tua rete regga.",
   "capCoverageCheckCtaLabel": "Verificare",
-  "capChomageHeadline": "Garantire i prossimi 90 giorni",
+  "capChomageHeadline": "Proteggere i prossimi 90 giorni",
   "capChomageWhyNow": "Disoccupato\u00a0: tre urgenze \u2014 i tuoi diritti AC, l\u2019impatto sul LPP e adeguare il budget.",
   "capChomageCtaLabel": "Vedere i miei diritti",
   "capChomageExpectedImpact": "stabilizzazione immediata",

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -13925,7 +13925,7 @@ class SEn extends S {
   String get demenagementTitreV2 => 'Moving cantons — how much do you save?';
 
   @override
-  String get demenagementCtaOptimal => 'Find the best canton for you';
+  String get demenagementCtaOptimal => 'Find the right canton for you';
 
   @override
   String demenagementInsightPositif(String mois) {
@@ -14591,7 +14591,7 @@ class SEn extends S {
 
   @override
   String get lamalFranchiseHeaderSubtitle =>
-      'Find the best deductible for your health costs';
+      'Find the right deductible for your health costs';
 
   @override
   String get lamalFranchiseIntro =>
@@ -15411,7 +15411,7 @@ class SEn extends S {
 
   @override
   String get dividendeVsSalaireHeaderInfo =>
-      'If you own an SA or Sàrl, you can pay yourself a combination of salary and dividends. Dividends are taxed at 50% (qualifying participation) and escape AVS contributions. Find the best-adapted split.';
+      'If you own an SA or Sàrl, you can pay yourself a combination of salary and dividends. Dividends are taxed at 50% (qualifying participation) and escape AVS contributions. Find the right split for your situation.';
 
   @override
   String get dividendeVsSalaireBenefice => 'Total profit';
@@ -15926,7 +15926,7 @@ class SEn extends S {
 
   @override
   String get providerComparatorChiffreChocSubtitle =>
-      'between the best and worst performing provider';
+      'between the highest and lowest performing provider';
 
   @override
   String get providerComparatorSectionParametres => 'Parameters';
@@ -22831,7 +22831,7 @@ class SEn extends S {
 
   @override
   String get reportActionDescDette =>
-      'It’s the best investment: you save 6-10 % per year on interest.';
+      'It’s a highly effective step: you save 6-10 % per year on interest.';
 
   @override
   String get reportActionTitleUrgence => 'Build your emergency fund';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -22160,7 +22160,7 @@ class SIt extends S {
   String get capCoverageCheckCtaLabel => 'Verificare';
 
   @override
-  String get capChomageHeadline => 'Garantire i prossimi 90 giorni';
+  String get capChomageHeadline => 'Proteggere i prossimi 90 giorni';
 
   @override
   String get capChomageWhyNow =>

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -22084,7 +22084,7 @@ class SPt extends S {
   String get capCoverageCheckCtaLabel => 'Verificar';
 
   @override
-  String get capChomageHeadline => 'Garantir os próximos 90 dias';
+  String get capChomageHeadline => 'Proteger os próximos 90 dias';
 
   @override
   String get capChomageWhyNow =>

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -10543,7 +10543,7 @@
   "capCoverageCheckSeniorWhyNow": "Depois dos 50, a lacuna entre rendimento e presta\u00e7\u00f5es AI\u00a0+\u00a0LPP pode ultrapassar 40\u00a0%. O teu IJM cobre o resto\u00a0?",
   "capCoverageCheckWhyNow": "IJM, AI, LPP invalidez \u2014 verifica que a tua rede aguenta.",
   "capCoverageCheckCtaLabel": "Verificar",
-  "capChomageHeadline": "Garantir os pr\u00f3ximos 90 dias",
+  "capChomageHeadline": "Proteger os pr\u00f3ximos 90 dias",
   "capChomageWhyNow": "Desempregado\u00a0: tr\u00eas urg\u00eancias \u2014 os teus direitos AC, o impacto no LPP e ajustar o or\u00e7amento.",
   "capChomageCtaLabel": "Ver os meus direitos",
   "capChomageExpectedImpact": "estabiliza\u00e7\u00e3o imediata",

--- a/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
@@ -4,6 +4,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
+import 'package:mint_mobile/services/financial_core/housing_cost_calculator.dart';
 import 'package:mint_mobile/services/financial_core/lpp_calculator.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
@@ -473,6 +474,7 @@ class ArbitrageEngine {
     double potentielRachatLpp = 0,
     bool isPropertyOwner = false,
     double tauxHypothecaire = 0.015,
+    double mortgageBalance = 0,
     int anneesAvantRetraite = 20,
     double rendement3a = 0.02,
     double rendementLpp = 0.0125,
@@ -539,6 +541,7 @@ class ArbitrageEngine {
         tauxMarginal: tauxMarginal,
         horizon: anneesAvantRetraite,
         startYear: startYear,
+        mortgageBalance: mortgageBalance,
       );
       options.add(TrajectoireOption(
         id: 'amort_indirect',
@@ -652,6 +655,7 @@ class ArbitrageEngine {
           tauxMarginal: variantTauxMarginal,
           horizon: anneesAvantRetraite,
           startYear: startYear,
+          mortgageBalance: mortgageBalance,
         );
         variantOptions.add(TrajectoireOption(
           id: 'amort_indirect',
@@ -906,7 +910,8 @@ class ArbitrageEngine {
       final interets = tempHyp * tauxHypotheque;
       final amortissement = prixBien * 0.01;
       final entretien = prixBien * tauxEntretien;
-      final valeurLocative = tempVal * 0.035;
+      final tauxVL = HousingCostCalculator.getValeurLocativeRate(canton);
+      final valeurLocative = tempVal * tauxVL;
       final netTaxableIncome = valeurLocative - interets;
       final taxImpact = netTaxableIncome > 0
           ? RetirementTaxCalculator.estimateMonthlyIncomeTax(
@@ -1457,19 +1462,35 @@ class ArbitrageEngine {
     final withdrawalPlan =
         <({String type, double amount, int age, double tax})>[];
 
+    // Group assets by withdrawal year to compute progressive tax on combined total.
+    final yearGroups = <int, List<RetirementAsset>>{};
     for (final asset in sortedAssets) {
-      final tax = RetirementTaxCalculator.capitalWithdrawalTax(
-        capitalBrut: asset.amount,
+      yearGroups.putIfAbsent(asset.earliestWithdrawalAge, () => []).add(asset);
+    }
+
+    for (final entry in yearGroups.entries) {
+      final age = entry.key;
+      final groupAssets = entry.value;
+      final groupTotal = groupAssets.fold<double>(0, (s, a) => s + a.amount);
+
+      // Compute progressive tax on the combined year total
+      final groupTax = RetirementTaxCalculator.capitalWithdrawalTax(
+        capitalBrut: groupTotal,
         canton: canton,
         isMarried: isMarried,
       );
-      totalTaxEtale += tax;
-      withdrawalPlan.add((
-        type: asset.type,
-        amount: asset.amount,
-        age: asset.earliestWithdrawalAge,
-        tax: tax,
-      ));
+      totalTaxEtale += groupTax;
+
+      // Split tax proportionally back to each asset
+      for (final asset in groupAssets) {
+        final share = groupTotal > 0 ? asset.amount / groupTotal : 0.0;
+        withdrawalPlan.add((
+          type: asset.type,
+          amount: asset.amount,
+          age: age,
+          tax: groupTax * share,
+        ));
+      }
     }
 
     final netEtale = totalCapital - totalTaxEtale;
@@ -1871,10 +1892,10 @@ class ArbitrageEngine {
         ));
         continue;
       }
-      // Add annual contribution
-      balance += montantAnnuel;
-      // Apply return
+      // Apply return on last year's balance first (consistent with LPP calculator)
       balance *= (1 + rendement);
+      // Then add this year's contribution
+      balance += montantAnnuel;
 
       // Tax saving from deduction
       final taxSaving = deductible ? montantAnnuel * tauxMarginal : 0.0;
@@ -1916,6 +1937,7 @@ class ArbitrageEngine {
     required double tauxMarginal,
     required int horizon,
     required int startYear,
+    double mortgageBalance = 0,
   }) {
     final snapshots = <YearlySnapshot>[];
     double balance3a = 0;
@@ -1939,8 +1961,11 @@ class ArbitrageEngine {
 
       // Tax benefits: 3a deduction + maintained mortgage interest deduction
       final taxSaving3a = contribution * tauxMarginal;
-      // Mortgage interest deduction maintained (not amortized directly)
-      final interestDeduction = contribution * tauxHypothecaire * tauxMarginal;
+      // Mortgage interest deduction maintained (full mortgage balance stays,
+      // since capital goes to 3a instead of direct amortization)
+      final interestDeduction = mortgageBalance > 0
+          ? mortgageBalance * tauxHypothecaire * tauxMarginal
+          : 0.0;
       final totalSaving = taxSaving3a + interestDeduction;
       cumulativeSaving += totalSaving;
 

--- a/apps/mobile/lib/services/financial_core/confidence_scorer.dart
+++ b/apps/mobile/lib/services/financial_core/confidence_scorer.dart
@@ -453,11 +453,21 @@ class ConfidenceScorer {
     // --- Composition menage ---
     final isCoupled = profile.etatCivil == CoachCivilStatus.marie ||
         profile.etatCivil == CoachCivilStatus.concubinage;
+    // Explicitly declared single/divorced/widowed: full points.
+    // Default celibataire (never explicitly set): partial points only (5),
+    // mirroring the logic in score().
+    final isExplicitlySingle = !isCoupled &&
+        (profile.etatCivil == CoachCivilStatus.divorce ||
+         profile.etatCivil == CoachCivilStatus.veuf);
     double menageScore;
     String menageStatus;
-    if (!isCoupled) {
+    if (isExplicitlySingle) {
       menageScore = _wMenage.toDouble();
       menageStatus = 'complete';
+    } else if (!isCoupled) {
+      // Default celibataire — not confirmed, give partial credit
+      menageScore = 5;
+      menageStatus = 'partial';
     } else if (profile.conjoint == null) {
       menageScore = 0;
       menageStatus = 'missing';

--- a/apps/mobile/lib/services/financial_core/housing_cost_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/housing_cost_calculator.dart
@@ -69,6 +69,14 @@ class HousingCostCalculator {
     'GL': 0.033,
   };
 
+  /// Look up the estimated valeur locative rate for a canton.
+  ///
+  /// Returns the cantonal rate if found, otherwise [defaultRate] (0.035).
+  /// Used by ArbitrageEngine for location-vs-propriete comparisons.
+  static double getValeurLocativeRate(String canton, {double defaultRate = 0.035}) {
+    return _tauxValeurLocative[canton.toUpperCase()] ?? defaultRate;
+  }
+
   /// Compute housing cost at retirement.
   ///
   /// Returns a [HousingCostResult] with the net monthly cost, fiscal impact,

--- a/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
+++ b/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
@@ -594,12 +594,12 @@ void main() {
       expect(blocs['objectifRetraite']!.score, 3.0); // default partial score
     });
 
-    test('compositionMenage is complete for single person', () {
+    test('compositionMenage is partial for default celibataire (unconfirmed)', () {
       final profile = _buildProfile(age: 45, salary: 8000, canton: 'VD');
       final blocs = ConfidenceScorer.scoreAsBlocs(profile);
-      // celibataire → complete
-      expect(blocs['compositionMenage']!.status, 'complete');
-      expect(blocs['compositionMenage']!.score, blocs['compositionMenage']!.maxScore);
+      // Default celibataire (not confirmed) → partial with 5 points
+      expect(blocs['compositionMenage']!.status, 'partial');
+      expect(blocs['compositionMenage']!.score, 5);
     });
 
     test('empty profile has zero score for missing blocs', () {
@@ -649,6 +649,7 @@ CoachProfile _buildProfile({
   int? anneesContribuees,
   int? arrivalAge,
   String? residencePermit,
+  CoachCivilStatus etatCivil = CoachCivilStatus.celibataire,
   Map<String, ProfileDataSource> dataSources = const {},
   Map<String, DateTime> dataTimestamps = const {},
   FinancialLiteracyLevel financialLiteracyLevel = FinancialLiteracyLevel.beginner,
@@ -668,7 +669,7 @@ CoachProfile _buildProfile({
     birthYear: DateTime.now().year - age,
     salaireBrutMensuel: salary,
     canton: canton,
-    etatCivil: CoachCivilStatus.celibataire,
+    etatCivil: etatCivil,
     employmentStatus: employmentStatus,
     arrivalAge: arrivalAge,
     residencePermit: residencePermit,

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -152,7 +152,7 @@ async def _get_orchestrator():
 # Patterns that indicate PII in memory_block content.
 _PII_PATTERNS = [
     re.compile(r"CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1}", re.IGNORECASE),  # IBAN
-    re.compile(r"\b\d{4}\b(?=\s+[A-Z])"),  # NPA (4-digit postal code before city)
+    re.compile(r"\b[1-9]\d{3}\b(?=\s+[A-Z]{2})"),  # NPA (Swiss postal code 1000-9999 before city name)
     re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"),  # email
     re.compile(r"\+?\d[\d\s]{8,14}\d"),  # phone numbers
 ]

--- a/services/backend/app/services/coach/structured_reasoning.py
+++ b/services/backend/app/services/coach/structured_reasoning.py
@@ -185,7 +185,7 @@ def _detect_deficit(profile: dict) -> Optional[ReasoningOutput]:
                     "Revoir les postes de dépenses pour identifier les marges "
                     "de réduction potentielles."
                 ),
-                intent_tag="budget_review",
+                intent_tag="budget_overview",
                 reasoning_trace=(
                     f"monthly_income={monthly_income} CHF, "
                     f"monthly_expenses={monthly_expenses} CHF, "
@@ -214,7 +214,7 @@ def _detect_deficit(profile: dict) -> Optional[ReasoningOutput]:
                 "Reconstituer une réserve de précaution d'au moins 3 mois "
                 "de charges avant tout autre investissement."
             ),
-            intent_tag="budget_review",
+            intent_tag="budget_overview",
             reasoning_trace=(
                 f"months_liquidity={months_liquidity:.1f} < seuil "
                 f"{_LIQUIDITY_DEFICIT_MONTHS} mois"
@@ -353,7 +353,7 @@ def _detect_gap_warning(profile: dict) -> Optional[ReasoningOutput]:
             "Explorer les leviers pour combler l'écart : versements 3a, "
             "rachat LPP, ou épargne libre selon la situation."
         ),
-        intent_tag="retirement_projection",
+        intent_tag="retirement_choice",
         reasoning_trace=(
             f"replacement_ratio={replacement_ratio:.2f} < "
             f"threshold={_REPLACEMENT_RATE_GAP_THRESHOLD:.2f}, "
@@ -410,7 +410,7 @@ def _detect_rachat_opportunity(profile: dict) -> Optional[ReasoningOutput]:
             "Vérifier le certificat de prévoyance pour confirmer le montant "
             "maximal de rachat et simuler l'impact fiscal."
         ),
-        intent_tag="lpp_rachat",
+        intent_tag="lpp_buyback",
         reasoning_trace=(
             f"lpp_buyback_max={lpp_buyback_max:.0f} CHF >= "
             f"min_threshold={_LPP_BUYBACK_MIN_CHF:.0f} CHF, "

--- a/services/backend/app/services/rag/llm_client.py
+++ b/services/backend/app/services/rag/llm_client.py
@@ -159,8 +159,21 @@ class LLMClient:
 
             text = "\n".join(text_parts)
 
+            # Extract actual token usage from the Anthropic response
+            actual_usage = None
+            if hasattr(response, "usage") and response.usage:
+                actual_usage = (
+                    response.usage.input_tokens + response.usage.output_tokens
+                )
+
             if tool_calls:
-                return {"text": text, "tool_calls": tool_calls}
+                result: dict = {"text": text, "tool_calls": tool_calls}
+                if actual_usage is not None:
+                    result["usage_tokens"] = actual_usage
+                return result
+            # Return dict with usage when available, plain string otherwise
+            if actual_usage is not None:
+                return {"text": text, "usage_tokens": actual_usage}
             return text
         except Exception as e:
             logger.error("Claude API call failed: %s", e)

--- a/services/backend/app/services/rag/orchestrator.py
+++ b/services/backend/app/services/rag/orchestrator.py
@@ -121,10 +121,12 @@ class RAGOrchestrator:
 
         # Step 5: Handle tool_use responses vs plain text
         tool_calls = None
+        actual_usage_tokens = None
         if isinstance(raw_response, dict):
-            # LLM returned structured response with tool calls
+            # LLM returned structured response (with tool calls and/or usage)
             response_text = raw_response.get("text", "")
             tool_calls = raw_response.get("tool_calls")
+            actual_usage_tokens = raw_response.get("usage_tokens")
         else:
             response_text = raw_response
 
@@ -142,10 +144,13 @@ class RAGOrchestrator:
                 sources.append(source)
         sources.extend(faq_sources)
 
-        # Estimate token usage (rough approximation)
-        tokens_used = self._estimate_tokens(
-            system_prompt, question, context_chunks, filtered["text"]
-        )
+        # Use actual API token usage when available, fall back to estimation
+        if actual_usage_tokens is not None:
+            tokens_used = actual_usage_tokens
+        else:
+            tokens_used = self._estimate_tokens(
+                system_prompt, question, context_chunks, filtered["text"]
+            )
 
         result = {
             "answer": filtered["text"],


### PR DESCRIPTION
## Summary
All 10 remaining MEDIUM audit findings closed. Zero audit debt.

### Calculator fixes
- **Valeur locative**: cantonal rate (2.8%-4.5%) instead of hardcoded 3.5%
- **Staggered withdrawal**: same-year assets now taxed together (progressive brackets)
- **Indirect amortization**: interest deduction uses mortgage balance, not contribution
- **Allocation trajectory**: return-before-contribution (consistent with LPP calculator)

### Confidence + Compliance
- **scoreAsBlocs**: unconfirmed celibataire gets 5/15 pts (partial), not full 15
- **English ARB**: 5 "best" → "right"/"highly effective" (banned absolute)
- **IT/PT ARB**: "Garantire"/"Garantir" → "Proteggere"/"Proteger"

### Backend
- **Intent tags**: structured_reasoning aligned to canonical coach_tools tags
- **NPA regex**: no longer redacts financial amounts (requires 2+ uppercase letters)
- **Token budget**: uses real Anthropic API usage instead of len/4 estimate

## Test plan
- [x] flutter analyze — 0 issues
- [x] flutter test — 8134 passed
- [x] pytest — 4438 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)