### PR TITLE
refactor: P2 hardcoded cleanup — retirement age, cantons, i18n, loading

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -10998,5 +10998,161 @@
   "employmentRetraite": "Pensioniert",
   "nationalitySuisse": "Schweiz",
   "nationalityEuAele": "EU/EFTA",
-  "nationalityAutre": "Andere"
+  "nationalityAutre": "Andere",
+
+  "stepStressTitle": "Was besch\u00e4ftigt dich am meisten?",
+  "stepStressSubtitle": "W\u00e4hle ein Thema \u2014 wir personalisieren dein Erlebnis.",
+  "stepStressRetirement": "Meine Pension",
+  "stepStressRetirementSub": "Werde ich genug zum Leben haben?",
+  "stepStressTaxes": "Meine Steuern",
+  "stepStressTaxesSub": "Zahle ich zu viel?",
+  "stepStressBudget": "Mein Budget",
+  "stepStressBudgetSub": "Wo geht mein Geld hin?",
+  "stepStressWealth": "Mein Verm\u00f6gen",
+  "stepStressWealthSub": "Wie kann ich es vermehren?",
+  "stepStressCouple": "Als Paar",
+  "stepStressCoupleSub": "Gemeinsam optimieren",
+  "stepStressCurious": "Einfach neugierig",
+  "stepStressCuriousSub": "Ich m\u00f6chte meine Situation verstehen",
+  "stepStressDisclaimer": "Bildungstool \u2014 stellt keine Finanzberatung dar (FIDLEG).",
+
+  "stepNextTitle": "Deine erste Bilanz ist bereit",
+  "stepNextConfidence": "Aktuelle Genauigkeit: {pct}\u00a0%. Je mehr du dein Profil erg\u00e4nzt, desto zuverl\u00e4ssiger die Projektionen.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Mein Profil verfeinern",
+  "stepNextDashboard": "Mein Dashboard ansehen",
+  "stepNextCheckin": "Meinen ersten Check-in machen",
+  "stepNextDisclaimer": "Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG). Quellen: AHVG Art. 34, BVG Art. 14-16, BVV3 Art. 7.",
+
+  "stepTopActionsTitle": "Deine 3 wichtigsten Aktionen",
+  "stepTopActionsSubtitle": "Basierend auf deiner Situation, hier ist der Anfang.",
+  "stepTopActionsEmpty": "Erg\u00e4nze dein Profil, um personalisierte Aktionen zu erhalten.",
+  "stepTopActionsContinue": "Weiter",
+  "stepTopActionsBack": "Zur\u00fcck",
+  "stepTopActionsImpact": "Gesch\u00e4tzter Impact: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Bildungsvorschl\u00e4ge. Stellt keine Finanzberatung dar (FIDLEG). Konsultiere eine Fachperson f\u00fcr einen individuellen Plan.",
+
+  "stepChocConfidenceInfo": "Sch\u00e4tzung basierend auf {count} Angaben. Je genauer du bist, desto zuverl\u00e4ssiger.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Genauigkeit: {pct}\u00a0%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "Um deine Beratung zu personalisieren",
+  "stepChocLiteracySubtitle": "3 kurze Fragen \u2014 keine richtige oder falsche Antwort.",
+  "stepChocLiteracyLpp": "Ich kenne den Betrag meines BVG-Guthabens",
+  "stepChocLiteracyConversion": "Ich weiss, was der Umwandlungssatz ist",
+  "stepChocLiteracy3a": "Ich habe bereits auf ein 3a-Konto eingezahlt",
+  "stepChocYes": "Ja",
+  "stepChocNo": "Nein",
+  "stepChocAction": "Was kann ich tun?",
+  "stepChocEnrich": "Mein Profil verfeinern",
+  "stepChocDashboard": "Mein Dashboard ansehen",
+  "stepChocDisclaimer": "Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG). Quellen: AHVG Art. 34, BVG Art. 14-16, BVV3 Art. 7.",
+
+  "stepJitTitle": "In 30 Sekunden verstehen",
+  "stepJitSi": "WENN",
+  "stepJitAlors": "DANN",
+  "stepJitAction": "Was kann ich tun?",
+  "stepJitBack": "Zur\u00fcck",
+  "stepJitDisclaimer": "Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG).",
+  "stepJitLiquidityCond": "deine Notfallersparnisse weniger als 2 Monate Ausgaben decken",
+  "stepJitLiquidityCons": "ein unerwartetes Ereignis (Jobverlust, dringende Reparatur) kann dich schnell in finanzielle Schwierigkeiten bringen.",
+  "stepJitLiquidityInsight": "Experten empfehlen 3 bis 6 Monate Fixkosten als Reserve. Selbst CHF 100/Monat auf einem Sparkonto machen \u00fcber 12 Monate einen erheblichen Unterschied.",
+  "stepJitLiquiditySource": "Empfehlung Budgetberatung Schweiz",
+  "stepJitRetirementCond": "deine Ersatzquote bei der Pensionierung unter 60\u00a0% liegt",
+  "stepJitRetirementCons": "dein Lebensstandard k\u00f6nnte erheblich sinken, wenn du aufh\u00f6rst zu arbeiten.",
+  "stepJitRetirementInsight": "In der Schweiz decken AHV und BVG durchschnittlich 60\u00a0% des letzten Gehalts. Die 3. S\u00e4ule und freies Sparen \u00fcberbr\u00fccken den Rest. Je fr\u00fcher du anf\u00e4ngst, desto geringer der monatliche Aufwand.",
+  "stepJitRetirementSource": "AHVG Art. 34 / BVG Art. 14",
+  "stepJitTax3aCond": "du nicht den Maximalbetrag in deine 3. S\u00e4ule einzahlst",
+  "stepJitTax3aCons": "du verpasst eine Steuerersparnis und zus\u00e4tzliches Alterskapital.",
+  "stepJitTax3aInsight": "Jeder in die S\u00e4ule 3a eingezahlte Franken ist steuerlich absetzbar. \u00dcber 20 Jahre kann der Unterschied zwischen 0 und dem Maximum (CHF 7'258) mehr als CHF 200'000 betragen.",
+  "stepJitTax3aSource": "BVV3 Art. 7 / DBG Art. 33",
+  "stepJitIncomeCond": "dein prognostiziertes Einkommen im Ruhestand gesch\u00e4tzt wird",
+  "stepJitIncomeCons": "diesen Betrag zu kennen erm\u00f6glicht dir, deine Vorsorgestrategie jetzt zu planen und anzupassen.",
+  "stepJitIncomeInsight": "Das Schweizer 3-S\u00e4ulen-System (AHV + BVG + 3a) deckt durchschnittlich 60\u00a0% des letzten Gehalts. Jede S\u00e4ule hat eigene Regeln und spezifische Optimierungshebel.",
+  "stepJitIncomeSource": "AHVG Art. 34 / BVG Art. 14 / BVV3 Art. 7",
+  "stepJitDefaultCond": "du noch keinen strukturierten Finanzplan hast",
+  "stepJitDefaultCons": "du riskierst, Steuer- und Vorsorge-Optimierungen zu verpassen.",
+  "stepJitDefaultInsight": "Eine j\u00e4hrliche Finanzbilanz identifiziert die wirkungsvollsten Hebel: 3a, BVG-Einkauf, Krankenkassen-Franchise, indirekte Amortisation.",
+  "stepJitDefaultSource": "MINT Bildungsempfehlung",
+
+  "stepOcrTitle": "Profil in 30 Sekunden anreichern",
+  "stepOcrSkip": "Ohne Dokument fortfahren",
+  "stepOcrIntro": "Scanne ein oder mehrere Dokumente, damit MINT deine Situation genauer berechnen kann.",
+  "stepOcrLppTitle": "Dein BVG-Pensionsschreiben",
+  "stepOcrLppSubtitle": "Guthaben, Umwandlungssatz, Einkaufsl\u00fccke",
+  "stepOcrLppBoost": "+27 Genauigkeitspunkte",
+  "stepOcrAvsTitle": "Dein AHV-Auszug",
+  "stepOcrAvsSubtitle": "Beitragsjahre, L\u00fccken, RAMD",
+  "stepOcrAvsBoost": "+22 Genauigkeitspunkte",
+  "stepOcrTaxTitle": "Deine Steuererkl\u00e4rung",
+  "stepOcrTaxSubtitle": "Steuerbares Einkommen, Verm\u00f6gen, Grenzsteuersatz",
+  "stepOcrTaxBoost": "+17 Genauigkeitspunkte",
+  "stepOcr3aTitle": "Dein 3a-Konto",
+  "stepOcr3aSubtitle": "Saldo, kumulierte Einzahlungen, Rendite",
+  "stepOcr3aBoost": "+7 Genauigkeitspunkte",
+  "stepOcrScanned": "Gescannt",
+  "stepOcrContinueWith": "Weiter ({count} Dokument{plural} gescannt)",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Ohne Dokument fortfahren",
+  "stepOcrDisclaimer": "Bildungstool \u2014 stellt keine Finanzberatung dar (FIDLEG). Dokumente werden auf deinem Ger\u00e4t verarbeitet, keine Daten gesendet (DSG Art. 6).",
+  "stepOcrLpdBanner": "Deine Dokumente werden auf deinem Ger\u00e4t verarbeitet. Nichts wird ins Internet gesendet.",
+  "stepOcrLpdTitle": "Private Verarbeitung auf deinem Ger\u00e4t",
+  "stepOcrLpdBody": "Dieses Dokument wird direkt auf deinem Telefon analysiert.\nKeine Daten werden \u00fcbers Internet gesendet.\nExtrahierte Informationen werden nach der Verarbeitung gel\u00f6scht.",
+  "stepOcrLpdLegal": "Rechtsgrundlage: DSG Art. 6 \u2014 Datenminimierung.",
+  "stepOcrLpdScan": "Dieses Dokument scannen",
+  "stepOcrLpdCancel": "Abbrechen",
+  "stepOcrSnackSuccess": "{count} Feld{plural} erfolgreich extrahiert",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Dokument verarbeitet \u2014 kein Feld automatisch erkannt",
+  "stepOcrSnackError": "Verarbeitungsfehler: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Bildscan im Web nicht verf\u00fcgbar. Nutze die mobile App oder importiere eine .txt-Datei.",
+
+  "stepQuestionsAgeYears": "{age} Jahre",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "Vereinigte Staaten",
+  "stepQuestionsCountryGb": "Vereinigtes K\u00f6nigreich",
+  "stepQuestionsCountryCa": "Kanada",
+  "stepQuestionsCountryIn": "Indien",
+  "stepQuestionsCountryCn": "China",
+  "stepQuestionsCountryBr": "Brasilien",
+  "stepQuestionsCountryAu": "Australien",
+  "stepQuestionsCountryJp": "Japan",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11026,5 +11026,161 @@
   "employmentRetraite": "Retired",
   "nationalitySuisse": "Swiss",
   "nationalityEuAele": "EU/EFTA",
-  "nationalityAutre": "Other"
+  "nationalityAutre": "Other",
+
+  "stepStressTitle": "What concerns you most?",
+  "stepStressSubtitle": "Pick a topic \u2014 we'll personalise your experience.",
+  "stepStressRetirement": "My retirement",
+  "stepStressRetirementSub": "Will I have enough to live on?",
+  "stepStressTaxes": "My taxes",
+  "stepStressTaxesSub": "Am I paying too much?",
+  "stepStressBudget": "My budget",
+  "stepStressBudgetSub": "Where does my money go?",
+  "stepStressWealth": "My wealth",
+  "stepStressWealthSub": "How can I grow it?",
+  "stepStressCouple": "As a couple",
+  "stepStressCoupleSub": "Optimise together",
+  "stepStressCurious": "Just curious",
+  "stepStressCuriousSub": "I want to understand my situation",
+  "stepStressDisclaimer": "Educational tool \u2014 does not constitute financial advice (FinSA).",
+
+  "stepNextTitle": "Your first assessment is ready",
+  "stepNextConfidence": "Current accuracy: {pct}%. The more you complete your profile, the more reliable the projections.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Refine my profile",
+  "stepNextDashboard": "View my dashboard",
+  "stepNextCheckin": "Do my first check-in",
+  "stepNextDisclaimer": "Simplified educational tool. Does not constitute financial advice (FinSA). Sources: OASI art. 34, BVG art. 14-16, BVV3 art. 7.",
+
+  "stepTopActionsTitle": "Your 3 priority actions",
+  "stepTopActionsSubtitle": "Based on your situation, here is where to start.",
+  "stepTopActionsEmpty": "Complete your profile to receive personalised actions.",
+  "stepTopActionsContinue": "Continue",
+  "stepTopActionsBack": "Back",
+  "stepTopActionsImpact": "Estimated impact: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Educational suggestions. Does not constitute financial advice (FinSA). Consult a specialist for a personalised plan.",
+
+  "stepChocConfidenceInfo": "Estimate based on {count} data points. The more you specify, the more reliable.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Accuracy: {pct}%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "To personalise your advice",
+  "stepChocLiteracySubtitle": "3 quick questions \u2014 no right or wrong answer.",
+  "stepChocLiteracyLpp": "I know the amount of my BVG pension assets",
+  "stepChocLiteracyConversion": "I know what the conversion rate is",
+  "stepChocLiteracy3a": "I have already contributed to a 3a account",
+  "stepChocYes": "Yes",
+  "stepChocNo": "No",
+  "stepChocAction": "What can I do?",
+  "stepChocEnrich": "Refine my profile",
+  "stepChocDashboard": "View my dashboard",
+  "stepChocDisclaimer": "Simplified educational tool. Does not constitute financial advice (FinSA). Sources: OASI art. 34, BVG art. 14-16, BVV3 art. 7.",
+
+  "stepJitTitle": "Understand in 30 seconds",
+  "stepJitSi": "IF",
+  "stepJitAlors": "THEN",
+  "stepJitAction": "What can I do?",
+  "stepJitBack": "Back",
+  "stepJitDisclaimer": "Simplified educational tool. Does not constitute financial advice (FinSA).",
+  "stepJitLiquidityCond": "your emergency savings cover less than 2 months of expenses",
+  "stepJitLiquidityCons": "an unexpected event (job loss, urgent repair) could put you in financial difficulty quickly.",
+  "stepJitLiquidityInsight": "Experts recommend 3 to 6 months of fixed expenses in reserve. Even CHF 100/month in a savings account makes a significant difference over 12 months.",
+  "stepJitLiquiditySource": "Swiss Budget Counselling recommendation",
+  "stepJitRetirementCond": "your replacement rate at retirement is below 60%",
+  "stepJitRetirementCons": "your standard of living could drop significantly when you stop working.",
+  "stepJitRetirementInsight": "In Switzerland, OASI and BVG cover an average of 60% of the last salary. The 3rd pillar and free savings bridge the gap. The earlier you start, the lower the monthly effort.",
+  "stepJitRetirementSource": "OASI art. 34 / BVG art. 14",
+  "stepJitTax3aCond": "you are not contributing the maximum to your 3rd pillar each year",
+  "stepJitTax3aCons": "you are missing out on a tax saving and additional retirement capital.",
+  "stepJitTax3aInsight": "Every franc paid into 3a is tax-deductible. Over 20 years, the difference between contributing 0 and the maximum (CHF 7,258) can exceed CHF 200,000.",
+  "stepJitTax3aSource": "BVV3 art. 7 / DBG art. 33",
+  "stepJitIncomeCond": "your projected retirement income is estimated",
+  "stepJitIncomeCons": "knowing this amount lets you plan and adjust your pension strategy now.",
+  "stepJitIncomeInsight": "The Swiss 3-pillar system (OASI + BVG + 3a) covers an average of 60% of the last salary. Each pillar has its own rules and specific optimisation levers.",
+  "stepJitIncomeSource": "OASI art. 34 / BVG art. 14 / BVV3 art. 7",
+  "stepJitDefaultCond": "you do not yet have a structured financial plan",
+  "stepJitDefaultCons": "you risk missing out on tax and pension optimisation opportunities.",
+  "stepJitDefaultInsight": "An annual financial review identifies the most impactful levers: 3a, BVG buyback, health insurance deductible, indirect amortisation.",
+  "stepJitDefaultSource": "MINT educational recommendation",
+
+  "stepOcrTitle": "Enrich your profile in 30 seconds",
+  "stepOcrSkip": "Continue without document",
+  "stepOcrIntro": "Scan one or more documents so MINT can calculate your situation more accurately.",
+  "stepOcrLppTitle": "Your BVG pension letter",
+  "stepOcrLppSubtitle": "Assets, conversion rate, buyback gap",
+  "stepOcrLppBoost": "+27 accuracy pts",
+  "stepOcrAvsTitle": "Your OASI extract",
+  "stepOcrAvsSubtitle": "Contribution years, gaps, AIME",
+  "stepOcrAvsBoost": "+22 accuracy pts",
+  "stepOcrTaxTitle": "Your tax return",
+  "stepOcrTaxSubtitle": "Taxable income, wealth, marginal rate",
+  "stepOcrTaxBoost": "+17 accuracy pts",
+  "stepOcr3aTitle": "Your 3a account",
+  "stepOcr3aSubtitle": "Balance, cumulative contributions, return",
+  "stepOcr3aBoost": "+7 accuracy pts",
+  "stepOcrScanned": "Scanned",
+  "stepOcrContinueWith": "Continue ({count} document{plural} scanned)",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Continue without document",
+  "stepOcrDisclaimer": "Educational tool \u2014 does not constitute financial advice (FinSA). Documents processed on your device, no data sent (DPA art. 6).",
+  "stepOcrLpdBanner": "Your documents are processed on your device. Nothing is sent to the Internet.",
+  "stepOcrLpdTitle": "Private processing on your device",
+  "stepOcrLpdBody": "This document is analysed directly on your phone.\nNo data is sent over the Internet.\nExtracted information is deleted after processing.",
+  "stepOcrLpdLegal": "Legal basis: DPA art. 6 \u2014 data minimisation.",
+  "stepOcrLpdScan": "Scan this document",
+  "stepOcrLpdCancel": "Cancel",
+  "stepOcrSnackSuccess": "{count} field{plural} extracted successfully",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Document processed \u2014 no field recognised automatically",
+  "stepOcrSnackError": "Processing error: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Image scanning not available on web. Use the mobile app or import a .txt file.",
+
+  "stepQuestionsAgeYears": "{age} years",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "United States",
+  "stepQuestionsCountryGb": "United Kingdom",
+  "stepQuestionsCountryCa": "Canada",
+  "stepQuestionsCountryIn": "India",
+  "stepQuestionsCountryCn": "China",
+  "stepQuestionsCountryBr": "Brazil",
+  "stepQuestionsCountryAu": "Australia",
+  "stepQuestionsCountryJp": "Japan",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -10991,5 +10991,161 @@
   "employmentRetraite": "Jubilado/a",
   "nationalitySuisse": "Suiza",
   "nationalityEuAele": "UE/AELC",
-  "nationalityAutre": "Otro"
+  "nationalityAutre": "Otro",
+
+  "stepStressTitle": "\u00bfQu\u00e9 te preocupa m\u00e1s?",
+  "stepStressSubtitle": "Elige un tema \u2014 personalizamos tu experiencia.",
+  "stepStressRetirement": "Mi jubilaci\u00f3n",
+  "stepStressRetirementSub": "\u00bfTendr\u00e9 suficiente para vivir?",
+  "stepStressTaxes": "Mis impuestos",
+  "stepStressTaxesSub": "\u00bfEstoy pagando demasiado?",
+  "stepStressBudget": "Mi presupuesto",
+  "stepStressBudgetSub": "\u00bfA d\u00f3nde va mi dinero?",
+  "stepStressWealth": "Mi patrimonio",
+  "stepStressWealthSub": "\u00bfC\u00f3mo hacerlo crecer?",
+  "stepStressCouple": "En pareja",
+  "stepStressCoupleSub": "Optimizar juntos",
+  "stepStressCurious": "Solo curioso",
+  "stepStressCuriousSub": "Quiero entender mi situaci\u00f3n",
+  "stepStressDisclaimer": "Herramienta educativa \u2014 no constituye asesoramiento financiero (LSFin).",
+
+  "stepNextTitle": "Tu primer balance est\u00e1 listo",
+  "stepNextConfidence": "Precisi\u00f3n actual: {pct}\u00a0%. Cuanto m\u00e1s completes tu perfil, m\u00e1s fiables ser\u00e1n las proyecciones.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Afinar mi perfil",
+  "stepNextDashboard": "Ver mi dashboard",
+  "stepNextCheckin": "Hacer mi primer check-in",
+  "stepNextDisclaimer": "Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin). Fuentes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepTopActionsTitle": "Tus 3 acciones prioritarias",
+  "stepTopActionsSubtitle": "Bas\u00e1ndose en tu situaci\u00f3n, aqu\u00ed es donde empezar.",
+  "stepTopActionsEmpty": "Completa tu perfil para recibir acciones personalizadas.",
+  "stepTopActionsContinue": "Continuar",
+  "stepTopActionsBack": "Volver",
+  "stepTopActionsImpact": "Impacto estimado: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Sugerencias educativas. No constituye asesoramiento financiero (LSFin). Consulta a un especialista para un plan personalizado.",
+
+  "stepChocConfidenceInfo": "Estimaci\u00f3n basada en {count} informaciones. Cuanto m\u00e1s precises, m\u00e1s fiable.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Precisi\u00f3n: {pct}\u00a0%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "Para personalizar tus consejos",
+  "stepChocLiteracySubtitle": "3 preguntas r\u00e1pidas \u2014 sin respuesta correcta o incorrecta.",
+  "stepChocLiteracyLpp": "Conozco el monto de mi capital LPP",
+  "stepChocLiteracyConversion": "S\u00e9 qu\u00e9 es la tasa de conversi\u00f3n",
+  "stepChocLiteracy3a": "Ya he aportado a una cuenta 3a",
+  "stepChocYes": "S\u00ed",
+  "stepChocNo": "No",
+  "stepChocAction": "\u00bfQu\u00e9 puedo hacer?",
+  "stepChocEnrich": "Afinar mi perfil",
+  "stepChocDashboard": "Ver mi dashboard",
+  "stepChocDisclaimer": "Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin). Fuentes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepJitTitle": "Comprender en 30 segundos",
+  "stepJitSi": "SI",
+  "stepJitAlors": "ENTONCES",
+  "stepJitAction": "\u00bfQu\u00e9 puedo hacer?",
+  "stepJitBack": "Volver",
+  "stepJitDisclaimer": "Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin).",
+  "stepJitLiquidityCond": "tus ahorros de emergencia cubren menos de 2 meses de gastos",
+  "stepJitLiquidityCons": "un imprevisto (p\u00e9rdida de empleo, reparaci\u00f3n urgente) podr\u00eda ponerte en dificultad financiera r\u00e1pidamente.",
+  "stepJitLiquidityInsight": "Los expertos recomiendan 3 a 6 meses de gastos fijos en reserva. Incluso CHF 100/mes en una cuenta de ahorros marca una diferencia significativa en 12 meses.",
+  "stepJitLiquiditySource": "Recomendaci\u00f3n presupuestaria Suiza",
+  "stepJitRetirementCond": "tu tasa de reemplazo en la jubilaci\u00f3n est\u00e1 por debajo del 60\u00a0%",
+  "stepJitRetirementCons": "tu nivel de vida podr\u00eda bajar significativamente cuando dejes de trabajar.",
+  "stepJitRetirementInsight": "En Suiza, el AVS y la LPP cubren en promedio el 60\u00a0% del \u00faltimo salario. El 3er pilar y el ahorro libre cubren el resto. Cuanto antes empieces, menor ser\u00e1 el esfuerzo mensual.",
+  "stepJitRetirementSource": "LAVS art. 34 / LPP art. 14",
+  "stepJitTax3aCond": "no aportas el m\u00e1ximo a tu 3er pilar cada a\u00f1o",
+  "stepJitTax3aCons": "est\u00e1s perdiendo un ahorro fiscal y un capital de jubilaci\u00f3n adicional.",
+  "stepJitTax3aInsight": "Cada franco aportado al 3a es deducible del ingreso imponible. En 20 a\u00f1os, la diferencia entre aportar 0 y el m\u00e1ximo (CHF 7'258) puede superar los CHF 200'000.",
+  "stepJitTax3aSource": "OPP3 art. 7 / LIFD art. 33",
+  "stepJitIncomeCond": "tu proyecci\u00f3n de ingresos de jubilaci\u00f3n est\u00e1 estimada",
+  "stepJitIncomeCons": "conocer este monto te permite planificar y ajustar tu estrategia de previsi\u00f3n ahora.",
+  "stepJitIncomeInsight": "El sistema suizo de 3 pilares (AVS + LPP + 3a) cubre en promedio el 60\u00a0% del \u00faltimo salario. Cada pilar tiene sus reglas y palancas de optimizaci\u00f3n espec\u00edficas.",
+  "stepJitIncomeSource": "LAVS art. 34 / LPP art. 14 / OPP3 art. 7",
+  "stepJitDefaultCond": "a\u00fan no tienes un plan financiero estructurado",
+  "stepJitDefaultCons": "corres el riesgo de perder oportunidades de optimizaci\u00f3n fiscal y de previsi\u00f3n.",
+  "stepJitDefaultInsight": "Un balance financiero anual permite identificar las palancas m\u00e1s impactantes: 3a, recompra LPP, franquicia LAMal, amortizaci\u00f3n indirecta.",
+  "stepJitDefaultSource": "Recomendaci\u00f3n educativa MINT",
+
+  "stepOcrTitle": "Enriquece tu perfil en 30 segundos",
+  "stepOcrSkip": "Continuar sin documento",
+  "stepOcrIntro": "Escanea uno o m\u00e1s documentos para que MINT calcule tu situaci\u00f3n con m\u00e1s precisi\u00f3n.",
+  "stepOcrLppTitle": "Tu carta de jubilaci\u00f3n LPP",
+  "stepOcrLppSubtitle": "Capital, tasa de conversi\u00f3n, laguna de recompra",
+  "stepOcrLppBoost": "+27 pts de precisi\u00f3n",
+  "stepOcrAvsTitle": "Tu extracto AVS",
+  "stepOcrAvsSubtitle": "A\u00f1os de cotizaci\u00f3n, lagunas, RAMD",
+  "stepOcrAvsBoost": "+22 pts de precisi\u00f3n",
+  "stepOcrTaxTitle": "Tu declaraci\u00f3n fiscal",
+  "stepOcrTaxSubtitle": "Ingreso imponible, fortuna, tasa marginal",
+  "stepOcrTaxBoost": "+17 pts de precisi\u00f3n",
+  "stepOcr3aTitle": "Tu cuenta 3a",
+  "stepOcr3aSubtitle": "Saldo, aportaciones acumuladas, rendimiento",
+  "stepOcr3aBoost": "+7 pts de precisi\u00f3n",
+  "stepOcrScanned": "Escaneado",
+  "stepOcrContinueWith": "Continuar ({count} documento{plural} escaneado{plural})",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Continuar sin documento",
+  "stepOcrDisclaimer": "Herramienta educativa \u2014 no constituye asesoramiento financiero (LSFin). Documentos procesados en tu dispositivo, ning\u00fan dato enviado (LPD art. 6).",
+  "stepOcrLpdBanner": "Tus documentos se procesan en tu dispositivo. Nada se env\u00eda a Internet.",
+  "stepOcrLpdTitle": "Procesamiento privado en tu dispositivo",
+  "stepOcrLpdBody": "Este documento se analiza directamente en tu tel\u00e9fono.\nNing\u00fan dato se env\u00eda por Internet.\nLa informaci\u00f3n extra\u00edda se elimina despu\u00e9s del procesamiento.",
+  "stepOcrLpdLegal": "Base legal: LPD art. 6 \u2014 minimizaci\u00f3n de datos.",
+  "stepOcrLpdScan": "Escanear este documento",
+  "stepOcrLpdCancel": "Cancelar",
+  "stepOcrSnackSuccess": "{count} campo{plural} extra\u00eddo{plural} con \u00e9xito",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Documento procesado \u2014 ning\u00fan campo reconocido autom\u00e1ticamente",
+  "stepOcrSnackError": "Error de procesamiento: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Escaneo de imagen no disponible en web. Usa la app m\u00f3vil o importa un archivo .txt.",
+
+  "stepQuestionsAgeYears": "{age} a\u00f1os",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "Estados Unidos",
+  "stepQuestionsCountryGb": "Reino Unido",
+  "stepQuestionsCountryCa": "Canad\u00e1",
+  "stepQuestionsCountryIn": "India",
+  "stepQuestionsCountryCn": "China",
+  "stepQuestionsCountryBr": "Brasil",
+  "stepQuestionsCountryAu": "Australia",
+  "stepQuestionsCountryJp": "Jap\u00f3n",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11473,5 +11473,161 @@
   "employmentRetraite": "Retrait\u00e9\u00b7e",
   "nationalitySuisse": "Suisse",
   "nationalityEuAele": "EU/AELE",
-  "nationalityAutre": "Autre"
+  "nationalityAutre": "Autre",
+
+  "stepStressTitle": "Qu\u2019est-ce qui te pr\u00e9occupe le plus\u00a0?",
+  "stepStressSubtitle": "Choisis un th\u00e8me \u2014 on personnalise ton exp\u00e9rience.",
+  "stepStressRetirement": "Ma retraite",
+  "stepStressRetirementSub": "Vais-je avoir assez pour vivre\u00a0?",
+  "stepStressTaxes": "Mes imp\u00f4ts",
+  "stepStressTaxesSub": "Est-ce que je paie trop\u00a0?",
+  "stepStressBudget": "Mon budget",
+  "stepStressBudgetSub": "O\u00f9 passe mon argent\u00a0?",
+  "stepStressWealth": "Mon patrimoine",
+  "stepStressWealthSub": "Comment le faire grandir\u00a0?",
+  "stepStressCouple": "En couple",
+  "stepStressCoupleSub": "Optimiser \u00e0 deux",
+  "stepStressCurious": "Juste curieux",
+  "stepStressCuriousSub": "Je veux comprendre ma situation",
+  "stepStressDisclaimer": "Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).",
+
+  "stepNextTitle": "Ton premier bilan est pr\u00eat",
+  "stepNextConfidence": "Pr\u00e9cision actuelle\u00a0: {pct}\u00a0%. Plus tu compl\u00e8tes ton profil, plus les projections seront fiables.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Affiner mon profil",
+  "stepNextDashboard": "Voir mon dashboard",
+  "stepNextCheckin": "Faire mon premier check-in",
+  "stepNextDisclaimer": "Outil \u00e9ducatif simplifi\u00e9. Ne constitue pas un conseil financier (LSFin). Sources\u00a0: LAVS art.\u00a034, LPP art.\u00a014-16, OPP3 art.\u00a07.",
+
+  "stepTopActionsTitle": "Tes 3 actions prioritaires",
+  "stepTopActionsSubtitle": "Bas\u00e9es sur ta situation, voici par o\u00f9 commencer.",
+  "stepTopActionsEmpty": "Compl\u00e8te ton profil pour recevoir des actions personnalis\u00e9es.",
+  "stepTopActionsContinue": "Continuer",
+  "stepTopActionsBack": "Retour",
+  "stepTopActionsImpact": "Impact estim\u00e9\u00a0: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Suggestions \u00e9ducatives. Ne constitue pas un conseil financier (LSFin). Consulte un\u00b7e sp\u00e9cialiste pour un plan personnalis\u00e9.",
+
+  "stepChocConfidenceInfo": "Estimation bas\u00e9e sur {count} informations. Plus tu pr\u00e9cises, plus c\u2019est fiable.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Pr\u00e9cision\u00a0: {pct}\u00a0%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "Pour personnaliser tes conseils",
+  "stepChocLiteracySubtitle": "3 questions rapides \u2014 aucune bonne ou mauvaise r\u00e9ponse.",
+  "stepChocLiteracyLpp": "Je connais le montant de mon avoir LPP",
+  "stepChocLiteracyConversion": "Je sais ce qu\u2019est le taux de conversion",
+  "stepChocLiteracy3a": "J\u2019ai d\u00e9j\u00e0 vers\u00e9 sur un compte 3a",
+  "stepChocYes": "Oui",
+  "stepChocNo": "Non",
+  "stepChocAction": "Qu\u2019est-ce que je peux faire\u00a0?",
+  "stepChocEnrich": "Affiner mon profil",
+  "stepChocDashboard": "Voir mon dashboard",
+  "stepChocDisclaimer": "Outil \u00e9ducatif simplifi\u00e9. Ne constitue pas un conseil financier (LSFin). Sources\u00a0: LAVS art.\u00a034, LPP art.\u00a014-16, OPP3 art.\u00a07.",
+
+  "stepJitTitle": "Comprendre en 30 secondes",
+  "stepJitSi": "SI",
+  "stepJitAlors": "ALORS",
+  "stepJitAction": "Que puis-je faire\u00a0?",
+  "stepJitBack": "Retour",
+  "stepJitDisclaimer": "Outil \u00e9ducatif simplifi\u00e9. Ne constitue pas un conseil financier (LSFin).",
+  "stepJitLiquidityCond": "ton \u00e9pargne de s\u00e9curit\u00e9 couvre moins de 2 mois de charges",
+  "stepJitLiquidityCons": "un impr\u00e9vu (perte d\u2019emploi, r\u00e9paration urgente) peut te mettre en difficult\u00e9 financi\u00e8re rapidement.",
+  "stepJitLiquidityInsight": "Les experts recommandent 3 \u00e0 6 mois de charges fixes en r\u00e9serve. M\u00eame 100\u00a0CHF/mois sur un compte \u00e9pargne fait une diff\u00e9rence significative sur 12 mois.",
+  "stepJitLiquiditySource": "Recommandation Budget-conseil Suisse",
+  "stepJitRetirementCond": "ton taux de remplacement \u00e0 la retraite est inf\u00e9rieur \u00e0 60\u00a0%",
+  "stepJitRetirementCons": "ton niveau de vie pourrait baisser significativement le jour o\u00f9 tu arr\u00eates de travailler.",
+  "stepJitRetirementInsight": "En Suisse, l\u2019AVS et la LPP couvrent en moyenne 60\u00a0% du dernier salaire. Le 3e pilier et l\u2019\u00e9pargne libre comblent le reste. Plus tu commences t\u00f4t, moins l\u2019effort mensuel est important.",
+  "stepJitRetirementSource": "LAVS art.\u00a034 / LPP art.\u00a014",
+  "stepJitTax3aCond": "tu ne verses pas le maximum dans ton 3e pilier chaque ann\u00e9e",
+  "stepJitTax3aCons": "tu passes \u00e0 c\u00f4t\u00e9 d\u2019une \u00e9conomie fiscale et d\u2019un capital retraite suppl\u00e9mentaire.",
+  "stepJitTax3aInsight": "Chaque franc vers\u00e9 en 3a est d\u00e9ductible du revenu imposable. Sur 20 ans, la diff\u00e9rence entre verser 0 et le plafond (7\u2019258\u00a0CHF) peut repr\u00e9senter plus de 200\u2019000\u00a0CHF.",
+  "stepJitTax3aSource": "OPP3 art.\u00a07 / LIFD art.\u00a033",
+  "stepJitIncomeCond": "ta projection de revenu \u00e0 la retraite est estim\u00e9e",
+  "stepJitIncomeCons": "conna\u00eetre ce montant te permet de planifier et d\u2019ajuster ta strat\u00e9gie de pr\u00e9voyance d\u00e8s maintenant.",
+  "stepJitIncomeInsight": "Le syst\u00e8me suisse \u00e0 3 piliers (AVS + LPP + 3a) couvre en moyenne 60\u00a0% du dernier salaire. Chaque pilier a ses r\u00e8gles et ses leviers d\u2019optimisation sp\u00e9cifiques.",
+  "stepJitIncomeSource": "LAVS art.\u00a034 / LPP art.\u00a014 / OPP3 art.\u00a07",
+  "stepJitDefaultCond": "tu n\u2019as pas encore un plan financier structur\u00e9",
+  "stepJitDefaultCons": "tu risques de passer \u00e0 c\u00f4t\u00e9 d\u2019opportunit\u00e9s d\u2019optimisation fiscale et de pr\u00e9voyance.",
+  "stepJitDefaultInsight": "Un bilan financier annuel permet d\u2019identifier les leviers les plus impactants\u00a0: 3a, rachat LPP, franchise LAMal, amortissement indirect.",
+  "stepJitDefaultSource": "Recommandation \u00e9ducative MINT",
+
+  "stepOcrTitle": "Enrichis ton profil en 30 secondes",
+  "stepOcrSkip": "Continuer sans document",
+  "stepOcrIntro": "Scanne un ou plusieurs documents pour que MINT calcule ta situation avec plus de pr\u00e9cision.",
+  "stepOcrLppTitle": "Ta lettre de retraite LPP",
+  "stepOcrLppSubtitle": "Avoir, taux de conversion, lacune de rachat",
+  "stepOcrLppBoost": "+27 pts de pr\u00e9cision",
+  "stepOcrAvsTitle": "Ton extrait AVS",
+  "stepOcrAvsSubtitle": "Ann\u00e9es de cotisation, lacunes, RAMD",
+  "stepOcrAvsBoost": "+22 pts de pr\u00e9cision",
+  "stepOcrTaxTitle": "Ta d\u00e9claration fiscale",
+  "stepOcrTaxSubtitle": "Revenu imposable, fortune, taux marginal",
+  "stepOcrTaxBoost": "+17 pts de pr\u00e9cision",
+  "stepOcr3aTitle": "Ton compte 3a",
+  "stepOcr3aSubtitle": "Solde, versements cumul\u00e9s, rendement",
+  "stepOcr3aBoost": "+7 pts de pr\u00e9cision",
+  "stepOcrScanned": "Scann\u00e9",
+  "stepOcrContinueWith": "Continuer ({count} document{plural} scann\u00e9{plural})",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Continuer sans document",
+  "stepOcrDisclaimer": "Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin). Documents trait\u00e9s sur ton appareil, aucune donn\u00e9e envoy\u00e9e (LPD art.\u00a06).",
+  "stepOcrLpdBanner": "Tes documents sont trait\u00e9s sur ton appareil. Rien n\u2019est envoy\u00e9 sur Internet.",
+  "stepOcrLpdTitle": "Traitement priv\u00e9 sur ton appareil",
+  "stepOcrLpdBody": "Ce document est analys\u00e9 directement sur ton t\u00e9l\u00e9phone.\nAucune donn\u00e9e n\u2019est envoy\u00e9e sur Internet.\nLes informations extraites sont supprim\u00e9es apr\u00e8s traitement.",
+  "stepOcrLpdLegal": "Base l\u00e9gale\u00a0: LPD art.\u00a06 \u2014 minimisation des donn\u00e9es.",
+  "stepOcrLpdScan": "Scanner ce document",
+  "stepOcrLpdCancel": "Annuler",
+  "stepOcrSnackSuccess": "{count} champ{plural} extrait{plural} avec succ\u00e8s",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Document trait\u00e9 \u2014 aucun champ reconnu automatiquement",
+  "stepOcrSnackError": "Erreur lors du traitement\u00a0: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Scan d\u2019image non disponible sur web. Utilise l\u2019app mobile ou importe un fichier .txt.",
+
+  "stepQuestionsAgeYears": "{age} ans",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "\u00c9tats-Unis",
+  "stepQuestionsCountryGb": "Royaume-Uni",
+  "stepQuestionsCountryCa": "Canada",
+  "stepQuestionsCountryIn": "Inde",
+  "stepQuestionsCountryCn": "Chine",
+  "stepQuestionsCountryBr": "Br\u00e9sil",
+  "stepQuestionsCountryAu": "Australie",
+  "stepQuestionsCountryJp": "Japon",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -10991,5 +10991,161 @@
   "employmentRetraite": "Pensionato/a",
   "nationalitySuisse": "Svizzera",
   "nationalityEuAele": "UE/AELS",
-  "nationalityAutre": "Altro"
+  "nationalityAutre": "Altro",
+
+  "stepStressTitle": "Cosa ti preoccupa di pi\u00f9?",
+  "stepStressSubtitle": "Scegli un tema \u2014 personalizziamo la tua esperienza.",
+  "stepStressRetirement": "La mia pensione",
+  "stepStressRetirementSub": "Avr\u00f2 abbastanza per vivere?",
+  "stepStressTaxes": "Le mie tasse",
+  "stepStressTaxesSub": "Sto pagando troppo?",
+  "stepStressBudget": "Il mio budget",
+  "stepStressBudgetSub": "Dove vanno i miei soldi?",
+  "stepStressWealth": "Il mio patrimonio",
+  "stepStressWealthSub": "Come farlo crescere?",
+  "stepStressCouple": "In coppia",
+  "stepStressCoupleSub": "Ottimizzare insieme",
+  "stepStressCurious": "Solo curioso",
+  "stepStressCuriousSub": "Voglio capire la mia situazione",
+  "stepStressDisclaimer": "Strumento educativo \u2014 non costituisce consulenza finanziaria (LSFin).",
+
+  "stepNextTitle": "Il tuo primo bilancio \u00e8 pronto",
+  "stepNextConfidence": "Precisione attuale: {pct}\u00a0%. Pi\u00f9 completi il tuo profilo, pi\u00f9 affidabili saranno le proiezioni.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Perfezionare il mio profilo",
+  "stepNextDashboard": "Visualizza la mia dashboard",
+  "stepNextCheckin": "Fare il mio primo check-in",
+  "stepNextDisclaimer": "Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin). Fonti: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepTopActionsTitle": "Le tue 3 azioni prioritarie",
+  "stepTopActionsSubtitle": "In base alla tua situazione, ecco da dove iniziare.",
+  "stepTopActionsEmpty": "Completa il tuo profilo per ricevere azioni personalizzate.",
+  "stepTopActionsContinue": "Continua",
+  "stepTopActionsBack": "Indietro",
+  "stepTopActionsImpact": "Impatto stimato: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Suggerimenti educativi. Non costituisce consulenza finanziaria (LSFin). Consulta uno specialista per un piano personalizzato.",
+
+  "stepChocConfidenceInfo": "Stima basata su {count} informazioni. Pi\u00f9 precisi i dati, pi\u00f9 affidabile il risultato.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Precisione: {pct}\u00a0%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "Per personalizzare i tuoi consigli",
+  "stepChocLiteracySubtitle": "3 domande rapide \u2014 nessuna risposta giusta o sbagliata.",
+  "stepChocLiteracyLpp": "Conosco l\u2019importo del mio avere LPP",
+  "stepChocLiteracyConversion": "So cos\u2019\u00e8 il tasso di conversione",
+  "stepChocLiteracy3a": "Ho gi\u00e0 versato su un conto 3a",
+  "stepChocYes": "S\u00ec",
+  "stepChocNo": "No",
+  "stepChocAction": "Cosa posso fare?",
+  "stepChocEnrich": "Perfezionare il mio profilo",
+  "stepChocDashboard": "Visualizza la mia dashboard",
+  "stepChocDisclaimer": "Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin). Fonti: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepJitTitle": "Capire in 30 secondi",
+  "stepJitSi": "SE",
+  "stepJitAlors": "ALLORA",
+  "stepJitAction": "Cosa posso fare?",
+  "stepJitBack": "Indietro",
+  "stepJitDisclaimer": "Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin).",
+  "stepJitLiquidityCond": "i tuoi risparmi di emergenza coprono meno di 2 mesi di spese",
+  "stepJitLiquidityCons": "un imprevisto (perdita del lavoro, riparazione urgente) potrebbe metterti in difficolt\u00e0 finanziaria rapidamente.",
+  "stepJitLiquidityInsight": "Gli esperti raccomandano 3-6 mesi di spese fisse come riserva. Anche CHF 100/mese su un conto risparmio fanno una differenza significativa in 12 mesi.",
+  "stepJitLiquiditySource": "Raccomandazione consulenza budget Svizzera",
+  "stepJitRetirementCond": "il tuo tasso di sostituzione alla pensione \u00e8 inferiore al 60\u00a0%",
+  "stepJitRetirementCons": "il tuo tenore di vita potrebbe calare significativamente quando smetterai di lavorare.",
+  "stepJitRetirementInsight": "In Svizzera, AVS e LPP coprono in media il 60\u00a0% dell\u2019ultimo salario. Il 3\u00b0 pilastro e il risparmio libero colmano il resto. Prima inizi, minore \u00e8 lo sforzo mensile.",
+  "stepJitRetirementSource": "LAVS art. 34 / LPP art. 14",
+  "stepJitTax3aCond": "non versi il massimo nel tuo 3\u00b0 pilastro ogni anno",
+  "stepJitTax3aCons": "stai perdendo un risparmio fiscale e un capitale pensionistico aggiuntivo.",
+  "stepJitTax3aInsight": "Ogni franco versato nel 3a \u00e8 deducibile dal reddito imponibile. In 20 anni, la differenza tra versare 0 e il massimo (CHF 7'258) pu\u00f2 superare CHF 200'000.",
+  "stepJitTax3aSource": "OPP3 art. 7 / LIFD art. 33",
+  "stepJitIncomeCond": "la tua proiezione di reddito pensionistico \u00e8 stimata",
+  "stepJitIncomeCons": "conoscere questo importo ti permette di pianificare e adattare la tua strategia previdenziale ora.",
+  "stepJitIncomeInsight": "Il sistema svizzero a 3 pilastri (AVS + LPP + 3a) copre in media il 60\u00a0% dell\u2019ultimo salario. Ogni pilastro ha le sue regole e leve di ottimizzazione specifiche.",
+  "stepJitIncomeSource": "LAVS art. 34 / LPP art. 14 / OPP3 art. 7",
+  "stepJitDefaultCond": "non hai ancora un piano finanziario strutturato",
+  "stepJitDefaultCons": "rischi di perdere opportunit\u00e0 di ottimizzazione fiscale e previdenziale.",
+  "stepJitDefaultInsight": "Un bilancio finanziario annuale permette di identificare le leve pi\u00f9 impattanti: 3a, riscatto LPP, franchigia LAMal, ammortamento indiretto.",
+  "stepJitDefaultSource": "Raccomandazione educativa MINT",
+
+  "stepOcrTitle": "Arricchisci il tuo profilo in 30 secondi",
+  "stepOcrSkip": "Continua senza documento",
+  "stepOcrIntro": "Scansiona uno o pi\u00f9 documenti affinch\u00e9 MINT calcoli la tua situazione con pi\u00f9 precisione.",
+  "stepOcrLppTitle": "La tua lettera pensionistica LPP",
+  "stepOcrLppSubtitle": "Avere, tasso di conversione, lacuna di riscatto",
+  "stepOcrLppBoost": "+27 punti di precisione",
+  "stepOcrAvsTitle": "Il tuo estratto AVS",
+  "stepOcrAvsSubtitle": "Anni di contribuzione, lacune, RAMD",
+  "stepOcrAvsBoost": "+22 punti di precisione",
+  "stepOcrTaxTitle": "La tua dichiarazione fiscale",
+  "stepOcrTaxSubtitle": "Reddito imponibile, patrimonio, aliquota marginale",
+  "stepOcrTaxBoost": "+17 punti di precisione",
+  "stepOcr3aTitle": "Il tuo conto 3a",
+  "stepOcr3aSubtitle": "Saldo, versamenti cumulati, rendimento",
+  "stepOcr3aBoost": "+7 punti di precisione",
+  "stepOcrScanned": "Scansionato",
+  "stepOcrContinueWith": "Continua ({count} documento{plural} scansionato{plural})",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Continua senza documento",
+  "stepOcrDisclaimer": "Strumento educativo \u2014 non costituisce consulenza finanziaria (LSFin). Documenti elaborati sul tuo dispositivo, nessun dato inviato (LPD art. 6).",
+  "stepOcrLpdBanner": "I tuoi documenti vengono elaborati sul tuo dispositivo. Niente viene inviato su Internet.",
+  "stepOcrLpdTitle": "Elaborazione privata sul tuo dispositivo",
+  "stepOcrLpdBody": "Questo documento viene analizzato direttamente sul tuo telefono.\nNessun dato viene inviato su Internet.\nLe informazioni estratte vengono eliminate dopo l\u2019elaborazione.",
+  "stepOcrLpdLegal": "Base giuridica: LPD art. 6 \u2014 minimizzazione dei dati.",
+  "stepOcrLpdScan": "Scansiona questo documento",
+  "stepOcrLpdCancel": "Annulla",
+  "stepOcrSnackSuccess": "{count} campo{plural} estratto{plural} con successo",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Documento elaborato \u2014 nessun campo riconosciuto automaticamente",
+  "stepOcrSnackError": "Errore di elaborazione: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Scansione immagini non disponibile su web. Usa l\u2019app mobile o importa un file .txt.",
+
+  "stepQuestionsAgeYears": "{age} anni",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "Stati Uniti",
+  "stepQuestionsCountryGb": "Regno Unito",
+  "stepQuestionsCountryCa": "Canada",
+  "stepQuestionsCountryIn": "India",
+  "stepQuestionsCountryCn": "Cina",
+  "stepQuestionsCountryBr": "Brasile",
+  "stepQuestionsCountryAu": "Australia",
+  "stepQuestionsCountryJp": "Giappone",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -41404,6 +41404,642 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Autre'**
   String get nationalityAutre;
+
+  /// No description provided for @stepStressTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Qu’est-ce qui te préoccupe le plus ?'**
+  String get stepStressTitle;
+
+  /// No description provided for @stepStressSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Choisis un thème — on personnalise ton expérience.'**
+  String get stepStressSubtitle;
+
+  /// No description provided for @stepStressRetirement.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ma retraite'**
+  String get stepStressRetirement;
+
+  /// No description provided for @stepStressRetirementSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Vais-je avoir assez pour vivre ?'**
+  String get stepStressRetirementSub;
+
+  /// No description provided for @stepStressTaxes.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mes impôts'**
+  String get stepStressTaxes;
+
+  /// No description provided for @stepStressTaxesSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Est-ce que je paie trop ?'**
+  String get stepStressTaxesSub;
+
+  /// No description provided for @stepStressBudget.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mon budget'**
+  String get stepStressBudget;
+
+  /// No description provided for @stepStressBudgetSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Où passe mon argent ?'**
+  String get stepStressBudgetSub;
+
+  /// No description provided for @stepStressWealth.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mon patrimoine'**
+  String get stepStressWealth;
+
+  /// No description provided for @stepStressWealthSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Comment le faire grandir ?'**
+  String get stepStressWealthSub;
+
+  /// No description provided for @stepStressCouple.
+  ///
+  /// In fr, this message translates to:
+  /// **'En couple'**
+  String get stepStressCouple;
+
+  /// No description provided for @stepStressCoupleSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Optimiser à deux'**
+  String get stepStressCoupleSub;
+
+  /// No description provided for @stepStressCurious.
+  ///
+  /// In fr, this message translates to:
+  /// **'Juste curieux'**
+  String get stepStressCurious;
+
+  /// No description provided for @stepStressCuriousSub.
+  ///
+  /// In fr, this message translates to:
+  /// **'Je veux comprendre ma situation'**
+  String get stepStressCuriousSub;
+
+  /// No description provided for @stepStressDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif — ne constitue pas un conseil financier (LSFin).'**
+  String get stepStressDisclaimer;
+
+  /// No description provided for @stepNextTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton premier bilan est prêt'**
+  String get stepNextTitle;
+
+  /// No description provided for @stepNextConfidence.
+  ///
+  /// In fr, this message translates to:
+  /// **'Précision actuelle : {pct} %. Plus tu complètes ton profil, plus les projections seront fiables.'**
+  String stepNextConfidence(int pct);
+
+  /// No description provided for @stepNextEnrich.
+  ///
+  /// In fr, this message translates to:
+  /// **'Affiner mon profil'**
+  String get stepNextEnrich;
+
+  /// No description provided for @stepNextDashboard.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voir mon dashboard'**
+  String get stepNextDashboard;
+
+  /// No description provided for @stepNextCheckin.
+  ///
+  /// In fr, this message translates to:
+  /// **'Faire mon premier check-in'**
+  String get stepNextCheckin;
+
+  /// No description provided for @stepNextDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin). Sources : LAVS art. 34, LPP art. 14-16, OPP3 art. 7.'**
+  String get stepNextDisclaimer;
+
+  /// No description provided for @stepTopActionsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes 3 actions prioritaires'**
+  String get stepTopActionsTitle;
+
+  /// No description provided for @stepTopActionsSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Basées sur ta situation, voici par où commencer.'**
+  String get stepTopActionsSubtitle;
+
+  /// No description provided for @stepTopActionsEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Complète ton profil pour recevoir des actions personnalisées.'**
+  String get stepTopActionsEmpty;
+
+  /// No description provided for @stepTopActionsContinue.
+  ///
+  /// In fr, this message translates to:
+  /// **'Continuer'**
+  String get stepTopActionsContinue;
+
+  /// No description provided for @stepTopActionsBack.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour'**
+  String get stepTopActionsBack;
+
+  /// No description provided for @stepTopActionsImpact.
+  ///
+  /// In fr, this message translates to:
+  /// **'Impact estimé : {amount}'**
+  String stepTopActionsImpact(String amount);
+
+  /// No description provided for @stepTopActionsDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Suggestions éducatives. Ne constitue pas un conseil financier (LSFin). Consulte un·e spécialiste pour un plan personnalisé.'**
+  String get stepTopActionsDisclaimer;
+
+  /// No description provided for @stepChocConfidenceInfo.
+  ///
+  /// In fr, this message translates to:
+  /// **'Estimation basée sur {count} informations. Plus tu précises, plus c’est fiable.'**
+  String stepChocConfidenceInfo(int count);
+
+  /// No description provided for @stepChocConfidenceLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Précision : {pct} %'**
+  String stepChocConfidenceLabel(int pct);
+
+  /// No description provided for @stepChocLiteracyTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pour personnaliser tes conseils'**
+  String get stepChocLiteracyTitle;
+
+  /// No description provided for @stepChocLiteracySubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'3 questions rapides — aucune bonne ou mauvaise réponse.'**
+  String get stepChocLiteracySubtitle;
+
+  /// No description provided for @stepChocLiteracyLpp.
+  ///
+  /// In fr, this message translates to:
+  /// **'Je connais le montant de mon avoir LPP'**
+  String get stepChocLiteracyLpp;
+
+  /// No description provided for @stepChocLiteracyConversion.
+  ///
+  /// In fr, this message translates to:
+  /// **'Je sais ce qu’est le taux de conversion'**
+  String get stepChocLiteracyConversion;
+
+  /// No description provided for @stepChocLiteracy3a.
+  ///
+  /// In fr, this message translates to:
+  /// **'J’ai déjà versé sur un compte 3a'**
+  String get stepChocLiteracy3a;
+
+  /// No description provided for @stepChocYes.
+  ///
+  /// In fr, this message translates to:
+  /// **'Oui'**
+  String get stepChocYes;
+
+  /// No description provided for @stepChocNo.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non'**
+  String get stepChocNo;
+
+  /// No description provided for @stepChocAction.
+  ///
+  /// In fr, this message translates to:
+  /// **'Qu’est-ce que je peux faire ?'**
+  String get stepChocAction;
+
+  /// No description provided for @stepChocEnrich.
+  ///
+  /// In fr, this message translates to:
+  /// **'Affiner mon profil'**
+  String get stepChocEnrich;
+
+  /// No description provided for @stepChocDashboard.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voir mon dashboard'**
+  String get stepChocDashboard;
+
+  /// No description provided for @stepChocDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin). Sources : LAVS art. 34, LPP art. 14-16, OPP3 art. 7.'**
+  String get stepChocDisclaimer;
+
+  /// No description provided for @stepJitTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Comprendre en 30 secondes'**
+  String get stepJitTitle;
+
+  /// No description provided for @stepJitSi.
+  ///
+  /// In fr, this message translates to:
+  /// **'SI'**
+  String get stepJitSi;
+
+  /// No description provided for @stepJitAlors.
+  ///
+  /// In fr, this message translates to:
+  /// **'ALORS'**
+  String get stepJitAlors;
+
+  /// No description provided for @stepJitAction.
+  ///
+  /// In fr, this message translates to:
+  /// **'Que puis-je faire ?'**
+  String get stepJitAction;
+
+  /// No description provided for @stepJitBack.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retour'**
+  String get stepJitBack;
+
+  /// No description provided for @stepJitDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin).'**
+  String get stepJitDisclaimer;
+
+  /// No description provided for @stepJitLiquidityCond.
+  ///
+  /// In fr, this message translates to:
+  /// **'ton épargne de sécurité couvre moins de 2 mois de charges'**
+  String get stepJitLiquidityCond;
+
+  /// No description provided for @stepJitLiquidityCons.
+  ///
+  /// In fr, this message translates to:
+  /// **'un imprévu (perte d’emploi, réparation urgente) peut te mettre en difficulté financière rapidement.'**
+  String get stepJitLiquidityCons;
+
+  /// No description provided for @stepJitLiquidityInsight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Les experts recommandent 3 à 6 mois de charges fixes en réserve. Même 100 CHF/mois sur un compte épargne fait une différence significative sur 12 mois.'**
+  String get stepJitLiquidityInsight;
+
+  /// No description provided for @stepJitLiquiditySource.
+  ///
+  /// In fr, this message translates to:
+  /// **'Recommandation Budget-conseil Suisse'**
+  String get stepJitLiquiditySource;
+
+  /// No description provided for @stepJitRetirementCond.
+  ///
+  /// In fr, this message translates to:
+  /// **'ton taux de remplacement à la retraite est inférieur à 60 %'**
+  String get stepJitRetirementCond;
+
+  /// No description provided for @stepJitRetirementCons.
+  ///
+  /// In fr, this message translates to:
+  /// **'ton niveau de vie pourrait baisser significativement le jour où tu arrêtes de travailler.'**
+  String get stepJitRetirementCons;
+
+  /// No description provided for @stepJitRetirementInsight.
+  ///
+  /// In fr, this message translates to:
+  /// **'En Suisse, l’AVS et la LPP couvrent en moyenne 60 % du dernier salaire. Le 3e pilier et l’épargne libre comblent le reste. Plus tu commences tôt, moins l’effort mensuel est important.'**
+  String get stepJitRetirementInsight;
+
+  /// No description provided for @stepJitRetirementSource.
+  ///
+  /// In fr, this message translates to:
+  /// **'LAVS art. 34 / LPP art. 14'**
+  String get stepJitRetirementSource;
+
+  /// No description provided for @stepJitTax3aCond.
+  ///
+  /// In fr, this message translates to:
+  /// **'tu ne verses pas le maximum dans ton 3e pilier chaque année'**
+  String get stepJitTax3aCond;
+
+  /// No description provided for @stepJitTax3aCons.
+  ///
+  /// In fr, this message translates to:
+  /// **'tu passes à côté d’une économie fiscale et d’un capital retraite supplémentaire.'**
+  String get stepJitTax3aCons;
+
+  /// No description provided for @stepJitTax3aInsight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Chaque franc versé en 3a est déductible du revenu imposable. Sur 20 ans, la différence entre verser 0 et le plafond (7’258 CHF) peut représenter plus de 200’000 CHF.'**
+  String get stepJitTax3aInsight;
+
+  /// No description provided for @stepJitTax3aSource.
+  ///
+  /// In fr, this message translates to:
+  /// **'OPP3 art. 7 / LIFD art. 33'**
+  String get stepJitTax3aSource;
+
+  /// No description provided for @stepJitIncomeCond.
+  ///
+  /// In fr, this message translates to:
+  /// **'ta projection de revenu à la retraite est estimée'**
+  String get stepJitIncomeCond;
+
+  /// No description provided for @stepJitIncomeCons.
+  ///
+  /// In fr, this message translates to:
+  /// **'connaître ce montant te permet de planifier et d’ajuster ta stratégie de prévoyance dès maintenant.'**
+  String get stepJitIncomeCons;
+
+  /// No description provided for @stepJitIncomeInsight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le système suisse à 3 piliers (AVS + LPP + 3a) couvre en moyenne 60 % du dernier salaire. Chaque pilier a ses règles et ses leviers d’optimisation spécifiques.'**
+  String get stepJitIncomeInsight;
+
+  /// No description provided for @stepJitIncomeSource.
+  ///
+  /// In fr, this message translates to:
+  /// **'LAVS art. 34 / LPP art. 14 / OPP3 art. 7'**
+  String get stepJitIncomeSource;
+
+  /// No description provided for @stepJitDefaultCond.
+  ///
+  /// In fr, this message translates to:
+  /// **'tu n’as pas encore un plan financier structuré'**
+  String get stepJitDefaultCond;
+
+  /// No description provided for @stepJitDefaultCons.
+  ///
+  /// In fr, this message translates to:
+  /// **'tu risques de passer à côté d’opportunités d’optimisation fiscale et de prévoyance.'**
+  String get stepJitDefaultCons;
+
+  /// No description provided for @stepJitDefaultInsight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Un bilan financier annuel permet d’identifier les leviers les plus impactants : 3a, rachat LPP, franchise LAMal, amortissement indirect.'**
+  String get stepJitDefaultInsight;
+
+  /// No description provided for @stepJitDefaultSource.
+  ///
+  /// In fr, this message translates to:
+  /// **'Recommandation éducative MINT'**
+  String get stepJitDefaultSource;
+
+  /// No description provided for @stepOcrTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Enrichis ton profil en 30 secondes'**
+  String get stepOcrTitle;
+
+  /// No description provided for @stepOcrSkip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Continuer sans document'**
+  String get stepOcrSkip;
+
+  /// No description provided for @stepOcrIntro.
+  ///
+  /// In fr, this message translates to:
+  /// **'Scanne un ou plusieurs documents pour que MINT calcule ta situation avec plus de précision.'**
+  String get stepOcrIntro;
+
+  /// No description provided for @stepOcrLppTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ta lettre de retraite LPP'**
+  String get stepOcrLppTitle;
+
+  /// No description provided for @stepOcrLppSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Avoir, taux de conversion, lacune de rachat'**
+  String get stepOcrLppSubtitle;
+
+  /// No description provided for @stepOcrLppBoost.
+  ///
+  /// In fr, this message translates to:
+  /// **'+27 pts de précision'**
+  String get stepOcrLppBoost;
+
+  /// No description provided for @stepOcrAvsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton extrait AVS'**
+  String get stepOcrAvsTitle;
+
+  /// No description provided for @stepOcrAvsSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Années de cotisation, lacunes, RAMD'**
+  String get stepOcrAvsSubtitle;
+
+  /// No description provided for @stepOcrAvsBoost.
+  ///
+  /// In fr, this message translates to:
+  /// **'+22 pts de précision'**
+  String get stepOcrAvsBoost;
+
+  /// No description provided for @stepOcrTaxTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ta déclaration fiscale'**
+  String get stepOcrTaxTitle;
+
+  /// No description provided for @stepOcrTaxSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Revenu imposable, fortune, taux marginal'**
+  String get stepOcrTaxSubtitle;
+
+  /// No description provided for @stepOcrTaxBoost.
+  ///
+  /// In fr, this message translates to:
+  /// **'+17 pts de précision'**
+  String get stepOcrTaxBoost;
+
+  /// No description provided for @stepOcr3aTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton compte 3a'**
+  String get stepOcr3aTitle;
+
+  /// No description provided for @stepOcr3aSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Solde, versements cumulés, rendement'**
+  String get stepOcr3aSubtitle;
+
+  /// No description provided for @stepOcr3aBoost.
+  ///
+  /// In fr, this message translates to:
+  /// **'+7 pts de précision'**
+  String get stepOcr3aBoost;
+
+  /// No description provided for @stepOcrScanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Scanné'**
+  String get stepOcrScanned;
+
+  /// No description provided for @stepOcrContinueWith.
+  ///
+  /// In fr, this message translates to:
+  /// **'Continuer ({count} document{plural} scanné{plural})'**
+  String stepOcrContinueWith(int count, String plural);
+
+  /// No description provided for @stepOcrContinueWithout.
+  ///
+  /// In fr, this message translates to:
+  /// **'Continuer sans document'**
+  String get stepOcrContinueWithout;
+
+  /// No description provided for @stepOcrDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif — ne constitue pas un conseil financier (LSFin). Documents traités sur ton appareil, aucune donnée envoyée (LPD art. 6).'**
+  String get stepOcrDisclaimer;
+
+  /// No description provided for @stepOcrLpdBanner.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes documents sont traités sur ton appareil. Rien n’est envoyé sur Internet.'**
+  String get stepOcrLpdBanner;
+
+  /// No description provided for @stepOcrLpdTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Traitement privé sur ton appareil'**
+  String get stepOcrLpdTitle;
+
+  /// No description provided for @stepOcrLpdBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ce document est analysé directement sur ton téléphone.\nAucune donnée n’est envoyée sur Internet.\nLes informations extraites sont supprimées après traitement.'**
+  String get stepOcrLpdBody;
+
+  /// No description provided for @stepOcrLpdLegal.
+  ///
+  /// In fr, this message translates to:
+  /// **'Base légale : LPD art. 6 — minimisation des données.'**
+  String get stepOcrLpdLegal;
+
+  /// No description provided for @stepOcrLpdScan.
+  ///
+  /// In fr, this message translates to:
+  /// **'Scanner ce document'**
+  String get stepOcrLpdScan;
+
+  /// No description provided for @stepOcrLpdCancel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Annuler'**
+  String get stepOcrLpdCancel;
+
+  /// No description provided for @stepOcrSnackSuccess.
+  ///
+  /// In fr, this message translates to:
+  /// **'{count} champ{plural} extrait{plural} avec succès'**
+  String stepOcrSnackSuccess(int count, String plural);
+
+  /// No description provided for @stepOcrSnackEmpty.
+  ///
+  /// In fr, this message translates to:
+  /// **'Document traité — aucun champ reconnu automatiquement'**
+  String get stepOcrSnackEmpty;
+
+  /// No description provided for @stepOcrSnackError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors du traitement : {error}'**
+  String stepOcrSnackError(String error);
+
+  /// No description provided for @stepOcrSnackWebOnly.
+  ///
+  /// In fr, this message translates to:
+  /// **'Scan d’image non disponible sur web. Utilise l’app mobile ou importe un fichier .txt.'**
+  String get stepOcrSnackWebOnly;
+
+  /// No description provided for @stepQuestionsAgeYears.
+  ///
+  /// In fr, this message translates to:
+  /// **'{age} ans'**
+  String stepQuestionsAgeYears(int age);
+
+  /// No description provided for @stepQuestionsCountryUs.
+  ///
+  /// In fr, this message translates to:
+  /// **'États-Unis'**
+  String get stepQuestionsCountryUs;
+
+  /// No description provided for @stepQuestionsCountryGb.
+  ///
+  /// In fr, this message translates to:
+  /// **'Royaume-Uni'**
+  String get stepQuestionsCountryGb;
+
+  /// No description provided for @stepQuestionsCountryCa.
+  ///
+  /// In fr, this message translates to:
+  /// **'Canada'**
+  String get stepQuestionsCountryCa;
+
+  /// No description provided for @stepQuestionsCountryIn.
+  ///
+  /// In fr, this message translates to:
+  /// **'Inde'**
+  String get stepQuestionsCountryIn;
+
+  /// No description provided for @stepQuestionsCountryCn.
+  ///
+  /// In fr, this message translates to:
+  /// **'Chine'**
+  String get stepQuestionsCountryCn;
+
+  /// No description provided for @stepQuestionsCountryBr.
+  ///
+  /// In fr, this message translates to:
+  /// **'Brésil'**
+  String get stepQuestionsCountryBr;
+
+  /// No description provided for @stepQuestionsCountryAu.
+  ///
+  /// In fr, this message translates to:
+  /// **'Australie'**
+  String get stepQuestionsCountryAu;
+
+  /// No description provided for @stepQuestionsCountryJp.
+  ///
+  /// In fr, this message translates to:
+  /// **'Japon'**
+  String get stepQuestionsCountryJp;
+
+  /// No description provided for @householdAcceptCodeHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'CODE'**
+  String get householdAcceptCodeHint;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23512,4 +23512,372 @@ class SDe extends S {
 
   @override
   String get nationalityAutre => 'Andere';
+
+  @override
+  String get stepStressTitle => 'Was beschäftigt dich am meisten?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Wähle ein Thema — wir personalisieren dein Erlebnis.';
+
+  @override
+  String get stepStressRetirement => 'Meine Pension';
+
+  @override
+  String get stepStressRetirementSub => 'Werde ich genug zum Leben haben?';
+
+  @override
+  String get stepStressTaxes => 'Meine Steuern';
+
+  @override
+  String get stepStressTaxesSub => 'Zahle ich zu viel?';
+
+  @override
+  String get stepStressBudget => 'Mein Budget';
+
+  @override
+  String get stepStressBudgetSub => 'Wo geht mein Geld hin?';
+
+  @override
+  String get stepStressWealth => 'Mein Vermögen';
+
+  @override
+  String get stepStressWealthSub => 'Wie kann ich es vermehren?';
+
+  @override
+  String get stepStressCouple => 'Als Paar';
+
+  @override
+  String get stepStressCoupleSub => 'Gemeinsam optimieren';
+
+  @override
+  String get stepStressCurious => 'Einfach neugierig';
+
+  @override
+  String get stepStressCuriousSub => 'Ich möchte meine Situation verstehen';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Bildungstool — stellt keine Finanzberatung dar (FIDLEG).';
+
+  @override
+  String get stepNextTitle => 'Deine erste Bilanz ist bereit';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Aktuelle Genauigkeit: $pct %. Je mehr du dein Profil ergänzt, desto zuverlässiger die Projektionen.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Mein Profil verfeinern';
+
+  @override
+  String get stepNextDashboard => 'Mein Dashboard ansehen';
+
+  @override
+  String get stepNextCheckin => 'Meinen ersten Check-in machen';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG). Quellen: AHVG Art. 34, BVG Art. 14-16, BVV3 Art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'Deine 3 wichtigsten Aktionen';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'Basierend auf deiner Situation, hier ist der Anfang.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Ergänze dein Profil, um personalisierte Aktionen zu erhalten.';
+
+  @override
+  String get stepTopActionsContinue => 'Weiter';
+
+  @override
+  String get stepTopActionsBack => 'Zurück';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Geschätzter Impact: $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Bildungsvorschläge. Stellt keine Finanzberatung dar (FIDLEG). Konsultiere eine Fachperson für einen individuellen Plan.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Schätzung basierend auf $count Angaben. Je genauer du bist, desto zuverlässiger.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Genauigkeit: $pct %';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'Um deine Beratung zu personalisieren';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 kurze Fragen — keine richtige oder falsche Antwort.';
+
+  @override
+  String get stepChocLiteracyLpp => 'Ich kenne den Betrag meines BVG-Guthabens';
+
+  @override
+  String get stepChocLiteracyConversion =>
+      'Ich weiss, was der Umwandlungssatz ist';
+
+  @override
+  String get stepChocLiteracy3a =>
+      'Ich habe bereits auf ein 3a-Konto eingezahlt';
+
+  @override
+  String get stepChocYes => 'Ja';
+
+  @override
+  String get stepChocNo => 'Nein';
+
+  @override
+  String get stepChocAction => 'Was kann ich tun?';
+
+  @override
+  String get stepChocEnrich => 'Mein Profil verfeinern';
+
+  @override
+  String get stepChocDashboard => 'Mein Dashboard ansehen';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG). Quellen: AHVG Art. 34, BVG Art. 14-16, BVV3 Art. 7.';
+
+  @override
+  String get stepJitTitle => 'In 30 Sekunden verstehen';
+
+  @override
+  String get stepJitSi => 'WENN';
+
+  @override
+  String get stepJitAlors => 'DANN';
+
+  @override
+  String get stepJitAction => 'Was kann ich tun?';
+
+  @override
+  String get stepJitBack => 'Zurück';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Vereinfachtes Bildungstool. Stellt keine Finanzberatung dar (FIDLEG).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'deine Notfallersparnisse weniger als 2 Monate Ausgaben decken';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'ein unerwartetes Ereignis (Jobverlust, dringende Reparatur) kann dich schnell in finanzielle Schwierigkeiten bringen.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Experten empfehlen 3 bis 6 Monate Fixkosten als Reserve. Selbst CHF 100/Monat auf einem Sparkonto machen über 12 Monate einen erheblichen Unterschied.';
+
+  @override
+  String get stepJitLiquiditySource => 'Empfehlung Budgetberatung Schweiz';
+
+  @override
+  String get stepJitRetirementCond =>
+      'deine Ersatzquote bei der Pensionierung unter 60 % liegt';
+
+  @override
+  String get stepJitRetirementCons =>
+      'dein Lebensstandard könnte erheblich sinken, wenn du aufhörst zu arbeiten.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'In der Schweiz decken AHV und BVG durchschnittlich 60 % des letzten Gehalts. Die 3. Säule und freies Sparen überbrücken den Rest. Je früher du anfängst, desto geringer der monatliche Aufwand.';
+
+  @override
+  String get stepJitRetirementSource => 'AHVG Art. 34 / BVG Art. 14';
+
+  @override
+  String get stepJitTax3aCond =>
+      'du nicht den Maximalbetrag in deine 3. Säule einzahlst';
+
+  @override
+  String get stepJitTax3aCons =>
+      'du verpasst eine Steuerersparnis und zusätzliches Alterskapital.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Jeder in die Säule 3a eingezahlte Franken ist steuerlich absetzbar. Über 20 Jahre kann der Unterschied zwischen 0 und dem Maximum (CHF 7\'258) mehr als CHF 200\'000 betragen.';
+
+  @override
+  String get stepJitTax3aSource => 'BVV3 Art. 7 / DBG Art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'dein prognostiziertes Einkommen im Ruhestand geschätzt wird';
+
+  @override
+  String get stepJitIncomeCons =>
+      'diesen Betrag zu kennen ermöglicht dir, deine Vorsorgestrategie jetzt zu planen und anzupassen.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'Das Schweizer 3-Säulen-System (AHV + BVG + 3a) deckt durchschnittlich 60 % des letzten Gehalts. Jede Säule hat eigene Regeln und spezifische Optimierungshebel.';
+
+  @override
+  String get stepJitIncomeSource => 'AHVG Art. 34 / BVG Art. 14 / BVV3 Art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'du noch keinen strukturierten Finanzplan hast';
+
+  @override
+  String get stepJitDefaultCons =>
+      'du riskierst, Steuer- und Vorsorge-Optimierungen zu verpassen.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'Eine jährliche Finanzbilanz identifiziert die wirkungsvollsten Hebel: 3a, BVG-Einkauf, Krankenkassen-Franchise, indirekte Amortisation.';
+
+  @override
+  String get stepJitDefaultSource => 'MINT Bildungsempfehlung';
+
+  @override
+  String get stepOcrTitle => 'Profil in 30 Sekunden anreichern';
+
+  @override
+  String get stepOcrSkip => 'Ohne Dokument fortfahren';
+
+  @override
+  String get stepOcrIntro =>
+      'Scanne ein oder mehrere Dokumente, damit MINT deine Situation genauer berechnen kann.';
+
+  @override
+  String get stepOcrLppTitle => 'Dein BVG-Pensionsschreiben';
+
+  @override
+  String get stepOcrLppSubtitle => 'Guthaben, Umwandlungssatz, Einkaufslücke';
+
+  @override
+  String get stepOcrLppBoost => '+27 Genauigkeitspunkte';
+
+  @override
+  String get stepOcrAvsTitle => 'Dein AHV-Auszug';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Beitragsjahre, Lücken, RAMD';
+
+  @override
+  String get stepOcrAvsBoost => '+22 Genauigkeitspunkte';
+
+  @override
+  String get stepOcrTaxTitle => 'Deine Steuererklärung';
+
+  @override
+  String get stepOcrTaxSubtitle =>
+      'Steuerbares Einkommen, Vermögen, Grenzsteuersatz';
+
+  @override
+  String get stepOcrTaxBoost => '+17 Genauigkeitspunkte';
+
+  @override
+  String get stepOcr3aTitle => 'Dein 3a-Konto';
+
+  @override
+  String get stepOcr3aSubtitle => 'Saldo, kumulierte Einzahlungen, Rendite';
+
+  @override
+  String get stepOcr3aBoost => '+7 Genauigkeitspunkte';
+
+  @override
+  String get stepOcrScanned => 'Gescannt';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Weiter ($count Dokument$plural gescannt)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Ohne Dokument fortfahren';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Bildungstool — stellt keine Finanzberatung dar (FIDLEG). Dokumente werden auf deinem Gerät verarbeitet, keine Daten gesendet (DSG Art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'Deine Dokumente werden auf deinem Gerät verarbeitet. Nichts wird ins Internet gesendet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Private Verarbeitung auf deinem Gerät';
+
+  @override
+  String get stepOcrLpdBody =>
+      'Dieses Dokument wird direkt auf deinem Telefon analysiert.\nKeine Daten werden übers Internet gesendet.\nExtrahierte Informationen werden nach der Verarbeitung gelöscht.';
+
+  @override
+  String get stepOcrLpdLegal =>
+      'Rechtsgrundlage: DSG Art. 6 — Datenminimierung.';
+
+  @override
+  String get stepOcrLpdScan => 'Dieses Dokument scannen';
+
+  @override
+  String get stepOcrLpdCancel => 'Abbrechen';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count Feld$plural erfolgreich extrahiert';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Dokument verarbeitet — kein Feld automatisch erkannt';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Verarbeitungsfehler: $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Bildscan im Web nicht verfügbar. Nutze die mobile App oder importiere eine .txt-Datei.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age Jahre';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'Vereinigte Staaten';
+
+  @override
+  String get stepQuestionsCountryGb => 'Vereinigtes Königreich';
+
+  @override
+  String get stepQuestionsCountryCa => 'Kanada';
+
+  @override
+  String get stepQuestionsCountryIn => 'Indien';
+
+  @override
+  String get stepQuestionsCountryCn => 'China';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brasilien';
+
+  @override
+  String get stepQuestionsCountryAu => 'Australien';
+
+  @override
+  String get stepQuestionsCountryJp => 'Japan';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23361,4 +23361,370 @@ class SEn extends S {
 
   @override
   String get nationalityAutre => 'Other';
+
+  @override
+  String get stepStressTitle => 'What concerns you most?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Pick a topic — we\'ll personalise your experience.';
+
+  @override
+  String get stepStressRetirement => 'My retirement';
+
+  @override
+  String get stepStressRetirementSub => 'Will I have enough to live on?';
+
+  @override
+  String get stepStressTaxes => 'My taxes';
+
+  @override
+  String get stepStressTaxesSub => 'Am I paying too much?';
+
+  @override
+  String get stepStressBudget => 'My budget';
+
+  @override
+  String get stepStressBudgetSub => 'Where does my money go?';
+
+  @override
+  String get stepStressWealth => 'My wealth';
+
+  @override
+  String get stepStressWealthSub => 'How can I grow it?';
+
+  @override
+  String get stepStressCouple => 'As a couple';
+
+  @override
+  String get stepStressCoupleSub => 'Optimise together';
+
+  @override
+  String get stepStressCurious => 'Just curious';
+
+  @override
+  String get stepStressCuriousSub => 'I want to understand my situation';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Educational tool — does not constitute financial advice (FinSA).';
+
+  @override
+  String get stepNextTitle => 'Your first assessment is ready';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Current accuracy: $pct%. The more you complete your profile, the more reliable the projections.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Refine my profile';
+
+  @override
+  String get stepNextDashboard => 'View my dashboard';
+
+  @override
+  String get stepNextCheckin => 'Do my first check-in';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Simplified educational tool. Does not constitute financial advice (FinSA). Sources: OASI art. 34, BVG art. 14-16, BVV3 art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'Your 3 priority actions';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'Based on your situation, here is where to start.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Complete your profile to receive personalised actions.';
+
+  @override
+  String get stepTopActionsContinue => 'Continue';
+
+  @override
+  String get stepTopActionsBack => 'Back';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Estimated impact: $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Educational suggestions. Does not constitute financial advice (FinSA). Consult a specialist for a personalised plan.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Estimate based on $count data points. The more you specify, the more reliable.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Accuracy: $pct%';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'To personalise your advice';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 quick questions — no right or wrong answer.';
+
+  @override
+  String get stepChocLiteracyLpp =>
+      'I know the amount of my BVG pension assets';
+
+  @override
+  String get stepChocLiteracyConversion => 'I know what the conversion rate is';
+
+  @override
+  String get stepChocLiteracy3a => 'I have already contributed to a 3a account';
+
+  @override
+  String get stepChocYes => 'Yes';
+
+  @override
+  String get stepChocNo => 'No';
+
+  @override
+  String get stepChocAction => 'What can I do?';
+
+  @override
+  String get stepChocEnrich => 'Refine my profile';
+
+  @override
+  String get stepChocDashboard => 'View my dashboard';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Simplified educational tool. Does not constitute financial advice (FinSA). Sources: OASI art. 34, BVG art. 14-16, BVV3 art. 7.';
+
+  @override
+  String get stepJitTitle => 'Understand in 30 seconds';
+
+  @override
+  String get stepJitSi => 'IF';
+
+  @override
+  String get stepJitAlors => 'THEN';
+
+  @override
+  String get stepJitAction => 'What can I do?';
+
+  @override
+  String get stepJitBack => 'Back';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Simplified educational tool. Does not constitute financial advice (FinSA).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'your emergency savings cover less than 2 months of expenses';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'an unexpected event (job loss, urgent repair) could put you in financial difficulty quickly.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Experts recommend 3 to 6 months of fixed expenses in reserve. Even CHF 100/month in a savings account makes a significant difference over 12 months.';
+
+  @override
+  String get stepJitLiquiditySource =>
+      'Swiss Budget Counselling recommendation';
+
+  @override
+  String get stepJitRetirementCond =>
+      'your replacement rate at retirement is below 60%';
+
+  @override
+  String get stepJitRetirementCons =>
+      'your standard of living could drop significantly when you stop working.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'In Switzerland, OASI and BVG cover an average of 60% of the last salary. The 3rd pillar and free savings bridge the gap. The earlier you start, the lower the monthly effort.';
+
+  @override
+  String get stepJitRetirementSource => 'OASI art. 34 / BVG art. 14';
+
+  @override
+  String get stepJitTax3aCond =>
+      'you are not contributing the maximum to your 3rd pillar each year';
+
+  @override
+  String get stepJitTax3aCons =>
+      'you are missing out on a tax saving and additional retirement capital.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Every franc paid into 3a is tax-deductible. Over 20 years, the difference between contributing 0 and the maximum (CHF 7,258) can exceed CHF 200,000.';
+
+  @override
+  String get stepJitTax3aSource => 'BVV3 art. 7 / DBG art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'your projected retirement income is estimated';
+
+  @override
+  String get stepJitIncomeCons =>
+      'knowing this amount lets you plan and adjust your pension strategy now.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'The Swiss 3-pillar system (OASI + BVG + 3a) covers an average of 60% of the last salary. Each pillar has its own rules and specific optimisation levers.';
+
+  @override
+  String get stepJitIncomeSource => 'OASI art. 34 / BVG art. 14 / BVV3 art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'you do not yet have a structured financial plan';
+
+  @override
+  String get stepJitDefaultCons =>
+      'you risk missing out on tax and pension optimisation opportunities.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'An annual financial review identifies the most impactful levers: 3a, BVG buyback, health insurance deductible, indirect amortisation.';
+
+  @override
+  String get stepJitDefaultSource => 'MINT educational recommendation';
+
+  @override
+  String get stepOcrTitle => 'Enrich your profile in 30 seconds';
+
+  @override
+  String get stepOcrSkip => 'Continue without document';
+
+  @override
+  String get stepOcrIntro =>
+      'Scan one or more documents so MINT can calculate your situation more accurately.';
+
+  @override
+  String get stepOcrLppTitle => 'Your BVG pension letter';
+
+  @override
+  String get stepOcrLppSubtitle => 'Assets, conversion rate, buyback gap';
+
+  @override
+  String get stepOcrLppBoost => '+27 accuracy pts';
+
+  @override
+  String get stepOcrAvsTitle => 'Your OASI extract';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Contribution years, gaps, AIME';
+
+  @override
+  String get stepOcrAvsBoost => '+22 accuracy pts';
+
+  @override
+  String get stepOcrTaxTitle => 'Your tax return';
+
+  @override
+  String get stepOcrTaxSubtitle => 'Taxable income, wealth, marginal rate';
+
+  @override
+  String get stepOcrTaxBoost => '+17 accuracy pts';
+
+  @override
+  String get stepOcr3aTitle => 'Your 3a account';
+
+  @override
+  String get stepOcr3aSubtitle => 'Balance, cumulative contributions, return';
+
+  @override
+  String get stepOcr3aBoost => '+7 accuracy pts';
+
+  @override
+  String get stepOcrScanned => 'Scanned';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Continue ($count document$plural scanned)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Continue without document';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Educational tool — does not constitute financial advice (FinSA). Documents processed on your device, no data sent (DPA art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'Your documents are processed on your device. Nothing is sent to the Internet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Private processing on your device';
+
+  @override
+  String get stepOcrLpdBody =>
+      'This document is analysed directly on your phone.\nNo data is sent over the Internet.\nExtracted information is deleted after processing.';
+
+  @override
+  String get stepOcrLpdLegal => 'Legal basis: DPA art. 6 — data minimisation.';
+
+  @override
+  String get stepOcrLpdScan => 'Scan this document';
+
+  @override
+  String get stepOcrLpdCancel => 'Cancel';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count field$plural extracted successfully';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Document processed — no field recognised automatically';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Processing error: $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Image scanning not available on web. Use the mobile app or import a .txt file.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age years';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'United States';
+
+  @override
+  String get stepQuestionsCountryGb => 'United Kingdom';
+
+  @override
+  String get stepQuestionsCountryCa => 'Canada';
+
+  @override
+  String get stepQuestionsCountryIn => 'India';
+
+  @override
+  String get stepQuestionsCountryCn => 'China';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brazil';
+
+  @override
+  String get stepQuestionsCountryAu => 'Australia';
+
+  @override
+  String get stepQuestionsCountryJp => 'Japan';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23477,4 +23477,369 @@ class SEs extends S {
 
   @override
   String get nationalityAutre => 'Otro';
+
+  @override
+  String get stepStressTitle => '¿Qué te preocupa más?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Elige un tema — personalizamos tu experiencia.';
+
+  @override
+  String get stepStressRetirement => 'Mi jubilación';
+
+  @override
+  String get stepStressRetirementSub => '¿Tendré suficiente para vivir?';
+
+  @override
+  String get stepStressTaxes => 'Mis impuestos';
+
+  @override
+  String get stepStressTaxesSub => '¿Estoy pagando demasiado?';
+
+  @override
+  String get stepStressBudget => 'Mi presupuesto';
+
+  @override
+  String get stepStressBudgetSub => '¿A dónde va mi dinero?';
+
+  @override
+  String get stepStressWealth => 'Mi patrimonio';
+
+  @override
+  String get stepStressWealthSub => '¿Cómo hacerlo crecer?';
+
+  @override
+  String get stepStressCouple => 'En pareja';
+
+  @override
+  String get stepStressCoupleSub => 'Optimizar juntos';
+
+  @override
+  String get stepStressCurious => 'Solo curioso';
+
+  @override
+  String get stepStressCuriousSub => 'Quiero entender mi situación';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Herramienta educativa — no constituye asesoramiento financiero (LSFin).';
+
+  @override
+  String get stepNextTitle => 'Tu primer balance está listo';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Precisión actual: $pct %. Cuanto más completes tu perfil, más fiables serán las proyecciones.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Afinar mi perfil';
+
+  @override
+  String get stepNextDashboard => 'Ver mi dashboard';
+
+  @override
+  String get stepNextCheckin => 'Hacer mi primer check-in';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin). Fuentes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'Tus 3 acciones prioritarias';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'Basándose en tu situación, aquí es donde empezar.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Completa tu perfil para recibir acciones personalizadas.';
+
+  @override
+  String get stepTopActionsContinue => 'Continuar';
+
+  @override
+  String get stepTopActionsBack => 'Volver';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Impacto estimado: $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Sugerencias educativas. No constituye asesoramiento financiero (LSFin). Consulta a un especialista para un plan personalizado.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Estimación basada en $count informaciones. Cuanto más precises, más fiable.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Precisión: $pct %';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'Para personalizar tus consejos';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 preguntas rápidas — sin respuesta correcta o incorrecta.';
+
+  @override
+  String get stepChocLiteracyLpp => 'Conozco el monto de mi capital LPP';
+
+  @override
+  String get stepChocLiteracyConversion => 'Sé qué es la tasa de conversión';
+
+  @override
+  String get stepChocLiteracy3a => 'Ya he aportado a una cuenta 3a';
+
+  @override
+  String get stepChocYes => 'Sí';
+
+  @override
+  String get stepChocNo => 'No';
+
+  @override
+  String get stepChocAction => '¿Qué puedo hacer?';
+
+  @override
+  String get stepChocEnrich => 'Afinar mi perfil';
+
+  @override
+  String get stepChocDashboard => 'Ver mi dashboard';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin). Fuentes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepJitTitle => 'Comprender en 30 segundos';
+
+  @override
+  String get stepJitSi => 'SI';
+
+  @override
+  String get stepJitAlors => 'ENTONCES';
+
+  @override
+  String get stepJitAction => '¿Qué puedo hacer?';
+
+  @override
+  String get stepJitBack => 'Volver';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Herramienta educativa simplificada. No constituye asesoramiento financiero (LSFin).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'tus ahorros de emergencia cubren menos de 2 meses de gastos';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'un imprevisto (pérdida de empleo, reparación urgente) podría ponerte en dificultad financiera rápidamente.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Los expertos recomiendan 3 a 6 meses de gastos fijos en reserva. Incluso CHF 100/mes en una cuenta de ahorros marca una diferencia significativa en 12 meses.';
+
+  @override
+  String get stepJitLiquiditySource => 'Recomendación presupuestaria Suiza';
+
+  @override
+  String get stepJitRetirementCond =>
+      'tu tasa de reemplazo en la jubilación está por debajo del 60 %';
+
+  @override
+  String get stepJitRetirementCons =>
+      'tu nivel de vida podría bajar significativamente cuando dejes de trabajar.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'En Suiza, el AVS y la LPP cubren en promedio el 60 % del último salario. El 3er pilar y el ahorro libre cubren el resto. Cuanto antes empieces, menor será el esfuerzo mensual.';
+
+  @override
+  String get stepJitRetirementSource => 'LAVS art. 34 / LPP art. 14';
+
+  @override
+  String get stepJitTax3aCond => 'no aportas el máximo a tu 3er pilar cada año';
+
+  @override
+  String get stepJitTax3aCons =>
+      'estás perdiendo un ahorro fiscal y un capital de jubilación adicional.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Cada franco aportado al 3a es deducible del ingreso imponible. En 20 años, la diferencia entre aportar 0 y el máximo (CHF 7\'258) puede superar los CHF 200\'000.';
+
+  @override
+  String get stepJitTax3aSource => 'OPP3 art. 7 / LIFD art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'tu proyección de ingresos de jubilación está estimada';
+
+  @override
+  String get stepJitIncomeCons =>
+      'conocer este monto te permite planificar y ajustar tu estrategia de previsión ahora.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'El sistema suizo de 3 pilares (AVS + LPP + 3a) cubre en promedio el 60 % del último salario. Cada pilar tiene sus reglas y palancas de optimización específicas.';
+
+  @override
+  String get stepJitIncomeSource => 'LAVS art. 34 / LPP art. 14 / OPP3 art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'aún no tienes un plan financiero estructurado';
+
+  @override
+  String get stepJitDefaultCons =>
+      'corres el riesgo de perder oportunidades de optimización fiscal y de previsión.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'Un balance financiero anual permite identificar las palancas más impactantes: 3a, recompra LPP, franquicia LAMal, amortización indirecta.';
+
+  @override
+  String get stepJitDefaultSource => 'Recomendación educativa MINT';
+
+  @override
+  String get stepOcrTitle => 'Enriquece tu perfil en 30 segundos';
+
+  @override
+  String get stepOcrSkip => 'Continuar sin documento';
+
+  @override
+  String get stepOcrIntro =>
+      'Escanea uno o más documentos para que MINT calcule tu situación con más precisión.';
+
+  @override
+  String get stepOcrLppTitle => 'Tu carta de jubilación LPP';
+
+  @override
+  String get stepOcrLppSubtitle =>
+      'Capital, tasa de conversión, laguna de recompra';
+
+  @override
+  String get stepOcrLppBoost => '+27 pts de precisión';
+
+  @override
+  String get stepOcrAvsTitle => 'Tu extracto AVS';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Años de cotización, lagunas, RAMD';
+
+  @override
+  String get stepOcrAvsBoost => '+22 pts de precisión';
+
+  @override
+  String get stepOcrTaxTitle => 'Tu declaración fiscal';
+
+  @override
+  String get stepOcrTaxSubtitle => 'Ingreso imponible, fortuna, tasa marginal';
+
+  @override
+  String get stepOcrTaxBoost => '+17 pts de precisión';
+
+  @override
+  String get stepOcr3aTitle => 'Tu cuenta 3a';
+
+  @override
+  String get stepOcr3aSubtitle => 'Saldo, aportaciones acumuladas, rendimiento';
+
+  @override
+  String get stepOcr3aBoost => '+7 pts de precisión';
+
+  @override
+  String get stepOcrScanned => 'Escaneado';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Continuar ($count documento$plural escaneado$plural)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Continuar sin documento';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Herramienta educativa — no constituye asesoramiento financiero (LSFin). Documentos procesados en tu dispositivo, ningún dato enviado (LPD art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'Tus documentos se procesan en tu dispositivo. Nada se envía a Internet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Procesamiento privado en tu dispositivo';
+
+  @override
+  String get stepOcrLpdBody =>
+      'Este documento se analiza directamente en tu teléfono.\nNingún dato se envía por Internet.\nLa información extraída se elimina después del procesamiento.';
+
+  @override
+  String get stepOcrLpdLegal =>
+      'Base legal: LPD art. 6 — minimización de datos.';
+
+  @override
+  String get stepOcrLpdScan => 'Escanear este documento';
+
+  @override
+  String get stepOcrLpdCancel => 'Cancelar';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count campo$plural extraído$plural con éxito';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Documento procesado — ningún campo reconocido automáticamente';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Error de procesamiento: $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Escaneo de imagen no disponible en web. Usa la app móvil o importa un archivo .txt.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age años';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'Estados Unidos';
+
+  @override
+  String get stepQuestionsCountryGb => 'Reino Unido';
+
+  @override
+  String get stepQuestionsCountryCa => 'Canadá';
+
+  @override
+  String get stepQuestionsCountryIn => 'India';
+
+  @override
+  String get stepQuestionsCountryCn => 'China';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brasil';
+
+  @override
+  String get stepQuestionsCountryAu => 'Australia';
+
+  @override
+  String get stepQuestionsCountryJp => 'Japón';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23474,4 +23474,371 @@ class SFr extends S {
 
   @override
   String get nationalityAutre => 'Autre';
+
+  @override
+  String get stepStressTitle => 'Qu’est-ce qui te préoccupe le plus ?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Choisis un thème — on personnalise ton expérience.';
+
+  @override
+  String get stepStressRetirement => 'Ma retraite';
+
+  @override
+  String get stepStressRetirementSub => 'Vais-je avoir assez pour vivre ?';
+
+  @override
+  String get stepStressTaxes => 'Mes impôts';
+
+  @override
+  String get stepStressTaxesSub => 'Est-ce que je paie trop ?';
+
+  @override
+  String get stepStressBudget => 'Mon budget';
+
+  @override
+  String get stepStressBudgetSub => 'Où passe mon argent ?';
+
+  @override
+  String get stepStressWealth => 'Mon patrimoine';
+
+  @override
+  String get stepStressWealthSub => 'Comment le faire grandir ?';
+
+  @override
+  String get stepStressCouple => 'En couple';
+
+  @override
+  String get stepStressCoupleSub => 'Optimiser à deux';
+
+  @override
+  String get stepStressCurious => 'Juste curieux';
+
+  @override
+  String get stepStressCuriousSub => 'Je veux comprendre ma situation';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Outil éducatif — ne constitue pas un conseil financier (LSFin).';
+
+  @override
+  String get stepNextTitle => 'Ton premier bilan est prêt';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Précision actuelle : $pct %. Plus tu complètes ton profil, plus les projections seront fiables.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Affiner mon profil';
+
+  @override
+  String get stepNextDashboard => 'Voir mon dashboard';
+
+  @override
+  String get stepNextCheckin => 'Faire mon premier check-in';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin). Sources : LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'Tes 3 actions prioritaires';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'Basées sur ta situation, voici par où commencer.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Complète ton profil pour recevoir des actions personnalisées.';
+
+  @override
+  String get stepTopActionsContinue => 'Continuer';
+
+  @override
+  String get stepTopActionsBack => 'Retour';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Impact estimé : $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Suggestions éducatives. Ne constitue pas un conseil financier (LSFin). Consulte un·e spécialiste pour un plan personnalisé.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Estimation basée sur $count informations. Plus tu précises, plus c’est fiable.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Précision : $pct %';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'Pour personnaliser tes conseils';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 questions rapides — aucune bonne ou mauvaise réponse.';
+
+  @override
+  String get stepChocLiteracyLpp => 'Je connais le montant de mon avoir LPP';
+
+  @override
+  String get stepChocLiteracyConversion =>
+      'Je sais ce qu’est le taux de conversion';
+
+  @override
+  String get stepChocLiteracy3a => 'J’ai déjà versé sur un compte 3a';
+
+  @override
+  String get stepChocYes => 'Oui';
+
+  @override
+  String get stepChocNo => 'Non';
+
+  @override
+  String get stepChocAction => 'Qu’est-ce que je peux faire ?';
+
+  @override
+  String get stepChocEnrich => 'Affiner mon profil';
+
+  @override
+  String get stepChocDashboard => 'Voir mon dashboard';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin). Sources : LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepJitTitle => 'Comprendre en 30 secondes';
+
+  @override
+  String get stepJitSi => 'SI';
+
+  @override
+  String get stepJitAlors => 'ALORS';
+
+  @override
+  String get stepJitAction => 'Que puis-je faire ?';
+
+  @override
+  String get stepJitBack => 'Retour';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Outil éducatif simplifié. Ne constitue pas un conseil financier (LSFin).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'ton épargne de sécurité couvre moins de 2 mois de charges';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'un imprévu (perte d’emploi, réparation urgente) peut te mettre en difficulté financière rapidement.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Les experts recommandent 3 à 6 mois de charges fixes en réserve. Même 100 CHF/mois sur un compte épargne fait une différence significative sur 12 mois.';
+
+  @override
+  String get stepJitLiquiditySource => 'Recommandation Budget-conseil Suisse';
+
+  @override
+  String get stepJitRetirementCond =>
+      'ton taux de remplacement à la retraite est inférieur à 60 %';
+
+  @override
+  String get stepJitRetirementCons =>
+      'ton niveau de vie pourrait baisser significativement le jour où tu arrêtes de travailler.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'En Suisse, l’AVS et la LPP couvrent en moyenne 60 % du dernier salaire. Le 3e pilier et l’épargne libre comblent le reste. Plus tu commences tôt, moins l’effort mensuel est important.';
+
+  @override
+  String get stepJitRetirementSource => 'LAVS art. 34 / LPP art. 14';
+
+  @override
+  String get stepJitTax3aCond =>
+      'tu ne verses pas le maximum dans ton 3e pilier chaque année';
+
+  @override
+  String get stepJitTax3aCons =>
+      'tu passes à côté d’une économie fiscale et d’un capital retraite supplémentaire.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Chaque franc versé en 3a est déductible du revenu imposable. Sur 20 ans, la différence entre verser 0 et le plafond (7’258 CHF) peut représenter plus de 200’000 CHF.';
+
+  @override
+  String get stepJitTax3aSource => 'OPP3 art. 7 / LIFD art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'ta projection de revenu à la retraite est estimée';
+
+  @override
+  String get stepJitIncomeCons =>
+      'connaître ce montant te permet de planifier et d’ajuster ta stratégie de prévoyance dès maintenant.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'Le système suisse à 3 piliers (AVS + LPP + 3a) couvre en moyenne 60 % du dernier salaire. Chaque pilier a ses règles et ses leviers d’optimisation spécifiques.';
+
+  @override
+  String get stepJitIncomeSource => 'LAVS art. 34 / LPP art. 14 / OPP3 art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'tu n’as pas encore un plan financier structuré';
+
+  @override
+  String get stepJitDefaultCons =>
+      'tu risques de passer à côté d’opportunités d’optimisation fiscale et de prévoyance.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'Un bilan financier annuel permet d’identifier les leviers les plus impactants : 3a, rachat LPP, franchise LAMal, amortissement indirect.';
+
+  @override
+  String get stepJitDefaultSource => 'Recommandation éducative MINT';
+
+  @override
+  String get stepOcrTitle => 'Enrichis ton profil en 30 secondes';
+
+  @override
+  String get stepOcrSkip => 'Continuer sans document';
+
+  @override
+  String get stepOcrIntro =>
+      'Scanne un ou plusieurs documents pour que MINT calcule ta situation avec plus de précision.';
+
+  @override
+  String get stepOcrLppTitle => 'Ta lettre de retraite LPP';
+
+  @override
+  String get stepOcrLppSubtitle =>
+      'Avoir, taux de conversion, lacune de rachat';
+
+  @override
+  String get stepOcrLppBoost => '+27 pts de précision';
+
+  @override
+  String get stepOcrAvsTitle => 'Ton extrait AVS';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Années de cotisation, lacunes, RAMD';
+
+  @override
+  String get stepOcrAvsBoost => '+22 pts de précision';
+
+  @override
+  String get stepOcrTaxTitle => 'Ta déclaration fiscale';
+
+  @override
+  String get stepOcrTaxSubtitle => 'Revenu imposable, fortune, taux marginal';
+
+  @override
+  String get stepOcrTaxBoost => '+17 pts de précision';
+
+  @override
+  String get stepOcr3aTitle => 'Ton compte 3a';
+
+  @override
+  String get stepOcr3aSubtitle => 'Solde, versements cumulés, rendement';
+
+  @override
+  String get stepOcr3aBoost => '+7 pts de précision';
+
+  @override
+  String get stepOcrScanned => 'Scanné';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Continuer ($count document$plural scanné$plural)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Continuer sans document';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Outil éducatif — ne constitue pas un conseil financier (LSFin). Documents traités sur ton appareil, aucune donnée envoyée (LPD art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'Tes documents sont traités sur ton appareil. Rien n’est envoyé sur Internet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Traitement privé sur ton appareil';
+
+  @override
+  String get stepOcrLpdBody =>
+      'Ce document est analysé directement sur ton téléphone.\nAucune donnée n’est envoyée sur Internet.\nLes informations extraites sont supprimées après traitement.';
+
+  @override
+  String get stepOcrLpdLegal =>
+      'Base légale : LPD art. 6 — minimisation des données.';
+
+  @override
+  String get stepOcrLpdScan => 'Scanner ce document';
+
+  @override
+  String get stepOcrLpdCancel => 'Annuler';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count champ$plural extrait$plural avec succès';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Document traité — aucun champ reconnu automatiquement';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Erreur lors du traitement : $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Scan d’image non disponible sur web. Utilise l’app mobile ou importe un fichier .txt.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age ans';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'États-Unis';
+
+  @override
+  String get stepQuestionsCountryGb => 'Royaume-Uni';
+
+  @override
+  String get stepQuestionsCountryCa => 'Canada';
+
+  @override
+  String get stepQuestionsCountryIn => 'Inde';
+
+  @override
+  String get stepQuestionsCountryCn => 'Chine';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brésil';
+
+  @override
+  String get stepQuestionsCountryAu => 'Australie';
+
+  @override
+  String get stepQuestionsCountryJp => 'Japon';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23515,4 +23515,372 @@ class SIt extends S {
 
   @override
   String get nationalityAutre => 'Altro';
+
+  @override
+  String get stepStressTitle => 'Cosa ti preoccupa di più?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Scegli un tema — personalizziamo la tua esperienza.';
+
+  @override
+  String get stepStressRetirement => 'La mia pensione';
+
+  @override
+  String get stepStressRetirementSub => 'Avrò abbastanza per vivere?';
+
+  @override
+  String get stepStressTaxes => 'Le mie tasse';
+
+  @override
+  String get stepStressTaxesSub => 'Sto pagando troppo?';
+
+  @override
+  String get stepStressBudget => 'Il mio budget';
+
+  @override
+  String get stepStressBudgetSub => 'Dove vanno i miei soldi?';
+
+  @override
+  String get stepStressWealth => 'Il mio patrimonio';
+
+  @override
+  String get stepStressWealthSub => 'Come farlo crescere?';
+
+  @override
+  String get stepStressCouple => 'In coppia';
+
+  @override
+  String get stepStressCoupleSub => 'Ottimizzare insieme';
+
+  @override
+  String get stepStressCurious => 'Solo curioso';
+
+  @override
+  String get stepStressCuriousSub => 'Voglio capire la mia situazione';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Strumento educativo — non costituisce consulenza finanziaria (LSFin).';
+
+  @override
+  String get stepNextTitle => 'Il tuo primo bilancio è pronto';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Precisione attuale: $pct %. Più completi il tuo profilo, più affidabili saranno le proiezioni.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Perfezionare il mio profilo';
+
+  @override
+  String get stepNextDashboard => 'Visualizza la mia dashboard';
+
+  @override
+  String get stepNextCheckin => 'Fare il mio primo check-in';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin). Fonti: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'Le tue 3 azioni prioritarie';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'In base alla tua situazione, ecco da dove iniziare.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Completa il tuo profilo per ricevere azioni personalizzate.';
+
+  @override
+  String get stepTopActionsContinue => 'Continua';
+
+  @override
+  String get stepTopActionsBack => 'Indietro';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Impatto stimato: $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Suggerimenti educativi. Non costituisce consulenza finanziaria (LSFin). Consulta uno specialista per un piano personalizzato.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Stima basata su $count informazioni. Più precisi i dati, più affidabile il risultato.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Precisione: $pct %';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'Per personalizzare i tuoi consigli';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 domande rapide — nessuna risposta giusta o sbagliata.';
+
+  @override
+  String get stepChocLiteracyLpp => 'Conosco l’importo del mio avere LPP';
+
+  @override
+  String get stepChocLiteracyConversion => 'So cos’è il tasso di conversione';
+
+  @override
+  String get stepChocLiteracy3a => 'Ho già versato su un conto 3a';
+
+  @override
+  String get stepChocYes => 'Sì';
+
+  @override
+  String get stepChocNo => 'No';
+
+  @override
+  String get stepChocAction => 'Cosa posso fare?';
+
+  @override
+  String get stepChocEnrich => 'Perfezionare il mio profilo';
+
+  @override
+  String get stepChocDashboard => 'Visualizza la mia dashboard';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin). Fonti: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepJitTitle => 'Capire in 30 secondi';
+
+  @override
+  String get stepJitSi => 'SE';
+
+  @override
+  String get stepJitAlors => 'ALLORA';
+
+  @override
+  String get stepJitAction => 'Cosa posso fare?';
+
+  @override
+  String get stepJitBack => 'Indietro';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Strumento educativo semplificato. Non costituisce consulenza finanziaria (LSFin).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'i tuoi risparmi di emergenza coprono meno di 2 mesi di spese';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'un imprevisto (perdita del lavoro, riparazione urgente) potrebbe metterti in difficoltà finanziaria rapidamente.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Gli esperti raccomandano 3-6 mesi di spese fisse come riserva. Anche CHF 100/mese su un conto risparmio fanno una differenza significativa in 12 mesi.';
+
+  @override
+  String get stepJitLiquiditySource =>
+      'Raccomandazione consulenza budget Svizzera';
+
+  @override
+  String get stepJitRetirementCond =>
+      'il tuo tasso di sostituzione alla pensione è inferiore al 60 %';
+
+  @override
+  String get stepJitRetirementCons =>
+      'il tuo tenore di vita potrebbe calare significativamente quando smetterai di lavorare.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'In Svizzera, AVS e LPP coprono in media il 60 % dell’ultimo salario. Il 3° pilastro e il risparmio libero colmano il resto. Prima inizi, minore è lo sforzo mensile.';
+
+  @override
+  String get stepJitRetirementSource => 'LAVS art. 34 / LPP art. 14';
+
+  @override
+  String get stepJitTax3aCond =>
+      'non versi il massimo nel tuo 3° pilastro ogni anno';
+
+  @override
+  String get stepJitTax3aCons =>
+      'stai perdendo un risparmio fiscale e un capitale pensionistico aggiuntivo.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Ogni franco versato nel 3a è deducibile dal reddito imponibile. In 20 anni, la differenza tra versare 0 e il massimo (CHF 7\'258) può superare CHF 200\'000.';
+
+  @override
+  String get stepJitTax3aSource => 'OPP3 art. 7 / LIFD art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'la tua proiezione di reddito pensionistico è stimata';
+
+  @override
+  String get stepJitIncomeCons =>
+      'conoscere questo importo ti permette di pianificare e adattare la tua strategia previdenziale ora.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'Il sistema svizzero a 3 pilastri (AVS + LPP + 3a) copre in media il 60 % dell’ultimo salario. Ogni pilastro ha le sue regole e leve di ottimizzazione specifiche.';
+
+  @override
+  String get stepJitIncomeSource => 'LAVS art. 34 / LPP art. 14 / OPP3 art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'non hai ancora un piano finanziario strutturato';
+
+  @override
+  String get stepJitDefaultCons =>
+      'rischi di perdere opportunità di ottimizzazione fiscale e previdenziale.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'Un bilancio finanziario annuale permette di identificare le leve più impattanti: 3a, riscatto LPP, franchigia LAMal, ammortamento indiretto.';
+
+  @override
+  String get stepJitDefaultSource => 'Raccomandazione educativa MINT';
+
+  @override
+  String get stepOcrTitle => 'Arricchisci il tuo profilo in 30 secondi';
+
+  @override
+  String get stepOcrSkip => 'Continua senza documento';
+
+  @override
+  String get stepOcrIntro =>
+      'Scansiona uno o più documenti affinché MINT calcoli la tua situazione con più precisione.';
+
+  @override
+  String get stepOcrLppTitle => 'La tua lettera pensionistica LPP';
+
+  @override
+  String get stepOcrLppSubtitle =>
+      'Avere, tasso di conversione, lacuna di riscatto';
+
+  @override
+  String get stepOcrLppBoost => '+27 punti di precisione';
+
+  @override
+  String get stepOcrAvsTitle => 'Il tuo estratto AVS';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Anni di contribuzione, lacune, RAMD';
+
+  @override
+  String get stepOcrAvsBoost => '+22 punti di precisione';
+
+  @override
+  String get stepOcrTaxTitle => 'La tua dichiarazione fiscale';
+
+  @override
+  String get stepOcrTaxSubtitle =>
+      'Reddito imponibile, patrimonio, aliquota marginale';
+
+  @override
+  String get stepOcrTaxBoost => '+17 punti di precisione';
+
+  @override
+  String get stepOcr3aTitle => 'Il tuo conto 3a';
+
+  @override
+  String get stepOcr3aSubtitle => 'Saldo, versamenti cumulati, rendimento';
+
+  @override
+  String get stepOcr3aBoost => '+7 punti di precisione';
+
+  @override
+  String get stepOcrScanned => 'Scansionato';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Continua ($count documento$plural scansionato$plural)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Continua senza documento';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Strumento educativo — non costituisce consulenza finanziaria (LSFin). Documenti elaborati sul tuo dispositivo, nessun dato inviato (LPD art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'I tuoi documenti vengono elaborati sul tuo dispositivo. Niente viene inviato su Internet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Elaborazione privata sul tuo dispositivo';
+
+  @override
+  String get stepOcrLpdBody =>
+      'Questo documento viene analizzato direttamente sul tuo telefono.\nNessun dato viene inviato su Internet.\nLe informazioni estratte vengono eliminate dopo l’elaborazione.';
+
+  @override
+  String get stepOcrLpdLegal =>
+      'Base giuridica: LPD art. 6 — minimizzazione dei dati.';
+
+  @override
+  String get stepOcrLpdScan => 'Scansiona questo documento';
+
+  @override
+  String get stepOcrLpdCancel => 'Annulla';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count campo$plural estratto$plural con successo';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Documento elaborato — nessun campo riconosciuto automaticamente';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Errore di elaborazione: $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Scansione immagini non disponibile su web. Usa l’app mobile o importa un file .txt.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age anni';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'Stati Uniti';
+
+  @override
+  String get stepQuestionsCountryGb => 'Regno Unito';
+
+  @override
+  String get stepQuestionsCountryCa => 'Canada';
+
+  @override
+  String get stepQuestionsCountryIn => 'India';
+
+  @override
+  String get stepQuestionsCountryCn => 'Cina';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brasile';
+
+  @override
+  String get stepQuestionsCountryAu => 'Australia';
+
+  @override
+  String get stepQuestionsCountryJp => 'Giappone';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23431,4 +23431,372 @@ class SPt extends S {
 
   @override
   String get nationalityAutre => 'Outro';
+
+  @override
+  String get stepStressTitle => 'O que mais te preocupa?';
+
+  @override
+  String get stepStressSubtitle =>
+      'Escolhe um tema — vamos personalizar a tua experiência.';
+
+  @override
+  String get stepStressRetirement => 'A minha reforma';
+
+  @override
+  String get stepStressRetirementSub => 'Terei o suficiente para viver?';
+
+  @override
+  String get stepStressTaxes => 'Os meus impostos';
+
+  @override
+  String get stepStressTaxesSub => 'Estou a pagar demais?';
+
+  @override
+  String get stepStressBudget => 'O meu orçamento';
+
+  @override
+  String get stepStressBudgetSub => 'Para onde vai o meu dinheiro?';
+
+  @override
+  String get stepStressWealth => 'O meu património';
+
+  @override
+  String get stepStressWealthSub => 'Como fazê-lo crescer?';
+
+  @override
+  String get stepStressCouple => 'Em casal';
+
+  @override
+  String get stepStressCoupleSub => 'Otimizar a dois';
+
+  @override
+  String get stepStressCurious => 'Apenas curioso';
+
+  @override
+  String get stepStressCuriousSub => 'Quero compreender a minha situação';
+
+  @override
+  String get stepStressDisclaimer =>
+      'Ferramenta educativa — não constitui aconselhamento financeiro (LSFin).';
+
+  @override
+  String get stepNextTitle => 'O teu primeiro balanço está pronto';
+
+  @override
+  String stepNextConfidence(int pct) {
+    return 'Precisão atual: $pct %. Quanto mais completares o teu perfil, mais fiáveis serão as projeções.';
+  }
+
+  @override
+  String get stepNextEnrich => 'Refinar o meu perfil';
+
+  @override
+  String get stepNextDashboard => 'Ver o meu dashboard';
+
+  @override
+  String get stepNextCheckin => 'Fazer o meu primeiro check-in';
+
+  @override
+  String get stepNextDisclaimer =>
+      'Ferramenta educativa simplificada. Não constitui aconselhamento financeiro (LSFin). Fontes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepTopActionsTitle => 'As tuas 3 ações prioritárias';
+
+  @override
+  String get stepTopActionsSubtitle =>
+      'Com base na tua situação, aqui é por onde começar.';
+
+  @override
+  String get stepTopActionsEmpty =>
+      'Completa o teu perfil para receber ações personalizadas.';
+
+  @override
+  String get stepTopActionsContinue => 'Continuar';
+
+  @override
+  String get stepTopActionsBack => 'Voltar';
+
+  @override
+  String stepTopActionsImpact(String amount) {
+    return 'Impacto estimado: $amount';
+  }
+
+  @override
+  String get stepTopActionsDisclaimer =>
+      'Sugestões educativas. Não constitui aconselhamento financeiro (LSFin). Consulta um especialista para um plano personalizado.';
+
+  @override
+  String stepChocConfidenceInfo(int count) {
+    return 'Estimativa baseada em $count informações. Quanto mais precisares, mais fiável.';
+  }
+
+  @override
+  String stepChocConfidenceLabel(int pct) {
+    return 'Precisão: $pct %';
+  }
+
+  @override
+  String get stepChocLiteracyTitle => 'Para personalizar os teus conselhos';
+
+  @override
+  String get stepChocLiteracySubtitle =>
+      '3 perguntas rápidas — sem resposta certa ou errada.';
+
+  @override
+  String get stepChocLiteracyLpp => 'Conheço o montante do meu capital LPP';
+
+  @override
+  String get stepChocLiteracyConversion => 'Sei o que é a taxa de conversão';
+
+  @override
+  String get stepChocLiteracy3a => 'Já contribuí para uma conta 3a';
+
+  @override
+  String get stepChocYes => 'Sim';
+
+  @override
+  String get stepChocNo => 'Não';
+
+  @override
+  String get stepChocAction => 'O que posso fazer?';
+
+  @override
+  String get stepChocEnrich => 'Refinar o meu perfil';
+
+  @override
+  String get stepChocDashboard => 'Ver o meu dashboard';
+
+  @override
+  String get stepChocDisclaimer =>
+      'Ferramenta educativa simplificada. Não constitui aconselhamento financeiro (LSFin). Fontes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.';
+
+  @override
+  String get stepJitTitle => 'Compreender em 30 segundos';
+
+  @override
+  String get stepJitSi => 'SE';
+
+  @override
+  String get stepJitAlors => 'ENTÃO';
+
+  @override
+  String get stepJitAction => 'O que posso fazer?';
+
+  @override
+  String get stepJitBack => 'Voltar';
+
+  @override
+  String get stepJitDisclaimer =>
+      'Ferramenta educativa simplificada. Não constitui aconselhamento financeiro (LSFin).';
+
+  @override
+  String get stepJitLiquidityCond =>
+      'as tuas poupanças de emergência cobrem menos de 2 meses de despesas';
+
+  @override
+  String get stepJitLiquidityCons =>
+      'um imprevisto (perda de emprego, reparação urgente) pode colocar-te em dificuldade financeira rapidamente.';
+
+  @override
+  String get stepJitLiquidityInsight =>
+      'Os especialistas recomendam 3 a 6 meses de despesas fixas em reserva. Mesmo CHF 100/mês numa conta poupança faz uma diferença significativa em 12 meses.';
+
+  @override
+  String get stepJitLiquiditySource =>
+      'Recomendação de consultoria orçamental Suíça';
+
+  @override
+  String get stepJitRetirementCond =>
+      'a tua taxa de substituição na reforma está abaixo de 60 %';
+
+  @override
+  String get stepJitRetirementCons =>
+      'o teu nível de vida pode diminuir significativamente quando parares de trabalhar.';
+
+  @override
+  String get stepJitRetirementInsight =>
+      'Na Suíça, o AVS e a LPP cobrem em média 60 % do último salário. O 3º pilar e a poupança livre preenchem o restante. Quanto mais cedo começares, menor o esforço mensal.';
+
+  @override
+  String get stepJitRetirementSource => 'LAVS art. 34 / LPP art. 14';
+
+  @override
+  String get stepJitTax3aCond =>
+      'não contribuís o máximo para o teu 3º pilar todos os anos';
+
+  @override
+  String get stepJitTax3aCons =>
+      'estás a perder uma poupança fiscal e um capital de reforma adicional.';
+
+  @override
+  String get stepJitTax3aInsight =>
+      'Cada franco contribuído para o 3a é dedutível do rendimento tributável. Em 20 anos, a diferença entre contribuir 0 e o máximo (CHF 7\'258) pode ultrapassar CHF 200\'000.';
+
+  @override
+  String get stepJitTax3aSource => 'OPP3 art. 7 / LIFD art. 33';
+
+  @override
+  String get stepJitIncomeCond =>
+      'a tua projeção de rendimento na reforma está estimada';
+
+  @override
+  String get stepJitIncomeCons =>
+      'conhecer este montante permite-te planear e ajustar a tua estratégia de previdência agora.';
+
+  @override
+  String get stepJitIncomeInsight =>
+      'O sistema suíço de 3 pilares (AVS + LPP + 3a) cobre em média 60 % do último salário. Cada pilar tem as suas regras e alavancas de otimização específicas.';
+
+  @override
+  String get stepJitIncomeSource => 'LAVS art. 34 / LPP art. 14 / OPP3 art. 7';
+
+  @override
+  String get stepJitDefaultCond =>
+      'ainda não tens um plano financeiro estruturado';
+
+  @override
+  String get stepJitDefaultCons =>
+      'arriscas perder oportunidades de otimização fiscal e de previdência.';
+
+  @override
+  String get stepJitDefaultInsight =>
+      'Um balanço financeiro anual permite identificar as alavancas mais impactantes: 3a, resgate LPP, franquia LAMal, amortização indireta.';
+
+  @override
+  String get stepJitDefaultSource => 'Recomendação educativa MINT';
+
+  @override
+  String get stepOcrTitle => 'Enriquece o teu perfil em 30 segundos';
+
+  @override
+  String get stepOcrSkip => 'Continuar sem documento';
+
+  @override
+  String get stepOcrIntro =>
+      'Digitaliza um ou mais documentos para que o MINT calcule a tua situação com mais precisão.';
+
+  @override
+  String get stepOcrLppTitle => 'A tua carta de reforma LPP';
+
+  @override
+  String get stepOcrLppSubtitle =>
+      'Capital, taxa de conversão, lacuna de resgate';
+
+  @override
+  String get stepOcrLppBoost => '+27 pts de precisão';
+
+  @override
+  String get stepOcrAvsTitle => 'O teu extrato AVS';
+
+  @override
+  String get stepOcrAvsSubtitle => 'Anos de contribuição, lacunas, RAMD';
+
+  @override
+  String get stepOcrAvsBoost => '+22 pts de precisão';
+
+  @override
+  String get stepOcrTaxTitle => 'A tua declaração fiscal';
+
+  @override
+  String get stepOcrTaxSubtitle =>
+      'Rendimento tributável, património, taxa marginal';
+
+  @override
+  String get stepOcrTaxBoost => '+17 pts de precisão';
+
+  @override
+  String get stepOcr3aTitle => 'A tua conta 3a';
+
+  @override
+  String get stepOcr3aSubtitle => 'Saldo, contribuições acumuladas, rendimento';
+
+  @override
+  String get stepOcr3aBoost => '+7 pts de precisão';
+
+  @override
+  String get stepOcrScanned => 'Digitalizado';
+
+  @override
+  String stepOcrContinueWith(int count, String plural) {
+    return 'Continuar ($count documento$plural digitalizado$plural)';
+  }
+
+  @override
+  String get stepOcrContinueWithout => 'Continuar sem documento';
+
+  @override
+  String get stepOcrDisclaimer =>
+      'Ferramenta educativa — não constitui aconselhamento financeiro (LSFin). Documentos processados no teu dispositivo, nenhum dado enviado (LPD art. 6).';
+
+  @override
+  String get stepOcrLpdBanner =>
+      'Os teus documentos são processados no teu dispositivo. Nada é enviado para a Internet.';
+
+  @override
+  String get stepOcrLpdTitle => 'Processamento privado no teu dispositivo';
+
+  @override
+  String get stepOcrLpdBody =>
+      'Este documento é analisado diretamente no teu telefone.\nNenhum dado é enviado pela Internet.\nAs informações extraídas são eliminadas após o processamento.';
+
+  @override
+  String get stepOcrLpdLegal =>
+      'Base legal: LPD art. 6 — minimização de dados.';
+
+  @override
+  String get stepOcrLpdScan => 'Digitalizar este documento';
+
+  @override
+  String get stepOcrLpdCancel => 'Cancelar';
+
+  @override
+  String stepOcrSnackSuccess(int count, String plural) {
+    return '$count campo$plural extraído$plural com sucesso';
+  }
+
+  @override
+  String get stepOcrSnackEmpty =>
+      'Documento processado — nenhum campo reconhecido automaticamente';
+
+  @override
+  String stepOcrSnackError(String error) {
+    return 'Erro de processamento: $error';
+  }
+
+  @override
+  String get stepOcrSnackWebOnly =>
+      'Digitalização de imagem não disponível na web. Usa a app móvel ou importa um ficheiro .txt.';
+
+  @override
+  String stepQuestionsAgeYears(int age) {
+    return '$age anos';
+  }
+
+  @override
+  String get stepQuestionsCountryUs => 'Estados Unidos';
+
+  @override
+  String get stepQuestionsCountryGb => 'Reino Unido';
+
+  @override
+  String get stepQuestionsCountryCa => 'Canadá';
+
+  @override
+  String get stepQuestionsCountryIn => 'Índia';
+
+  @override
+  String get stepQuestionsCountryCn => 'China';
+
+  @override
+  String get stepQuestionsCountryBr => 'Brasil';
+
+  @override
+  String get stepQuestionsCountryAu => 'Austrália';
+
+  @override
+  String get stepQuestionsCountryJp => 'Japão';
+
+  @override
+  String get householdAcceptCodeHint => 'CODE';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -10992,5 +10992,161 @@
   "employmentRetraite": "Reformado/a",
   "nationalitySuisse": "Su\u00ed\u00e7a",
   "nationalityEuAele": "UE/EFTA",
-  "nationalityAutre": "Outro"
+  "nationalityAutre": "Outro",
+
+  "stepStressTitle": "O que mais te preocupa?",
+  "stepStressSubtitle": "Escolhe um tema \u2014 vamos personalizar a tua experi\u00eancia.",
+  "stepStressRetirement": "A minha reforma",
+  "stepStressRetirementSub": "Terei o suficiente para viver?",
+  "stepStressTaxes": "Os meus impostos",
+  "stepStressTaxesSub": "Estou a pagar demais?",
+  "stepStressBudget": "O meu or\u00e7amento",
+  "stepStressBudgetSub": "Para onde vai o meu dinheiro?",
+  "stepStressWealth": "O meu patrim\u00f3nio",
+  "stepStressWealthSub": "Como faz\u00ea-lo crescer?",
+  "stepStressCouple": "Em casal",
+  "stepStressCoupleSub": "Otimizar a dois",
+  "stepStressCurious": "Apenas curioso",
+  "stepStressCuriousSub": "Quero compreender a minha situa\u00e7\u00e3o",
+  "stepStressDisclaimer": "Ferramenta educativa \u2014 n\u00e3o constitui aconselhamento financeiro (LSFin).",
+
+  "stepNextTitle": "O teu primeiro balan\u00e7o est\u00e1 pronto",
+  "stepNextConfidence": "Precis\u00e3o atual: {pct}\u00a0%. Quanto mais completares o teu perfil, mais fi\u00e1veis ser\u00e3o as proje\u00e7\u00f5es.",
+  "@stepNextConfidence": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepNextEnrich": "Refinar o meu perfil",
+  "stepNextDashboard": "Ver o meu dashboard",
+  "stepNextCheckin": "Fazer o meu primeiro check-in",
+  "stepNextDisclaimer": "Ferramenta educativa simplificada. N\u00e3o constitui aconselhamento financeiro (LSFin). Fontes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepTopActionsTitle": "As tuas 3 a\u00e7\u00f5es priorit\u00e1rias",
+  "stepTopActionsSubtitle": "Com base na tua situa\u00e7\u00e3o, aqui \u00e9 por onde come\u00e7ar.",
+  "stepTopActionsEmpty": "Completa o teu perfil para receber a\u00e7\u00f5es personalizadas.",
+  "stepTopActionsContinue": "Continuar",
+  "stepTopActionsBack": "Voltar",
+  "stepTopActionsImpact": "Impacto estimado: {amount}",
+  "@stepTopActionsImpact": {
+    "placeholders": {
+      "amount": { "type": "String" }
+    }
+  },
+  "stepTopActionsDisclaimer": "Sugest\u00f5es educativas. N\u00e3o constitui aconselhamento financeiro (LSFin). Consulta um especialista para um plano personalizado.",
+
+  "stepChocConfidenceInfo": "Estimativa baseada em {count} informa\u00e7\u00f5es. Quanto mais precisares, mais fi\u00e1vel.",
+  "@stepChocConfidenceInfo": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "stepChocConfidenceLabel": "Precis\u00e3o: {pct}\u00a0%",
+  "@stepChocConfidenceLabel": {
+    "placeholders": {
+      "pct": { "type": "int" }
+    }
+  },
+  "stepChocLiteracyTitle": "Para personalizar os teus conselhos",
+  "stepChocLiteracySubtitle": "3 perguntas r\u00e1pidas \u2014 sem resposta certa ou errada.",
+  "stepChocLiteracyLpp": "Conhe\u00e7o o montante do meu capital LPP",
+  "stepChocLiteracyConversion": "Sei o que \u00e9 a taxa de convers\u00e3o",
+  "stepChocLiteracy3a": "J\u00e1 contribu\u00ed para uma conta 3a",
+  "stepChocYes": "Sim",
+  "stepChocNo": "N\u00e3o",
+  "stepChocAction": "O que posso fazer?",
+  "stepChocEnrich": "Refinar o meu perfil",
+  "stepChocDashboard": "Ver o meu dashboard",
+  "stepChocDisclaimer": "Ferramenta educativa simplificada. N\u00e3o constitui aconselhamento financeiro (LSFin). Fontes: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.",
+
+  "stepJitTitle": "Compreender em 30 segundos",
+  "stepJitSi": "SE",
+  "stepJitAlors": "ENT\u00c3O",
+  "stepJitAction": "O que posso fazer?",
+  "stepJitBack": "Voltar",
+  "stepJitDisclaimer": "Ferramenta educativa simplificada. N\u00e3o constitui aconselhamento financeiro (LSFin).",
+  "stepJitLiquidityCond": "as tuas poupan\u00e7as de emerg\u00eancia cobrem menos de 2 meses de despesas",
+  "stepJitLiquidityCons": "um imprevisto (perda de emprego, repara\u00e7\u00e3o urgente) pode colocar-te em dificuldade financeira rapidamente.",
+  "stepJitLiquidityInsight": "Os especialistas recomendam 3 a 6 meses de despesas fixas em reserva. Mesmo CHF 100/m\u00eas numa conta poupan\u00e7a faz uma diferen\u00e7a significativa em 12 meses.",
+  "stepJitLiquiditySource": "Recomenda\u00e7\u00e3o de consultoria or\u00e7amental Su\u00ed\u00e7a",
+  "stepJitRetirementCond": "a tua taxa de substitui\u00e7\u00e3o na reforma est\u00e1 abaixo de 60\u00a0%",
+  "stepJitRetirementCons": "o teu n\u00edvel de vida pode diminuir significativamente quando parares de trabalhar.",
+  "stepJitRetirementInsight": "Na Su\u00ed\u00e7a, o AVS e a LPP cobrem em m\u00e9dia 60\u00a0% do \u00faltimo sal\u00e1rio. O 3\u00ba pilar e a poupan\u00e7a livre preenchem o restante. Quanto mais cedo come\u00e7ares, menor o esfor\u00e7o mensal.",
+  "stepJitRetirementSource": "LAVS art. 34 / LPP art. 14",
+  "stepJitTax3aCond": "n\u00e3o contribu\u00eds o m\u00e1ximo para o teu 3\u00ba pilar todos os anos",
+  "stepJitTax3aCons": "est\u00e1s a perder uma poupan\u00e7a fiscal e um capital de reforma adicional.",
+  "stepJitTax3aInsight": "Cada franco contribu\u00eddo para o 3a \u00e9 dedut\u00edvel do rendimento tribut\u00e1vel. Em 20 anos, a diferen\u00e7a entre contribuir 0 e o m\u00e1ximo (CHF 7'258) pode ultrapassar CHF 200'000.",
+  "stepJitTax3aSource": "OPP3 art. 7 / LIFD art. 33",
+  "stepJitIncomeCond": "a tua proje\u00e7\u00e3o de rendimento na reforma est\u00e1 estimada",
+  "stepJitIncomeCons": "conhecer este montante permite-te planear e ajustar a tua estrat\u00e9gia de previd\u00eancia agora.",
+  "stepJitIncomeInsight": "O sistema su\u00ed\u00e7o de 3 pilares (AVS + LPP + 3a) cobre em m\u00e9dia 60\u00a0% do \u00faltimo sal\u00e1rio. Cada pilar tem as suas regras e alavancas de otimiza\u00e7\u00e3o espec\u00edficas.",
+  "stepJitIncomeSource": "LAVS art. 34 / LPP art. 14 / OPP3 art. 7",
+  "stepJitDefaultCond": "ainda n\u00e3o tens um plano financeiro estruturado",
+  "stepJitDefaultCons": "arriscas perder oportunidades de otimiza\u00e7\u00e3o fiscal e de previd\u00eancia.",
+  "stepJitDefaultInsight": "Um balan\u00e7o financeiro anual permite identificar as alavancas mais impactantes: 3a, resgate LPP, franquia LAMal, amortiza\u00e7\u00e3o indireta.",
+  "stepJitDefaultSource": "Recomenda\u00e7\u00e3o educativa MINT",
+
+  "stepOcrTitle": "Enriquece o teu perfil em 30 segundos",
+  "stepOcrSkip": "Continuar sem documento",
+  "stepOcrIntro": "Digitaliza um ou mais documentos para que o MINT calcule a tua situa\u00e7\u00e3o com mais precis\u00e3o.",
+  "stepOcrLppTitle": "A tua carta de reforma LPP",
+  "stepOcrLppSubtitle": "Capital, taxa de convers\u00e3o, lacuna de resgate",
+  "stepOcrLppBoost": "+27 pts de precis\u00e3o",
+  "stepOcrAvsTitle": "O teu extrato AVS",
+  "stepOcrAvsSubtitle": "Anos de contribui\u00e7\u00e3o, lacunas, RAMD",
+  "stepOcrAvsBoost": "+22 pts de precis\u00e3o",
+  "stepOcrTaxTitle": "A tua declara\u00e7\u00e3o fiscal",
+  "stepOcrTaxSubtitle": "Rendimento tribut\u00e1vel, patrim\u00f3nio, taxa marginal",
+  "stepOcrTaxBoost": "+17 pts de precis\u00e3o",
+  "stepOcr3aTitle": "A tua conta 3a",
+  "stepOcr3aSubtitle": "Saldo, contribui\u00e7\u00f5es acumuladas, rendimento",
+  "stepOcr3aBoost": "+7 pts de precis\u00e3o",
+  "stepOcrScanned": "Digitalizado",
+  "stepOcrContinueWith": "Continuar ({count} documento{plural} digitalizado{plural})",
+  "@stepOcrContinueWith": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrContinueWithout": "Continuar sem documento",
+  "stepOcrDisclaimer": "Ferramenta educativa \u2014 n\u00e3o constitui aconselhamento financeiro (LSFin). Documentos processados no teu dispositivo, nenhum dado enviado (LPD art. 6).",
+  "stepOcrLpdBanner": "Os teus documentos s\u00e3o processados no teu dispositivo. Nada \u00e9 enviado para a Internet.",
+  "stepOcrLpdTitle": "Processamento privado no teu dispositivo",
+  "stepOcrLpdBody": "Este documento \u00e9 analisado diretamente no teu telefone.\nNenhum dado \u00e9 enviado pela Internet.\nAs informa\u00e7\u00f5es extra\u00eddas s\u00e3o eliminadas ap\u00f3s o processamento.",
+  "stepOcrLpdLegal": "Base legal: LPD art. 6 \u2014 minimiza\u00e7\u00e3o de dados.",
+  "stepOcrLpdScan": "Digitalizar este documento",
+  "stepOcrLpdCancel": "Cancelar",
+  "stepOcrSnackSuccess": "{count} campo{plural} extra\u00eddo{plural} com sucesso",
+  "@stepOcrSnackSuccess": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "plural": { "type": "String" }
+    }
+  },
+  "stepOcrSnackEmpty": "Documento processado \u2014 nenhum campo reconhecido automaticamente",
+  "stepOcrSnackError": "Erro de processamento: {error}",
+  "@stepOcrSnackError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "stepOcrSnackWebOnly": "Digitaliza\u00e7\u00e3o de imagem n\u00e3o dispon\u00edvel na web. Usa a app m\u00f3vel ou importa um ficheiro .txt.",
+
+  "stepQuestionsAgeYears": "{age} anos",
+  "@stepQuestionsAgeYears": {
+    "placeholders": {
+      "age": { "type": "int" }
+    }
+  },
+  "stepQuestionsCountryUs": "Estados Unidos",
+  "stepQuestionsCountryGb": "Reino Unido",
+  "stepQuestionsCountryCa": "Canad\u00e1",
+  "stepQuestionsCountryIn": "\u00cdndia",
+  "stepQuestionsCountryCn": "China",
+  "stepQuestionsCountryBr": "Brasil",
+  "stepQuestionsCountryAu": "Austr\u00e1lia",
+  "stepQuestionsCountryJp": "Jap\u00e3o",
+
+  "householdAcceptCodeHint": "CODE"
 }

--- a/apps/mobile/lib/screens/achievements_screen.dart
+++ b/apps/mobile/lib/screens/achievements_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -138,11 +139,9 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             if (_loading)
-              const Center(
-                child: Padding(
+              const Padding(
                   padding: EdgeInsets.all(MintSpacing.xl),
-                  child: CircularProgressIndicator(),
-                ),
+                  child: MintLoadingSkeleton(),
               )
             else if (_hasError)
               Container(

--- a/apps/mobile/lib/screens/admin_analytics_screen.dart
+++ b/apps/mobile/lib/screens/admin_analytics_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -92,11 +93,9 @@ class _AdminAnalyticsScreenState extends State<AdminAnalyticsScreen> {
         ),
       ),
       body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
-          ? const Center(
-              child: Padding(
+          ? const Padding(
                 padding: EdgeInsets.only(top: 60),
-                child: CircularProgressIndicator(),
-              ),
+                child: MintLoadingSkeleton(),
             )
           : _error != null
               ? _buildError(l10n)

--- a/apps/mobile/lib/screens/admin_observability_screen.dart
+++ b/apps/mobile/lib/screens/admin_observability_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/api_service.dart';
@@ -128,7 +129,7 @@ class _AdminObservabilityScreenState extends State<AdminObservabilityScreen> {
         ),
       ),
       body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
-          ? const Center(child: CircularProgressIndicator())
+          ? const MintLoadingSkeleton()
           : _error != null
               ? _buildError(l10n)
               : RefreshIndicator(

--- a/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
@@ -243,7 +243,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
                   // ── Sensitivity ──
                   BreakevenIndicatorWidget(
                     breakevenYear: _result!.breakevenYear,
-                    ageRetraite: 65,
+                    ageRetraite: avsAgeReferenceHomme,
                     horizon: _anneesAvantRetraite,
                     sensitivity: _result!.sensitivity,
                   ),

--- a/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/allocation_annuelle_screen.dart
@@ -46,7 +46,7 @@ class _AllocationAnnuelleScreenState extends State<AllocationAnnuelleScreen> {
   bool _hasRachatLpp = true;
   bool _isPropertyOwner = false;
   int _anneesAvantRetraite = 20;
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   // ── Hypothesis sliders ──
   Map<String, double> _hypotheses = {

--- a/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
@@ -41,7 +41,7 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
   final _capitalCtrl = TextEditingController(text: '200000');
   final _loyerCtrl = TextEditingController(text: '2000');
   final _prixBienCtrl = TextEditingController(text: '800000');
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _isMarried = false;
   bool _hasEstimatedValues = false;
 
@@ -78,7 +78,7 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
     final profile = context.read<CoachProfileProvider>().profile;
     if (profile == null) return;
 
-    final canton = profile.canton.isNotEmpty ? profile.canton : 'VD';
+    final canton = profile.canton.isNotEmpty ? profile.canton : 'ZH';
     final isMarried = profile.etatCivil == CoachCivilStatus.marie;
     final patrimoine = profile.patrimoine;
 

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -50,7 +50,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
 
   // ── Estimate mode controllers ──
   final _ageCtrl = TextEditingController(text: '50');
-  final _ageRetraiteSlider = ValueNotifier<double>(65);
+  final _ageRetraiteSlider = ValueNotifier<double>(avsAgeReferenceHomme.toDouble());
   final _salaryCtrl = TextEditingController(text: '100000');
   final _lppTotalCtrl = TextEditingController(text: '350000');
 

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
@@ -62,7 +63,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
   final _tcSurobCtrl = TextEditingController(text: '5.0');
 
   // ── Shared inputs ──
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _isMarried = false;
 
   // ── Hypothesis sliders ──
@@ -428,7 +429,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
                 if (_isLoading && _result == null)
                   const Padding(
                     padding: EdgeInsets.symmetric(vertical: MintSpacing.lg),
-                    child: Center(child: CircularProgressIndicator()),
+                    child: MintLoadingSkeleton(),
                   ),
 
                 if (_hasError && _result == null)

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -7,6 +7,7 @@
 // consistency with PulseScreen. Falls back to plan.available when not.
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -195,7 +196,7 @@ class _BudgetScreenState extends State<BudgetScreen>
           final plan = provider.plan;
 
           if (plan == null) {
-            return const Center(child: CircularProgressIndicator());
+            return const MintLoadingSkeleton();
           }
 
           // Hero number: BudgetSnapshot.present.monthlyFree when available,

--- a/apps/mobile/lib/screens/cantonal_benchmark_screen.dart
+++ b/apps/mobile/lib/screens/cantonal_benchmark_screen.dart
@@ -4,6 +4,7 @@
 // Opt-in only. ZERO ranked comparisons, ZERO social comparison.
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -88,11 +89,9 @@ class _CantonalBenchmarkScreenState extends State<CantonalBenchmarkScreen> {
             child: Padding(
               padding: const EdgeInsets.all(20),
               child: _loading
-                  ? const Center(
-                      child: Padding(
+                  ? const Padding(
                         padding: EdgeInsets.only(top: 60),
-                        child: CircularProgressIndicator(),
-                      ),
+                        child: MintLoadingSkeleton(),
                     )
                   : _hasError
                       ? Container(

--- a/apps/mobile/lib/screens/coach/conversation_history_screen.dart
+++ b/apps/mobile/lib/screens/coach/conversation_history_screen.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/coach/conversation_store.dart';
@@ -99,11 +100,7 @@ class _ConversationHistoryScreenState extends State<ConversationHistoryScreen> {
           // ── Body ──
           if (_isLoading)
             const SliverFillRemaining(
-              child: Center(
-                child: CircularProgressIndicator(
-                  color: MintColors.primary,
-                ),
-              ),
+              child: MintLoadingSkeleton(),
             )
           else if (_error != null)
             SliverFillRemaining(

--- a/apps/mobile/lib/screens/coach/weekly_recap_screen.dart
+++ b/apps/mobile/lib/screens/coach/weekly_recap_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -106,7 +107,7 @@ class _WeeklyRecapScreenState extends State<WeeklyRecapScreen> {
         centerTitle: false,
       ),
       body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: _loading
-          ? const Center(child: CircularProgressIndicator())
+          ? const MintLoadingSkeleton()
           : _errorKey != null
               ? _buildEmpty(l)
               : _buildContent(l))),

--- a/apps/mobile/lib/screens/concubinage_screen.dart
+++ b/apps/mobile/lib/screens/concubinage_screen.dart
@@ -44,7 +44,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
   double _revenu1 = 80000;
   double _revenu2 = 60000;
   double _patrimoine = 300000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   Map<String, dynamic>? _comparisonResult;
 
   // ── Tab 2: Protection ─────────────────────────────────

--- a/apps/mobile/lib/screens/consent_dashboard_screen.dart
+++ b/apps/mobile/lib/screens/consent_dashboard_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/privacy_service.dart';
@@ -69,7 +70,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
       profileId: 'local',
       profileData: {
         'birthYear': 1990,
-        'canton': 'VD',
+        'canton': 'ZH',
         'income': 80000,
         'analyticsEnabled': _consents['analytics'],
         'coachingEnabled': _consents['coaching_notifications'],
@@ -137,7 +138,7 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
             style: MintTextStyles.headlineMedium(),
           ),
         ),
-        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const Center(child: CircularProgressIndicator()))),
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const MintLoadingSkeleton())),
       );
     }
 

--- a/apps/mobile/lib/screens/coverage_check_screen.dart
+++ b/apps/mobile/lib/screens/coverage_check_screen.dart
@@ -33,7 +33,7 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
   bool _aFamille = false;
   bool _estLocataire = true;
   bool _voyagesFrequents = false;
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   // ── State — Current coverage ───────────────────────────────
   bool _aIjmCollective = true;

--- a/apps/mobile/lib/screens/debt_prevention/help_resources_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/help_resources_screen.dart
@@ -21,7 +21,7 @@ class HelpResourcesScreen extends StatefulWidget {
 }
 
 class _HelpResourcesScreenState extends State<HelpResourcesScreen> {
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/lib/screens/deces_proche_screen.dart
+++ b/apps/mobile/lib/screens/deces_proche_screen.dart
@@ -25,7 +25,7 @@ class DecesProcheScreen extends StatefulWidget {
 class _DecesProcheScreenState extends State<DecesProcheScreen> {
   // ── Input state ──
   String _lienParente = 'conjoint';
-  String _canton = 'VD';
+  String _canton = 'ZH';
   double _fortuneDefunt = 500000;
   double _lppDefunt = 200000;
   double _pilier3aDefunt = 50000;

--- a/apps/mobile/lib/screens/donation_screen.dart
+++ b/apps/mobile/lib/screens/donation_screen.dart
@@ -52,7 +52,7 @@ class _DonationScreenState extends State<DonationScreen> {
   double _montant = 100000;
   int _donateurAge = 55;
   String _lienParente = 'descendant';
-  String _canton = 'VD';
+  String _canton = 'ZH';
   String _typeDonation = 'especes';
   double _valeurImmobiliere = 500000;
   bool _avancementHoirie = true;

--- a/apps/mobile/lib/screens/expat_screen.dart
+++ b/apps/mobile/lib/screens/expat_screen.dart
@@ -40,14 +40,14 @@ class _ExpatScreenState extends State<ExpatScreen>
   late TabController _tabController;
 
   // ── Tab 1: Forfait inputs ─────────────────────────────
-  String _forfaitCanton = 'VD';
+  String _forfaitCanton = 'ZH';
   double _livingExpenses = 1000000;
   double _actualIncome = 5000000;
   Map<String, dynamic>? _forfaitResult;
 
   // ── Tab 2: Depart inputs ──────────────────────────────
   DateTime _departureDate = DateTime.now().add(const Duration(days: 180));
-  String _departCanton = 'VD';
+  String _departCanton = 'ZH';
   double _pillar3aBalance = 80000;
   double _lppBalance = 250000;
   Map<String, dynamic>? _departResult;

--- a/apps/mobile/lib/screens/expert/expert_tier_screen.dart
+++ b/apps/mobile/lib/screens/expert/expert_tier_screen.dart
@@ -18,6 +18,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
@@ -394,10 +395,7 @@ class _LoadingView extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const CircularProgressIndicator(
-            color: MintColors.primary,
-            strokeWidth: 2,
-          ),
+          const MintLoadingSkeleton(),
           const SizedBox(height: MintSpacing.md),
           Text(
             text,

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -879,7 +879,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     final l10n = S.of(context)!;
     final net = _result?.netEstime ?? _salaire * 0.85;
     final annualSavings = net * 0.20 * 12;
-    final years = (65 - _age).clamp(0, 45);
+    final years = (avsAgeReferenceHomme - _age).clamp(0, 45);
     final fv = _fvAnnuity(annualSavings, years);
     return Budget503020Widget(
       netSalary: net,
@@ -937,7 +937,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     final scenarios = scenarioAges
         .map((a) => TimeLapseScenario(
               startAge: a,
-              capitalAt65: _fvAnnuity(annual3a, (65 - a).clamp(0, 45)),
+              capitalAt65: _fvAnnuity(annual3a, (avsAgeReferenceHomme - a).clamp(0, 45)),
             ))
         .toList();
 

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -46,7 +47,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
 
   // ── Shared inputs ───────────────────────────────────────
   double _revenuBrut = 100000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   String? _commune;
   String _etatCivil = 'celibataire';
   int _nombreEnfants = 0;
@@ -66,7 +67,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
   List<Map<String, dynamic>> _allCantons = [];
 
   // ── Tab 3: Demenager ───────────────────────────────────
-  String _cantonDepart = 'VD';
+  String _cantonDepart = 'ZH';
   String? _communeDepart;
   String _cantonArrivee = 'ZG';
   String? _communeArrivee;
@@ -791,7 +792,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
 
   Widget _buildTab2AllCantons() {
     if (_allCantons.isEmpty) {
-      return const Center(child: CircularProgressIndicator());
+      return const MintLoadingSkeleton();
     }
 
     final maxCharge = _allCantons.isNotEmpty

--- a/apps/mobile/lib/screens/gender_gap_screen.dart
+++ b/apps/mobile/lib/screens/gender_gap_screen.dart
@@ -29,7 +29,7 @@ class _GenderGapScreenState extends State<GenderGapScreen> {
   int _age = 40;
   double _avoirLpp = 120000;
   int _anneesCotisation = 15;
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   GenderGapResult? _result;
 

--- a/apps/mobile/lib/screens/household/accept_invitation_screen.dart
+++ b/apps/mobile/lib/screens/household/accept_invitation_screen.dart
@@ -43,11 +43,12 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
   @override
   Widget build(BuildContext context) {
     final household = context.watch<HouseholdProvider>();
+    final l = S.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          'Rejoindre un ménage',
+          l.acceptInvitationTitle,
           style: MintTextStyles.titleMedium(),
         ),
         backgroundColor: MintColors.white,
@@ -58,13 +59,13 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
       body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Padding(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: _accepted
-            ? _buildSuccess(context)
-            : _buildForm(context, household),
+            ? _buildSuccess(context, l)
+            : _buildForm(context, household, l),
       ))),
     );
   }
 
-  Widget _buildForm(BuildContext context, HouseholdProvider household) {
+  Widget _buildForm(BuildContext context, HouseholdProvider household, S l) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -72,13 +73,13 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
         const Icon(Icons.people, size: 64, color: MintColors.primary),
         const SizedBox(height: 24),
         MintEntrance(child: Text(
-          'Entre le code recu de ton/ta partenaire',
+          l.acceptInvitationPrompt,
           textAlign: TextAlign.center,
           style: MintTextStyles.headlineMedium().copyWith(fontSize: 18),
         )),
         const SizedBox(height: MintSpacing.sm),
         MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
-          'Le code est valable 72 heures apres l\'envoi.',
+          l.acceptInvitationCodeValidity,
           textAlign: TextAlign.center,
           style: MintTextStyles.bodyMedium(),
         )),
@@ -89,7 +90,7 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
           textCapitalization: TextCapitalization.characters,
           style: MintTextStyles.headlineLarge().copyWith(fontSize: 28, letterSpacing: 6),
           decoration: InputDecoration(
-            hintText: 'CODE',
+            hintText: l.householdAcceptCodeHint,
             hintStyle: MintTextStyles.headlineLarge(color: MintColors.greyBorder).copyWith(
               fontSize: 28,
               fontWeight: FontWeight.w300,
@@ -115,7 +116,7 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
         const SizedBox(height: 24),
         MintEntrance(delay: const Duration(milliseconds: 300), child: Semantics(
           button: true,
-          label: 'Rejoindre le menage',
+          label: l.acceptInvitationJoin,
           child: FilledButton(
             onPressed: household.isLoading
                 ? null
@@ -141,7 +142,7 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
                   ),
                 )
               : Text(
-                  'Rejoindre le menage',
+                  l.acceptInvitationJoin,
                   style: MintTextStyles.titleMedium(color: MintColors.white),
                 ),
         ),
@@ -150,7 +151,7 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
     );
   }
 
-  Widget _buildSuccess(BuildContext context) {
+  Widget _buildSuccess(BuildContext context, S l) {
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -169,20 +170,19 @@ class _AcceptInvitationScreenState extends State<AcceptInvitationScreen> {
           ),
           const SizedBox(height: 24),
           Text(
-            'Bienvenue dans le menage !',
+            l.acceptInvitationSuccess,
             style: MintTextStyles.headlineMedium(),
           ),
           const SizedBox(height: MintSpacing.md),
           Text(
-            'Tu as rejoint le menage Couple+. Tes projections '
-            'de retraite sont desormais liees.',
+            l.acceptInvitationSuccessBody,
             textAlign: TextAlign.center,
             style: MintTextStyles.bodyMedium(),
           ),
           const SizedBox(height: 32),
           FilledButton(
             onPressed: () => context.go('/couple'),
-            child: Text(S.of(context)!.acceptInvitationVoirMenage),
+            child: Text(l.acceptInvitationVoirMenage),
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/household/household_screen.dart
+++ b/apps/mobile/lib/screens/household/household_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
@@ -65,7 +66,7 @@ class _HouseholdScreenState extends State<HouseholdScreen> {
           : !sub.isPaid
               ? _buildUpsellCard(context)
               : household.isLoading && !household.hasHousehold
-                  ? const Center(child: CircularProgressIndicator())
+                  ? const MintLoadingSkeleton()
                   : _buildContent(context, household))),
     );
   }

--- a/apps/mobile/lib/screens/housing_sale_screen.dart
+++ b/apps/mobile/lib/screens/housing_sale_screen.dart
@@ -57,7 +57,7 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
   double _investissementsValorisants = 50000;
   double _fraisAcquisition = 30000;
   double _hypothequeRestante = 600000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _residencePrincipale = true;
   bool _projetRemploi = false;
   double _prixRemploi = 900000;

--- a/apps/mobile/lib/screens/independant_screen.dart
+++ b/apps/mobile/lib/screens/independant_screen.dart
@@ -44,7 +44,7 @@ class _IndependantScreenState extends State<IndependantScreen> {
   bool _hasIjm = false;
   bool _hasLaa = false;
   bool _has3a = false;
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   IndependantResult? _result;
 

--- a/apps/mobile/lib/screens/independants/ijm_screen.dart
+++ b/apps/mobile/lib/screens/independants/ijm_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -42,7 +43,7 @@ class _IjmScreenState extends State<IjmScreen> {
         changed = true;
       }
       final age = profile.age;
-      if (age >= 18 && age <= 65) {
+      if (age >= 18 && age <= avsAgeReferenceHomme) {
         _age = age;
         changed = true;
       }

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -54,7 +55,7 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
         changed = true;
       }
       final age = profile.age;
-      if (age >= 25 && age <= 65) {
+      if (age >= 25 && age <= avsAgeReferenceHomme) {
         _age = age;
         changed = true;
       }
@@ -493,7 +494,7 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
       ('25-34 ans', '7%', _age >= 25 && _age <= 34),
       ('35-44 ans', '10%', _age >= 35 && _age <= 44),
       ('45-54 ans', '15%', _age >= 45 && _age <= 54),
-      ('55-65 ans', '18%', _age >= 55 && _age <= 65),
+      ('55-65 ans', '18%', _age >= 55 && _age <= avsAgeReferenceHomme),
     ];
 
     return MintSurface(

--- a/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/epl_screen.dart
@@ -72,7 +72,7 @@ class _EplScreenState extends State<EplScreen> {
 
         // Age
         final age = profile.age;
-        if (age >= 25 && age <= 65) _age = age;
+        if (age >= 25 && age <= avsAgeReferenceHomme) _age = age;
 
         // Canton
         if (cantonFullNames.containsKey(profile.canton)) {
@@ -469,7 +469,7 @@ class _EplScreenState extends State<EplScreen> {
       eplAmount: result.montantSouhaiteApplicable,
       eplRepaid: 0,
       currentAge: _age,
-      retirementAge: 65,
+      retirementAge: avsAgeReferenceHomme,
       grossAnnualSalary: _grossAnnualSalary,
       caisseReturn: lppTauxInteretMin / 100,
       conversionRate: lppTauxConversionMinDecimal,

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -38,7 +38,7 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   int _horizon = 3;
 
   // --- Fiscal situation ---
-  String _canton = 'VD';
+  String _canton = 'ZH';
   String _civilStatus = 'single';
   bool _manualTauxOverride = false;
   double _manualTaux = 0.32;

--- a/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
+++ b/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -1497,7 +1498,7 @@ class _CoachingPreferenceSheetState extends State<_CoachingPreferenceSheet> {
     if (!_loaded) {
       return const SizedBox(
         height: 200,
-        child: Center(child: CircularProgressIndicator()),
+        child: MintLoadingSkeleton(),
       );
     }
 

--- a/apps/mobile/lib/screens/mariage_screen.dart
+++ b/apps/mobile/lib/screens/mariage_screen.dart
@@ -49,7 +49,7 @@ class _MariageScreenState extends State<MariageScreen>
   // ── Tab 1: Impots inputs ──────────────────────────────
   double _revenu1 = 80000;
   double _revenu2 = 60000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   int _nbEnfants = 0;
   Map<String, dynamic>? _fiscalResult;
 

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -64,7 +64,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   double _epargneDispo = 100000;
   double _avoir3a = 50000;
   double _avoirLpp = 200000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _showAdvancedParams = false;
 
   void _initializeFromProfile() {

--- a/apps/mobile/lib/screens/mortgage/epl_combined_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/epl_combined_screen.dart
@@ -30,7 +30,7 @@ class _EplCombinedScreenState extends State<EplCombinedScreen> {
   double _avoir3a = 60000;
   double _avoirLpp = 200000;
   double _prixCible = 900000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
 
   EplCombinedResult get _result => EplCombinedCalculator.calculate(
         epargneCash: _epargneCash,

--- a/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/imputed_rental_screen.dart
@@ -27,7 +27,7 @@ class _ImputedRentalScreenState extends State<ImputedRentalScreen> {
   double _valeurVenale = 900000;
   double _interetsAnnuels = 15000;
   double _fraisEntretien = 3000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _bienAncien = true;
   double _tauxMarginal = 0.30;
 

--- a/apps/mobile/lib/screens/naissance_screen.dart
+++ b/apps/mobile/lib/screens/naissance_screen.dart
@@ -49,7 +49,7 @@ class _NaissanceScreenState extends State<NaissanceScreen>
   Map<String, dynamic>? _congeResult;
 
   // ── Tab 2: Allocations inputs ─────────────────────────
-  String _cantonAlloc = 'VD';
+  String _cantonAlloc = 'ZH';
   int _nbEnfantsAlloc = 1;
   Map<String, dynamic>? _allocResult;
   List<Map<String, dynamic>> _allocRanking = [];

--- a/apps/mobile/lib/screens/onboarding/chiffre_choc_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/chiffre_choc_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
@@ -193,7 +194,7 @@ class _ChiffreChocScreenState extends State<ChiffreChocScreen>
 
     if (choc == null || profile == null) {
       return Scaffold(
-        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const Center(child: CircularProgressIndicator()))),
+        body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: const MintLoadingSkeleton())),
       );
     }
 

--- a/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
@@ -110,7 +110,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
     final coord = (gross - lppDeductionCoordination)
         .clamp(lppSalaireCoordMin, lppSalaireCoordMax);
     double balance = 0;
-    for (int a = 25; a < age && a < 65; a++) {
+    for (int a = 25; a < age && a < avsAgeReferenceHomme; a++) {
       balance *= 1.01;
       balance += coord * getLppBonificationRate(a);
     }
@@ -125,7 +125,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
     final lppAnnual = LppCalculator.projectToRetirement(
       currentBalance: lppBalance,
       currentAge: age,
-      retirementAge: 65,
+      retirementAge: avsAgeReferenceHomme,
       grossAnnualSalary: gross,
       caisseReturn: 0.01,
       conversionRate: lppTauxConversionMinDecimal,

--- a/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
@@ -40,7 +40,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
   final _nameController = TextEditingController();
   double _age = 45;
   double _salary = 85000;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   bool _saving = false;
 
   @override

--- a/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
 import 'package:mint_mobile/screens/onboarding/smart_onboarding_viewmodel.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
@@ -168,6 +169,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
   Widget build(BuildContext context) {
     final choc = widget.viewModel.chiffreChoc;
     final vm = widget.viewModel;
+    final l = S.of(context)!;
 
     if (choc == null) {
       return const Scaffold(
@@ -294,8 +296,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
-                              'Estimation bas\u00e9e sur $infoCount informations. '
-                              'Plus tu pr\u00e9cises, plus c\'est fiable.',
+                              l.stepChocConfidenceInfo(infoCount),
                               style: GoogleFonts.inter(
                                 fontSize: 12,
                                 color: MintColors.textMuted,
@@ -309,7 +310,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                       Row(
                         children: [
                           Text(
-                            'Precision: ${confidence.round()}%',
+                            l.stepChocConfidenceLabel(confidence.round()),
                             style: GoogleFonts.inter(
                               fontSize: 12,
                               fontWeight: FontWeight.w600,
@@ -336,7 +337,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Pour personnaliser tes conseils',
+                      l.stepChocLiteracyTitle,
                       style: GoogleFonts.montserrat(
                         fontSize: 14,
                         fontWeight: FontWeight.w600,
@@ -345,7 +346,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '3 questions rapides — aucune bonne ou mauvaise reponse.',
+                      l.stepChocLiteracySubtitle,
                       style: GoogleFonts.inter(
                         fontSize: 12,
                         color: MintColors.textMuted,
@@ -353,7 +354,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     ),
                     const SizedBox(height: 12),
                     _LiteracyQuestion(
-                      question: 'Je connais le montant de mon avoir LPP',
+                      question: l.stepChocLiteracyLpp,
                       value: _knowsLppBalance,
                       onChanged: (v) {
                         setState(() => _knowsLppBalance = v);
@@ -362,7 +363,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     ),
                     const SizedBox(height: 10),
                     _LiteracyQuestion(
-                      question: 'Je sais ce qu\'est le taux de conversion',
+                      question: l.stepChocLiteracyConversion,
                       value: _knowsConversionRate,
                       onChanged: (v) {
                         setState(() => _knowsConversionRate = v);
@@ -371,7 +372,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     ),
                     const SizedBox(height: 10),
                     _LiteracyQuestion(
-                      question: 'J\'ai deja verse sur un compte 3a',
+                      question: l.stepChocLiteracy3a,
                       value: _hasDone3a,
                       onChanged: (v) {
                         setState(() => _hasDone3a = v);
@@ -405,7 +406,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     ),
                   ),
                   child: Text(
-                    'Qu\'est-ce que je peux faire ?',
+                    l.stepChocAction,
                     style: GoogleFonts.inter(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
@@ -442,7 +443,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        'Affiner mon profil',
+                        l.stepChocEnrich,
                         style: GoogleFonts.inter(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -470,7 +471,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
                     padding: const EdgeInsets.symmetric(vertical: 14),
                   ),
                   child: Text(
-                    'Voir mon dashboard',
+                    l.stepChocDashboard,
                     style: GoogleFonts.inter(
                       fontSize: 15,
                       fontWeight: FontWeight.w500,
@@ -482,8 +483,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
 
               // ── DISCLAIMER ───────────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 300), child: Text(
-                'Outil \u00e9ducatif simplifi\u00e9. Ne constitue pas un conseil financier (LSFin). '
-                'Sources: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.',
+                l.stepChocDisclaimer,
                 style: GoogleFonts.inter(
                   fontSize: 10,
                   color: MintColors.textMuted,
@@ -539,6 +539,7 @@ class _LiteracyQuestion extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
     return MintSurface(
       tone: MintSurfaceTone.porcelaine,
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
@@ -558,13 +559,13 @@ class _LiteracyQuestion extends StatelessWidget {
           ),
           const SizedBox(width: 12),
           _LiteracyChip(
-            label: 'Oui',
+            label: l.stepChocYes,
             selected: value == true,
             onTap: () => onChanged(value == true ? null : true),
           ),
           const SizedBox(width: 8),
           _LiteracyChip(
-            label: 'Non',
+            label: l.stepChocNo,
             selected: value == false,
             onTap: () => onChanged(value == false ? null : false),
           ),

--- a/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_chiffre_choc.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
 import 'package:mint_mobile/screens/onboarding/smart_onboarding_viewmodel.dart';
@@ -170,7 +171,7 @@ class _StepChiffreChocState extends State<StepChiffreChoc>
 
     if (choc == null) {
       return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+        body: MintLoadingSkeleton(),
       );
     }
 

--- a/apps/mobile/lib/screens/onboarding/steps/step_jit_explanation.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_jit_explanation.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
 import 'package:mint_mobile/services/analytics_events.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
@@ -51,7 +52,8 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
 
   @override
   Widget build(BuildContext context) {
-    final explanation = _explanationForType(widget.chiffreChoc?.type);
+    final l = S.of(context)!;
+    final explanation = _explanationForType(widget.chiffreChoc?.type, l);
 
     return Scaffold(
       backgroundColor: MintColors.background,
@@ -65,7 +67,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
 
               // ── HEADER ─────────────────────────────────────────────
               MintEntrance(child: Text(
-                'Comprendre en 30 secondes',
+                l.stepJitTitle,
                 style: GoogleFonts.montserrat(
                   fontSize: 22,
                   fontWeight: FontWeight.w700,
@@ -84,7 +86,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
                       children: [
                         // SI...
                         _ConditionRow(
-                          label: 'SI',
+                          label: l.stepJitSi,
                           color: MintColors.warning,
                           text: explanation.condition,
                         ),
@@ -92,7 +94,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
 
                         // ALORS...
                         _ConditionRow(
-                          label: 'ALORS',
+                          label: l.stepJitAlors,
                           color: MintColors.success,
                           text: explanation.consequence,
                         ),
@@ -146,7 +148,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
               // ── NAVIGATION ──────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 200), child: Semantics(
                 button: true,
-                label: 'Que puis-je faire ?',
+                label: l.stepJitAction,
                 child: SizedBox(
                   width: double.infinity,
                   child: FilledButton(
@@ -160,7 +162,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
                     ),
                   ),
                   child: Text(
-                    'Que puis-je faire ?',
+                    l.stepJitAction,
                     style: GoogleFonts.inter(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
@@ -174,7 +176,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
                 child: TextButton(
                   onPressed: widget.onBack,
                   child: Text(
-                    'Retour',
+                    l.stepJitBack,
                     style: GoogleFonts.inter(
                       fontSize: 14,
                       color: MintColors.textSecondary,
@@ -186,8 +188,7 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
 
               // ── DISCLAIMER ──────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 400), child: Text(
-                'Outil éducatif simplifié. Ne constitue pas un conseil '
-                'financier (LSFin).',
+                l.stepJitDisclaimer,
                 style: GoogleFonts.inter(
                   fontSize: 10,
                   color: MintColors.textMuted,
@@ -203,67 +204,37 @@ class _StepJitExplanationState extends State<StepJitExplanation> {
     );
   }
 
-  _JitExplanation _explanationForType(ChiffreChocType? type) {
+  _JitExplanation _explanationForType(ChiffreChocType? type, S l) {
     return switch (type) {
-      ChiffreChocType.liquidityAlert => const _JitExplanation(
-          condition:
-              'ton épargne de sécurité couvre moins de 2 mois de charges',
-          consequence:
-              'un imprévu (perte d\'emploi, réparation urgente) peut '
-              'te mettre en difficulté financière rapidement.',
-          insight:
-              'Les experts recommandent 3 à 6 mois de charges fixes en '
-              'réserve. Même 100 CHF/mois sur un compte épargne fait une '
-              'différence significative sur 12 mois.',
-          source: 'Recommandation Budget-conseil Suisse',
+      ChiffreChocType.liquidityAlert => _JitExplanation(
+          condition: l.stepJitLiquidityCond,
+          consequence: l.stepJitLiquidityCons,
+          insight: l.stepJitLiquidityInsight,
+          source: l.stepJitLiquiditySource,
         ),
-      ChiffreChocType.retirementGap => const _JitExplanation(
-          condition:
-              'ton taux de remplacement à la retraite est inférieur à 60%',
-          consequence:
-              'ton niveau de vie pourrait baisser significativement '
-              'le jour où tu arrêtes de travailler.',
-          insight:
-              'En Suisse, l\'AVS et la LPP couvrent en moyenne 60% du '
-              'dernier salaire. Le 3e pilier et l\'épargne libre comblent '
-              'le reste. Plus tu commences tôt, moins l\'effort mensuel '
-              'est important.',
-          source: 'LAVS art. 34 / LPP art. 14',
+      ChiffreChocType.retirementGap => _JitExplanation(
+          condition: l.stepJitRetirementCond,
+          consequence: l.stepJitRetirementCons,
+          insight: l.stepJitRetirementInsight,
+          source: l.stepJitRetirementSource,
         ),
-      ChiffreChocType.taxSaving3a => const _JitExplanation(
-          condition:
-              'tu ne verses pas le maximum dans ton 3e pilier chaque année',
-          consequence:
-              'tu passes à côté d\'une économie fiscale et d\'un capital '
-              'retraite supplémentaire.',
-          insight:
-              'Chaque franc versé en 3a est déductible du revenu imposable. '
-              'Sur 20 ans, la différence entre verser 0 et le plafond '
-              '(7\'258 CHF) peut représenter plus de 200\'000 CHF.',
-          source: 'OPP3 art. 7 / LIFD art. 33',
+      ChiffreChocType.taxSaving3a => _JitExplanation(
+          condition: l.stepJitTax3aCond,
+          consequence: l.stepJitTax3aCons,
+          insight: l.stepJitTax3aInsight,
+          source: l.stepJitTax3aSource,
         ),
-      ChiffreChocType.retirementIncome => const _JitExplanation(
-          condition:
-              'ta projection de revenu à la retraite est estimée',
-          consequence:
-              'connaître ce montant te permet de planifier '
-              'et d\'ajuster ta stratégie de prévoyance dès maintenant.',
-          insight:
-              'Le système suisse à 3 piliers (AVS + LPP + 3a) couvre en '
-              'moyenne 60% du dernier salaire. Chaque pilier a ses règles '
-              'et ses leviers d\'optimisation spécifiques.',
-          source: 'LAVS art. 34 / LPP art. 14 / OPP3 art. 7',
+      ChiffreChocType.retirementIncome => _JitExplanation(
+          condition: l.stepJitIncomeCond,
+          consequence: l.stepJitIncomeCons,
+          insight: l.stepJitIncomeInsight,
+          source: l.stepJitIncomeSource,
         ),
-      _ => const _JitExplanation(
-          condition: 'tu n\'as pas encore un plan financier structuré',
-          consequence:
-              'tu risques de passer à côté d\'opportunités d\'optimisation '
-              'fiscale et de prévoyance.',
-          insight:
-              'Un bilan financier annuel permet d\'identifier les leviers '
-              'les plus impactants : 3a, rachat LPP, franchise LAMal, '
-              'amortissement indirect.',
-          source: 'Recommandation éducative MINT',
+      _ => _JitExplanation(
+          condition: l.stepJitDefaultCond,
+          consequence: l.stepJitDefaultCons,
+          insight: l.stepJitDefaultInsight,
+          source: l.stepJitDefaultSource,
         ),
     };
   }

--- a/apps/mobile/lib/screens/onboarding/steps/step_next_step.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_next_step.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/analytics_events.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -30,6 +31,7 @@ class StepNextStep extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final confidencePct = confidenceScore.round();
+    final l = S.of(context)!;
 
     return Scaffold(
       backgroundColor: MintColors.background,
@@ -61,7 +63,7 @@ class StepNextStep extends StatelessWidget {
 
               // ── HEADING ─────────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
-                'Ton premier bilan est pret',
+                l.stepNextTitle,
                 style: GoogleFonts.montserrat(
                   fontSize: 24,
                   fontWeight: FontWeight.w700,
@@ -71,9 +73,7 @@ class StepNextStep extends StatelessWidget {
               )),
               const SizedBox(height: 12),
               MintEntrance(delay: const Duration(milliseconds: 200), child: Text(
-                'Precision actuelle : $confidencePct%. '
-                'Plus tu completes ton profil, plus les projections '
-                'seront fiables.',
+                l.stepNextConfidence(confidencePct),
                 style: GoogleFonts.inter(
                   fontSize: 14,
                   color: MintColors.textSecondary,
@@ -87,7 +87,7 @@ class StepNextStep extends StatelessWidget {
               // ── PRIMARY CTA — enrich ────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 300), child: Semantics(
                 button: true,
-                label: 'Affiner mon profil',
+                label: l.stepNextEnrich,
                 child: SizedBox(
                   width: double.infinity,
                   child: FilledButton(
@@ -108,7 +108,7 @@ class StepNextStep extends StatelessWidget {
                     ),
                   ),
                   child: Text(
-                    'Affiner mon profil',
+                    l.stepNextEnrich,
                     style: GoogleFonts.inter(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
@@ -143,7 +143,7 @@ class StepNextStep extends StatelessWidget {
                     ),
                   ),
                   child: Text(
-                    'Voir mon dashboard',
+                    l.stepNextDashboard,
                     style: GoogleFonts.inter(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
@@ -166,7 +166,7 @@ class StepNextStep extends StatelessWidget {
                     },
                     icon: const Icon(Icons.receipt_long_rounded, size: 18),
                     label: Text(
-                      'Faire mon premier check-in',
+                      l.stepNextCheckin,
                       style: GoogleFonts.inter(
                         fontSize: 14,
                         fontWeight: FontWeight.w500,
@@ -183,9 +183,7 @@ class StepNextStep extends StatelessWidget {
 
               // ── DISCLAIMER ──────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 400), child: Text(
-                'Outil educatif simplifie. Ne constitue pas un conseil '
-                'financier (LSFin). '
-                'Sources: LAVS art. 34, LPP art. 14-16, OPP3 art. 7.',
+                l.stepNextDisclaimer,
                 style: GoogleFonts.inter(
                   fontSize: 10,
                   color: MintColors.textMuted,

--- a/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/screens/onboarding/smart_onboarding_viewmodel.dart';
 import 'package:mint_mobile/services/document_parser/avs_extract_parser.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
@@ -50,38 +51,6 @@ class StepOcrUpload extends StatefulWidget {
 }
 
 class _StepOcrUploadState extends State<StepOcrUpload> {
-  // Documents disponibles dans ce step
-  static const _documents = [
-    (
-      type: DocumentType.lppCertificate,
-      title: 'Ta lettre de retraite LPP',
-      subtitle: 'Avoir, taux de conversion, lacune de rachat',
-      icon: Icons.account_balance_outlined,
-      confidenceBoost: '+27 pts de précision',
-    ),
-    (
-      type: DocumentType.avsExtract,
-      title: 'Ton extrait AVS',
-      subtitle: 'Années de cotisation, lacunes, RAMD',
-      icon: Icons.security_outlined,
-      confidenceBoost: '+22 pts de précision',
-    ),
-    (
-      type: DocumentType.taxDeclaration,
-      title: 'Ta déclaration fiscale',
-      subtitle: 'Revenu imposable, fortune, taux marginal',
-      icon: Icons.receipt_long_outlined,
-      confidenceBoost: '+17 pts de précision',
-    ),
-    (
-      type: DocumentType.threeAAttestation,
-      title: 'Ton compte 3a',
-      subtitle: 'Solde, versements cumulés, rendement',
-      icon: Icons.savings_outlined,
-      confidenceBoost: '+7 pts de précision',
-    ),
-  ];
-
   DocumentType? _scanning;
   final Set<DocumentType> _scanned = {};
   final _imagePicker = ImagePicker();
@@ -103,10 +72,12 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
         });
         final count = result.fields.where((f) => f.confidence >= 0.5).length;
         if (mounted) {
+          final l = S.of(context)!;
+          final plural = count > 1 ? 's' : '';
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
             content: Text(count > 0
-                ? '$count champ${count > 1 ? 's' : ''} extrait${count > 1 ? 's' : ''} avec succès'
-                : 'Document traité — aucun champ reconnu automatiquement'),
+                ? l.stepOcrSnackSuccess(count, plural)
+                : l.stepOcrSnackEmpty),
             duration: const Duration(seconds: 3),
           ));
         }
@@ -117,8 +88,9 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
     } catch (e) {
       if (mounted) {
         setState(() => _scanning = null);
+        final l = S.of(context)!;
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text('Erreur lors du traitement : $e'),
+          content: Text(l.stepOcrSnackError('$e')),
           duration: const Duration(seconds: 4),
         ));
       }
@@ -156,12 +128,10 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
 
     // Image on web — OCR not possible without ML Kit (mobile only).
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-        content: Text(
-          'Scan d\'image non disponible sur web. '
-          'Utilise l\'app mobile ou importe un fichier .txt.',
-        ),
-        duration: Duration(seconds: 5),
+      final l = S.of(context)!;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(l.stepOcrSnackWebOnly),
+        duration: const Duration(seconds: 5),
       ));
     }
     // Mark as "attempted" so user gets visual feedback
@@ -220,6 +190,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
 
   Future<bool> _showLpdConfirmation(DocumentType type) async {
     if (!mounted) return false;
+    final l = S.of(context)!;
     final result = await showModalBottomSheet<bool>(
       context: context,
       backgroundColor: MintColors.background,
@@ -263,7 +234,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                     const SizedBox(width: 12),
                     Expanded(
                       child: Text(
-                        'Traitement privé sur ton appareil',
+                        l.stepOcrLpdTitle,
                         style: GoogleFonts.montserrat(
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
@@ -275,9 +246,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                 ),
                 const SizedBox(height: 12),
                 Text(
-                  'Ce document est analysé directement sur ton téléphone.\n'
-                  'Aucune donnée n\'est envoyée sur Internet.\n'
-                  'Les informations extraites sont supprimées après traitement.',
+                  l.stepOcrLpdBody,
                   style: GoogleFonts.inter(
                     fontSize: 14,
                     color: MintColors.textSecondary,
@@ -286,7 +255,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Base légale : LPD art. 6 — minimisation des données.',
+                  l.stepOcrLpdLegal,
                   style: GoogleFonts.inter(
                     fontSize: 11,
                     color: MintColors.textMuted,
@@ -295,7 +264,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                 const SizedBox(height: 20),
                 Semantics(
                   button: true,
-                  label: 'Scanner ce document',
+                  label: l.stepOcrLpdScan,
                   child: SizedBox(
                     width: double.infinity,
                     child: FilledButton(
@@ -309,7 +278,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                         ),
                       ),
                       child: Text(
-                        'Scanner ce document',
+                        l.stepOcrLpdScan,
                       style: GoogleFonts.inter(
                         fontSize: 15,
                         fontWeight: FontWeight.w600,
@@ -324,7 +293,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                   child: TextButton(
                     onPressed: () => Navigator.of(ctx).pop(false),
                     child: Text(
-                      'Annuler',
+                      l.stepOcrLpdCancel,
                       style: GoogleFonts.inter(
                         fontSize: 14,
                         color: MintColors.textSecondary,
@@ -344,6 +313,13 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
   @override
   Widget build(BuildContext context) {
     final scannedCount = _scanned.length;
+    final l = S.of(context)!;
+
+    final docTitles = [l.stepOcrLppTitle, l.stepOcrAvsTitle, l.stepOcrTaxTitle, l.stepOcr3aTitle];
+    final docSubtitles = [l.stepOcrLppSubtitle, l.stepOcrAvsSubtitle, l.stepOcrTaxSubtitle, l.stepOcr3aSubtitle];
+    final docBoosts = [l.stepOcrLppBoost, l.stepOcrAvsBoost, l.stepOcrTaxBoost, l.stepOcr3aBoost];
+    const docTypes = [DocumentType.lppCertificate, DocumentType.avsExtract, DocumentType.taxDeclaration, DocumentType.threeAAttestation];
+    const docIcons = [Icons.account_balance_outlined, Icons.security_outlined, Icons.receipt_long_outlined, Icons.savings_outlined];
 
     return Scaffold(
       body: CustomScrollView(
@@ -357,7 +333,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
               titlePadding:
                   const EdgeInsets.only(left: 24, bottom: 16, right: 24),
               title: Text(
-                'Enrichis ton profil en 30 secondes',
+                l.stepOcrTitle,
                 style: GoogleFonts.montserrat(
                   fontWeight: FontWeight.w700,
                   fontSize: 16,
@@ -391,7 +367,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                     child: TextButton(
                       onPressed: widget.onNext,
                       child: Text(
-                        'Continuer sans document',
+                        l.stepOcrSkip,
                         style: GoogleFonts.inter(
                           fontSize: 13,
                           color: MintColors.textSecondary,
@@ -403,13 +379,12 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                   const SizedBox(height: 4),
 
                   // ── Banniere LPD — obligatoire avant tout scan ──────────
-                  const _LpdBanner(),
+                  _LpdBanner(text: l.stepOcrLpdBanner),
                   const SizedBox(height: 24),
 
                   // ── Texte intro ─────────────────────────────────────────
                   MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
-                    'Scanne un ou plusieurs documents pour que MINT calcule '
-                    'ta situation avec plus de precision.',
+                    l.stepOcrIntro,
                     style: GoogleFonts.inter(
                       fontSize: 14,
                       color: MintColors.textSecondary,
@@ -419,21 +394,22 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                   const SizedBox(height: 20),
 
                   // ── Cartes documents ────────────────────────────────────
-                  ..._documents.map((doc) {
-                    final isScanned = _scanned.contains(doc.type);
-                    final isScanning = _scanning == doc.type;
+                  ...List.generate(docTypes.length, (i) {
+                    final isScanned = _scanned.contains(docTypes[i]);
+                    final isScanning = _scanning == docTypes[i];
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 12),
                       child: _DocumentCard(
-                        title: doc.title,
-                        subtitle: doc.subtitle,
-                        icon: doc.icon,
-                        confidenceBoost: doc.confidenceBoost,
+                        title: docTitles[i],
+                        subtitle: docSubtitles[i],
+                        icon: docIcons[i],
+                        confidenceBoost: docBoosts[i],
                         isScanned: isScanned,
                         isLoading: isScanning,
+                        scannedLabel: l.stepOcrScanned,
                         onTap: isScanning
                             ? null
-                            : () => _scanDocument(doc.type),
+                            : () => _scanDocument(docTypes[i]),
                       ),
                     );
                   }),
@@ -457,8 +433,8 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
                       ),
                       child: Text(
                         scannedCount > 0
-                            ? 'Continuer ($scannedCount document${scannedCount > 1 ? 's' : ''} scanné${scannedCount > 1 ? 's' : ''})'
-                            : 'Continuer sans document',
+                            ? l.stepOcrContinueWith(scannedCount, scannedCount > 1 ? 's' : '')
+                            : l.stepOcrContinueWithout,
                         style: GoogleFonts.inter(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -470,8 +446,7 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
 
                   // Disclaimer FINMA/LPD
                   MintEntrance(delay: const Duration(milliseconds: 200), child: Text(
-                    'Outil éducatif — ne constitue pas un conseil financier (LSFin). '
-                    'Documents traités sur ton appareil, aucune donnée envoyée (LPD art. 6).',
+                    l.stepOcrDisclaimer,
                     style: GoogleFonts.inter(
                       fontSize: 11,
                       color: MintColors.textMuted,
@@ -495,7 +470,8 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
 // ════════════════════════════════════════════════════════════════════════════
 
 class _LpdBanner extends StatelessWidget {
-  const _LpdBanner();
+  final String text;
+  const _LpdBanner({required this.text});
 
   @override
   Widget build(BuildContext context) {
@@ -517,8 +493,7 @@ class _LpdBanner extends StatelessWidget {
           const SizedBox(width: 10),
           Expanded(
             child: Text(
-              'Tes documents sont traités sur ton appareil. '
-              'Rien n\'est envoyé sur Internet.',
+              text,
               style: GoogleFonts.inter(
                 fontSize: 13,
                 color: MintColors.primary,
@@ -544,6 +519,7 @@ class _DocumentCard extends StatelessWidget {
   final String confidenceBoost;
   final bool isScanned;
   final bool isLoading;
+  final String scannedLabel;
   final VoidCallback? onTap;
 
   const _DocumentCard({
@@ -553,6 +529,7 @@ class _DocumentCard extends StatelessWidget {
     required this.confidenceBoost,
     required this.isScanned,
     required this.isLoading,
+    required this.scannedLabel,
     this.onTap,
   });
 
@@ -645,7 +622,7 @@ class _DocumentCard extends StatelessWidget {
                 ),
               ),
               child: Text(
-                isScanned ? 'Scanné' : confidenceBoost,
+                isScanned ? scannedLabel : confidenceBoost,
                 style: GoogleFonts.inter(
                   fontSize: 11,
                   fontWeight: FontWeight.w600,

--- a/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
@@ -592,6 +592,7 @@ class _AgePickerState extends State<_AgePicker> {
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
     return MintSurface(
       tone: MintSurfaceTone.porcelaine,
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 12),
@@ -628,7 +629,7 @@ class _AgePickerState extends State<_AgePicker> {
                   final isSelected = age == widget.value;
                   return Center(
                     child: Text(
-                      '$age ans',
+                      l.stepQuestionsAgeYears(age),
                       style: GoogleFonts.montserrat(
                         fontSize: isSelected ? 24 : 18,
                         fontWeight:
@@ -670,7 +671,7 @@ class _AgePickerState extends State<_AgePicker> {
                     ),
                   ),
                   child: Text(
-                    '$age ans',
+                    l.stepQuestionsAgeYears(age),
                     style: GoogleFonts.inter(
                       fontSize: 12,
                       fontWeight:
@@ -703,20 +704,23 @@ class _EmploymentStatusChips extends StatelessWidget {
     required this.onChanged,
   });
 
-  static const _options = [
-    ('salarie', 'Salarie\u00b7e'),
-    ('independant', 'Independant\u00b7e'),
-    ('sans_emploi', 'Sans emploi'),
-    ('retraite', 'Retraite\u00b7e'),
-  ];
+  static const _keys = ['salarie', 'independant', 'sans_emploi', 'retraite'];
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    final labels = [
+      l.employmentSalarie,
+      l.employmentIndependant,
+      l.employmentSansEmploi,
+      l.employmentRetraite,
+    ];
     return Wrap(
       spacing: 10,
       runSpacing: 10,
-      children: _options.map((option) {
-        final (key, label) = option;
+      children: List.generate(_keys.length, (i) {
+        final key = _keys[i];
+        final label = labels[i];
         final isSelected = key == value;
         return InkWell(
           borderRadius: BorderRadius.circular(20),
@@ -745,7 +749,7 @@ class _EmploymentStatusChips extends StatelessWidget {
             ),
           ),
         );
-      }).toList(),
+      }),
     );
   }
 }
@@ -763,19 +767,22 @@ class _NationalityChips extends StatelessWidget {
     required this.onChanged,
   });
 
-  static const _options = [
-    ('CH', 'Suisse'),
-    ('EU', 'EU/AELE'),
-    ('OTHER', 'Autre'),
-  ];
+  static const _keys = ['CH', 'EU', 'OTHER'];
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    final labels = [
+      l.nationalitySuisse,
+      l.nationalityEuAele,
+      l.nationalityAutre,
+    ];
     return Wrap(
       spacing: 10,
       runSpacing: 10,
-      children: _options.map((option) {
-        final (key, label) = option;
+      children: List.generate(_keys.length, (i) {
+        final key = _keys[i];
+        final label = labels[i];
         final isSelected = key == value;
         return InkWell(
           borderRadius: BorderRadius.circular(20),
@@ -804,7 +811,7 @@ class _NationalityChips extends StatelessWidget {
             ),
           ),
         );
-      }).toList(),
+      }),
     );
   }
 }
@@ -819,21 +826,21 @@ class _CountryPicker extends StatelessWidget {
 
   const _CountryPicker({required this.value, required this.onChanged});
 
-  // Common non-EU/non-CH nationalities in Switzerland
-  static const _countries = [
-    ('US', 'États-Unis'),
-    ('GB', 'Royaume-Uni'),
-    ('CA', 'Canada'),
-    ('IN', 'Inde'),
-    ('CN', 'Chine'),
-    ('BR', 'Brésil'),
-    ('AU', 'Australie'),
-    ('JP', 'Japon'),
-  ];
+  static const _countryCodes = ['US', 'GB', 'CA', 'IN', 'CN', 'BR', 'AU', 'JP'];
 
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
+    final countryLabels = [
+      l.stepQuestionsCountryUs,
+      l.stepQuestionsCountryGb,
+      l.stepQuestionsCountryCa,
+      l.stepQuestionsCountryIn,
+      l.stepQuestionsCountryCn,
+      l.stepQuestionsCountryBr,
+      l.stepQuestionsCountryAu,
+      l.stepQuestionsCountryJp,
+    ];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -849,8 +856,9 @@ class _CountryPicker extends StatelessWidget {
         Wrap(
           spacing: 8,
           runSpacing: 8,
-          children: _countries.map((entry) {
-            final (code, label) = entry;
+          children: List.generate(_countryCodes.length, (i) {
+            final code = _countryCodes[i];
+            final label = countryLabels[i];
             final selected = value == code;
             return InkWell(
               borderRadius: BorderRadius.circular(20),
@@ -877,7 +885,7 @@ class _CountryPicker extends StatelessWidget {
                 ),
               ),
             );
-          }).toList(),
+          }),
         ),
       ],
     );

--- a/apps/mobile/lib/screens/onboarding/steps/step_stress_selector.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_stress_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/screens/onboarding/smart_onboarding_viewmodel.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -20,43 +21,22 @@ class StepStressSelector extends StatelessWidget {
     required this.onNext,
   });
 
-  static const _options = [
-    _StressOption(
-      id: 'stress_retraite',
-      icon: Icons.trending_up,
-      label: 'Ma retraite',
-      subtitle: 'Vais-je avoir assez pour vivre ?',
-    ),
-    _StressOption(
-      id: 'stress_impots',
-      icon: Icons.receipt_long,
-      label: 'Mes impots',
-      subtitle: 'Est-ce que je paie trop ?',
-    ),
-    _StressOption(
-      id: 'stress_budget',
-      icon: Icons.account_balance_wallet,
-      label: 'Mon budget',
-      subtitle: 'Ou passe mon argent ?',
-    ),
-    _StressOption(
-      id: 'stress_patrimoine',
-      icon: Icons.savings,
-      label: 'Mon patrimoine',
-      subtitle: 'Comment le faire grandir ?',
-    ),
-    _StressOption(
-      id: 'stress_couple',
-      icon: Icons.people,
-      label: 'En couple',
-      subtitle: 'Optimiser a deux',
-    ),
-    _StressOption(
-      id: 'stress_general',
-      icon: Icons.explore,
-      label: 'Juste curieux',
-      subtitle: 'Je veux comprendre ma situation',
-    ),
+  static const _optionIds = [
+    'stress_retraite',
+    'stress_impots',
+    'stress_budget',
+    'stress_patrimoine',
+    'stress_couple',
+    'stress_general',
+  ];
+
+  static const _optionIcons = [
+    Icons.trending_up,
+    Icons.receipt_long,
+    Icons.account_balance_wallet,
+    Icons.savings,
+    Icons.people,
+    Icons.explore,
   ];
 
   void _select(BuildContext context, String id) {
@@ -73,6 +53,25 @@ class StepStressSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
+
+    final labels = [
+      l.stepStressRetirement,
+      l.stepStressTaxes,
+      l.stepStressBudget,
+      l.stepStressWealth,
+      l.stepStressCouple,
+      l.stepStressCurious,
+    ];
+    final subtitles = [
+      l.stepStressRetirementSub,
+      l.stepStressTaxesSub,
+      l.stepStressBudgetSub,
+      l.stepStressWealthSub,
+      l.stepStressCoupleSub,
+      l.stepStressCuriousSub,
+    ];
+
     return Scaffold(
       body: CustomScrollView(
         slivers: [
@@ -84,7 +83,7 @@ class StepStressSelector extends StatelessWidget {
               titlePadding:
                   const EdgeInsets.only(left: 24, bottom: 16, right: 24),
               title: Text(
-                'Qu\'est-ce qui te preoccupe le plus ?',
+                l.stepStressTitle,
                 style: GoogleFonts.montserrat(
                   fontWeight: FontWeight.w700,
                   fontSize: 16,
@@ -112,7 +111,7 @@ class StepStressSelector extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   MintEntrance(child: Text(
-                    'Choisis un theme — on personnalise ton experience.',
+                    l.stepStressSubtitle,
                     style: GoogleFonts.inter(
                       fontSize: 15,
                       color: MintColors.textSecondary,
@@ -120,17 +119,19 @@ class StepStressSelector extends StatelessWidget {
                     ),
                   )),
                   const SizedBox(height: 24),
-                  ..._options.map((opt) => Padding(
+                  ...List.generate(_optionIds.length, (i) => Padding(
                         padding: const EdgeInsets.only(bottom: 12),
                         child: _StressCard(
-                          option: opt,
-                          isSelected: viewModel.stressType == opt.id,
-                          onTap: () => _select(context, opt.id),
+                          icon: _optionIcons[i],
+                          label: labels[i],
+                          subtitle: subtitles[i],
+                          isSelected: viewModel.stressType == _optionIds[i],
+                          onTap: () => _select(context, _optionIds[i]),
                         ),
                       )),
                   const SizedBox(height: 16),
                   MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
-                    'Outil educatif — ne constitue pas un conseil financier (LSFin).',
+                    l.stepStressDisclaimer,
                     style: GoogleFonts.inter(
                       fontSize: 11,
                       color: MintColors.textMuted,
@@ -149,27 +150,17 @@ class StepStressSelector extends StatelessWidget {
   }
 }
 
-class _StressOption {
-  final String id;
+class _StressCard extends StatelessWidget {
   final IconData icon;
   final String label;
   final String subtitle;
-
-  const _StressOption({
-    required this.id,
-    required this.icon,
-    required this.label,
-    required this.subtitle,
-  });
-}
-
-class _StressCard extends StatelessWidget {
-  final _StressOption option;
   final bool isSelected;
   final VoidCallback onTap;
 
   const _StressCard({
-    required this.option,
+    required this.icon,
+    required this.label,
+    required this.subtitle,
     required this.isSelected,
     required this.onTap,
   });
@@ -183,7 +174,7 @@ class _StressCard extends StatelessWidget {
       borderRadius: BorderRadius.circular(16),
       child: Semantics(
         button: true,
-        label: option.label,
+        label: label,
         child: InkWell(
           borderRadius: BorderRadius.circular(16),
           onTap: onTap,
@@ -208,7 +199,7 @@ class _StressCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Icon(
-                  option.icon,
+                  icon,
                   color: isSelected
                       ? MintColors.primary
                       : MintColors.textSecondary,
@@ -221,7 +212,7 @@ class _StressCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      option.label,
+                      label,
                       style: GoogleFonts.montserrat(
                         fontSize: 15,
                         fontWeight: FontWeight.w600,
@@ -230,7 +221,7 @@ class _StressCard extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      option.subtitle,
+                      subtitle,
                       style: GoogleFonts.inter(
                         fontSize: 13,
                         color: MintColors.textSecondary,

--- a/apps/mobile/lib/screens/onboarding/steps/step_top_actions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_top_actions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/analytics_events.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
 import 'package:mint_mobile/services/coaching_service.dart';
@@ -29,6 +30,7 @@ class StepTopActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final top3 = tips.take(3).toList();
+    final l = S.of(context)!;
 
     return Scaffold(
       backgroundColor: MintColors.background,
@@ -42,7 +44,7 @@ class StepTopActions extends StatelessWidget {
 
               // ── HEADER ─────────────────────────────────────────────
               MintEntrance(child: Text(
-                'Tes 3 actions prioritaires',
+                l.stepTopActionsTitle,
                 style: GoogleFonts.montserrat(
                   fontSize: 22,
                   fontWeight: FontWeight.w700,
@@ -51,7 +53,7 @@ class StepTopActions extends StatelessWidget {
               )),
               const SizedBox(height: 8),
               MintEntrance(delay: const Duration(milliseconds: 100), child: Text(
-                'Basees sur ta situation, voici par ou commencer.',
+                l.stepTopActionsSubtitle,
                 style: GoogleFonts.inter(
                   fontSize: 14,
                   color: MintColors.textSecondary,
@@ -65,7 +67,7 @@ class StepTopActions extends StatelessWidget {
                 child: MintEntrance(delay: const Duration(milliseconds: 200), child: top3.isEmpty
                     ? Center(
                         child: Text(
-                          'Complete ton profil pour recevoir des actions personnalisees.',
+                          l.stepTopActionsEmpty,
                           style: GoogleFonts.inter(
                             fontSize: 14,
                             color: MintColors.textMuted,
@@ -113,7 +115,7 @@ class StepTopActions extends StatelessWidget {
                     ),
                   ),
                   child: Text(
-                    'Continuer',
+                    l.stepTopActionsContinue,
                     style: GoogleFonts.inter(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
@@ -126,7 +128,7 @@ class StepTopActions extends StatelessWidget {
                 child: TextButton(
                   onPressed: onBack,
                   child: Text(
-                    'Retour',
+                    l.stepTopActionsBack,
                     style: GoogleFonts.inter(
                       fontSize: 14,
                       color: MintColors.textSecondary,
@@ -138,9 +140,7 @@ class StepTopActions extends StatelessWidget {
 
               // ── DISCLAIMER ──────────────────────────────────────────
               MintEntrance(delay: const Duration(milliseconds: 400), child: Text(
-                'Suggestions educatives. Ne constitue pas un conseil '
-                'financier (LSFin). Consulte un·e specialiste pour un '
-                'plan personnalise.',
+                l.stepTopActionsDisclaimer,
                 style: GoogleFonts.inter(
                   fontSize: 10,
                   color: MintColors.textMuted,
@@ -179,6 +179,7 @@ class _ActionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = _priorityColor(tip.priority);
+    final l = S.of(context)!;
 
     return Semantics(
       button: true,
@@ -237,7 +238,7 @@ class _ActionCard extends StatelessWidget {
                   if (tip.estimatedImpactChf != null) ...[
                     const SizedBox(height: 8),
                     Text(
-                      'Impact estime : ${CoachingService.formatChf(tip.estimatedImpactChf!)}',
+                      l.stepTopActionsImpact(CoachingService.formatChf(tip.estimatedImpactChf!)),
                       style: GoogleFonts.inter(
                         fontSize: 12,
                         fontWeight: FontWeight.w600,

--- a/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart
@@ -180,7 +180,7 @@ class _ProviderComparatorScreenState extends State<ProviderComparatorScreen> {
             format: l.providerComparatorLabelAgeFormat(_age),
             onChanged: (v) => setState(() {
               _age = v.round();
-              _duree = (65 - _age).clamp(5, 45);
+              _duree = (avsAgeReferenceHomme - _age).clamp(5, 45);
             }),
           )),
           const SizedBox(height: MintSpacing.sm + 4),

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -30,7 +30,7 @@ class StaggeredWithdrawalScreen extends StatefulWidget {
 class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
   double _avoirTotal = 300000;
   int _nbComptes = 3;
-  String _canton = 'VD';
+  String _canton = 'ZH';
   double _revenuImposable = 120000;
   int _ageRetraitDebut = 60;
   int _ageRetraitFin = 64;

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -65,11 +65,11 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
         if (revenu > 0) {
           _revenuImposable = revenu;
         }
-        final targetAge = profile.targetRetirementAge ?? 65;
+        final targetAge = profile.targetRetirementAge ?? avsAgeReferenceHomme;
         // Withdrawal typically starts 5 years before retirement
-        final computedDebut = (targetAge - 5).clamp(60, 65);
+        final computedDebut = (targetAge - 5).clamp(60, avsAgeReferenceHomme);
         _ageRetraitDebut = computedDebut;
-        _ageRetraitFin = targetAge.clamp(computedDebut, 65);
+        _ageRetraitFin = targetAge.clamp(computedDebut, avsAgeReferenceHomme);
       });
     } catch (_) {
       // Provider not in tree (tests) — keep defaults

--- a/apps/mobile/lib/screens/portfolio_screen.dart
+++ b/apps/mobile/lib/screens/portfolio_screen.dart
@@ -45,9 +45,10 @@ class PortfolioScreen extends StatelessWidget {
             const SizedBox(height: 32),
             MintEntrance(delay: const Duration(milliseconds: 200), child: _buildSectionHeader('Répartition par Enveloppe')),
             const SizedBox(height: 12),
-            MintEntrance(delay: const Duration(milliseconds: 300), child: _buildAccountItem('Libre (Compte Placement)', 'CHF 73\'508.90', icon: Icons.trending_up, color: MintColors.primary)),
-            MintEntrance(delay: const Duration(milliseconds: 400), child: _buildAccountItem('Lié (Pilier 3a)', 'CHF 18\'369.74', icon: Icons.savings_outlined, color: MintColors.success)),
-            _buildAccountItem('Réservé (Fonds d\'urgence)', 'CHF 10\'800.00', icon: Icons.account_balance_wallet_outlined, color: MintColors.warning),
+            // TODO: wire to real portfolio data from profile.patrimoine
+            MintEntrance(delay: const Duration(milliseconds: 300), child: _buildAccountItem('Libre (Compte Placement)', 'CHF\u00a0\u2014', icon: Icons.trending_up, color: MintColors.primary)),
+            MintEntrance(delay: const Duration(milliseconds: 400), child: _buildAccountItem('Lié (Pilier 3a)', 'CHF\u00a0\u2014', icon: Icons.savings_outlined, color: MintColors.success)),
+            _buildAccountItem('Réservé (Fonds d\'urgence)', 'CHF\u00a0\u2014', icon: Icons.account_balance_wallet_outlined, color: MintColors.warning),
             const SizedBox(height: 32),
             SafeModeGate(
               hasDebt: hasDebt,
@@ -140,24 +141,13 @@ class PortfolioScreen extends StatelessWidget {
             style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.w500),
           ),
           const SizedBox(height: MintSpacing.sm),
+          // TODO: wire to real portfolio data from profile.patrimoine
           Semantics(
-            label: 'CHF 102\'678.64',
+            label: 'CHF\u00a0\u2014',
             child: Text(
-              'CHF 102\'678.64',
+              'CHF\u00a0\u2014',
               style: MintTextStyles.displayMedium(),
             ),
-          ),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.trending_up, color: MintColors.success, size: 16),
-              const SizedBox(width: 4),
-              Text(
-                '509.30 (0.50%) aujourd\'hui',
-                style: MintTextStyles.bodySmall(color: MintColors.success).copyWith(fontWeight: FontWeight.w600),
-              ),
-            ],
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -113,7 +113,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
           final profile = profileProvider.profile!;
           if (profile.birthYear != null) {
             final age = DateTime.now().year - profile.birthYear!;
-            _years = (65 - age).clamp(5, 45);
+            _years = (avsAgeReferenceHomme - age).clamp(5, 45);
           }
 
           if (profile.employmentStatus == EmploymentStatus.selfEmployed &&

--- a/apps/mobile/lib/screens/simulator_compound_screen.dart
+++ b/apps/mobile/lib/screens/simulator_compound_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/domain/calculators.dart';
 import 'package:intl/intl.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -52,7 +53,7 @@ class _SimulatorCompoundScreenState extends State<SimulatorCompoundScreen> {
           _principal = profile.patrimoine.epargneLiquide;
         }
         if (profile.age > 0) {
-          _years = (65 - profile.age).clamp(5, 45);
+          _years = (avsAgeReferenceHomme - profile.age).clamp(5, 45);
         }
       });
       _calculate();

--- a/apps/mobile/lib/screens/slm_settings_screen.dart
+++ b/apps/mobile/lib/screens/slm_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/slm_provider.dart';
 import 'package:mint_mobile/services/slm/slm_download_service.dart';
@@ -213,7 +214,7 @@ class SlmSettingsScreen extends StatelessWidget {
       return const MintSurface(
         padding: EdgeInsets.all(MintSpacing.lg),
         radius: 16,
-        child: Center(child: CircularProgressIndicator()),
+        child: MintLoadingSkeleton(),
       );
     }
 

--- a/apps/mobile/lib/screens/unemployment_screen.dart
+++ b/apps/mobile/lib/screens/unemployment_screen.dart
@@ -57,7 +57,7 @@ class _UnemploymentScreenState extends State<UnemploymentScreen>
       final salaireMensuel = p.revenuBrutAnnuel > 0
           ? (p.revenuBrutAnnuel / 12).clamp(1500.0, 12646.0)
           : 6000.0;
-      final age = p.age > 0 ? p.age.clamp(18, 65) : 35;
+      final age = p.age > 0 ? p.age.clamp(18, avsAgeReferenceHomme) : 35;
       setState(() {
         _gainAssure = salaireMensuel.roundToDouble();
         _age = age;

--- a/apps/mobile/lib/services/budget_living_engine.dart
+++ b/apps/mobile/lib/services/budget_living_engine.dart
@@ -49,7 +49,7 @@ class BudgetLivingEngine {
     //    a) Retired (age >= targetRetirementAge): budget based on actual rentes.
     //    b) Pre-retirement (has salary + valid age): full projection + gap.
     //    c) No usable data (zero salary and not retired): present-only.
-    final targetRetirementAge = profile.targetRetirementAge ?? 65;
+    final targetRetirementAge = profile.targetRetirementAge ?? avsAgeReferenceHomme;
     final isRetired = profile.age > 0 && profile.age >= targetRetirementAge;
 
     // Case a: user is already in retirement — show rente income, no gap.

--- a/apps/mobile/lib/services/coach/coach_context_builder.dart
+++ b/apps/mobile/lib/services/coach/coach_context_builder.dart
@@ -69,7 +69,7 @@ class CoachContextBuilder {
   static CoachContext build({
     String firstName = '',
     int age = 30,
-    String canton = 'VD',
+    String canton = 'ZH',
     String archetype = 'swiss_native',
     double friTotal = 0,
     double friDelta = 0,

--- a/apps/mobile/lib/services/coach/coach_models.dart
+++ b/apps/mobile/lib/services/coach/coach_models.dart
@@ -88,7 +88,7 @@ class CoachContext {
     this.firstName = 'utilisateur',
     this.archetype = 'swiss_native',
     this.age = 30,
-    this.canton = 'VD',
+    this.canton = 'ZH',
     this.friTotal = 0.0,
     this.friDelta = 0.0,
     this.primaryFocus = '',

--- a/apps/mobile/lib/services/coach/jitai_nudge_service.dart
+++ b/apps/mobile/lib/services/coach/jitai_nudge_service.dart
@@ -578,7 +578,7 @@ class JitaiNudgeService {
           'Attention\u00a0: chaque année d\'anticipation réduit ta rente '
           'd\'environ 6 à 7\u00a0%, selon le barème en vigueur (LAVS art.\u00a040).';
     }
-    if (age == 65) {
+    if (age == avsAgeReferenceHomme) {
       return 'C\'est l\'année de référence AVS\u00a0! '
           'Vérifie que ta demande de rente est en cours.';
     }

--- a/apps/mobile/lib/services/coach_narrative_service.dart
+++ b/apps/mobile/lib/services/coach_narrative_service.dart
@@ -258,13 +258,13 @@ class CoachNarrativeService {
     double replacementRatio = 0;
     try {
       final salary = profile.revenuBrutAnnuel;
-      if (salary > 0 && profile.age < 65) {
+      if (salary > 0 && profile.age < avsAgeReferenceHomme) {
         final avsMonthly = AvsCalculator.renteFromRAMD(salary);
         final lppBalance = (profile.prevoyance.avoirLppTotal ?? 0).toDouble();
         final lppAnnual = LppCalculator.projectToRetirement(
           currentBalance: lppBalance,
           currentAge: profile.age,
-          retirementAge: 65,
+          retirementAge: avsAgeReferenceHomme,
           grossAnnualSalary: salary,
           caisseReturn: 0.01,
           conversionRate: profile.prevoyance.tauxConversion,
@@ -908,13 +908,13 @@ class CoachNarrativeService {
     double replacementRate = 0;
     try {
       final salary = profile.revenuBrutAnnuel;
-      if (salary > 0 && profile.age < 65) {
+      if (salary > 0 && profile.age < avsAgeReferenceHomme) {
         final avsMonthly = AvsCalculator.renteFromRAMD(salary);
         final lppBalance = (profile.prevoyance.avoirLppTotal ?? 0).toDouble();
         final lppAnnual = LppCalculator.projectToRetirement(
           currentBalance: lppBalance,
           currentAge: profile.age,
-          retirementAge: 65,
+          retirementAge: avsAgeReferenceHomme,
           grossAnnualSalary: salary,
           caisseReturn: 0.01,
           conversionRate: profile.prevoyance.tauxConversion,
@@ -934,9 +934,9 @@ class CoachNarrativeService {
       buffer.writeln(
           '- Taux de remplacement estime : ~${(replacementRate * 100).toStringAsFixed(0)}%');
     }
-    if (retirementAge < 65) {
+    if (retirementAge < avsAgeReferenceHomme) {
       buffer.writeln(
-          '- Retraite anticipee : penalite AVS de ${((65 - retirementAge) * 6.8).toStringAsFixed(1)}% '
+          '- Retraite anticipee : penalite AVS de ${((avsAgeReferenceHomme - retirementAge) * 6.8).toStringAsFixed(1)}% '
           '+ taux conversion LPP reduit');
     }
     buffer.writeln();

--- a/apps/mobile/lib/services/coaching_service.dart
+++ b/apps/mobile/lib/services/coaching_service.dart
@@ -135,7 +135,7 @@ class CoachingService {
   static const double _plafond3aIndependant = pilier3aPlafondSansLpp;
 
   /// Swiss legal retirement age (post-AVS21 reform, unified at 65).
-  static const int _ageRetraite = 65;
+  static const int _ageRetraite = avsAgeReferenceHomme;
 
   // Cantonal marginal tax rates removed — replaced by
   // RetirementTaxCalculator.estimateMarginalRate(income, canton)

--- a/apps/mobile/lib/services/coaching_service.dart
+++ b/apps/mobile/lib/services/coaching_service.dart
@@ -915,7 +915,7 @@ R\u00e9\u00e9cris le message en 3-4 phrases max. Personnalise en croisant la sit
   static CoachingProfile buildDemoProfile() {
     return const CoachingProfile(
       age: 35,
-      canton: 'VD',
+      canton: 'ZH',
       revenuAnnuel: 85000,
       has3a: false,
       montant3a: 0,

--- a/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
@@ -1405,7 +1405,7 @@ class ArbitrageEngine {
   /// Legal basis: LIFD art. 38 (progressive capital withdrawal tax).
   static ArbitrageResult compareCalendrierRetraits({
     required List<RetirementAsset> assets,
-    int ageRetraite = 65,
+    int ageRetraite = avsAgeReferenceHomme,
     String canton = 'VD',
     bool isMarried = false,
     Map<String, ProfileDataSource>? dataSources,

--- a/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
@@ -479,7 +479,7 @@ class ArbitrageEngine {
     double rendement3a = 0.02,
     double rendementLpp = 0.0125,
     double rendementMarche = 0.04,
-    String canton = 'VD',
+    String canton = 'ZH',
     Map<String, ProfileDataSource>? dataSources,
     S? l,
   }) {
@@ -876,7 +876,7 @@ class ArbitrageEngine {
     required double capitalDisponible,
     required double loyerMensuelActuel,
     required double prixBien,
-    String canton = 'VD',
+    String canton = 'ZH',
     int horizonAnnees = 20,
     double rendementMarche = 0.04,
     double appreciationImmo = 0.015,
@@ -1134,7 +1134,7 @@ class ArbitrageEngine {
     double rendementLpp = 0.0125,
     double rendementMarche = 0.04,
     double tauxConversion = lppTauxConversionMinDecimal,
-    String canton = 'VD',
+    String canton = 'ZH',
     bool isMarried = false,
     Map<String, ProfileDataSource>? dataSources,
   }) {
@@ -1406,7 +1406,7 @@ class ArbitrageEngine {
   static ArbitrageResult compareCalendrierRetraits({
     required List<RetirementAsset> assets,
     int ageRetraite = avsAgeReferenceHomme,
-    String canton = 'VD',
+    String canton = 'ZH',
     bool isMarried = false,
     Map<String, ProfileDataSource>? dataSources,
   }) {

--- a/apps/mobile/lib/services/financial_core/avs_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/avs_calculator.dart
@@ -52,11 +52,11 @@ class AvsCalculator {
     if (retirementAge < 63) {
       // AVS anticipation only possible from 63 (LAVS art. 40)
       return 0.0;
-    } else if (retirementAge < 65) {
-      final yearsEarly = 65 - retirementAge;
+    } else if (retirementAge < avsAgeReferenceHomme) {
+      final yearsEarly = avsAgeReferenceHomme - retirementAge;
       rente *= (1.0 - avsReductionAnticipation * yearsEarly);
-    } else if (retirementAge > 65) {
-      final yearsLate = (retirementAge - 65).clamp(1, 5);
+    } else if (retirementAge > avsAgeReferenceHomme) {
+      final yearsLate = (retirementAge - avsAgeReferenceHomme).clamp(1, 5);
       final bonus = avsDeferralBonus[yearsLate] ?? avsDeferralBonus[5]!;
       rente *= (1.0 + bonus);
     }

--- a/apps/mobile/lib/services/financial_core/bayesian_enricher.dart
+++ b/apps/mobile/lib/services/financial_core/bayesian_enricher.dart
@@ -360,10 +360,10 @@ class BayesianProfileEnricher {
         (salaireBrut - lppDeductionCoordination).clamp(lppSalaireCoordMin, double.infinity);
 
     // Start age: 25 for Swiss natives, arrivalAge for expats (LPP art. 7)
-    final startAge = arrivalAge != null ? arrivalAge.clamp(25, 65) : 25;
+    final startAge = arrivalAge != null ? arrivalAge.clamp(25, avsAgeReferenceHomme) : 25;
 
     double total = 0;
-    for (int a = startAge; a < age && a < 65; a++) {
+    for (int a = startAge; a < age && a < avsAgeReferenceHomme; a++) {
       final taux = getLppBonificationRate(a);
       total = total * 1.01 + salaireCoordonne * taux; // 1% rendement
     }

--- a/apps/mobile/lib/services/financial_core/coach_reasoner.dart
+++ b/apps/mobile/lib/services/financial_core/coach_reasoner.dart
@@ -46,7 +46,7 @@ class CoachReasonerService {
 
     final age = DateTime.now().year - profile.birthYear;
     final yearsToRetirement =
-        ((profile.targetRetirementAge ?? 65) - age).clamp(0, 45);
+        ((profile.targetRetirementAge ?? avsAgeReferenceHomme) - age).clamp(0, 45);
     if (yearsToRetirement <= 0) {
       return ReasonerResult(
           recommendations: results, confidence: confidence);
@@ -384,7 +384,7 @@ class CoachReasonerService {
     if (prev.nombre3a < 2) return null; // need >= 2 accounts to stagger
     if (prev.totalEpargne3a < 20000) return null; // trivial amounts
 
-    final retirementAge = profile.targetRetirementAge ?? 65;
+    final retirementAge = profile.targetRetirementAge ?? avsAgeReferenceHomme;
     final yearsToRetirement = (retirementAge - age).clamp(0, 45);
     if (yearsToRetirement > 10) return null; // only relevant near retirement
 
@@ -471,7 +471,7 @@ class CoachReasonerService {
     if (totalLP < 20000) return null; // too small
     if (prev.librePassage.length >= 2) return null; // already split
 
-    final retirementAge = profile.targetRetirementAge ?? 65;
+    final retirementAge = profile.targetRetirementAge ?? avsAgeReferenceHomme;
     final yearsToRetirement = (retirementAge - age).clamp(0, 45);
     if (yearsToRetirement > 15) return null; // not urgent yet
 

--- a/apps/mobile/lib/services/financial_core/cross_pillar_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/cross_pillar_calculator.dart
@@ -713,7 +713,7 @@ class CrossPillarCalculator {
     // LAVS art. 39: +5.2% on individual rente per year deferred from 65
     final avsMonthlyAt65 = AvsCalculator.computeMonthlyRente(
       currentAge: currentAge,
-      retirementAge: 65,
+      retirementAge: avsAgeReferenceHomme,
       lacunes: profile.prevoyance.lacunesAVS ?? 0,
       anneesContribuees: profile.prevoyance.anneesContribuees,
       arrivalAge: profile.arrivalAge,

--- a/apps/mobile/lib/services/financial_core/fri_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/fri_calculator.dart
@@ -79,7 +79,7 @@ class FriInput {
     this.employerDependencyRatio = 0,
     this.archetype = 'swiss_native',
     this.age = 30,
-    this.canton = 'VD',
+    this.canton = 'ZH',
   });
 }
 

--- a/apps/mobile/lib/services/financial_core/housing_cost_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/housing_cost_calculator.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
@@ -249,7 +250,7 @@ class HousingCostCalculator {
     String? housingStatus,
     String canton = 'ZH',
     int currentAge = 50,
-    int targetRetirementAge = 65,
+    int targetRetirementAge = avsAgeReferenceHomme,
     double? propertyMarketValue,
     double? mortgageBalance,
     double? mortgageRate,

--- a/apps/mobile/lib/services/financial_core/lpp_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/lpp_calculator.dart
@@ -43,7 +43,7 @@ class LppCalculator {
   static double adjustedConversionRate({
     required double baseRate,
     required int retirementAge,
-    int referenceAge = 65,
+    int referenceAge = avsAgeReferenceHomme,
     double reductionPerYear = lppEarlyRetirementRateReduction,
   }) {
     if (retirementAge >= referenceAge) return baseRate;
@@ -145,7 +145,7 @@ class LppCalculator {
     required String canton,
     bool isMarried = false,
     int? horizonYears,
-    int retirementAge = 65,
+    int retirementAge = avsAgeReferenceHomme,
   }) {
     if (lppCapitalPct <= 0 || annualRente <= 0) return annualRente / 12;
 

--- a/apps/mobile/lib/services/financial_core/monte_carlo_service.dart
+++ b/apps/mobile/lib/services/financial_core/monte_carlo_service.dart
@@ -62,7 +62,7 @@ class MonteCarloProjectionService {
   /// [seed] : graine pour le generateur aleatoire (tests reproductibles).
   static MonteCarloResult simulate({
     required CoachProfile profile,
-    int retirementAgeUser = 65,
+    int retirementAgeUser = avsAgeReferenceHomme,
     double lppCapitalPct = 0.0,
     double? depensesMensuelles,
     int numSimulations = 1000,
@@ -85,8 +85,8 @@ class MonteCarloProjectionService {
     final hasConjoint = profile.isCouple && profile.conjoint != null;
     final conjoint = profile.conjoint;
     final conjointAge = conjoint?.age;
-    // Default conjoint retirement age: 65 (could differ but we simplify)
-    const conjointRetirementAge = 65;
+    // Default conjoint retirement age: avsAgeReferenceHomme (could differ but we simplify)
+    const conjointRetirementAge = avsAgeReferenceHomme;
 
     // ── Early retirement: AVS deferred start (LAVS art. 40) ─
     // AVS anticipation only possible from age 63. If retirement < 63,
@@ -539,7 +539,7 @@ class MonteCarloProjectionService {
           : 'ZH',
       currentAge: profile.age,
       targetRetirementAge:
-          retirementAge ?? profile.targetRetirementAge ?? 65,
+          retirementAge ?? profile.targetRetirementAge ?? avsAgeReferenceHomme,
       propertyMarketValue: profile.patrimoine.propertyMarketValue,
       mortgageBalance: profile.patrimoine.mortgageBalance,
       mortgageRate: profile.patrimoine.mortgageRate,

--- a/apps/mobile/lib/services/financial_core/tax_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/tax_calculator.dart
@@ -80,7 +80,7 @@ class NetIncomeBreakdown {
 
     // 2. LPP employe (~50% de la bonification totale sur salaire coordonne)
     double lppEmployee = 0;
-    if (grossSalary >= lppSeuilEntree && age >= 25 && age <= 65) {
+    if (grossSalary >= lppSeuilEntree && age >= 25 && age <= avsAgeReferenceHomme) {
       final salaireCoord = (grossSalary - lppDeductionCoordination)
           .clamp(lppSalaireCoordMin, lppSalaireCoordMax);
       final totalBonif = getLppBonificationRate(age);

--- a/apps/mobile/lib/services/financial_core/withdrawal_sequencing_service.dart
+++ b/apps/mobile/lib/services/financial_core/withdrawal_sequencing_service.dart
@@ -124,7 +124,7 @@ class WithdrawalSequencingService {
   /// [lppCapitalPct]: fraction du LPP retiree en capital (0.0 = 100% rente).
   static WithdrawalSequencingResult optimize({
     required CoachProfile profile,
-    int retirementAge = 65,
+    int retirementAge = avsAgeReferenceHomme,
     double lppCapitalPct = 0.0,
   }) {
     final currentYear = DateTime.now().year;
@@ -396,7 +396,7 @@ class WithdrawalSequencingService {
     // OPP3 art. 3: retrait anticipe 3a possible 5 ans avant l'age AVS
     // de reference (65), soit au plus tot a 60 ans. La fenetre ne depend
     // PAS de l'age de retraite choisi par l'utilisateur.
-    const int avsReferenceAge = 65;
+    const int avsReferenceAge = avsAgeReferenceHomme;
     final earliestWithdrawalAge =
         (avsReferenceAge - 5).clamp(currentAge, 99); // = max(currentAge, 60)
     final latestWithdrawalAge =

--- a/apps/mobile/lib/services/financial_report_service.dart
+++ b/apps/mobile/lib/services/financial_report_service.dart
@@ -144,7 +144,7 @@ class FinancialReportService {
     return UserProfile(
       firstName: answers['q_firstname'] as String?,
       birthYear: birthYear,
-      canton: answers['q_canton'] as String? ?? 'VD',
+      canton: answers['q_canton'] as String? ?? 'ZH',
       civilStatus: answers['q_civil_status'] as String? ?? 'single',
       childrenCount: _parseInt(answers['q_children']) ?? 0,
       employmentStatus: answers['q_employment_status'] as String? ?? 'employee',

--- a/apps/mobile/lib/services/financial_report_service.dart
+++ b/apps/mobile/lib/services/financial_report_service.dart
@@ -293,7 +293,7 @@ class FinancialReportService {
     }
     for (int year = 0; year < profile.yearsToRetirement; year++) {
       final ageThisYear = profile.age + year;
-      if (ageThisYear >= 25 && ageThisYear <= 65) {
+      if (ageThisYear >= 25 && ageThisYear <= avsAgeReferenceHomme) {
         final rate = getLppBonificationRate(ageThisYear);
         estimatedLppGrowth += coordinatedSalary * rate;
       }
@@ -642,7 +642,7 @@ class FinancialReportService {
 
     final userRente = AvsCalculator.computeMonthlyRente(
       currentAge: profile.age,
-      retirementAge: 65,
+      retirementAge: avsAgeReferenceHomme,
       lacunes: profile.avsGapYears ?? 0,
       anneesContribuees: profile.contributionYears,
       grossAnnualSalary: grossAnnualSalary,
@@ -653,7 +653,7 @@ class FinancialReportService {
       // TODO: Accept spouse income for more accurate couple AVS computation.
       final spouseRente = AvsCalculator.computeMonthlyRente(
         currentAge: profile.age, // Approximate: same age assumed for spouse
-        retirementAge: 65,
+        retirementAge: avsAgeReferenceHomme,
         lacunes: profile.spouseAvsGapYears ?? 0,
         anneesContribuees: profile.spouseContributionYears,
         grossAnnualSalary: grossAnnualSalary,

--- a/apps/mobile/lib/services/independants_service.dart
+++ b/apps/mobile/lib/services/independants_service.dart
@@ -319,7 +319,7 @@ class IndependantsService {
     int age,
     int delaiCarence,
   ) {
-    if (revenuMensuel <= 0 || age < 18 || age > 65) {
+    if (revenuMensuel <= 0 || age < 18 || age > avsAgeReferenceHomme) {
       return IjmResult(
         revenuMensuel: revenuMensuel,
         age: age,

--- a/apps/mobile/lib/services/job_comparison_service.dart
+++ b/apps/mobile/lib/services/job_comparison_service.dart
@@ -287,7 +287,7 @@ class JobComparisonService {
 
     // Compute pension delta
     final annualPensionDelta = deltaRente * 12;
-    // Assume 20 years of retirement (65 to 85)
+    // Assume 20 years of retirement (avsAgeReferenceHomme to 85)
     final lifetimePensionDelta = annualPensionDelta * 20;
 
     // Determine verdict
@@ -374,10 +374,10 @@ class JobComparisonService {
     );
   }
 
-  /// Project retirement capital at age 65 with annual contributions.
+  /// Project retirement capital at retirement age with annual contributions.
   /// Delegates to LppCalculator.projectToRetirement() from financial_core.
   static double _projectCapital(LPPPlanInput plan, int yearsToRetirement) {
-    final currentAge = 65 - yearsToRetirement;
+    final currentAge = avsAgeReferenceHomme - yearsToRetirement;
     final salaireAssure = plan.effectiveSalaireAssure;
     // Compute effective bonification rate from plan's total contribution
     // (employee + employer) relative to the insured salary.
@@ -389,7 +389,7 @@ class JobComparisonService {
     return LppCalculator.projectToRetirement(
       currentBalance: plan.avoirVieillesse,
       currentAge: currentAge,
-      retirementAge: 65,
+      retirementAge: avsAgeReferenceHomme,
       grossAnnualSalary: plan.salaireBrut,
       caisseReturn: 0.0125, // BVG minimum interest rate
       conversionRate: 1.0, // Return raw capital, not rente

--- a/apps/mobile/lib/services/lifecycle_phase_service.dart
+++ b/apps/mobile/lib/services/lifecycle_phase_service.dart
@@ -165,7 +165,7 @@ class LifecyclePhaseService {
     if (age < 35) return LifecyclePhase.construction;
     if (age < 45) return LifecyclePhase.acceleration;
     if (age < 55) return LifecyclePhase.consolidation;
-    if (age < 65) return LifecyclePhase.transition;
+    if (age < avsAgeReferenceHomme) return LifecyclePhase.transition;
     if (age < 75) return LifecyclePhase.retraite;
     return LifecyclePhase.transmission;
   }

--- a/apps/mobile/lib/services/pillar_3a_deep_service.dart
+++ b/apps/mobile/lib/services/pillar_3a_deep_service.dart
@@ -98,8 +98,8 @@ class StaggeredWithdrawalSimulator {
     // Clamp inputs
     final clampedComptes = nbComptes.clamp(1, 5);
     final clampedAvoir = avoirTotal.clamp(0.0, 1000000.0);
-    final clampedDebut = ageRetraitDebut.clamp(59, 65);
-    final clampedFin = ageRetraitFin.clamp(clampedDebut, 65);
+    final clampedDebut = ageRetraitDebut.clamp(59, avsAgeReferenceHomme);
+    final clampedFin = ageRetraitFin.clamp(clampedDebut, avsAgeReferenceHomme);
 
     final tauxBase = tauxImpotRetraitCapital[canton.toUpperCase()] ?? 0.065;
 

--- a/apps/mobile/lib/services/reengagement_engine.dart
+++ b/apps/mobile/lib/services/reengagement_engine.dart
@@ -122,7 +122,7 @@ class ReengagementEngine {
   /// current month. Multiple messages may apply (e.g. quarterly + monthly).
   static List<ReengagementMessage> generateMessages({
     DateTime? today,
-    String canton = 'VD',
+    String canton = 'ZH',
     double taxSaving3a = 0,
     double friTotal = 0,
     double friDelta = 0,

--- a/apps/mobile/lib/services/retirement_projection_service.dart
+++ b/apps/mobile/lib/services/retirement_projection_service.dart
@@ -188,13 +188,13 @@ class RetirementProjectionService {
   /// Projette les revenus du menage a la retraite.
   static RetirementProjectionResult project({
     required CoachProfile profile,
-    int retirementAgeUser = 65,
+    int retirementAgeUser = avsAgeReferenceHomme,
     int? retirementAgeConjoint,
     double? depensesMensuelles,
     double lppCapitalPct = 0.0,
     S? l,
   }) {
-    final conjAge = retirementAgeConjoint ?? 65;
+    final conjAge = retirementAgeConjoint ?? avsAgeReferenceHomme;
     final expenses =
         depensesMensuelles ?? _estimateRetirementExpenses(profile);
 
@@ -290,7 +290,7 @@ class RetirementProjectionService {
   static List<RetirementIncomeSource> _computeIncomes({
     required CoachProfile profile,
     required int ageUser,
-    int ageConjoint = 65,
+    int ageConjoint = avsAgeReferenceHomme,
     double lppCapitalPct = 0.0,
     S? l,
   }) {
@@ -603,7 +603,7 @@ class RetirementProjectionService {
   static List<RetirementPhase> _computePhases({
     required CoachProfile profile,
     required int ageUser,
-    int ageConjoint = 65,
+    int ageConjoint = avsAgeReferenceHomme,
     double lppCapitalPct = 0.0,
     S? l,
   }) {
@@ -942,7 +942,7 @@ class RetirementProjectionService {
 
   static List<EarlyRetirementScenario> _computeEarlyRetirementComparisons({
     required CoachProfile profile,
-    int ageConjoint = 65,
+    int ageConjoint = avsAgeReferenceHomme,
     double lppCapitalPct = 0.0,
     S? l,
   }) {
@@ -981,7 +981,7 @@ class RetirementProjectionService {
       }
     }
 
-    final ref = sourcesForAge(65);
+    final ref = sourcesForAge(avsAgeReferenceHomme);
     final refTotal = ref.fold(0.0, (sum, s) => sum + s.monthlyAmount);
     final scenarios = <EarlyRetirementScenario>[];
 
@@ -990,16 +990,16 @@ class RetirementProjectionService {
       final total = sources.fold(0.0, (sum, s) => sum + s.monthlyAmount);
 
       double adjustmentPct = 0;
-      if (age < 65) {
-        adjustmentPct = -(avsReductionAnticipation * (65 - age) * 100);
-      } else if (age > 65) {
+      if (age < avsAgeReferenceHomme) {
+        adjustmentPct = -(avsReductionAnticipation * (avsAgeReferenceHomme - age) * 100);
+      } else if (age > avsAgeReferenceHomme) {
         final bonus =
-            avsDeferralBonus[(age - 65).clamp(1, 5)];
+            avsDeferralBonus[(age - avsAgeReferenceHomme).clamp(1, 5)];
         adjustmentPct = (bonus ?? 0) * 100;
       }
 
       final yearsThis = _lifeExpectancy - age;
-      const yearsRef = _lifeExpectancy - 65;
+      const yearsRef = _lifeExpectancy - avsAgeReferenceHomme;
       final cumulative =
           (total * 12 * yearsThis) - (refTotal * 12 * yearsRef);
 
@@ -1128,7 +1128,7 @@ class RetirementProjectionService {
           ? profile.canton.toUpperCase()
           : 'ZH',
       currentAge: profile.age,
-      targetRetirementAge: profile.targetRetirementAge ?? 65,
+      targetRetirementAge: profile.targetRetirementAge ?? avsAgeReferenceHomme,
       propertyMarketValue: profile.patrimoine.propertyMarketValue,
       mortgageBalance: profile.patrimoine.mortgageBalance,
       mortgageRate: profile.patrimoine.mortgageRate,

--- a/apps/mobile/lib/services/retirement_service.dart
+++ b/apps/mobile/lib/services/retirement_service.dart
@@ -52,7 +52,7 @@ class RetirementService {
   @Deprecated('Use AvsCalculator.computeMonthlyRente() from financial_core')
   static Map<String, dynamic> estimateAvs({
     required int ageActuel,
-    int ageRetraite = 65,
+    int ageRetraite = avsAgeReferenceHomme,
     bool isCouple = false,
     int anneesLacunes = 0,
     int esperanceVie = 87,
@@ -129,7 +129,7 @@ class RetirementService {
     required double capitalLpp,
     double? conversionRate,
     String canton = 'ZH',
-    int ageRetraite = 65,
+    int ageRetraite = avsAgeReferenceHomme,
     int esperanceVie = 87,
   }) {
     // Rente — use provided blended rate or minimum legal fallback

--- a/apps/mobile/lib/services/segments_service.dart
+++ b/apps/mobile/lib/services/segments_service.dart
@@ -103,7 +103,7 @@ class GenderGapService {
   static const double tauxConversion = lppTauxConversionMinDecimal;
 
   /// Swiss legal retirement age (post-AVS21).
-  static const int ageRetraite = 65;
+  static const int ageRetraite = avsAgeReferenceHomme;
 
   /// LPP contribution rates by age bracket (employee + employer).
   /// Source of truth: getLppBonificationRate() in social_insurance.dart

--- a/apps/mobile/test/services/coach_context_builder_test.dart
+++ b/apps/mobile/test/services/coach_context_builder_test.dart
@@ -70,7 +70,7 @@ void main() {
 
       expect(ctx.firstName, '');
       expect(ctx.age, 30);
-      expect(ctx.canton, 'VD');
+      expect(ctx.canton, 'ZH');
       expect(ctx.archetype, 'swiss_native');
       expect(ctx.friTotal, 0);
       expect(ctx.friDelta, 0);

--- a/apps/mobile/test/services/financial_core/fri_calculator_test.dart
+++ b/apps/mobile/test/services/financial_core/fri_calculator_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(inp.replacementRatio, 0);
       expect(inp.archetype, 'swiss_native');
       expect(inp.age, 30);
-      expect(inp.canton, 'VD');
+      expect(inp.canton, 'ZH');
     });
   });
 

--- a/apps/mobile/test/services/financial_report_service_test.dart
+++ b/apps/mobile/test/services/financial_report_service_test.dart
@@ -102,14 +102,14 @@ void main() {
   // ═══════════════════════════════════════════════════════════════════════
 
   group('UserProfile building', () {
-    test('defaults canton to VD when missing', () {
+    test('defaults canton to ZH when missing', () {
       final answers = <String, dynamic>{
         'q_birth_year': 1990,
         'q_employment_status': 'employee',
         'q_net_income_period_chf': 5000.0,
       };
       final report = service.generateReport(answers);
-      expect(report.profile.canton, equals('VD'));
+      expect(report.profile.canton, equals('ZH'));
     });
 
     test('defaults civilStatus to single when missing', () {
@@ -523,7 +523,7 @@ void main() {
 
     test('empty answers use all defaults', () {
       final report = service.generateReport({});
-      expect(report.profile.canton, equals('VD'));
+      expect(report.profile.canton, equals('ZH'));
       expect(report.profile.civilStatus, equals('single'));
       expect(report.profile.monthlyNetIncome, equals(5000.0));
       expect(report.profile.childrenCount, equals(0));


### PR DESCRIPTION
## Summary — Production readiness: eliminate hardcoded values

### P2-1: Raw '65' → avsAgeReferenceHomme (34 files, 80+ replacements)
Every retirement age reference now uses the centralized constant. If AVS reform changes the reference age, ONE constant update propagates everywhere.

### P2-2: Canton defaults unified (30 files)
All fallback cantons changed from mixed VD/ZH to consistent 'ZH'. Same user now sees same tax rates across all screens.

### P2-3: Portfolio + Loading (16 files)
- Portfolio hardcoded CHF amounts → placeholder dashes
- 16 CircularProgressIndicator → MintLoadingSkeleton (premium shimmer)

### P2-4: i18n extraction (8 onboarding files, 98 new ARB keys)
All hardcoded French strings in onboarding step screens extracted to 6 ARB files (FR/EN/DE/ES/IT/PT). Every new user now sees translated onboarding.

## Metrics
- 93 files changed, +4166 / -448
- 98 new i18n keys × 6 languages = 588 translations
- flutter analyze: 0 issues | flutter test: 8134 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)