### PR TITLE
fix: Sprint A — 5 broken contracts (ask_user_input, CTA routes, neutrality, budget, rente tax)

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -244,8 +244,8 @@ final _router = GoRouter(
     GoRoute(path: '/app/explore', redirect: (_, __) => '/home?tab=2'),
     GoRoute(path: '/app/dossier', redirect: (_, __) => '/home?tab=3'),
 
-    // /pulse → redirect to home (Pulse is tab 0 of the shell)
-    GoRoute(path: '/pulse', redirect: (_, __) => '/'),
+    // /pulse → redirect to home tab 0 (Pulse is tab 0 of the shell)
+    GoRoute(path: '/pulse', redirect: (_, __) => '/home?tab=0'),
 
     // ── EXPLORER HUBS (7 thematic hubs) ──────────────────────
     GoRoute(

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -1641,7 +1641,8 @@ class _CoachChatScreenState extends State<CoachChatScreen>
             ));
           }
         case 'salary':
-          // Contract: ask_user_input(field_key='salary') sends ANNUAL gross salary.
+        case 'salaireBrut':
+          // Contract: ask_user_input(field_key='salaireBrut') sends ANNUAL gross salary.
           // ChatAmountInput displays "CHF" with no period suffix.
           // We convert to monthly for storage (profile.salaireBrutMensuel).
           final salary = double.tryParse(value);
@@ -1656,6 +1657,64 @@ class _CoachChatScreenState extends State<CoachChatScreen>
             canton: value,
             updatedAt: DateTime.now(),
           ));
+        case 'avoirLpp':
+          final avoir = double.tryParse(value);
+          if (avoir != null) {
+            final prev = profile.prevoyance;
+            provider.updateProfile(profile.copyWith(
+              prevoyance: PrevoyanceProfile(
+                anneesContribuees: prev.anneesContribuees,
+                lacunesAVS: prev.lacunesAVS,
+                renteAVSEstimeeMensuelle: prev.renteAVSEstimeeMensuelle,
+                nomCaisse: prev.nomCaisse,
+                avoirLppTotal: avoir,
+                avoirLppObligatoire: prev.avoirLppObligatoire,
+                avoirLppSurobligatoire: prev.avoirLppSurobligatoire,
+                rachatMaximum: prev.rachatMaximum,
+                rachatEffectue: prev.rachatEffectue,
+                tauxConversion: prev.tauxConversion,
+                tauxConversionSuroblig: prev.tauxConversionSuroblig,
+                rendementCaisse: prev.rendementCaisse,
+                salaireAssure: prev.salaireAssure,
+                ramd: prev.ramd,
+                nombre3a: prev.nombre3a,
+                totalEpargne3a: prev.totalEpargne3a,
+                comptes3a: prev.comptes3a,
+                canContribute3a: prev.canContribute3a,
+                librePassage: prev.librePassage,
+              ),
+              updatedAt: DateTime.now(),
+            ));
+          }
+        case 'epargne3a':
+          final epargne = double.tryParse(value);
+          if (epargne != null) {
+            final prev = profile.prevoyance;
+            provider.updateProfile(profile.copyWith(
+              prevoyance: PrevoyanceProfile(
+                anneesContribuees: prev.anneesContribuees,
+                lacunesAVS: prev.lacunesAVS,
+                renteAVSEstimeeMensuelle: prev.renteAVSEstimeeMensuelle,
+                nomCaisse: prev.nomCaisse,
+                avoirLppTotal: prev.avoirLppTotal,
+                avoirLppObligatoire: prev.avoirLppObligatoire,
+                avoirLppSurobligatoire: prev.avoirLppSurobligatoire,
+                rachatMaximum: prev.rachatMaximum,
+                rachatEffectue: prev.rachatEffectue,
+                tauxConversion: prev.tauxConversion,
+                tauxConversionSuroblig: prev.tauxConversionSuroblig,
+                rendementCaisse: prev.rendementCaisse,
+                salaireAssure: prev.salaireAssure,
+                ramd: prev.ramd,
+                nombre3a: prev.nombre3a,
+                totalEpargne3a: epargne,
+                comptes3a: prev.comptes3a,
+                canContribute3a: prev.canContribute3a,
+                librePassage: prev.librePassage,
+              ),
+              updatedAt: DateTime.now(),
+            ));
+          }
         default:
           break;
       }

--- a/apps/mobile/lib/services/cap_sequence_engine.dart
+++ b/apps/mobile/lib/services/cap_sequence_engine.dart
@@ -110,7 +110,7 @@ class CapSequenceEngine {
         titleKey: 'capStepRetirement01Title',
         descriptionKey: 'capStepRetirement01Desc',
         status: hasSalary ? CapStepStatus.completed : CapStepStatus.upcoming,
-        intentTag: '/profile/income',
+        intentTag: '/profile',
         impactEstimate: null,
       ),
       CapStep(
@@ -119,7 +119,7 @@ class CapSequenceEngine {
         titleKey: 'capStepRetirement02Title',
         descriptionKey: 'capStepRetirement02Desc',
         status: hasAge ? CapStepStatus.completed : CapStepStatus.upcoming,
-        intentTag: '/avs',
+        intentTag: '/retraite',
         impactEstimate: _estimateAvsMonthly(profile),
       ),
       CapStep(
@@ -128,7 +128,7 @@ class CapSequenceEngine {
         titleKey: 'capStepRetirement03Title',
         descriptionKey: 'capStepRetirement03Desc',
         status: hasLpp ? CapStepStatus.completed : CapStepStatus.upcoming,
-        intentTag: '/lpp-deep',
+        intentTag: '/rachat-lpp',
         impactEstimate: _estimateLppMonthly(profile),
       ),
       CapStep(
@@ -207,7 +207,7 @@ class CapSequenceEngine {
             : hasSalary
                 ? CapStepStatus.upcoming
                 : CapStepStatus.blocked,
-        intentTag: '/fiscalite',
+        intentTag: '/fiscal',
         impactEstimate: null,
       ),
       CapStep(
@@ -255,7 +255,7 @@ class CapSequenceEngine {
         titleKey: 'capStepBudget01Title',
         descriptionKey: 'capStepBudget01Desc',
         status: hasIncome ? CapStepStatus.completed : CapStepStatus.upcoming,
-        intentTag: '/profile/income',
+        intentTag: '/profile',
         impactEstimate: null,
       ),
       CapStep(
@@ -357,7 +357,7 @@ class CapSequenceEngine {
         titleKey: 'capStepHousing01Title',
         descriptionKey: 'capStepHousing01Desc',
         status: hasIncome ? CapStepStatus.completed : CapStepStatus.upcoming,
-        intentTag: '/profile/income',
+        intentTag: '/profile',
         impactEstimate: null,
       ),
       CapStep(
@@ -370,7 +370,7 @@ class CapSequenceEngine {
             : hasIncome
                 ? CapStepStatus.upcoming
                 : CapStepStatus.blocked,
-        intentTag: '/profile/patrimoine',
+        intentTag: '/app/dossier',
         impactEstimate: null,
       ),
       CapStep(

--- a/apps/mobile/lib/widgets/coach/widget_renderer.dart
+++ b/apps/mobile/lib/widgets/coach/widget_renderer.dart
@@ -247,8 +247,8 @@ class WidgetRenderer {
     Map<String, dynamic> p,
     void Function(String field, String value)? onInputSubmitted,
   ) {
-    final field = p['field'] as String? ?? '';
-    final message = p['message'] as String? ?? p['prompt_text'] as String?;
+    final field = p['field_key'] as String? ?? p['field'] as String? ?? '';
+    final message = p['prompt_text'] as String? ?? p['message'] as String?;
 
     switch (field) {
       case 'name':
@@ -265,10 +265,27 @@ class WidgetRenderer {
         );
 
       case 'salary':
+      case 'salaireBrut':
         return ChatAmountInput(
           label: message ?? S.of(context)?.onboardingSmartSalaryLabel ?? 'Salary',
           onSubmitted: (amount) {
-            onInputSubmitted?.call('salary', '${amount.round()}');
+            onInputSubmitted?.call('salaireBrut', '${amount.round()}');
+          },
+        );
+
+      case 'avoirLpp':
+        return ChatAmountInput(
+          label: message ?? 'Avoir LPP (CHF)',
+          onSubmitted: (amount) {
+            onInputSubmitted?.call('avoirLpp', '${amount.round()}');
+          },
+        );
+
+      case 'epargne3a':
+        return ChatAmountInput(
+          label: message ?? '\u00c9pargne 3a (CHF)',
+          onSubmitted: (amount) {
+            onInputSubmitted?.call('epargne3a', '${amount.round()}');
           },
         );
 

--- a/services/backend/app/api/v1/endpoints/pillar_3a_deep.py
+++ b/services/backend/app/api/v1/endpoints/pillar_3a_deep.py
@@ -180,8 +180,8 @@ def compare_providers(
             )
             for p in result.projections
         ],
-        meilleurCapital=result.meilleur_capital,
-        pireCapital=result.pire_capital,
+        capitalPlusHaut=result.capital_plus_haut,
+        capitalPlusBas=result.capital_plus_bas,
         differenceMax=result.difference_max,
         age=result.age,
         versementAnnuel=result.versement_annuel,

--- a/services/backend/app/api/v1/endpoints/retirement.py
+++ b/services/backend/app/api/v1/endpoints/retirement.py
@@ -94,8 +94,11 @@ def compare_lpp(request: Request, body: LppConversionRequest) -> LppConversionRe
     )
     return LppConversionResponse(
         capital_total=result.capital_total,
-        option_rente_mensuelle=result.option_rente_mensuelle,
+        option_rente_brute_mensuelle=result.option_rente_brute_mensuelle,
         option_rente_annuelle=result.option_rente_annuelle,
+        rente_impot_annuel=result.rente_impot_annuel,
+        option_rente_nette_mensuelle=result.option_rente_nette_mensuelle,
+        option_rente_nette_annuelle=result.option_rente_nette_annuelle,
         option_capital_brut=result.option_capital_brut,
         option_capital_impot=result.option_capital_impot,
         option_capital_net=result.option_capital_net,
@@ -132,7 +135,8 @@ def budget_retirement(request: Request, body: RetirementBudgetRequest) -> Retire
         is_couple=body.is_couple,
     )
     return RetirementBudgetResponse(
-        revenus_mensuels=result.revenus_mensuels,
+        revenus_garantis=result.revenus_garantis,
+        capital_epuisable=result.capital_epuisable,
         total_revenus_mensuels=result.total_revenus_mensuels,
         depenses_mensuelles_estimees=result.depenses_mensuelles_estimees,
         solde_mensuel=result.solde_mensuel,

--- a/services/backend/app/schemas/pillar_3a_deep.py
+++ b/services/backend/app/schemas/pillar_3a_deep.py
@@ -280,17 +280,17 @@ class ProviderCompareResponse(BaseModel):
     projections: List[ProviderProjectionResponse] = Field(
         ..., description="Projections par provider"
     )
-    meilleurCapital: str = Field(
-        ..., alias="meilleurCapital",
-        description="Nom du provider au meilleur capital final"
+    capitalPlusHaut: str = Field(
+        ..., alias="capitalPlusHaut",
+        description="Nom du provider au capital final le plus haut"
     )
-    pireCapital: str = Field(
-        ..., alias="pireCapital",
-        description="Nom du provider au pire capital final"
+    capitalPlusBas: str = Field(
+        ..., alias="capitalPlusBas",
+        description="Nom du provider au capital final le plus bas"
     )
     differenceMax: float = Field(
         ..., alias="differenceMax",
-        description="Difference max entre meilleur et pire (CHF)"
+        description="Ecart max entre le plus haut et le plus bas (CHF)"
     )
 
     # Input summary

--- a/services/backend/app/schemas/retirement.py
+++ b/services/backend/app/schemas/retirement.py
@@ -155,11 +155,20 @@ class LppConversionResponse(BaseModel):
     capital_total: float = Field(
         ..., description="Capital LPP total (CHF)",
     )
-    option_rente_mensuelle: float = Field(
-        ..., description="Rente mensuelle a vie (CHF)",
+    option_rente_brute_mensuelle: float = Field(
+        ..., description="Rente brute mensuelle a vie (CHF)",
     )
     option_rente_annuelle: float = Field(
-        ..., description="Rente annuelle a vie (CHF)",
+        ..., description="Rente brute annuelle a vie (CHF)",
+    )
+    rente_impot_annuel: float = Field(
+        ..., description="Impot annuel estime sur la rente (LIFD art. 22) (CHF)",
+    )
+    option_rente_nette_mensuelle: float = Field(
+        ..., description="Rente nette mensuelle apres impot sur le revenu (CHF)",
+    )
+    option_rente_nette_annuelle: float = Field(
+        ..., description="Rente nette annuelle apres impot sur le revenu (CHF)",
     )
     option_capital_brut: float = Field(
         ..., description="Capital brut (CHF)",
@@ -171,7 +180,7 @@ class LppConversionResponse(BaseModel):
         ..., description="Capital net apres impot (CHF)",
     )
     breakeven_age: int = Field(
-        ..., description="Age de breakeven (rente > capital net)",
+        ..., description="Age de breakeven (rente nette > capital net)",
     )
     recommandation_neutre: str = Field(
         ..., description="Recommandation neutre sans biais",
@@ -238,11 +247,14 @@ class RetirementBudgetResponse(BaseModel):
         alias_generator=to_camel,
     )
 
-    revenus_mensuels: Dict[str, float] = Field(
-        ..., description="Detail des revenus mensuels par source",
+    revenus_garantis: Dict[str, float] = Field(
+        ..., description="Revenus garantis mensuels par source (AVS, LPP, autres)",
+    )
+    capital_epuisable: Dict[str, float] = Field(
+        ..., description="Capital epuisable mensualise par source (3a). Ce n'est pas un revenu garanti.",
     )
     total_revenus_mensuels: float = Field(
-        ..., description="Total des revenus mensuels (CHF)",
+        ..., description="Total des revenus mensuels (revenus garantis + capital epuisable) (CHF)",
     )
     depenses_mensuelles_estimees: float = Field(
         ..., description="Depenses mensuelles estimees (CHF)",

--- a/services/backend/app/services/pillar_3a_deep/provider_comparator_service.py
+++ b/services/backend/app/services/pillar_3a_deep/provider_comparator_service.py
@@ -149,10 +149,10 @@ class ProviderComparisonResult:
 
     projections: List[ProviderProjection]
 
-    # Best/worst
-    meilleur_capital: str        # Name of provider with highest final capital
-    pire_capital: str            # Name of provider with lowest final capital
-    difference_max: float        # CHF difference between best and worst
+    # Highest/lowest
+    capital_plus_haut: str       # Name of provider with highest final capital
+    capital_plus_bas: str        # Name of provider with lowest final capital
+    difference_max: float        # CHF difference between highest and lowest
 
     # Input summary
     age: int
@@ -228,8 +228,8 @@ class ProviderComparatorService:
                 warning = (
                     f"L'assurance 3a coute environ {perte_vs_fintech:,.0f} CHF de rendement "
                     f"perdu sur {duree} ans par rapport a une solution fintech. "
-                    f"Privilegiez une solution bancaire ou fintech sauf si besoin "
-                    f"specifique (liberation de primes en cas d'invalidite)."
+                    f"Les solutions bancaires et fintech affichent generalement des frais "
+                    f"plus bas que les assurances, mais chaque situation est differente."
                 ).replace(",", "'")
 
             projections.append(ProviderProjection(
@@ -246,15 +246,15 @@ class ProviderComparatorService:
                 warning=warning,
             ))
 
-        # Find best and worst
+        # Find highest and lowest
         projections_sorted = sorted(projections, key=lambda p: p.capital_final, reverse=True)
-        meilleur = projections_sorted[0]
-        pire = projections_sorted[-1]
-        difference = round(meilleur.capital_final - pire.capital_final, 2)
+        plus_haut = projections_sorted[0]
+        plus_bas = projections_sorted[-1]
+        difference = round(plus_haut.capital_final - plus_bas.capital_final, 2)
 
         # Chiffre choc
         chiffre_choc = (
-            f"Difference entre meilleur fintech et assurance sur {duree} ans : "
+            f"\u00c9cart entre le capital le plus haut et le plus bas sur {duree} ans : "
             f"{difference:,.0f} CHF"
         ).replace(",", "'")
 
@@ -269,8 +269,8 @@ class ProviderComparatorService:
 
         return ProviderComparisonResult(
             projections=projections,
-            meilleur_capital=meilleur.nom,
-            pire_capital=pire.nom,
+            capital_plus_haut=plus_haut.nom,
+            capital_plus_bas=plus_bas.nom,
             difference_max=difference,
             age=age,
             versement_annuel=versement_annuel,

--- a/services/backend/app/services/retirement/lpp_conversion_service.py
+++ b/services/backend/app/services/retirement/lpp_conversion_service.py
@@ -41,12 +41,15 @@ _DEFAULT_TAUX_RETRAIT = 0.065
 class LppConversionResult:
     """Complete result of LPP rente vs capital comparison."""
     capital_total: float               # Total LPP capital (CHF)
-    option_rente_mensuelle: float      # Monthly pension with conversion rate
-    option_rente_annuelle: float       # Annual pension
+    option_rente_brute_mensuelle: float  # Gross monthly pension
+    option_rente_annuelle: float       # Gross annual pension
+    rente_impot_annuel: float          # Estimated annual income tax on rente (LIFD art. 22)
+    option_rente_nette_mensuelle: float  # Net monthly pension after income tax
+    option_rente_nette_annuelle: float   # Net annual pension after income tax
     option_capital_brut: float         # Gross capital amount
     option_capital_impot: float        # Estimated capital withdrawal tax
     option_capital_net: float          # Net capital after tax
-    breakeven_age: int                 # Age where cumulative rente > net capital
+    breakeven_age: int                 # Age where cumulative net rente > net capital
     recommandation_neutre: str         # Neutral comparison text
     chiffre_choc: str                  # Educational shock figure
     sources: List[str] = field(default_factory=list)
@@ -72,6 +75,7 @@ class LppConversionService:
         canton: str = "ZH",
         retirement_age: int = 65,
         life_expectancy: int = 87,
+        taux_marginal_revenu: float = 0.25,
     ) -> LppConversionResult:
         """Compare rente vs capital withdrawal for given LPP capital.
 
@@ -80,6 +84,9 @@ class LppConversionService:
             canton: Canton code for tax estimation.
             retirement_age: Age at retirement.
             life_expectancy: Assumed life expectancy.
+            taux_marginal_revenu: Estimated marginal income tax rate for rente
+                taxation (LIFD art. 22 — rente LPP is taxable income).
+                Default 0.25 (25%) for mid-income retirees.
 
         Returns:
             LppConversionResult with complete comparison.
@@ -87,22 +94,30 @@ class LppConversionService:
         capital_lpp = max(0.0, capital_lpp)
         canton_upper = canton.upper() if canton else "ZH"
 
-        # Rente option
-        rente_annuelle = round(capital_lpp * LPP_CONVERSION_RATE, 2)
-        rente_mensuelle = round(rente_annuelle / 12, 2)
+        # Rente option — gross
+        rente_brute_annuelle = round(capital_lpp * LPP_CONVERSION_RATE, 2)
+        rente_brute_mensuelle = round(rente_brute_annuelle / 12, 2)
+
+        # Rente income tax (LIFD art. 22 — rente LPP is taxable income)
+        taux_marginal = max(0.0, min(0.50, taux_marginal_revenu))
+        rente_impot_annuel = round(rente_brute_annuelle * taux_marginal, 2)
+
+        # Rente net after income tax
+        rente_nette_annuelle = round(rente_brute_annuelle - rente_impot_annuel, 2)
+        rente_nette_mensuelle = round(rente_nette_annuelle / 12, 2)
 
         # Capital option
         taux = TAUX_IMPOT_RETRAIT_CAPITAL.get(canton_upper, _DEFAULT_TAUX_RETRAIT)
         impot = calculate_progressive_capital_tax(capital_lpp, taux)
         capital_net = round(capital_lpp - impot, 2)
 
-        # Breakeven
+        # Breakeven — uses net rente (after tax) vs net capital
         duree = max(0, life_expectancy - retirement_age)
         breakeven = retirement_age
-        if rente_annuelle > 0:
+        if rente_nette_annuelle > 0:
             cumul = 0.0
             for y in range(duree + 1):
-                cumul += rente_annuelle
+                cumul += rente_nette_annuelle
                 if cumul >= capital_net:
                     breakeven = retirement_age + y
                     break
@@ -110,21 +125,25 @@ class LppConversionService:
                 breakeven = life_expectancy  # Never reached
 
         recommandation = (
-            f"La rente LPP te verse CHF {rente_mensuelle:,.0f}/mois a vie. "
-            f"Le capital te donne CHF {capital_net:,.0f} net apres impot. "
-            f"Si tu vis au-dela de {breakeven} ans, la rente est plus avantageuse en cumul. "
+            f"La rente LPP te verse CHF {rente_nette_mensuelle:,.0f}/mois net a vie "
+            f"(brut CHF {rente_brute_mensuelle:,.0f}, impot ~CHF {round(rente_impot_annuel / 12):,.0f}/mois). "
+            f"Le capital te donne CHF {capital_net:,.0f} net apres impot de retrait. "
+            f"Si tu vis au-dela de {breakeven} ans, la rente nette est plus avantageuse en cumul. "
             f"Aucune option n'est universellement meilleure — cela depend de ta situation."
         )
 
         chiffre_choc = (
-            f"Rente = CHF {rente_mensuelle:,.0f}/mois a vie | "
+            f"Rente = CHF {rente_nette_mensuelle:,.0f}/mois net a vie | "
             f"Capital = CHF {capital_net:,.0f} net (breakeven a {breakeven} ans)"
         )
 
         return LppConversionResult(
             capital_total=capital_lpp,
-            option_rente_mensuelle=rente_mensuelle,
-            option_rente_annuelle=rente_annuelle,
+            option_rente_brute_mensuelle=rente_brute_mensuelle,
+            option_rente_annuelle=rente_brute_annuelle,
+            rente_impot_annuel=rente_impot_annuel,
+            option_rente_nette_mensuelle=rente_nette_mensuelle,
+            option_rente_nette_annuelle=rente_nette_annuelle,
             option_capital_brut=capital_lpp,
             option_capital_impot=impot,
             option_capital_net=capital_net,
@@ -133,6 +152,7 @@ class LppConversionService:
             chiffre_choc=chiffre_choc,
             sources=[
                 "LPP art. 14 (taux de conversion 6.8% minimum obligatoire)",
+                "LIFD art. 22 (rente LPP imposable comme revenu)",
                 "LIFD art. 38 (imposition des prestations en capital)",
             ],
         )

--- a/services/backend/app/services/retirement/retirement_budget_service.py
+++ b/services/backend/app/services/retirement/retirement_budget_service.py
@@ -27,8 +27,9 @@ DISCLAIMER = (
 @dataclass
 class RetirementBudget:
     """Complete retirement budget reconciliation."""
-    revenus_mensuels: Dict[str, float]    # breakdown by source
-    total_revenus_mensuels: float
+    revenus_garantis: Dict[str, float]    # guaranteed income by source (AVS, LPP rente, other)
+    capital_epuisable: Dict[str, float]   # capital-based income by source (3a mensualisé)
+    total_revenus_mensuels: float         # revenus_garantis + capital_epuisable
     depenses_mensuelles_estimees: float
     solde_mensuel: float                  # positive = surplus, negative = deficit
     taux_remplacement: float              # % of pre-retirement income
@@ -87,18 +88,23 @@ class RetirementBudgetService:
         Returns:
             RetirementBudget with complete reconciliation.
         """
-        # Income breakdown
-        mensualise_3a = round(
+        # Income breakdown — separated into guaranteed income and depletable capital.
+        # 3a is consumption of capital, NOT guaranteed income like AVS/LPP rente.
+        capital_epuisable_mensuel = round(
             capital_3a_net / (self.DUREE_MENSUALISATION_3A * 12), 2
         ) if capital_3a_net > 0 else 0.0
 
-        revenus = {
+        revenus_garantis = {
             "avs": round(avs_mensuel, 2),
             "lpp": round(lpp_mensuel, 2),
-            "3a_mensualise": mensualise_3a,
             "autres": round(autres_revenus, 2),
         }
-        total_revenus = round(sum(revenus.values()), 2)
+        capital_epuisable = {
+            "3a_mensualise": capital_epuisable_mensuel,
+        }
+        total_revenus = round(
+            sum(revenus_garantis.values()) + sum(capital_epuisable.values()), 2
+        )
         solde = round(total_revenus - depenses_mensuelles, 2)
 
         # Replacement rate
@@ -151,7 +157,8 @@ class RetirementBudgetService:
         ]
 
         return RetirementBudget(
-            revenus_mensuels=revenus,
+            revenus_garantis=revenus_garantis,
+            capital_epuisable=capital_epuisable,
             total_revenus_mensuels=total_revenus,
             depenses_mensuelles_estimees=depenses_mensuelles,
             solde_mensuel=solde,

--- a/services/backend/tests/test_retirement.py
+++ b/services/backend/tests/test_retirement.py
@@ -208,12 +208,23 @@ class TestLppConversion:
     """Tests for LppConversionService.compare()."""
 
     def test_rente_calculation(self, lpp_service):
-        """Rente should be capital * 6.8% / 12 monthly."""
+        """Gross rente should be capital * 6.8% / 12 monthly."""
         result = lpp_service.compare(capital_lpp=500_000)
         expected_annual = 500_000 * LPP_CONVERSION_RATE
         expected_monthly = round(expected_annual / 12, 2)
         assert result.option_rente_annuelle == expected_annual
-        assert result.option_rente_mensuelle == expected_monthly
+        assert result.option_rente_brute_mensuelle == expected_monthly
+
+    def test_rente_income_tax(self, lpp_service):
+        """Rente should be taxed as income (LIFD art. 22)."""
+        result = lpp_service.compare(capital_lpp=500_000, taux_marginal_revenu=0.25)
+        expected_annual = 500_000 * LPP_CONVERSION_RATE
+        expected_tax = round(expected_annual * 0.25, 2)
+        assert result.rente_impot_annuel == expected_tax
+        assert result.option_rente_nette_annuelle == round(expected_annual - expected_tax, 2)
+        assert result.option_rente_nette_mensuelle == round((expected_annual - expected_tax) / 12, 2)
+        # Net rente should be less than gross rente
+        assert result.option_rente_nette_mensuelle < result.option_rente_brute_mensuelle
 
     def test_capital_tax_zurich(self, lpp_service):
         """ZH capital tax should use the correct base rate."""
@@ -523,7 +534,10 @@ class TestRetirementEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert "capitalTotal" in data
-        assert "optionRenteMensuelle" in data
+        assert "optionRenteBruteMensuelle" in data
+        assert "renteImpotAnnuel" in data
+        assert "optionRenteNetteMensuelle" in data
+        assert "optionRenteNetteAnnuelle" in data
         assert "optionCapitalNet" in data
         assert "breakevenAge" in data
         assert "recommandationNeutre" in data
@@ -545,7 +559,8 @@ class TestRetirementEndpoints:
         )
         assert response.status_code == 200
         data = response.json()
-        assert "revenusMensuels" in data
+        assert "revenusGarantis" in data
+        assert "capitalEpuisable" in data
         assert "soldeMensuel" in data
         assert "tauxRemplacement" in data
         assert "pcPotentiellementEligible" in data

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -11327,7 +11327,7 @@
         "description": "Response for LPP capital vs rente comparison.",
         "properties": {
           "breakevenAge": {
-            "description": "Age de breakeven (rente > capital net)",
+            "description": "Age de breakeven (rente nette > capital net)",
             "title": "Breakevenage",
             "type": "integer"
           },
@@ -11362,19 +11362,34 @@
             "type": "number"
           },
           "optionRenteAnnuelle": {
-            "description": "Rente annuelle a vie (CHF)",
+            "description": "Rente brute annuelle a vie (CHF)",
             "title": "Optionrenteannuelle",
             "type": "number"
           },
-          "optionRenteMensuelle": {
-            "description": "Rente mensuelle a vie (CHF)",
-            "title": "Optionrentemensuelle",
+          "optionRenteBruteMensuelle": {
+            "description": "Rente brute mensuelle a vie (CHF)",
+            "title": "Optionrentebrutemensuelle",
+            "type": "number"
+          },
+          "optionRenteNetteAnnuelle": {
+            "description": "Rente nette annuelle apres impot sur le revenu (CHF)",
+            "title": "Optionrentenetteannuelle",
+            "type": "number"
+          },
+          "optionRenteNetteMensuelle": {
+            "description": "Rente nette mensuelle apres impot sur le revenu (CHF)",
+            "title": "Optionrentenettemensuelle",
             "type": "number"
           },
           "recommandationNeutre": {
             "description": "Recommandation neutre sans biais",
             "title": "Recommandationneutre",
             "type": "string"
+          },
+          "renteImpotAnnuel": {
+            "description": "Impot annuel estime sur la rente (LIFD art. 22) (CHF)",
+            "title": "Renteimpotannuel",
+            "type": "number"
           },
           "sources": {
             "description": "Sources legales",
@@ -11387,8 +11402,11 @@
         },
         "required": [
           "capitalTotal",
-          "optionRenteMensuelle",
+          "optionRenteBruteMensuelle",
           "optionRenteAnnuelle",
+          "renteImpotAnnuel",
+          "optionRenteNetteMensuelle",
+          "optionRenteNetteAnnuelle",
           "optionCapitalBrut",
           "optionCapitalImpot",
           "optionCapitalNet",
@@ -14214,13 +14232,23 @@
             "title": "Baselegale",
             "type": "string"
           },
+          "capitalPlusBas": {
+            "description": "Nom du provider au capital final le plus bas",
+            "title": "Capitalplusbas",
+            "type": "string"
+          },
+          "capitalPlusHaut": {
+            "description": "Nom du provider au capital final le plus haut",
+            "title": "Capitalplushaut",
+            "type": "string"
+          },
           "chiffreChoc": {
             "description": "Chiffre choc",
             "title": "Chiffrechoc",
             "type": "string"
           },
           "differenceMax": {
-            "description": "Difference max entre meilleur et pire (CHF)",
+            "description": "Ecart max entre le plus haut et le plus bas (CHF)",
             "title": "Differencemax",
             "type": "number"
           },
@@ -14232,16 +14260,6 @@
           "duree": {
             "title": "Duree",
             "type": "integer"
-          },
-          "meilleurCapital": {
-            "description": "Nom du provider au meilleur capital final",
-            "title": "Meilleurcapital",
-            "type": "string"
-          },
-          "pireCapital": {
-            "description": "Nom du provider au pire capital final",
-            "title": "Pirecapital",
-            "type": "string"
           },
           "profilRisque": {
             "title": "Profilrisque",
@@ -14269,8 +14287,8 @@
         },
         "required": [
           "projections",
-          "meilleurCapital",
-          "pireCapital",
+          "capitalPlusHaut",
+          "capitalPlusBas",
           "differenceMax",
           "age",
           "versementAnnuel",
@@ -16320,6 +16338,14 @@
             "title": "Alertes",
             "type": "array"
           },
+          "capitalEpuisable": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "Capital epuisable mensualise par source (3a). Ce n'est pas un revenu garanti.",
+            "title": "Capitalepuisable",
+            "type": "object"
+          },
           "checklist": {
             "description": "Checklist de preparation a la retraite",
             "items": {
@@ -16353,12 +16379,12 @@
             "title": "Pcpotentiellementeligible",
             "type": "boolean"
           },
-          "revenusMensuels": {
+          "revenusGarantis": {
             "additionalProperties": {
               "type": "number"
             },
-            "description": "Detail des revenus mensuels par source",
-            "title": "Revenusmensuels",
+            "description": "Revenus garantis mensuels par source (AVS, LPP, autres)",
+            "title": "Revenusgarantis",
             "type": "object"
           },
           "soldeMensuel": {
@@ -16380,13 +16406,14 @@
             "type": "number"
           },
           "totalRevenusMensuels": {
-            "description": "Total des revenus mensuels (CHF)",
+            "description": "Total des revenus mensuels (revenus garantis + capital epuisable) (CHF)",
             "title": "Totalrevenusmensuels",
             "type": "number"
           }
         },
         "required": [
-          "revenusMensuels",
+          "revenusGarantis",
+          "capitalEpuisable",
           "totalRevenusMensuels",
           "depensesMensuellesEstimees",
           "soldeMensuel",


### PR DESCRIPTION
## 5 broken contracts fixed

- **A1**: ask_user_input — frontend now reads `field_key`, handles salaireBrut/avoirLpp/epargne3a
- **A2**: 5 dead CTA routes fixed + /pulse redirects to shell tab 0
- **A3**: 3a provider comparator — meilleur/pire → capital_plus_haut/bas, Privilégiez removed
- **A4**: Budget retraite — 3a capital separated as `capital_epuisable` vs `revenus_garantis`
- **A5**: LPP rente vs capital — annual income tax on rente modeled (LIFD art. 22)

Tests: 8134 Flutter + 4439 Backend | OpenAPI regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)