### PR TITLE
feat(confidence): FRI gate < 50 + uncertainty bands < 70

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11154,5 +11154,14 @@
   "stepQuestionsCountryAu": "Australien",
   "stepQuestionsCountryJp": "Japan",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Vervollständige dein Profil, um deinen Score zu sehen",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0Monat",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11182,5 +11182,14 @@
   "stepQuestionsCountryAu": "Australia",
   "stepQuestionsCountryJp": "Japan",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Complete your profile to see your score",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0month",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11147,5 +11147,14 @@
   "stepQuestionsCountryAu": "Australia",
   "stepQuestionsCountryJp": "Jap\u00f3n",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Completa tu perfil para ver tu puntuación",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0mes",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11629,5 +11629,14 @@
   "stepQuestionsCountryAu": "Australie",
   "stepQuestionsCountryJp": "Japon",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Complète ton profil pour voir ton score",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0mois",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11147,5 +11147,14 @@
   "stepQuestionsCountryAu": "Australia",
   "stepQuestionsCountryJp": "Giappone",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Completa il tuo profilo per vedere il tuo punteggio",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0mese",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -42040,6 +42040,18 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'CODE'**
   String get householdAcceptCodeHint;
+
+  /// No description provided for @friInsufficientData.
+  ///
+  /// In fr, this message translates to:
+  /// **'Complète ton profil pour voir ton score'**
+  String get friInsufficientData;
+
+  /// No description provided for @projectionUncertaintyBand.
+  ///
+  /// In fr, this message translates to:
+  /// **'CHF {low} — {high} / mois'**
+  String projectionUncertaintyBand(String low, String high);
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23880,4 +23880,13 @@ class SDe extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData =>
+      'Vervollständige dein Profil, um deinen Score zu sehen';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / Monat';
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23727,4 +23727,12 @@ class SEn extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData => 'Complete your profile to see your score';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / month';
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23842,4 +23842,12 @@ class SEs extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData => 'Completa tu perfil para ver tu puntuación';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / mes';
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23841,4 +23841,12 @@ class SFr extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData => 'Complète ton profil pour voir ton score';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / mois';
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23883,4 +23883,13 @@ class SIt extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData =>
+      'Completa il tuo profilo per vedere il tuo punteggio';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / mese';
+  }
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23799,4 +23799,13 @@ class SPt extends S {
 
   @override
   String get householdAcceptCodeHint => 'CODE';
+
+  @override
+  String get friInsufficientData =>
+      'Completa o teu perfil para ver a tua pontuação';
+
+  @override
+  String projectionUncertaintyBand(String low, String high) {
+    return 'CHF $low — $high / mês';
+  }
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11148,5 +11148,14 @@
   "stepQuestionsCountryAu": "Austr\u00e1lia",
   "stepQuestionsCountryJp": "Jap\u00e3o",
 
-  "householdAcceptCodeHint": "CODE"
+  "householdAcceptCodeHint": "CODE",
+
+  "friInsufficientData": "Completa o teu perfil para ver a tua pontuação",
+  "projectionUncertaintyBand": "CHF\u00a0{low}\u00a0—\u00a0{high}\u00a0/\u00a0mês",
+  "@projectionUncertaintyBand": {
+    "placeholders": {
+      "low": {"type": "String"},
+      "high": {"type": "String"}
+    }
+  }
 }

--- a/apps/mobile/lib/screens/pulse/pulse_screen.dart
+++ b/apps/mobile/lib/screens/pulse/pulse_screen.dart
@@ -269,6 +269,27 @@ class _PulseScreenState extends State<PulseScreen> {
                     }
                   },
                 )),
+                // Uncertainty band: ±15% when confidence < 70 and
+                // dominant number is a financial projection (CHF or %).
+                if ((mintState?.confidenceScore ?? 0) < 70 &&
+                    dominantNumber.value > 0 &&
+                    (dominantNumber.type == _NumberType.chf ||
+                        dominantNumber.type == _NumberType.percentage)) ...[
+                  const SizedBox(height: 4),
+                  Center(
+                    child: Text(
+                      dominantNumber.type == _NumberType.chf
+                          ? l.projectionUncertaintyBand(
+                              formatChf(dominantNumber.value.abs() * 0.85),
+                              formatChf(dominantNumber.value.abs() * 1.15),
+                            )
+                          : '${(dominantNumber.value * 0.85).round()}\u00a0—\u00a0${(dominantNumber.value * 1.15).round()}\u00a0%',
+                      style: MintTextStyles.labelSmall(
+                        color: MintColors.textMuted,
+                      ).copyWith(fontSize: 12, fontStyle: FontStyle.italic),
+                    ),
+                  ),
+                ],
                 const SizedBox(height: MintSpacing.xs),
                 Align(
                   alignment: Alignment.centerRight,
@@ -465,8 +486,11 @@ class _PulseScreenState extends State<PulseScreen> {
       }
     }
     // FRI score as tertiary fallback.
+    // Gated: FRI is hidden when confidence < 50 — data too incomplete
+    // for a meaningful score (SOT.md §Confidence Gate).
     final friScore = mintState?.friScore;
-    if (friScore != null) {
+    final confidenceForGate = mintState?.confidenceScore ?? 0;
+    if (friScore != null && confidenceForGate >= 50) {
       return _DominantNumber(
         value: friScore,
         format: (v) => '${v.round()}/100',
@@ -511,6 +535,11 @@ class _PulseScreenState extends State<PulseScreen> {
         return l.pulseLabelReplacementRate;
       }
       return l.pulseLabelRetirementIncome;
+    }
+    // When FRI is gated (confidence < 50), show enrichment prompt instead.
+    final confidenceForGate = mintState?.confidenceScore ?? 0;
+    if (confidenceForGate < 50) {
+      return l.friInsufficientData;
     }
     return l.pulseLabelFinancialScore;
   }

--- a/apps/mobile/lib/widgets/coach/retirement_hero_zone.dart
+++ b/apps/mobile/lib/widgets/coach/retirement_hero_zone.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
@@ -212,6 +213,10 @@ class _RetirementHeroZoneState extends State<RetirementHeroZone> {
     final prefix = widget.isApproximate ? '~' : '';
     final ageLabel = _scrubbedAge != null ? ' à $_scrubbedAge ans' : '';
 
+    // Uncertainty band: ±15% when confidence < 70 (isApproximate).
+    final lowBand = (income * 0.85).round();
+    final highBand = (income * 1.15).round();
+
     return Column(
       children: [
         if (_scrubbedAge != null)
@@ -225,6 +230,21 @@ class _RetirementHeroZoneState extends State<RetirementHeroZone> {
             style: MintTextStyles.displayMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w800, height: 1.2),
           ),
         ),
+        // Uncertainty band — shown when confidence < 70%
+        if (widget.isApproximate && income > 0)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              S.of(context)?.projectionUncertaintyBand(
+                formatChf(lowBand.toDouble()),
+                formatChf(highBand.toDouble()),
+              ) ?? 'CHF\u00a0${formatChf(lowBand.toDouble())}\u00a0—\u00a0${formatChf(highBand.toDouble())}\u00a0/\u00a0mois',
+              style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(
+                fontSize: 12,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ),
         if (widget.isCouple && widget.partnerMonthlyIncome != null)
           Padding(
             padding: const EdgeInsets.only(top: 4),


### PR DESCRIPTION
## Summary
- **C1**: FRI score hidden when confidence < 50% — shows "Complète ton profil pour voir ton score"
- **C2**: Uncertainty bands (±15%) shown on projections when confidence < 70%
- **C3**: Backend/frontend confidence naming verified consistent

2 new i18n keys × 6 languages. Tests: 8134 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)