### PR TITLE
fix: V4 audit — forceRecompute, i18n widgets, error codes, +20 tests

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11301,5 +11301,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "Dieses Bildungstool liefert indikative Schätzungen und stellt keine persönliche Rechts-, Steuer- oder Notariatsberatung im Sinne des FIDLEG dar. Konsultiere einen Spezialisten (Notar) für deine Situation."
+  "donationDisclaimerFallback": "Dieses Bildungstool liefert indikative Schätzungen und stellt keine persönliche Rechts-, Steuer- oder Notariatsberatung im Sinne des FIDLEG dar. Konsultiere einen Spezialisten (Notar) für deine Situation.",
+
+  "widgetRetirementTitle": "Deine Renten\u00fcbersicht",
+  "widgetRetirementToday": "Heute",
+  "widgetRetirementFuture": "Bei Pensionierung",
+  "widgetBudgetTitle": "Dein Budget",
+  "widgetBudgetIncome": "Einnahmen",
+  "widgetBudgetExpenses": "Ausgaben",
+  "widgetPillarTitle": "Deine 3 S\u00e4ulen",
+  "widgetPillarAvsLpp": "AHV + BVG",
+  "widgetPillar3a": "S\u00e4ule 3a",
+  "widgetPillarNotDeclared": "Nicht angegeben",
+  "widgetBudgetLabel": "Budget",
+  "widgetInputLppLabel": "BVG-Guthaben (CHF)",
+  "widgetInput3aLabel": "S\u00e4ule-3a-Ersparnisse (CHF)",
+  "widgetScoreFallback": "Score",
+  "widgetInputSalaryFallback": "Gehalt",
+
+  "scoreGaugeLevelExcellent": "Ausgezeichnet",
+  "scoreGaugeLevelGood": "Gut",
+  "scoreGaugeLevelAttention": "Achtung",
+  "scoreGaugeLevelCritical": "Kritisch",
+  "scoreGaugeTitle": "Finanzielle Fitness",
+  "scoreGaugeSubtitle": "Gesamtscore \u00b7 3 S\u00e4ulen",
+  "scoreGaugeGainTitle": "Was dich weitergebracht hat",
+  "scoreGaugeNextTitle": "Um weiter zu steigen",
+  "scoreGaugeDisclaimer": "Bildungssch\u00e4tzungen \u2014 keine Finanzberatung.",
+  "scoreGaugeSemanticsLabel": "Finanzielle Fitness. {score} von 100. Stufe {level}. Budget {budget}, Vorsorge {prevoyance}, Verm\u00f6gen {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Budget",
+  "scoreGaugeSectionPrevoyance": "Vorsorge",
+  "scoreGaugeSectionPatrimoine": "Verm\u00f6gen",
+
+  "byokErrorSaveFailed": "Fehler beim Speichern des Schl\u00fcssels.",
+  "byokErrorNotConfigured": "Konfiguriere zuerst einen Anbieter und Schl\u00fcssel.",
+  "byokErrorConnection": "Verbindungsfehler. Pr\u00fcfe deine Internetverbindung.",
+
+  "authErrorNetwork": "Service nicht erreichbar. Pr\u00fcfe dein Netzwerk und versuche es erneut.",
+  "authErrorEmailUsed": "Diese E-Mail wird bereits verwendet. Melde dich an oder setze dein Passwort zur\u00fcck.",
+  "authErrorIncorrect": "E-Mail oder Passwort falsch.",
+  "authErrorRegistration": "Registrierung derzeit nicht verf\u00fcgbar. Nutze den lokalen Modus.",
+  "authErrorService": "Kontodienst in dieser Umgebung nicht verf\u00fcgbar. Nutze den lokalen Modus.",
+  "authErrorInvalid": "Die eingegebenen Daten sind ung\u00fcltig.",
+  "authErrorExpired": "Dieser Link ist abgelaufen. Fordere einen neuen an.",
+  "authErrorNotVerified": "Deine E-Mail ist noch nicht best\u00e4tigt. Best\u00e4tige deine E-Mail und versuche es erneut.",
+  "authErrorGeneric": "Aktion derzeit nicht m\u00f6glich. Versuche es in K\u00fcrze erneut."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11329,5 +11329,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "This educational tool provides indicative estimates and does not constitute personalized legal, tax or notarial advice within the meaning of FinSA. Consult a specialist (notary) for your situation."
+  "donationDisclaimerFallback": "This educational tool provides indicative estimates and does not constitute personalized legal, tax or notarial advice within the meaning of FinSA. Consult a specialist (notary) for your situation.",
+
+  "widgetRetirementTitle": "Your retirement overview",
+  "widgetRetirementToday": "Today",
+  "widgetRetirementFuture": "At retirement",
+  "widgetBudgetTitle": "Your budget",
+  "widgetBudgetIncome": "Income",
+  "widgetBudgetExpenses": "Expenses",
+  "widgetPillarTitle": "Your 3 pillars",
+  "widgetPillarAvsLpp": "AVS + LPP",
+  "widgetPillar3a": "3rd pillar",
+  "widgetPillarNotDeclared": "Not declared",
+  "widgetBudgetLabel": "Budget",
+  "widgetInputLppLabel": "LPP balance (CHF)",
+  "widgetInput3aLabel": "Pillar 3a savings (CHF)",
+  "widgetScoreFallback": "Score",
+  "widgetInputSalaryFallback": "Salary",
+
+  "scoreGaugeLevelExcellent": "Excellent",
+  "scoreGaugeLevelGood": "Good",
+  "scoreGaugeLevelAttention": "Attention",
+  "scoreGaugeLevelCritical": "Critical",
+  "scoreGaugeTitle": "Financial fitness",
+  "scoreGaugeSubtitle": "Composite score \u00b7 3 pillars",
+  "scoreGaugeGainTitle": "What helped you improve",
+  "scoreGaugeNextTitle": "To improve further",
+  "scoreGaugeDisclaimer": "Educational estimates \u2014 not financial advice.",
+  "scoreGaugeSemanticsLabel": "Financial fitness score. {score} out of 100. Level {level}. Budget {budget}, Pension {prevoyance}, Assets {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Budget",
+  "scoreGaugeSectionPrevoyance": "Pension",
+  "scoreGaugeSectionPatrimoine": "Assets",
+
+  "byokErrorSaveFailed": "Error saving the key.",
+  "byokErrorNotConfigured": "Configure a provider and key first.",
+  "byokErrorConnection": "Connection error. Check your internet.",
+
+  "authErrorNetwork": "Service unavailable. Check your network and try again.",
+  "authErrorEmailUsed": "This email is already in use. Log in or reset your password.",
+  "authErrorIncorrect": "Incorrect email or password.",
+  "authErrorRegistration": "Registration unavailable. Use local mode and try again later.",
+  "authErrorService": "Account service not available on this environment. Use local mode.",
+  "authErrorInvalid": "The entered information is invalid.",
+  "authErrorExpired": "This reset link has expired. Request a new one.",
+  "authErrorNotVerified": "Your email is not yet verified. Check your email and try again.",
+  "authErrorGeneric": "Action not possible right now. Try again shortly."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11294,5 +11294,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "Esta herramienta educativa proporciona estimaciones indicativas y no constituye asesoramiento jurídico, fiscal o notarial personalizado. Consulta a un especialista (notario) para tu situación."
+  "donationDisclaimerFallback": "Esta herramienta educativa proporciona estimaciones indicativas y no constituye asesoramiento jurídico, fiscal o notarial personalizado. Consulta a un especialista (notario) para tu situación.",
+
+  "widgetRetirementTitle": "Tu resumen de jubilaci\u00f3n",
+  "widgetRetirementToday": "Hoy",
+  "widgetRetirementFuture": "En la jubilaci\u00f3n",
+  "widgetBudgetTitle": "Tu presupuesto",
+  "widgetBudgetIncome": "Ingresos",
+  "widgetBudgetExpenses": "Gastos",
+  "widgetPillarTitle": "Tus 3 pilares",
+  "widgetPillarAvsLpp": "AVS + LPP",
+  "widgetPillar3a": "3er pilar",
+  "widgetPillarNotDeclared": "No declarado",
+  "widgetBudgetLabel": "Presupuesto",
+  "widgetInputLppLabel": "Saldo LPP (CHF)",
+  "widgetInput3aLabel": "Ahorro pilar 3a (CHF)",
+  "widgetScoreFallback": "Puntuaci\u00f3n",
+  "widgetInputSalaryFallback": "Salario",
+
+  "scoreGaugeLevelExcellent": "Excelente",
+  "scoreGaugeLevelGood": "Bueno",
+  "scoreGaugeLevelAttention": "Atenci\u00f3n",
+  "scoreGaugeLevelCritical": "Cr\u00edtico",
+  "scoreGaugeTitle": "Forma financiera",
+  "scoreGaugeSubtitle": "Puntuaci\u00f3n compuesta \u00b7 3 pilares",
+  "scoreGaugeGainTitle": "Lo que te hizo subir",
+  "scoreGaugeNextTitle": "Para subir m\u00e1s",
+  "scoreGaugeDisclaimer": "Estimaciones educativas \u2014 no constituye asesoramiento financiero.",
+  "scoreGaugeSemanticsLabel": "Puntuaci\u00f3n de forma financiera. {score} de 100. Nivel {level}. Presupuesto {budget}, Previsi\u00f3n {prevoyance}, Patrimonio {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Presupuesto",
+  "scoreGaugeSectionPrevoyance": "Previsi\u00f3n",
+  "scoreGaugeSectionPatrimoine": "Patrimonio",
+
+  "byokErrorSaveFailed": "Error al guardar la clave.",
+  "byokErrorNotConfigured": "Configura primero un proveedor y una clave.",
+  "byokErrorConnection": "Error de conexi\u00f3n. Verifica tu conexi\u00f3n a internet.",
+
+  "authErrorNetwork": "Servicio no disponible. Verifica tu red e int\u00e9ntalo de nuevo.",
+  "authErrorEmailUsed": "Este correo ya est\u00e1 en uso. Inicia sesi\u00f3n o restablece tu contrase\u00f1a.",
+  "authErrorIncorrect": "Correo o contrase\u00f1a incorrectos.",
+  "authErrorRegistration": "Registro no disponible. Usa el modo local e int\u00e9ntalo m\u00e1s tarde.",
+  "authErrorService": "Servicio de cuenta no disponible en este entorno. Usa el modo local.",
+  "authErrorInvalid": "La informaci\u00f3n ingresada no es v\u00e1lida.",
+  "authErrorExpired": "Este enlace ha expirado. Solicita uno nuevo.",
+  "authErrorNotVerified": "Tu correo a\u00fan no est\u00e1 verificado. Verifica tu correo e int\u00e9ntalo de nuevo.",
+  "authErrorGeneric": "Acci\u00f3n no disponible. Int\u00e9ntalo en unos instantes."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11776,5 +11776,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil juridique, fiscal ou notarial personnalisé au sens de la LSFin. Consulte un·e spécialiste (notaire) pour ta situation."
+  "donationDisclaimerFallback": "Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil juridique, fiscal ou notarial personnalisé au sens de la LSFin. Consulte un·e spécialiste (notaire) pour ta situation.",
+
+  "widgetRetirementTitle": "Ton aper\u00e7u retraite",
+  "widgetRetirementToday": "Aujourd\u2019hui",
+  "widgetRetirementFuture": "\u00c0 la retraite",
+  "widgetBudgetTitle": "Ton budget",
+  "widgetBudgetIncome": "Revenus",
+  "widgetBudgetExpenses": "D\u00e9penses",
+  "widgetPillarTitle": "Tes 3 piliers",
+  "widgetPillarAvsLpp": "AVS + LPP",
+  "widgetPillar3a": "3e pilier",
+  "widgetPillarNotDeclared": "Non d\u00e9clar\u00e9",
+  "widgetBudgetLabel": "Budget",
+  "widgetInputLppLabel": "Avoir LPP (CHF)",
+  "widgetInput3aLabel": "\u00c9pargne 3a (CHF)",
+  "widgetScoreFallback": "Score",
+  "widgetInputSalaryFallback": "Salaire",
+
+  "scoreGaugeLevelExcellent": "Excellent",
+  "scoreGaugeLevelGood": "Bon",
+  "scoreGaugeLevelAttention": "Attention",
+  "scoreGaugeLevelCritical": "Critique",
+  "scoreGaugeTitle": "Forme financi\u00e8re",
+  "scoreGaugeSubtitle": "Score composite \u00b7 3 piliers",
+  "scoreGaugeGainTitle": "Ce qui t\u2019a fait monter",
+  "scoreGaugeNextTitle": "Pour monter encore",
+  "scoreGaugeDisclaimer": "Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier.",
+  "scoreGaugeSemanticsLabel": "Score de forme financi\u00e8re. {score} sur 100. Niveau {level}. Budget {budget}, Pr\u00e9voyance {prevoyance}, Patrimoine {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Budget",
+  "scoreGaugeSectionPrevoyance": "Pr\u00e9voyance",
+  "scoreGaugeSectionPatrimoine": "Patrimoine",
+
+  "byokErrorSaveFailed": "Erreur lors de la sauvegarde.",
+  "byokErrorNotConfigured": "Configure d\u2019abord un fournisseur et une cl\u00e9.",
+  "byokErrorConnection": "Erreur de connexion. V\u00e9rifie ta connexion internet.",
+
+  "authErrorNetwork": "Connexion au service indisponible. V\u00e9rifie ton r\u00e9seau et r\u00e9essaie.",
+  "authErrorEmailUsed": "Cet e-mail est d\u00e9j\u00e0 utilis\u00e9. Connecte-toi ou r\u00e9initialise ton mot de passe.",
+  "authErrorIncorrect": "E-mail ou mot de passe incorrect.",
+  "authErrorRegistration": "Inscription indisponible pour le moment. Utilise le mode local puis r\u00e9essaie plus tard.",
+  "authErrorService": "Le service de compte n\u2019est pas disponible sur cet environnement. Utilise le mode local.",
+  "authErrorInvalid": "Les informations saisies sont invalides.",
+  "authErrorExpired": "Ce lien de r\u00e9initialisation a expir\u00e9. Demande un nouveau lien.",
+  "authErrorNotVerified": "Ton e-mail n\u2019est pas encore v\u00e9rifi\u00e9. V\u00e9rifie ton e-mail puis r\u00e9essaie.",
+  "authErrorGeneric": "Action impossible pour le moment. R\u00e9essaie dans quelques instants."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11294,5 +11294,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "Questo strumento educativo fornisce stime indicative e non costituisce consulenza giuridica, fiscale o notarile personalizzata ai sensi della LSF. Consulta uno specialista (notaio) per la tua situazione."
+  "donationDisclaimerFallback": "Questo strumento educativo fornisce stime indicative e non costituisce consulenza giuridica, fiscale o notarile personalizzata ai sensi della LSF. Consulta uno specialista (notaio) per la tua situazione.",
+
+  "widgetRetirementTitle": "Il tuo riepilogo pensionistico",
+  "widgetRetirementToday": "Oggi",
+  "widgetRetirementFuture": "Al pensionamento",
+  "widgetBudgetTitle": "Il tuo budget",
+  "widgetBudgetIncome": "Entrate",
+  "widgetBudgetExpenses": "Spese",
+  "widgetPillarTitle": "I tuoi 3 pilastri",
+  "widgetPillarAvsLpp": "AVS + LPP",
+  "widgetPillar3a": "3\u00b0 pilastro",
+  "widgetPillarNotDeclared": "Non dichiarato",
+  "widgetBudgetLabel": "Budget",
+  "widgetInputLppLabel": "Avere LPP (CHF)",
+  "widgetInput3aLabel": "Risparmio pilastro 3a (CHF)",
+  "widgetScoreFallback": "Punteggio",
+  "widgetInputSalaryFallback": "Stipendio",
+
+  "scoreGaugeLevelExcellent": "Eccellente",
+  "scoreGaugeLevelGood": "Buono",
+  "scoreGaugeLevelAttention": "Attenzione",
+  "scoreGaugeLevelCritical": "Critico",
+  "scoreGaugeTitle": "Forma finanziaria",
+  "scoreGaugeSubtitle": "Punteggio composito \u00b7 3 pilastri",
+  "scoreGaugeGainTitle": "Cosa ti ha fatto salire",
+  "scoreGaugeNextTitle": "Per salire ancora",
+  "scoreGaugeDisclaimer": "Stime educative \u2014 non costituisce consulenza finanziaria.",
+  "scoreGaugeSemanticsLabel": "Punteggio di forma finanziaria. {score} su 100. Livello {level}. Budget {budget}, Previdenza {prevoyance}, Patrimonio {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Budget",
+  "scoreGaugeSectionPrevoyance": "Previdenza",
+  "scoreGaugeSectionPatrimoine": "Patrimonio",
+
+  "byokErrorSaveFailed": "Errore durante il salvataggio della chiave.",
+  "byokErrorNotConfigured": "Configura prima un fornitore e una chiave.",
+  "byokErrorConnection": "Errore di connessione. Verifica la tua connessione internet.",
+
+  "authErrorNetwork": "Servizio non raggiungibile. Verifica la tua rete e riprova.",
+  "authErrorEmailUsed": "Questa e-mail \u00e8 gi\u00e0 in uso. Accedi o reimposta la tua password.",
+  "authErrorIncorrect": "E-mail o password errati.",
+  "authErrorRegistration": "Registrazione non disponibile. Usa la modalit\u00e0 locale e riprova pi\u00f9 tardi.",
+  "authErrorService": "Servizio account non disponibile in questo ambiente. Usa la modalit\u00e0 locale.",
+  "authErrorInvalid": "Le informazioni inserite non sono valide.",
+  "authErrorExpired": "Questo link \u00e8 scaduto. Richiedine uno nuovo.",
+  "authErrorNotVerified": "La tua e-mail non \u00e8 ancora verificata. Verifica la tua e-mail e riprova.",
+  "authErrorGeneric": "Azione non disponibile al momento. Riprova tra qualche istante."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -42718,6 +42718,247 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil juridique, fiscal ou notarial personnalisé au sens de la LSFin. Consulte un·e spécialiste (notaire) pour ta situation.'**
   String get donationDisclaimerFallback;
+
+  /// No description provided for @widgetRetirementTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton aperçu retraite'**
+  String get widgetRetirementTitle;
+
+  /// No description provided for @widgetRetirementToday.
+  ///
+  /// In fr, this message translates to:
+  /// **'Aujourd’hui'**
+  String get widgetRetirementToday;
+
+  /// No description provided for @widgetRetirementFuture.
+  ///
+  /// In fr, this message translates to:
+  /// **'À la retraite'**
+  String get widgetRetirementFuture;
+
+  /// No description provided for @widgetBudgetTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton budget'**
+  String get widgetBudgetTitle;
+
+  /// No description provided for @widgetBudgetIncome.
+  ///
+  /// In fr, this message translates to:
+  /// **'Revenus'**
+  String get widgetBudgetIncome;
+
+  /// No description provided for @widgetBudgetExpenses.
+  ///
+  /// In fr, this message translates to:
+  /// **'Dépenses'**
+  String get widgetBudgetExpenses;
+
+  /// No description provided for @widgetPillarTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes 3 piliers'**
+  String get widgetPillarTitle;
+
+  /// No description provided for @widgetPillarAvsLpp.
+  ///
+  /// In fr, this message translates to:
+  /// **'AVS + LPP'**
+  String get widgetPillarAvsLpp;
+
+  /// No description provided for @widgetPillar3a.
+  ///
+  /// In fr, this message translates to:
+  /// **'3e pilier'**
+  String get widgetPillar3a;
+
+  /// No description provided for @widgetPillarNotDeclared.
+  ///
+  /// In fr, this message translates to:
+  /// **'Non déclaré'**
+  String get widgetPillarNotDeclared;
+
+  /// No description provided for @widgetBudgetLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Budget'**
+  String get widgetBudgetLabel;
+
+  /// No description provided for @widgetInputLppLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Avoir LPP (CHF)'**
+  String get widgetInputLppLabel;
+
+  /// No description provided for @widgetInput3aLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Épargne 3a (CHF)'**
+  String get widgetInput3aLabel;
+
+  /// No description provided for @widgetScoreFallback.
+  ///
+  /// In fr, this message translates to:
+  /// **'Score'**
+  String get widgetScoreFallback;
+
+  /// No description provided for @widgetInputSalaryFallback.
+  ///
+  /// In fr, this message translates to:
+  /// **'Salaire'**
+  String get widgetInputSalaryFallback;
+
+  /// No description provided for @scoreGaugeLevelExcellent.
+  ///
+  /// In fr, this message translates to:
+  /// **'Excellent'**
+  String get scoreGaugeLevelExcellent;
+
+  /// No description provided for @scoreGaugeLevelGood.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bon'**
+  String get scoreGaugeLevelGood;
+
+  /// No description provided for @scoreGaugeLevelAttention.
+  ///
+  /// In fr, this message translates to:
+  /// **'Attention'**
+  String get scoreGaugeLevelAttention;
+
+  /// No description provided for @scoreGaugeLevelCritical.
+  ///
+  /// In fr, this message translates to:
+  /// **'Critique'**
+  String get scoreGaugeLevelCritical;
+
+  /// No description provided for @scoreGaugeTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Forme financière'**
+  String get scoreGaugeTitle;
+
+  /// No description provided for @scoreGaugeSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Score composite · 3 piliers'**
+  String get scoreGaugeSubtitle;
+
+  /// No description provided for @scoreGaugeGainTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ce qui t’a fait monter'**
+  String get scoreGaugeGainTitle;
+
+  /// No description provided for @scoreGaugeNextTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pour monter encore'**
+  String get scoreGaugeNextTitle;
+
+  /// No description provided for @scoreGaugeDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Estimations éducatives — ne constitue pas un conseil financier.'**
+  String get scoreGaugeDisclaimer;
+
+  /// No description provided for @scoreGaugeSemanticsLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Score de forme financière. {score} sur 100. Niveau {level}. Budget {budget}, Prévoyance {prevoyance}, Patrimoine {patrimoine}.'**
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine);
+
+  /// No description provided for @scoreGaugeSectionBudget.
+  ///
+  /// In fr, this message translates to:
+  /// **'Budget'**
+  String get scoreGaugeSectionBudget;
+
+  /// No description provided for @scoreGaugeSectionPrevoyance.
+  ///
+  /// In fr, this message translates to:
+  /// **'Prévoyance'**
+  String get scoreGaugeSectionPrevoyance;
+
+  /// No description provided for @scoreGaugeSectionPatrimoine.
+  ///
+  /// In fr, this message translates to:
+  /// **'Patrimoine'**
+  String get scoreGaugeSectionPatrimoine;
+
+  /// No description provided for @byokErrorSaveFailed.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur lors de la sauvegarde.'**
+  String get byokErrorSaveFailed;
+
+  /// No description provided for @byokErrorNotConfigured.
+  ///
+  /// In fr, this message translates to:
+  /// **'Configure d’abord un fournisseur et une clé.'**
+  String get byokErrorNotConfigured;
+
+  /// No description provided for @byokErrorConnection.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur de connexion. Vérifie ta connexion internet.'**
+  String get byokErrorConnection;
+
+  /// No description provided for @authErrorNetwork.
+  ///
+  /// In fr, this message translates to:
+  /// **'Connexion au service indisponible. Vérifie ton réseau et réessaie.'**
+  String get authErrorNetwork;
+
+  /// No description provided for @authErrorEmailUsed.
+  ///
+  /// In fr, this message translates to:
+  /// **'Cet e-mail est déjà utilisé. Connecte-toi ou réinitialise ton mot de passe.'**
+  String get authErrorEmailUsed;
+
+  /// No description provided for @authErrorIncorrect.
+  ///
+  /// In fr, this message translates to:
+  /// **'E-mail ou mot de passe incorrect.'**
+  String get authErrorIncorrect;
+
+  /// No description provided for @authErrorRegistration.
+  ///
+  /// In fr, this message translates to:
+  /// **'Inscription indisponible pour le moment. Utilise le mode local puis réessaie plus tard.'**
+  String get authErrorRegistration;
+
+  /// No description provided for @authErrorService.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.'**
+  String get authErrorService;
+
+  /// No description provided for @authErrorInvalid.
+  ///
+  /// In fr, this message translates to:
+  /// **'Les informations saisies sont invalides.'**
+  String get authErrorInvalid;
+
+  /// No description provided for @authErrorExpired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ce lien de réinitialisation a expiré. Demande un nouveau lien.'**
+  String get authErrorExpired;
+
+  /// No description provided for @authErrorNotVerified.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton e-mail n’est pas encore vérifié. Vérifie ton e-mail puis réessaie.'**
+  String get authErrorNotVerified;
+
+  /// No description provided for @authErrorGeneric.
+  ///
+  /// In fr, this message translates to:
+  /// **'Action impossible pour le moment. Réessaie dans quelques instants.'**
+  String get authErrorGeneric;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -24257,4 +24257,137 @@ class SDe extends S {
   @override
   String get donationDisclaimerFallback =>
       'Dieses Bildungstool liefert indikative Schätzungen und stellt keine persönliche Rechts-, Steuer- oder Notariatsberatung im Sinne des FIDLEG dar. Konsultiere einen Spezialisten (Notar) für deine Situation.';
+
+  @override
+  String get widgetRetirementTitle => 'Deine Rentenübersicht';
+
+  @override
+  String get widgetRetirementToday => 'Heute';
+
+  @override
+  String get widgetRetirementFuture => 'Bei Pensionierung';
+
+  @override
+  String get widgetBudgetTitle => 'Dein Budget';
+
+  @override
+  String get widgetBudgetIncome => 'Einnahmen';
+
+  @override
+  String get widgetBudgetExpenses => 'Ausgaben';
+
+  @override
+  String get widgetPillarTitle => 'Deine 3 Säulen';
+
+  @override
+  String get widgetPillarAvsLpp => 'AHV + BVG';
+
+  @override
+  String get widgetPillar3a => 'Säule 3a';
+
+  @override
+  String get widgetPillarNotDeclared => 'Nicht angegeben';
+
+  @override
+  String get widgetBudgetLabel => 'Budget';
+
+  @override
+  String get widgetInputLppLabel => 'BVG-Guthaben (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Säule-3a-Ersparnisse (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Score';
+
+  @override
+  String get widgetInputSalaryFallback => 'Gehalt';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Ausgezeichnet';
+
+  @override
+  String get scoreGaugeLevelGood => 'Gut';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Achtung';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Kritisch';
+
+  @override
+  String get scoreGaugeTitle => 'Finanzielle Fitness';
+
+  @override
+  String get scoreGaugeSubtitle => 'Gesamtscore · 3 Säulen';
+
+  @override
+  String get scoreGaugeGainTitle => 'Was dich weitergebracht hat';
+
+  @override
+  String get scoreGaugeNextTitle => 'Um weiter zu steigen';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Bildungsschätzungen — keine Finanzberatung.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Finanzielle Fitness. $score von 100. Stufe $level. Budget $budget, Vorsorge $prevoyance, Vermögen $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Budget';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Vorsorge';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Vermögen';
+
+  @override
+  String get byokErrorSaveFailed => 'Fehler beim Speichern des Schlüssels.';
+
+  @override
+  String get byokErrorNotConfigured =>
+      'Konfiguriere zuerst einen Anbieter und Schlüssel.';
+
+  @override
+  String get byokErrorConnection =>
+      'Verbindungsfehler. Prüfe deine Internetverbindung.';
+
+  @override
+  String get authErrorNetwork =>
+      'Service nicht erreichbar. Prüfe dein Netzwerk und versuche es erneut.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'Diese E-Mail wird bereits verwendet. Melde dich an oder setze dein Passwort zurück.';
+
+  @override
+  String get authErrorIncorrect => 'E-Mail oder Passwort falsch.';
+
+  @override
+  String get authErrorRegistration =>
+      'Registrierung derzeit nicht verfügbar. Nutze den lokalen Modus.';
+
+  @override
+  String get authErrorService =>
+      'Kontodienst in dieser Umgebung nicht verfügbar. Nutze den lokalen Modus.';
+
+  @override
+  String get authErrorInvalid => 'Die eingegebenen Daten sind ungültig.';
+
+  @override
+  String get authErrorExpired =>
+      'Dieser Link ist abgelaufen. Fordere einen neuen an.';
+
+  @override
+  String get authErrorNotVerified =>
+      'Deine E-Mail ist noch nicht bestätigt. Bestätige deine E-Mail und versuche es erneut.';
+
+  @override
+  String get authErrorGeneric =>
+      'Aktion derzeit nicht möglich. Versuche es in Kürze erneut.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -24104,4 +24104,135 @@ class SEn extends S {
   @override
   String get donationDisclaimerFallback =>
       'This educational tool provides indicative estimates and does not constitute personalized legal, tax or notarial advice within the meaning of FinSA. Consult a specialist (notary) for your situation.';
+
+  @override
+  String get widgetRetirementTitle => 'Your retirement overview';
+
+  @override
+  String get widgetRetirementToday => 'Today';
+
+  @override
+  String get widgetRetirementFuture => 'At retirement';
+
+  @override
+  String get widgetBudgetTitle => 'Your budget';
+
+  @override
+  String get widgetBudgetIncome => 'Income';
+
+  @override
+  String get widgetBudgetExpenses => 'Expenses';
+
+  @override
+  String get widgetPillarTitle => 'Your 3 pillars';
+
+  @override
+  String get widgetPillarAvsLpp => 'AVS + LPP';
+
+  @override
+  String get widgetPillar3a => '3rd pillar';
+
+  @override
+  String get widgetPillarNotDeclared => 'Not declared';
+
+  @override
+  String get widgetBudgetLabel => 'Budget';
+
+  @override
+  String get widgetInputLppLabel => 'LPP balance (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Pillar 3a savings (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Score';
+
+  @override
+  String get widgetInputSalaryFallback => 'Salary';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Excellent';
+
+  @override
+  String get scoreGaugeLevelGood => 'Good';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Attention';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Critical';
+
+  @override
+  String get scoreGaugeTitle => 'Financial fitness';
+
+  @override
+  String get scoreGaugeSubtitle => 'Composite score · 3 pillars';
+
+  @override
+  String get scoreGaugeGainTitle => 'What helped you improve';
+
+  @override
+  String get scoreGaugeNextTitle => 'To improve further';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Educational estimates — not financial advice.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Financial fitness score. $score out of 100. Level $level. Budget $budget, Pension $prevoyance, Assets $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Budget';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Pension';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Assets';
+
+  @override
+  String get byokErrorSaveFailed => 'Error saving the key.';
+
+  @override
+  String get byokErrorNotConfigured => 'Configure a provider and key first.';
+
+  @override
+  String get byokErrorConnection => 'Connection error. Check your internet.';
+
+  @override
+  String get authErrorNetwork =>
+      'Service unavailable. Check your network and try again.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'This email is already in use. Log in or reset your password.';
+
+  @override
+  String get authErrorIncorrect => 'Incorrect email or password.';
+
+  @override
+  String get authErrorRegistration =>
+      'Registration unavailable. Use local mode and try again later.';
+
+  @override
+  String get authErrorService =>
+      'Account service not available on this environment. Use local mode.';
+
+  @override
+  String get authErrorInvalid => 'The entered information is invalid.';
+
+  @override
+  String get authErrorExpired =>
+      'This reset link has expired. Request a new one.';
+
+  @override
+  String get authErrorNotVerified =>
+      'Your email is not yet verified. Check your email and try again.';
+
+  @override
+  String get authErrorGeneric =>
+      'Action not possible right now. Try again shortly.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -24220,4 +24220,136 @@ class SEs extends S {
   @override
   String get donationDisclaimerFallback =>
       'Esta herramienta educativa proporciona estimaciones indicativas y no constituye asesoramiento jurídico, fiscal o notarial personalizado. Consulta a un especialista (notario) para tu situación.';
+
+  @override
+  String get widgetRetirementTitle => 'Tu resumen de jubilación';
+
+  @override
+  String get widgetRetirementToday => 'Hoy';
+
+  @override
+  String get widgetRetirementFuture => 'En la jubilación';
+
+  @override
+  String get widgetBudgetTitle => 'Tu presupuesto';
+
+  @override
+  String get widgetBudgetIncome => 'Ingresos';
+
+  @override
+  String get widgetBudgetExpenses => 'Gastos';
+
+  @override
+  String get widgetPillarTitle => 'Tus 3 pilares';
+
+  @override
+  String get widgetPillarAvsLpp => 'AVS + LPP';
+
+  @override
+  String get widgetPillar3a => '3er pilar';
+
+  @override
+  String get widgetPillarNotDeclared => 'No declarado';
+
+  @override
+  String get widgetBudgetLabel => 'Presupuesto';
+
+  @override
+  String get widgetInputLppLabel => 'Saldo LPP (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Ahorro pilar 3a (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Puntuación';
+
+  @override
+  String get widgetInputSalaryFallback => 'Salario';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Excelente';
+
+  @override
+  String get scoreGaugeLevelGood => 'Bueno';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Atención';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Crítico';
+
+  @override
+  String get scoreGaugeTitle => 'Forma financiera';
+
+  @override
+  String get scoreGaugeSubtitle => 'Puntuación compuesta · 3 pilares';
+
+  @override
+  String get scoreGaugeGainTitle => 'Lo que te hizo subir';
+
+  @override
+  String get scoreGaugeNextTitle => 'Para subir más';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Estimaciones educativas — no constituye asesoramiento financiero.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Puntuación de forma financiera. $score de 100. Nivel $level. Presupuesto $budget, Previsión $prevoyance, Patrimonio $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Presupuesto';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Previsión';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Patrimonio';
+
+  @override
+  String get byokErrorSaveFailed => 'Error al guardar la clave.';
+
+  @override
+  String get byokErrorNotConfigured =>
+      'Configura primero un proveedor y una clave.';
+
+  @override
+  String get byokErrorConnection =>
+      'Error de conexión. Verifica tu conexión a internet.';
+
+  @override
+  String get authErrorNetwork =>
+      'Servicio no disponible. Verifica tu red e inténtalo de nuevo.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'Este correo ya está en uso. Inicia sesión o restablece tu contraseña.';
+
+  @override
+  String get authErrorIncorrect => 'Correo o contraseña incorrectos.';
+
+  @override
+  String get authErrorRegistration =>
+      'Registro no disponible. Usa el modo local e inténtalo más tarde.';
+
+  @override
+  String get authErrorService =>
+      'Servicio de cuenta no disponible en este entorno. Usa el modo local.';
+
+  @override
+  String get authErrorInvalid => 'La información ingresada no es válida.';
+
+  @override
+  String get authErrorExpired => 'Este enlace ha expirado. Solicita uno nuevo.';
+
+  @override
+  String get authErrorNotVerified =>
+      'Tu correo aún no está verificado. Verifica tu correo e inténtalo de nuevo.';
+
+  @override
+  String get authErrorGeneric =>
+      'Acción no disponible. Inténtalo en unos instantes.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -24216,4 +24216,137 @@ class SFr extends S {
   @override
   String get donationDisclaimerFallback =>
       'Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil juridique, fiscal ou notarial personnalisé au sens de la LSFin. Consulte un·e spécialiste (notaire) pour ta situation.';
+
+  @override
+  String get widgetRetirementTitle => 'Ton aperçu retraite';
+
+  @override
+  String get widgetRetirementToday => 'Aujourd’hui';
+
+  @override
+  String get widgetRetirementFuture => 'À la retraite';
+
+  @override
+  String get widgetBudgetTitle => 'Ton budget';
+
+  @override
+  String get widgetBudgetIncome => 'Revenus';
+
+  @override
+  String get widgetBudgetExpenses => 'Dépenses';
+
+  @override
+  String get widgetPillarTitle => 'Tes 3 piliers';
+
+  @override
+  String get widgetPillarAvsLpp => 'AVS + LPP';
+
+  @override
+  String get widgetPillar3a => '3e pilier';
+
+  @override
+  String get widgetPillarNotDeclared => 'Non déclaré';
+
+  @override
+  String get widgetBudgetLabel => 'Budget';
+
+  @override
+  String get widgetInputLppLabel => 'Avoir LPP (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Épargne 3a (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Score';
+
+  @override
+  String get widgetInputSalaryFallback => 'Salaire';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Excellent';
+
+  @override
+  String get scoreGaugeLevelGood => 'Bon';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Attention';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Critique';
+
+  @override
+  String get scoreGaugeTitle => 'Forme financière';
+
+  @override
+  String get scoreGaugeSubtitle => 'Score composite · 3 piliers';
+
+  @override
+  String get scoreGaugeGainTitle => 'Ce qui t’a fait monter';
+
+  @override
+  String get scoreGaugeNextTitle => 'Pour monter encore';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Estimations éducatives — ne constitue pas un conseil financier.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Score de forme financière. $score sur 100. Niveau $level. Budget $budget, Prévoyance $prevoyance, Patrimoine $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Budget';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Prévoyance';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Patrimoine';
+
+  @override
+  String get byokErrorSaveFailed => 'Erreur lors de la sauvegarde.';
+
+  @override
+  String get byokErrorNotConfigured =>
+      'Configure d’abord un fournisseur et une clé.';
+
+  @override
+  String get byokErrorConnection =>
+      'Erreur de connexion. Vérifie ta connexion internet.';
+
+  @override
+  String get authErrorNetwork =>
+      'Connexion au service indisponible. Vérifie ton réseau et réessaie.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'Cet e-mail est déjà utilisé. Connecte-toi ou réinitialise ton mot de passe.';
+
+  @override
+  String get authErrorIncorrect => 'E-mail ou mot de passe incorrect.';
+
+  @override
+  String get authErrorRegistration =>
+      'Inscription indisponible pour le moment. Utilise le mode local puis réessaie plus tard.';
+
+  @override
+  String get authErrorService =>
+      'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.';
+
+  @override
+  String get authErrorInvalid => 'Les informations saisies sont invalides.';
+
+  @override
+  String get authErrorExpired =>
+      'Ce lien de réinitialisation a expiré. Demande un nouveau lien.';
+
+  @override
+  String get authErrorNotVerified =>
+      'Ton e-mail n’est pas encore vérifié. Vérifie ton e-mail puis réessaie.';
+
+  @override
+  String get authErrorGeneric =>
+      'Action impossible pour le moment. Réessaie dans quelques instants.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -24262,4 +24262,137 @@ class SIt extends S {
   @override
   String get donationDisclaimerFallback =>
       'Questo strumento educativo fornisce stime indicative e non costituisce consulenza giuridica, fiscale o notarile personalizzata ai sensi della LSF. Consulta uno specialista (notaio) per la tua situazione.';
+
+  @override
+  String get widgetRetirementTitle => 'Il tuo riepilogo pensionistico';
+
+  @override
+  String get widgetRetirementToday => 'Oggi';
+
+  @override
+  String get widgetRetirementFuture => 'Al pensionamento';
+
+  @override
+  String get widgetBudgetTitle => 'Il tuo budget';
+
+  @override
+  String get widgetBudgetIncome => 'Entrate';
+
+  @override
+  String get widgetBudgetExpenses => 'Spese';
+
+  @override
+  String get widgetPillarTitle => 'I tuoi 3 pilastri';
+
+  @override
+  String get widgetPillarAvsLpp => 'AVS + LPP';
+
+  @override
+  String get widgetPillar3a => '3° pilastro';
+
+  @override
+  String get widgetPillarNotDeclared => 'Non dichiarato';
+
+  @override
+  String get widgetBudgetLabel => 'Budget';
+
+  @override
+  String get widgetInputLppLabel => 'Avere LPP (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Risparmio pilastro 3a (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Punteggio';
+
+  @override
+  String get widgetInputSalaryFallback => 'Stipendio';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Eccellente';
+
+  @override
+  String get scoreGaugeLevelGood => 'Buono';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Attenzione';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Critico';
+
+  @override
+  String get scoreGaugeTitle => 'Forma finanziaria';
+
+  @override
+  String get scoreGaugeSubtitle => 'Punteggio composito · 3 pilastri';
+
+  @override
+  String get scoreGaugeGainTitle => 'Cosa ti ha fatto salire';
+
+  @override
+  String get scoreGaugeNextTitle => 'Per salire ancora';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Stime educative — non costituisce consulenza finanziaria.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Punteggio di forma finanziaria. $score su 100. Livello $level. Budget $budget, Previdenza $prevoyance, Patrimonio $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Budget';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Previdenza';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Patrimonio';
+
+  @override
+  String get byokErrorSaveFailed =>
+      'Errore durante il salvataggio della chiave.';
+
+  @override
+  String get byokErrorNotConfigured =>
+      'Configura prima un fornitore e una chiave.';
+
+  @override
+  String get byokErrorConnection =>
+      'Errore di connessione. Verifica la tua connessione internet.';
+
+  @override
+  String get authErrorNetwork =>
+      'Servizio non raggiungibile. Verifica la tua rete e riprova.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'Questa e-mail è già in uso. Accedi o reimposta la tua password.';
+
+  @override
+  String get authErrorIncorrect => 'E-mail o password errati.';
+
+  @override
+  String get authErrorRegistration =>
+      'Registrazione non disponibile. Usa la modalità locale e riprova più tardi.';
+
+  @override
+  String get authErrorService =>
+      'Servizio account non disponibile in questo ambiente. Usa la modalità locale.';
+
+  @override
+  String get authErrorInvalid => 'Le informazioni inserite non sono valide.';
+
+  @override
+  String get authErrorExpired => 'Questo link è scaduto. Richiedine uno nuovo.';
+
+  @override
+  String get authErrorNotVerified =>
+      'La tua e-mail non è ancora verificata. Verifica la tua e-mail e riprova.';
+
+  @override
+  String get authErrorGeneric =>
+      'Azione non disponibile al momento. Riprova tra qualche istante.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -24177,4 +24177,136 @@ class SPt extends S {
   @override
   String get donationDisclaimerFallback =>
       'Esta ferramenta educativa fornece estimativas indicativas e não constitui aconselhamento jurídico, fiscal ou notarial personalizado. Consulta um especialista (notário) para a tua situação.';
+
+  @override
+  String get widgetRetirementTitle => 'O teu resumo de reforma';
+
+  @override
+  String get widgetRetirementToday => 'Hoje';
+
+  @override
+  String get widgetRetirementFuture => 'Na reforma';
+
+  @override
+  String get widgetBudgetTitle => 'O teu orçamento';
+
+  @override
+  String get widgetBudgetIncome => 'Receitas';
+
+  @override
+  String get widgetBudgetExpenses => 'Despesas';
+
+  @override
+  String get widgetPillarTitle => 'Os teus 3 pilares';
+
+  @override
+  String get widgetPillarAvsLpp => 'AVS + LPP';
+
+  @override
+  String get widgetPillar3a => '3º pilar';
+
+  @override
+  String get widgetPillarNotDeclared => 'Não declarado';
+
+  @override
+  String get widgetBudgetLabel => 'Orçamento';
+
+  @override
+  String get widgetInputLppLabel => 'Saldo LPP (CHF)';
+
+  @override
+  String get widgetInput3aLabel => 'Poupança pilar 3a (CHF)';
+
+  @override
+  String get widgetScoreFallback => 'Pontuação';
+
+  @override
+  String get widgetInputSalaryFallback => 'Salário';
+
+  @override
+  String get scoreGaugeLevelExcellent => 'Excelente';
+
+  @override
+  String get scoreGaugeLevelGood => 'Bom';
+
+  @override
+  String get scoreGaugeLevelAttention => 'Atenção';
+
+  @override
+  String get scoreGaugeLevelCritical => 'Crítico';
+
+  @override
+  String get scoreGaugeTitle => 'Forma financeira';
+
+  @override
+  String get scoreGaugeSubtitle => 'Pontuação composta · 3 pilares';
+
+  @override
+  String get scoreGaugeGainTitle => 'O que te fez subir';
+
+  @override
+  String get scoreGaugeNextTitle => 'Para subir mais';
+
+  @override
+  String get scoreGaugeDisclaimer =>
+      'Estimativas educativas — não constitui aconselhamento financeiro.';
+
+  @override
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
+    return 'Pontuação de forma financeira. $score de 100. Nível $level. Orçamento $budget, Previdência $prevoyance, Património $patrimoine.';
+  }
+
+  @override
+  String get scoreGaugeSectionBudget => 'Orçamento';
+
+  @override
+  String get scoreGaugeSectionPrevoyance => 'Previdência';
+
+  @override
+  String get scoreGaugeSectionPatrimoine => 'Património';
+
+  @override
+  String get byokErrorSaveFailed => 'Erro ao guardar a chave.';
+
+  @override
+  String get byokErrorNotConfigured =>
+      'Configura primeiro um fornecedor e uma chave.';
+
+  @override
+  String get byokErrorConnection =>
+      'Erro de conexão. Verifica a tua conexão à internet.';
+
+  @override
+  String get authErrorNetwork =>
+      'Serviço indisponível. Verifica a tua rede e tenta novamente.';
+
+  @override
+  String get authErrorEmailUsed =>
+      'Este e-mail já está em uso. Inicia sessão ou redefine a tua palavra-passe.';
+
+  @override
+  String get authErrorIncorrect => 'E-mail ou palavra-passe incorretos.';
+
+  @override
+  String get authErrorRegistration =>
+      'Registo indisponível. Usa o modo local e tenta mais tarde.';
+
+  @override
+  String get authErrorService =>
+      'Serviço de conta indisponível neste ambiente. Usa o modo local.';
+
+  @override
+  String get authErrorInvalid => 'As informações inseridas são inválidas.';
+
+  @override
+  String get authErrorExpired => 'Este link expirou. Solicita um novo.';
+
+  @override
+  String get authErrorNotVerified =>
+      'O teu e-mail ainda não foi verificado. Verifica o teu e-mail e tenta novamente.';
+
+  @override
+  String get authErrorGeneric =>
+      'Ação indisponível de momento. Tenta daqui a pouco.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11295,5 +11295,58 @@
       "pct": {"type": "String"}
     }
   },
-  "donationDisclaimerFallback": "Esta ferramenta educativa fornece estimativas indicativas e não constitui aconselhamento jurídico, fiscal ou notarial personalizado. Consulta um especialista (notário) para a tua situação."
+  "donationDisclaimerFallback": "Esta ferramenta educativa fornece estimativas indicativas e não constitui aconselhamento jurídico, fiscal ou notarial personalizado. Consulta um especialista (notário) para a tua situação.",
+
+  "widgetRetirementTitle": "O teu resumo de reforma",
+  "widgetRetirementToday": "Hoje",
+  "widgetRetirementFuture": "Na reforma",
+  "widgetBudgetTitle": "O teu or\u00e7amento",
+  "widgetBudgetIncome": "Receitas",
+  "widgetBudgetExpenses": "Despesas",
+  "widgetPillarTitle": "Os teus 3 pilares",
+  "widgetPillarAvsLpp": "AVS + LPP",
+  "widgetPillar3a": "3\u00ba pilar",
+  "widgetPillarNotDeclared": "N\u00e3o declarado",
+  "widgetBudgetLabel": "Or\u00e7amento",
+  "widgetInputLppLabel": "Saldo LPP (CHF)",
+  "widgetInput3aLabel": "Poupan\u00e7a pilar 3a (CHF)",
+  "widgetScoreFallback": "Pontua\u00e7\u00e3o",
+  "widgetInputSalaryFallback": "Sal\u00e1rio",
+
+  "scoreGaugeLevelExcellent": "Excelente",
+  "scoreGaugeLevelGood": "Bom",
+  "scoreGaugeLevelAttention": "Aten\u00e7\u00e3o",
+  "scoreGaugeLevelCritical": "Cr\u00edtico",
+  "scoreGaugeTitle": "Forma financeira",
+  "scoreGaugeSubtitle": "Pontua\u00e7\u00e3o composta \u00b7 3 pilares",
+  "scoreGaugeGainTitle": "O que te fez subir",
+  "scoreGaugeNextTitle": "Para subir mais",
+  "scoreGaugeDisclaimer": "Estimativas educativas \u2014 n\u00e3o constitui aconselhamento financeiro.",
+  "scoreGaugeSemanticsLabel": "Pontua\u00e7\u00e3o de forma financeira. {score} de 100. N\u00edvel {level}. Or\u00e7amento {budget}, Previd\u00eancia {prevoyance}, Patrim\u00f3nio {patrimoine}.",
+  "@scoreGaugeSemanticsLabel": {
+    "placeholders": {
+      "score": {"type": "String"},
+      "level": {"type": "String"},
+      "budget": {"type": "String"},
+      "prevoyance": {"type": "String"},
+      "patrimoine": {"type": "String"}
+    }
+  },
+  "scoreGaugeSectionBudget": "Or\u00e7amento",
+  "scoreGaugeSectionPrevoyance": "Previd\u00eancia",
+  "scoreGaugeSectionPatrimoine": "Patrim\u00f3nio",
+
+  "byokErrorSaveFailed": "Erro ao guardar a chave.",
+  "byokErrorNotConfigured": "Configura primeiro um fornecedor e uma chave.",
+  "byokErrorConnection": "Erro de conex\u00e3o. Verifica a tua conex\u00e3o \u00e0 internet.",
+
+  "authErrorNetwork": "Servi\u00e7o indispon\u00edvel. Verifica a tua rede e tenta novamente.",
+  "authErrorEmailUsed": "Este e-mail j\u00e1 est\u00e1 em uso. Inicia sess\u00e3o ou redefine a tua palavra-passe.",
+  "authErrorIncorrect": "E-mail ou palavra-passe incorretos.",
+  "authErrorRegistration": "Registo indispon\u00edvel. Usa o modo local e tenta mais tarde.",
+  "authErrorService": "Servi\u00e7o de conta indispon\u00edvel neste ambiente. Usa o modo local.",
+  "authErrorInvalid": "As informa\u00e7\u00f5es inseridas s\u00e3o inv\u00e1lidas.",
+  "authErrorExpired": "Este link expirou. Solicita um novo.",
+  "authErrorNotVerified": "O teu e-mail ainda n\u00e3o foi verificado. Verifica o teu e-mail e tenta novamente.",
+  "authErrorGeneric": "A\u00e7\u00e3o indispon\u00edvel de momento. Tenta daqui a pouco."
 }

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -1,7 +1,67 @@
 import 'package:flutter/foundation.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/api_service.dart';
+
+/// Error codes for authentication operations.
+///
+/// The provider sets an error code; the UI layer translates it to a
+/// localized message via `AppLocalizations`.
+enum AuthError {
+  /// Network unavailable or service unreachable.
+  networkUnavailable,
+
+  /// Email already registered.
+  emailAlreadyUsed,
+
+  /// Wrong email or password.
+  incorrectCredentials,
+
+  /// Registration temporarily unavailable.
+  registrationUnavailable,
+
+  /// Auth service not available on this environment.
+  serviceUnavailable,
+
+  /// Input data is invalid.
+  invalidInput,
+
+  /// Reset link has expired.
+  linkExpired,
+
+  /// Email not yet verified.
+  emailNotVerified,
+
+  /// Generic fallback error.
+  genericError,
+}
+
+/// Translate an [AuthError] code to a localized user-facing string.
+///
+/// Called by UI screens (login, register, profile) to display the error.
+String localizeAuthError(AuthError error, S l) {
+  switch (error) {
+    case AuthError.networkUnavailable:
+      return l.authErrorNetwork;
+    case AuthError.emailAlreadyUsed:
+      return l.authErrorEmailUsed;
+    case AuthError.incorrectCredentials:
+      return l.authErrorIncorrect;
+    case AuthError.registrationUnavailable:
+      return l.authErrorRegistration;
+    case AuthError.serviceUnavailable:
+      return l.authErrorService;
+    case AuthError.invalidInput:
+      return l.authErrorInvalid;
+    case AuthError.linkExpired:
+      return l.authErrorExpired;
+    case AuthError.emailNotVerified:
+      return l.authErrorNotVerified;
+    case AuthError.genericError:
+      return l.authErrorGeneric;
+  }
+}
 
 /// Provider for managing authentication state
 /// Handles login, register, logout, and auth persistence
@@ -11,7 +71,7 @@ class AuthProvider extends ChangeNotifier {
   String? _email;
   String? _displayName;
   bool _isLoading = false;
-  String? _error;
+  AuthError? _error;
   bool _requiresEmailVerification = false;
 
   bool get isLoggedIn => _isLoggedIn;
@@ -19,7 +79,7 @@ class AuthProvider extends ChangeNotifier {
   String? get email => _email;
   String? get displayName => _displayName;
   bool get isLoading => _isLoading;
-  String? get error => _error;
+  AuthError? get error => _error;
   bool get requiresEmailVerification => _requiresEmailVerification;
 
   /// Check stored auth on app startup
@@ -307,7 +367,7 @@ class AuthProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  String _toUserFriendlyAuthError(Object error) {
+  AuthError _toUserFriendlyAuthError(Object error) {
     final raw = error.toString().replaceAll('Exception: ', '').trim();
     final lower = raw.toLowerCase();
 
@@ -317,39 +377,39 @@ class AuthProvider extends ChangeNotifier {
         lower.contains('connection refused') ||
         lower.contains('errno = 8') ||
         lower.contains('errno = 61')) {
-      return 'Connexion au service indisponible. Vérifie ton réseau et réessaie.';
+      return AuthError.networkUnavailable;
     }
 
     if (lower.contains('existe déjà')) {
-      return 'Cet e-mail est déjà utilisé. Connecte-toi ou réinitialise ton mot de passe.';
+      return AuthError.emailAlreadyUsed;
     }
 
     if (lower.contains('incorrect')) {
-      return 'E-mail ou mot de passe incorrect.';
+      return AuthError.incorrectCredentials;
     }
 
     if (lower.contains('registration failed') ||
         lower.contains('inscription impossible') ||
         lower.contains('service indisponible')) {
-      return 'Inscription indisponible pour le moment. Utilise le mode local puis réessaie plus tard.';
+      return AuthError.registrationUnavailable;
     }
 
     if (lower.contains('authentication requise') ||
         lower.contains('unauthorized') ||
         lower.contains('forbidden')) {
-      return 'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.';
+      return AuthError.serviceUnavailable;
     }
 
     if (lower.contains('invalid') || lower.contains('invalide')) {
-      return 'Les informations saisies sont invalides.';
+      return AuthError.invalidInput;
     }
     if (lower.contains('expir')) {
-      return 'Ce lien de réinitialisation a expiré. Demande un nouveau lien.';
+      return AuthError.linkExpired;
     }
     if (lower.contains('non vérifié') || lower.contains('not verified')) {
-      return 'Ton e-mail n’est pas encore vérifié. Vérifie ton e-mail puis réessaie.';
+      return AuthError.emailNotVerified;
     }
 
-    return 'Action impossible pour le moment. Réessaie dans quelques instants.';
+    return AuthError.genericError;
   }
 }

--- a/apps/mobile/lib/providers/byok_provider.dart
+++ b/apps/mobile/lib/providers/byok_provider.dart
@@ -2,6 +2,24 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:mint_mobile/services/rag_service.dart';
 
+/// Error codes for BYOK operations.
+///
+/// The provider sets an error code; the UI layer translates it to a
+/// localized message via `AppLocalizations`.
+enum ByokError {
+  /// Key save failed (secure storage write error).
+  saveFailed,
+
+  /// Provider or API key not configured before testing.
+  notConfigured,
+
+  /// Network / connection error during key test.
+  connectionError,
+
+  /// API returned an error (see [ByokProvider.apiErrorMessage] for detail).
+  apiError,
+}
+
 /// Manages BYOK (Bring Your Own Key) API key storage and state.
 ///
 /// Uses flutter_secure_storage for secure persistence of the user's
@@ -19,7 +37,8 @@ class ByokProvider extends ChangeNotifier {
   bool _isConfigured = false;
   bool _isLoading = false;
   bool _isTesting = false;
-  String? _testError;
+  ByokError? _testError;
+  String? _apiErrorMessage;
   bool _testSuccess = false;
 
   ByokProvider({
@@ -34,7 +53,10 @@ class ByokProvider extends ChangeNotifier {
   bool get isConfigured => _isConfigured;
   bool get isLoading => _isLoading;
   bool get isTesting => _isTesting;
-  String? get testError => _testError;
+  ByokError? get testError => _testError;
+
+  /// Detailed error message from the API (only set when [testError] == [ByokError.apiError]).
+  String? get apiErrorMessage => _apiErrorMessage;
   bool get testSuccess => _testSuccess;
 
   /// Masked display of the API key (e.g. "sk-...abc1")
@@ -94,7 +116,7 @@ class ByokProvider extends ChangeNotifier {
       if (kDebugMode) {
         debugPrint('ByokProvider: Error saving key: $e');
       }
-      _testError = 'Erreur lors de la sauvegarde.';
+      _testError = ByokError.saveFailed;
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -128,7 +150,7 @@ class ByokProvider extends ChangeNotifier {
   /// Returns true if the key works, false otherwise.
   Future<bool> testKey() async {
     if (_apiKey == null || _provider == null) {
-      _testError = 'Configure d\'abord un fournisseur et une cl\u00e9.';
+      _testError = ByokError.notConfigured;
       _testSuccess = false;
       notifyListeners();
       return false;
@@ -151,11 +173,12 @@ class ByokProvider extends ChangeNotifier {
       return true;
     } on RagApiException catch (e) {
       _testSuccess = false;
-      _testError = e.message;
+      _testError = ByokError.apiError;
+      _apiErrorMessage = e.message;
       return false;
     } catch (e) {
       _testSuccess = false;
-      _testError = 'Erreur de connexion. V\u00e9rifie ta connexion internet.';
+      _testError = ByokError.connectionError;
       return false;
     } finally {
       _isTesting = false;
@@ -166,6 +189,7 @@ class ByokProvider extends ChangeNotifier {
   /// Reset test state (useful when navigating away).
   void resetTestState() {
     _testError = null;
+    _apiErrorMessage = null;
     _testSuccess = false;
     _isTesting = false;
     notifyListeners();

--- a/apps/mobile/lib/providers/mint_state_provider.dart
+++ b/apps/mobile/lib/providers/mint_state_provider.dart
@@ -116,8 +116,10 @@ class MintStateProvider extends ChangeNotifier {
         _pendingRecompute = false;
         final queued = _pendingProfile!;
         _pendingProfile = null;
-        // Recurse for the queued call.
-        await recompute(queued);
+        // Recurse for the queued call — use _doRecompute to bypass the
+        // identical-profile guard. The queued call may have come from
+        // forceRecompute, which must always run regardless of _lastProfile.
+        await _doRecompute(queued);
       }
     }
   }

--- a/apps/mobile/lib/screens/auth/forgot_password_screen.dart
+++ b/apps/mobile/lib/screens/auth/forgot_password_screen.dart
@@ -226,7 +226,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                   Padding(
                     padding: const EdgeInsets.only(bottom: MintSpacing.sm + 4),
                     child: Text(
-                      auth.error!,
+                      localizeAuthError(auth.error!, l10n),
                       style: MintTextStyles.bodyMedium(color: MintColors.error),
                     ),
                   ),

--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -175,7 +175,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         const SizedBox(width: MintSpacing.sm + 4),
                         Expanded(
                           child: Text(
-                            authProvider.error!,
+                            localizeAuthError(authProvider.error!, l10n),
                             style: MintTextStyles.bodyMedium(
                               color: MintColors.error,
                             ),

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -528,7 +528,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         const SizedBox(width: MintSpacing.sm + 4),
                         Expanded(
                           child: Text(
-                            authProvider.error!,
+                            localizeAuthError(authProvider.error!, l10n),
                             style: MintTextStyles.bodyMedium(
                               color: MintColors.error,
                             ),

--- a/apps/mobile/lib/screens/auth/verify_email_screen.dart
+++ b/apps/mobile/lib/screens/auth/verify_email_screen.dart
@@ -152,7 +152,7 @@ class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
                 Padding(
                   padding: const EdgeInsets.only(bottom: MintSpacing.sm),
                   child: Text(
-                    auth.error!,
+                    localizeAuthError(auth.error!, l10n),
                     style: MintTextStyles.bodyMedium(color: MintColors.error),
                   ),
                 ),

--- a/apps/mobile/lib/screens/byok_settings_screen.dart
+++ b/apps/mobile/lib/screens/byok_settings_screen.dart
@@ -102,7 +102,7 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
 
             // Feedback
             if (byok.testSuccess) _buildSuccessFeedback(s),
-            if (byok.testError != null) _buildErrorFeedback(byok.testError!),
+            if (byok.testError != null) _buildErrorFeedback(_localizeByokError(byok.testError!, byok.apiErrorMessage, s)),
             const SizedBox(height: MintSpacing.md),
 
             // Clear key (if configured)
@@ -460,6 +460,20 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
         ),
       ],
     );
+  }
+
+  /// Translate a [ByokError] code to a localized user-facing string.
+  String _localizeByokError(ByokError error, String? apiMessage, S s) {
+    switch (error) {
+      case ByokError.saveFailed:
+        return s.byokErrorSaveFailed;
+      case ByokError.notConfigured:
+        return s.byokErrorNotConfigured;
+      case ByokError.connectionError:
+        return s.byokErrorConnection;
+      case ByokError.apiError:
+        return apiMessage ?? s.byokErrorConnection;
+    }
   }
 
   Widget _buildErrorFeedback(String error) {

--- a/apps/mobile/lib/screens/profile_screen.dart
+++ b/apps/mobile/lib/screens/profile_screen.dart
@@ -758,7 +758,9 @@ class ProfileScreen extends StatelessWidget {
     final l = S.of(context)!;
     final message = success
         ? l.profileDeleteAccountSuccess
-        : (authProvider.error ?? l.profileDeleteAccountError);
+        : (authProvider.error != null
+            ? localizeAuthError(authProvider.error!, l)
+            : l.profileDeleteAccountError);
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text(message)));
     if (success) {

--- a/apps/mobile/lib/widgets/coach/mint_score_gauge.dart
+++ b/apps/mobile/lib/widgets/coach/mint_score_gauge.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 
@@ -106,12 +107,12 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
     return MintColors.scoreCritique;
   }
 
-  /// Label du niveau
-  String get _levelLabel {
-    if (widget.score >= 80) return 'Excellent';
-    if (widget.score >= 60) return 'Bon';
-    if (widget.score >= 40) return 'Attention';
-    return 'Critique';
+  /// Label du niveau — localized via ARB keys.
+  String _levelLabel(S? l) {
+    if (widget.score >= 80) return l?.scoreGaugeLevelExcellent ?? 'Excellent';
+    if (widget.score >= 60) return l?.scoreGaugeLevelGood ?? 'Bon';
+    if (widget.score >= 40) return l?.scoreGaugeLevelAttention ?? 'Attention';
+    return l?.scoreGaugeLevelCritical ?? 'Critique';
   }
 
   /// Symbole de tendance
@@ -149,10 +150,18 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context);
+    final levelLabel = _levelLabel(l);
     return Semantics(
-      label: 'Score de forme financière. ${ widget.score} sur 100. '
-          'Niveau $_levelLabel. '
-          'Budget ${widget.budgetScore}, Prévoyance ${widget.prevoyanceScore}, '
+      label: l?.scoreGaugeSemanticsLabel(
+        '${widget.score}',
+        levelLabel,
+        '${widget.budgetScore}',
+        '${widget.prevoyanceScore}',
+        '${widget.patrimoineScore}',
+      ) ?? 'Score de forme financi\u00e8re. ${widget.score} sur 100. '
+          'Niveau $levelLabel. '
+          'Budget ${widget.budgetScore}, Pr\u00e9voyance ${widget.prevoyanceScore}, '
           'Patrimoine ${widget.patrimoineScore}.',
       child: GestureDetector(
         onTap: widget.onTap,
@@ -176,24 +185,24 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _buildHeader(),
+                  _buildHeader(l, levelLabel),
                   const SizedBox(height: 20),
                   _buildGauge(constraints.maxWidth),
                   const SizedBox(height: 24),
-                  _buildSubScores(),
+                  _buildSubScores(l),
                   // P1-H: Gamification panels
                   if (widget.recentGains != null &&
                       widget.recentGains!.isNotEmpty) ...[
                     const SizedBox(height: 16),
-                    _buildGainHistory(),
+                    _buildGainHistory(l),
                   ],
                   if (widget.nextActions != null &&
                       widget.nextActions!.isNotEmpty) ...[
                     const SizedBox(height: 16),
-                    _buildNextActions(),
+                    _buildNextActions(l),
                   ],
                   const SizedBox(height: 16),
-                  _buildDisclaimer(),
+                  _buildDisclaimer(l),
                 ],
               ),
             );
@@ -207,7 +216,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
   //  HEADER
   // ────────────────────────────────────────────────────────────
 
-  Widget _buildHeader() {
+  Widget _buildHeader(S? l, String levelLabel) {
     return Row(
       children: [
         Container(
@@ -229,11 +238,11 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Forme financière',
+                l?.scoreGaugeTitle ?? 'Forme financi\u00e8re',
                 style: MintTextStyles.titleMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
               ),
               Text(
-                'Score composite  ·  3 piliers',
+                l?.scoreGaugeSubtitle ?? 'Score composite \u00b7 3 piliers',
                 style: MintTextStyles.labelSmall(color: MintColors.textSecondary).copyWith(fontSize: 12),
               ),
             ],
@@ -247,7 +256,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
-            _levelLabel,
+            levelLabel,
             style: MintTextStyles.labelSmall(color: _scoreColor).copyWith(fontSize: 12, fontWeight: FontWeight.w600),
           ),
         ),
@@ -328,7 +337,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
   //  SUB-SCORE BARS
   // ────────────────────────────────────────────────────────────
 
-  Widget _buildSubScores() {
+  Widget _buildSubScores(S? l) {
     return AnimatedBuilder(
       animation: _fillAnimation,
       builder: (context, _) {
@@ -345,19 +354,19 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
             child: Column(
               children: [
                 _buildSubScoreBar(
-                  label: 'Budget',
+                  label: l?.scoreGaugeSectionBudget ?? 'Budget',
                   score: widget.budgetScore,
                   icon: Icons.account_balance_wallet_outlined,
                 ),
                 const SizedBox(height: 12),
                 _buildSubScoreBar(
-                  label: 'Prévoyance',
+                  label: l?.scoreGaugeSectionPrevoyance ?? 'Pr\u00e9voyance',
                   score: widget.prevoyanceScore,
                   icon: Icons.shield_outlined,
                 ),
                 const SizedBox(height: 12),
                 _buildSubScoreBar(
-                  label: 'Patrimoine',
+                  label: l?.scoreGaugeSectionPatrimoine ?? 'Patrimoine',
                   score: widget.patrimoineScore,
                   icon: Icons.trending_up,
                 ),
@@ -428,7 +437,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
   //  P1-H: GAIN HISTORY
   // ────────────────────────────────────────────────────────────
 
-  Widget _buildGainHistory() {
+  Widget _buildGainHistory(S? l) {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
@@ -439,7 +448,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Ce qui t\u2019a fait monter',
+            l?.scoreGaugeGainTitle ?? 'Ce qui t\u2019a fait monter',
             style: MintTextStyles.labelSmall(color: MintColors.scoreExcellent).copyWith(fontSize: 12, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
@@ -472,7 +481,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
   //  P1-H: NEXT ACTIONS
   // ────────────────────────────────────────────────────────────
 
-  Widget _buildNextActions() {
+  Widget _buildNextActions(S? l) {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
@@ -483,7 +492,7 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Pour monter encore',
+            l?.scoreGaugeNextTitle ?? 'Pour monter encore',
             style: MintTextStyles.labelSmall(color: MintColors.primary).copyWith(fontSize: 12, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 8),
@@ -516,9 +525,9 @@ class _MintScoreGaugeState extends State<MintScoreGauge>
   //  DISCLAIMER
   // ────────────────────────────────────────────────────────────
 
-  Widget _buildDisclaimer() {
+  Widget _buildDisclaimer(S? l) {
     return Text(
-      'Estimations éducatives \u2014 ne constitue pas un conseil financier.',
+      l?.scoreGaugeDisclaimer ?? 'Estimations \u00e9ducatives \u2014 ne constitue pas un conseil financier.',
       textAlign: TextAlign.center,
       style: MintTextStyles.micro(color: MintColors.textMuted),
     );

--- a/apps/mobile/lib/widgets/coach/widget_renderer.dart
+++ b/apps/mobile/lib/widgets/coach/widget_renderer.dart
@@ -62,11 +62,12 @@ class WidgetRenderer {
 
   static Widget _buildRetirementComparison(
       BuildContext context, Map<String, dynamic> p) {
+    final l = S.of(context);
     return ChatComparisonCard(
-      title: 'Ton aper\u00e7u retraite',
-      leftLabel: 'Aujourd\u2019hui',
+      title: l?.widgetRetirementTitle ?? 'Ton aper\u00e7u retraite',
+      leftLabel: l?.widgetRetirementToday ?? 'Aujourd\u2019hui',
       leftValue: 'CHF\u00a0${_fmt(p['today_monthly'])}/mois',
-      rightLabel: '\u00c0 la retraite',
+      rightLabel: l?.widgetRetirementFuture ?? '\u00c0 la retraite',
       rightValue: 'CHF\u00a0${_fmt(p['retirement_monthly'])}/mois',
       leftAmount: (p['today_monthly'] as num?)?.toDouble() ?? 0,
       rightAmount: (p['retirement_monthly'] as num?)?.toDouble() ?? 0,
@@ -77,11 +78,12 @@ class WidgetRenderer {
 
   static Widget _buildBudgetOverview(
       BuildContext context, Map<String, dynamic> p) {
+    final l = S.of(context);
     return ChatComparisonCard(
-      title: 'Ton budget',
-      leftLabel: 'Revenus',
+      title: l?.widgetBudgetTitle ?? 'Ton budget',
+      leftLabel: l?.widgetBudgetIncome ?? 'Revenus',
       leftValue: 'CHF\u00a0${_fmt(p['income_monthly'])}/mois',
-      rightLabel: 'D\u00e9penses',
+      rightLabel: l?.widgetBudgetExpenses ?? 'D\u00e9penses',
       rightValue: 'CHF\u00a0${_fmt(p['expenses_monthly'])}/mois',
       leftAmount: (p['income_monthly'] as num?)?.toDouble() ?? 0,
       rightAmount: (p['expenses_monthly'] as num?)?.toDouble() ?? 0,
@@ -93,7 +95,7 @@ class WidgetRenderer {
   static Widget _buildScoreGauge(
       BuildContext context, Map<String, dynamic> p) {
     return ChatGaugeCard(
-      title: p['title'] as String? ?? 'Score',
+      title: p['title'] as String? ?? S.of(context)?.widgetScoreFallback ?? 'Score',
       value: (p['value'] as num?)?.toDouble() ?? 0,
       maxValue: (p['max_value'] as num?)?.toDouble() ?? 100,
       valueLabel: p['label'] as String? ?? '\u2014',
@@ -134,12 +136,13 @@ class WidgetRenderer {
     final p3a = (p['pillar_3a_monthly'] as num?)?.toDouble() ?? 0;
     final total = avs + lpp + p3a;
 
+    final l = S.of(context);
     return ChatComparisonCard(
-      title: 'Tes 3 piliers',
-      leftLabel: 'AVS + LPP',
+      title: l?.widgetPillarTitle ?? 'Tes 3 piliers',
+      leftLabel: l?.widgetPillarAvsLpp ?? 'AVS + LPP',
       leftValue: 'CHF\u00a0${_fmt(avs + lpp)}/mois',
-      rightLabel: '3e pilier',
-      rightValue: p3a > 0 ? 'CHF\u00a0${_fmt(p3a)}/mois' : 'Non d\u00e9clar\u00e9',
+      rightLabel: l?.widgetPillar3a ?? '3e pilier',
+      rightValue: p3a > 0 ? 'CHF\u00a0${_fmt(p3a)}/mois' : (l?.widgetPillarNotDeclared ?? 'Non d\u00e9clar\u00e9'),
       leftAmount: avs + lpp,
       rightAmount: p3a > 0 ? p3a : total * 0.1,
       narrative: p['narrative'] as String?,
@@ -227,7 +230,7 @@ class WidgetRenderer {
     }
 
     return ChatFactCard(
-      eyebrow: 'Budget',
+      eyebrow: l?.widgetBudgetLabel ?? 'Budget',
       value: 'CHF\u00a0${_fmt(presentFree)}/mois',
       description: narrative ?? (l?.budgetSnapshotFreeLabel ?? 'Ton libre mensuel'),
       onTap: () => context.push('/budget'),
@@ -267,7 +270,7 @@ class WidgetRenderer {
       case 'salary':
       case 'salaireBrut':
         return ChatAmountInput(
-          label: message ?? S.of(context)?.onboardingSmartSalaryLabel ?? 'Salary',
+          label: message ?? S.of(context)?.onboardingSmartSalaryLabel ?? S.of(context)?.widgetInputSalaryFallback ?? 'Salary',
           onSubmitted: (amount) {
             onInputSubmitted?.call('salaireBrut', '${amount.round()}');
           },
@@ -275,7 +278,7 @@ class WidgetRenderer {
 
       case 'avoirLpp':
         return ChatAmountInput(
-          label: message ?? 'Avoir LPP (CHF)',
+          label: message ?? S.of(context)?.widgetInputLppLabel ?? 'Avoir LPP (CHF)',
           onSubmitted: (amount) {
             onInputSubmitted?.call('avoirLpp', '${amount.round()}');
           },
@@ -283,7 +286,7 @@ class WidgetRenderer {
 
       case 'epargne3a':
         return ChatAmountInput(
-          label: message ?? '\u00c9pargne 3a (CHF)',
+          label: message ?? S.of(context)?.widgetInput3aLabel ?? '\u00c9pargne 3a (CHF)',
           onSubmitted: (amount) {
             onInputSubmitted?.call('epargne3a', '${amount.round()}');
           },

--- a/apps/mobile/test/providers/byok_provider_test.dart
+++ b/apps/mobile/test/providers/byok_provider_test.dart
@@ -220,7 +220,7 @@ void main() {
       final result = await provider.testKey();
 
       expect(result, isFalse);
-      expect(provider.testError, contains('Configure'));
+      expect(provider.testError, equals(ByokError.notConfigured));
       expect(provider.testSuccess, isFalse);
     });
 
@@ -245,7 +245,8 @@ void main() {
 
       expect(result, isFalse);
       expect(provider.testSuccess, isFalse);
-      expect(provider.testError, 'Invalid API key provided');
+      expect(provider.testError, equals(ByokError.apiError));
+      expect(provider.apiErrorMessage, 'Invalid API key provided');
       expect(provider.isTesting, isFalse);
     });
 
@@ -258,7 +259,7 @@ void main() {
 
       expect(result, isFalse);
       expect(provider.testSuccess, isFalse);
-      expect(provider.testError, contains('connexion'));
+      expect(provider.testError, equals(ByokError.connectionError));
       expect(provider.isTesting, isFalse);
     });
 

--- a/apps/mobile/test/services/financial_core/tornado_sensitivity_service_test.dart
+++ b/apps/mobile/test/services/financial_core/tornado_sensitivity_service_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/financial_core/tornado_sensitivity_service.dart';
+
+// ════════════════════════════════════════════════════════════════
+//  TORNADO SENSITIVITY SERVICE — edge-case tests
+//
+//  Covers: zero values, negative-like inputs, boundary retirement ages,
+//  single-variable profiles, very large values, empty contributions,
+//  multiple zeros, extreme ages, and variable isolation.
+// ════════════════════════════════════════════════════════════════
+
+void main() {
+  group('TornadoSensitivityService — edge cases', () {
+    // ──────────────────────────────────────────────────────────
+    //  1. Zero salary produces limited variables
+    // ──────────────────────────────────────────────────────────
+    test('zero salary skips salary variable', () {
+      final profile = _buildProfile(salaireBrutMensuel: 0);
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final labels = result.map((v) => v.label).toList();
+      expect(labels, isNot(contains('Salaire brut')));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  2. Boundary retirement age: minimum (58)
+    // ──────────────────────────────────────────────────────────
+    test('retirement age at boundary 58 does not crash', () {
+      final profile = _buildProfile(birthYear: DateTime.now().year - 57);
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 58,
+      );
+      // Should still return variables (at least LPP strategy, taux, rendement)
+      expect(result, isNotEmpty);
+      for (final v in result) {
+        expect(v.swing, greaterThanOrEqualTo(0));
+      }
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  3. Boundary retirement age: maximum (70)
+    // ──────────────────────────────────────────────────────────
+    test('retirement age at boundary 70 does not crash', () {
+      final profile = _buildProfile(birthYear: DateTime.now().year - 45);
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 70,
+      );
+      expect(result, isNotEmpty);
+      // Age variable should still exist since 70-2=68 < 70
+      final ageVars = result.where((v) => v.label.contains('ge de d'));
+      expect(ageVars.isNotEmpty, isTrue);
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  4. Very large salary (1M/month)
+    // ──────────────────────────────────────────────────────────
+    test('very large salary produces valid results without overflow', () {
+      final profile = _buildProfile(salaireBrutMensuel: 1000000);
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      expect(result, isNotEmpty);
+      for (final v in result) {
+        expect(v.baseValue.isFinite, isTrue, reason: '${v.label} baseValue should be finite');
+        expect(v.swing.isFinite, isTrue, reason: '${v.label} swing should be finite');
+        expect(v.swing, greaterThanOrEqualTo(0), reason: '${v.label} swing >= 0');
+      }
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  5. Very large LPP avoir (10M)
+    // ──────────────────────────────────────────────────────────
+    test('very large LPP avoir does not overflow', () {
+      final profile = _buildProfile(
+        avoirLppTotal: 10000000,
+        salaireBrutMensuel: 20000,
+      );
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final lppVar = result.firstWhere(
+        (v) => v.label == 'Avoir LPP actuel',
+      );
+      expect(lppVar.swing.isFinite, isTrue);
+      expect(lppVar.highValue, greaterThan(lppVar.lowValue));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  6. Empty contributions list — no 3a/libre variables
+    // ──────────────────────────────────────────────────────────
+    test('empty contributions skips epargne 3a and libre mensuelle', () {
+      final profile = _buildProfile(
+        plannedContributions: const [],
+        totalEpargne3a: 0,
+      );
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final labels = result.map((v) => v.label).toList();
+      expect(labels, isNot(contains('\u00c9pargne 3a mensuelle')));
+      expect(labels, isNot(contains('\u00c9pargne libre mensuelle')));
+      expect(labels, isNot(contains('Capital 3e pilier')));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  7. All zeros patrimoine — no patrimoine variables
+    // ──────────────────────────────────────────────────────────
+    test('zero patrimoine skips investissements and epargne liquide', () {
+      final profile = _buildProfile(
+        epargneLiquide: 0,
+        investissements: 0,
+      );
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final labels = result.map((v) => v.label).toList();
+      expect(labels, isNot(contains('Investissements libres')));
+      expect(labels, isNot(contains('\u00c9pargne liquide')));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  8. Null anneesContribuees — AVS years variable excluded
+    // ──────────────────────────────────────────────────────────
+    test('null anneesContribuees excludes AVS years variable', () {
+      final profile = _buildProfile(anneesContribuees: null);
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final labels = result.map((v) => v.label).toList();
+      expect(labels, isNot(contains('Ann\u00e9es AVS cotis\u00e9es')));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  9. Single variable isolation — tauxConversion always present
+    // ──────────────────────────────────────────────────────────
+    test('taux conversion variable always present even with minimal profile', () {
+      final profile = _buildProfile(
+        salaireBrutMensuel: 5000,
+        avoirLppTotal: 0,
+        totalEpargne3a: 0,
+        epargneLiquide: 0,
+        investissements: 0,
+        plannedContributions: const [],
+      );
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      final labels = result.map((v) => v.label).toList();
+      expect(labels, contains('Taux de conversion LPP'));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  10. Retirement at exactly current age — no crash
+    // ──────────────────────────────────────────────────────────
+    test('retirement age equal to current age does not crash', () {
+      // Person born 65 years ago, retiring at 65 — edge case
+      final profile = _buildProfile(birthYear: DateTime.now().year - 65);
+      // This might produce limited or empty results, but must not throw
+      final result = TornadoSensitivityService.compute(
+        profile: profile,
+        retirementAgeUser: 65,
+      );
+      // All variables should have valid (finite) values
+      for (final v in result) {
+        expect(v.baseValue.isFinite, isTrue);
+        expect(v.lowValue.isFinite, isTrue);
+        expect(v.highValue.isFinite, isTrue);
+      }
+    });
+  });
+}
+
+// ════════════════════════════════════════════════════════════════
+//  TEST HELPERS
+// ════════════════════════════════════════════════════════════════
+
+CoachProfile _buildProfile({
+  int? birthYear,
+  double salaireBrutMensuel = 8000,
+  double? avoirLppTotal = 200000,
+  double totalEpargne3a = 40000,
+  int nombre3a = 2,
+  int? anneesContribuees = 20,
+  double epargneLiquide = 15000,
+  double investissements = 50000,
+  List<PlannedMonthlyContribution>? plannedContributions,
+}) {
+  return CoachProfile(
+    firstName: 'Edge',
+    birthYear: birthYear ?? DateTime.now().year - 45,
+    canton: 'ZH',
+    salaireBrutMensuel: salaireBrutMensuel,
+    employmentStatus: 'salarie',
+    etatCivil: CoachCivilStatus.celibataire,
+    prevoyance: PrevoyanceProfile(
+      avoirLppTotal: avoirLppTotal,
+      tauxConversion: 0.068,
+      rendementCaisse: 0.02,
+      totalEpargne3a: totalEpargne3a,
+      nombre3a: nombre3a,
+      anneesContribuees: anneesContribuees,
+      lacunesAVS: 1,
+    ),
+    patrimoine: PatrimoineProfile(
+      epargneLiquide: epargneLiquide,
+      investissements: investissements,
+    ),
+    depenses: const DepensesProfile(
+      loyer: 1500,
+      assuranceMaladie: 400,
+    ),
+    plannedContributions: plannedContributions ?? const [
+      PlannedMonthlyContribution(
+        id: '3a_edge',
+        label: '3a Test',
+        amount: 604,
+        category: '3a',
+      ),
+      PlannedMonthlyContribution(
+        id: 'invest_edge',
+        label: 'Investissements',
+        amount: 400,
+        category: 'investissement',
+      ),
+    ],
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(2050),
+      label: 'Retraite',
+    ),
+  );
+}

--- a/apps/mobile/test/services/financial_core/withdrawal_sequencing_service_test.dart
+++ b/apps/mobile/test/services/financial_core/withdrawal_sequencing_service_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/financial_core/withdrawal_sequencing_service.dart';
+
+// ════════════════════════════════════════════════════════════════
+//  WITHDRAWAL SEQUENCING SERVICE — edge-case tests
+//
+//  Covers: zero values, negative-like inputs, single asset,
+//  multiple assets same year, empty list, very large values,
+//  already-retired profiles, young profiles, extreme lppCapitalPct.
+// ════════════════════════════════════════════════════════════════
+
+void main() {
+  group('WithdrawalSequencingService — edge cases', () {
+    // ──────────────────────────────────────────────────────────
+    //  1. Already retired (age >= retirementAge) returns empty
+    // ──────────────────────────────────────────────────────────
+    test('already retired person returns empty sequences', () {
+      final profile = _buildProfile(birthYear: 1950); // age ~76
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+      );
+      expect(result.optimizedSequence, isEmpty);
+      expect(result.naiveSequence, isEmpty);
+      expect(result.totalTaxOptimized, equals(0));
+      expect(result.totalTaxNaive, equals(0));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  2. Very young person (age 25, retirement 65)
+    // ──────────────────────────────────────────────────────────
+    test('very young person (25) produces valid results', () {
+      final profile = _buildProfile(
+        birthYear: DateTime.now().year - 25,
+        nombre3a: 2,
+        totalEpargne3a: 20000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+      );
+      // Should have events (at least 3a withdrawals)
+      expect(result.optimizedSequence, isNotEmpty);
+      // All events should be in the future
+      final currentYear = DateTime.now().year;
+      for (final e in result.optimizedSequence) {
+        expect(e.year, greaterThan(currentYear));
+      }
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  3. Single 3a account — one event in both sequences
+    // ──────────────────────────────────────────────────────────
+    test('single 3a account produces exactly one event per sequence', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 1,
+        totalEpargne3a: 100000,
+        avoirLppTotal: null,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 0.0,
+      );
+      expect(result.optimizedSequence.length, equals(1));
+      expect(result.naiveSequence.length, equals(1));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  4. Very large capital (5M total) — no overflow
+    // ──────────────────────────────────────────────────────────
+    test('very large capital does not overflow', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 5,
+        totalEpargne3a: 5000000,
+        avoirLppTotal: 2000000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 1.0,
+      );
+      expect(result.totalTaxOptimized.isFinite, isTrue);
+      expect(result.totalTaxNaive.isFinite, isTrue);
+      expect(result.taxSavings.isFinite, isTrue);
+      // With 5 accounts of 1M each, staggering should produce big savings
+      expect(result.taxSavings, greaterThan(0));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  5. Zero 3a + zero LPP capital — empty sequences
+    // ──────────────────────────────────────────────────────────
+    test('zero capital on all sources returns empty', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 0,
+        totalEpargne3a: 0,
+        avoirLppTotal: 0,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 1.0,
+      );
+      expect(result.optimizedSequence, isEmpty);
+      expect(result.naiveSequence, isEmpty);
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  6. LPP capital 100% — includes LPP event
+    // ──────────────────────────────────────────────────────────
+    test('lppCapitalPct 1.0 includes full LPP capital event', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 0,
+        totalEpargne3a: 0,
+        avoirLppTotal: 500000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 1.0,
+      );
+      // Should have exactly one LPP event
+      final lppEvents = result.optimizedSequence
+          .where((e) => e.source == 'lpp_capital')
+          .toList();
+      expect(lppEvents.length, equals(1));
+      expect(lppEvents.first.amount, greaterThan(0));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  7. Multiple 3a same-sized — staggered into different years
+    // ──────────────────────────────────────────────────────────
+    test('multiple same-sized 3a accounts spread across years', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 4,
+        totalEpargne3a: 400000, // 100k each
+        avoirLppTotal: null,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 0.0,
+      );
+      final years = result.optimizedSequence.map((e) => e.year).toSet();
+      // With 4 accounts and a 5-year window (60-65), they should be spread
+      expect(years.length, greaterThanOrEqualTo(3));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  8. Effective rate between 0 and 1 for all events
+    // ──────────────────────────────────────────────────────────
+    test('effective rate is between 0 and 1 for all events', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 3,
+        totalEpargne3a: 300000,
+        avoirLppTotal: 200000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 0.5,
+      );
+      for (final e in [...result.optimizedSequence, ...result.naiveSequence]) {
+        expect(e.effectiveRate, greaterThanOrEqualTo(0),
+            reason: '${e.source}: effective rate >= 0');
+        expect(e.effectiveRate, lessThanOrEqualTo(1),
+            reason: '${e.source}: effective rate <= 1');
+      }
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  9. Savings percent between 0 and 1
+    // ──────────────────────────────────────────────────────────
+    test('savings percent is between 0 and 1', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 3,
+        totalEpargne3a: 240000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+      );
+      expect(result.savingsPercent, greaterThanOrEqualTo(0));
+      expect(result.savingsPercent, lessThanOrEqualTo(1));
+    });
+
+    // ──────────────────────────────────────────────────────────
+    //  10. LPP capital at exactly 0% — no LPP events
+    // ──────────────────────────────────────────────────────────
+    test('lppCapitalPct 0.0 excludes LPP events even with large LPP', () {
+      final profile = _buildProfile(
+        birthYear: 1970,
+        nombre3a: 1,
+        totalEpargne3a: 50000,
+        avoirLppTotal: 1000000,
+      );
+      final result = WithdrawalSequencingService.optimize(
+        profile: profile,
+        retirementAge: 65,
+        lppCapitalPct: 0.0,
+      );
+      final lppEvents = result.optimizedSequence
+          .where((e) => e.source == 'lpp_capital')
+          .toList();
+      expect(lppEvents, isEmpty);
+      final lppNaiveEvents = result.naiveSequence
+          .where((e) => e.source == 'lpp_capital')
+          .toList();
+      expect(lppNaiveEvents, isEmpty);
+    });
+  });
+}
+
+// ════════════════════════════════════════════════════════════════
+//  TEST HELPERS
+// ════════════════════════════════════════════════════════════════
+
+CoachProfile _buildProfile({
+  int birthYear = 1970,
+  String canton = 'ZH',
+  CoachCivilStatus etatCivil = CoachCivilStatus.celibataire,
+  double salaireBrutMensuel = 8000,
+  int nombre3a = 3,
+  double totalEpargne3a = 240000,
+  double? avoirLppTotal,
+  double tauxConversion = 0.068,
+  double rendementCaisse = 0.02,
+}) {
+  final accounts = List.generate(
+    nombre3a,
+    (i) => Compte3a(
+      provider: 'Test Provider ${i + 1}',
+      solde: nombre3a > 0 ? totalEpargne3a / nombre3a : 0,
+      rendementEstime: 0.0, // Zero growth for predictable tests
+    ),
+  );
+
+  return CoachProfile(
+    birthYear: birthYear,
+    canton: canton,
+    etatCivil: etatCivil,
+    salaireBrutMensuel: salaireBrutMensuel,
+    prevoyance: PrevoyanceProfile(
+      nombre3a: nombre3a,
+      totalEpargne3a: totalEpargne3a,
+      comptes3a: accounts,
+      avoirLppTotal: avoirLppTotal,
+      tauxConversion: tauxConversion,
+      rendementCaisse: rendementCaisse,
+    ),
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(birthYear + 65, 12, 31),
+      label: 'Retraite a 65 ans',
+    ),
+  );
+}

--- a/services/backend/app/services/independant_service.py
+++ b/services/backend/app/services/independant_service.py
@@ -7,7 +7,7 @@ and protection gap identification for self-employed workers in Switzerland.
 Sources:
     - LAVS art. 8 (cotisations independants: ~10.6%, bareme degressif)
     - LAVS art. 9 (revenu determinant)
-    - OPP3 art. 7 (3a grand plafond: 20% du revenu net, max 35'280 CHF)
+    - OPP3 art. 7 (3a grand plafond: 20% du revenu net, max 36'288 CHF)
     - LPP art. 4 (affiliation volontaire pour independants)
     - LAA art. 4 (assurance accident obligatoire salaries, facultative independants)
     - LCA (assurance IJM: perte de gain maladie, pas d'obligation legale)
@@ -149,7 +149,7 @@ class IndependantService:
     def calculate_3a_plafond(self, revenu_net: float) -> float:
         """Calculate 3a grand plafond for self-employed without LPP.
 
-        OPP3 art. 7: 20% of net income, max 35'280 CHF.
+        OPP3 art. 7: 20% of net income, max 36'288 CHF.
 
         Args:
             revenu_net: Annual net income.


### PR DESCRIPTION
## Audit V4 — 6 critical findings fixed

- **P3**: MintStateProvider.forceRecompute queued call no longer silently skipped
- **W1/W4**: 35 hardcoded FR strings extracted from widget_renderer + score_gauge
- **P1/P2**: ByokError + AuthError enums replace hardcoded FR error strings (12 i18n keys)
- **B1**: Backend docstring corrected (35'280 → 36'288)
- **T1/T2**: 20 new edge-case tests for tornado_sensitivity + withdrawal_sequencing

Tests: 8154 Flutter (+20) + 4439 Backend | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)