### PR TITLE
fix(security): V6 audit — analytics auth, subscription guard, consent mapping, account isolation

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -3,6 +3,11 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
+import 'package:mint_mobile/services/memory/coach_memory_service.dart';
+import 'package:mint_mobile/services/cap_memory_store.dart';
+import 'package:mint_mobile/services/coach/precomputed_insights_service.dart';
+import 'package:mint_mobile/services/analytics_service.dart';
 
 /// Error codes for authentication operations.
 ///
@@ -213,6 +218,8 @@ class AuthProvider extends ChangeNotifier {
     try {
       await ApiService.deleteAccount();
       await AuthService.logout();
+      // V6-4 audit fix: purge ALL local data on account deletion
+      await _purgeLocalData();
       _isLoggedIn = false;
       _userId = null;
       _email = null;
@@ -299,9 +306,11 @@ class AuthProvider extends ChangeNotifier {
     }
   }
 
-  /// Logout
+  /// Logout — V6-4 audit fix: purge ALL local data to prevent
+  /// cross-account data bleed on shared devices.
   Future<void> logout() async {
     await AuthService.logout();
+    await _purgeLocalData();
     _isLoggedIn = false;
     _userId = null;
     _email = null;
@@ -309,6 +318,35 @@ class AuthProvider extends ChangeNotifier {
     _requiresEmailVerification = false;
     _error = null;
     notifyListeners();
+  }
+
+  /// V6-4 audit fix: purge ALL local data artifacts to prevent
+  /// cross-account data bleed on shared devices.
+  /// Same purge sequence as profile_screen.dart deleteAccount flow.
+  Future<void> _purgeLocalData() async {
+    try {
+      // Purge conversation history
+      final store = ConversationStore();
+      final conversations = await store.listConversations();
+      for (final conv in conversations) {
+        await store.deleteConversation(conv.id);
+      }
+      // Purge coach memory (insights)
+      await CoachMemoryService.clear();
+      // Purge CapEngine memory
+      await CapMemoryStore.clear();
+      // Purge analytics queue
+      await AnalyticsService().clearLocalQueue();
+      // Clear all SharedPreferences (nuclear option)
+      final prefs = await SharedPreferences.getInstance();
+      await PrecomputedInsightsService.clear(prefs);
+      await prefs.clear();
+    } catch (e) {
+      // Purge is best-effort — never block auth flow
+      if (kDebugMode) {
+        debugPrint('[AuthProvider] Local data purge failed: $e');
+      }
+    }
   }
 
   /// Migrate local anonymous data to the authenticated account.

--- a/apps/mobile/lib/screens/consent_dashboard_screen.dart
+++ b/apps/mobile/lib/screens/consent_dashboard_screen.dart
@@ -59,13 +59,18 @@ class _ConsentDashboardScreenState extends State<ConsentDashboardScreen> {
   }
 
   /// Maps PrivacyService category IDs to ConsentManager ConsentType.
+  /// V6-3 audit fix: align toggles to correct ConsentType keys.
   ConsentType? _mapCategoryToConsentType(String categoryId) {
     switch (categoryId) {
       case 'coaching_notifications':
         return ConsentType.notifications;
       case 'rag_queries':
-        return ConsentType.byokDataSharing;
+        return ConsentType.ragQueries;
       case 'analytics':
+        return ConsentType.analytics;
+      case 'open_banking':
+        return ConsentType.byokDataSharing;
+      case 'document_upload':
         return ConsentType.snapshotStorage;
       default:
         return null;

--- a/apps/mobile/lib/services/analytics_service.dart
+++ b/apps/mobile/lib/services/analytics_service.dart
@@ -20,7 +20,8 @@ class AnalyticsService {
   AnalyticsService._internal();
 
   static const String _sessionIdKey = 'analytics_session_id';
-  static const String _consentKey = 'analytics_consent';
+  // V6-3 audit fix: aligned to ConsentManager canonical key (consent_analytics).
+  static const String _consentKey = 'consent_analytics';
   static const String _eventsQueueKey = 'analytics_events_queue';
   static const int _maxQueueSize = 50;
   static const int _flushThreshold = 10;
@@ -120,11 +121,11 @@ class AnalyticsService {
     }
 
     final event = {
-      'name': name,
-      'category': category,
+      'event_name': name,
+      'event_category': category,
       'timestamp': DateTime.now().toIso8601String(),
       'session_id': _sessionId,
-      if (data != null) 'data': data,
+      if (data != null) 'event_data': data,
       if (screenName != null) 'screen_name': screenName,
     };
 

--- a/apps/mobile/lib/services/consent_manager.dart
+++ b/apps/mobile/lib/services/consent_manager.dart
@@ -31,7 +31,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 // Revocation immediate sans consequence sur le service de base.
 // ────────────────────────────────────────────────────────────
 
-/// The 3 independent consent types.
+/// The independent consent types.
 enum ConsentType {
   /// BYOK data sharing: CoachContext fields sent to LLM provider.
   byokDataSharing,
@@ -41,6 +41,12 @@ enum ConsentType {
 
   /// Notifications: personalized push with financial numbers.
   notifications,
+
+  /// Analytics: anonymous event tracking for product improvement.
+  analytics,
+
+  /// RAG queries: knowledge-base queries for coach personalization.
+  ragQueries,
 }
 
 /// State of a single consent toggle.

--- a/apps/mobile/lib/services/openfinance/open_finance_service.dart
+++ b/apps/mobile/lib/services/openfinance/open_finance_service.dart
@@ -408,6 +408,7 @@ class OpenFinanceService {
     final now = DateTime.now();
     final connectionId = 'conn_${institutionId}_${now.millisecondsSinceEpoch}';
 
+    // SAFETY: mock connections use system_estimate confidence (V6-5 audit fix).
     final connection = FinanceConnection(
       id: connectionId,
       type: type,
@@ -415,7 +416,7 @@ class OpenFinanceService {
       status: ConnectionStatus.active,
       lastSync: now,
       frequency: SyncFrequency.daily,
-      dataConfidence: 1.0,
+      dataConfidence: _mockDataConfidence,
     );
 
     final consent = ConsentRecord(
@@ -636,6 +637,11 @@ class OpenFinanceService {
     }
   }
 
+  /// SAFETY: mock data must never claim openBanking confidence (V6-5 audit fix).
+  /// Mock data is capped at 0.25 (system_estimate level) to prevent
+  /// mock values from being treated as verified openBanking data.
+  static const double _mockDataConfidence = 0.25;
+
   /// Generate mock data points for a connection (balances only).
   static List<FinanceDataPoint> _generateMockDataPoints(
     String connectionId,
@@ -653,8 +659,8 @@ class OpenFinanceService {
           fieldPath: 'patrimoine.epargneLiquide',
           value: 45230.0,
           asOf: now,
-          source: 'bLink API \u2014 $connectionId',
-          confidence: 1.0,
+          source: 'bLink API \u2014 $connectionId (mock)',
+          confidence: _mockDataConfidence,
         ),
       ];
     }
@@ -666,8 +672,8 @@ class OpenFinanceService {
           fieldPath: 'prevoyance.totalEpargne3a',
           value: 32000.0,
           asOf: now,
-          source: 'bLink API \u2014 $connectionId',
-          confidence: 1.0,
+          source: 'bLink API \u2014 $connectionId (mock)',
+          confidence: _mockDataConfidence,
         ),
       ];
     }
@@ -677,8 +683,8 @@ class OpenFinanceService {
           fieldPath: 'prevoyance.avoirLppTotal',
           value: 70377.0,
           asOf: now,
-          source: 'bLink API \u2014 $connectionId',
-          confidence: 1.0,
+          source: 'bLink API \u2014 $connectionId (mock)',
+          confidence: _mockDataConfidence,
         ),
       ];
     }
@@ -688,8 +694,8 @@ class OpenFinanceService {
         fieldPath: 'patrimoine.capitalLibre',
         value: 10000.0,
         asOf: now,
-        source: 'bLink API \u2014 $connectionId',
-        confidence: 1.0,
+        source: 'bLink API \u2014 $connectionId (mock)',
+        confidence: _mockDataConfidence,
       ),
     ];
   }

--- a/apps/mobile/lib/services/subscription_service.dart
+++ b/apps/mobile/lib/services/subscription_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/ios_iap_service.dart';
 
@@ -331,6 +332,13 @@ class SubscriptionService {
       return purchased;
     }
 
+    // V6-2 audit fix: non-iOS paid upgrades require backend verification
+    // in release mode. Local mock grants only allowed in debug mode.
+    if (tier.isPaid && !kDebugMode) {
+      final refreshed = await refreshFromBackend();
+      return refreshed.tier.rank >= tier.rank;
+    }
+
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
     if (tier == SubscriptionTier.free) {
@@ -342,6 +350,7 @@ class SubscriptionService {
       return true;
     }
 
+    // Debug-only mock grant (never reached in release builds)
     _state = SubscriptionState(
       tier: tier,
       isTrialActive: false,
@@ -374,7 +383,6 @@ class SubscriptionService {
   }
 
   static Future<bool> startTrial() async {
-    await Future<void>.delayed(const Duration(milliseconds: 100));
     // Already a paid subscriber (not on trial) — cannot start trial
     if (_state.tier.isPaid && !_state.isTrialActive) {
       return false;
@@ -383,7 +391,16 @@ class SubscriptionService {
       return false;
     }
 
-    // Trial gives premium-level access
+    // V6-2 audit fix: in release mode, trials must be verified by backend.
+    // Local mock trial grants only allowed in debug mode.
+    if (!kDebugMode) {
+      final refreshed = await refreshFromBackend();
+      return refreshed.isTrialActive;
+    }
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    // Debug-only mock trial grant (never reached in release builds)
     _state = SubscriptionState(
       tier: SubscriptionTier.premium,
       isTrialActive: true,

--- a/apps/mobile/test/services/open_finance_service_test.dart
+++ b/apps/mobile/test/services/open_finance_service_test.dart
@@ -81,7 +81,8 @@ void main() {
     expect(conn.type, FinanceProvider.bank);
     expect(conn.institutionName, 'UBS');
     expect(conn.status, ConnectionStatus.active);
-    expect(conn.dataConfidence, 1.0);
+    // V6-5 audit fix: mock data capped at system_estimate confidence (0.25)
+    expect(conn.dataConfidence, 0.25);
     expect(conn.lastSync, isNotNull);
   });
 
@@ -147,7 +148,8 @@ void main() {
 
     expect(dataPoints, isNotEmpty);
     for (final dp in dataPoints) {
-      expect(dp.confidence, 1.0);
+      // V6-5 audit fix: mock data capped at system_estimate confidence (0.25)
+      expect(dp.confidence, 0.25);
       expect(dp.fieldPath, isNotEmpty);
       expect(dp.source, contains('bLink API'));
     }

--- a/services/backend/app/api/v1/endpoints/analytics.py
+++ b/services/backend/app/api/v1/endpoints/analytics.py
@@ -2,12 +2,14 @@
 Analytics endpoints for event tracking and analytics queries.
 """
 
+import os
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func, distinct
 from app.core.auth import require_current_user
+from app.core.config import settings
 from app.core.database import get_db
 from app.models.analytics_event import AnalyticsEvent
 from app.models.user import User
@@ -22,19 +24,41 @@ from app.schemas.analytics import (
 router = APIRouter()
 
 
+def _require_admin_user(user: User) -> None:
+    """Require admin access for analytics read endpoints (V6-1 audit fix)."""
+    allowlist_raw = os.getenv("AUTH_ADMIN_EMAIL_ALLOWLIST")
+    if allowlist_raw is None:
+        allowlist_raw = settings.AUTH_ADMIN_EMAIL_ALLOWLIST
+    allowlist_raw = allowlist_raw.strip()
+    allowlist = {
+        entry.strip().lower()
+        for entry in allowlist_raw.split(",")
+        if entry.strip()
+    }
+    email = (user.email or "").strip().lower()
+    is_allowlisted = bool(email and allowlist and email in allowlist)
+    if not is_allowlisted:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+
 @router.post("/events", response_model=AnalyticsEventBatchResponse, status_code=status.HTTP_201_CREATED)
 def post_analytics_events(
     batch: AnalyticsEventBatch,
     db: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
 ) -> AnalyticsEventBatchResponse:
     """
     Batch analytics event ingestion endpoint.
 
-    This endpoint accepts multiple analytics events at once for efficient bulk insertion.
-    No authentication required - supports anonymous tracking with optional user_id linkage.
+    Requires authentication. The authenticated user's ID is used as user_id
+    for all events (V6-1 audit fix: prevents fake user_id injection).
 
     Args:
         batch: Batch of analytics events to store
+        current_user: Authenticated user from JWT token
         db: Database session
 
     Returns:
@@ -48,7 +72,7 @@ def post_analytics_events(
             event_category=event_data.event_category,
             event_data=event_data.event_data,
             session_id=event_data.session_id,
-            user_id=event_data.user_id,
+            user_id=current_user.id,
             screen_name=event_data.screen_name,
             timestamp=event_data.timestamp if event_data.timestamp else datetime.now(timezone.utc),
             app_version=event_data.app_version,
@@ -71,10 +95,12 @@ def get_analytics_summary(
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     db: Session = Depends(get_db),
-    _user: User = Depends(require_current_user),
+    current_user: User = Depends(require_current_user),
 ) -> AnalyticsSummaryResponse:
     """
     Get analytics summary with key metrics.
+
+    Admin-only endpoint (V6-1 audit fix): exposes global product data.
 
     Returns aggregated statistics including total events, unique sessions,
     and breakdowns by category and screen name.
@@ -88,6 +114,7 @@ def get_analytics_summary(
     Returns:
         AnalyticsSummaryResponse with summary statistics
     """
+    _require_admin_user(current_user)
     # Determine date range
     if start_date:
         date_range_start = start_date
@@ -152,10 +179,12 @@ def get_funnel_analysis(
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     db: Session = Depends(get_db),
-    _user: User = Depends(require_current_user),
+    current_user: User = Depends(require_current_user),
 ) -> FunnelQueryResponse:
     """
     Get funnel conversion analysis.
+
+    Admin-only endpoint (V6-1 audit fix): exposes global product data.
 
     Calculates conversion rates through a series of event steps.
     Steps parameter should be comma-separated event names.
@@ -173,6 +202,7 @@ def get_funnel_analysis(
     Example:
         GET /analytics/funnel?steps=landing_view,onboarding_start,wizard_started,wizard_completed
     """
+    _require_admin_user(current_user)
     # Parse steps
     step_names = [s.strip() for s in steps.split(',') if s.strip()]
 

--- a/services/backend/app/schemas/analytics.py
+++ b/services/backend/app/schemas/analytics.py
@@ -29,7 +29,7 @@ class AnalyticsEventCreate(BaseModel):
     @field_validator('event_category')
     @classmethod
     def validate_event_category(cls, v: str) -> str:
-        valid_categories = ["navigation", "engagement", "conversion", "error"]
+        valid_categories = ["navigation", "engagement", "conversion", "error", "system", "experiment"]
         if v not in valid_categories:
             raise ValueError(f'event_category must be one of {valid_categories}')
         return v

--- a/services/backend/tests/test_analytics.py
+++ b/services/backend/tests/test_analytics.py
@@ -2,8 +2,16 @@
 Tests for analytics endpoints - event tracking and analytics queries.
 """
 
+import os
+import pytest
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
+
+
+@pytest.fixture
+def admin_env(monkeypatch):
+    """Set AUTH_ADMIN_EMAIL_ALLOWLIST so test@mint.ch is recognized as admin."""
+    monkeypatch.setenv("AUTH_ADMIN_EMAIL_ALLOWLIST", "test@mint.ch")
 
 
 def test_post_single_event_anonymous(client):
@@ -185,7 +193,7 @@ def test_post_events_validation_too_many_events(client):
     assert response.status_code == 422
 
 
-def test_get_analytics_summary_default(client):
+def test_get_analytics_summary_default(client, admin_env):
     """Test getting analytics summary with default parameters (7 days)."""
     # Post some test events
     session_1 = str(uuid4())
@@ -238,7 +246,7 @@ def test_get_analytics_summary_default(client):
     assert "date_range_end" in data
 
 
-def test_get_analytics_summary_custom_days(client):
+def test_get_analytics_summary_custom_days(client, admin_env):
     """Test getting analytics summary with custom day range."""
     # Post event
     events = {
@@ -259,7 +267,7 @@ def test_get_analytics_summary_custom_days(client):
     assert data["total_events"] == 1
 
 
-def test_get_analytics_summary_date_range_filter(client):
+def test_get_analytics_summary_date_range_filter(client, admin_env):
     """Test analytics summary with custom date range."""
     # Post events with different timestamps
     now = datetime.now(timezone.utc)
@@ -291,7 +299,7 @@ def test_get_analytics_summary_date_range_filter(client):
     assert data["total_events"] == 1  # Only recent event
 
 
-def test_get_analytics_summary_empty(client):
+def test_get_analytics_summary_empty(client, admin_env):
     """Test analytics summary with no events."""
     response = client.get("/api/v1/analytics/summary")
     assert response.status_code == 200
@@ -302,7 +310,7 @@ def test_get_analytics_summary_empty(client):
     assert data["events_by_screen"] == {}
 
 
-def test_get_funnel_analysis_basic(client):
+def test_get_funnel_analysis_basic(client, admin_env):
     """Test basic funnel analysis with multiple steps."""
     session_1 = str(uuid4())
     session_2 = str(uuid4())
@@ -356,7 +364,7 @@ def test_get_funnel_analysis_basic(client):
     assert steps[3]["conversion_rate"] == 66.67  # 2/3 * 100
 
 
-def test_get_funnel_analysis_empty_steps(client):
+def test_get_funnel_analysis_empty_steps(client, admin_env):
     """Test funnel analysis with no steps provided."""
     response = client.get("/api/v1/analytics/funnel?steps=")
     assert response.status_code == 200
@@ -364,7 +372,7 @@ def test_get_funnel_analysis_empty_steps(client):
     assert data["steps"] == []
 
 
-def test_get_funnel_analysis_no_matching_events(client):
+def test_get_funnel_analysis_no_matching_events(client, admin_env):
     """Test funnel analysis with steps that have no matching events."""
     response = client.get("/api/v1/analytics/funnel?steps=nonexistent_step1,nonexistent_step2")
     assert response.status_code == 200
@@ -375,7 +383,7 @@ def test_get_funnel_analysis_no_matching_events(client):
     assert steps[1]["count"] == 0
 
 
-def test_get_funnel_analysis_date_range(client):
+def test_get_funnel_analysis_date_range(client, admin_env):
     """Test funnel analysis with date range filtering."""
     now = datetime.now(timezone.utc)
     old_event_time = now - timedelta(days=10)
@@ -406,7 +414,7 @@ def test_get_funnel_analysis_date_range(client):
     assert data["steps"][0]["count"] == 1  # Only recent event
 
 
-def test_analytics_privacy_no_pii(client):
+def test_analytics_privacy_no_pii(client, admin_env):
     """Test that analytics events don't contain PII - only anonymous session_id."""
     event_data = {
         "events": [
@@ -430,7 +438,7 @@ def test_analytics_privacy_no_pii(client):
     # No email, no user details exposed
 
 
-def test_analytics_multiple_events_same_session(client):
+def test_analytics_multiple_events_same_session(client, admin_env):
     """Test that multiple events with same session_id are tracked correctly."""
     session_id = str(uuid4())
     events = {
@@ -461,3 +469,48 @@ def test_analytics_multiple_events_same_session(client):
     data = response.json()
     assert data["total_events"] == 3
     assert data["unique_sessions"] == 1  # All events from same session
+
+
+def test_analytics_summary_requires_admin(client):
+    """V6-1: summary endpoint requires admin access."""
+    # Default client has test@mint.ch but NO admin allowlist configured
+    response = client.get("/api/v1/analytics/summary")
+    assert response.status_code == 403
+    assert "Admin access required" in response.json()["detail"]
+
+
+def test_analytics_funnel_requires_admin(client):
+    """V6-1: funnel endpoint requires admin access."""
+    response = client.get("/api/v1/analytics/funnel?steps=landing_view")
+    assert response.status_code == 403
+    assert "Admin access required" in response.json()["detail"]
+
+
+def test_post_events_system_category(client):
+    """V6-1: system category is now accepted by backend."""
+    event_data = {
+        "events": [
+            {
+                "event_name": "analytics_consent_granted",
+                "event_category": "system",
+                "session_id": str(uuid4()),
+            }
+        ]
+    }
+    response = client.post("/api/v1/analytics/events", json=event_data)
+    assert response.status_code == 201
+
+
+def test_post_events_experiment_category(client):
+    """V6-1: experiment category is now accepted by backend."""
+    event_data = {
+        "events": [
+            {
+                "event_name": "experiment_exposed",
+                "event_category": "experiment",
+                "session_id": str(uuid4()),
+            }
+        ]
+    }
+    response = client.post("/api/v1/analytics/events", json=event_data)
+    assert response.status_code == 201

--- a/services/backend/tests/test_auth.py
+++ b/services/backend/tests/test_auth.py
@@ -882,7 +882,11 @@ def test_admin_onboarding_quality_returns_metrics(auth_client: TestClient):
             "event_data": "{\"time_spent_seconds\": 160}",
         },
     ]
-    ingest = auth_client.post("/api/v1/analytics/events", json={"events": events})
+    ingest = auth_client.post(
+        "/api/v1/analytics/events",
+        json={"events": events},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
     assert ingest.status_code == 201
 
     try:
@@ -952,7 +956,11 @@ def test_admin_onboarding_quality_cohorts_returns_breakdown(auth_client: TestCli
             "platform": "android",
         },
     ]
-    ingest = auth_client.post("/api/v1/analytics/events", json={"events": events})
+    ingest = auth_client.post(
+        "/api/v1/analytics/events",
+        json={"events": events},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
     assert ingest.status_code == 201
 
     try:


### PR DESCRIPTION
## V6 — 6 findings closed

### CRITIQUE
- **Analytics**: auth required on POST, admin gate on GET summary/funnel, field contract aligned
- **Subscriptions**: non-iOS upgrades require backend verification in release mode

### ÉLEVÉE
- **Consent mapping**: analytics→analytics, rag→ragQueries, added open_banking/document_upload
- **Account isolation**: logout + deleteAccount purge ALL local data

### MOYENNE
- **OpenFinanceService**: mock data capped at confidence 0.25

Tests: 8154 Flutter + 4443 Backend | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)