### PR TITLE
fix: V7 audit — notification routes, sync, state provider, 3a centralized, auth

### DIFF
--- a/apps/mobile/lib/providers/mint_state_provider.dart
+++ b/apps/mobile/lib/providers/mint_state_provider.dart
@@ -89,7 +89,6 @@ class MintStateProvider extends ChangeNotifier {
     }
 
     _isRecomputing = true;
-    _lastProfile = profile;
     try {
       final prefs = await SharedPreferences.getInstance();
       final newState = await MintStateEngine.compute(
@@ -97,6 +96,10 @@ class MintStateProvider extends ChangeNotifier {
         prefs: prefs,
       );
       _state = newState;
+      // Mark this profile as successfully computed AFTER state is set.
+      // If _doRecompute throws, _lastProfile stays at its previous value,
+      // so the next recompute(sameProfile) will retry instead of no-op.
+      _lastProfile = profile;
       // Pre-compute insight at profile-change time (Cleo 3.0 pattern).
       // Runs asynchronously after state is set — does not block notifyListeners.
       // Silent degradation: never throws, cache failure is non-fatal.
@@ -110,6 +113,7 @@ class MintStateProvider extends ChangeNotifier {
     } catch (_) {
       // Engine errors must not crash the app.
       // State remains at its previous value.
+      // _lastProfile is NOT set here — next call with same profile will retry.
     } finally {
       _isRecomputing = false;
       if (_pendingRecompute && _pendingProfile != null) {

--- a/apps/mobile/lib/services/cap_sequence_engine.dart
+++ b/apps/mobile/lib/services/cap_sequence_engine.dart
@@ -2,6 +2,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart' show S;
 import 'package:mint_mobile/models/cap_sequence.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 // ────────────────────────────────────────────────────────────────
 //  CAP SEQUENCE ENGINE
@@ -460,13 +461,17 @@ class CapSequenceEngine {
     return avoir * taux / 12;
   }
 
-  /// Annual 3a tax saving estimate (rough 25% marginal rate).
+  /// Annual 3a tax saving estimate using canton-aware marginal rate.
   static double? _estimate3aImpact(CoachProfile profile) {
     if (profile.salaireBrutMensuel <= 0) return null;
-    // Max 3a salarié LPP = 7'258 CHF/an (2025/2026)
-    const max3aAnnuelLocal = 7258.0;
-    // Conservative 25% TMI estimate → monthly impact = annual savings / 12
-    return (max3aAnnuelLocal * 0.25) / 12;
+    final grossAnnual = profile.salaireBrutMensuel * 12;
+    final canton = profile.canton.isNotEmpty ? profile.canton : 'ZH';
+    final annualSaving = RetirementTaxCalculator.estimate3aTaxSaving(
+      grossAnnualSalary: grossAnnual,
+      canton: canton,
+    );
+    // Monthly impact = annual savings / 12
+    return annualSaving / 12;
   }
 
   /// Rough LPP buyback monthly benefit (rachat × taux conversion / 12).

--- a/apps/mobile/lib/services/financial_core/tax_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/tax_calculator.dart
@@ -378,6 +378,28 @@ class RetirementTaxCalculator {
     return totallySaved;
   }
 
+  /// Estimate annual 3a tax saving using canton-aware marginal rate.
+  ///
+  /// Replaces hardcoded `7258 * 0.25` patterns. Uses the real marginal rate
+  /// for the user's income level, canton, and family situation.
+  ///
+  /// Legal basis: OPP3 art. 7 (plafond 3a), LIFD (impot federal).
+  static double estimate3aTaxSaving({
+    required double grossAnnualSalary,
+    required String canton,
+    bool isMarried = false,
+    int children = 0,
+  }) {
+    if (grossAnnualSalary <= 0) return 0;
+    final marginalRate = estimateMarginalRate(
+      grossAnnualSalary,
+      canton,
+      isMarried: isMarried,
+      children: children,
+    );
+    return pilier3aPlafondAvecLpp * marginalRate;
+  }
+
   /// Estimate retirement income tax (annual → monthly).
   ///
   /// CRITICAL: revenuAnnuelImposable must EXCLUDE capital SWR withdrawals.

--- a/apps/mobile/lib/widgets/pulse/focus_selector.dart
+++ b/apps/mobile/lib/widgets/pulse/focus_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 
@@ -343,9 +344,12 @@ class _FocusSelectorState extends State<FocusSelector> {
 
   String _taxApercu(CoachProfile p) {
     if (p.salaireBrutMensuel <= 0) return 'Économies potentielles';
-    // Rough 3a tax saving estimate
-    const marginalRate = 0.25; // ~25% average marginal rate
-    final saving3a = (7258 * marginalRate).round();
+    final grossAnnual = p.salaireBrutMensuel * 12;
+    final canton = p.canton.isNotEmpty ? p.canton : 'ZH';
+    final saving3a = RetirementTaxCalculator.estimate3aTaxSaving(
+      grossAnnualSalary: grossAnnual,
+      canton: canton,
+    ).round();
     return '~CHF $saving3a/an récupérables';
   }
 

--- a/services/backend/app/api/v1/endpoints/config.py
+++ b/services/backend/app/api/v1/endpoints/config.py
@@ -2,9 +2,11 @@
 Config endpoints -- feature flags (INV-10).
 """
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
+from app.core.auth import require_current_user
 from app.core.rate_limit import limiter
+from app.models.user import User
 from pydantic import BaseModel
 from app.services.feature_flags import FeatureFlags
 
@@ -22,7 +24,9 @@ class FeatureFlagsResponse(BaseModel):
 @router.get("/feature-flags", response_model=FeatureFlagsResponse)
 @limiter.limit("60/minute")
 def get_feature_flags(
-    request: Request) -> FeatureFlagsResponse:
+    request: Request,
+    _user: User = Depends(require_current_user),
+) -> FeatureFlagsResponse:
     flags = FeatureFlags.get_flags()
     return FeatureFlagsResponse(
         enableCouplePlusTier=flags["enable_couple_plus_tier"],

--- a/services/backend/app/api/v1/endpoints/rag.py
+++ b/services/backend/app/api/v1/endpoints/rag.py
@@ -259,11 +259,12 @@ async def rag_ingest(request: Request, body: RAGIngestRequest, _user: User = Dep
 
 
 @router.get("/status", response_model=RAGStatusResponse)
-async def rag_status():
+async def rag_status(_user: User = Depends(require_current_user)):
     """
     Check RAG system status.
 
     Returns vector store readiness, document count, and available collections.
+    Requires authentication to prevent reconnaissance of internal state.
     """
     try:
         vector_store = _get_vector_store()

--- a/services/backend/app/api/v1/endpoints/sync.py
+++ b/services/backend/app/api/v1/endpoints/sync.py
@@ -39,7 +39,10 @@ def claim_local_data(
     """
     One-shot migration of local mobile data to the authenticated user's cloud profile.
 
-    Idempotency strategy: upsert on latest profile for (user_id, device_id claim marker).
+    Merge policy: Last write wins, version-gated. Same or older version is a no-op.
+    If the existing profile already contains a localDataClaim whose localDataVersion
+    is >= the incoming version, we skip the overwrite and return the existing data.
+    This prevents stale replays from older devices or retry storms.
     """
     now = datetime.now(timezone.utc)
     existing_profile = (
@@ -48,6 +51,24 @@ def claim_local_data(
         .order_by(ProfileModel.updated_at.desc())
         .first()
     )
+
+    # --- Version-based idempotence gate ---
+    # If the profile already has a claim with a version >= the incoming one,
+    # return early (no-op) to prevent stale replays.
+    if existing_profile and existing_profile.data:
+        existing_claim = existing_profile.data.get("localDataClaim", {})
+        existing_meta = existing_claim.get("meta", {})
+        existing_version = existing_meta.get("localDataVersion", 0)
+        if existing_version >= body.local_data_version:
+            merged_fields_count = (
+                len(body.mini_onboarding) + len(body.wizard_answers)
+            )
+            return ClaimLocalDataResponse(
+                status="ok",
+                profile_id=existing_profile.id,
+                created_profile=False,
+                merged_fields_count=merged_fields_count,
+            )
 
     claim_blob = {
         "meta": {

--- a/services/backend/app/services/notifications/notification_scheduler_service.py
+++ b/services/backend/app/services/notifications/notification_scheduler_service.py
@@ -103,7 +103,7 @@ class NotificationSchedulerService:
                     f"Il reste {days_oct1} jours pour ton 3a. "
                     f"Economie estimee : CHF {chf_saving}."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 scheduled_date=oct1,
                 personal_number=f"CHF {chf_saving}",
                 time_reference=f"{days_oct1} jours",
@@ -122,7 +122,7 @@ class NotificationSchedulerService:
                     f"Il reste {days_nov1} jours. "
                     f"Economie estimee : CHF {chf_saving}."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 scheduled_date=nov1,
                 personal_number=f"CHF {chf_saving}",
                 time_reference=f"{days_nov1} jours",
@@ -142,7 +142,7 @@ class NotificationSchedulerService:
                     f"CHF {chf_saving} d\u2019economie en jeu. "
                     f"{days_dec1} jours restants."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 scheduled_date=dec1,
                 personal_number=f"CHF {chf_saving}",
                 time_reference=f"{days_dec1} jours",
@@ -161,7 +161,7 @@ class NotificationSchedulerService:
                     f"{days_dec20} jours. Dernier rappel 3a. "
                     f"CHF {chf_saving} d\u2019economie potentielle."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 scheduled_date=dec20,
                 personal_number=f"CHF {chf_saving}",
                 time_reference=f"{days_dec20} jours",
@@ -180,7 +180,7 @@ class NotificationSchedulerService:
                     f"Ton economie potentielle a change. "
                     f"Plafond 3a : CHF 7\u2019258."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 scheduled_date=jan5,
                 personal_number="CHF 7\u2019258",
                 time_reference=str(year + 1),
@@ -214,7 +214,7 @@ class NotificationSchedulerService:
                         f"Ton check-in mensuel est disponible. "
                         f"Mois de {month_names[month]} {year}."
                     ),
-                    deeplink="/check-in",
+                    deeplink="/coach/checkin",
                     scheduled_date=first_of_month,
                     personal_number=f"{month}/12",
                     time_reference=f"{month_names[month]} {year}",
@@ -264,7 +264,7 @@ class NotificationSchedulerService:
                         f"Depuis ton dernier check-in : "
                         f"{sign}{fri_delta:.1f} points sur ton score de solidite."
                     ),
-                    deeplink="/dashboard",
+                    deeplink="/home?tab=0",
                     scheduled_date=today,
                     personal_number=f"{sign}{fri_delta:.1f} points",
                     time_reference="dernier check-in",
@@ -280,7 +280,7 @@ class NotificationSchedulerService:
                         "Check-in termine. Ton score de solidite "
                         "est stable depuis le dernier check-in."
                     ),
-                    deeplink="/dashboard",
+                    deeplink="/home?tab=0",
                     scheduled_date=today,
                     personal_number="0 point",
                     time_reference="dernier check-in",
@@ -297,7 +297,7 @@ class NotificationSchedulerService:
                         "Ton profil a ete mis a jour. "
                         "Nouvelles projections disponibles des maintenant."
                     ),
-                    deeplink="/dashboard",
+                    deeplink="/home?tab=0",
                     scheduled_date=today,
                     personal_number="1 mise a jour",
                     time_reference="maintenant",
@@ -314,7 +314,7 @@ class NotificationSchedulerService:
                         f"Ta solidite a progresse de {fri_delta:.1f} points "
                         f"depuis la derniere evaluation."
                     ),
-                    deeplink="/dashboard",
+                    deeplink="/home?tab=0",
                     scheduled_date=today,
                     personal_number=f"+{fri_delta:.1f} points",
                     time_reference="derniere evaluation",

--- a/services/backend/app/services/reengagement/reengagement_engine.py
+++ b/services/backend/app/services/reengagement/reengagement_engine.py
@@ -114,7 +114,7 @@ class ReengagementEngine:
                     f"Nouveaux plafonds 3a: CHF {plafond_3a_str}. "
                     f"Ton economie potentielle : CHF {saving_str}."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 personal_number=f"CHF {saving_str}",
                 time_constraint="Annee fiscale 2026",
                 month=1,
@@ -160,7 +160,7 @@ class ReengagementEngine:
                     f"Il reste {days_left} jours pour verser ton 3a. "
                     f"Economie estimee : CHF {saving_str}."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 personal_number=f"CHF {saving_str}",
                 time_constraint=f"{days_left} jours restants",
                 month=10,
@@ -175,7 +175,7 @@ class ReengagementEngine:
                     f"Il reste {days_left} jours. "
                     f"Economie estimee : CHF {saving_str}."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 personal_number=f"CHF {saving_str}",
                 time_constraint=f"{days_left} jours restants",
                 month=11,
@@ -190,7 +190,7 @@ class ReengagementEngine:
                     f"Dernier mois. "
                     f"CHF {saving_str} d'economie en jeu."
                 ),
-                deeplink="/3a",
+                deeplink="/pilier-3a",
                 personal_number=f"CHF {saving_str}",
                 time_constraint="Dernier mois",
                 month=12,
@@ -208,7 +208,7 @@ class ReengagementEngine:
                     f"Ton score de solidite: {fri_str} "
                     f"({delta_str} ce trimestre)."
                 ),
-                deeplink="/dashboard",
+                deeplink="/home?tab=0",
                 personal_number=f"{fri_str}/100",
                 time_constraint="Bilan trimestriel",
                 month=month,

--- a/services/backend/tests/test_notifications.py
+++ b/services/backend/tests/test_notifications.py
@@ -81,7 +81,7 @@ class TestCalendarNotifications:
         n = oct_notifs[0]
         assert "jours" in n.body
         assert "1\u2019820" in n.body
-        assert n.deeplink == "/3a"
+        assert n.deeplink == "/pilier-3a"
         assert n.tier == NotificationTier.calendar
 
     def test_3a_dec20_last_reminder(self):
@@ -213,7 +213,7 @@ class TestEventNotifications:
         assert len(result) >= 1
         assert "profil" in result[0].body.lower()
         assert "projections" in result[0].body.lower()
-        assert result[0].deeplink == "/dashboard"
+        assert result[0].deeplink == "/home?tab=0"
 
     def test_fri_improvement_without_check_in(self):
         """FRI improvement without check-in should generate a separate notification."""


### PR DESCRIPTION
## V7 — 6 findings closed

### CRITIQUE
- **Notification routes**: backend aligned to mobile GoRouter canonical paths

### ÉLEVÉE
- **Sync idempotence**: version-gated, older versions rejected
- **State provider**: _lastProfile set AFTER successful compute (no stale on error)
- **3a tax**: centralized estimate3aTaxSaving() replaces hardcoded 7258*25%

### MOYENNE
- **/rag/status + /config/feature-flags**: auth required

Tests: 8154 Flutter + 4443 Backend | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)