### PR TITLE
fix: V8 business truth — AVS21 gender, 13e breakeven, 3a 59-70, lifecycle unified

### DIFF
--- a/apps/mobile/lib/constants/social_insurance.dart
+++ b/apps/mobile/lib/constants/social_insurance.dart
@@ -105,6 +105,24 @@ const int avsAgeReferenceHomme = 65;
 /// Age de reference AVS femmes (depuis reforme AVS 21).
 const int avsAgeReferenceFemme = 65;
 
+/// AVS21 reference age by gender and birth year (LAVS art. 21 al. 1).
+///
+/// Women born 1961-1963 have transitional reference ages:
+/// - Born 1960 or earlier: 64 (pre-AVS21)
+/// - Born 1961: 64 years 3 months (simplified to 64 for annual calc)
+/// - Born 1962: 64 years 6 months (simplified to 64 for annual calc)
+/// - Born 1963: 64 years 9 months (simplified to 65 for annual calc)
+/// - Born 1964+: 65 (full AVS21 alignment)
+/// Men: 65 (unchanged).
+int avsReferenceAge({required int birthYear, required bool isFemale}) {
+  if (!isFemale) return avsAgeReferenceHomme; // 65
+  if (birthYear <= 1960) return 64;
+  if (birthYear == 1961) return 64; // +3 months (simplified to 64)
+  if (birthYear == 1962) return 64; // +6 months (simplified to 64)
+  if (birthYear == 1963) return 65; // +9 months (simplified to 65)
+  return avsAgeReferenceFemme; // 65
+}
+
 /// Reduction par annee d'anticipation de la rente AVS: 6.8%.
 const double avsReductionAnticipation = 0.068;
 

--- a/apps/mobile/lib/models/age_band_policy.dart
+++ b/apps/mobile/lib/models/age_band_policy.dart
@@ -38,6 +38,11 @@ enum LifeEventType {
   debtCrisis,
 }
 
+/// Age-based data-collection policy.
+///
+/// Canonical rule (unified across all classifiers):
+/// Retirement = avsAgeReferenceHomme (65). Pre-retirement = 5 years before.
+/// See also: LifecycleDetector, LifecyclePhaseService.
 class AgeBandPolicy {
   final AgeBand band;
   final String label;

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -1136,6 +1136,11 @@ class CoachProfile {
   /// Used by CoachingService for life event nudges.
   final String? familyChange;
 
+  /// Gender: 'M', 'F', or null (unknown).
+  /// Used for AVS21 transitional reference age calculation.
+  /// Women born 1961-1963 have transitional ages (LAVS art. 21 al. 1).
+  final String? gender;
+
   /// Target retirement age chosen by the user (58-70).
   /// Null means default (65 ans, age legal AVS).
   /// LAVS art. 40: anticipation possible des 63 ans.
@@ -1200,6 +1205,7 @@ class CoachProfile {
     this.arrivalAge,
     this.residencePermit,
     this.familyChange,
+    this.gender,
     this.targetRetirementAge,
     this.initialProjectionSnapshot,
     Map<String, ProfileDataSource> dataSources = const {},
@@ -1494,6 +1500,7 @@ class CoachProfile {
     int? arrivalAge,
     String? residencePermit,
     String? familyChange,
+    String? gender,
     int? targetRetirementAge,
     Map<String, dynamic>? initialProjectionSnapshot,
     Map<String, ProfileDataSource>? dataSources,
@@ -1532,6 +1539,7 @@ class CoachProfile {
       arrivalAge: arrivalAge ?? this.arrivalAge,
       residencePermit: residencePermit ?? this.residencePermit,
       familyChange: familyChange ?? this.familyChange,
+      gender: gender ?? this.gender,
       targetRetirementAge: targetRetirementAge ?? this.targetRetirementAge,
       initialProjectionSnapshot:
           initialProjectionSnapshot ?? this.initialProjectionSnapshot,
@@ -1715,6 +1723,7 @@ class CoachProfile {
       arrivalAge: json['arrivalAge'] as int?,
       residencePermit: json['residencePermit'] as String?,
       familyChange: json['familyChange'] as String?,
+      gender: json['gender'] as String?,
       targetRetirementAge: json['targetRetirementAge'] as int?,
       initialProjectionSnapshot:
           json['initialProjectionSnapshot'] as Map<String, dynamic>?,
@@ -1774,6 +1783,7 @@ class CoachProfile {
         'arrivalAge': arrivalAge,
         'residencePermit': residencePermit,
         'familyChange': familyChange,
+        'gender': gender,
         'targetRetirementAge': targetRetirementAge,
         'initialProjectionSnapshot': initialProjectionSnapshot,
         'dataSources': dataSources.map((k, v) => MapEntry(k, v.name)),

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -67,9 +67,10 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
         }
         final targetAge = profile.targetRetirementAge ?? avsAgeReferenceHomme;
         // Withdrawal typically starts 5 years before retirement
-        final computedDebut = (targetAge - 5).clamp(60, avsAgeReferenceHomme);
+        // 3a withdrawal: 59-70 (OPP3 art. 3 al. 1 + deferral).
+        final computedDebut = (targetAge - 5).clamp(59, 70);
         _ageRetraitDebut = computedDebut;
-        _ageRetraitFin = targetAge.clamp(computedDebut, avsAgeReferenceHomme);
+        _ageRetraitFin = targetAge.clamp(computedDebut, 70);
       });
     } catch (_) {
       // Provider not in tree (tests) — keep defaults
@@ -254,10 +255,10 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
           MintEntrance(delay: const Duration(milliseconds: 400), child: _buildSliderRow(label: l.staggered3aRevenuImposable, value: _revenuImposable, min: 30000, max: 300000, divisions: 54, format: 'CHF ${formatChf(_revenuImposable)}', onChanged: (v) => setState(() => _revenuImposable = v))),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          _buildSliderRow(label: l.staggered3aAgeDebut, value: _ageRetraitDebut.toDouble(), min: 60, max: 65, divisions: 5, format: '$_ageRetraitDebut ${l.staggered3aAns}', onChanged: (v) { setState(() { _ageRetraitDebut = v.round(); if (_ageRetraitFin < _ageRetraitDebut) _ageRetraitFin = _ageRetraitDebut; }); _emitScreenReturn(); }),
+          _buildSliderRow(label: l.staggered3aAgeDebut, value: _ageRetraitDebut.toDouble(), min: 59, max: 70, divisions: 11, format: '$_ageRetraitDebut ${l.staggered3aAns}', onChanged: (v) { setState(() { _ageRetraitDebut = v.round(); if (_ageRetraitFin < _ageRetraitDebut) _ageRetraitFin = _ageRetraitDebut; }); _emitScreenReturn(); }),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          _buildSliderRow(label: l.staggered3aAgeFin, value: _ageRetraitFin.toDouble(), min: _ageRetraitDebut.toDouble(), max: 65, divisions: (65 - _ageRetraitDebut).clamp(1, 6), format: '$_ageRetraitFin ${l.staggered3aAns}', onChanged: (v) { setState(() => _ageRetraitFin = v.round()); _emitScreenReturn(); }),
+          _buildSliderRow(label: l.staggered3aAgeFin, value: _ageRetraitFin.toDouble(), min: _ageRetraitDebut.toDouble(), max: 70, divisions: (70 - _ageRetraitDebut).clamp(1, 11), format: '$_ageRetraitFin ${l.staggered3aAns}', onChanged: (v) { setState(() => _ageRetraitFin = v.round()); _emitScreenReturn(); }),
         ],
       ),
     );

--- a/apps/mobile/lib/services/educational_insert_service.dart
+++ b/apps/mobile/lib/services/educational_insert_service.dart
@@ -306,7 +306,7 @@ class EducationalInsertService {
             'Les retraits de la même année sont additionnés pour le calcul du taux (impôt progressif).',
             'La stratégie d\'échelonnement : ouvrir 4-5 comptes dès le départ et les retirer sur 4-5 années différentes (à partir de 59/60 ans).',
             'Les retraits 3a et LPP en capital de la même année se cumulent pour l\'imposition.',
-            'L\'âge de retrait anticipé est 59 ans (femmes) / 60 ans (hommes) sans condition (OPP3 art. 3 al. 1).',
+            'L\'âge de retrait anticipé est 5 ans avant l\'âge de référence AVS\u00a0: 60 ans (hommes), 59 ans (femmes nées avant 1964) ou 60 ans (femmes nées dès 1964) — OPP3 art. 3 al. 1.',
           ],
           disclaimer:
               'Information à caractère éducatif. L\'économie d\'impôt dépend du canton '

--- a/apps/mobile/lib/services/financial_core/avs_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/avs_calculator.dart
@@ -18,6 +18,11 @@ class AvsCalculator {
   /// - Income level via RAMD proxy — LAVS art. 34, echelle 44
   /// - Early retirement penalty (6.8%/yr from 63) — LAVS art. 40
   /// - Deferral bonus (up to +31.5% at 70) — LAVS art. 39
+  /// - Gender-aware reference age for AVS21 (LAVS art. 21 al. 1)
+  ///
+  /// [isFemale] and [birthYear] are optional — when provided, the
+  /// reference age accounts for AVS21 transitional cohorts (women
+  /// born 1961-1963). When omitted, defaults to 65 (male/unknown).
   static double computeMonthlyRente({
     required int currentAge,
     required int retirementAge,
@@ -25,7 +30,14 @@ class AvsCalculator {
     int? anneesContribuees,
     int? arrivalAge,
     double grossAnnualSalary = 0,
+    bool? isFemale,
+    int? birthYear,
   }) {
+    // Determine gender-aware reference age (AVS21, LAVS art. 21 al. 1)
+    final refAge = (isFemale != null && birthYear != null)
+        ? avsReferenceAge(birthYear: birthYear, isFemale: isFemale)
+        : avsAgeReferenceHomme;
+
     // 1. Contribution years
     int currentYears;
     if (anneesContribuees != null) {
@@ -48,15 +60,15 @@ class AvsCalculator {
     final baseRente = renteFromRAMD(grossAnnualSalary);
     double rente = baseRente * gapFactor;
 
-    // 3. Early/late retirement adjustments
+    // 3. Early/late retirement adjustments relative to gender-aware refAge
     if (retirementAge < 63) {
       // AVS anticipation only possible from 63 (LAVS art. 40)
       return 0.0;
-    } else if (retirementAge < avsAgeReferenceHomme) {
-      final yearsEarly = avsAgeReferenceHomme - retirementAge;
+    } else if (retirementAge < refAge) {
+      final yearsEarly = refAge - retirementAge;
       rente *= (1.0 - avsReductionAnticipation * yearsEarly);
-    } else if (retirementAge > avsAgeReferenceHomme) {
-      final yearsLate = (retirementAge - avsAgeReferenceHomme).clamp(1, 5);
+    } else if (retirementAge > refAge) {
+      final yearsLate = (retirementAge - refAge).clamp(1, 5);
       final bonus = avsDeferralBonus[yearsLate] ?? avsDeferralBonus[5]!;
       rente *= (1.0 + bonus);
     }

--- a/apps/mobile/lib/services/lifecycle/lifecycle_detector.dart
+++ b/apps/mobile/lib/services/lifecycle/lifecycle_detector.dart
@@ -98,21 +98,22 @@ class LifecycleDetector {
 
   /// Core age-to-phase mapping.
   ///
-  /// Boundaries:
+  /// Canonical rule (unified across all classifiers):
+  /// - Retirement = avsAgeReferenceHomme (65). Pre-retirement = 5 years before (60).
   /// - < 25  → demarrage
   /// - 25-34 → construction
   /// - 35-44 → acceleration
   /// - 45-54 → consolidation
-  /// - 55-60 → transition (pre-retirement countdown)
-  /// - 61-67 → retraite
-  /// - > 67  → transmission
+  /// - 55-64 → transition (pre-retirement: starts ~5 years before ref age)
+  /// - 65-74 → retraite (starts at avsAgeReferenceHomme)
+  /// - 75+   → transmission
   static LifecyclePhase _phaseFromAge(int age) {
     if (age < 25) return LifecyclePhase.demarrage;
     if (age < 35) return LifecyclePhase.construction;
     if (age < 45) return LifecyclePhase.acceleration;
     if (age < 55) return LifecyclePhase.consolidation;
-    if (age <= 60) return LifecyclePhase.transition;
-    if (age <= 67) return LifecyclePhase.retraite;
+    if (age < avsAgeReferenceHomme) return LifecyclePhase.transition;
+    if (age < 75) return LifecyclePhase.retraite;
     return LifecyclePhase.transmission;
   }
 }

--- a/apps/mobile/lib/services/lifecycle_phase_service.dart
+++ b/apps/mobile/lib/services/lifecycle_phase_service.dart
@@ -142,6 +142,9 @@ class LifecyclePhaseService {
 
   /// Core phase detection — age-based with situation overrides.
   ///
+  /// Canonical rule (unified across all classifiers):
+  /// Retirement = avsAgeReferenceHomme (65). Pre-retirement = 5 years before.
+  ///
   /// Age bands overlap at boundaries; situation signals disambiguate:
   /// - Already retired (employmentStatus) → retraite/transmission
   /// - Target retirement < standard age → may shift to transition earlier

--- a/apps/mobile/lib/services/pillar_3a_deep_service.dart
+++ b/apps/mobile/lib/services/pillar_3a_deep_service.dart
@@ -98,8 +98,10 @@ class StaggeredWithdrawalSimulator {
     // Clamp inputs
     final clampedComptes = nbComptes.clamp(1, 5);
     final clampedAvoir = avoirTotal.clamp(0.0, 1000000.0);
-    final clampedDebut = ageRetraitDebut.clamp(59, avsAgeReferenceHomme);
-    final clampedFin = ageRetraitFin.clamp(clampedDebut, avsAgeReferenceHomme);
+    // 3a withdrawal allowed from 59 (women pre-1964) up to 70 (deferral).
+    // Backend allows 59-70; mobile must match (OPP3 art. 3 al. 1).
+    final clampedDebut = ageRetraitDebut.clamp(59, 70);
+    final clampedFin = ageRetraitFin.clamp(clampedDebut, 70);
 
     final tauxBase = tauxImpotRetraitCapital[canton.toUpperCase()] ?? 0.065;
 

--- a/apps/mobile/test/services/lifecycle/lifecycle_detector_test.dart
+++ b/apps/mobile/test/services/lifecycle/lifecycle_detector_test.dart
@@ -169,16 +169,16 @@ void main() {
       expect(LifecycleDetector.detect(profile, now: now), LifecyclePhase.transition);
     });
 
-    // age 67 → retraite (upper boundary)
-    test('age 67 → retraite (boundary)', () {
+    // age 67 → retraite (well within retraite band 65-74)
+    test('age 67 → retraite', () {
       final profile = makeProfile(birthYear: 1959);
       expect(LifecycleDetector.detect(profile, now: now), LifecyclePhase.retraite);
     });
 
-    // age 68 → transmission (just past retraite boundary)
-    test('age 68 → transmission (just past retraite)', () {
+    // age 68 → retraite (retraite band = 65-74, unified with LifecyclePhaseService)
+    test('age 68 → retraite (within 65-74 band)', () {
       final profile = makeProfile(birthYear: 1958);
-      expect(LifecycleDetector.detect(profile, now: now), LifecyclePhase.transmission);
+      expect(LifecycleDetector.detect(profile, now: now), LifecyclePhase.retraite);
     });
   });
 

--- a/services/backend/app/schemas/profile.py
+++ b/services/backend/app/schemas/profile.py
@@ -41,6 +41,9 @@ class ProfileBase(BaseModel):
     hasVoluntaryLpp: Optional[bool] = None
     primaryActivity: Optional[str] = None
 
+    # ⭐ Genre (AVS21 transitional reference ages — LAVS art. 21 al. 1)
+    gender: Optional[str] = None  # 'M', 'F', or None (unknown)
+
     # ⭐ Nouveaux champs pour AVS
     hasAvsGaps: Optional[bool] = None
     avsContributionYears: Optional[int] = None
@@ -71,6 +74,7 @@ class ProfileUpdate(BaseModel):
     factfindCompletionIndex: Optional[float] = None
 
     # ⭐ Nouveaux champs
+    gender: Optional[str] = None
     employmentStatus: Optional[str] = None
     has2ndPillar: Optional[bool] = None
     legalForm: Optional[str] = None

--- a/services/backend/app/services/educational_content_service.py
+++ b/services/backend/app/services/educational_content_service.py
@@ -447,7 +447,7 @@ _register(InsertContent(
         "Savoir que les retraits de la meme annee sont additionnes pour le calcul du taux.",
         "Decouvrir la strategie d'echelonnement : ouvrir 4-5 comptes et les retirer sur 4-5 annees differentes.",
         "Comprendre que les retraits 3a et LPP en capital de la meme annee se cumulent pour l'imposition.",
-        "Savoir que l'age de retrait anticipe est 59 ans (femmes) / 60 ans (hommes) sans condition (OPP3 art. 3 al. 1).",
+        "Savoir que l'age de retrait anticipe est 5 ans avant l'age de reference AVS : 60 ans (hommes), 59 ans (femmes nees avant 1964) ou 60 ans (femmes nees des 1964) — OPP3 art. 3 al. 1.",
     ],
     disclaimer=DISCLAIMER,
     sources=[

--- a/services/backend/app/services/family/mariage_service.py
+++ b/services/backend/app/services/family/mariage_service.py
@@ -312,27 +312,32 @@ class MariageService:
             sources = ["CC art. 221 (communaute de biens)"]
 
         else:  # participation_acquets (defaut)
-            # Simplification : on considere tout le patrimoine comme acquets
-            # (biens propres = 0, ce qui est le cas le plus courant)
-            acquets_1 = patrimoine_1
-            acquets_2 = patrimoine_2
-            total_acquets = acquets_1 + acquets_2
-            part_1 = patrimoine_1 + (acquets_2 - acquets_1) / 2 if total_acquets > 0 else patrimoine_1
-            part_2 = patrimoine_2 + (acquets_1 - acquets_2) / 2 if total_acquets > 0 else patrimoine_2
-            # Simplification : 50/50 des acquets totaux
+            # Simplification: assumes all patrimoine is acquêts (gains during
+            # marriage). True "biens propres" (pre-marriage assets + inheritances
+            # + donations, CC art. 198) distinction requires pre-marriage asset
+            # data not available in current profile. The 50/50 split on total
+            # patrimoine is therefore a worst-case educational scenario.
+            # CC art. 196-220 (participation aux acquêts).
             part_1 = total / 2
             part_2 = total / 2
             description = (
-                "Participation aux acquets (CC art. 181) : regime ordinaire par "
-                "defaut. Chacun garde ses biens propres (herites, apportes). "
-                "Les acquets (biens acquis pendant le mariage) sont partages 50/50."
+                "Participation aux acquets (CC art. 196-220) : regime ordinaire par "
+                "defaut. En theorie, chacun garde ses biens propres (herites, recus par "
+                "donation, apportes avant le mariage — CC art. 198) et seuls les acquets "
+                "(biens acquis pendant le mariage) sont partages 50/50."
             )
             explication = (
-                f"Acquets totaux estimes CHF {total:,.0f} divises en 2 = "
+                f"Simplification: MINT ne dispose pas de la repartition biens propres/acquets. "
+                f"L'estimation considere la totalite du patrimoine "
+                f"(CHF {total:,.0f}) comme acquets et le divise en 2 = "
                 f"CHF {part_1:,.0f} chacun. "
-                f"Note: les biens propres (heritage, biens d'avant mariage) ne sont pas partages."
+                f"Si tu possedes des biens propres (heritage, biens d'avant mariage), "
+                f"ta part reelle serait plus elevee."
             )
-            sources = ["CC art. 181 (participation aux acquets — regime ordinaire)"]
+            sources = [
+                "CC art. 196-220 (participation aux acquets — regime ordinaire)",
+                "CC art. 198 (definition des biens propres)",
+            ]
 
         return RegimeMatrimonial(
             regime=regime,

--- a/services/backend/app/services/rag/faq_service.py
+++ b/services/backend/app/services/rag/faq_service.py
@@ -254,7 +254,7 @@ _FAQ_DATA: list[FaqEntry] = [
         question="Quand puis-je retirer mon pilier 3a?",
         answer=(
             "Le pilier 3a peut être retiré dans les cas suivants (OPP3 art. 3): "
-            "- 5 ans avant l'âge de retraite AVS (dès 60 ans pour les hommes, 60 ans pour les femmes) "
+            "- 5 ans avant l'âge de référence AVS (dès 60 ans pour les hommes ; 59 ans pour les femmes nées avant 1964, 60 ans dès 1964) "
             "- Achat d'un logement principal (EPL) "
             "- Début d'une activité indépendante "
             "- Départ définitif de Suisse (si hors UE/AELE) "

--- a/services/backend/app/services/retirement/avs_estimation_service.py
+++ b/services/backend/app/services/retirement/avs_estimation_service.py
@@ -221,6 +221,9 @@ class AvsEstimationService:
 
         normal_rente_mensuelle = AVS_RENTE_MAX_MENSUELLE * gap_factor
 
+        # Annual rente uses 13 payments (13e rente) when active, not 12.
+        nb_rentes = AVS_NOMBRE_RENTES_PAR_AN if AVS_13EME_RENTE_ACTIVE else 12
+
         # Compare cumulative amounts year by year
         cumul_scenario = 0.0
         cumul_normal = 0.0
@@ -228,9 +231,9 @@ class AvsEstimationService:
 
         for age in range(start_age, life_expectancy + 1):
             if age >= retirement_age:
-                cumul_scenario += rente_mensuelle * 12
+                cumul_scenario += rente_mensuelle * nb_rentes
             if age >= AVS_RETIREMENT_AGE:
-                cumul_normal += normal_rente_mensuelle * 12
+                cumul_normal += normal_rente_mensuelle * nb_rentes
 
             if scenario == "ajournement" and cumul_scenario > cumul_normal and cumul_normal > 0:
                 return age
@@ -241,9 +244,9 @@ class AvsEstimationService:
             cumul_normal = 0.0
             for age in range(start_age, life_expectancy + 1):
                 if age >= retirement_age:
-                    cumul_scenario += rente_mensuelle * 12
+                    cumul_scenario += rente_mensuelle * nb_rentes
                 if age >= AVS_RETIREMENT_AGE:
-                    cumul_normal += normal_rente_mensuelle * 12
+                    cumul_normal += normal_rente_mensuelle * nb_rentes
                 if cumul_normal > cumul_scenario and cumul_scenario > 0:
                     return age
 


### PR DESCRIPTION
## V8 — Business truth unification (6 findings)

### CRITIQUE
- **AVS21 gender**: `gender` field added to CoachProfile + backend Profile. `avsReferenceAge()` handles women born 1961-1963 transitional cohorts (LAVS art. 21 al. 1)

### ÉLEVÉE
- **13e rente breakeven**: backend `_calculate_breakeven()` now uses 13 months (was 12)
- **3a withdrawal**: slider range 59-70 (was 60-65), aligned with backend 59-70
- **Educational content**: 3a age text corrected across FAQ, educational service, and insert service
- **Lifecycle unified**: all 3 classifiers use same boundaries (55-64 transition, 65+ retraite)

### MOYENNE
- **Mariage**: removed false biens propres claim, honest CC art. 196-220 simplification

Tests: 8154 Flutter + 4463 Backend | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)