### PR TITLE
fix: V10 financial engines — mortgage LPP, unemployment 520, amortization, 3a constant

### DIFF
--- a/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
@@ -867,8 +867,8 @@ class ArbitrageEngine {
   /// Compare renting + investing surplus vs buying property.
   ///
   /// Option A: Rent, invest the down payment at market return.
-  /// Option B: Buy with 80% mortgage, 1% amortization/year,
-  ///   1% maintenance/year, valeur locative taxable.
+  /// Option B: Buy with 80% mortgage, amortize 2nd rank (80->65% LTV)
+  ///   over 15 years, 1% maintenance/year, valeur locative taxable.
   ///
   /// Legal basis: FINMA affordability (5% theoretical rate),
   ///   LIFD art. 21 (valeur locative), LIFD art. 33 (interest deduction).
@@ -897,6 +897,11 @@ class ArbitrageEngine {
     double hypotheque = prixBien - fondsPropres;
     double valeurBien = prixBien;
 
+    // 2nd rank: from 80% LTV to 65% LTV over max 15 years
+    final seuil1erRang = prixBien * 0.65;
+    final deuxiemeRang = math.max(0.0, hypotheque - seuil1erRang);
+    final amortAnnuel2ndRank = deuxiemeRang > 0 ? deuxiemeRang / 15 : 0.0;
+
     // First pass: compute annual proprio costs to get the cashflow delta
     final annualProprioCharges = <double>[];
     double tempHyp = hypotheque;
@@ -908,7 +913,8 @@ class ArbitrageEngine {
       }
       tempVal *= (1 + appreciationImmo);
       final interets = tempHyp * tauxHypotheque;
-      final amortissement = prixBien * 0.01;
+      // Amortization: 2nd rank only, stops when mortgage reaches 1st rank level
+      final amortissement = tempHyp > seuil1erRang ? amortAnnuel2ndRank : 0.0;
       final entretien = prixBien * tauxEntretien;
       final tauxVL = HousingCostCalculator.getValeurLocativeRate(canton);
       final valeurLocative = tempVal * tauxVL;
@@ -922,7 +928,7 @@ class ArbitrageEngine {
               12
           : 0.0;
       annualProprioCharges.add(interets + amortissement + entretien + taxImpact);
-      tempHyp = math.max(0, tempHyp - amortissement);
+      tempHyp = math.max(seuil1erRang, tempHyp - amortissement);
     }
 
     // ── Option A: Rent + Invest ──
@@ -975,8 +981,9 @@ class ArbitrageEngine {
         continue;
       }
       valeurBien *= (1 + appreciationImmo);
-      final amortissement = prixBien * 0.01;
-      hypotheque = math.max(0, hypotheque - amortissement);
+      // Amortization: 2nd rank only, stops when mortgage reaches 1st rank level
+      final amortissement = hypotheque > seuil1erRang ? amortAnnuel2ndRank : 0.0;
+      hypotheque = math.max(seuil1erRang, hypotheque - amortissement);
 
       buySnapshots.add(YearlySnapshot(
         year: startYear + y,

--- a/apps/mobile/lib/services/first_job_service.dart
+++ b/apps/mobile/lib/services/first_job_service.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FIRST JOB SERVICE — Sprint S19 / Chomage (LACI) + Premier emploi
@@ -210,8 +211,11 @@ class FirstJobService {
         ),
     ];
 
-    // 3a recommendation
-    const economie3a = pilier3aPlafondAvecLpp * 0.25; // ~25% marginal tax estimate
+    // 3a recommendation — canton-aware marginal rate
+    final economie3a = RetirementTaxCalculator.estimate3aTaxSaving(
+      grossAnnualSalary: annuel,
+      canton: canton,
+    );
 
     // LAMal franchise comparison
     final franchiseData = _calculateFranchiseOptions(age, canton);

--- a/apps/mobile/lib/services/unemployment_service.dart
+++ b/apps/mobile/lib/services/unemployment_service.dart
@@ -188,11 +188,13 @@ class UnemploymentService {
   }
 
   /// Calculate the number of daily indemnities based on age and contributions.
+  ///
+  /// SECO rules: 55+ with >= 22 months = senior = 520 days (LACI art. 27 al. 2).
+  /// Uses centralized constants from social_insurance.dart.
   static int _calculateDuration(int age, int moisCotisation) {
-    if (age >= 60 && moisCotisation >= 22) return 520;
-    if (age >= 55 && moisCotisation >= 22) return 400;
-    if (age >= 25 && moisCotisation >= 18) return 260;
-    if (moisCotisation >= 12) return 200;
+    if (age >= acAgeSeuillSenior && moisCotisation >= 22) return acJoursSenior; // 55+ = 520
+    if (age >= 25 && moisCotisation >= 18) return acJoursIntermediaireCotisation; // 260
+    if (moisCotisation >= 12) return acJoursMinCotisation; // 200
     return 0;
   }
 

--- a/apps/mobile/test/services/first_job_service_test.dart
+++ b/apps/mobile/test/services/first_job_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/services/first_job_service.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 
 /// Unit tests for FirstJobService
@@ -285,14 +286,22 @@ void main() {
       expect(result.montantMensuelSuggere3a, closeTo(7258.0 / 12, 0.01));
     });
 
-    test('estimated tax saving is ~25% of 3a max', () {
+    test('estimated tax saving uses canton-aware marginal rate', () {
       final result = FirstJobService.analyzeSalary(
         salaireBrutMensuel: 6000,
         age: 25,
         canton: 'ZH',
       );
 
-      expect(result.economieFiscaleEstimee3a, closeTo(7258.0 * 0.25, 0.01));
+      // Should match RetirementTaxCalculator.estimate3aTaxSaving
+      final expected = RetirementTaxCalculator.estimate3aTaxSaving(
+        grossAnnualSalary: 6000 * 12,
+        canton: 'ZH',
+      );
+      expect(result.economieFiscaleEstimee3a, closeTo(expected, 0.01));
+      // Reasonable range: 10-40% of 3a max (varies by canton + income)
+      expect(result.economieFiscaleEstimee3a, greaterThan(pilier3aPlafondAvecLpp * 0.10));
+      expect(result.economieFiscaleEstimee3a, lessThan(pilier3aPlafondAvecLpp * 0.40));
     });
 
     test('3a alerte warns against insurance-linked 3a', () {

--- a/apps/mobile/test/services/unemployment_service_test.dart
+++ b/apps/mobile/test/services/unemployment_service_test.dart
@@ -217,14 +217,15 @@ void main() {
       expect(result.nombreIndemnites, 520);
     });
 
-    test('age >= 55, cotisation >= 22 mois => 400 indemnites', () {
+    test('age >= 55, cotisation >= 22 mois => 520 indemnites (SECO senior)', () {
+      // SECO rules: 55+ = senior = 520 days (LACI art. 27 al. 2)
       final result = UnemploymentService.calculateBenefits(
         gainAssureMensuel: 6000,
         age: 55,
         moisCotisation: 22,
       );
 
-      expect(result.nombreIndemnites, 400);
+      expect(result.nombreIndemnites, 520);
     });
 
     test('age >= 25, cotisation >= 18 mois => 260 indemnites', () {
@@ -257,8 +258,8 @@ void main() {
       expect(result.dureeMois, closeTo(260 / 21.75, 0.01));
     });
 
-    test('age 55 avec seulement 18 mois cotisation => 260 (pas 400)', () {
-      // 55+ needs >= 22 mois for 400, with only 18 falls to age>=25 bracket
+    test('age 55 avec seulement 18 mois cotisation => 260 (pas 520)', () {
+      // 55+ needs >= 22 mois for senior 520, with only 18 falls to age>=25 bracket
       final result = UnemploymentService.calculateBenefits(
         gainAssureMensuel: 6000,
         age: 55,

--- a/services/backend/app/api/v1/endpoints/scenarios.py
+++ b/services/backend/app/api/v1/endpoints/scenarios.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Request
 from app.core.rate_limit import limiter
 from pydantic import UUID4
 from app.schemas.scenario import Scenario, ScenarioCreate, ScenarioKind
+from app.constants.social_insurance import PILIER_3A_PLAFOND_AVEC_LPP
 from app.services.rules_engine import (
     calculate_compound_interest,
     calculate_leasing_opportunity_cost,
@@ -41,7 +42,7 @@ def _compute_scenario_outputs(kind: ScenarioKind, inputs: dict) -> dict:
         )
     elif kind == ScenarioKind.pillar3a:
         return calculate_pillar3a_tax_benefit(
-            annual_contribution=inputs.get("annualContribution", 7056),
+            annual_contribution=inputs.get("annualContribution", PILIER_3A_PLAFOND_AVEC_LPP),
             marginal_tax_rate=inputs.get("marginalTaxRate", 0.25),
             years=inputs.get("years", 30),
             annual_return=inputs.get("annualReturn", 4.0),

--- a/services/backend/app/services/arbitrage/location_vs_propriete.py
+++ b/services/backend/app/services/arbitrage/location_vs_propriete.py
@@ -169,14 +169,20 @@ def _build_propriete_option(
     cumulative_costs = 0.0
     cumulative_tax_savings = 0.0
 
+    # 2nd rank: from 80% LTV to 65% LTV over max 15 years
+    seuil_premier_rang = prix_bien * 0.65
+    deuxieme_rang = max(0.0, mortgage - seuil_premier_rang)
+    amort_annuel_2nd_rank = deuxieme_rang / 15 if deuxieme_rang > 0 else 0.0
+
     for year in range(1, horizon + 1):
         # Annual costs
         mortgage_interest = mortgage * taux_hypotheque
-        amortization = prix_bien * _FINMA_AMORTISSEMENT
+        # Amortization: 2nd rank only, over 15 years, then stops
+        amortization = amort_annuel_2nd_rank if mortgage > seuil_premier_rang else 0.0
         maintenance = prix_bien * taux_entretien
 
-        # Reduce mortgage by amortization (floor at 0)
-        mortgage = max(0.0, mortgage - amortization)
+        # Reduce mortgage by amortization (floor at 1st rank level)
+        mortgage = max(seuil_premier_rang, mortgage - amortization)
 
         # Total annual cost
         annual_cost = mortgage_interest + amortization + maintenance
@@ -333,10 +339,16 @@ def compare_location_vs_propriete(
         f"flexibilite et fiscalite."
     )
 
+    # Amortization: 2nd rank from 80% to 65% LTV over 15 years
+    initial_mortgage = prix_bien * (1 - _FONDS_PROPRES_MIN)
+    seuil_1er_rang = prix_bien * 0.65
+    deuxieme_rang_hyp = max(0.0, initial_mortgage - seuil_1er_rang)
+    amort_annuel_2nd_rank = deuxieme_rang_hyp / 15 if deuxieme_rang_hyp > 0 else 0.0
+
     # FINMA affordability check
     annual_theoretical_cost = (
-        prix_bien * (1 - _FONDS_PROPRES_MIN) * _FINMA_TAUX_THEORIQUE
-        + prix_bien * _FINMA_AMORTISSEMENT
+        initial_mortgage * _FINMA_TAUX_THEORIQUE
+        + amort_annuel_2nd_rank
         + prix_bien * _FINMA_FRAIS_ACCESSOIRES
     )
 
@@ -350,7 +362,7 @@ def compare_location_vs_propriete(
         f"Hypotheque: {(1 - _FONDS_PROPRES_MIN) * 100:.0f}% ({prix_bien * (1 - _FONDS_PROPRES_MIN):,.0f} CHF)",
         f"Taux hypothecaire reel: {taux_hypotheque * 100:.1f}%/an",
         f"Taux theorique FINMA: {_FINMA_TAUX_THEORIQUE * 100:.0f}% (Tragbarkeitsrechnung)",
-        f"Amortissement: {_FINMA_AMORTISSEMENT * 100:.0f}%/an du prix d'achat",
+        f"Amortissement: 2e rang (80% -> 65% LTV) sur 15 ans ({amort_annuel_2nd_rank:,.0f} CHF/an)",
         f"Frais d'entretien: {taux_entretien * 100:.0f}%/an du prix d'achat",
         f"Charges annuelles theoriques: {annual_theoretical_cost:,.0f} CHF (ratio FINMA)",
         f"Rendement marche (scenario location): {rendement_marche * 100:.1f}%/an",

--- a/services/backend/app/services/mortgage/affordability_service.py
+++ b/services/backend/app/services/mortgage/affordability_service.py
@@ -144,48 +144,79 @@ class AffordabilityService:
         prix_achat = max(0.0, prix_achat)
         canton = (canton.upper() if canton else "ZH")[:2]
 
-        # 1. Total equity
-        fonds_propres_total = epargne_disponible + avoir_3a + avoir_lpp
+        # 1. Non-LPP equity (hard equity)
+        fp_base = epargne_disponible + avoir_3a
 
-        # 2. Max affordable price based on income
+        # 2. Max affordable price: solve LPP circular dependency algebraically.
+        #    LPP can contribute max 10% of purchase price as equity.
+        #    Total equity = fp_base + min(avoir_lpp, prix_max * 10%).
+        #    Required equity = prix_max * 20%.
+        #
+        #    Case A: LPP >= prix_max * 10% (LPP covers full 2nd-rank equity)
+        #      => fp_total = fp_base + prix_max * 0.10
+        #      => prix_max = fp_total / 0.20 = (fp_base + prix_max * 0.10) / 0.20
+        #      => prix_max * 0.20 = fp_base + prix_max * 0.10
+        #      => prix_max * 0.10 = fp_base
+        #      => prix_max = fp_base / 0.10
+        #
+        #    Case B: LPP < prix_max * 10% (all LPP is used but not enough)
+        #      => fp_total = fp_base + avoir_lpp
+        #      => prix_max = fp_total / 0.20 = (fp_base + avoir_lpp) / 0.20
+
+        # Solve for max price from equity constraint
+        if FONDS_PROPRES_MIN_PCT > 0:
+            # Case A: assumes LPP covers full 10% contribution
+            prix_max_case_a = fp_base / (FONDS_PROPRES_MIN_PCT - PART_2E_PILIER_MAX)  # fp_base / 0.10
+            # Check if LPP actually covers 10% at this price
+            if avoir_lpp >= prix_max_case_a * PART_2E_PILIER_MAX:
+                prix_max_equity = prix_max_case_a
+            else:
+                # Case B: all LPP is used
+                prix_max_equity = (fp_base + avoir_lpp) / FONDS_PROPRES_MIN_PCT
+        else:
+            prix_max_equity = 0.0
+
+        # Compute the effective fonds propres at prix_max_equity
+        lpp_at_max = min(avoir_lpp, prix_max_equity * PART_2E_PILIER_MAX)
+        fonds_propres_total = fp_base + lpp_at_max
+
+        # 3. Max affordable price based on income (capacity constraint)
         #    Theoretical annual costs = mortgage * (5% + 1%) + price * 1%
         #    = (price - equity) * 6% + price * 1%
-        #    = price * 6% - equity * 6% + price * 1%
         #    = price * 7% - equity * 6%
         #    Max costs = income * 33.33%
-        #    => price * 7% - equity * 6% <= income * 33.33%
         #    => price <= (income * 33.33% + equity * 6%) / 7%
         if revenu_brut_annuel > 0:
-            prix_max = (revenu_brut_annuel * RATIO_CHARGES_MAX
-                        + fonds_propres_total * (TAUX_THEORIQUE + TAUX_AMORTISSEMENT)) / (
+            prix_max_income = (revenu_brut_annuel * RATIO_CHARGES_MAX
+                               + fonds_propres_total * (TAUX_THEORIQUE + TAUX_AMORTISSEMENT)) / (
                 TAUX_THEORIQUE + TAUX_AMORTISSEMENT + TAUX_FRAIS_ACCESSOIRES
             )
-            prix_max = round(prix_max, 2)
+            prix_max_income = round(prix_max_income, 2)
         else:
-            prix_max = 0.0
+            prix_max_income = 0.0
 
-        # Also ensure at least 20% equity for the max price
-        # price_max_equity = equity / 20% = equity * 5
-        prix_max_equity = fonds_propres_total / FONDS_PROPRES_MIN_PCT if FONDS_PROPRES_MIN_PCT > 0 else 0.0
-        prix_max = round(min(prix_max, prix_max_equity), 2)
+        prix_max = round(min(prix_max_income, prix_max_equity), 2)
 
-        # 3. If a target price is given, calculate specifics
+        # 4. If a target price is given, calculate specifics
         if prix_achat > 0:
-            fonds_propres_requis = prix_achat * FONDS_PROPRES_MIN_PCT
-            fonds_propres_suffisants = fonds_propres_total >= fonds_propres_requis
-
             # 2nd pillar cap: max 10% of purchase price
             lpp_utilisable = min(avoir_lpp, prix_achat * PART_2E_PILIER_MAX)
-            fonds_propres_effectifs = epargne_disponible + avoir_3a + lpp_utilisable
+            fonds_propres_effectifs = fp_base + lpp_utilisable
+            fonds_propres_total = fonds_propres_effectifs
+
+            fonds_propres_requis = prix_achat * FONDS_PROPRES_MIN_PCT
+            fonds_propres_suffisants = fonds_propres_total >= fonds_propres_requis
 
             montant_hypothecaire = max(0.0, prix_achat - fonds_propres_effectifs)
         else:
             # No target price: use max price
             prix_achat_calc = prix_max
+            lpp_utilisable = min(avoir_lpp, prix_achat_calc * PART_2E_PILIER_MAX)
+            fonds_propres_effectifs = fp_base + lpp_utilisable
+            fonds_propres_total = fonds_propres_effectifs
+
             fonds_propres_requis = prix_achat_calc * FONDS_PROPRES_MIN_PCT
             fonds_propres_suffisants = fonds_propres_total >= fonds_propres_requis
-            lpp_utilisable = min(avoir_lpp, prix_achat_calc * PART_2E_PILIER_MAX)
-            fonds_propres_effectifs = epargne_disponible + avoir_3a + lpp_utilisable
             montant_hypothecaire = max(0.0, prix_achat_calc - fonds_propres_effectifs)
 
         # 4. Theoretical monthly costs

--- a/services/backend/app/services/onboarding/minimal_profile_service.py
+++ b/services/backend/app/services/onboarding/minimal_profile_service.py
@@ -237,9 +237,15 @@ def _estimate_lpp_from_age_25(
 def _compute_marginal_tax_rate(gross_salary: float, canton: str) -> float:
     """Approximate marginal tax rate based on cantonal capital tax rates.
 
+    NOTE: This is a rough approximation (capital_tax_rate * 3.5).
+    The canonical marginal rate computation is in the mobile
+    RetirementTaxCalculator.estimateMarginalRate() using AFC 2024 data.
+    This approximation is acceptable for onboarding chiffre-choc
+    (educational, with +/-5% tolerance). Final displays in the mobile
+    app MUST use RetirementTaxCalculator, not this backend approximation.
+
     Uses TAUX_IMPOT_RETRAIT_CAPITAL as a proxy for cantonal tax burden,
-    scaled by income level. This is a rough approximation suitable for
-    the simplified onboarding context.
+    scaled by income level.
 
     Args:
         gross_salary: Annual gross salary.
@@ -252,7 +258,7 @@ def _compute_marginal_tax_rate(gross_salary: float, canton: str) -> float:
 
     # Scale from capital withdrawal rate to income tax approximation
     # Capital withdrawal rates are ~5-8%, income marginal rates are ~15-40%
-    # Use a multiplier of ~3.5x as rough proxy
+    # Use a multiplier of ~3.5x as rough proxy (see note above)
     income_factor = base_rate * 3.5
 
     # Adjust for income level

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -7277,6 +7277,7 @@
         "type": "object"
       },
       "EmploymentStatus": {
+        "description": "Coaching-internal French dialect. Profile API uses English ('employee', 'self_employed', 'retired').\nIf integrating with Profile API, map: salarie↔employee, independant↔self_employed, retraite↔retired.",
         "enum": [
           "salarie",
           "independant",


### PR DESCRIPTION
## V10 — 6 financial engine divergences fixed

### CRITIQUE
- **Mortgage**: LPP 10% circular dependency solved algebraically (backend overestimated)
- **Unemployment**: 55-59yo now gets 520 days (was 400, SECO rules)

### ÉLEVÉE
- **First job**: 3a tax saving uses canton-aware `estimate3aTaxSaving()` (was flat 25%)
- **Location vs propriété**: amortization = 2nd rank 80%→65% LTV over 15yr (was 1% of price forever)
- **Marginal rate**: backend approximation documented, mobile AFC 2024 is canonical

### MOYENNE
- **Scenarios**: legacy 3a 7056 → 7258 via centralized constant

OpenAPI regenerated. Tests: 8154 Flutter + 4463 Backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)