### PR TITLE
fix: V11 orchestration truth — premature returns, screenId, tab deeplinks, auth redirect, fallback

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -171,9 +171,11 @@ final _router = GoRouter(
     // Check if current path is protected
     final isProtected = protectedPrefixes.any((p) => path.startsWith(p));
 
-    // If protected and not logged in, redirect to register with return URL
+    // If protected and not logged in, redirect to register with return URL.
+    // V11-5: Use state.uri.toString() (not just path) to preserve query params
+    // (e.g. /couple/accept?code=XYZ).
     if (isProtected && !isLoggedIn) {
-      return '/auth/register?redirect=${Uri.encodeComponent(path)}';
+      return '/auth/register?redirect=${Uri.encodeComponent(state.uri.toString())}';
     }
 
     // Routes that REQUIRE a completed profile (financial screens)
@@ -203,6 +205,16 @@ final _router = GoRouter(
         if (!path.startsWith('/onboarding')) {
           return '/onboarding/smart';
         }
+      }
+    }
+
+    // V11-4: Consume pending notification route at the router level.
+    // The shell may not be mounted yet (auth/onboarding gates), so consuming
+    // here ensures the deep link fires regardless of shell lifecycle.
+    if (state.uri.path == '/' || state.uri.path == '/home') {
+      final pendingRoute = NotificationService.consumePendingRoute();
+      if (pendingRoute != null && pendingRoute.isNotEmpty) {
+        return pendingRoute;
       }
     }
 

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -36,6 +36,11 @@ import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 ///
 /// NEVER ranks options. Side-by-side comparison only.
 /// All text in French, informal "tu". No banned terms.
+///
+/// PREFILL: When navigated from coach via RouteSuggestionCard,
+/// GoRouterState.extra may contain {'prefill': Map<String, dynamic>}
+/// with pre-computed values. Currently reads from CoachProfileProvider.
+/// TODO: merge prefill with profile data for coach-optimized defaults.
 class RenteVsCapitalScreen extends StatefulWidget {
   const RenteVsCapitalScreen({super.key});
 

--- a/apps/mobile/lib/screens/disability/disability_gap_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_gap_screen.dart
@@ -37,6 +37,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
   double _savings = 30000;
   bool _hasIjm = true;
   bool _seededFromProfile = false;
+  bool _hasUserInteracted = false;
 
   @override
   void didChangeDependencies() {
@@ -54,6 +55,10 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
         if (savings > 0) _savings = savings.clamp(0.0, 500000.0);
       });
     }
+  }
+
+  void _emitScreenReturn() {
+    if (!_hasUserInteracted) return;
     ScreenCompletionTracker.markCompletedWithReturn(
       'disability_gap',
       ScreenReturn.completed(
@@ -368,7 +373,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
             max: 25000,
             divisions: 46,
             format: (v) => "CHF ${_fmtChf(v)}",
-            onChanged: (v) => setState(() => _grossMonthly = v),
+            onChanged: (v) { _hasUserInteracted = true; setState(() => _grossMonthly = v); _emitScreenReturn(); },
           ),
           const SizedBox(height: 12),
           _buildSliderRow(
@@ -378,7 +383,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
             max: 64,
             divisions: 46,
             format: (v) => S.of(context)!.disabilityGapAgeLabel(v.toInt()),
-            onChanged: (v) => setState(() => _age = v.toInt()),
+            onChanged: (v) { _hasUserInteracted = true; setState(() => _age = v.toInt()); _emitScreenReturn(); },
           ),
           const SizedBox(height: 12),
           _buildSliderRow(
@@ -388,7 +393,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
             max: 200000,
             divisions: 40,
             format: (v) => "CHF ${_fmtChf(v)}",
-            onChanged: (v) => setState(() => _savings = v),
+            onChanged: (v) { _hasUserInteracted = true; setState(() => _savings = v); _emitScreenReturn(); },
           ),
           const SizedBox(height: 16),
           Row(
@@ -402,7 +407,7 @@ class _DisabilityGapScreenState extends State<DisabilityGapScreen> {
               ),
               Switch(
                 value: _hasIjm,
-                onChanged: (v) => setState(() => _hasIjm = v),
+                onChanged: (v) { _hasUserInteracted = true; setState(() => _hasIjm = v); _emitScreenReturn(); },
                 activeTrackColor: MintColors.primary,
               ),
             ],

--- a/apps/mobile/lib/screens/lamal_franchise_screen.dart
+++ b/apps/mobile/lib/screens/lamal_franchise_screen.dart
@@ -34,6 +34,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
   double _primeMensuelle = 350;
   double _depensesSante = 2000;
   bool _isChild = false;
+  bool _hasUserInteracted = false;
 
   LamalFranchiseResult? _result;
 
@@ -75,6 +76,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
         isChild: _isChild,
       );
     });
+    if (!_hasUserInteracted) return;
     final optimalEconomie = _result?.comparaison
             .where((c) => c.isOptimal)
             .map((c) => c.economieVs300)
@@ -273,6 +275,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
               child: GestureDetector(
                 onTap: () {
                   if (_isChild) {
+                    _hasUserInteracted = true;
                     _isChild = false;
                     _compute();
                   }
@@ -318,6 +321,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
               child: GestureDetector(
                 onTap: () {
                   if (!_isChild) {
+                    _hasUserInteracted = true;
                     _isChild = true;
                     _compute();
                   }
@@ -372,6 +376,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
         divisions: 40,
         formatValue: (v) => LamalFranchiseService.formatChf(v),
         onChanged: (value) {
+          _hasUserInteracted = true;
           _primeMensuelle = value;
           _compute();
         },
@@ -397,6 +402,7 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
                 : MintColors.success,
         formatValue: (v) => LamalFranchiseService.formatChf(v),
         onChanged: (value) {
+          _hasUserInteracted = true;
           _depensesSante = value;
           _compute();
         },

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -81,23 +81,12 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
       );
 
   bool _prefilled = false;
+  bool _hasUserInteracted = false;
 
   @override
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('lpp_deep');
-    ScreenCompletionTracker.markCompletedWithReturn(
-      'rachat_echelonne',
-      ScreenReturn.completed(
-        route: '/lpp-deep/rachat-echelonne',
-        updatedFields: {
-          'rachatOptimalAnnuel': _rachatMax / _horizon,
-          'rachatEconomieFiscale': _result.delta,
-        },
-        confidenceDelta: 0.02,
-        nextCapSuggestion: 'pilier_3a',
-      ),
-    );
     _heroController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 800),
@@ -148,8 +137,26 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   }
 
   void _onInputChanged() {
+    _hasUserInteracted = true;
     _heroController.forward(from: 0);
     setState(() {});
+    _emitScreenReturn();
+  }
+
+  void _emitScreenReturn() {
+    if (!_hasUserInteracted) return;
+    ScreenCompletionTracker.markCompletedWithReturn(
+      'rachat_echelonne',
+      ScreenReturn.completed(
+        route: '/lpp-deep/rachat-echelonne',
+        updatedFields: {
+          'rachatOptimalAnnuel': _rachatMax / _horizon,
+          'rachatEconomieFiscale': _result.delta,
+        },
+        confidenceDelta: 0.02,
+        nextCapSuggestion: 'pilier_3a',
+      ),
+    );
   }
 
   @override

--- a/apps/mobile/lib/screens/main_navigation_shell.dart
+++ b/apps/mobile/lib/screens/main_navigation_shell.dart
@@ -180,6 +180,26 @@ class _MainNavigationShellState extends State<MainNavigationShell>
 
   @override
   Widget build(BuildContext context) {
+    // V11-3: Re-read ?tab= on every build so that subsequent go('/home?tab=3')
+    // calls actually update the tab, not just the first one.
+    try {
+      final rawTab =
+          GoRouterState.of(context).uri.queryParameters['tab'];
+      if (rawTab != null) {
+        final tabIndex = int.tryParse(rawTab) ?? 0;
+        if (tabIndex >= 0 && tabIndex < _tabs.length && tabIndex != _currentIndex) {
+          // Schedule the state update to avoid calling setState during build.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted && _currentIndex != tabIndex) {
+              setState(() => _currentIndex = tabIndex);
+            }
+          });
+        }
+      }
+    } catch (_) {
+      // No GoRouter in tree (unit tests).
+    }
+
     return Scaffold(
       body: IndexedStack(
         index: _currentIndex,

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -28,6 +28,11 @@ import 'package:mint_mobile/widgets/premium/mint_confidence_notice.dart';
 /// Layout S55: enjeu d'abord, consequence avant controle, matiere chaude.
 /// Le resultat (prix max accessible) domine. Les sliders suivent.
 /// Base legale : directive ASB sur le credit hypothecaire.
+///
+/// PREFILL: When navigated from coach via RouteSuggestionCard,
+/// GoRouterState.extra may contain {'prefill': Map<String, dynamic>}
+/// with pre-computed values. Currently reads from CoachProfileProvider.
+/// TODO: merge prefill with profile data for coach-optimized defaults.
 class AffordabilityScreen extends StatefulWidget {
   const AffordabilityScreen({super.key});
 
@@ -36,17 +41,19 @@ class AffordabilityScreen extends StatefulWidget {
 }
 
 class _AffordabilityScreenState extends State<AffordabilityScreen> {
+  bool _hasUserInteracted = false;
+
   @override
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('mortgage');
-    _emitScreenReturn();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeFromProfile();
     });
   }
 
   void _emitScreenReturn() {
+    if (!_hasUserInteracted) return;
     final result = _result;
     final screenReturn = ScreenReturn.changedInputs(
       route: '/mortgage/affordability',
@@ -287,7 +294,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                         max: 300000,
                         divisions: 50,
                         formatValue: (_) => 'CHF\u00a0${formatChf(_revenuBrut)}',
-                        onChanged: (v) { setState(() => _revenuBrut = v); _emitScreenReturn(); },
+                        onChanged: (v) { _hasUserInteracted = true; setState(() => _revenuBrut = v); _emitScreenReturn(); },
                       ),
                       const SizedBox(height: MintSpacing.md),
 
@@ -299,7 +306,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                         max: 3000000,
                         divisions: 56,
                         formatValue: (_) => 'CHF\u00a0${formatChf(_prixAchat)}',
-                        onChanged: (v) { setState(() => _prixAchat = v); _emitScreenReturn(); },
+                        onChanged: (v) { _hasUserInteracted = true; setState(() => _prixAchat = v); _emitScreenReturn(); },
                       ),
                       const SizedBox(height: MintSpacing.md),
 
@@ -312,7 +319,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                         divisions: 100,
                         formatValue: (_) =>
                             'CHF\u00a0${formatChf(_epargneDispo)}',
-                        onChanged: (v) { setState(() => _epargneDispo = v); _emitScreenReturn(); },
+                        onChanged: (v) { _hasUserInteracted = true; setState(() => _epargneDispo = v); _emitScreenReturn(); },
                       ),
 
                       // Progressive disclosure: 3a + LPP behind toggle
@@ -352,7 +359,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                           divisions: 60,
                           formatValue: (_) =>
                               'CHF\u00a0${formatChf(_avoir3a)}',
-                          onChanged: (v) { setState(() => _avoir3a = v); _emitScreenReturn(); },
+                          onChanged: (v) { _hasUserInteracted = true; setState(() => _avoir3a = v); _emitScreenReturn(); },
                         ),
                         const SizedBox(height: MintSpacing.md),
                         MintPremiumSlider(
@@ -363,7 +370,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                           divisions: 100,
                           formatValue: (_) =>
                               'CHF\u00a0${formatChf(_avoirLpp)}',
-                          onChanged: (v) { setState(() => _avoirLpp = v); _emitScreenReturn(); },
+                          onChanged: (v) { _hasUserInteracted = true; setState(() => _avoirLpp = v); _emitScreenReturn(); },
                         ),
                       ],
                     ],

--- a/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
+++ b/apps/mobile/lib/screens/pillar_3a_deep/staggered_withdrawal_screen.dart
@@ -19,6 +19,11 @@ import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 /// Permet de comparer l'impot en bloc vs echelonne et d'identifier
 /// le nombre optimal de comptes 3a.
 /// Base legale : OPP3, LIFD art. 38.
+///
+/// PREFILL: When navigated from coach via RouteSuggestionCard,
+/// GoRouterState.extra may contain {'prefill': Map<String, dynamic>}
+/// with pre-computed values. Currently reads from CoachProfileProvider.
+/// TODO: merge prefill with profile data for coach-optimized defaults.
 class StaggeredWithdrawalScreen extends StatefulWidget {
   const StaggeredWithdrawalScreen({super.key});
 
@@ -34,11 +39,11 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
   double _revenuImposable = 120000;
   int _ageRetraitDebut = 60;
   int _ageRetraitFin = 64;
+  bool _hasUserInteracted = false;
 
   @override
   void initState() {
     super.initState();
-    _emitScreenReturn();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeFromProfile();
     });
@@ -87,10 +92,11 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
         ageRetraitFin: _ageRetraitFin,
       );
 
-  // _emitScreenReturn is called from primary initState above
-  // (merged with profile initialization)
+  // _emitScreenReturn is called on user interaction (slider change, button tap).
+  // NOT on initState — prevents premature stream emission before user action.
 
   void _emitScreenReturn() {
+    if (!_hasUserInteracted) return;
     final plan = '${_nbComptes}x_$_ageRetraitDebut-$_ageRetraitFin';
     final screenReturn = ScreenReturn.changedInputs(
       route: '/3a-deep/staggered-withdrawal',
@@ -243,22 +249,22 @@ class _StaggeredWithdrawalScreenState extends State<StaggeredWithdrawalScreen> {
           MintEntrance(child: Text(l.staggered3aParametres, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w700, letterSpacing: 0.5))),
           const SizedBox(height: MintSpacing.md),
 
-          MintEntrance(delay: const Duration(milliseconds: 100), child: _buildSliderRow(label: l.staggered3aAvoirTotal, value: _avoirTotal, min: 0, max: 1000000, divisions: 200, format: 'CHF ${formatChf(_avoirTotal)}', onChanged: (v) => setState(() => _avoirTotal = v))),
+          MintEntrance(delay: const Duration(milliseconds: 100), child: _buildSliderRow(label: l.staggered3aAvoirTotal, value: _avoirTotal, min: 0, max: 1000000, divisions: 200, format: 'CHF ${formatChf(_avoirTotal)}', onChanged: (v) { _hasUserInteracted = true; setState(() => _avoirTotal = v); _emitScreenReturn(); })),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          MintEntrance(delay: const Duration(milliseconds: 200), child: _buildSliderRow(label: l.staggered3aNbComptes, value: _nbComptes.toDouble(), min: 1, max: 5, divisions: 4, format: '$_nbComptes', onChanged: (v) { setState(() => _nbComptes = v.round()); _emitScreenReturn(); })),
+          MintEntrance(delay: const Duration(milliseconds: 200), child: _buildSliderRow(label: l.staggered3aNbComptes, value: _nbComptes.toDouble(), min: 1, max: 5, divisions: 4, format: '$_nbComptes', onChanged: (v) { _hasUserInteracted = true; setState(() => _nbComptes = v.round()); _emitScreenReturn(); })),
           const SizedBox(height: MintSpacing.sm + 4),
 
           MintEntrance(delay: const Duration(milliseconds: 300), child: _buildCantonDropdown(l)),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          MintEntrance(delay: const Duration(milliseconds: 400), child: _buildSliderRow(label: l.staggered3aRevenuImposable, value: _revenuImposable, min: 30000, max: 300000, divisions: 54, format: 'CHF ${formatChf(_revenuImposable)}', onChanged: (v) => setState(() => _revenuImposable = v))),
+          MintEntrance(delay: const Duration(milliseconds: 400), child: _buildSliderRow(label: l.staggered3aRevenuImposable, value: _revenuImposable, min: 30000, max: 300000, divisions: 54, format: 'CHF ${formatChf(_revenuImposable)}', onChanged: (v) { _hasUserInteracted = true; setState(() => _revenuImposable = v); _emitScreenReturn(); })),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          _buildSliderRow(label: l.staggered3aAgeDebut, value: _ageRetraitDebut.toDouble(), min: 59, max: 70, divisions: 11, format: '$_ageRetraitDebut ${l.staggered3aAns}', onChanged: (v) { setState(() { _ageRetraitDebut = v.round(); if (_ageRetraitFin < _ageRetraitDebut) _ageRetraitFin = _ageRetraitDebut; }); _emitScreenReturn(); }),
+          _buildSliderRow(label: l.staggered3aAgeDebut, value: _ageRetraitDebut.toDouble(), min: 59, max: 70, divisions: 11, format: '$_ageRetraitDebut ${l.staggered3aAns}', onChanged: (v) { _hasUserInteracted = true; setState(() { _ageRetraitDebut = v.round(); if (_ageRetraitFin < _ageRetraitDebut) _ageRetraitFin = _ageRetraitDebut; }); _emitScreenReturn(); }),
           const SizedBox(height: MintSpacing.sm + 4),
 
-          _buildSliderRow(label: l.staggered3aAgeFin, value: _ageRetraitFin.toDouble(), min: _ageRetraitDebut.toDouble(), max: 70, divisions: (70 - _ageRetraitDebut).clamp(1, 11), format: '$_ageRetraitFin ${l.staggered3aAns}', onChanged: (v) { setState(() => _ageRetraitFin = v.round()); _emitScreenReturn(); }),
+          _buildSliderRow(label: l.staggered3aAgeFin, value: _ageRetraitFin.toDouble(), min: _ageRetraitDebut.toDouble(), max: 70, divisions: (70 - _ageRetraitDebut).clamp(1, 11), format: '$_ageRetraitFin ${l.staggered3aAns}', onChanged: (v) { _hasUserInteracted = true; setState(() => _ageRetraitFin = v.round()); _emitScreenReturn(); }),
         ],
       ),
     );

--- a/apps/mobile/lib/services/navigation/route_planner.dart
+++ b/apps/mobile/lib/services/navigation/route_planner.dart
@@ -244,6 +244,16 @@ class RoutePlanner {
         );
 
       case ReadinessLevel.blocked:
+        // V11-6: If the entry has a fallbackRoute, redirect there instead of
+        // just listing missing fields. The fallback guides the user through
+        // a capture flow (e.g. onboarding, scan, chat prompt) rather than
+        // leaving them stuck with a list of missing data.
+        if (entry.fallbackRoute != null) {
+          return RouteDecision.openWithWarning(
+            entry.fallbackRoute!,
+            missingFields: readiness.missingFields,
+          );
+        }
         return RouteDecision.askFirst(readiness.missingFields);
     }
   }

--- a/apps/mobile/lib/widgets/coach/route_suggestion_card.dart
+++ b/apps/mobile/lib/widgets/coach/route_suggestion_card.dart
@@ -154,21 +154,60 @@ class RouteSuggestionCard extends StatelessWidget {
     );
   }
 
+  /// Maps GoRouter routes to the screenId used by ScreenCompletionTracker.
+  ///
+  /// Screens register their results under specific IDs that may not match the
+  /// route path directly. This canonical map ensures the card reads the same
+  /// key the screen writes to.
+  static const _routeToScreenId = <String, String>{
+    '/mortgage/affordability': 'affordability',
+    '/3a-deep/staggered-withdrawal': 'staggered_withdrawal',
+    '/lpp-deep/rachat-echelonne': 'rachat_echelonne',
+    '/assurances/lamal': 'lamal_franchise',
+    '/invalidite': 'disability_gap',
+    '/rente-vs-capital': 'rente_vs_capital',
+    '/divorce': 'divorce_simulator',
+    '/retraite': 'retirement_dashboard',
+    '/budget': 'budget',
+    '/3a': 'pillar_3a',
+    '/lpp-deep/libre-passage': 'libre_passage',
+    '/lpp-deep/epl': 'epl',
+    '/mortgage/amortization': 'amortization',
+    '/mortgage/epl-combined': 'epl_combined',
+    '/mortgage/imputed-rental': 'imputed_rental',
+    '/mortgage/saron-vs-fixed': 'saron_vs_fixed',
+    '/decaissement': 'decaissement',
+    '/fiscal': 'fiscal_comparator',
+  };
+
+  /// Resolve the canonical screenId for the given route.
+  ///
+  /// Falls back to the path-derived heuristic (strip leading slash, replace
+  /// non-alphanumeric characters with underscores) when no explicit mapping
+  /// exists.
+  static String _resolveScreenId(String route) {
+    return _routeToScreenId[route] ??
+        route.replaceAll(RegExp(r'^/'), '').replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
+  }
+
   Future<void> _navigateAndReturn(BuildContext context) async {
     // Snapshot profile state and wall-clock time before navigation.
     final hashBefore = profileHashFn?.call();
     final entryTime = DateTime.now();
 
-    // Derive a screen ID from the route by stripping leading slash and
-    // replacing non-alphanumeric characters with underscores.
-    final screenId =
-        route.replaceAll(RegExp(r'^/'), '').replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
+    // Resolve the canonical screen ID used by ScreenCompletionTracker.
+    final screenId = _resolveScreenId(route);
+
+    // Clear stale tracker entry BEFORE navigating so old results don't
+    // contaminate the return-contract detection.
+    await ScreenCompletionTracker.clear(screenId);
 
     // Navigate — context.push awaited synchronously. Any async work involving
     // ScreenCompletionTracker happens after the mounted check below so that
     // context is never accessed across an async gap.
     // Pass prefill data via `extra` so the target screen can pre-populate
     // fields with known profile values (screens opt in by reading extra).
+    if (!context.mounted) return;
     final extra = prefill != null ? {'prefill': prefill} : null;
     await context.push(route, extra: extra); // ignore: use_build_context_synchronously — guarded by mounted check immediately below
 

--- a/apps/mobile/test/services/navigation/route_planner_test.dart
+++ b/apps/mobile/test/services/navigation/route_planner_test.dart
@@ -319,11 +319,15 @@ void main() {
       expect(decision.missingFields, contains('salaireBrut'));
     });
 
-    test('budget_overview without salary → askFirst', () {
+    test('budget_overview without salary → redirects to fallbackRoute', () {
       final profile = _minimalProfile();
       final planner = RoutePlanner(registry: registry, profile: profile);
       final decision = planner.plan('budget_overview', confidence: 0.9);
-      expect(decision.action, RouteAction.askFirst);
+      // V11-6: When blocked AND fallbackRoute is set, the planner redirects
+      // to the fallback route (openWithWarning) instead of askFirst.
+      expect(decision.action, RouteAction.openWithWarning);
+      expect(decision.route, '/onboarding/quick-start');
+      expect(decision.missingFields, isNotEmpty);
     });
 
     test('askFirst decision has no route', () {


### PR DESCRIPTION
## V11 — 7 orchestration truth findings fixed

### CRITIQUE
- **Premature ScreenReturn**: 5 screens now gate emit behind `_hasUserInteracted` flag
- **ScreenId mismatch**: canonical route→screenId map + tracker clear before navigation

### ÉLEVÉE
- **Tab deeplinks**: shell re-reads `?tab=` on every build (not just initState)
- **Notification cold start**: consumed in GoRouter redirect, not shell mount
- **Auth redirect**: `state.uri.toString()` preserves query params through auth
- **fallbackRoute**: RoutePlanner now redirects to fallback when blocked (was dead data)

### MOYENNE
- **Prefill**: documented in 3 screens, TODO for merge with profile data

Tests: 8154 Flutter | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)