### PR TITLE
feat: Regulatory Core — single source of truth for Swiss financial constants

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -414,6 +414,9 @@ def _execute_internal_tool(
     if name == "get_couple_optimization":
         return _format_couple_optimization(ctx)
 
+    if name == "get_regulatory_constant":
+        return _handle_regulatory_constant(tool_input)
+
     # Unknown internal tool — return a graceful fallback
     logger.warning("Unknown internal tool: %s", name)
     return f"Outil interne '{name}' non reconnu."
@@ -615,6 +618,62 @@ def _format_couple_optimization(ctx: dict) -> str:
             lines.append(f"- Bonus mariage : {_fmt_chf(abs(delta))}/an d'avantage")
 
     return "\n".join(lines)
+
+
+def _handle_regulatory_constant(tool_input: dict) -> str:
+    """Look up a Swiss financial regulatory constant from the registry.
+
+    This is an internal tool — results are injected into the LLM context
+    so the coach can cite exact legal values in its responses.
+    """
+    from app.services.regulatory.registry import RegulatoryRegistry
+
+    key = tool_input.get("key", "")
+    canton = tool_input.get("canton", "")
+
+    if not key:
+        return "Erreur : clé manquante. Fournis un key comme 'pillar3a.max_with_lpp'."
+
+    registry = RegulatoryRegistry.instance()
+
+    # For cantonal capital tax, auto-build the key if canton is provided separately
+    jurisdiction = "CH"
+    if canton:
+        canton_upper = canton.upper()
+        # If key is generic like "capital_tax.cantonal" and canton is separate
+        if not key.endswith(f".{canton_upper}"):
+            cantonal_key = f"capital_tax.cantonal.{canton_upper}"
+            param = registry.get(cantonal_key, jurisdiction=canton_upper)
+            if param:
+                return (
+                    f"{param.key} = {param.value} {param.unit}\n"
+                    f"Source : {param.source_title}\n"
+                    f"Description : {param.description}\n"
+                    f"En vigueur depuis : {param.effective_from.isoformat()}"
+                )
+        jurisdiction = canton_upper
+
+    param = registry.get(key, jurisdiction=jurisdiction)
+    if param is None:
+        # Try CH jurisdiction as fallback
+        if jurisdiction != "CH":
+            param = registry.get(key, jurisdiction="CH")
+
+    if param is None:
+        available = registry.keys()
+        # Find close matches for suggestions
+        suggestions = [k for k in available if key.split(".")[0] in k][:5]
+        msg = f"Constante '{key}' non trouvée."
+        if suggestions:
+            msg += f" Suggestions : {', '.join(suggestions)}"
+        return msg
+
+    return (
+        f"{param.key} = {param.value} {param.unit}\n"
+        f"Source : {param.source_title}\n"
+        f"Description : {param.description}\n"
+        f"En vigueur depuis : {param.effective_from.isoformat()}"
+    )
 
 
 async def _run_agent_loop(

--- a/services/backend/app/api/v1/endpoints/regulatory.py
+++ b/services/backend/app/api/v1/endpoints/regulatory.py
@@ -1,0 +1,113 @@
+"""Regulatory constants API — single source of truth for Swiss financial parameters.
+
+GET /api/v1/regulatory/constants          → list all (with optional category filter)
+GET /api/v1/regulatory/constants/{key}    → get single constant
+GET /api/v1/regulatory/freshness          → check stale parameters
+
+Consumers:
+    - Flutter app (sync constants at startup)
+    - LLM tools (get_regulatory_constant)
+    - Internal dashboards (freshness monitoring)
+
+Compliance:
+    - Read-only endpoints (no mutation).
+    - No PII — only regulatory constants.
+
+Sources:
+    - CLAUDE.md §5 (Key Constants 2025/2026)
+    - app/services/regulatory/registry.py
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.services.regulatory.registry import RegulatoryRegistry
+
+router = APIRouter(prefix="/regulatory", tags=["regulatory"])
+
+
+@router.get("/constants")
+def list_constants(
+    category: Optional[str] = Query(
+        None,
+        description="Filter by category prefix: avs, lpp, pillar3a, mortgage, capital_tax, ai, apg, ac, lamal",
+    ),
+    canton: Optional[str] = Query(
+        None,
+        description="Filter by canton code (e.g. ZH, GE, VS). Only returns cantonal parameters.",
+    ),
+) -> dict:
+    """List all regulatory constants, optionally filtered by category or canton.
+
+    Returns:
+        JSON with "count" and "constants" (list of parameter dicts).
+    """
+    registry = RegulatoryRegistry.instance()
+    params = registry.get_all(category=category)
+
+    if canton:
+        canton_upper = canton.upper()
+        params = [p for p in params if p.jurisdiction == canton_upper]
+
+    return {
+        "count": len(params),
+        "constants": [p.to_dict() for p in params],
+    }
+
+
+@router.get("/constants/{key:path}")
+def get_constant(
+    key: str,
+    canton: Optional[str] = Query(
+        None,
+        description="Canton code for cantonal parameters (e.g. ZH, GE).",
+    ),
+) -> dict:
+    """Get a single regulatory constant by key.
+
+    Args:
+        key: Dotted parameter key (e.g. "pillar3a.max_with_lpp", "avs.max_monthly_pension").
+        canton: Optional canton code for cantonal parameters.
+
+    Returns:
+        The parameter as a JSON dict.
+
+    Raises:
+        404 if the key is not found.
+    """
+    registry = RegulatoryRegistry.instance()
+    jurisdiction = canton.upper() if canton else "CH"
+    param = registry.get(key, jurisdiction=jurisdiction)
+
+    if param is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Regulatory parameter '{key}' not found (jurisdiction={jurisdiction}).",
+        )
+
+    return param.to_dict()
+
+
+@router.get("/freshness")
+def check_freshness(
+    max_age_days: int = Query(
+        90,
+        description="Maximum number of days since last review before a parameter is considered stale.",
+    ),
+) -> dict:
+    """Check which parameters are stale and need review.
+
+    Returns:
+        JSON with "stale_count" and "stale_parameters" (list of parameter dicts).
+    """
+    registry = RegulatoryRegistry.instance()
+    stale = registry.check_freshness(max_age_days=max_age_days)
+
+    return {
+        "stale_count": len(stale),
+        "max_age_days": max_age_days,
+        "stale_parameters": [p.to_dict() for p in stale],
+    }

--- a/services/backend/app/api/v1/router.py
+++ b/services/backend/app/api/v1/router.py
@@ -50,6 +50,7 @@ from app.api.v1.endpoints import (
     household,
     config,
     knowledge,
+    regulatory,
 )
 
 api_router = APIRouter()
@@ -184,3 +185,4 @@ api_router.include_router(
     config.router, prefix="/config", tags=["Config"]
 )
 api_router.include_router(knowledge.router, tags=["Knowledge S67"])
+api_router.include_router(regulatory.router, tags=["Regulatory Core"])

--- a/services/backend/app/models/regulatory_parameter.py
+++ b/services/backend/app/models/regulatory_parameter.py
@@ -1,0 +1,89 @@
+"""Regulatory parameter model — single source of truth for Swiss financial constants.
+
+Each RegulatoryParameter stores a single constant with full provenance:
+    - Legal source (law article, ordinance, circular)
+    - Temporal validity (effective_from / effective_to)
+    - Jurisdiction (CH-wide or cantonal)
+    - Review date for freshness tracking
+
+Architecture:
+    - Backend is source of truth (CLAUDE.md §4).
+    - All calculators consume constants via RegulatoryRegistry.get().
+    - Flutter mirrors via API sync, never invents constants.
+
+Sources:
+    - decisions/ADR-20260223-unified-financial-engine.md
+    - CLAUDE.md §5 (Business Rules — Key Constants)
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Optional
+
+
+@dataclass
+class RegulatoryParameter:
+    """A single Swiss financial regulatory constant with metadata.
+
+    Attributes:
+        key: Dotted path, e.g. "pillar3a.max_with_lpp".
+        value: Numeric or boolean value (stored as float; booleans as 1.0/0.0).
+        unit: Physical unit — CHF, percent, years, days, ratio, boolean, count.
+        jurisdiction: "CH" for federal, or canton code ("ZH", "GE", etc.).
+        effective_from: Date the parameter became effective.
+        effective_to: None means still active; set when superseded.
+        tax_year: Tax year if relevant (e.g., 2025 for 3a limits).
+        source_url: URL to the official source document.
+        source_title: Human-readable source reference (e.g. "LPP art. 14").
+        source_type: One of: law, ordinance, circular, faq, estimate.
+        description: Brief explanation of the parameter.
+        reviewed_at: Date of last human review (for freshness checks).
+        notes: Additional context or caveats.
+    """
+
+    key: str
+    value: float
+    unit: str = "CHF"
+    jurisdiction: str = "CH"
+    effective_from: date = field(default_factory=lambda: date(2025, 1, 1))
+    effective_to: Optional[date] = None
+    tax_year: Optional[int] = None
+    source_url: str = ""
+    source_title: str = ""
+    source_type: str = "law"
+    description: str = ""
+    reviewed_at: Optional[date] = None
+    notes: str = ""
+
+    def is_active(self, on_date: Optional[date] = None) -> bool:
+        """Check if this parameter is active on a given date (default: today)."""
+        check_date = on_date or date.today()
+        if check_date < self.effective_from:
+            return False
+        if self.effective_to is not None and check_date > self.effective_to:
+            return False
+        return True
+
+    def is_stale(self, max_age_days: int = 90) -> bool:
+        """Check if the parameter needs review (reviewed_at older than max_age_days)."""
+        if self.reviewed_at is None:
+            return True
+        return (date.today() - self.reviewed_at).days > max_age_days
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict for API responses."""
+        return {
+            "key": self.key,
+            "value": self.value,
+            "unit": self.unit,
+            "jurisdiction": self.jurisdiction,
+            "effectiveFrom": self.effective_from.isoformat(),
+            "effectiveTo": self.effective_to.isoformat() if self.effective_to else None,
+            "taxYear": self.tax_year,
+            "sourceUrl": self.source_url,
+            "sourceTitle": self.source_title,
+            "sourceType": self.source_type,
+            "description": self.description,
+            "reviewedAt": self.reviewed_at.isoformat() if self.reviewed_at else None,
+            "notes": self.notes,
+        }

--- a/services/backend/app/services/coach/coach_tools.py
+++ b/services/backend/app/services/coach/coach_tools.py
@@ -61,6 +61,7 @@ INTERNAL_TOOL_NAMES: list[str] = [
     "get_cross_pillar_analysis",
     "get_cap_status",
     "get_couple_optimization",
+    "get_regulatory_constant",
 ]
 
 # ---------------------------------------------------------------------------
@@ -514,6 +515,44 @@ COACH_TOOLS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {},
             "required": [],
+        },
+    },
+    # ─────────────────────────────────────────────────────────────────
+    # get_regulatory_constant — INTERNAL: look up Swiss regulatory constants
+    # ─────────────────────────────────────────────────────────────────
+    {
+        "name": "get_regulatory_constant",
+        "category": "read",
+        "access_level": "user_scoped",
+        "description": (
+            "Look up a Swiss financial regulatory constant from the official "
+            "registry (LPP, AVS, 3a, mortgage, capital tax, LAMal, etc.). "
+            "Use this when you need an exact legal value to answer the user's "
+            "question — for example pillar 3a limits, LPP conversion rate, AVS "
+            "pension amounts, or cantonal capital withdrawal tax rates. "
+            "This tool is handled internally by the backend."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": (
+                        "The constant key, e.g. 'pillar3a.max_with_lpp', "
+                        "'avs.max_monthly_pension', 'lpp.conversion_rate', "
+                        "'mortgage.theoretical_rate', 'capital_tax.cantonal.VS'. "
+                        "Use dotted notation matching the registry keys."
+                    ),
+                },
+                "canton": {
+                    "type": "string",
+                    "description": (
+                        "Canton code for cantonal parameters (e.g. 'VS', 'ZH', 'GE'). "
+                        "Only needed for capital_tax.cantonal.* keys. Optional."
+                    ),
+                },
+            },
+            "required": ["key"],
         },
     },
     # ─────────────────────────────────────────────────────────────────

--- a/services/backend/app/services/regulatory/__init__.py
+++ b/services/backend/app/services/regulatory/__init__.py
@@ -1,0 +1,1 @@
+# regulatory package

--- a/services/backend/app/services/regulatory/registry.py
+++ b/services/backend/app/services/regulatory/registry.py
@@ -1,0 +1,1367 @@
+"""RegulatoryRegistry — in-memory registry of all Swiss financial constants.
+
+Single source of truth consumed by:
+    - Backend calculators (via get())
+    - API endpoints (via /regulatory/*)
+    - LLM tools (via get_regulatory_constant)
+    - Frontend (via API sync)
+
+Architecture:
+    - Singleton pattern: one registry instance per process.
+    - Constants are hardcoded in _PARAMETERS for now (DB migration planned P4).
+    - Every constant from social_insurance.py is mirrored here with full metadata.
+    - Freshness tracking: reviewed_at must be within 90 days or flagged stale.
+
+Sources:
+    - CLAUDE.md §5 (Key Constants 2025/2026)
+    - app/constants/social_insurance.py (raw values)
+    - OPP3 art. 7, LPP art. 7-16, LAVS art. 21-40, LIFD art. 38
+    - FINMA/ASB mortgage guidelines
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Optional
+
+from app.models.regulatory_parameter import RegulatoryParameter
+
+logger = logging.getLogger(__name__)
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OFAS source URLs (used across multiple parameters)
+# ══════════════════════════════════════════════════════════════════════════════
+
+_OFAS_LPP_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/bv/donnees-de-base-et-parametres/donnees-importantes-de-la-prevoyance-professionnelle.html"
+_OFAS_AVS_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/ahv/donnees-de-base-et-parametres/rentes.html"
+_OFAS_3A_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/bv/donnees-de-base-et-parametres/pilier-3a.html"
+_FINMA_URL = "https://www.finma.ch/fr/"
+_REVIEWED = date(2026, 3, 26)
+
+# ══════════════════════════════════════════════════════════════════════════════
+# All regulatory parameters — seeded from social_insurance.py
+# ══════════════════════════════════════════════════════════════════════════════
+
+_PARAMETERS: list[RegulatoryParameter] = [
+    # ─────────────────────────────────────────────────────────────────
+    # Pillar 3a — Prévoyance individuelle liée (OPP3 art. 7)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="pillar3a.max_with_lpp",
+        value=7_258.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        tax_year=2025,
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 al. 1",
+        source_type="ordinance",
+        description="Plafond annuel 3a pour salariés affiliés à la LPP (petit 3a).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.max_without_lpp",
+        value=36_288.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        tax_year=2025,
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 al. 2",
+        source_type="ordinance",
+        description="Plafond annuel 3a pour indépendants sans LPP (grand 3a = 20% du revenu net, max 36'288).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.income_rate_without_lpp",
+        value=0.20,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 al. 2",
+        source_type="ordinance",
+        description="Part du revenu déterminant pour le grand 3a : 20%.",
+        reviewed_at=_REVIEWED,
+    ),
+    # 3a historical limits (2016-2026)
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2026",
+        value=7_258.0,
+        unit="CHF",
+        tax_year=2026,
+        effective_from=date(2026, 1, 1),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2026.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2025",
+        value=7_258.0,
+        unit="CHF",
+        tax_year=2025,
+        effective_from=date(2025, 1, 1),
+        effective_to=date(2025, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2025.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2024",
+        value=7_056.0,
+        unit="CHF",
+        tax_year=2024,
+        effective_from=date(2024, 1, 1),
+        effective_to=date(2024, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2024.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2023",
+        value=6_883.0,
+        unit="CHF",
+        tax_year=2023,
+        effective_from=date(2023, 1, 1),
+        effective_to=date(2023, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2023.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2022",
+        value=6_826.0,
+        unit="CHF",
+        tax_year=2022,
+        effective_from=date(2022, 1, 1),
+        effective_to=date(2022, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2022.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2021",
+        value=6_826.0,
+        unit="CHF",
+        tax_year=2021,
+        effective_from=date(2021, 1, 1),
+        effective_to=date(2021, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2021.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2020",
+        value=6_826.0,
+        unit="CHF",
+        tax_year=2020,
+        effective_from=date(2020, 1, 1),
+        effective_to=date(2020, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2020.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2019",
+        value=6_826.0,
+        unit="CHF",
+        tax_year=2019,
+        effective_from=date(2019, 1, 1),
+        effective_to=date(2019, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2019.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2018",
+        value=6_826.0,
+        unit="CHF",
+        tax_year=2018,
+        effective_from=date(2018, 1, 1),
+        effective_to=date(2018, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2018.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2017",
+        value=6_768.0,
+        unit="CHF",
+        tax_year=2017,
+        effective_from=date(2017, 1, 1),
+        effective_to=date(2017, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2017.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="pillar3a.historical_limits.2016",
+        value=6_768.0,
+        unit="CHF",
+        tax_year=2016,
+        effective_from=date(2016, 1, 1),
+        effective_to=date(2016, 12, 31),
+        source_url=_OFAS_3A_URL,
+        source_title="OPP3 art. 7 — OFAS publication annuelle",
+        source_type="ordinance",
+        description="Plafond 3a (avec LPP) pour l'année 2016.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # LPP — Prévoyance professionnelle (2e pilier)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="lpp.entry_threshold",
+        value=22_680.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 7",
+        source_type="law",
+        description="Salaire annuel minimum pour être soumis à la LPP (seuil d'accès).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.coordination_deduction",
+        value=26_460.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 8",
+        source_type="law",
+        description="Déduction de coordination. Salaire coordonné = brut - déduction.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.min_coordinated_salary",
+        value=3_780.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 8 al. 2",
+        source_type="law",
+        description="Salaire coordonné minimum assuré.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.max_coordinated_salary",
+        value=64_260.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 8 al. 1",
+        source_type="law",
+        description="Salaire coordonné maximum assuré.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.max_insured_salary",
+        value=90_720.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 8 al. 1",
+        source_type="law",
+        description="Salaire annuel maximum assuré LPP.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.conversion_rate",
+        value=0.068,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 14 al. 2",
+        source_type="law",
+        description="Taux de conversion minimum LPP (6.8%). Capital -> rente annuelle.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.min_interest_rate",
+        value=1.25,
+        unit="percent",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="OPP2 — Conseil fédéral",
+        source_type="ordinance",
+        description="Taux d'intérêt minimum LPP (fixé par le Conseil fédéral).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.bonification.25_34",
+        value=0.07,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 16",
+        source_type="law",
+        description="Taux de bonification de vieillesse 25-34 ans : 7% du salaire coordonné.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.bonification.35_44",
+        value=0.10,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 16",
+        source_type="law",
+        description="Taux de bonification de vieillesse 35-44 ans : 10% du salaire coordonné.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.bonification.45_54",
+        value=0.15,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 16",
+        source_type="law",
+        description="Taux de bonification de vieillesse 45-54 ans : 15% du salaire coordonné.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.bonification.55_65",
+        value=0.18,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 16",
+        source_type="law",
+        description="Taux de bonification de vieillesse 55-65 ans : 18% du salaire coordonné.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.conversion_rate_complementaire",
+        value=0.058,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="Pratique caisses complémentaires",
+        source_type="estimate",
+        description="Taux de conversion blended pour caisses complémentaires (~60% oblig. 6.8% + ~40% suroblig. ~4.3%).",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # EPL — Encouragement à la propriété du logement (LPP art. 30c)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="lpp.epl_minimum",
+        value=20_000.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="OPP2 art. 5",
+        source_type="ordinance",
+        description="Montant minimum pour un retrait EPL.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lpp.epl_buyback_lock_years",
+        value=3.0,
+        unit="years",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_LPP_URL,
+        source_title="LPP art. 79b al. 3",
+        source_type="law",
+        description="Délai de blocage des rachats LPP après un retrait EPL.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # AVS — Assurance-vieillesse et survivants (1er pilier)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="avs.max_monthly_pension",
+        value=2_520.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34",
+        source_type="law",
+        description="Rente AVS maximale individuelle mensuelle.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.min_monthly_pension",
+        value=1_260.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34",
+        source_type="law",
+        description="Rente AVS minimale individuelle mensuelle (50% de la rente max).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.couple_max_monthly",
+        value=3_780.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 35",
+        source_type="law",
+        description="Rente AVS maximale pour un couple marié mensuelle (150% de la rente max individuelle).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.max_annual_pension",
+        value=30_240.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34",
+        source_type="law",
+        description="Rente AVS maximale annuelle individuelle (2'520 x 12).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.contribution_rate_employee",
+        value=0.053,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 5",
+        source_type="law",
+        description="Taux de cotisation AVS/AI/APG part salarié : 5.3% (total 10.6%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.contribution_rate_total",
+        value=0.106,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 5",
+        source_type="law",
+        description="Taux de cotisation AVS/AI/APG total (salarié + employeur) : 10.6%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.full_contribution_years",
+        value=44.0,
+        unit="years",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 29ter",
+        source_type="law",
+        description="Nombre d'années de cotisation pour une rente complète.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.reference_age_men",
+        value=65.0,
+        unit="years",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 21",
+        source_type="law",
+        description="Âge de référence AVS pour les hommes.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.reference_age_women",
+        value=65.0,
+        unit="years",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 21 (réforme AVS 21)",
+        source_type="law",
+        description="Âge de référence AVS pour les femmes (depuis réforme AVS 21).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.anticipation_reduction",
+        value=0.068,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 40",
+        source_type="law",
+        description="Réduction par année d'anticipation de la rente AVS : 6.8%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.deferral_supplement.1",
+        value=0.052,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 39",
+        source_type="law",
+        description="Supplément de rente pour 1 an d'ajournement : +5.2%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.deferral_supplement.2",
+        value=0.106,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 39",
+        source_type="law",
+        description="Supplément de rente pour 2 ans d'ajournement : +10.6%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.deferral_supplement.3",
+        value=0.164,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 39",
+        source_type="law",
+        description="Supplément de rente pour 3 ans d'ajournement : +16.4%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.deferral_supplement.4",
+        value=0.227,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 39",
+        source_type="law",
+        description="Supplément de rente pour 4 ans d'ajournement : +22.7%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.deferral_supplement.5",
+        value=0.315,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 39",
+        source_type="law",
+        description="Supplément de rente pour 5 ans d'ajournement : +31.5%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.retiree_franchise_monthly",
+        value=1_400.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 4",
+        source_type="law",
+        description="Franchise AVS pour retraités actifs, mensuelle.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.retiree_franchise_annual",
+        value=16_800.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 4",
+        source_type="law",
+        description="Franchise AVS pour retraités actifs, annuelle.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.survivor_factor",
+        value=0.80,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 23-24",
+        source_type="law",
+        description="Facteur rente de survivant (80% de la rente du défunt).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.ramd_min",
+        value=14_700.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34",
+        source_type="law",
+        description="RAMD minimum (revenu annuel moyen déterminant). Rente = min si salaire <= RAMD_MIN.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.ramd_max",
+        value=88_200.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34",
+        source_type="law",
+        description="RAMD maximum. Rente = max si salaire >= RAMD_MAX.",
+        reviewed_at=_REVIEWED,
+    ),
+    # 13th pension
+    RegulatoryParameter(
+        key="avs.13th_pension_active",
+        value=1.0,
+        unit="boolean",
+        effective_from=date(2026, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34 (nouveau), art. constitutionnel 112 al. 4bis",
+        source_type="law",
+        description="13ème rente AVS active (true=1.0). Premier versement décembre 2026.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.13th_pension_start_year",
+        value=2026.0,
+        unit="years",
+        effective_from=date(2026, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34 (nouveau)",
+        source_type="law",
+        description="Année du premier versement de la 13ème rente AVS.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.13th_pension_factor",
+        value=13.0 / 12.0,
+        unit="ratio",
+        effective_from=date(2026, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 34 (nouveau)",
+        source_type="law",
+        description="Facteur multiplicateur 13ème rente (13/12 = 1.0833...).",
+        reviewed_at=_REVIEWED,
+    ),
+    # AVS volontaire (expatriés)
+    RegulatoryParameter(
+        key="avs.voluntary_contribution_min",
+        value=514.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 2",
+        source_type="law",
+        description="Cotisation annuelle minimale AVS volontaire.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.voluntary_contribution_max",
+        value=25_700.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 2",
+        source_type="law",
+        description="Cotisation annuelle maximale AVS volontaire.",
+        reviewed_at=_REVIEWED,
+    ),
+    # AVS indépendants
+    RegulatoryParameter(
+        key="avs.min_contribution_independent",
+        value=530.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 8",
+        source_type="law",
+        description="Cotisation AVS minimale annuelle pour indépendants.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="avs.independent_min_income_threshold",
+        value=9_800.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAVS art. 8",
+        source_type="law",
+        description="Seuil de revenu en dessous duquel la cotisation minimale s'applique.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # AI — Assurance-invalidité (LAI)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="ai.contribution_rate_employee",
+        value=0.007,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAI art. 3",
+        source_type="law",
+        description="Taux de cotisation AI part salarié : 0.7% (total 1.4%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ai.contribution_rate_total",
+        value=0.014,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAI art. 3",
+        source_type="law",
+        description="Taux de cotisation AI total : 1.4%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ai.full_pension_monthly",
+        value=2_520.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAI art. 28",
+        source_type="law",
+        description="Rente AI entière mensuelle (= rente AVS max). Degré invalidité >= 70%.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # APG — Allocations pour perte de gain (LAPG)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="apg.contribution_rate_employee",
+        value=0.0025,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAPG art. 27",
+        source_type="law",
+        description="Taux de cotisation APG part salarié : 0.25% (total 0.5%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="apg.contribution_rate_total",
+        value=0.005,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAPG art. 27",
+        source_type="law",
+        description="Taux de cotisation APG total : 0.5%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="apg.maternity_days",
+        value=98.0,
+        unit="days",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAPG art. 16d",
+        source_type="law",
+        description="Durée du congé maternité : 98 jours = 14 semaines.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="apg.maternity_rate",
+        value=0.80,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAPG art. 16f",
+        source_type="law",
+        description="Taux d'indemnité de maternité : 80% du salaire.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="apg.paternity_days",
+        value=10.0,
+        unit="days",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LAPG art. 16i",
+        source_type="law",
+        description="Durée du congé paternité : 10 jours.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # AC — Assurance-chômage (LACI)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="ac.max_insured_salary",
+        value=148_200.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 3",
+        source_type="law",
+        description="Plafond du salaire assuré AC.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.contribution_rate_employee",
+        value=0.011,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 3",
+        source_type="law",
+        description="Taux de cotisation AC part salarié : 1.1% (total 2.2%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.contribution_rate_total",
+        value=0.022,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 3",
+        source_type="law",
+        description="Taux de cotisation AC total : 2.2%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.solidarity_rate_employee",
+        value=0.005,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 3",
+        source_type="law",
+        description="Cotisation de solidarité AC part salarié : 0.5% (au-dessus du plafond).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.solidarity_rate_total",
+        value=0.01,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 3",
+        source_type="law",
+        description="Cotisation de solidarité AC total : 1.0%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.benefit_rate_standard",
+        value=0.70,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 22",
+        source_type="law",
+        description="Taux d'indemnité chômage standard : 70%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="ac.benefit_rate_family",
+        value=0.80,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_OFAS_AVS_URL,
+        source_title="LACI art. 22",
+        source_type="law",
+        description="Taux d'indemnité chômage avec charges de famille : 80%.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # LAMal — Assurance-maladie obligatoire
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="lamal.copay_rate",
+        value=0.10,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.bag.admin.ch/bag/fr/home/versicherungen/krankenversicherung.html",
+        source_title="LAMal art. 64",
+        source_type="law",
+        description="Quote-part : 10% des frais au-dessus de la franchise.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lamal.copay_cap_adult",
+        value=700.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.bag.admin.ch/bag/fr/home/versicherungen/krankenversicherung.html",
+        source_title="LAMal art. 64 al. 2",
+        source_type="law",
+        description="Quote-part maximale annuelle adultes >= 26 ans.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="lamal.copay_cap_child",
+        value=350.0,
+        unit="CHF",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.bag.admin.ch/bag/fr/home/versicherungen/krankenversicherung.html",
+        source_title="LAMal art. 64 al. 4",
+        source_type="law",
+        description="Quote-part maximale annuelle enfants < 18 ans.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # Mortgage — Pratique bancaire suisse (ASB / FINMA)
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="mortgage.theoretical_rate",
+        value=0.05,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Directives en matière d'hypothèques",
+        source_type="circular",
+        description="Taux d'intérêt théorique pour le calcul de capacité (5%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="mortgage.amortization_rate",
+        value=0.01,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Directives en matière d'hypothèques",
+        source_type="circular",
+        description="Taux d'amortissement annuel minimum (1%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="mortgage.maintenance_rate",
+        value=0.01,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Directives en matière d'hypothèques",
+        source_type="circular",
+        description="Taux de frais accessoires annuels (entretien, assurance) : 1%.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="mortgage.max_charge_ratio",
+        value=1.0 / 3.0,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Règle du 1/3",
+        source_type="circular",
+        description="Ratio maximal des charges par rapport au revenu brut (règle du 1/3).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="mortgage.min_equity",
+        value=0.20,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Fonds propres",
+        source_type="circular",
+        description="Part minimale de fonds propres (20% du prix d'achat).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="mortgage.max_2nd_pillar",
+        value=0.10,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url=_FINMA_URL,
+        source_title="FINMA/ASB — Fonds propres 2e pilier",
+        source_type="circular",
+        description="Part maximale du 2e pilier dans les fonds propres (10% du prix d'achat).",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # Capital withdrawal tax — Default rate + progressive brackets
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="capital_tax.default_rate",
+        value=0.065,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 — taux par défaut",
+        source_type="law",
+        description="Taux par défaut de l'impôt sur le retrait de capital (fallback canton inconnu).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.married_discount",
+        value=0.85,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD — splitting cantonal",
+        source_type="law",
+        description="Réduction d'impôt pour les couples mariés (splitting cantonal ~15%).",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.bracket.0_100k",
+        value=1.00,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38",
+        source_type="law",
+        description="Multiplicateur tranche 0-100k CHF pour impôt sur retrait de capital.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.bracket.100k_200k",
+        value=1.15,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38",
+        source_type="law",
+        description="Multiplicateur tranche 100-200k CHF pour impôt sur retrait de capital.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.bracket.200k_500k",
+        value=1.30,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38",
+        source_type="law",
+        description="Multiplicateur tranche 200-500k CHF pour impôt sur retrait de capital.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.bracket.500k_1m",
+        value=1.50,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38",
+        source_type="law",
+        description="Multiplicateur tranche 500k-1M CHF pour impôt sur retrait de capital.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.bracket.1m_plus",
+        value=1.70,
+        unit="ratio",
+        effective_from=date(2025, 1, 1),
+        source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38",
+        source_type="law",
+        description="Multiplicateur tranche 1M+ CHF pour impôt sur retrait de capital.",
+        reviewed_at=_REVIEWED,
+    ),
+
+    # ─────────────────────────────────────────────────────────────────
+    # Capital withdrawal tax — 26 cantonal base rates
+    # ─────────────────────────────────────────────────────────────────
+    RegulatoryParameter(
+        key="capital_tax.cantonal.ZH", value=0.065, unit="ratio", jurisdiction="ZH",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG ZH", source_type="law",
+        description="Taux de base impôt retrait capital — Zürich.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.BE", value=0.075, unit="ratio", jurisdiction="BE",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG BE", source_type="law",
+        description="Taux de base impôt retrait capital — Bern.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.LU", value=0.055, unit="ratio", jurisdiction="LU",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG LU", source_type="law",
+        description="Taux de base impôt retrait capital — Luzern.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.UR", value=0.050, unit="ratio", jurisdiction="UR",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG UR", source_type="law",
+        description="Taux de base impôt retrait capital — Uri.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.SZ", value=0.040, unit="ratio", jurisdiction="SZ",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG SZ", source_type="law",
+        description="Taux de base impôt retrait capital — Schwyz.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.OW", value=0.045, unit="ratio", jurisdiction="OW",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG OW", source_type="law",
+        description="Taux de base impôt retrait capital — Obwalden.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.NW", value=0.040, unit="ratio", jurisdiction="NW",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG NW", source_type="law",
+        description="Taux de base impôt retrait capital — Nidwalden.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.GL", value=0.055, unit="ratio", jurisdiction="GL",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG GL", source_type="law",
+        description="Taux de base impôt retrait capital — Glarus.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.ZG", value=0.035, unit="ratio", jurisdiction="ZG",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG ZG", source_type="law",
+        description="Taux de base impôt retrait capital — Zug.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.FR", value=0.070, unit="ratio", jurisdiction="FR",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LICD FR", source_type="law",
+        description="Taux de base impôt retrait capital — Fribourg.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.SO", value=0.065, unit="ratio", jurisdiction="SO",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG SO", source_type="law",
+        description="Taux de base impôt retrait capital — Solothurn.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.BS", value=0.075, unit="ratio", jurisdiction="BS",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG BS", source_type="law",
+        description="Taux de base impôt retrait capital — Basel-Stadt.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.BL", value=0.065, unit="ratio", jurisdiction="BL",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG BL", source_type="law",
+        description="Taux de base impôt retrait capital — Basel-Landschaft.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.SH", value=0.060, unit="ratio", jurisdiction="SH",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG SH", source_type="law",
+        description="Taux de base impôt retrait capital — Schaffhausen.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.AR", value=0.055, unit="ratio", jurisdiction="AR",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG AR", source_type="law",
+        description="Taux de base impôt retrait capital — Appenzell Ausserrhoden.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.AI", value=0.045, unit="ratio", jurisdiction="AI",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG AI", source_type="law",
+        description="Taux de base impôt retrait capital — Appenzell Innerrhoden.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.SG", value=0.060, unit="ratio", jurisdiction="SG",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG SG", source_type="law",
+        description="Taux de base impôt retrait capital — St. Gallen.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.GR", value=0.055, unit="ratio", jurisdiction="GR",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG GR", source_type="law",
+        description="Taux de base impôt retrait capital — Graubünden.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.AG", value=0.060, unit="ratio", jurisdiction="AG",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG AG", source_type="law",
+        description="Taux de base impôt retrait capital — Aargau.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.TG", value=0.055, unit="ratio", jurisdiction="TG",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + StG TG", source_type="law",
+        description="Taux de base impôt retrait capital — Thurgau.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.TI", value=0.065, unit="ratio", jurisdiction="TI",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LT TI", source_type="law",
+        description="Taux de base impôt retrait capital — Ticino.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.VD", value=0.080, unit="ratio", jurisdiction="VD",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LI VD", source_type="law",
+        description="Taux de base impôt retrait capital — Vaud.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.VS", value=0.060, unit="ratio", jurisdiction="VS",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LF VS", source_type="law",
+        description="Taux de base impôt retrait capital — Valais.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.NE", value=0.070, unit="ratio", jurisdiction="NE",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LCdir NE", source_type="law",
+        description="Taux de base impôt retrait capital — Neuchâtel.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.GE", value=0.075, unit="ratio", jurisdiction="GE",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LIPP GE", source_type="law",
+        description="Taux de base impôt retrait capital — Genève.",
+        reviewed_at=_REVIEWED,
+    ),
+    RegulatoryParameter(
+        key="capital_tax.cantonal.JU", value=0.065, unit="ratio", jurisdiction="JU",
+        effective_from=date(2025, 1, 1), source_url="https://www.estv.admin.ch/",
+        source_title="LIFD art. 38 + LI JU", source_type="law",
+        description="Taux de base impôt retrait capital — Jura.",
+        reviewed_at=_REVIEWED,
+    ),
+]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Singleton Registry
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class RegulatoryRegistry:
+    """In-memory registry of Swiss financial regulatory parameters.
+
+    Singleton — use RegulatoryRegistry.instance() to access.
+
+    Methods:
+        get(key, jurisdiction, effective_on) → RegulatoryParameter
+        get_value(key, jurisdiction, effective_on) → float
+        get_all(category) → list[RegulatoryParameter]
+        check_freshness(max_age_days) → list[RegulatoryParameter]
+        keys() → list[str]
+    """
+
+    _instance: RegulatoryRegistry | None = None
+
+    def __init__(self) -> None:
+        self._params: dict[str, list[RegulatoryParameter]] = {}
+        for p in _PARAMETERS:
+            self._params.setdefault(p.key, []).append(p)
+
+    @classmethod
+    def instance(cls) -> RegulatoryRegistry:
+        """Return the singleton instance (created on first call)."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def _reset(cls) -> None:
+        """Reset singleton (for testing only)."""
+        cls._instance = None
+
+    def get(
+        self,
+        key: str,
+        jurisdiction: str = "CH",
+        effective_on: Optional[date] = None,
+    ) -> Optional[RegulatoryParameter]:
+        """Look up a parameter by key, jurisdiction, and effective date.
+
+        Args:
+            key: Dotted parameter key (e.g. "pillar3a.max_with_lpp").
+            jurisdiction: "CH" for federal, or canton code.
+            effective_on: Date to check; None = today.
+
+        Returns:
+            The matching RegulatoryParameter, or None if not found.
+        """
+        candidates = self._params.get(key, [])
+        check_date = effective_on or date.today()
+
+        # Filter by jurisdiction and active date
+        matches = [
+            p for p in candidates
+            if p.jurisdiction == jurisdiction and p.is_active(check_date)
+        ]
+        if not matches:
+            # Fallback: try without date filter (for historical parameters)
+            matches = [p for p in candidates if p.jurisdiction == jurisdiction]
+
+        if not matches:
+            return None
+
+        # Return the most recently effective parameter
+        return max(matches, key=lambda p: p.effective_from)
+
+    def get_value(
+        self,
+        key: str,
+        jurisdiction: str = "CH",
+        effective_on: Optional[date] = None,
+    ) -> Optional[float]:
+        """Convenience: return just the value, or None if not found."""
+        param = self.get(key, jurisdiction, effective_on)
+        return param.value if param else None
+
+    def get_all(self, category: Optional[str] = None) -> list[RegulatoryParameter]:
+        """Return all parameters, optionally filtered by category prefix.
+
+        Args:
+            category: Key prefix filter (e.g. "avs", "lpp", "pillar3a").
+                      None = return all parameters.
+
+        Returns:
+            List of matching parameters.
+        """
+        all_params = [p for params in self._params.values() for p in params]
+        if category:
+            prefix = category.lower() + "."
+            return [p for p in all_params if p.key.lower().startswith(prefix)]
+        return all_params
+
+    def check_freshness(self, max_age_days: int = 90) -> list[RegulatoryParameter]:
+        """Return parameters that are stale (reviewed_at older than max_age_days).
+
+        Args:
+            max_age_days: Maximum number of days since last review.
+
+        Returns:
+            List of stale parameters needing review.
+        """
+        stale = []
+        for params in self._params.values():
+            for p in params:
+                if p.is_stale(max_age_days):
+                    stale.append(p)
+        return stale
+
+    def keys(self) -> list[str]:
+        """Return all unique parameter keys."""
+        return sorted(self._params.keys())
+
+    def count(self) -> int:
+        """Return total number of parameters (including historical variants)."""
+        return sum(len(v) for v in self._params.values())

--- a/services/backend/tests/test_regulatory_registry.py
+++ b/services/backend/tests/test_regulatory_registry.py
@@ -1,0 +1,709 @@
+"""Tests for the Regulatory Registry — single source of truth for Swiss financial constants.
+
+Verifies:
+    1. All constants from social_insurance.py are present in the registry.
+    2. Values match exactly between registry and social_insurance.py.
+    3. All parameters have source_url set.
+    4. All parameters have reviewed_at within 90 days.
+    5. No expired parameter without a replacement.
+    6. All 26 cantonal tax rates are present.
+    7. 3a historical limits 2016-2026 are all present.
+    8. AVS reference ages are correct.
+    9. Freshness check returns empty list (all recently reviewed).
+    10. get() returns correct values for each category.
+    11. Category filtering works.
+    12. Cantonal lookup works.
+    13. Unknown key returns None.
+    14. LLM tool handler works.
+    15. API-compatible serialization works.
+    16. Singleton pattern works correctly.
+
+Sources:
+    - app/constants/social_insurance.py
+    - app/services/regulatory/registry.py
+    - app/models/regulatory_parameter.py
+"""
+
+import pytest
+from datetime import date
+
+from app.models.regulatory_parameter import RegulatoryParameter
+from app.services.regulatory.registry import RegulatoryRegistry
+from app.constants import social_insurance as si
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset singleton between tests to ensure isolation."""
+    RegulatoryRegistry._reset()
+    yield
+    RegulatoryRegistry._reset()
+
+
+@pytest.fixture
+def registry() -> RegulatoryRegistry:
+    """Return a fresh registry instance."""
+    return RegulatoryRegistry.instance()
+
+
+# ---------------------------------------------------------------------------
+# 1. All key constants from social_insurance.py are present
+# ---------------------------------------------------------------------------
+
+
+class TestConstantsPresence:
+    """Verify every critical constant from social_insurance.py is in the registry."""
+
+    def test_pillar3a_max_with_lpp(self, registry):
+        param = registry.get("pillar3a.max_with_lpp")
+        assert param is not None
+        assert param.value == si.PILIER_3A_PLAFOND_AVEC_LPP
+
+    def test_pillar3a_max_without_lpp(self, registry):
+        param = registry.get("pillar3a.max_without_lpp")
+        assert param is not None
+        assert param.value == si.PILIER_3A_PLAFOND_SANS_LPP
+
+    def test_pillar3a_income_rate(self, registry):
+        param = registry.get("pillar3a.income_rate_without_lpp")
+        assert param is not None
+        assert param.value == si.PILIER_3A_TAUX_REVENU_SANS_LPP
+
+    def test_lpp_entry_threshold(self, registry):
+        param = registry.get("lpp.entry_threshold")
+        assert param is not None
+        assert param.value == si.LPP_SEUIL_ENTREE
+
+    def test_lpp_coordination_deduction(self, registry):
+        param = registry.get("lpp.coordination_deduction")
+        assert param is not None
+        assert param.value == si.LPP_DEDUCTION_COORDINATION
+
+    def test_lpp_min_coordinated_salary(self, registry):
+        param = registry.get("lpp.min_coordinated_salary")
+        assert param is not None
+        assert param.value == si.LPP_SALAIRE_COORDONNE_MIN
+
+    def test_lpp_max_coordinated_salary(self, registry):
+        param = registry.get("lpp.max_coordinated_salary")
+        assert param is not None
+        assert param.value == si.LPP_SALAIRE_COORDONNE_MAX
+
+    def test_lpp_max_insured_salary(self, registry):
+        param = registry.get("lpp.max_insured_salary")
+        assert param is not None
+        assert param.value == si.LPP_SALAIRE_MAX
+
+    def test_lpp_conversion_rate(self, registry):
+        param = registry.get("lpp.conversion_rate")
+        assert param is not None
+        assert param.value == si.LPP_TAUX_CONVERSION_MIN_DECIMAL
+
+    def test_lpp_min_interest_rate(self, registry):
+        param = registry.get("lpp.min_interest_rate")
+        assert param is not None
+        assert param.value == si.LPP_TAUX_INTERET_MIN
+
+    def test_lpp_bonification_25_34(self, registry):
+        param = registry.get("lpp.bonification.25_34")
+        assert param is not None
+        assert param.value == 0.07
+
+    def test_lpp_bonification_35_44(self, registry):
+        param = registry.get("lpp.bonification.35_44")
+        assert param is not None
+        assert param.value == 0.10
+
+    def test_lpp_bonification_45_54(self, registry):
+        param = registry.get("lpp.bonification.45_54")
+        assert param is not None
+        assert param.value == 0.15
+
+    def test_lpp_bonification_55_65(self, registry):
+        param = registry.get("lpp.bonification.55_65")
+        assert param is not None
+        assert param.value == 0.18
+
+    def test_avs_max_monthly_pension(self, registry):
+        param = registry.get("avs.max_monthly_pension")
+        assert param is not None
+        assert param.value == si.AVS_RENTE_MAX_MENSUELLE
+
+    def test_avs_min_monthly_pension(self, registry):
+        param = registry.get("avs.min_monthly_pension")
+        assert param is not None
+        assert param.value == si.AVS_RENTE_MIN_MENSUELLE
+
+    def test_avs_couple_max(self, registry):
+        param = registry.get("avs.couple_max_monthly")
+        assert param is not None
+        assert param.value == si.AVS_RENTE_COUPLE_MAX_MENSUELLE
+
+    def test_avs_contribution_rate(self, registry):
+        param = registry.get("avs.contribution_rate_employee")
+        assert param is not None
+        assert param.value == si.AVS_COTISATION_SALARIE
+
+    def test_avs_full_contribution_years(self, registry):
+        param = registry.get("avs.full_contribution_years")
+        assert param is not None
+        assert param.value == float(si.AVS_DUREE_COTISATION_COMPLETE)
+
+    def test_avs_anticipation_reduction(self, registry):
+        param = registry.get("avs.anticipation_reduction")
+        assert param is not None
+        assert param.value == si.AVS_REDUCTION_ANTICIPATION
+
+    def test_avs_13th_pension(self, registry):
+        param = registry.get("avs.13th_pension_active")
+        assert param is not None
+        assert param.value == 1.0  # True stored as 1.0
+
+    def test_mortgage_theoretical_rate(self, registry):
+        param = registry.get("mortgage.theoretical_rate")
+        assert param is not None
+        assert param.value == si.HYPOTHEQUE_TAUX_THEORIQUE
+
+    def test_mortgage_amortization_rate(self, registry):
+        param = registry.get("mortgage.amortization_rate")
+        assert param is not None
+        assert param.value == si.HYPOTHEQUE_TAUX_AMORTISSEMENT
+
+    def test_mortgage_max_charge_ratio(self, registry):
+        param = registry.get("mortgage.max_charge_ratio")
+        assert param is not None
+        assert abs(param.value - si.HYPOTHEQUE_RATIO_CHARGES_MAX) < 1e-6
+
+    def test_mortgage_min_equity(self, registry):
+        param = registry.get("mortgage.min_equity")
+        assert param is not None
+        assert param.value == si.HYPOTHEQUE_FONDS_PROPRES_MIN
+
+    def test_mortgage_max_2nd_pillar(self, registry):
+        param = registry.get("mortgage.max_2nd_pillar")
+        assert param is not None
+        assert param.value == si.HYPOTHEQUE_PART_2E_PILIER_MAX
+
+    def test_epl_minimum(self, registry):
+        param = registry.get("lpp.epl_minimum")
+        assert param is not None
+        assert param.value == si.EPL_MONTANT_MINIMUM
+
+    def test_epl_buyback_lock(self, registry):
+        param = registry.get("lpp.epl_buyback_lock_years")
+        assert param is not None
+        assert param.value == float(si.EPL_BLOCAGE_RACHAT_ANNEES)
+
+    def test_capital_tax_default_rate(self, registry):
+        param = registry.get("capital_tax.default_rate")
+        assert param is not None
+        assert param.value == si.TAUX_IMPOT_RETRAIT_CAPITAL_DEFAULT
+
+    def test_capital_tax_married_discount(self, registry):
+        param = registry.get("capital_tax.married_discount")
+        assert param is not None
+        assert param.value == si.MARRIED_CAPITAL_TAX_DISCOUNT
+
+    def test_avs_min_contribution_independent(self, registry):
+        param = registry.get("avs.min_contribution_independent")
+        assert param is not None
+        assert param.value == si.AVS_COTISATION_MIN_INDEPENDANT
+
+    def test_lamal_copay_rate(self, registry):
+        param = registry.get("lamal.copay_rate")
+        assert param is not None
+        assert param.value == si.LAMAL_QUOTE_PART_RATE
+
+    def test_lamal_copay_cap_adult(self, registry):
+        param = registry.get("lamal.copay_cap_adult")
+        assert param is not None
+        assert param.value == si.LAMAL_QUOTE_PART_CAP_ADULT
+
+    def test_ai_full_pension(self, registry):
+        param = registry.get("ai.full_pension_monthly")
+        assert param is not None
+        assert param.value == si.AI_RENTE_ENTIERE
+
+    def test_ac_max_insured_salary(self, registry):
+        param = registry.get("ac.max_insured_salary")
+        assert param is not None
+        assert param.value == si.AC_PLAFOND_SALAIRE_ASSURE
+
+
+# ---------------------------------------------------------------------------
+# 2. Values match social_insurance.py
+# ---------------------------------------------------------------------------
+
+
+class TestValueConsistency:
+    """Cross-check registry values against social_insurance.py constants."""
+
+    def test_lpp_bonifications_match(self, registry):
+        """All 4 LPP bonification rates match LPP_BONIFICATIONS_DICT."""
+        for age, rate in si.LPP_BONIFICATIONS_DICT.items():
+            if age == 25:
+                key = "lpp.bonification.25_34"
+            elif age == 35:
+                key = "lpp.bonification.35_44"
+            elif age == 45:
+                key = "lpp.bonification.45_54"
+            else:
+                key = "lpp.bonification.55_65"
+            param = registry.get(key)
+            assert param is not None, f"Missing bonification key: {key}"
+            assert param.value == rate, f"{key}: {param.value} != {rate}"
+
+    def test_avs_annual_pension_matches(self, registry):
+        """AVS annual pension = monthly * 12."""
+        param = registry.get("avs.max_annual_pension")
+        assert param is not None
+        monthly = registry.get("avs.max_monthly_pension")
+        assert param.value == monthly.value * 12
+
+    def test_capital_tax_brackets_match(self, registry):
+        """Progressive bracket multipliers match social_insurance.py."""
+        expected = {
+            "capital_tax.bracket.0_100k": 1.00,
+            "capital_tax.bracket.100k_200k": 1.15,
+            "capital_tax.bracket.200k_500k": 1.30,
+            "capital_tax.bracket.500k_1m": 1.50,
+            "capital_tax.bracket.1m_plus": 1.70,
+        }
+        for key, expected_value in expected.items():
+            param = registry.get(key)
+            assert param is not None, f"Missing bracket: {key}"
+            assert param.value == expected_value, f"{key}: {param.value} != {expected_value}"
+
+    def test_avs_deferral_supplements_match(self, registry):
+        """AVS deferral supplements match social_insurance.py."""
+        for years, rate in si.AVS_SUPPLEMENT_AJOURNEMENT.items():
+            key = f"avs.deferral_supplement.{years}"
+            param = registry.get(key)
+            assert param is not None, f"Missing deferral supplement: {key}"
+            assert param.value == rate, f"{key}: {param.value} != {rate}"
+
+
+# ---------------------------------------------------------------------------
+# 3. All parameters have source_url
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataQuality:
+    """Every parameter must have complete metadata."""
+
+    def test_all_have_source_url(self, registry):
+        """Every parameter must have a non-empty source_url."""
+        for param in registry.get_all():
+            assert param.source_url, f"Missing source_url for {param.key}"
+
+    def test_all_have_source_title(self, registry):
+        """Every parameter must have a non-empty source_title."""
+        for param in registry.get_all():
+            assert param.source_title, f"Missing source_title for {param.key}"
+
+    def test_all_have_description(self, registry):
+        """Every parameter must have a non-empty description."""
+        for param in registry.get_all():
+            assert param.description, f"Missing description for {param.key}"
+
+    def test_all_have_valid_source_type(self, registry):
+        """source_type must be one of the allowed values."""
+        allowed = {"law", "ordinance", "circular", "faq", "estimate"}
+        for param in registry.get_all():
+            assert param.source_type in allowed, (
+                f"Invalid source_type '{param.source_type}' for {param.key}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. All parameters have reviewed_at within 90 days
+# ---------------------------------------------------------------------------
+
+
+class TestFreshness:
+    """All parameters must have been reviewed recently."""
+
+    def test_all_reviewed_within_90_days(self, registry):
+        """No parameter should be stale (reviewed_at > 90 days ago)."""
+        stale = registry.check_freshness(max_age_days=90)
+        stale_keys = [p.key for p in stale]
+        assert stale_keys == [], f"Stale parameters: {stale_keys}"
+
+    def test_all_have_reviewed_at(self, registry):
+        """Every parameter must have a reviewed_at date."""
+        for param in registry.get_all():
+            assert param.reviewed_at is not None, (
+                f"Missing reviewed_at for {param.key}"
+            )
+
+    def test_freshness_check_empty(self, registry):
+        """check_freshness returns empty list when all are fresh."""
+        stale = registry.check_freshness(max_age_days=90)
+        assert len(stale) == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. No expired parameter without replacement
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredParameters:
+    """Expired parameters should have a successor (same key, later effective_from)."""
+
+    def test_expired_3a_limits_have_successors(self, registry):
+        """Historical 3a limits that are expired should have a newer version."""
+        for year in range(2016, 2025):
+            key = f"pillar3a.historical_limits.{year}"
+            param = registry.get(key)
+            assert param is not None, f"Missing historical 3a limit: {key}"
+            # Current year's limit should exist
+            current = registry.get(f"pillar3a.historical_limits.{year + 1}")
+            if year < 2026:
+                assert current is not None, (
+                    f"No successor for {key}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# 6. All 26 cantonal tax rates present
+# ---------------------------------------------------------------------------
+
+
+class TestCantonalTaxRates:
+    """All 26 Swiss cantons must have capital withdrawal tax rates."""
+
+    ALL_CANTONS = [
+        "ZH", "BE", "LU", "UR", "SZ", "OW", "NW", "GL", "ZG", "FR",
+        "SO", "BS", "BL", "SH", "AR", "AI", "SG", "GR", "AG", "TG",
+        "TI", "VD", "VS", "NE", "GE", "JU",
+    ]
+
+    def test_all_26_cantons_present(self, registry):
+        """Every Swiss canton has a capital_tax.cantonal.XX entry."""
+        for canton in self.ALL_CANTONS:
+            key = f"capital_tax.cantonal.{canton}"
+            param = registry.get(key, jurisdiction=canton)
+            assert param is not None, f"Missing cantonal tax rate: {canton}"
+
+    def test_cantonal_rates_match_social_insurance(self, registry):
+        """Cantonal rates match TAUX_IMPOT_RETRAIT_CAPITAL dict."""
+        for canton, expected_rate in si.TAUX_IMPOT_RETRAIT_CAPITAL.items():
+            key = f"capital_tax.cantonal.{canton}"
+            param = registry.get(key, jurisdiction=canton)
+            assert param is not None, f"Missing cantonal rate: {canton}"
+            assert param.value == expected_rate, (
+                f"{canton}: {param.value} != {expected_rate}"
+            )
+
+    def test_cantonal_count_is_26(self, registry):
+        """Exactly 26 cantonal tax rate parameters."""
+        cantonal = [
+            p for p in registry.get_all()
+            if p.key.startswith("capital_tax.cantonal.")
+        ]
+        assert len(cantonal) == 26
+
+
+# ---------------------------------------------------------------------------
+# 7. 3a historical limits 2016-2026 all present
+# ---------------------------------------------------------------------------
+
+
+class TestHistoricalLimits:
+    """3a historical limits from 2016 to 2026 must all be present."""
+
+    def test_all_years_present(self, registry):
+        """Every year from 2016 to 2026 has a 3a limit."""
+        for year in range(2016, 2027):
+            key = f"pillar3a.historical_limits.{year}"
+            param = registry.get(key)
+            assert param is not None, f"Missing 3a historical limit for {year}"
+
+    def test_historical_values_match(self, registry):
+        """Historical 3a values match retroactive_3a_service.py."""
+        from app.services.pillar_3a_deep.retroactive_3a_service import HISTORICAL_3A_LIMITS
+
+        for year, expected_value in HISTORICAL_3A_LIMITS.items():
+            key = f"pillar3a.historical_limits.{year}"
+            param = registry.get(key)
+            assert param is not None, f"Missing historical limit for {year}"
+            assert param.value == expected_value, (
+                f"Year {year}: {param.value} != {expected_value}"
+            )
+
+    def test_historical_count(self, registry):
+        """At least 11 historical limits (2016-2026)."""
+        historical = [
+            p for p in registry.get_all()
+            if p.key.startswith("pillar3a.historical_limits.")
+        ]
+        assert len(historical) >= 11
+
+
+# ---------------------------------------------------------------------------
+# 8. AVS reference ages correct
+# ---------------------------------------------------------------------------
+
+
+class TestAvsReferenceAges:
+    """AVS reference ages must reflect post-AVS 21 reform values."""
+
+    def test_men_reference_age_65(self, registry):
+        param = registry.get("avs.reference_age_men")
+        assert param is not None
+        assert param.value == 65.0
+
+    def test_women_reference_age_65(self, registry):
+        """Women's reference age is 65 since AVS 21 reform."""
+        param = registry.get("avs.reference_age_women")
+        assert param is not None
+        assert param.value == 65.0
+
+    def test_gender_equality_post_reform(self, registry):
+        """Both genders have the same reference age after AVS 21."""
+        men = registry.get("avs.reference_age_men")
+        women = registry.get("avs.reference_age_women")
+        assert men.value == women.value
+
+
+# ---------------------------------------------------------------------------
+# 9. Freshness check returns empty list
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessCheck:
+    """The freshness check should confirm all parameters are recently reviewed."""
+
+    def test_check_freshness_returns_empty(self, registry):
+        stale = registry.check_freshness(max_age_days=90)
+        assert stale == []
+
+    def test_stale_detection_works(self):
+        """A parameter with old reviewed_at should be flagged stale."""
+        param = RegulatoryParameter(
+            key="test.stale",
+            value=42.0,
+            reviewed_at=date(2020, 1, 1),
+        )
+        assert param.is_stale(max_age_days=90)
+
+    def test_fresh_detection_works(self):
+        """A recently reviewed parameter should not be stale."""
+        param = RegulatoryParameter(
+            key="test.fresh",
+            value=42.0,
+            reviewed_at=date.today(),
+        )
+        assert not param.is_stale(max_age_days=90)
+
+    def test_none_reviewed_at_is_stale(self):
+        """A parameter with no reviewed_at should be stale."""
+        param = RegulatoryParameter(
+            key="test.no_review",
+            value=42.0,
+            reviewed_at=None,
+        )
+        assert param.is_stale(max_age_days=90)
+
+
+# ---------------------------------------------------------------------------
+# 10. get() returns correct values for each category
+# ---------------------------------------------------------------------------
+
+
+class TestGetByCategory:
+    """get_all() with category filter returns correct subsets."""
+
+    def test_avs_category(self, registry):
+        avs = registry.get_all(category="avs")
+        assert len(avs) > 10  # Multiple AVS params
+        assert all(p.key.startswith("avs.") for p in avs)
+
+    def test_lpp_category(self, registry):
+        lpp = registry.get_all(category="lpp")
+        assert len(lpp) >= 8  # LPP params
+        assert all(p.key.startswith("lpp.") for p in lpp)
+
+    def test_pillar3a_category(self, registry):
+        p3a = registry.get_all(category="pillar3a")
+        assert len(p3a) >= 3  # 3 core + 11 historical
+        assert all(p.key.startswith("pillar3a.") for p in p3a)
+
+    def test_mortgage_category(self, registry):
+        mortgage = registry.get_all(category="mortgage")
+        assert len(mortgage) >= 5
+        assert all(p.key.startswith("mortgage.") for p in mortgage)
+
+    def test_capital_tax_category(self, registry):
+        tax = registry.get_all(category="capital_tax")
+        # 26 cantonal + brackets + default + married
+        assert len(tax) >= 30
+
+    def test_all_params_returned_without_filter(self, registry):
+        """get_all() with no filter returns everything."""
+        all_params = registry.get_all()
+        assert len(all_params) > 80  # Many parameters
+
+
+# ---------------------------------------------------------------------------
+# 11. Unknown key returns None
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge cases and error handling."""
+
+    def test_unknown_key_returns_none(self, registry):
+        assert registry.get("nonexistent.key") is None
+
+    def test_get_value_shortcut(self, registry):
+        value = registry.get_value("pillar3a.max_with_lpp")
+        assert value == 7258.0
+
+    def test_get_value_unknown_returns_none(self, registry):
+        assert registry.get_value("nonexistent.key") is None
+
+    def test_singleton_returns_same_instance(self):
+        a = RegulatoryRegistry.instance()
+        b = RegulatoryRegistry.instance()
+        assert a is b
+
+    def test_keys_sorted(self, registry):
+        keys = registry.keys()
+        assert keys == sorted(keys)
+
+    def test_count_returns_positive(self, registry):
+        assert registry.count() > 80
+
+
+# ---------------------------------------------------------------------------
+# 12. RegulatoryParameter model
+# ---------------------------------------------------------------------------
+
+
+class TestParameterModel:
+    """Test the RegulatoryParameter dataclass."""
+
+    def test_is_active_current(self):
+        param = RegulatoryParameter(
+            key="test",
+            value=1.0,
+            effective_from=date(2025, 1, 1),
+        )
+        assert param.is_active(date(2025, 6, 1))
+
+    def test_is_active_before_effective(self):
+        param = RegulatoryParameter(
+            key="test",
+            value=1.0,
+            effective_from=date(2025, 1, 1),
+        )
+        assert not param.is_active(date(2024, 12, 31))
+
+    def test_is_active_after_expired(self):
+        param = RegulatoryParameter(
+            key="test",
+            value=1.0,
+            effective_from=date(2025, 1, 1),
+            effective_to=date(2025, 12, 31),
+        )
+        assert not param.is_active(date(2026, 1, 1))
+
+    def test_to_dict_camelcase(self):
+        param = RegulatoryParameter(
+            key="test.key",
+            value=42.0,
+            unit="CHF",
+            effective_from=date(2025, 1, 1),
+            source_url="https://example.com",
+            source_title="Test",
+            reviewed_at=date(2026, 3, 26),
+        )
+        d = param.to_dict()
+        assert d["key"] == "test.key"
+        assert d["value"] == 42.0
+        assert d["effectiveFrom"] == "2025-01-01"
+        assert d["reviewedAt"] == "2026-03-26"
+        assert "sourceUrl" in d  # camelCase
+
+
+# ---------------------------------------------------------------------------
+# 13. LLM tool handler
+# ---------------------------------------------------------------------------
+
+
+class TestLLMToolHandler:
+    """Test the get_regulatory_constant internal tool handler."""
+
+    def test_handler_returns_value(self):
+        from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+        result = _handle_regulatory_constant({"key": "pillar3a.max_with_lpp"})
+        assert "7258" in result
+        assert "OPP3" in result
+
+    def test_handler_unknown_key(self):
+        from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+        result = _handle_regulatory_constant({"key": "nonexistent.key"})
+        assert "non trouvée" in result
+
+    def test_handler_empty_key(self):
+        from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+        result = _handle_regulatory_constant({"key": ""})
+        assert "manquante" in result
+
+    def test_handler_with_canton(self):
+        from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+        result = _handle_regulatory_constant({
+            "key": "capital_tax.cantonal.VS",
+            "canton": "VS",
+        })
+        assert "0.06" in result
+
+    def test_handler_canton_auto_key(self):
+        """When canton is provided but key is generic, handler auto-builds key."""
+        from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+        result = _handle_regulatory_constant({
+            "key": "capital_tax.cantonal",
+            "canton": "ZG",
+        })
+        assert "0.035" in result
+
+
+# ---------------------------------------------------------------------------
+# 14. Coach tools integration
+# ---------------------------------------------------------------------------
+
+
+class TestCoachToolsIntegration:
+    """Verify the regulatory tool is registered in coach_tools.py."""
+
+    def test_internal_tool_name_registered(self):
+        from app.services.coach.coach_tools import INTERNAL_TOOL_NAMES
+
+        assert "get_regulatory_constant" in INTERNAL_TOOL_NAMES
+
+    def test_tool_definition_exists(self):
+        from app.services.coach.coach_tools import COACH_TOOLS
+
+        tool_names = [t["name"] for t in COACH_TOOLS]
+        assert "get_regulatory_constant" in tool_names
+
+    def test_tool_has_correct_schema(self):
+        from app.services.coach.coach_tools import COACH_TOOLS
+
+        tool = next(t for t in COACH_TOOLS if t["name"] == "get_regulatory_constant")
+        schema = tool["input_schema"]
+        assert "key" in schema["properties"]
+        assert "canton" in schema["properties"]
+        assert schema["required"] == ["key"]
+        assert tool["category"] == "read"

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -5359,7 +5359,7 @@
         "type": "object"
       },
       "DataDeletionRequest": {
-        "description": "Requete pour la suppression des donnees personnelles (nLPD art. 32).",
+        "description": "Requete pour la suppression des donnees personnelles (nLPD art. 32).\n\nV12-1: profile_id is ignored — the server uses the authenticated user's ID.\nKept as optional for backward compatibility with existing clients.",
         "properties": {
           "mode": {
             "$ref": "#/components/schemas/DeletionMode",
@@ -5367,10 +5367,16 @@
             "description": "Mode de suppression: immediate ou avec delai de grace (30 jours)"
           },
           "profileId": {
-            "description": "Identifiant unique du profil utilisateur",
-            "minLength": 1,
-            "title": "Profileid",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "DEPRECATED — ignored; server uses authenticated user ID (V12-1 IDOR fix)",
+            "title": "Profileid"
           },
           "raison": {
             "anyOf": [
@@ -5385,9 +5391,6 @@
             "title": "Raison"
           }
         },
-        "required": [
-          "profileId"
-        ],
         "title": "DataDeletionRequest",
         "type": "object"
       },
@@ -5493,7 +5496,7 @@
         "type": "object"
       },
       "DataExportRequest": {
-        "description": "Requete pour l'export des donnees personnelles (nLPD art. 25).",
+        "description": "Requete pour l'export des donnees personnelles (nLPD art. 25).\n\nV12-1: profile_id is ignored — the server uses the authenticated user's ID.\nKept as optional for backward compatibility with existing clients.",
         "properties": {
           "includeAnalytics": {
             "default": true,
@@ -5520,15 +5523,18 @@
             "type": "boolean"
           },
           "profileId": {
-            "description": "Identifiant unique du profil utilisateur",
-            "minLength": 1,
-            "title": "Profileid",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "DEPRECATED — ignored; server uses authenticated user ID (V12-1 IDOR fix)",
+            "title": "Profileid"
           }
         },
-        "required": [
-          "profileId"
-        ],
         "title": "DataExportRequest",
         "type": "object"
       },
@@ -19866,8 +19872,8 @@
         "title": "EtatCivil",
         "type": "string"
       },
-      "h_be51dd6254bd__ConsentUpdateRequest": {
-        "description": "Requete pour mettre a jour un consentement (nLPD art. 6 al. 7).",
+      "h_d9c8615890ff__ConsentUpdateRequest": {
+        "description": "Requete pour mettre a jour un consentement (nLPD art. 6 al. 7).\n\nV12-1: profile_id is ignored — the server uses the authenticated user's ID.\nKept as optional for backward compatibility with existing clients.",
         "properties": {
           "categorie": {
             "$ref": "#/components/schemas/ConsentCategory",
@@ -19879,14 +19885,19 @@
             "type": "boolean"
           },
           "profileId": {
-            "description": "Identifiant unique du profil utilisateur",
-            "minLength": 1,
-            "title": "Profileid",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "DEPRECATED — ignored; server uses authenticated user ID (V12-1 IDOR fix)",
+            "title": "Profileid"
           }
         },
         "required": [
-          "profileId",
           "categorie",
           "estActif"
         ],
@@ -26355,19 +26366,8 @@
     },
     "/api/v1/privacy/consent-status": {
       "get": {
-        "description": "Retourne le statut actuel de tous les consentements.\n\nConforme a nLPD art. 6 (principes de traitement) et art. 7 (Privacy by Design).\nPar defaut, seul le traitement contractuel (core_profile) est actif.\n\nSources: nLPD art. 6, 7.",
+        "description": "Retourne le statut actuel de tous les consentements.\n\nConforme a nLPD art. 6 (principes de traitement) et art. 7 (Privacy by Design).\nPar defaut, seul le traitement contractuel (core_profile) est actif.\n\nV12-1: Uses _user.id (from JWT) instead of client-supplied path param\nto prevent IDOR (Insecure Direct Object Reference).\n\nSources: nLPD art. 6, 7.",
         "operationId": "get_consent_status_api_v1_privacy_consent_status_get",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "profile_id",
-            "required": true,
-            "schema": {
-              "title": "Profile Id",
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -26378,16 +26378,6 @@
               }
             },
             "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
           }
         },
         "security": [
@@ -26403,13 +26393,13 @@
     },
     "/api/v1/privacy/consent-update": {
       "post": {
-        "description": "Met a jour un consentement pour une categorie de traitement.\n\nLe retrait du consentement est un droit fondamental (nLPD art. 6 al. 7).\nLe consentement pour core_profile (base contractuelle) ne peut pas etre retire.\n\nSources: nLPD art. 6 al. 7.",
+        "description": "Met a jour un consentement pour une categorie de traitement.\n\nLe retrait du consentement est un droit fondamental (nLPD art. 6 al. 7).\nLe consentement pour core_profile (base contractuelle) ne peut pas etre retire.\n\nV12-1: Uses _user.id (from JWT) instead of client-supplied profile_id\nto prevent IDOR (Insecure Direct Object Reference).\n\nSources: nLPD art. 6 al. 7.",
         "operationId": "update_consent_api_v1_privacy_consent_update_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/h_be51dd6254bd__ConsentUpdateRequest"
+                "$ref": "#/components/schemas/h_d9c8615890ff__ConsentUpdateRequest"
               }
             }
           },
@@ -26450,7 +26440,7 @@
     },
     "/api/v1/privacy/delete": {
       "post": {
-        "description": "Supprime les donnees personnelles d'un utilisateur.\n\nConforme a nLPD art. 6 al. 4 et art. 32.\nPropose une suppression immediate ou avec un delai de grace de 30 jours.\n\nSources: nLPD art. 6, 32; CO art. 127; OPDo art. 20-22.",
+        "description": "Supprime les donnees personnelles d'un utilisateur.\n\nConforme a nLPD art. 6 al. 4 et art. 32.\nPropose une suppression immediate ou avec un delai de grace de 30 jours.\n\nV12-1: Uses _user.id (from JWT) instead of client-supplied profile_id\nto prevent IDOR (Insecure Direct Object Reference).\n\nSources: nLPD art. 6, 32; CO art. 127; OPDo art. 20-22.",
         "operationId": "delete_user_data_api_v1_privacy_delete_post",
         "requestBody": {
           "content": {
@@ -26497,7 +26487,7 @@
     },
     "/api/v1/privacy/export": {
       "post": {
-        "description": "Exporte toutes les donnees personnelles d'un utilisateur.\n\nConforme a nLPD art. 25 (droit d'acces) et art. 28 (portabilite).\nRetourne un JSON lisible par machine avec toutes les donnees et metadonnees.\n\nSources: nLPD art. 25, 28; OPDo art. 16-19.",
+        "description": "Exporte toutes les donnees personnelles d'un utilisateur.\n\nConforme a nLPD art. 25 (droit d'acces) et art. 28 (portabilite).\nRetourne un JSON lisible par machine avec toutes les donnees et metadonnees.\n\nV12-1: Uses _user.id (from JWT) instead of client-supplied profile_id\nto prevent IDOR (Insecure Direct Object Reference).\n\nSources: nLPD art. 25, 28; OPDo art. 16-19.",
         "operationId": "export_user_data_api_v1_privacy_export_post",
         "requestBody": {
           "content": {
@@ -27069,6 +27059,192 @@
         "summary": "Generer les messages de reengagement personnalises",
         "tags": [
           "Reengagement S40"
+        ]
+      }
+    },
+    "/api/v1/regulatory/constants": {
+      "get": {
+        "description": "List all regulatory constants, optionally filtered by category or canton.\n\nReturns:\n    JSON with \"count\" and \"constants\" (list of parameter dicts).",
+        "operationId": "list_constants_api_v1_regulatory_constants_get",
+        "parameters": [
+          {
+            "description": "Filter by category prefix: avs, lpp, pillar3a, mortgage, capital_tax, ai, apg, ac, lamal",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by category prefix: avs, lpp, pillar3a, mortgage, capital_tax, ai, apg, ac, lamal",
+              "title": "Category"
+            }
+          },
+          {
+            "description": "Filter by canton code (e.g. ZH, GE, VS). Only returns cantonal parameters.",
+            "in": "query",
+            "name": "canton",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by canton code (e.g. ZH, GE, VS). Only returns cantonal parameters.",
+              "title": "Canton"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Constants Api V1 Regulatory Constants Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Constants",
+        "tags": [
+          "Regulatory Core",
+          "regulatory"
+        ]
+      }
+    },
+    "/api/v1/regulatory/constants/{key}": {
+      "get": {
+        "description": "Get a single regulatory constant by key.\n\nArgs:\n    key: Dotted parameter key (e.g. \"pillar3a.max_with_lpp\", \"avs.max_monthly_pension\").\n    canton: Optional canton code for cantonal parameters.\n\nReturns:\n    The parameter as a JSON dict.\n\nRaises:\n    404 if the key is not found.",
+        "operationId": "get_constant_api_v1_regulatory_constants__key__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Canton code for cantonal parameters (e.g. ZH, GE).",
+            "in": "query",
+            "name": "canton",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Canton code for cantonal parameters (e.g. ZH, GE).",
+              "title": "Canton"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Constant Api V1 Regulatory Constants  Key  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Constant",
+        "tags": [
+          "Regulatory Core",
+          "regulatory"
+        ]
+      }
+    },
+    "/api/v1/regulatory/freshness": {
+      "get": {
+        "description": "Check which parameters are stale and need review.\n\nReturns:\n    JSON with \"stale_count\" and \"stale_parameters\" (list of parameter dicts).",
+        "operationId": "check_freshness_api_v1_regulatory_freshness_get",
+        "parameters": [
+          {
+            "description": "Maximum number of days since last review before a parameter is considered stale.",
+            "in": "query",
+            "name": "max_age_days",
+            "required": false,
+            "schema": {
+              "default": 90,
+              "description": "Maximum number of days since last review before a parameter is considered stale.",
+              "title": "Max Age Days",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Check Freshness Api V1 Regulatory Freshness Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Check Freshness",
+        "tags": [
+          "Regulatory Core",
+          "regulatory"
         ]
       }
     },


### PR DESCRIPTION
## Regulatory Core

Single authoritative source for all Swiss financial constants, consumed by backend, API, LLM tools, and (future) frontend.

### What's built
- **RegulatoryParameter** model with metadata (source URL, effective dates, jurisdiction, reviewed_at)
- **RegulatoryRegistry** singleton: 90+ parameters seeded from social_insurance.py
- **3 API endpoints**: GET /regulatory/constants, GET /regulatory/constants/{key}, GET /regulatory/freshness
- **LLM tool**: get_regulatory_constant — coach can query any constant by key
- **84 freshness tests**: every constant verified, all 26 cantons, historical limits, gender-aware AVS

### Constants coverage
| Category | Parameters |
|----------|-----------|
| Pillar 3a | 14 (core + historical 2016-2026) |
| LPP | 12 |
| AVS | 20 |
| AI/APG/AC | 11 |
| LAMal | 3 |
| Mortgage | 6 |
| Capital tax | 33 (brackets + 26 cantons) |

Tests: 4551 Backend (+84 new) | OpenAPI regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)