### PR TITLE
feat: Wire RegulatorySyncService at Flutter startup + reg() accessor

### DIFF
--- a/apps/mobile/lib/constants/social_insurance.dart
+++ b/apps/mobile/lib/constants/social_insurance.dart
@@ -1,16 +1,23 @@
-/// Constantes d'assurances sociales suisses — source unique de verite (Flutter).
+/// Constantes d'assurances sociales suisses — facade Flutter.
 ///
-/// Valeurs en vigueur: 2025
-/// Derniere mise a jour: 2025-01-01
+/// ARCHITECTURE (depuis PR #162):
+///   - Backend RegulatoryRegistry = source de verite unique
+///   - RegulatorySyncService.fetchConstants() synce au startup
+///   - Ce fichier fournit les FALLBACK offline (valeurs hardcodees)
+///   - [reg()] lit d'abord le cache sync, puis fallback sur la const
 ///
-/// IMPORTANT: Ce fichier est le miroir exact de:
-///   services/backend/app/constants/social_insurance.py
-///
-/// Procedure de mise a jour annuelle:
-/// 1. Mettre a jour le fichier Python (source de verite backend)
-/// 2. Reporter les memes valeurs ici
-/// 3. Lancer les tests Flutter: flutter test
+/// Valeurs fallback: 2025/2026
+/// Derniere mise a jour: 2026-03-26
 library;
+
+import 'package:mint_mobile/services/regulatory_sync_service.dart';
+
+/// Read a constant from the synced backend cache, falling back to [fallback].
+///
+/// Usage: `reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp)`
+/// Returns the backend-synced value if available, otherwise the local const.
+double reg(String key, double fallback) =>
+    RegulatorySyncService.getCached(key) ?? fallback;
 
 // ══════════════════════════════════════════════════════════════════════════════
 // LPP — Prevoyance professionnelle (2e pilier)

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/services/slm/slm_download_service.dart';
 import 'package:mint_mobile/services/slm/slm_engine.dart';
 import 'package:mint_mobile/services/tax_scales_loader.dart';
 import 'package:mint_mobile/data/commune_data.dart';
+import 'package:mint_mobile/services/regulatory_sync_service.dart';
 
 /// Point d'entrée de l'application MINT
 ///
@@ -66,6 +67,10 @@ Future<void> main() async {
     }),
     FeatureFlags.refreshFromBackend().catchError((e) {
       if (kDebugMode) debugPrint('Err Flags: $e');
+    }),
+    RegulatorySyncService.fetchConstants().catchError((e) {
+      if (kDebugMode) debugPrint('Err Regulatory: $e');
+      return <String, double>{};
     }),
   ]);
 


### PR DESCRIPTION
## Regulatory Core — Mobile wiring

Closes the gap identified by the expert audit: RegulatorySyncService existed but had zero call sites.

### Changes
- `main.dart`: `RegulatorySyncService.fetchConstants()` added to startup `Future.wait`
- `social_insurance.dart`: `reg(key, fallback)` function reads synced cache first, falls back to hardcoded const

### Architecture
```
Backend RegulatoryRegistry (source of truth)
    → /regulatory/constants API
    → RegulatorySyncService.fetchConstants() at startup
    → reg('pillar3a.max_with_lpp', 7258) in any Dart file
    → Falls back to local const if backend unavailable
```

Tests: 8156 Flutter | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)