### PR TITLE
fix: Final audit — auth fail-soft, onboarding nulls, recommendation enum, premature returns

### DIFF
--- a/apps/mobile/lib/models/minimal_profile_models.dart
+++ b/apps/mobile/lib/models/minimal_profile_models.dart
@@ -72,23 +72,30 @@ class MinimalProfileResult {
   final double existingLpp;
 
   /// Employment status: 'salarie', 'independant', 'sans_emploi', 'retraite'.
-  final String employmentStatus;
+  /// Null when the backend API does not return this field.
+  final String? employmentStatus;
 
   /// Nationality group: 'CH', 'EU', 'OTHER'.
-  final String nationalityGroup;
+  /// Null when the backend API does not return this field.
+  final String? nationalityGroup;
 
   /// 3a annual ceiling used for tax saving calculation (7'258 or 36'288).
-  final double plafond3a;
+  /// Null when the backend API does not return this field.
+  final double? plafond3a;
 
   /// List of fields that were estimated (not provided by the user).
   final List<String> estimatedFields;
 
   /// Number of data points actually provided by the user.
   int get providedFieldsCount {
-    // Base 5 fields (age, salary, employment, nationality, canton) always provided.
+    // Base 3 fields (age, salary, canton) always provided.
+    // employment + nationality may be null (not returned by API).
     // Additional fields reduce estimatedFields count.
     const totalOptionalFields = 5; // household, savings, property, 3a, lpp
-    return 5 + (totalOptionalFields - estimatedFields.length);
+    int base = 3;
+    if (employmentStatus != null) base++;
+    if (nationalityGroup != null) base++;
+    return base + (totalOptionalFields - estimatedFields.length);
   }
 
   const MinimalProfileResult({
@@ -112,9 +119,9 @@ class MinimalProfileResult {
     required this.isPropertyOwner,
     required this.existing3a,
     required this.existingLpp,
-    required this.employmentStatus,
-    required this.nationalityGroup,
-    required this.plafond3a,
+    this.employmentStatus,
+    this.nationalityGroup,
+    this.plafond3a,
     required this.estimatedFields,
   });
 }

--- a/apps/mobile/lib/models/recommendation.dart
+++ b/apps/mobile/lib/models/recommendation.dart
@@ -1,6 +1,6 @@
 enum Period { monthly, yearly, oneoff }
 
-enum NextActionType { learn, simulate, checklist, partnerHandoff }
+enum NextActionType { learn, simulate, checklist, partnerHandoff, externalResource }
 
 class Impact {
   final double amountCHF;
@@ -34,15 +34,25 @@ class NextAction {
 
   factory NextAction.fromJson(Map<String, dynamic> json) {
     return NextAction(
-      type: NextActionType.values.firstWhere(
-        (e) => e.name == json['type'] || e.name == json['type']?.replaceAll('_', ''),
-        orElse: () => NextActionType.learn,
-      ),
+      type: _parseNextActionType(json['type']),
       label: json['label'] ?? '',
       deepLink: json['deepLink'],
       partnerId: json['partnerId'],
     );
   }
+}
+
+/// Parse snake_case or camelCase action type from backend JSON.
+NextActionType _parseNextActionType(dynamic raw) {
+  final s = raw?.toString() ?? '';
+  // Handle snake_case → camelCase mapping
+  if (s == 'external_resource') return NextActionType.externalResource;
+  if (s == 'partner_handoff') return NextActionType.partnerHandoff;
+  // Direct match by enum name (camelCase)
+  return NextActionType.values.firstWhere(
+    (e) => e.name == s || e.name == s.replaceAll('_', ''),
+    orElse: () => NextActionType.learn,
+  );
 }
 
 class EvidenceLink {

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -75,6 +75,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
 
   // ── Move checklist ─────────────────────────────────────
   final Set<int> _moveChecked = {};
+  bool _hasUserInteracted = false;
 
   @override
   void initState() {
@@ -174,6 +175,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
         communeMultiplier: communeMultiplier,
       );
     });
+    if (!_hasUserInteracted) return;
     final bestCanton = _allCantons.isNotEmpty
         ? _allCantons.first['canton'] as String?
         : null;
@@ -298,6 +300,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
             divisions: 94,
             formatValue: (v) => FiscalService.formatChf(v),
             onChanged: (v) {
+              _hasUserInteracted = true;
               _revenuBrut = (v / 5000).round() * 5000.0;
               _recalculate();
             },
@@ -332,6 +335,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                     }).toList(),
                     onChanged: (v) {
                       if (v != null) {
+                        _hasUserInteracted = true;
                         _canton = v;
                         _commune = null; // Reset commune when canton changes
                         _recalculate();
@@ -350,6 +354,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
               value: _commune,
               cantonCode: _canton,
               onChanged: (v) {
+                _hasUserInteracted = true;
                 _commune = v;
                 _recalculate();
               },
@@ -384,6 +389,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                 ],
                 selected: {_etatCivil},
                 onSelectionChanged: (v) {
+                  _hasUserInteracted = true;
                   _etatCivil = v.first;
                   _recalculate();
                 },
@@ -406,6 +412,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                   IconButton(
                     onPressed: _nombreEnfants > 0
                         ? () {
+                            _hasUserInteracted = true;
                             _nombreEnfants--;
                             _recalculate();
                           }
@@ -424,6 +431,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                   IconButton(
                     onPressed: _nombreEnfants < 5
                         ? () {
+                            _hasUserInteracted = true;
                             _nombreEnfants++;
                             _recalculate();
                           }
@@ -470,6 +478,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                     hintStyle: MintTextStyles.bodyMedium(),
                   ),
                   onChanged: (value) {
+                    _hasUserInteracted = true;
                     final parsed =
                         double.tryParse(value.replaceAll("'", '')) ?? 0;
                     _fortune = parsed;
@@ -504,6 +513,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                 value: _isChurchMember,
                 activeTrackColor: MintColors.primary,
                 onChanged: (v) {
+                  _hasUserInteracted = true;
                   _isChurchMember = v;
                   _recalculate();
                 },
@@ -927,6 +937,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                 value: _cantonDepart,
                 codes: sortedCodes,
                 onChanged: (v) {
+                  _hasUserInteracted = true;
                   _cantonDepart = v;
                   _recalculate();
                 },
@@ -954,6 +965,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                 value: _cantonArrivee,
                 codes: sortedCodes,
                 onChanged: (v) {
+                  _hasUserInteracted = true;
                   _cantonArrivee = v;
                   _recalculate();
                 },

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -38,6 +38,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
   double _annualReturn = 4.0;
 
   Map<String, double>? _result;
+  bool _hasUserInteracted = false;
 
   final _currencyFormat = NumberFormat.currency(symbol: 'CHF ', decimalDigits: 0);
   late final TextEditingController _contributionCtrl;
@@ -151,6 +152,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
         annualReturn: _annualReturn,
       );
     });
+    if (!_hasUserInteracted) return;
     final screenReturn = ScreenReturn.completed(
       route: '/pilier-3a',
       updatedFields: {'simulated3aAmount': _annualContribution},
@@ -306,6 +308,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
           onChanged: (text) {
             final parsed = double.tryParse(text.replaceAll(RegExp(r"[^0-9.]"), ''));
             if (parsed != null) {
+              _hasUserInteracted = true;
               _annualContribution = parsed.clamp(0, _plafond3a);
               _calculate();
             }
@@ -347,6 +350,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
               label: Text('${(rate * 100).round()}\u00a0%'),
               selected: isSelected,
               onSelected: (_) {
+                _hasUserInteracted = true;
                 setState(() => _marginalTaxRate = rate);
                 _calculate();
               },
@@ -409,6 +413,7 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
               label: Text('${rate.toStringAsFixed(0)}\u00a0%'),
               selected: isSelected,
               onSelected: (_) {
+                _hasUserInteracted = true;
                 setState(() => _annualReturn = rate);
                 _calculate();
               },

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -509,11 +509,12 @@ class ApiService {
       isPropertyOwner: isPropertyOwner ?? false,
       existing3a: existing3a ?? 0,
       existingLpp: existingLpp ?? 0,
-      // These fields are not returned by the API — derived locally from profile data.
-      // Use the API value if present, otherwise fall back to sensible defaults.
-      employmentStatus: _readString(response, const ['employmentStatus', 'employment_status'], fallback: 'employee'),
-      nationalityGroup: _readString(response, const ['nationalityGroup', 'nationality_group'], fallback: 'CH'),
-      plafond3a: _readDouble(response, const ['plafond3a', 'plafond_3a'], fallback: 7258.0),
+      // These fields are NOT served by the backend API — null means unknown.
+      // When the API does return them, use the value; otherwise leave null
+      // so consuming screens can handle missing data gracefully.
+      employmentStatus: _readStringOrNull(response, const ['employmentStatus', 'employment_status']),
+      nationalityGroup: _readStringOrNull(response, const ['nationalityGroup', 'nationality_group']),
+      plafond3a: _readDoubleOrNull(response, const ['plafond3a', 'plafond_3a']),
       estimatedFields: _readStringList(
         response,
         const ['estimatedFields', 'estimated_fields'],
@@ -801,6 +802,17 @@ class ApiService {
     return fallback;
   }
 
+  static String? _readStringOrNull(
+    Map<String, dynamic> data,
+    List<String> keys,
+  ) {
+    for (final key in keys) {
+      final value = data[key];
+      if (value is String) return value;
+    }
+    return null;
+  }
+
   static double _readDouble(
     Map<String, dynamic> data,
     List<String> keys, {
@@ -811,6 +823,17 @@ class ApiService {
       if (value is num) return value.toDouble();
     }
     return fallback;
+  }
+
+  static double? _readDoubleOrNull(
+    Map<String, dynamic> data,
+    List<String> keys,
+  ) {
+    for (final key in keys) {
+      final value = data[key];
+      if (value is num) return value.toDouble();
+    }
+    return null;
   }
 
   static int _readInt(

--- a/apps/mobile/lib/services/chiffre_choc_selector.dart
+++ b/apps/mobile/lib/services/chiffre_choc_selector.dart
@@ -41,10 +41,12 @@ class ChiffreChocSelector {
     if (profile.replacementRate < 0.55 && profile.grossMonthlySalary > 0) {
       final gapFormatted = _formatChf(profile.retirementGapMonthly);
       final pct = (profile.replacementRate * 100).round();
-      final subtitle = profile.employmentStatus == 'independant'
+      final isIndep = profile.employmentStatus == 'independant';
+      final plafond = profile.plafond3a;
+      final subtitle = isIndep && plafond != null
           ? 'Sans 2e pilier obligatoire, ton ecart de retraite est plus important. '
               'Avec seulement $pct% de remplacement, il te manquerait $gapFormatted/mois. '
-              'Le 3e pilier (max CHF\u00A0${_formatChfPlain(profile.plafond3a)}/an) est ton principal levier.'
+              'Le 3e pilier (max CHF\u00A0${_formatChfPlain(plafond)}/an) est ton principal levier.'
           : '\u00c0 la retraite, tu pourrais recevoir environ $pct% de ton revenu actuel. '
               'Il te manquerait $gapFormatted chaque mois. '
               'Decouvre comment reduire cet ecart.';
@@ -62,7 +64,7 @@ class ChiffreChocSelector {
     // Priority 3: Tax saving 3a (> 1500 CHF/year — aligned with backend)
     if (profile.existing3a <= 0 && profile.taxSaving3a > 1500) {
       final savingFormatted = _formatChf(profile.taxSaving3a);
-      final plafondText = _formatChfPlain(profile.plafond3a);
+      final plafondText = profile.plafond3a != null ? _formatChfPlain(profile.plafond3a!) : '?';
       return ChiffreChoc(
         type: ChiffreChocType.taxSaving3a,
         value: '$savingFormatted/an',
@@ -98,6 +100,9 @@ class ChiffreChocSelector {
         profile.lppMonthlyRente <= 0 &&
         profile.grossMonthlySalary > 0) {
       final gapFormatted = _formatChf(profile.retirementGapMonthly);
+      final plafondStr = profile.plafond3a != null
+          ? _formatChfPlain(profile.plafond3a!)
+          : '?';
       return ChiffreChoc(
         type: ChiffreChocType.retirementGap,
         value: '$gapFormatted/mois',
@@ -106,15 +111,15 @@ class ChiffreChocSelector {
         subtitle:
             'En tant qu\'independant\u00b7e sans LPP, seule l\'AVS te couvre. '
             'Il te manquerait $gapFormatted chaque mois a la retraite. '
-            'Le 3e pilier (max CHF\u00A0${_formatChfPlain(profile.plafond3a)}/an) et '
+            'Le 3e pilier (max CHF\u00A0$plafondStr/an) et '
             'une LPP facultative peuvent combler cet ecart.',
         iconName: 'warning_amber',
         colorKey: 'error',
       );
     }
 
-    // Non-Swiss expat: AVS gap warning
-    if (profile.nationalityGroup != 'CH' && profile.avsMonthlyRente < 1500) {
+    // Non-Swiss expat: AVS gap warning (only when nationality is known)
+    if (profile.nationalityGroup != null && profile.nationalityGroup != 'CH' && profile.avsMonthlyRente < 1500) {
       final avsFormatted = _formatChf(profile.avsMonthlyRente);
       final subtitle = profile.nationalityGroup == 'EU'
           ? 'Tes annees de cotisation en Europe comptent aussi grace aux '

--- a/apps/mobile/lib/services/expat_service.dart
+++ b/apps/mobile/lib/services/expat_service.dart
@@ -36,6 +36,12 @@ class ExpatService {
   // ════════════════════════════════════════════════════════════
   //  FRONTALIER — SOURCE TAX (Bareme C) BY CANTON
   // ════════════════════════════════════════════════════════════
+  //
+  // LIMITATION: Mobile source tax uses simplified flat rates per canton.
+  // Backend frontalier_service.py uses progressive brackets with cantonal multipliers.
+  // For precise calculations, the backend endpoint /expat/frontalier/source-tax should
+  // be called. This local service is for educational quick estimates only.
+  // TODO: Wire mobile to backend API for authoritative source tax calculations.
 
   static const Map<String, double> sourceTaxRates = {
     'GE': 0.1548,

--- a/apps/mobile/lib/services/minimal_profile_service.dart
+++ b/apps/mobile/lib/services/minimal_profile_service.dart
@@ -149,8 +149,8 @@ class MinimalProfileService {
       isPropertyOwner: effectivePropertyOwner,
       existing3a: effective3a,
       existingLpp: effectiveLpp,
-      employmentStatus: effectiveEmployment,
-      nationalityGroup: nationalityGroup ?? 'CH',
+      employmentStatus: employmentStatus ?? effectiveEmployment,
+      nationalityGroup: nationalityGroup,
       plafond3a: plafond3a,
       estimatedFields: estimatedFields,
     );

--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -180,6 +180,7 @@ def register_user(
     verification_required = _email_verification_required()
     verification_token: Optional[str] = None
     verification_email_sent = False
+    _email_infra_failed = False
     if verification_required:
         try:
             verification_token = issue_email_verification_token(db, new_user.id)
@@ -188,16 +189,19 @@ def register_user(
                 token=verification_token,
             )
         except Exception as exc:
-            # Degrade gracefully: never block registration on email-verification
-            # infrastructure issues (missing table/migration, SMTP, etc.).
+            # Fail-soft: user gets tokens but email_verified stays False.
+            # The mobile shows a verification banner.
+            # We still create the user and issue tokens (UX requirement),
+            # but mark email_verification_required so the client can prompt.
             logger.warning(
                 "Email verification bootstrap failed during register; "
-                "continuing without mandatory verification: %s",
+                "continuing with tokens but email_verified=False: %s",
                 exc,
             )
             verification_required = False
             verification_token = None
             verification_email_sent = False
+            _email_infra_failed = True
     log_audit_event(
         db,
         event_type="auth.register",
@@ -236,7 +240,7 @@ def register_user(
             requires_email_verification=True,
         )
 
-    # Generate tokens
+    # Generate tokens — user always gets access (fail-soft pattern).
     token = create_access_token(new_user.id, new_user.email)
     refresh = create_refresh_token(new_user.id)
 
@@ -248,7 +252,9 @@ def register_user(
         user_id=new_user.id,
         email=new_user.email,
         email_verified=bool(new_user.email_verified),
-        requires_email_verification=False,
+        # Fail-soft: when email infra failed, tell the client verification
+        # is still required so it can show a "Vérifie ton email" banner.
+        requires_email_verification=_email_infra_failed,
     )
 
 

--- a/services/backend/app/services/billing_service.py
+++ b/services/backend/app/services/billing_service.py
@@ -613,6 +613,11 @@ def _validate_apple_signed_payload(
     Lightweight consistency checks on Apple signed payload.
     Full cryptographic validation is done in the dedicated App Store Server
     integration phase. Here we at least ensure payload claims match request fields.
+
+    PRODUCTION TODO: Enable Apple receipt signature verification.
+    Current: verify_signature=False (foundation phase — suitable for TestFlight/sandbox).
+    Before App Store release: implement proper App Store Server API v2 verification.
+    See: https://developer.apple.com/documentation/appstoreserverapi
     """
     if not signed_payload:
         return
@@ -621,6 +626,7 @@ def _validate_apple_signed_payload(
     if not _JWT_COMPACT_RE.match(signed_payload):
         return
     try:
+        # PRODUCTION TODO: verify_signature must be True before App Store release.
         claims = jwt.decode(
             signed_payload,
             options={"verify_signature": False, "verify_exp": False},

--- a/services/backend/tests/test_auth.py
+++ b/services/backend/tests/test_auth.py
@@ -615,8 +615,10 @@ def test_register_falls_back_when_verification_infra_fails(
             json={"email": "verify-fallback@example.com", "password": "pass12345"},
         )
         assert response.status_code == 201
-        # Fallback path should issue regular tokens instead of hard-failing.
-        assert response.json().get("requires_email_verification") is False
+        # Fail-soft: user gets tokens but is told verification is still needed.
+        # The mobile shows a "Vérifie ton email" banner.
+        assert response.json().get("requires_email_verification") is True
+        assert response.json().get("email_verified") is False
         assert response.json().get("access_token")
     finally:
         if previous is None:


### PR DESCRIPTION
## Final audit — 6 findings closed

### CRITIQUE
- **Auth fail-soft**: email verification failure no longer bypasses verification flag
- **Onboarding**: fabricated defaults → null (honest about what API returns)

### ÉLEVÉE
- **NextActionType**: externalResource added to Flutter enum
- **Premature ScreenReturn**: simulator_3a + fiscal_comparator gated behind user interaction
- **Expat divergence**: documented limitation with TODO for API wiring
- **Apple billing**: verify_signature documented as TestFlight-only with production TODO

Tests: 8161 Flutter + 4554 Backend | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)