### PR TITLE
fix: Final audit 7 — hydration race resolved, AVS21 in report/onboarding

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -153,9 +153,9 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>();
 // F4-1: Router is now a function so it can receive AuthProvider as
 // refreshListenable. GoRouter re-evaluates redirects whenever
 // AuthProvider notifies (e.g. after checkAuth() restores a session).
-GoRouter _createRouter(AuthProvider authProvider) => GoRouter(
+GoRouter _createRouter(Listenable refreshListenable) => GoRouter(
   navigatorKey: _rootNavigatorKey,
-  refreshListenable: authProvider,
+  refreshListenable: refreshListenable,
   observers: [AnalyticsRouteObserver()],
   initialLocation: '/',
   errorBuilder: (context, state) => _MintErrorScreen(error: state.error),
@@ -210,8 +210,8 @@ GoRouter _createRouter(AuthProvider authProvider) => GoRouter(
       (p) => path.startsWith(p),
     );
     if (requiresProfile && isLoggedIn) {
-      final hasProfile = context.read<CoachProfileProvider>().hasProfile;
-      if (!hasProfile) {
+      final coachProfile = context.read<CoachProfileProvider>();
+      if (!coachProfile.hasProfile && !coachProfile.isHydrating) {
         // Skip if already on the onboarding flow
         if (!path.startsWith('/onboarding')) {
           return '/onboarding/smart';
@@ -978,14 +978,20 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
   // F4-1: AuthProvider created here so it can be passed both to
   // MultiProvider (for descendant widgets) and to GoRouter as
   // refreshListenable (so redirects re-evaluate on auth state change).
+  // F7-1: CoachProfileProvider also created here so GoRouter re-evaluates
+  // when hydration state changes (isHydrating → false after API response).
   late final AuthProvider _authProvider;
+  late final CoachProfileProvider _coachProfileProvider;
   late final GoRouter _router;
 
   @override
   void initState() {
     super.initState();
     _authProvider = AuthProvider()..checkAuth();
-    _router = _createRouter(_authProvider);
+    _coachProfileProvider = CoachProfileProvider()..loadFromWizard();
+    _router = _createRouter(
+      Listenable.merge([_authProvider, _coachProfileProvider]),
+    );
     WidgetsBinding.instance.addObserver(this);
     AnalyticsService().init();
     NotificationService().init();
@@ -1041,12 +1047,10 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
         ChangeNotifierProvider(create: (_) => HouseholdProvider()),
         // F5-1: CoachProfileProvider re-hydrates from wizard data when auth
         // state changes, then merges remote profile data from GET /profiles/me.
+        // F7-1: Instance created at _MintAppState level (for refreshListenable),
+        // re-used here via ChangeNotifierProxyProvider for auth-reactive updates.
         ChangeNotifierProxyProvider<AuthProvider, CoachProfileProvider>(
-          create: (_) {
-            final provider = CoachProfileProvider();
-            provider.loadFromWizard();
-            return provider;
-          },
+          create: (_) => _coachProfileProvider,
           update: (_, auth, coachProvider) {
             final provider = coachProvider ?? CoachProfileProvider();
             if (!auth.isLoggedIn) {
@@ -1066,8 +1070,11 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
             // Scenario A: Local profile exists → merge (local takes priority).
             // Scenario B: Local profile is NULL but backend has one → create from remote.
             // Only attempted once per session to avoid redundant API calls.
+            // F7-1: startHydrating/finishHydrating bracket the async call so
+            // GoRouter does NOT redirect to onboarding while fetch is in flight.
             if (auth.isLoggedIn && provider.isLoaded && !provider.remoteHydrationDone) {
               provider.markRemoteHydrationDone();
+              provider.startHydrating();
               ApiService.getMyProfile().then((remoteData) {
                 if (remoteData != null) {
                   if (provider.hasProfile) {
@@ -1076,7 +1083,10 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
                     provider.createFromRemoteProfile(remoteData);
                   }
                 }
-              }).catchError((_) {});
+                provider.finishHydrating();
+              }).catchError((_) {
+                provider.finishHydrating();
+              });
             }
             return provider;
           },

--- a/apps/mobile/lib/models/financial_report.dart
+++ b/apps/mobile/lib/models/financial_report.dart
@@ -67,6 +67,10 @@ class UserProfile {
   final String employmentStatus;
   final double monthlyNetIncome;
 
+  /// Gender: 'M', 'F', or null (AVS21 reference age — LAVS art. 21 al. 1).
+  /// When null, AvsCalculator defaults to male reference age (65).
+  final String? gender;
+
   // Nouvelle logique AVS : lacunes calculées depuis le triage
   final int? avsGapYears;
   final int? spouseAvsGapYears;
@@ -85,6 +89,7 @@ class UserProfile {
     required this.childrenCount,
     required this.employmentStatus,
     required this.monthlyNetIncome,
+    this.gender,
     this.avsGapYears,
     this.spouseAvsGapYears,
     this.contributionYears,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -28,6 +28,7 @@ class CoachProfileProvider extends ChangeNotifier {
   bool _isLoaded = false;
   bool _isPartialProfile = false;
   bool _remoteHydrationDone = false;
+  bool _isHydrating = false;
   int? _previousScore;
   List<Map<String, dynamic>> _scoreHistory = [];
   bool _profileUpdatedSinceBudget = false;
@@ -73,8 +74,26 @@ class CoachProfileProvider extends ChangeNotifier {
   /// True if remote profile hydration has already been attempted.
   bool get remoteHydrationDone => _remoteHydrationDone;
 
+  /// True while an async hydration from backend is in progress.
+  /// GoRouter uses this to avoid redirecting to onboarding prematurely.
+  bool get isHydrating => _isHydrating;
+
   /// Mark remote hydration as done (prevents duplicate API calls).
   void markRemoteHydrationDone() => _remoteHydrationDone = true;
+
+  /// Signal that async hydration has started.
+  /// GoRouter (via refreshListenable) re-evaluates redirects on notify.
+  void startHydrating() {
+    _isHydrating = true;
+    notifyListeners();
+  }
+
+  /// Signal that async hydration has completed (success or error).
+  /// GoRouter (via refreshListenable) re-evaluates redirects on notify.
+  void finishHydrating() {
+    _isHydrating = false;
+    notifyListeners();
+  }
 
   /// True si un profil est disponible (wizard complete).
   bool get hasProfile => _profile != null;
@@ -1690,6 +1709,7 @@ class CoachProfileProvider extends ChangeNotifier {
     _isPartialProfile = false;
     _isLoaded = false;
     _remoteHydrationDone = false;
+    _isHydrating = false;
     _previousScore = null;
     _scoreHistory = [];
     _lastAnswers = const {};

--- a/apps/mobile/lib/services/financial_report_service.dart
+++ b/apps/mobile/lib/services/financial_report_service.dart
@@ -150,6 +150,7 @@ class FinancialReportService {
       employmentStatus: answers['q_employment_status'] as String? ?? 'employee',
       monthlyNetIncome:
           _parseDouble(answers['q_net_income_period_chf']) ?? 5000,
+      gender: answers['q_gender'] as String?,
       // Nouvelle logique AVS (triage lacunes)
       avsGapYears: _calculateAvsGaps(answers, birthYear),
       spouseAvsGapYears: _calculateSpouseAvsGaps(answers, birthYear),
@@ -641,30 +642,39 @@ class FinancialReportService {
       age: profile.age,
     );
 
-    final refAgeAvs = reg('avs.reference_age_men', avsAgeReferenceHomme.toDouble()).toInt();
-    // F6-2: isFemale/birthYear not passed — UserProfile (wizard answers) does not
-    // capture gender. Defaults to male reference age (65). Acceptable for this
-    // report-level estimate; gender-aware age is used in CoachProfile-based screens.
+    // F7-2: Pass gender and birthYear so AvsCalculator uses the correct
+    // AVS21 reference age (64F / 65M — LAVS art. 21 al. 1).
+    final isFemale = profile.gender == 'F';
+    final refAgeAvs = profile.gender != null
+        ? avsReferenceAge(birthYear: profile.birthYear, isFemale: isFemale)
+        : reg('avs.reference_age_men', avsAgeReferenceHomme.toDouble()).toInt();
     final userRente = AvsCalculator.computeMonthlyRente(
       currentAge: profile.age,
       retirementAge: refAgeAvs,
       lacunes: profile.avsGapYears ?? 0,
       anneesContribuees: profile.contributionYears,
       grossAnnualSalary: grossAnnualSalary,
+      isFemale: profile.gender != null ? isFemale : null,
+      birthYear: profile.gender != null ? profile.birthYear : null,
     );
 
     if (profile.isMarried) {
       // Spouse rente: use same gross salary assumption (no spouse salary available)
       // TODO: Accept spouse income for more accurate couple AVS computation.
-      // F6-2: isFemale/birthYear not passed for spouse — UserProfile has no
-      // spouse gender field. Defaults to male reference age. Same limitation
-      // as user rente above (wizard answers model lacks gender).
+      // F7-2: Spouse gender is inferred as opposite of user for AVS21.
+      // If user gender unknown, both default to male reference age (65).
+      final spouseIsFemale = profile.gender == 'M';
+      final spouseRefAge = profile.gender != null
+          ? avsReferenceAge(birthYear: profile.birthYear, isFemale: spouseIsFemale)
+          : reg('avs.reference_age_men', avsAgeReferenceHomme.toDouble()).toInt();
       final spouseRente = AvsCalculator.computeMonthlyRente(
         currentAge: profile.age, // Approximate: same age assumed for spouse
-        retirementAge: refAgeAvs,
+        retirementAge: spouseRefAge,
         lacunes: profile.spouseAvsGapYears ?? 0,
         anneesContribuees: profile.spouseContributionYears,
         grossAnnualSalary: grossAnnualSalary,
+        isFemale: profile.gender != null ? spouseIsFemale : null,
+        birthYear: profile.gender != null ? profile.birthYear : null,
       );
 
       // Apply married couple cap (LAVS art. 35 — 150% of individual max)

--- a/apps/mobile/lib/services/minimal_profile_service.dart
+++ b/apps/mobile/lib/services/minimal_profile_service.dart
@@ -38,6 +38,11 @@ class MinimalProfileService {
     String? lppCaisseType,
     double? totalDebts,
     double? monthlyDebtService,
+    /// Gender: 'M', 'F', or null. Passed to AvsCalculator for AVS21
+    /// reference age (LAVS art. 21 al. 1). Null defaults to male (65).
+    String? gender,
+    /// Birth year — used with [gender] for AVS21 transitional cohorts.
+    int? birthYear,
   }) {
     final estimatedFields = <String>[];
 
@@ -69,22 +74,27 @@ class MinimalProfileService {
         ?? (isIndependantNoLpp ? 0.0 : _estimateLppBalance(age, grossSalary));
     if (existingLpp == null) estimatedFields.add('existingLpp');
 
-    // F3-3: Default retirement age uses avsAgeReferenceHomme (65) from constants.
-    // Gender-aware age requires profile gender which is not available in minimal inputs.
-    final effectiveRetAge = targetRetirementAge ?? avsAgeReferenceHomme;
+    // F7-2: Use gender-aware retirement age when gender + birth year are provided.
+    // Falls back to male reference age (65) when gender is unknown.
+    final effectiveBirthYear = birthYear ?? (DateTime.now().year - age);
+    final effectiveRetAge = targetRetirementAge
+        ?? (gender != null
+            ? avsReferenceAge(birthYear: effectiveBirthYear, isFemale: gender == 'F')
+            : avsAgeReferenceHomme);
 
     // --- AVS monthly rente (financial_core) ---
     // Sans emploi: use minimum AVS contribution salary
     final avsGrossSalary = isSansEmploi
         ? reg('lpp.entry_threshold', lppSeuilEntree) // minimum contribution base
         : grossSalary;
-    // F6-2: isFemale/birthYear not passed — MinimalProfileService inputs
-    // do not include gender. This is the local fallback for quick estimates;
-    // defaults to male reference age (65). Acceptable for onboarding snapshots.
+    // F7-2: Pass gender and birthYear when available so AvsCalculator
+    // uses AVS21 reference age (64F / 65M — LAVS art. 21 al. 1).
     final avsMonthly = AvsCalculator.computeMonthlyRente(
       currentAge: age,
       retirementAge: effectiveRetAge,
       grossAnnualSalary: avsGrossSalary,
+      isFemale: gender != null ? gender == 'F' : null,
+      birthYear: gender != null ? effectiveBirthYear : null,
     );
 
     // --- LPP projection (financial_core) ---

--- a/apps/mobile/test/integration/profile_hydration_test.dart
+++ b/apps/mobile/test/integration/profile_hydration_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Integration tests for F7-1: Profile hydration race condition fix.
+///
+/// Validates that the GoRouter redirect logic correctly handles
+/// the async hydration window where the backend profile is being
+/// fetched but has not yet arrived.
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('Profile hydration state machine', () {
+    test('hasProfile=false + isHydrating=true → router must NOT redirect to onboarding', () {
+      // Simulates the window between login and API response.
+      final provider = CoachProfileProvider();
+
+      // Initial state: no profile, not hydrating.
+      expect(provider.hasProfile, isFalse);
+      expect(provider.isHydrating, isFalse);
+
+      // Start hydrating (API call in flight).
+      provider.startHydrating();
+      expect(provider.isHydrating, isTrue);
+      expect(provider.hasProfile, isFalse);
+
+      // Router decision: logged in, no profile, BUT hydrating.
+      // The redirect condition is:
+      //   !hasProfile && !isHydrating → redirect to onboarding
+      // Since isHydrating=true, redirect must NOT fire.
+      final shouldRedirectToOnboarding =
+          !provider.hasProfile && !provider.isHydrating;
+      expect(shouldRedirectToOnboarding, isFalse,
+          reason: 'Router must wait for hydration to complete before redirecting');
+    });
+
+    test('hasProfile=false + isHydrating=false → router DOES redirect to onboarding', () {
+      // Simulates a user who genuinely has no backend profile.
+      final provider = CoachProfileProvider();
+
+      expect(provider.hasProfile, isFalse);
+      expect(provider.isHydrating, isFalse);
+
+      // Router decision: logged in, no profile, not hydrating.
+      // This means hydration completed and no profile was found.
+      final shouldRedirectToOnboarding =
+          !provider.hasProfile && !provider.isHydrating;
+      expect(shouldRedirectToOnboarding, isTrue,
+          reason: 'Router must redirect when hydration is done and no profile exists');
+    });
+
+    test('createFromRemoteProfile sets hasProfile=true → router allows /home', () {
+      // Simulates successful hydration from backend.
+      final provider = CoachProfileProvider();
+
+      // Start hydrating.
+      provider.startHydrating();
+      expect(provider.hasProfile, isFalse);
+      expect(provider.isHydrating, isTrue);
+
+      // Backend returns profile data.
+      provider.createFromRemoteProfile({
+        'birth_year': 1977,
+        'canton': 'VS',
+        'income_gross_yearly': 122207.0,
+        'gender': 'M',
+        'employment_status': 'salarie',
+      });
+
+      // Finish hydrating.
+      provider.finishHydrating();
+
+      expect(provider.hasProfile, isTrue);
+      expect(provider.isHydrating, isFalse);
+
+      // Router decision: profile exists → no redirect needed.
+      final shouldRedirectToOnboarding =
+          !provider.hasProfile && !provider.isHydrating;
+      expect(shouldRedirectToOnboarding, isFalse,
+          reason: 'Router must allow navigation when profile exists');
+    });
+
+    test('startHydrating notifies listeners (triggers GoRouter re-evaluation)', () {
+      final provider = CoachProfileProvider();
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.startHydrating();
+      expect(notified, isTrue,
+          reason: 'startHydrating must call notifyListeners for GoRouter refresh');
+    });
+
+    test('finishHydrating notifies listeners (triggers GoRouter re-evaluation)', () {
+      final provider = CoachProfileProvider();
+      provider.startHydrating();
+
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.finishHydrating();
+      expect(notified, isTrue,
+          reason: 'finishHydrating must call notifyListeners for GoRouter refresh');
+    });
+
+    test('clear resets isHydrating to false', () {
+      final provider = CoachProfileProvider();
+      provider.startHydrating();
+      expect(provider.isHydrating, isTrue);
+
+      provider.clear();
+      expect(provider.isHydrating, isFalse);
+      expect(provider.hasProfile, isFalse);
+    });
+
+    test('hydration error path: finishHydrating called even on failure', () {
+      // Simulates API error during hydration.
+      final provider = CoachProfileProvider();
+
+      provider.startHydrating();
+      expect(provider.isHydrating, isTrue);
+
+      // API call fails — catchError calls finishHydrating.
+      provider.finishHydrating();
+      expect(provider.isHydrating, isFalse);
+      expect(provider.hasProfile, isFalse);
+
+      // Router should redirect to onboarding (hydration done, no profile).
+      final shouldRedirect = !provider.hasProfile && !provider.isHydrating;
+      expect(shouldRedirect, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Final Audit 7

### CRITIQUE → FERMÉ
- **Hydration race**: `isHydrating` flag prevents router from redirecting to onboarding while `/profiles/me` fetch is in progress
- GoRouter `refreshListenable` uses `Listenable.merge([auth, coachProfile])` to re-evaluate on hydration state change
- Backend-only user: login → hydrating (no redirect) → profile created → home

### ÉLEVÉE → FERMÉ
- **AVS21 in FinancialReportService**: `UserProfile.gender` added, `_estimateAvsRent` now gender-aware
- **AVS21 in MinimalProfileService**: `gender`/`birthYear` params added, gender-aware retirement age when available

### Tests (+7)
- 7 hydration integration tests (premature redirect prevention, state machine, listener notifications)

Tests: 8175 Flutter (+7) | 0 analyze issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)