### PR TITLE
feat: EVI Bridge — coach enrichment priorities

### DIFF
--- a/apps/mobile/lib/services/coach/context_injector_service.dart
+++ b/apps/mobile/lib/services/coach/context_injector_service.dart
@@ -19,6 +19,7 @@ import 'package:mint_mobile/services/nudge/nudge_engine.dart';
 import 'package:mint_mobile/services/nudge/nudge_persistence.dart';
 import 'package:mint_mobile/services/navigation/screen_registry.dart';
 import 'package:mint_mobile/services/voice/regional_voice_service.dart';
+import 'package:mint_mobile/services/financial_core/confidence_scorer.dart';
 import 'package:mint_mobile/models/mint_user_state.dart';
 import 'package:mint_mobile/models/coaching_preference.dart';
 
@@ -272,6 +273,15 @@ class ContextInjectorService {
       }
     }
 
+    // ── EVI Bridge — Enrichment priorities ─────────────────────
+    // Inject the top enrichment prompts ranked by Expected Value of
+    // Information so the coach can propose the most impactful next
+    // data capture action (scan, question, document).
+    String enrichmentBlock = '';
+    if (profile != null) {
+      enrichmentBlock = _buildEnrichmentBlock(profile);
+    }
+
     // ── Budget Vivant ─────────────────────────────────────────
     // Inject the BudgetSnapshot into the memory block so Claude can
     // reason about the user's real numbers (margin, retirement gap,
@@ -315,6 +325,7 @@ class ContextInjectorService {
       planBlock: planBlock,
       recentInsightsBlock: recentInsightsBlock,
       budgetBlock: budgetBlock,
+      enrichmentBlock: enrichmentBlock,
     );
 
     return EnrichedContext(
@@ -327,6 +338,69 @@ class ContextInjectorService {
       relevantScreens: relevantScreens,
       capSequencePlan: capSequencePlan,
     );
+  }
+
+  /// Maximum enrichment prompts surfaced in the memory block.
+  static const int _maxEnrichmentInContext = 3;
+
+  /// Build the EVI-ranked enrichment block for the coach system prompt.
+  ///
+  /// Uses [ConfidenceScorer] to get the top enrichment prompts ranked by
+  /// impact, then formats them so the coach can proactively propose
+  /// the most valuable next data capture action.
+  ///
+  /// The block tells Claude:
+  /// - Current confidence level
+  /// - Top 3 actions to improve it (with expected gain in points)
+  /// - Whether to route to /scan or ask a question
+  static String _buildEnrichmentBlock(CoachProfile profile) {
+    final confidence = ConfidenceScorer.score(profile);
+    final topPrompts = confidence.prompts.take(_maxEnrichmentInContext).toList();
+
+    if (topPrompts.isEmpty) return '';
+
+    final lines = <String>['ENRICHISSEMENT PRIORITAIRE\u00a0:'];
+    lines.add('Score de confiance actuel\u00a0: ${confidence.score.round()}/100 '
+        '(${confidence.level})');
+
+    if (confidence.score < ConfidenceScorer.minConfidenceForProjection) {
+      lines.add('IMPORTANT\u00a0: La confiance est trop basse pour des projections fiables. '
+          'Propose activement la meilleure action ci-dessous.');
+    }
+
+    for (final prompt in topPrompts) {
+      final route = _enrichmentRoute(prompt.category);
+      lines.add('- ${prompt.label} (+${prompt.impact}\u00a0pts) '
+          '\u2192 ${prompt.action}${route != null ? ' [route\u00a0: $route]' : ''}');
+    }
+
+    // Bayesian EVI ranking if available (more precise than component weights)
+    final bayesian = confidence.bayesianResult;
+    if (bayesian != null && bayesian.rankedPrompts.isNotEmpty) {
+      final topEvi = bayesian.rankedPrompts.first;
+      if (topEvi.field != topPrompts.first.category) {
+        // EVI suggests a different top priority — add a hint
+        lines.add('EVI prioritaire\u00a0: ${topEvi.label} '
+            '(incertitude actuelle\u00a0: \u00b1CHF\u00a0${topEvi.currentUncertainty.round()})');
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  /// Map enrichment category to the best route for data capture.
+  static String? _enrichmentRoute(String category) {
+    return switch (category) {
+      'lpp' => '/scan',
+      'avs' => '/scan/avs-guide',
+      '3a' => '/scan',
+      'patrimoine' => null, // Coach asks conversationally
+      'menage' => null, // Coach asks conversationally
+      'income' => null, // Coach asks conversationally
+      'objectif_retraite' => null, // Coach asks conversationally
+      'foreign_pension' => null,
+      _ => null,
+    };
   }
 
   /// Build the formatted nudges block for the memory block.
@@ -602,6 +676,7 @@ class ContextInjectorService {
     String planBlock = '',
     String recentInsightsBlock = '',
     String budgetBlock = '',
+    String enrichmentBlock = '',
   }) {
     final parts = <String>[];
 
@@ -643,6 +718,12 @@ class ContextInjectorService {
     if (budgetBlock.isNotEmpty) {
       parts.add('');
       parts.add(budgetBlock);
+    }
+
+    // EVI-ranked enrichment priorities (coach should propose these)
+    if (enrichmentBlock.isNotEmpty) {
+      parts.add('');
+      parts.add(enrichmentBlock);
     }
 
     // Relevant screens for this phase (route_to_screen hints)

--- a/apps/mobile/lib/widgets/coach/low_confidence_card.dart
+++ b/apps/mobile/lib/widgets/coach/low_confidence_card.dart
@@ -7,8 +7,12 @@ import 'package:mint_mobile/theme/colors.dart';
 
 /// Card displayed when confidence score < 40%.
 ///
-/// Shows educational message + top 3 enrichment prompts with CTA.
-/// Pure presentational widget — computes confidence from profile.
+/// Shows educational message + top 3 EVI-ranked enrichment prompts with CTA.
+/// Each prompt shows its expected confidence gain (+X pts) and routes to
+/// the appropriate data capture surface (scan, question, etc.).
+///
+/// S57 EVI Bridge: prompts now route to category-specific screens,
+/// not just a generic /scan button.
 class LowConfidenceCard extends StatelessWidget {
   final CoachProfile profile;
 
@@ -18,6 +22,15 @@ class LowConfidenceCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final confidence = ConfidenceScorer.score(profile);
     final topPrompts = confidence.prompts.take(3).toList();
+
+    // Determine the best CTA route from the highest-impact prompt
+    final bestRoute = topPrompts.isNotEmpty
+        ? _routeForCategory(topPrompts.first.category) ?? '/scan'
+        : '/scan';
+    final bestLabel = topPrompts.isNotEmpty
+        ? topPrompts.first.action
+        : 'Compl\u00e9ter mon profil';
+
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(20),
@@ -39,54 +52,108 @@ class LowConfidenceCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   'Pas assez de donn\u00e9es pour une projection fiable',
-                  style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
+                  style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                      .copyWith(fontWeight: FontWeight.w700),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          // Confidence score bar
+          Row(
+            children: [
+              Text(
+                '${confidence.score.round()}/100',
+                style: MintTextStyles.labelSmall(color: MintColors.textSecondary)
+                    .copyWith(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: (confidence.score / 100).clamp(0.0, 1.0),
+                    minHeight: 6,
+                    backgroundColor: MintColors.lightBorder,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      confidence.score >= 70
+                          ? MintColors.success
+                          : confidence.score >= 40
+                              ? MintColors.warning
+                              : MintColors.error,
+                    ),
+                  ),
                 ),
               ),
             ],
           ),
           const SizedBox(height: 12),
           Text(
-            'En Suisse, le taux de remplacement moyen est de 60-70% '
-            'du dernier salaire. Pour estimer le tien, '
-            'compl\u00e8te quelques informations :',
-            style: MintTextStyles.bodySmall(color: MintColors.textSecondary).copyWith(height: 1.4),
+            'Voici ce qui am\u00e9liorerait le plus tes projections\u00a0:',
+            style: MintTextStyles.bodySmall(color: MintColors.textSecondary)
+                .copyWith(height: 1.4),
           ),
-          const SizedBox(height: 16),
-          ...topPrompts.map((p) => Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 6, vertical: 2),
-                      decoration: BoxDecoration(
-                        color: MintColors.primary.withValues(alpha: 0.12),
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Text(
-                        '+${p.impact}%',
-                        style: MintTextStyles.labelSmall(color: MintColors.primary).copyWith(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        p.label,
-                        style: MintTextStyles.bodySmall(color: MintColors.textPrimary),
-                      ),
-                    ),
-                  ],
-                ),
-              )),
           const SizedBox(height: 12),
+          // EVI-ranked prompts with tappable rows
+          ...topPrompts.map((p) {
+            final route = _routeForCategory(p.category);
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: InkWell(
+                onTap: route != null ? () => context.push(route) : null,
+                borderRadius: BorderRadius.circular(10),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: MintColors.primary.withValues(alpha: 0.12),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: Text(
+                          '+${p.impact}\u00a0pts',
+                          style: MintTextStyles.labelSmall(
+                                  color: MintColors.primary)
+                              .copyWith(fontWeight: FontWeight.w700),
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          p.label,
+                          style: MintTextStyles.bodySmall(
+                              color: MintColors.textPrimary),
+                        ),
+                      ),
+                      if (route != null)
+                        const Icon(Icons.chevron_right,
+                            size: 18, color: MintColors.textMuted),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          }),
+          const SizedBox(height: 12),
+          // Primary CTA — drives to the highest-impact action
           SizedBox(
             width: double.infinity,
             child: FilledButton.icon(
-              onPressed: () => context.push('/scan'),
-              icon: const Icon(Icons.edit_outlined, size: 18),
+              onPressed: () => context.push(bestRoute),
+              icon: Icon(
+                _iconForCategory(
+                    topPrompts.isNotEmpty ? topPrompts.first.category : ''),
+                size: 18,
+              ),
               label: Text(
-                'Compl\u00e9ter mon profil',
-                style: MintTextStyles.bodySmall(color: MintColors.white).copyWith(fontWeight: FontWeight.w600),
+                bestLabel,
+                style: MintTextStyles.bodySmall(color: MintColors.white)
+                    .copyWith(fontWeight: FontWeight.w600),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
               style: FilledButton.styleFrom(
                 backgroundColor: MintColors.primary,
@@ -107,5 +174,34 @@ class LowConfidenceCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  /// Map enrichment category to the best data capture route.
+  static String? _routeForCategory(String category) {
+    return switch (category) {
+      'lpp' => '/scan',
+      'avs' => '/scan/avs-guide',
+      '3a' => '/scan',
+      'patrimoine' => null, // Coach handles conversationally
+      'menage' => null,
+      'income' => null,
+      'objectif_retraite' => null,
+      'foreign_pension' => null,
+      _ => null,
+    };
+  }
+
+  /// Icon for each enrichment category.
+  static IconData _iconForCategory(String category) {
+    return switch (category) {
+      'lpp' => Icons.document_scanner_outlined,
+      'avs' => Icons.document_scanner_outlined,
+      '3a' => Icons.document_scanner_outlined,
+      'patrimoine' => Icons.account_balance_wallet_outlined,
+      'menage' => Icons.people_outline,
+      'income' => Icons.payments_outlined,
+      'objectif_retraite' => Icons.flag_outlined,
+      _ => Icons.edit_outlined,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- **EVI Bridge**: les top enrichment prompts (classés par Expected Value of Information) sont maintenant injectés dans le system prompt du coach
- **LowConfidenceCard améliorée**: confidence bar, prompts cliquables avec routes par catégorie, CTA dynamique

## What the coach now knows
```
ENRICHISSEMENT PRIORITAIRE :
Score de confiance actuel : 32/100 (low)
IMPORTANT : La confiance est trop basse pour des projections fiables.
- Ajoute ton solde LPP (+18 pts) → Ajoute ton certificat de prevoyance [route : /scan]
- Commande ton extrait AVS (+7 pts) → Demande ton releve CI [route : /scan/avs-guide]
- Fixe un objectif retraite (+7 pts) → A quel age souhaites-tu prendre ta retraite ?
```

## Changes
- `context_injector_service.dart`: nouveau block `ENRICHISSEMENT PRIORITAIRE` dans le memory block
- `low_confidence_card.dart`: confidence bar, per-prompt routes, category icons, dynamic CTA

## Test plan
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 8190 passed
- [ ] Manual: ouvrir le chat avec un profil low-confidence → coach propose le scan LPP
- [ ] Manual: tapper un prompt dans LowConfidenceCard → route vers /scan ou /scan/avs-guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)