### PR TITLE
docs: RFC Agent Loop Stateful — multi-screen orchestration

### DIFF
--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -1,6 +1,6 @@
 # RFC : Agent Loop Stateful — Multi-Screen Orchestration
 
-> Date : 2026-03-27 (V2 — réécrite après audit)
+> Date : 2026-03-27 (V2.3 — après 4 audits)
 > Statut : **DRAFT** — À valider avant implémentation
 > Auteur : Team Lead (S57)
 > Dépendances : ChiffreChoc V2, EVI Bridge, Confidence Doctrine (tous livrés)
@@ -264,7 +264,7 @@ Voir §6.2 pour le détail du canonical return path.
 
 ---
 
-## 6. Contrats de synchronisation (V2.1 — ajoutés post-audit)
+## 6. Contrats de synchronisation
 
 ### 6.1 SequenceRun → CapSequence (plan visible)
 

--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -24,7 +24,7 @@ Le coach peut aujourd'hui router vers **un seul écran** à la fois. Quand l'uti
 | `CapSequence` + `CapStep` | Plan visible (Pulse, Dossier, coach context) | Inchangé — reste le seul plan |
 | `ScreenReturn` | Contrat de retour écran | +`stepOutputs` (données structurées) |
 | `RoutePlanner` | Intent → readiness → route décision | +awareness du run actif |
-| `CapMemory` | Historique des actions | +`activeRunId` pour gater le realtime |
+| `CapMemory` | Historique des actions | +`stepProposals` pour l'anti-boucle |
 | `CapSequenceEngine` | Construit les plans | +`SequenceTemplate` pour les parcours guidés |
 
 **Ce qui est NOUVEAU (et uniquement ça) :**
@@ -156,8 +156,8 @@ class SequenceCoordinator {
         return SequenceAction.complete();
 
       case ScreenOutcome.abandoned:
-        // Anti-boucle: count proposals (not completions)
-        final proposals = memory.proposalCount(currentStepDef.id);
+        // Anti-boucle: count proposals scoped to this run (not completions)
+        final proposals = memory.proposalCount(run.runId, currentStepDef.id);
         if (proposals >= 2) {
           // Skip this step, try next
           if (currentStepDef.isOptional) {
@@ -176,19 +176,25 @@ class SequenceCoordinator {
 }
 ```
 
-### 3.6 Integration CoachChatScreen — gater le realtime
+### 3.6 Integration CoachChatScreen
+
+`_onRealtimeScreenReturn(ScreenReturn)` reste le **seul point d'entrée** pour
+les retours d'écrans. Sa branche legacy est bypassée quand un run est actif :
 
 ```dart
-// Dans _handleRouteReturn :
-if (_hasActiveSequenceRun()) {
-  // Guided sequence mode — delegate to SequenceCoordinator
+// Dans _onRealtimeScreenReturn (point d'entrée unique) :
+final activeRun = await SequenceStore.load();
+if (activeRun != null && activeRun.status == SequenceRunStatus.active) {
+  // SEQUENCE MODE: bypass debounce + legacy reaction, delegate to coordinator
   final action = SequenceCoordinator.decide(...);
   _applySequenceAction(action);
-  return; // Skip _onRealtimeScreenReturn — no double message
+  return;
 }
-// Normal mode — existing behavior
-_onRealtimeScreenReturn(screenReturn);
+// NORMAL MODE: existing debounced behavior (inchangé)
+_debouncedLegacyReaction(screenReturn);
 ```
+
+Voir §6.2 pour le détail du canonical return path.
 
 ---
 
@@ -247,6 +253,14 @@ _onRealtimeScreenReturn(screenReturn);
 ### 5.5 Cohérence des données
 - Si un output d'étape N est invalidé (profil changé), les étapes N+1..K sont re-évaluées
 - Les étapes invalidées passent à `pending` (pas supprimées)
+
+### 5.6 Source de vérité du run actif
+- `SequenceStore` (SharedPreferences, clé `mint_sequence_run`) est la **seule source
+  de vérité** pour savoir si un run est actif et quel est son état
+- `CapMemory` NE stocke PAS de `activeRunId` — pas de double vérité
+- Le check `activeRun != null` dans le coach passe toujours par `SequenceStore.load()`
+- `CapMemory.stepProposals` est indexé par `{runId}_{stepId}` — il dépend du runId
+  mais ne le gouverne pas
 
 ---
 

--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -1,6 +1,6 @@
 # RFC : Agent Loop Stateful — Multi-Screen Orchestration
 
-> Date : 2026-03-27
+> Date : 2026-03-27 (V2 — réécrite après audit)
 > Statut : **DRAFT** — À valider avant implémentation
 > Auteur : Team Lead (S57)
 > Dépendances : ChiffreChoc V2, EVI Bridge, Confidence Doctrine (tous livrés)
@@ -9,336 +9,291 @@
 
 ## 1. Problème
 
-Le coach peut aujourd'hui router vers **un seul écran** à la fois. Quand l'utilisateur dit "je veux acheter un appart", le coach ouvre `/hypotheque` et s'arrête là. Il ne peut pas enchaîner : accessibilité → gap fonds propres → EPL → fiscalité retrait.
-
-Ce qui manque :
-- **Pas de mémoire de séquence** — chaque écran est indépendant
-- **Pas de transfert d'outputs** — l'écran 2 ne sait pas ce que l'écran 1 a calculé
-- **Pas de progression visible** — l'utilisateur ne voit pas "étape 2/4"
-- **Pas de branching** — le même parcours pour tous les archétypes
-- **Pas d'anti-boucle** — si l'écran échoue, rien n'empêche de re-router dessus
+Le coach peut aujourd'hui router vers **un seul écran** à la fois. Quand l'utilisateur dit "je veux acheter un appart", le coach ouvre `/hypotheque` et s'arrête. Il ne peut pas enchaîner : accessibilité → EPL → fiscalité retrait → résumé.
 
 ---
 
-## 2. Ce qui existe déjà
+## 2. Principe directeur : étendre, pas réinventer
 
-| Composant | Ce qu'il fait | Limitation |
+> L'audit a identifié un risque critique : créer un second système de plans
+> parallèle à `CapSequence`. Cette RFC V2 l'évite en **réutilisant les
+> abstractions existantes** et en ajoutant uniquement une couche runtime.
+
+| Existant | Rôle (inchangé) | Extension RFC |
 |---|---|---|
-| `RoutePlanner` | Intent → readiness gate → route décision | Stateless, 1 écran à la fois |
-| `ScreenRegistry` | 60+ écrans routables, requiredFields, prefill | Pas de graphe de dépendances |
-| `CapSequenceEngine` | Plan multi-étapes (retraite, budget, logement) | Hardcodé, pas de branching archetype |
-| `CapMemory` | Tracks completedActions, abandonedFlows | Flat list, pas de contexte par étape |
-| `ScreenReturn` | outcome (completed/abandoned/changedInputs) | Pas de données de sortie structurées |
-| `CoachChatScreen._handleRouteReturn` | Réagit au retour d'un écran | Pas de chaînage vers l'écran suivant |
-| `CoachOrchestrator` agent loop | tool_use → execute → re-call LLM | Pas de state machine de parcours |
+| `CapSequence` + `CapStep` | Plan visible (Pulse, Dossier, coach context) | Inchangé — reste le seul plan |
+| `ScreenReturn` | Contrat de retour écran | +`stepOutputs` (données structurées) |
+| `RoutePlanner` | Intent → readiness → route décision | +awareness du run actif |
+| `CapMemory` | Historique des actions | +`activeRunId` pour gater le realtime |
+| `CapSequenceEngine` | Construit les plans | +`SequenceTemplate` pour les parcours guidés |
+
+**Ce qui est NOUVEAU (et uniquement ça) :**
+- `SequenceTemplate` — définition statique d'un parcours (étapes, output mapping)
+- `SequenceRun` — état runtime d'un parcours en cours (léger, persisté en SharedPreferences)
+- `SequenceCoordinator` — logique de décision (étend, ne remplace pas, le flux existant)
 
 ---
 
-## 3. Design proposé
+## 3. Architecture
 
-### 3.1 Concept : Guided Sequence
+### 3.1 Sélection de séquence : le CODE décide, pas le LLM
 
-```
-Utilisateur : "Je veux acheter un bien immobilier"
-    ↓
-Coach (LLM) : "OK, voyons ça en 4 étapes."
-    ↓
-[SequenceCard: "Parcours achat immobilier" — 0/4 étapes]
-    ↓
-Étape 1 : /hypotheque (accessibilité) → output: {capaciteAchat: 850000, fondsNecessaires: 170000}
-    ↓
-Étape 2 : /epl (EPL) → prefill: {fondsNecessaires: 170000} → output: {eplMontant: 50000}
-    ↓
-Étape 3 : /fiscalite/retrait-capital → prefill: {montantRetrait: 50000} → output: {impotRetrait: 3200}
-    ↓
-Étape 4 : Coach résumé → "Capacité 850k, EPL 50k, impôt 3200. Ton plan est prêt."
-    ↓
-[SequenceCard: "Parcours achat immobilier" — 4/4 ✓]
-```
-
-### 3.2 Nouveau modèle : GuidedSequence
+**Règle absolue** (alignée avec `CHAT_TO_SCREEN_ORCHESTRATION_STRATEGY.md`) :
+- Le LLM retourne une **intention** (ex: `housing_purchase`)
+- Le **code** mappe l'intention → `SequenceTemplate` correspondant
+- Le LLM ne connaît **jamais** les IDs de séquence
 
 ```dart
-/// A multi-screen guided sequence toward a goal.
-class GuidedSequence {
-  final String id;                    // 'housing_purchase_2026'
-  final String goalLabel;             // 'Achat immobilier'
-  final List<SequenceStep> steps;     // Ordered steps
-  final String archetypeFilter;       // 'all' | 'swiss_native' | 'expat_us'
-  final DateTime createdAt;
-  final SequenceStatus status;        // active | completed | abandoned | paused
+/// Maps a user intent to a guided sequence template.
+/// Pure function — the LLM never sees sequence IDs.
+static SequenceTemplate? templateForIntent(String intentTag) {
+  return switch (intentTag) {
+    'housing_purchase' => SequenceTemplate.housingPurchase,
+    'retirement_choice' || 'retirement_projection' => SequenceTemplate.retirementPrep,
+    'simulator_3a' || 'tax_optimization_3a' => SequenceTemplate.optimize3a,
+    _ => null, // Single-screen intent — no sequence
+  };
+}
+```
+
+### 3.2 SequenceTemplate — Définition statique
+
+```dart
+/// Static definition of a guided multi-screen sequence.
+/// Immutable. Defined in code, not generated by LLM.
+class SequenceTemplate {
+  final String id;                    // 'housing_purchase'
+  final String goalLabelKey;          // ARB key: 'sequenceHousingGoal'
+  final List<SequenceStepDef> steps;  // Ordered step definitions
+  final String? archetypeFilter;      // null = all, 'expat_us' = only expats
+
+  /// Pre-defined V1 templates (3 parcours).
+  static const housingPurchase = SequenceTemplate(...);
+  static const retirementPrep = SequenceTemplate(...);
+  static const optimize3a = SequenceTemplate(...);
 }
 
-class SequenceStep {
+class SequenceStepDef {
   final String id;                    // 'housing_01_affordability'
   final int order;
-  final String intentTag;             // 'housing_purchase' (maps to ScreenRegistry)
-  final String route;                 // '/hypotheque'
-  final StepStatus status;            // pending | active | completed | skipped | blocked
-  final Map<String, dynamic> inputFromPrior;  // Pre-filled from previous step outputs
-  final Map<String, dynamic> output;  // Captured on completion
-  final StepBlockReason? blockReason;
-  final String? fallbackRoute;        // If blocked, where to redirect
-}
-
-enum StepStatus { pending, active, completed, skipped, blocked }
-
-enum StepBlockReason {
-  prerequisiteIncomplete,   // Step N-1 must complete first
-  insufficientData,         // Need document scan or profile enrichment
-  archetypeNotApplicable,   // Step not relevant for this archetype
-  userDeclined,             // User explicitly skipped
+  final String intentTag;             // Maps to ScreenRegistry entry
+  final String titleKey;              // ARB key
+  final Map<String, String> outputMapping; // Maps output keys to next step input keys
+  final bool isOptional;              // Can be skipped without blocking
 }
 ```
 
-### 3.3 Persistence : SequenceStore
+### 3.3 SequenceRun — État runtime (léger)
 
 ```dart
-/// Persists active sequences in SharedPreferences.
-/// Lightweight — one sequence active at a time.
-class SequenceStore {
-  static const _key = 'mint_active_sequence';
+/// Runtime state of an active guided sequence.
+/// Persisted in SharedPreferences. One active run at a time.
+class SequenceRun {
+  final String templateId;            // 'housing_purchase'
+  final String runId;                 // UUID, created when sequence starts
+  final DateTime startedAt;
+  final Map<String, StepRunState> stepStates; // step ID → state
+  final Map<String, Map<String, dynamic>> stepOutputs; // step ID → outputs
+  final SequenceRunStatus status;     // active | paused | completed | abandoned
 
-  Future<GuidedSequence?> load();
-  Future<void> save(GuidedSequence sequence);
-  Future<void> clear();
+  /// Progress fraction (0.0 – 1.0).
+  double get progress => completedCount / stepStates.length;
+  int get completedCount => stepStates.values
+      .where((s) => s == StepRunState.completed || s == StepRunState.skipped)
+      .length;
+}
 
-  /// Record step completion with output data.
-  Future<void> completeStep(String stepId, Map<String, dynamic> output);
+enum StepRunState { pending, active, completed, skipped, blocked }
+enum SequenceRunStatus { active, paused, completed, abandoned }
+```
 
-  /// Record step abandonment with friction context.
-  Future<void> abandonStep(String stepId, String frictionContext);
+### 3.4 ScreenReturn étendu (pas remplacé)
+
+```dart
+/// Extension du contrat existant — ajout d'outputs structurés.
+class ScreenReturn {
+  // ... (tous les champs existants inchangés)
+
+  /// Structured outputs from this screen for sequence step transfer.
+  /// Example: {'capacite_achat': 850000, 'fonds_propres_requis': 170000}
+  /// Null when not in a guided sequence or screen doesn't produce outputs.
+  final Map<String, dynamic>? stepOutputs;  // NOUVEAU
 }
 ```
 
-### 3.4 Orchestration : SequenceAgent
+### 3.5 SequenceCoordinator — Logique de décision
 
 ```dart
-/// Decides what happens after each step return.
+/// Decides what happens after each step in a guided sequence.
 ///
-/// Pure function — no side effects, fully testable.
-class SequenceAgent {
+/// NOT a pure function — needs profile + readiness context.
+/// Integrates with RoutePlanner, not parallel to it.
+class SequenceCoordinator {
 
-  /// Given current sequence state + step outcome, decide next action.
-  static SequenceAction decide(GuidedSequence sequence, ScreenReturn stepReturn) {
-    final currentStep = sequence.steps.firstWhere((s) => s.status == StepStatus.active);
+  /// Decide the next action after a step returns.
+  static SequenceAction decide({
+    required SequenceTemplate template,
+    required SequenceRun run,
+    required ScreenReturn stepReturn,
+    required CoachProfile profile,
+    required RoutePlanner planner,  // For readiness checks
+    required CapMemory memory,      // For anti-loop history
+  }) {
+    final currentStepDef = template.steps
+        .firstWhere((s) => run.stepStates[s.id] == StepRunState.active);
 
     switch (stepReturn.outcome) {
       case ScreenOutcome.completed:
-        // Mark step completed, find next non-blocked step
-        final nextStep = _findNextStep(sequence, currentStep);
+        // Merge outputs
+        final outputs = stepReturn.stepOutputs ?? {};
+        // Find next step + check readiness via RoutePlanner
+        final nextStep = _findNextReady(template, run, profile, planner);
         if (nextStep != null) {
-          return SequenceAction.advance(
-            nextStep: nextStep,
-            prefill: _buildPrefill(sequence, nextStep),
-            progressLabel: '${_completedCount(sequence) + 1}/${sequence.steps.length}',
-          );
+          // Build prefill from accumulated outputs via outputMapping
+          final prefill = _buildPrefill(template, run, nextStep, outputs);
+          return SequenceAction.advance(nextStep: nextStep, prefill: prefill);
         }
-        return SequenceAction.complete(summary: _buildSummary(sequence));
+        return SequenceAction.complete();
 
       case ScreenOutcome.abandoned:
-        // Don't re-propose same step immediately — offer alternatives
-        return SequenceAction.pause(
-          message: 'Pas de souci. On peut continuer plus tard.',
-          canResume: true,
-        );
+        // Anti-boucle: count proposals (not completions)
+        final proposals = memory.proposalCount(currentStepDef.id);
+        if (proposals >= 2) {
+          // Skip this step, try next
+          if (currentStepDef.isOptional) {
+            return SequenceAction.skip(stepId: currentStepDef.id);
+          }
+          return SequenceAction.pause(canResume: true);
+        }
+        return SequenceAction.retry(stepId: currentStepDef.id);
 
       case ScreenOutcome.changedInputs:
-        // Re-evaluate: prior step outputs may be invalidated
-        return SequenceAction.reEvaluate(
-          invalidatedSteps: _findInvalidated(sequence, stepReturn.updatedFields),
-        );
+        // Re-evaluate readiness of remaining steps
+        final invalidated = _findInvalidatedSteps(template, run, stepReturn);
+        return SequenceAction.reEvaluate(invalidatedSteps: invalidated);
     }
   }
-
-  /// Anti-boucle : never propose the same step more than 2x in a session.
-  static bool _shouldSkip(GuidedSequence sequence, SequenceStep step) {
-    final attempts = sequence.steps
-        .where((s) => s.id == step.id && s.status == StepStatus.completed)
-        .length;
-    return attempts >= 2;
-  }
-}
-
-/// What the agent decides after a step.
-sealed class SequenceAction {
-  const SequenceAction._();
-
-  /// Advance to the next step (auto or user-prompted).
-  const factory SequenceAction.advance({
-    required SequenceStep nextStep,
-    required Map<String, dynamic> prefill,
-    required String progressLabel,
-  }) = _Advance;
-
-  /// Sequence complete — show summary.
-  const factory SequenceAction.complete({required String summary}) = _Complete;
-
-  /// User abandoned — pause and offer resumption.
-  const factory SequenceAction.pause({
-    required String message,
-    required bool canResume,
-  }) = _Pause;
-
-  /// Profile changed — re-evaluate affected steps.
-  const factory SequenceAction.reEvaluate({
-    required List<String> invalidatedSteps,
-  }) = _ReEvaluate;
 }
 ```
 
-### 3.5 Coach Chat intégration
-
-L'intégration dans `CoachChatScreen` :
-
-```
-1. Coach détecte l'intention multi-étapes (LLM retourne un tool_use avec sequence_id)
-2. SequenceStore.load() — reprendre une séquence existante ou en créer une nouvelle
-3. Afficher SequenceProgressCard (barre de progression + étape courante)
-4. Ouvrir l'écran de l'étape courante (via RoutePlanner, avec prefill des outputs précédents)
-5. Au retour : SequenceAgent.decide() → action
-6. Si advance → afficher message de transition + ouvrir étape suivante
-7. Si complete → afficher résumé + célébration
-8. Si pause → stocker dans SequenceStore pour reprise future
-9. Si reEvaluate → recalculer les étapes affectées
-```
-
-### 3.6 Output transfer entre étapes
-
-Le mécanisme de transfert d'outputs entre écrans :
+### 3.6 Integration CoachChatScreen — gater le realtime
 
 ```dart
-/// Each simulator screen can return structured outputs via ScreenReturn.
-/// The SequenceAgent merges these outputs into the prefill of the next step.
-///
-/// Example flow:
-/// Step 1 (/hypotheque) returns: {capacite_achat: 850000, fonds_propres_requis: 170000}
-/// Step 2 (/epl) receives prefill: {montant_necessaire: 170000}
-/// Step 2 (/epl) returns: {montant_epl: 50000, impact_rente: -200}
-/// Step 3 (/fiscal) receives prefill: {montant_retrait: 50000}
-```
-
-Chaque `SequenceStep` déclare un `outputMapping` :
-
-```dart
-/// Maps output keys from this step to input keys of the next step.
-/// Example: {'capacite_achat': 'montant_bien_cible', 'fonds_propres_requis': 'montant_necessaire'}
-final Map<String, String> outputMapping;
+// Dans _handleRouteReturn :
+if (_hasActiveSequenceRun()) {
+  // Guided sequence mode — delegate to SequenceCoordinator
+  final action = SequenceCoordinator.decide(...);
+  _applySequenceAction(action);
+  return; // Skip _onRealtimeScreenReturn — no double message
+}
+// Normal mode — existing behavior
+_onRealtimeScreenReturn(screenReturn);
 ```
 
 ---
 
-## 4. Séquences pré-définies (V1)
-
-Pour le premier prototype, 3 séquences hardcodées :
+## 4. Séquences V1 (3 parcours)
 
 ### 4.1 Achat immobilier (4 étapes)
 
-| Étape | Route | Input de l'étape précédente | Output |
+| # | Intent | Route | Output → Next Input |
 |---|---|---|---|
-| 1. Accessibilité | `/hypotheque` | — | capacité_achat, fonds_propres_requis |
-| 2. EPL | `/epl` | fonds_propres_requis | montant_epl, impact_rente |
-| 3. Fiscalité retrait | `/fiscalite/retrait-capital` | montant_epl | impot_retrait |
-| 4. Résumé coach | (inline) | tous les outputs | — |
+| 1 | `housing_purchase` | `/hypotheque` | `capacite_achat`, `fonds_propres_requis` → step 2 `montant_necessaire` |
+| 2 | `early_pension_withdrawal` | `/epl` | `montant_epl`, `impact_rente` → step 3 `montant_retrait` |
+| 3 | `cantonal_fiscal_comparator` | `/fiscal` | `impot_retrait` |
+| 4 | (coach inline) | — | Résumé des 3 outputs |
 
 ### 4.2 Optimisation 3a (3 étapes)
 
-| Étape | Route | Input | Output |
+| # | Intent | Route | Output → Next Input |
 |---|---|---|---|
-| 1. Simulateur 3a | `/pilier-3a` | — | contribution_annuelle, economie_fiscale |
-| 2. Retrait échelonné | `/3a-deep/staggered-withdrawal` | contribution_annuelle | gain_echelonnement |
-| 3. Rendement réel | `/3a-deep/real-return` | contribution_annuelle | rendement_net_inflation |
+| 1 | `simulator_3a` | `/pilier-3a` | `contribution_annuelle`, `economie_fiscale` |
+| 2 | `tax_optimization_3a` | `/3a-deep/staggered-withdrawal` | `gain_echelonnement` |
+| 3 | `real_return_3a` | `/3a-deep/real-return` | `rendement_net_inflation` |
 
 ### 4.3 Préparation retraite (5 étapes)
 
-| Étape | Route | Input | Output |
+| # | Intent | Route | Output → Next Input |
 |---|---|---|---|
-| 1. Projection | `/retraite` | — | taux_remplacement, gap_mensuel |
-| 2. Rente vs Capital | `/rente-vs-capital` | gap_mensuel | decision_mixte |
-| 3. Rachat LPP | `/rachat-lpp` | gap_mensuel | economie_rachat |
-| 4. Décaissement | `/decaissement` | decision_mixte | calendrier_optimal |
-| 5. Résumé coach | (inline) | tous | — |
+| 1 | `retirement_projection` | `/retraite` | `taux_remplacement`, `gap_mensuel` |
+| 2 | `retirement_choice` | `/rente-vs-capital` | `decision_mixte` |
+| 3 | `lpp_buyback` | `/rachat-lpp` | `economie_rachat` |
+| 4 | `withdrawal_sequencing` | `/decaissement` | `calendrier_optimal` |
+| 5 | (coach inline) | — | Résumé complet |
 
 ---
 
-## 5. Anti-patterns et garde-fous
+## 5. Garde-fous
 
 ### 5.1 Anti-boucle
-- Jamais plus de 2 tentatives sur la même étape dans une session
-- Si l'utilisateur abandonne 2 fois → step marqué `skipped`, on passe au suivant
+- Compter les **propositions** d'une étape (via `CapMemory.proposalCount`), pas les completions
+- Seuil : 2 propositions abandonnées → skip (si optional) ou pause (si required)
 
 ### 5.2 Anti-forçage
-- L'utilisateur peut toujours quitter la séquence ("Je veux faire autre chose")
-- Le coach propose, ne force jamais
-- Séquence pausée = resumable, pas perdue
+- Toujours "Prêt pour l'étape suivante ?" — jamais d'auto-navigation
+- Bouton "Quitter le parcours" toujours visible
+- Séquence pausée = resumable à la prochaine session
 
-### 5.3 Cohérence des données
-- Si un output de l'étape 1 est invalidé (profil changé), les étapes suivantes sont re-évaluées
-- Le `SequenceAgent.reEvaluate()` marque les étapes affectées comme `pending`
+### 5.3 Pas de double message
+- Quand une `SequenceRun` est active, `_onRealtimeScreenReturn()` est gaté
+- Seul le `SequenceCoordinator` produit le message de transition
 
 ### 5.4 Pas de séquences imbriquées
-- V1 : une seule séquence active à la fois
-- Si l'utilisateur lance une nouvelle séquence, l'ancienne est pausée
+- V1 : une seule `SequenceRun` active
+- Lancer une nouvelle séquence pause l'ancienne
+
+### 5.5 Cohérence des données
+- Si un output d'étape N est invalidé (profil changé), les étapes N+1..K sont re-évaluées
+- Les étapes invalidées passent à `pending` (pas supprimées)
 
 ---
 
 ## 6. Plan d'implémentation
 
-### Phase 1 : Modèles + Store (1 sprint)
-- `GuidedSequence`, `SequenceStep`, `SequenceAction` models
+### Phase 1 : Modèles + Coordinator + Tests (1 sprint)
+- `SequenceTemplate`, `SequenceRun` models
+- `SequenceCoordinator.decide()` (avec profile + planner + memory en input)
+- `ScreenReturn` + `stepOutputs` field
 - `SequenceStore` (SharedPreferences)
-- `SequenceAgent.decide()` (pure function)
-- Tests unitaires (20+)
+- 3 templates V1 hardcodés
+- 25+ tests unitaires
 
 ### Phase 2 : UI + Chat integration (1 sprint)
-- `SequenceProgressCard` widget (barre + étape courante)
-- `CoachChatScreen` : détection d'intention séquence + rendering
-- Modification de `_handleRouteReturn` pour chaîner les étapes
-- 1 parcours vertical fonctionnel (achat immobilier)
+- `SequenceProgressCard` widget
+- `CoachChatScreen` : gate realtime, delegate to coordinator
+- 1 parcours vertical E2E (achat immobilier)
 
-### Phase 3 : Archetype branching + output transfer (1 sprint)
-- `outputMapping` entre étapes
-- Branching par archétype (expat_us skip, indep_no_lpp adaptation)
-- 3 parcours complets
-- Tests d'intégration E2E
+### Phase 3 : Output transfer + archetype (1 sprint)
+- `outputMapping` câblé entre étapes réelles
+- Branching par archétype dans les templates
+- 3 parcours complets testés E2E
 
 ---
 
 ## 7. Ce qu'on NE fait PAS
 
-- **Pas de multi-séquence simultanée** — V1 = une seule active
-- **Pas de séquences dynamiques générées par le LLM** — V1 = 3 séquences hardcodées
-- **Pas d'auto-advance sans confirmation** — toujours "Prêt pour l'étape suivante ?"
-- **Pas de rollback complet** — si étape 1 est invalidée, on re-propose mais on ne supprime pas les données
+- **Pas de nouveau modèle de plan** — `CapSequence` reste le seul plan visible
+- **Pas de sélection de séquence par le LLM** — le code mappe intent → template
+- **Pas de séquences dynamiques** — V1 = 3 templates hardcodés
+- **Pas d'auto-advance** — toujours confirmation utilisateur
+- **Pas de remplacement de ScreenReturn** — extension avec `stepOutputs`
 
 ---
 
 ## 8. Métriques de succès
 
-| Métrique | Baseline (actuel) | Cible |
+| Métrique | Baseline | Cible |
 |---|---|---|
 | Écrans visités par session | ~1.5 | 3+ |
-| Taux de complétion d'un parcours complet | 0% (pas de parcours) | 40% |
-| Temps sur le parcours achat immo | — | < 10 min pour 4 étapes |
+| Taux de complétion parcours complet | 0% | 40% |
+| Temps parcours achat immo | — | < 10 min |
 | Taux d'abandon après étape 1 | — | < 30% |
 
 ---
 
-## 9. Risques
+## 9. Décision requise
 
-| Risque | Probabilité | Mitigation |
-|---|---|---|
-| Complexité du state machine | Élevée | SequenceAgent est une pure function, 100% testable |
-| Output mapping fragile entre écrans | Moyenne | Typage fort, tests de contrat par séquence |
-| UX trop directive ("tunnel") | Moyenne | Toujours proposer, jamais forcer. Bouton "Quitter le parcours" |
-| Régression sur le chat existant | Faible | Le chat sans séquence fonctionne exactement comme avant |
-
----
-
-## 10. Décision requise
-
-Avant de coder :
-1. **Approuver les 3 séquences V1** (achat immo, 3a, retraite)
-2. **Confirmer l'approche "propose, ne force pas"** — auto-advance avec confirmation
-3. **Valider le stockage SharedPreferences** vs backend pour l'état de séquence
-4. **Décider** : Phase 1 seule (modèles + tests) ou Phase 1+2 (modèles + UI) dans le prochain sprint ?
+1. **Valider les 3 séquences V1** et leurs étapes
+2. **Confirmer** : `CapSequence` = plan visible unique, `SequenceRun` = runtime uniquement
+3. **Confirmer** : SharedPreferences pour `SequenceRun` (pas backend)
+4. **Décider** : Phase 1 seule ou Phase 1+2 dans le prochain sprint ?

--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -1,0 +1,344 @@
+# RFC : Agent Loop Stateful — Multi-Screen Orchestration
+
+> Date : 2026-03-27
+> Statut : **DRAFT** — À valider avant implémentation
+> Auteur : Team Lead (S57)
+> Dépendances : ChiffreChoc V2, EVI Bridge, Confidence Doctrine (tous livrés)
+
+---
+
+## 1. Problème
+
+Le coach peut aujourd'hui router vers **un seul écran** à la fois. Quand l'utilisateur dit "je veux acheter un appart", le coach ouvre `/hypotheque` et s'arrête là. Il ne peut pas enchaîner : accessibilité → gap fonds propres → EPL → fiscalité retrait.
+
+Ce qui manque :
+- **Pas de mémoire de séquence** — chaque écran est indépendant
+- **Pas de transfert d'outputs** — l'écran 2 ne sait pas ce que l'écran 1 a calculé
+- **Pas de progression visible** — l'utilisateur ne voit pas "étape 2/4"
+- **Pas de branching** — le même parcours pour tous les archétypes
+- **Pas d'anti-boucle** — si l'écran échoue, rien n'empêche de re-router dessus
+
+---
+
+## 2. Ce qui existe déjà
+
+| Composant | Ce qu'il fait | Limitation |
+|---|---|---|
+| `RoutePlanner` | Intent → readiness gate → route décision | Stateless, 1 écran à la fois |
+| `ScreenRegistry` | 60+ écrans routables, requiredFields, prefill | Pas de graphe de dépendances |
+| `CapSequenceEngine` | Plan multi-étapes (retraite, budget, logement) | Hardcodé, pas de branching archetype |
+| `CapMemory` | Tracks completedActions, abandonedFlows | Flat list, pas de contexte par étape |
+| `ScreenReturn` | outcome (completed/abandoned/changedInputs) | Pas de données de sortie structurées |
+| `CoachChatScreen._handleRouteReturn` | Réagit au retour d'un écran | Pas de chaînage vers l'écran suivant |
+| `CoachOrchestrator` agent loop | tool_use → execute → re-call LLM | Pas de state machine de parcours |
+
+---
+
+## 3. Design proposé
+
+### 3.1 Concept : Guided Sequence
+
+```
+Utilisateur : "Je veux acheter un bien immobilier"
+    ↓
+Coach (LLM) : "OK, voyons ça en 4 étapes."
+    ↓
+[SequenceCard: "Parcours achat immobilier" — 0/4 étapes]
+    ↓
+Étape 1 : /hypotheque (accessibilité) → output: {capaciteAchat: 850000, fondsNecessaires: 170000}
+    ↓
+Étape 2 : /epl (EPL) → prefill: {fondsNecessaires: 170000} → output: {eplMontant: 50000}
+    ↓
+Étape 3 : /fiscalite/retrait-capital → prefill: {montantRetrait: 50000} → output: {impotRetrait: 3200}
+    ↓
+Étape 4 : Coach résumé → "Capacité 850k, EPL 50k, impôt 3200. Ton plan est prêt."
+    ↓
+[SequenceCard: "Parcours achat immobilier" — 4/4 ✓]
+```
+
+### 3.2 Nouveau modèle : GuidedSequence
+
+```dart
+/// A multi-screen guided sequence toward a goal.
+class GuidedSequence {
+  final String id;                    // 'housing_purchase_2026'
+  final String goalLabel;             // 'Achat immobilier'
+  final List<SequenceStep> steps;     // Ordered steps
+  final String archetypeFilter;       // 'all' | 'swiss_native' | 'expat_us'
+  final DateTime createdAt;
+  final SequenceStatus status;        // active | completed | abandoned | paused
+}
+
+class SequenceStep {
+  final String id;                    // 'housing_01_affordability'
+  final int order;
+  final String intentTag;             // 'housing_purchase' (maps to ScreenRegistry)
+  final String route;                 // '/hypotheque'
+  final StepStatus status;            // pending | active | completed | skipped | blocked
+  final Map<String, dynamic> inputFromPrior;  // Pre-filled from previous step outputs
+  final Map<String, dynamic> output;  // Captured on completion
+  final StepBlockReason? blockReason;
+  final String? fallbackRoute;        // If blocked, where to redirect
+}
+
+enum StepStatus { pending, active, completed, skipped, blocked }
+
+enum StepBlockReason {
+  prerequisiteIncomplete,   // Step N-1 must complete first
+  insufficientData,         // Need document scan or profile enrichment
+  archetypeNotApplicable,   // Step not relevant for this archetype
+  userDeclined,             // User explicitly skipped
+}
+```
+
+### 3.3 Persistence : SequenceStore
+
+```dart
+/// Persists active sequences in SharedPreferences.
+/// Lightweight — one sequence active at a time.
+class SequenceStore {
+  static const _key = 'mint_active_sequence';
+
+  Future<GuidedSequence?> load();
+  Future<void> save(GuidedSequence sequence);
+  Future<void> clear();
+
+  /// Record step completion with output data.
+  Future<void> completeStep(String stepId, Map<String, dynamic> output);
+
+  /// Record step abandonment with friction context.
+  Future<void> abandonStep(String stepId, String frictionContext);
+}
+```
+
+### 3.4 Orchestration : SequenceAgent
+
+```dart
+/// Decides what happens after each step return.
+///
+/// Pure function — no side effects, fully testable.
+class SequenceAgent {
+
+  /// Given current sequence state + step outcome, decide next action.
+  static SequenceAction decide(GuidedSequence sequence, ScreenReturn stepReturn) {
+    final currentStep = sequence.steps.firstWhere((s) => s.status == StepStatus.active);
+
+    switch (stepReturn.outcome) {
+      case ScreenOutcome.completed:
+        // Mark step completed, find next non-blocked step
+        final nextStep = _findNextStep(sequence, currentStep);
+        if (nextStep != null) {
+          return SequenceAction.advance(
+            nextStep: nextStep,
+            prefill: _buildPrefill(sequence, nextStep),
+            progressLabel: '${_completedCount(sequence) + 1}/${sequence.steps.length}',
+          );
+        }
+        return SequenceAction.complete(summary: _buildSummary(sequence));
+
+      case ScreenOutcome.abandoned:
+        // Don't re-propose same step immediately — offer alternatives
+        return SequenceAction.pause(
+          message: 'Pas de souci. On peut continuer plus tard.',
+          canResume: true,
+        );
+
+      case ScreenOutcome.changedInputs:
+        // Re-evaluate: prior step outputs may be invalidated
+        return SequenceAction.reEvaluate(
+          invalidatedSteps: _findInvalidated(sequence, stepReturn.updatedFields),
+        );
+    }
+  }
+
+  /// Anti-boucle : never propose the same step more than 2x in a session.
+  static bool _shouldSkip(GuidedSequence sequence, SequenceStep step) {
+    final attempts = sequence.steps
+        .where((s) => s.id == step.id && s.status == StepStatus.completed)
+        .length;
+    return attempts >= 2;
+  }
+}
+
+/// What the agent decides after a step.
+sealed class SequenceAction {
+  const SequenceAction._();
+
+  /// Advance to the next step (auto or user-prompted).
+  const factory SequenceAction.advance({
+    required SequenceStep nextStep,
+    required Map<String, dynamic> prefill,
+    required String progressLabel,
+  }) = _Advance;
+
+  /// Sequence complete — show summary.
+  const factory SequenceAction.complete({required String summary}) = _Complete;
+
+  /// User abandoned — pause and offer resumption.
+  const factory SequenceAction.pause({
+    required String message,
+    required bool canResume,
+  }) = _Pause;
+
+  /// Profile changed — re-evaluate affected steps.
+  const factory SequenceAction.reEvaluate({
+    required List<String> invalidatedSteps,
+  }) = _ReEvaluate;
+}
+```
+
+### 3.5 Coach Chat intégration
+
+L'intégration dans `CoachChatScreen` :
+
+```
+1. Coach détecte l'intention multi-étapes (LLM retourne un tool_use avec sequence_id)
+2. SequenceStore.load() — reprendre une séquence existante ou en créer une nouvelle
+3. Afficher SequenceProgressCard (barre de progression + étape courante)
+4. Ouvrir l'écran de l'étape courante (via RoutePlanner, avec prefill des outputs précédents)
+5. Au retour : SequenceAgent.decide() → action
+6. Si advance → afficher message de transition + ouvrir étape suivante
+7. Si complete → afficher résumé + célébration
+8. Si pause → stocker dans SequenceStore pour reprise future
+9. Si reEvaluate → recalculer les étapes affectées
+```
+
+### 3.6 Output transfer entre étapes
+
+Le mécanisme de transfert d'outputs entre écrans :
+
+```dart
+/// Each simulator screen can return structured outputs via ScreenReturn.
+/// The SequenceAgent merges these outputs into the prefill of the next step.
+///
+/// Example flow:
+/// Step 1 (/hypotheque) returns: {capacite_achat: 850000, fonds_propres_requis: 170000}
+/// Step 2 (/epl) receives prefill: {montant_necessaire: 170000}
+/// Step 2 (/epl) returns: {montant_epl: 50000, impact_rente: -200}
+/// Step 3 (/fiscal) receives prefill: {montant_retrait: 50000}
+```
+
+Chaque `SequenceStep` déclare un `outputMapping` :
+
+```dart
+/// Maps output keys from this step to input keys of the next step.
+/// Example: {'capacite_achat': 'montant_bien_cible', 'fonds_propres_requis': 'montant_necessaire'}
+final Map<String, String> outputMapping;
+```
+
+---
+
+## 4. Séquences pré-définies (V1)
+
+Pour le premier prototype, 3 séquences hardcodées :
+
+### 4.1 Achat immobilier (4 étapes)
+
+| Étape | Route | Input de l'étape précédente | Output |
+|---|---|---|---|
+| 1. Accessibilité | `/hypotheque` | — | capacité_achat, fonds_propres_requis |
+| 2. EPL | `/epl` | fonds_propres_requis | montant_epl, impact_rente |
+| 3. Fiscalité retrait | `/fiscalite/retrait-capital` | montant_epl | impot_retrait |
+| 4. Résumé coach | (inline) | tous les outputs | — |
+
+### 4.2 Optimisation 3a (3 étapes)
+
+| Étape | Route | Input | Output |
+|---|---|---|---|
+| 1. Simulateur 3a | `/pilier-3a` | — | contribution_annuelle, economie_fiscale |
+| 2. Retrait échelonné | `/3a-deep/staggered-withdrawal` | contribution_annuelle | gain_echelonnement |
+| 3. Rendement réel | `/3a-deep/real-return` | contribution_annuelle | rendement_net_inflation |
+
+### 4.3 Préparation retraite (5 étapes)
+
+| Étape | Route | Input | Output |
+|---|---|---|---|
+| 1. Projection | `/retraite` | — | taux_remplacement, gap_mensuel |
+| 2. Rente vs Capital | `/rente-vs-capital` | gap_mensuel | decision_mixte |
+| 3. Rachat LPP | `/rachat-lpp` | gap_mensuel | economie_rachat |
+| 4. Décaissement | `/decaissement` | decision_mixte | calendrier_optimal |
+| 5. Résumé coach | (inline) | tous | — |
+
+---
+
+## 5. Anti-patterns et garde-fous
+
+### 5.1 Anti-boucle
+- Jamais plus de 2 tentatives sur la même étape dans une session
+- Si l'utilisateur abandonne 2 fois → step marqué `skipped`, on passe au suivant
+
+### 5.2 Anti-forçage
+- L'utilisateur peut toujours quitter la séquence ("Je veux faire autre chose")
+- Le coach propose, ne force jamais
+- Séquence pausée = resumable, pas perdue
+
+### 5.3 Cohérence des données
+- Si un output de l'étape 1 est invalidé (profil changé), les étapes suivantes sont re-évaluées
+- Le `SequenceAgent.reEvaluate()` marque les étapes affectées comme `pending`
+
+### 5.4 Pas de séquences imbriquées
+- V1 : une seule séquence active à la fois
+- Si l'utilisateur lance une nouvelle séquence, l'ancienne est pausée
+
+---
+
+## 6. Plan d'implémentation
+
+### Phase 1 : Modèles + Store (1 sprint)
+- `GuidedSequence`, `SequenceStep`, `SequenceAction` models
+- `SequenceStore` (SharedPreferences)
+- `SequenceAgent.decide()` (pure function)
+- Tests unitaires (20+)
+
+### Phase 2 : UI + Chat integration (1 sprint)
+- `SequenceProgressCard` widget (barre + étape courante)
+- `CoachChatScreen` : détection d'intention séquence + rendering
+- Modification de `_handleRouteReturn` pour chaîner les étapes
+- 1 parcours vertical fonctionnel (achat immobilier)
+
+### Phase 3 : Archetype branching + output transfer (1 sprint)
+- `outputMapping` entre étapes
+- Branching par archétype (expat_us skip, indep_no_lpp adaptation)
+- 3 parcours complets
+- Tests d'intégration E2E
+
+---
+
+## 7. Ce qu'on NE fait PAS
+
+- **Pas de multi-séquence simultanée** — V1 = une seule active
+- **Pas de séquences dynamiques générées par le LLM** — V1 = 3 séquences hardcodées
+- **Pas d'auto-advance sans confirmation** — toujours "Prêt pour l'étape suivante ?"
+- **Pas de rollback complet** — si étape 1 est invalidée, on re-propose mais on ne supprime pas les données
+
+---
+
+## 8. Métriques de succès
+
+| Métrique | Baseline (actuel) | Cible |
+|---|---|---|
+| Écrans visités par session | ~1.5 | 3+ |
+| Taux de complétion d'un parcours complet | 0% (pas de parcours) | 40% |
+| Temps sur le parcours achat immo | — | < 10 min pour 4 étapes |
+| Taux d'abandon après étape 1 | — | < 30% |
+
+---
+
+## 9. Risques
+
+| Risque | Probabilité | Mitigation |
+|---|---|---|
+| Complexité du state machine | Élevée | SequenceAgent est une pure function, 100% testable |
+| Output mapping fragile entre écrans | Moyenne | Typage fort, tests de contrat par séquence |
+| UX trop directive ("tunnel") | Moyenne | Toujours proposer, jamais forcer. Bouton "Quitter le parcours" |
+| Régression sur le chat existant | Faible | Le chat sans séquence fonctionne exactement comme avant |
+
+---
+
+## 10. Décision requise
+
+Avant de coder :
+1. **Approuver les 3 séquences V1** (achat immo, 3a, retraite)
+2. **Confirmer l'approche "propose, ne force pas"** — auto-advance avec confirmation
+3. **Valider le stockage SharedPreferences** vs backend pour l'état de séquence
+4. **Décider** : Phase 1 seule (modèles + tests) ou Phase 1+2 (modèles + UI) dans le prochain sprint ?

--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -235,8 +235,10 @@ _onRealtimeScreenReturn(screenReturn);
 - Séquence pausée = resumable à la prochaine session
 
 ### 5.3 Pas de double message
-- Quand une `SequenceRun` est active, `_onRealtimeScreenReturn()` est gaté
-- Seul le `SequenceCoordinator` produit le message de transition
+- `_onRealtimeScreenReturn()` reste le point d'entrée unique
+- Quand une `SequenceRun` est active, sa **branche legacy** (message générique
+  + coach reaction) est bypassée au profit du `SequenceCoordinator`
+- Le handler realtime n'est PAS gaté — il est réorienté
 
 ### 5.4 Pas de séquences imbriquées
 - V1 : une seule `SequenceRun` active
@@ -255,24 +257,33 @@ _onRealtimeScreenReturn(screenReturn);
 `SequenceRun` ne rend **rien visible directement**. La projection sur le plan visible
 passe toujours par `CapSequenceEngine`.
 
-**Contrat** : `CapSequenceEngine.build()` accepte un paramètre optionnel `activeRun` :
+**Contrat** : `CapSequenceEngine.build()` garde sa signature actuelle et accepte
+un paramètre optionnel `activeRun` :
 
 ```dart
-/// Builds the visible CapSequence, optionally influenced by an active run.
+/// Current API (inchangée) :
+/// static CapSequence build({
+///   required CoachProfile profile,
+///   required CapMemory memory,
+///   required String goalIntentTag,
+///   required S l,
+/// })
 ///
-/// When [activeRun] is non-null, the engine projects the run state onto
-/// the CapStep statuses:
+/// Migration : ajouter un paramètre optionnel activeRun.
+/// Quand activeRun est non-null, le run state projette sur les CapStepStatus :
 ///   StepRunState.completed → CapStepStatus.completed
 ///   StepRunState.active    → CapStepStatus.current
 ///   StepRunState.skipped   → CapStepStatus.completed (grayed out in UI)
 ///   StepRunState.blocked   → CapStepStatus.blocked
 ///   StepRunState.pending   → CapStepStatus.upcoming
 ///
-/// When [activeRun] is null, behavior is identical to today (profile + memory only).
-static CapSequence build(
-  CoachProfile profile,
-  CapMemory memory, {
-  SequenceRun? activeRun,
+/// Quand activeRun est null : comportement identique à aujourd'hui.
+static CapSequence build({
+  required CoachProfile profile,
+  required CapMemory memory,
+  required String goalIntentTag,
+  required S l,
+  SequenceRun? activeRun,  // NOUVEAU — optionnel, backward-compatible
 })
 ```
 
@@ -289,18 +300,27 @@ Deux canaux existent dans `CoachChatScreen` :
 `_onRealtimeScreenReturn(ScreenReturn)` car il porte les `stepOutputs`.
 
 ```
-Séquence active :
-  ScreenReturn (avec stepOutputs) → _onRealtimeScreenReturn
-    → détecte activeRun → delegate SequenceCoordinator.decide()
-    → _handleRouteReturn IGNORÉ (gaté)
-
-Pas de séquence :
-  → comportement actuel inchangé (les deux canaux fonctionnent)
+_onRealtimeScreenReturn(ScreenReturn) {
+  if (activeSequenceRun != null) {
+    // SEQUENCE MODE: delegate to coordinator, bypass legacy reaction
+    // Debounce: BYPASSED — sequence transitions should feel immediate
+    final action = SequenceCoordinator.decide(...);
+    _applySequenceAction(action);
+    return;
+  }
+  // NORMAL MODE: existing behavior (debounced 2s, coach generic reaction)
+  _debouncedLegacyReaction(screenReturn);
+}
 ```
+
+**Debounce** : le debounce de 2s (existant pour les sliders/inputs fréquents)
+est **bypassé** quand une séquence est active. Les transitions entre étapes
+doivent être immédiates — l'utilisateur a déjà terminé un écran complet,
+pas juste bougé un slider.
 
 Le `RouteSuggestionCard` continue de construire un `ScreenReturn` comme aujourd'hui.
 La seule différence : quand une séquence est active, le coordinator consomme le
-`ScreenReturn` au lieu du handler legacy.
+`ScreenReturn` au lieu de la branche legacy.
 
 ### 6.3 Contrat de persistance
 
@@ -348,14 +368,19 @@ alors que `ScreenRegistry` utilise `intentTag` pour les identifiants sémantique
 
 **Résolution pour la RFC** :
 - `SequenceStepDef.intentTag` = **sémantique** (comme `ScreenRegistry`). Ex: `simulator_3a`
-- La résolution `intentTag → route` passe TOUJOURS par `ScreenRegistry.entryForIntent()`
+- La résolution `intentTag → route` passe TOUJOURS par `MintScreenRegistry.findByIntentStatic()`
 - `CapStep.intentTag` (champ existant) reste tel quel (dette acceptée, pas de renommage)
 - Un commentaire est ajouté : `/// LEGACY: contains GoRouter route, not semantic intent. See ROUTE_POLICY.md.`
 
 ```dart
 // Dans SequenceCoordinator, le mapping est explicite :
-final entry = MintScreenRegistry.entryForIntent(stepDef.intentTag);
-final route = entry?.route ?? stepDef.intentTag; // fallback si pas dans registry
+final entry = MintScreenRegistry.findByIntentStatic(stepDef.intentTag);
+if (entry == null) {
+  // FAIL-SAFE: unknown intent → pause sequence + log, never navigate blindly
+  debugPrint('[SequenceCoordinator] Unknown intent: ${stepDef.intentTag}');
+  return SequenceAction.pause(canResume: true);
+}
+final route = entry.route;
 ```
 
 ---

--- a/docs/RFC_AGENT_LOOP_STATEFUL.md
+++ b/docs/RFC_AGENT_LOOP_STATEFUL.md
@@ -248,7 +248,119 @@ _onRealtimeScreenReturn(screenReturn);
 
 ---
 
-## 6. Plan d'implémentation
+## 6. Contrats de synchronisation (V2.1 — ajoutés post-audit)
+
+### 6.1 SequenceRun → CapSequence (plan visible)
+
+`SequenceRun` ne rend **rien visible directement**. La projection sur le plan visible
+passe toujours par `CapSequenceEngine`.
+
+**Contrat** : `CapSequenceEngine.build()` accepte un paramètre optionnel `activeRun` :
+
+```dart
+/// Builds the visible CapSequence, optionally influenced by an active run.
+///
+/// When [activeRun] is non-null, the engine projects the run state onto
+/// the CapStep statuses:
+///   StepRunState.completed → CapStepStatus.completed
+///   StepRunState.active    → CapStepStatus.current
+///   StepRunState.skipped   → CapStepStatus.completed (grayed out in UI)
+///   StepRunState.blocked   → CapStepStatus.blocked
+///   StepRunState.pending   → CapStepStatus.upcoming
+///
+/// When [activeRun] is null, behavior is identical to today (profile + memory only).
+static CapSequence build(
+  CoachProfile profile,
+  CapMemory memory, {
+  SequenceRun? activeRun,
+})
+```
+
+**Règle** : `CapSequenceEngine` reste la SEULE source de `CapStepStatus`.
+`SequenceRun` est un **input**, pas un remplacement.
+
+### 6.2 Canonical return path
+
+Deux canaux existent dans `CoachChatScreen` :
+- `_handleRouteReturn(ScreenOutcome)` — retour simplifié depuis `RouteSuggestionCard`
+- `_onRealtimeScreenReturn(ScreenReturn)` — retour riche global (debounced)
+
+**Décision** : pendant une séquence guidée, le chemin canonique est
+`_onRealtimeScreenReturn(ScreenReturn)` car il porte les `stepOutputs`.
+
+```
+Séquence active :
+  ScreenReturn (avec stepOutputs) → _onRealtimeScreenReturn
+    → détecte activeRun → delegate SequenceCoordinator.decide()
+    → _handleRouteReturn IGNORÉ (gaté)
+
+Pas de séquence :
+  → comportement actuel inchangé (les deux canaux fonctionnent)
+```
+
+Le `RouteSuggestionCard` continue de construire un `ScreenReturn` comme aujourd'hui.
+La seule différence : quand une séquence est active, le coordinator consomme le
+`ScreenReturn` au lieu du handler legacy.
+
+### 6.3 Contrat de persistance
+
+#### stepOutputs
+
+```dart
+/// Allowed types in stepOutputs values:
+///   - double (CHF amounts, percentages, rates)
+///   - int (years, counts)
+///   - String (identifiers, labels — max 200 chars)
+///   - bool (decisions, flags)
+///
+/// NOT allowed:
+///   - Lists, nested Maps (flatten before storing)
+///   - Large blobs (images, documents)
+///   - Computed objects (re-derive from profile)
+///
+/// Total size budget per step: < 2 KB JSON.
+/// Total size budget per run: < 20 KB JSON.
+```
+
+Sérialisation : `jsonEncode(Map<String, dynamic>)` dans SharedPreferences sous la clé
+`mint_sequence_run`. Un seul run actif, écrasé à chaque mise à jour.
+
+#### proposalCount
+
+Ajout dans `CapMemory` (pas un nouveau store) :
+
+```dart
+/// Track how many times a step has been proposed to the user in the current run.
+/// Key: "{runId}_{stepId}", Value: count.
+/// Cleared when the run completes or is abandoned.
+/// NOT time-windowed — scoped to the run lifetime.
+final Map<String, int> stepProposals; // NOUVEAU dans CapMemory
+```
+
+Enregistré quand : juste AVANT que le `RouteSuggestionCard` s'affiche pour une étape.
+Incrémenté à chaque re-proposition (y compris après abandon + retry).
+Réinitialisé quand le `SequenceRun` passe à `completed` ou `abandoned`.
+
+### 6.4 intentTag vs route (clarification de nommage)
+
+**Problème hérité** : `CapStep.intentTag` contient des routes GoRouter (`/pilier-3a`),
+alors que `ScreenRegistry` utilise `intentTag` pour les identifiants sémantiques (`simulator_3a`).
+
+**Résolution pour la RFC** :
+- `SequenceStepDef.intentTag` = **sémantique** (comme `ScreenRegistry`). Ex: `simulator_3a`
+- La résolution `intentTag → route` passe TOUJOURS par `ScreenRegistry.entryForIntent()`
+- `CapStep.intentTag` (champ existant) reste tel quel (dette acceptée, pas de renommage)
+- Un commentaire est ajouté : `/// LEGACY: contains GoRouter route, not semantic intent. See ROUTE_POLICY.md.`
+
+```dart
+// Dans SequenceCoordinator, le mapping est explicite :
+final entry = MintScreenRegistry.entryForIntent(stepDef.intentTag);
+final route = entry?.route ?? stepDef.intentTag; // fallback si pas dans registry
+```
+
+---
+
+## 7. Plan d'implémentation
 
 ### Phase 1 : Modèles + Coordinator + Tests (1 sprint)
 - `SequenceTemplate`, `SequenceRun` models
@@ -270,7 +382,7 @@ _onRealtimeScreenReturn(screenReturn);
 
 ---
 
-## 7. Ce qu'on NE fait PAS
+## 8. Ce qu'on NE fait PAS
 
 - **Pas de nouveau modèle de plan** — `CapSequence` reste le seul plan visible
 - **Pas de sélection de séquence par le LLM** — le code mappe intent → template
@@ -280,7 +392,7 @@ _onRealtimeScreenReturn(screenReturn);
 
 ---
 
-## 8. Métriques de succès
+## 9. Métriques de succès
 
 | Métrique | Baseline | Cible |
 |---|---|---|
@@ -291,7 +403,7 @@ _onRealtimeScreenReturn(screenReturn);
 
 ---
 
-## 9. Décision requise
+## 10. Décision requise
 
 1. **Valider les 3 séquences V1** et leurs étapes
 2. **Confirmer** : `CapSequence` = plan visible unique, `SequenceRun` = runtime uniquement


### PR DESCRIPTION
## Summary
RFC pour l'agent loop stateful — le coach qui enchaîne plusieurs écrans avec mémoire, transfert d'outputs, et progression visible.

**Ce n'est PAS du code.** C'est un document d'architecture à valider avant implémentation.

## Contenu de la RFC
- Problème : le coach route vers 1 écran, pas une séquence
- 6 gaps identifiés (state, intent→sequence, output transfer, archetype branching, fallback, loop)
- Design : `GuidedSequence` + `SequenceAgent` (pure function) + `SequenceStore`
- 3 séquences V1 : achat immo (4 étapes), 3a (3 étapes), retraite (5 étapes)
- Anti-patterns : anti-boucle, anti-forçage, pas de séquences imbriquées
- Plan 3 phases : modèles → UI → branching archetype

## Décisions à prendre
1. Approuver les 3 séquences V1
2. Confirmer "propose, ne force pas"
3. SharedPreferences vs backend pour l'état
4. Phase 1 seule ou Phase 1+2 dans le prochain sprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)