### PR TITLE
feat: Chantier 4 — scan delta in coach chat

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -2087,15 +2087,29 @@ class _CoachChatScreenState extends State<CoachChatScreen>
 
       // Build a context-rich summary from the real simulation data.
       final buf = StringBuffer();
-      buf.write('Je viens de simuler ${pending.route}');
-      if (pending.updatedFields != null && pending.updatedFields!.isNotEmpty) {
-        final highlights = pending.updatedFields!.entries
-            .take(3)
-            .map((e) => '${e.key}: ${e.value}')
-            .join(', ');
-        buf.write(' ($highlights)');
+      // Special handling for document scan returns — human-readable delta.
+      if (pending.route == '/scan/impact' &&
+          pending.updatedFields?['scannedDocument'] != null) {
+        final doc = pending.updatedFields!['scannedDocument'];
+        final delta = pending.updatedFields!['confidenceDelta'];
+        final newConf = pending.updatedFields!['newConfidence'];
+        buf.write('Je viens de scanner mon $doc. ');
+        if (delta is num && delta > 0) {
+          buf.write('Ma précision a gagné +$delta points');
+          if (newConf is num) buf.write(' ($newConf\u00a0%)');
+          buf.write('.');
+        }
+      } else {
+        buf.write('Je viens de simuler ${pending.route}');
+        if (pending.updatedFields != null && pending.updatedFields!.isNotEmpty) {
+          final highlights = pending.updatedFields!.entries
+              .take(3)
+              .map((e) => '${e.key}: ${e.value}')
+              .join(', ');
+          buf.write(' ($highlights)');
+        }
+        buf.write('.');
       }
-      buf.write('.');
 
       _sendMessage(buf.toString());
     });

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -6,7 +6,9 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
+import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -461,7 +463,26 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
           height: 56,
           child: FilledButton.icon(
             onPressed: () {
-            // Navigate back to root dashboard via GoRouter
+            // Emit ScreenReturn so the coach chat can show a delta message.
+            final docLabel = switch (widget.result.documentType) {
+              DocumentType.lppCertificate => 'certificat LPP',
+              DocumentType.avsExtract => 'extrait AVS',
+              DocumentType.taxDeclaration => 'déclaration fiscale',
+              DocumentType.salaryCertificate => 'certificat de salaire',
+              _ => 'document',
+            };
+            ScreenCompletionTracker.markCompletedWithReturn(
+              'document_scan',
+              ScreenReturn.completed(
+                route: '/scan/impact',
+                updatedFields: {
+                  'scannedDocument': docLabel,
+                  'confidenceDelta': _deltaPoints,
+                  'newConfidence': _newConfidence,
+                },
+                confidenceDelta: _deltaPoints / 100.0,
+              ),
+            );
             context.go('/home');
           },
           icon: const Icon(Icons.dashboard_outlined, size: 22),


### PR DESCRIPTION
## Summary
Document scan completion now emits a ScreenReturn that the coach chat
consumes to show a human-readable delta message. Closes the gap between
the scan impact screen (visual delta) and the chat (no signal).

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8310 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)