### PR TITLE
fix: Chantier 7 — suppress analytics side effects in sequence mode

### DIFF
--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -67,7 +67,6 @@ class _BudgetScreenState extends State<BudgetScreen>
   @override
   void initState() {
     super.initState();
-    ReportPersistenceService.markSimulatorExplored('budget');
     _staggerController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1200),
@@ -78,6 +77,9 @@ class _BudgetScreenState extends State<BudgetScreen>
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _readSequenceContext();
+      if (_seqRunId == null) {
+        ReportPersistenceService.markSimulatorExplored('budget');
+      }
       try {
         context.read<BudgetProvider>().setInputs(widget.inputs);
         _staggerController.forward();

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -91,7 +91,6 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   @override
   void initState() {
     super.initState();
-    ReportPersistenceService.markSimulatorExplored('lpp_deep');
     _heroController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 800),
@@ -109,6 +108,9 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
           _seqStepId = extra['stepId'] as String?;
         }
       } catch (_) {}
+      if (_seqRunId == null) {
+        ReportPersistenceService.markSimulatorExplored('lpp_deep');
+      }
     });
   }
 

--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -51,9 +51,11 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   @override
   void initState() {
     super.initState();
-    ReportPersistenceService.markSimulatorExplored('mortgage');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _readSequenceContext();
+      if (_seqRunId == null) {
+        ReportPersistenceService.markSimulatorExplored('mortgage');
+      }
       _initializeFromProfile();
     });
   }

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -57,12 +57,14 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
   void initState() {
     super.initState();
     _contributionCtrl = TextEditingController();
-    ReportPersistenceService.markSimulatorExplored('3a');
     _initializeFromProfile();
     _contributionCtrl.text = _annualContribution.round().toString();
     _calculate();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _readSequenceContext();
+      if (_seqRunId == null) {
+        ReportPersistenceService.markSimulatorExplored('3a');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
Final hardening audit fix — 4 screens had unguarded
ReportPersistenceService.markSimulatorExplored() calls that polluted
analytics when opened as sequence steps.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8310 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)