### PR TITLE
fix: rachat LPP inversé + ratio 4200% + anti-bullshit manifesto

### DIFF
--- a/apps/mobile/lib/services/response_card_service.dart
+++ b/apps/mobile/lib/services/response_card_service.dart
@@ -555,11 +555,11 @@ class ResponseCardService {
         prompts.add(l.rcSuggestedPromptAllegerImpots);
       case LifecyclePhase.acceleration:
         prompts.add(l.rcSuggestedPromptAllegerImpots);
-        if (!hasLpp) prompts.add(l.rcSuggestedPromptRachatLpp);
+        if (hasLpp) prompts.add(l.rcSuggestedPromptRachatLpp);
         prompts.add(l.rcSuggestedPromptVersement3a);
       case LifecyclePhase.consolidation:
         prompts.add(l.rcSuggestedPrompt50PlusRetirement);
-        if (!hasLpp) prompts.add(l.rcSuggestedPromptRachatLpp);
+        if (hasLpp) prompts.add(l.rcSuggestedPromptRachatLpp);
         prompts.add(l.rcSuggestedPromptRenteOuCapital);
       case LifecyclePhase.transition:
         prompts.add(l.rcSuggestedPrompt50PlusRetirement);

--- a/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
+++ b/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
@@ -224,7 +224,7 @@ List<SequenceSummaryItem> _buildTensionSummary(
     items.add(SequenceSummaryItem(
       icon: Icons.speed_outlined,
       label: l.summaryRatioEndettement,
-      value: '${(ratio * 100).toStringAsFixed(0)}\u00a0%',
+      value: '${ratio.toStringAsFixed(0)}\u00a0%',
     ));
   }
   final marge = step1?['marge_mensuelle'];

--- a/apps/mobile/test/services/sequence/sequence_summary_builder_test.dart
+++ b/apps/mobile/test/services/sequence/sequence_summary_builder_test.dart
@@ -137,7 +137,7 @@ void main() {
         templateId: 'financial_tension',
         allOutputs: {
           'tension_01_diagnostic': {
-            'ratio_endettement': 0.42,
+            'ratio_endettement': 42.0,
             'marge_mensuelle': -200.0,
           },
           'tension_02_budget': {
@@ -165,7 +165,7 @@ void main() {
         templateId: 'financial_tension',
         allOutputs: {
           'tension_01_diagnostic': {
-            'ratio_endettement': 0.55,
+            'ratio_endettement': 55.0,
             'marge_mensuelle': -350.0,
           },
         },

--- a/docs/COHORT_OS_PHASE6A_FIX_PLAN.md
+++ b/docs/COHORT_OS_PHASE6A_FIX_PLAN.md
@@ -1,0 +1,142 @@
+# Cohort OS Phase 6A Fix Plan
+
+> Statut: plan immediat
+> Role: corriger le point 6 proprement, PR par PR
+> Scope: cohortes Phase 6A uniquement
+
+---
+
+## PR 1 — Corriger le bug suggestion chips
+
+### Objectif
+
+Fermer la contradiction metier deja live dans `suggestedPrompts()`.
+
+### A corriger
+
+- `rachat LPP` ne doit jamais etre suggere si `hasLpp == false`
+
+### Fichiers
+
+- [response_card_service.dart](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/services/response_card_service.dart)
+- [response_card_service_test.dart](/Users/julienbattaglia/Desktop/MINT/apps/mobile/test/services/response_card_service_test.dart)
+
+### Tests a ajouter
+
+- profil acceleration avec LPP -> prompt rachat present ou autorise
+- profil acceleration sans LPP -> prompt rachat absent
+- profil consolidation sans LPP -> prompt rachat absent
+
+### Verdict attendu
+
+- plus aucune suggestion LPP incoherente
+
+---
+
+## PR 2 — Rewriter la spec Cohort OS
+
+### Objectif
+
+Faire de `COHORT_OS_SPEC.md` une spec executable, pas une vision pseudo-code.
+
+### A corriger
+
+- retirer le preambule conversationnel
+- remplacer la notion de nouvelle SOT cohortes
+- aligner tous les champs sur `CoachProfile` reel
+- supprimer `ExplorerHubController` tant qu'il n'existe pas
+
+### Fichiers
+
+- [COHORT_OS_SPEC.md](/Users/julienbattaglia/Desktop/MINT/docs/COHORT_OS_SPEC.md)
+
+### Verdict attendu
+
+- la spec est directement utilisable par les agents
+
+---
+
+## PR 3 — Projection cohort produit
+
+### Objectif
+
+Introduire une projection produit legere basee sur `LifecyclePhaseService`.
+
+### A livrer
+
+- petit type `ProductCohort` ou equivalent
+- mapping `LifecyclePhase -> ProductCohort`
+- fonction pure, sans nouvelle SOT
+
+### Fichiers probables
+
+- nouveau service leger dans `apps/mobile/lib/services/`
+- tests associes
+
+### Verdict attendu
+
+- 6 cohortes produit exploitables sans casser le lifecycle existant
+
+---
+
+## PR 4 — Coach context cohort-aware
+
+### Objectif
+
+Injecter la cohorte produit dans le contexte coach sans rigidifier le systeme.
+
+### Fichiers
+
+- [context_injector_service.dart](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/services/coach/context_injector_service.dart)
+- tests associes
+
+### A prouver
+
+- ton adapte
+- sujets prioritaires adaptes
+- sujets a ne pas pousser adaptes
+
+---
+
+## PR 5 — Pulse / Cap priorisation minimale
+
+### Objectif
+
+Prouver qu'une meme app parait differente selon la cohorte.
+
+### Scope limite
+
+- priorite du cap
+- formulation
+- ordre d'affichage minimum
+
+### A eviter
+
+- refonte complete du `CapEngine`
+
+---
+
+## PR 6 — Golden personas + assertions
+
+### Objectif
+
+Mettre fin aux regressions silencieuses cohort-aware.
+
+### A livrer
+
+- 6 personas golden
+- 18 assertions minimum
+- tests comportementaux sur suggestions / coach context / Pulse
+
+### Verdict attendu
+
+- les cohortes ne sont plus une intuition, mais un contrat teste
+
+---
+
+## Règles de passage
+
+- ne pas lancer PR 3 avant fermeture de PR 1 et PR 2
+- ne pas etendre Explorer avant validation PR 4 et PR 5
+- ne pas generaliser les 18 journeys avant que les 6 personas soient verts
+

--- a/docs/COHORT_OS_SPEC.md
+++ b/docs/COHORT_OS_SPEC.md
@@ -1,1276 +1,421 @@
-I'll read the three documents you've specified to understand MINT's architecture and then design a production-ready cohort system.
-Excellent. I have the three documents. Now let me design the production-ready OS de cohortes for MINT. I'll structure this as a comprehensive specification that can be directly implemented by the team.
+# Cohort OS Spec
+
+> Statut: spec produit corrigee, pre-implementation
+> Role: adapter MINT par cohortes sans creer de seconde source de verite
+> Scope: coach, suggestion chips, Pulse, priorisation de surfaces
+> Non-scope: nouvelle engine de classification parallele, refonte visuelle globale
 
 ---
 
-# OS de Cohortes — MINT Cohort Operating System (Production Spec)
+## 1. Principe directeur
 
-## Executive Summary
+L'OS de cohortes ne doit pas creer un nouveau systeme de classification a cote
+de l'existant.
 
-This spec defines a **life-phase-based cohort engine** that adapts MINT's experience across 6 age bands (18-99). Rather than generic content, each cohort sees:
-- **Different guided sequences** (journeys via coach)
-- **Different Explorer tab priorities** (tools + hub order)
-- **Different coach tone** (vocabulary, pacing, reassurance style)
-- **Different CTA chips** (contextual calls-to-action)
-- **Different Pulse caps** (priority actions on Aujourd'hui)
-- **Different content suppression** (never show retirement planning to 22yo)
+**Source de verite canonique**:
+- [LifecyclePhaseService](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/services/lifecycle_phase_service.dart)
+- [CoachProfile](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/models/coach_profile.dart)
+- [ContentAdapterService](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/services/content_adapter_service.dart)
 
-**Implementation strategy**: Build a stateless `CohortDetectionService` that determines cohort from `CoachProfile` + life events + confidence signals. Inject cohort into `CapEngine`, `ExplorerHubController`, and `CoachContextInjectorService`. UI remains unchanged; logic adapts beneath.
+**Regle absolue**:
+- `LifecyclePhaseService` reste le classifieur canonique
+- l'OS de cohortes est une **projection produit** du lifecycle existant
+- aucune nouvelle SOT de type `CohortDetectionService` n'est introduite en Phase 6A
 
----
+Autrement dit:
 
-## 1. COHORT DEFINITIONS (18-99)
-
-### Cohort 1: **18-27 (First Steps)**
-
-**Definition**: Recently employed, learning financial independence, no major commitments yet.
-
-**Detection Logic**:
-```dart
-// CohortDetectionService.detectCohort(CoachProfile profile, List<LifeEvent> events)
-age >= 18 && age <= 27 &&
-  (firstJobEvent != null || newJobEvent != null || events.contains(firstJob)) &&
-  profile.totalAssets < 50_000 &&
-  profile.monthlyDebt == 0 // or debt from studies only
-  → Cohort1_FirstSteps
+```text
+LifecyclePhase + profile context + major life signals
+-> projection cohort product
+-> adaptation de l'experience
 ```
 
-**Archetype**: mostly `swiss_native` + some `expat_eu` (AU pairs, exchange students). Low profile completeness (50-60%).
+et non:
 
-**Cap typique**: "Comprendre mon premier salaire" / "Organiser mon budget"
-
-#### 1.1 Top 3 Guided Sequences (Journeys)
-
-| Journey | Coach Opening | Flow | ARB Key Pattern | Why This Cohort |
-|---------|--------------|------|-----------------|-----------------|
-| **J1: Premier Salaire Maîtrisé** | "Tu viens de recevoir ta première fiche de paie. On décortique ensemble?" | 1. Brut vs Net (AVS/LPP/IR expliqué) → 2. Budget mensuel simple (revenus - charges fixes) → 3. Épargne réaliste (10% early) → 4. Résumé: "Tu disposes de CHF X/mois" | `journey_first_salary_*` | Foundation for lifetime. High emotional impact (first independence moment). Low complexity (3a/LPP not yet critical). |
-| **J2: Sortir d'une Tension Budget** | "Ton budget te serre? Voyons où on peut retrouver de l'air." | 1. Diagnostic rapide (revenus vs charges) → 2. Leaking money audit (Netflix, abos, petits crédits) → 3. Plan d'action (cut cheapest item → free up CHF Y/mois) → 4. Win: "Retrouvé CHF Z, c'est X% de liberté de plus" | `journey_budget_tension_*` | Very common at 22 (student debt lingering, first apt costs, lifestyle inflation). Quick wins = high conversion. |
-| **J3: Comparaison d'Offre Job** | "Nouvelle offre en main? Regardons si ça paie vraiment plus." | 1. Brut comparé → 2. Impôt + charges (canton change?) → 3. Bonus/13e impact → 4. Net monthly delta → 5. Non-financial factor (trajet, lifestyle, learning) | `journey_job_comparison_*` | Age 24-27: first job hops. Prevents bad decisions (higher gross ≠ higher net after taxes + canton shift). |
-
-**Wording/Tone Rules for Cohort 1**:
-- **Vocab**: Simple, no jargon. "Impôt" > "fiscalité". "Argent de poche" is OK, but not "allocation".
-- **Tone**: Supportive mentor (think TikTok financial educateur, not bank). "Cool, on va décortiquer ensemble" vs "Voici votre situation fiscale".
-- **Reassurance**: Early financial stress is normal. "Presque tous les Suisses passent par là."
-- **Avoid**: Tax optimization language, succession, LIFD art 38, anything over CHF 100k capital.
-
-**Explorer Tab Priorities (Cohort 1)**:
-
-Hub order:
-1. **Travail & Statut** (50% space) — premier emploi, comparaison offre, chômage (RIP emotional hit)
-2. **Famille** (25%) — concubinage basics, naissance planning (avoid divorce)
-3. **Fiscalité** (15%) — déclaration 1ère année, déductions simple
-4. **Logement** (10%) — louer vs acheter (not yet buying, but good to know)
-5. Hide: Retraite, Patrimoine & Succession, Santé & Protection (unless disability event triggered)
-
-**Screens to Prioritize** (Explorer tiles):
-- `first_job_screen` — ★★★★★ (T1 board = 10/10)
-- `job_comparison_screen` — ★★★★★
-- `budget_breakdown_screen` (new) — simplified spending by category
-- `tax_declaration_simple_screen` (new) — "your first tax return in 3 steps"
-- `unemployment_safety_net_screen` — emotional, but crucial
-- Hide: `retirement_dashboard`, `succession_planner`, `lpp_deep` tabs
-
-**CTA Chips (Coach) for Cohort 1**:
-
-When coach recommends next step, offer these:
-```
-// ARB: ctaChip_cohort1_*
-"📊 Voir mon budget mensuel"      // Opens budget_breakdown
-"🎯 Tester une autre offre"       // Opens job_comparison  
-"🏦 Comprendre ma fiche de paie" // Opens first_job_screen
-"💰 Plan épargne 1ère année"      // Opens savings_goal_screen (new)
-"⚠️ Je suis au chômage, aide!"    // Opens unemployment_safety
-```
-
-**Pulse Cap (Aujourd'hui Tab) for Cohort 1**:
-
-What MINT shows as the #1 action on landing:
-
-```
-IF age 18-21 && firstJobEvent recent:
-  CAP: "Ton premier salaire en chiffres"
-  → Icon: 💶
-  → Subtitle: "Comprendre ce que tu gagnes vraiment"
-  → CTA: "Décortiquer"
-  → Delta: "Tu vas libérer CHF X/mois"
-  
-ELSE IF age 22-27 && newJobOffer detected:
-  CAP: "Comparer deux offres"
-  → Icon: ⚖️
-  → Subtitle: "Voir la vraie différence"
-  → CTA: "Comparer"
-  
-ELSE IF debt ratio > 0.3:
-  CAP: "Retrouver de l'air ce mois"
-  → Icon: 🌬️
-  → CTA: "Voir où couper"
-  
-ELSE:
-  CAP: "Construire ton épargne"
-  → Icon: 🌱
-  → Subtitle: "10% = une fondation solide"
-  → CTA: "Planifier"
+```text
+Nouveau moteur cohortes
+-> concurrence le lifecycle existant
+-> derive du code et des prompts
 ```
 
 ---
 
-### Cohort 2: **28-37 (Build Phase)**
+## 2. Pourquoi cet OS existe
 
-**Definition**: Establishes major life structures: partner, first child, first home, stable career.
+MINT doit cesser d'etre percu comme une app finance generique.
 
-**Detection Logic**:
-```dart
-age >= 28 && age <= 37 &&
-  (marriageEvent != null || concubinageEvent != null || 
-   housingPurchaseEvent != null || birthEvent != null) &&
-  profile.monthlyIncome >= 4_500 // dual income or established single
-  → Cohort2_BuildPhase
-```
+L'objectif de l'OS de cohortes est de faire en sorte que:
+- un 22 ans
+- un couple de 34 ans avec projet immo
+- un independant de 47 ans
+- un pre-retraite de 59 ans
+- un retraite de 72 ans
 
-**Archetype**: mostly `swiss_native` + `couple_mode`, some `independant_with_lpp`. Profile completeness 65-80%.
+n'aient pas l'impression d'utiliser la meme app.
 
-**Cap typique**: "Construire sans me piéger" / "Arbitrer famille vs ambition"
+L'OS de cohortes adapte:
+- les suggestion chips
+- le ton coach
+- les priorites Pulse
+- l'ordre des surfaces mises en avant
+- la densite de contenu
+- les sujets a pousser ou a taire
 
-#### 2.1 Top 3 Guided Sequences
-
-| Journey | Coach Opening | Flow | ARB Key | Why This Cohort |
-|---------|--------------|------|---------|-----------------|
-| **J1: Acheter sans se Piéger** | "Vous songez à acheter? On test la vraie capacité d'emprunt." | 1. Patrimoine + revenus → 2. Capacité FINMA/stress test → 3. Fonds propres (EPL vs 3a vs cash) → 4. Coûts cachés (frais, assurance) → 5. Arbitrage: loyer restant vs remboursement implicite → 6. Résumé: "Capacité CHF X à taux 5% stress" | `journey_housing_affordability_*` | Biggest life decision. Suisse-specific (FINMA, EPL, imputed rental). High conversion (emotional + material impact). |
-| **J2: Couple Financier** | "À deux, les règles changent—impôts, retraite, couple-mode. On voit?" | 1. Mariage vs concubinage impact (fiscalité, AVS) → 2. Revenus asymétriques (gestion commune?) → 3. LPP à deux (rachat ensemble?) → 4. Couple-mode pref (séparé vs commun) → 5. Succession si enfants → 6. Résumé: "gain/perte fiscale CHF Z/an" | `journey_couple_financial_*` | Couples avoid tax planning discussions. Coach making it safe = high value. Foundational for next 30 years. |
-| **J3: Naissance & Coûts** | "Bébé arrive bientôt? Regardons le vrai coût et les aides." | 1. Coûts directs (alimentation, soin, vêtements) → 2. Garde (crèche, nanny, grands-parents) → 3. Déductions & aides canton → 4. Impact budget famille → 5. Impact LPP (congé maternité, interruption?) → 6. Résumé: "Budget +CHF X/mois après aides" | `journey_birth_costs_*` | Emotionally charged. Aides vary by canton (high delta). LPP pause often forgotten. Real numbers = high trust. |
-
-**Wording/Tone for Cohort 2**:
-- **Vocab**: Assume some financial literacy. "Charge hypothécaire", "coordination LPP", "fiscalité du couple" OK.
-- **Tone**: Trusted advisor (Swiss confidence: pragmatic, no fluff, factual). "Voyons les chiffres" > "Mon intuition te dit".
-- **Reassurance**: Adulting is complex. "La plupart des couples navigent ça ensemble. On te guide pas à pas."
-- **Avoid**: Lifestyle aspirationalism ("acheter la maison de rêve"), vague optimism about returns.
-
-**Explorer Tab Priorities (Cohort 2)**:
-
-Hub order:
-1. **Logement** (35%) — acheter, EPL, amortissement, imputation locative
-2. **Famille** (25%) — mariage, concubinage, naissance, enfants, couple-mode
-3. **Fiscalité** (20%) — déclaration couple, déductions enfants, allocation familiale
-4. **Travail & Statut** (10%) — interruption travail, congé parental
-5. **Retraite** (10%) — 3a couple, rachat LPP intro (not yet optimization)
-6. Hide: Patrimoine & Succession (unless inheritance event), Santé (unless disability)
-
-**Screens to Prioritize**:
-- `affordability_screen` (housing) — ★★★★★
-- `couple_mode_setup_screen` — ★★★★★ (new or refocus)
-- `birth_costs_breakdown_screen` — ★★★★★ (new)
-- `epl_combined_screen` — ★★★★ (mortgage + 3a EPL combined view)
-- `marriage_tax_impact_screen` — ★★★★★
-- `tax_deductions_children_screen` — ★★★★
-- Hide: `succession_planner`, `lpp_deep` advanced tabs, `forex_expat_planning`
-
-**CTA Chips (Coach) for Cohort 2**:
-
-```
-// ARB: ctaChip_cohort2_*
-"🏠 Tester ma capacité d'achat"
-"👫 Voir l'impact couple"
-"📋 Déductions enfants, canton par canton"
-"💚 Plan naissance budget"
-"🔄 Mariage: gain ou perte?"
-"💰 Maximiser 3a à deux"
-```
-
-**Pulse Cap for Cohort 2**:
-
-```
-IF housingPurchaseEvent in last 12 months:
-  CAP: "Sécuriser votre hypothèque"
-  → Subtitle: "Réviser EPL, amortissement, assurance"
-  → CTA: "Audit 30 min"
-
-ELSE IF marriageEvent in last 3 months OR concubinageEvent:
-  CAP: "Adapter votre fiscalité"
-  → Subtitle: "Gain/perte: calcul personnalisé"
-  → CTA: "Voir l'impact"
-
-ELSE IF pregnancyEvent OR birthEvent in last 12 months:
-  CAP: "Préparer l'arrivée financièrement"
-  → Subtitle: "Aides, garde, déductions: CHF X libérés"
-  → CTA: "Plan naissance"
-
-ELSE IF LPP == nil OR LPP.lastUpdate > 2 years:
-  CAP: "Vérifier votre certificat LPP"
-  → Subtitle: "Data fraîche = projections exactes"
-  → CTA: "Scanner"
-
-ELSE:
-  CAP: "Construire votre 3a couple"
-  → Subtitle: "CHF X/an d'avantage fiscal"
-  → CTA: "Planifier"
-```
+Il ne change pas:
+- le design system
+- la structure generale de navigation
+- les moteurs financiers
 
 ---
 
-### Cohort 3: **38-52 (Densification)**
+## 3. Modele cible
 
-**Definition**: Peak earning, complex family, overlapping goals (children + aging parents + career), first serious debt or mortgage stress.
+## 3.1 6 cohortes produit
 
-**Detection Logic**:
-```dart
-age >= 38 && age <= 52 &&
-  (profile.monthlyIncome >= 6_000 || profile.monthlyDebt >= 2_000) &&
-  (children.isNotEmpty || elderCare.detected) &&
-  profile.totalAssets >= 100_000
-  → Cohort3_Densification
+Les cohortes sont un modele produit, pas une SOT technique autonome.
+
+| Cohorte | Phase dominante | Definition produit |
+|---|---|---|
+| 18-27 Premier pas | `demarrage` | premier salaire, budget, comparaison d'offre |
+| 28-37 Construction | `construction` | logement, couple, enfants, premiers arbitrages forts |
+| 38-52 Densification | `acceleration` + `consolidation` | arbitrages complexes, protection, retraite preview |
+| 53-64 Pre-retraite | `transition` | preparation, fiscalite de sortie, decaissement |
+| 65-74 Retraite active | `retraite` | rythme de consommation, protection, succession vivante |
+| 75+ Transmission | `transmission` | simplification, transmission, clarte patrimoniale |
+
+## 3.2 Regle de projection
+
+Projection recommandee:
+
+```text
+LifecyclePhase.demarrage      -> Cohorte Premier pas
+LifecyclePhase.construction   -> Cohorte Construction
+LifecyclePhase.acceleration   -> Cohorte Densification
+LifecyclePhase.consolidation  -> Cohorte Densification
+LifecyclePhase.transition     -> Cohorte Pre-retraite
+LifecyclePhase.retraite       -> Cohorte Retraite active
+LifecyclePhase.transmission   -> Cohorte Transmission
 ```
 
-**Archetype**: `swiss_native`, often `independant_with_lpp` or `couple_mode_complex`. Profile completeness 75-85%.
-
-**Cap typique**: "Prioriser les bons leviers" / "Protéger sans surcharger"
-
-#### 3.1 Top 3 Guided Sequences
-
-| Journey | Coach Opening | Flow | ARB Key | Why |
-|---------|--------------|------|---------|-----|
-| **J1: Densifier sans se Tendre** | "Carrière, famille, dettes, assurances: on priorise les CHF qui comptent vraiment." | 1. Audit complet (revenus, charges, dettes, assurances) → 2. Stress test (perte revenu, invalidité) → 3. Gaps identification (LPP insuffisante? IJM missing?) → 4. Leviers par ordre impact (insurance d'abord, puis 3a, puis EPL rachat) → 5. Plan 12 mois → 6. Résumé: "CHF Z protégé, XXX optimisé/an" | `journey_densification_*` | High complexity (multiple goals conflict). Needs prioritization, not overwhelm. Suisse-specific risk = invalidity gap + LPP shortfall. |
-| **J2: Retraite Sérieuse (Preview)** | "À 38-52, c'est le moment de vérifier: tu es on track?" | 1. Scan LPP (profiler gap) → 2. AVS trajectory → 3. 3a capital → 4. Projection retraite 65 → 5. Confidence assessment (data quality) → 6. First levier (rachat LPP? 3a boost?) | `journey_retirement_preview_*` | Many have done nothing. First wake-up call time. Not optimization—just "are we OK?" Confidence usually 40-60% (missing docs). |
-| **J3: Protéger la Famille** | "Invalidité, décès, responsabilité: vérifi ton filet." | 1. What if you = disabled (LPP AI, IJM, income loss) → 2. What if you = deceased (family budget, assurances, succession) → 3. Current coverage audit (LPP, private, corporate) → 4. Gaps list → 5. Next steps (IJM yes/no? Private policy? Testament?) → 6. Résumé: "Filet CHF X, gaps CHF Y" | `journey_protection_audit_*` | Age 38-52 = dependents peak + disability risk rising. Suisse-specific = layered pillars (LPP + private + corporate). Most overlook. Emotional + practical. |
-
-**Wording/Tone for Cohort 3**:
-- **Vocab**: Full financial terminology OK. "Coordination", "surobligation", "testament", "invalidité", "rachat", "progressive fiscale".
-- **Tone**: Serious, efficient, no drama. "Voici le diagnostic. Voici l'ordre logique. Voici le timeline." Not patronizing, not reassuring—just clear.
-- **Reassurance**: "À 50, il est encore tôt pour agir. À 55, c'est urgent." (mild urgency, not panic)
-- **Avoid**: Scarcity messaging ("hurry before it's too late"), gambling language ("opportunity"), over-optimization ("max out everything").
-
-**Explorer Tab Priorities (Cohort 3)**:
-
-Hub order:
-1. **Retraite** (30%) — projection, 3a, LPP, rachat, décaissement preview
-2. **Fiscalité** (25%) — revenus élevés, déductions, optimisation
-3. **Santé & Protection** (20%) — invalidité, assurances, protection familiale
-4. **Famille** (15%) — enfants grands, succession intro
-5. **Logement** (10%) — EPL final, refinance, immeuble locatif?
-6. Hide: Patrimoine (unless wealth > CHF 500k), Travail (unless entrepreneurship)
-
-**Screens to Prioritize**:
-- `retirement_dashboard_screen` — ★★★★★ (now with confidence band)
-- `lpp_deep_service` suite (projection, rachat, AI) — ★★★★★
-- `protection_audit_screen` (new) — IJM, assurances, gaps
-- `tax_optimization_screen` — ★★★★★ (now focused on this cohort)
-- `3a_deep` simulateur — ★★★★
-- `monte_carlo_screen` — ★★★★ (reintroduce: "Will it last 40+ years?")
-- Hide: `first_job`, `budget_basic`, `unemployment` (relegated to "Help" or archive)
-
-**CTA Chips (Coach) for Cohort 3**:
-
-```
-// ARB: ctaChip_cohort3_*
-"🎯 Ma projection retraite (honnête)"
-"🔒 Vérifier mon filet de protection"
-"📋 Audit LPP: rachat possible?"
-"💰 3a boost: économiser CHF X/an"
-"📑 Testament & succession (si enfants)"
-"⚠️ Stress test: et si je suis invalide?"
-```
-
-**Pulse Cap for Cohort 3**:
-
-```
-IF lppCertificate == nil OR lastUpdate > 2 years:
-  CAP: "Scanner votre certificat LPP"
-  → Subtitle: "Data = CHF 50k+ de clarté"
-  → CTA: "Scanner"
-
-ELSE IF retirementConfidence < 50:
-  CAP: "Clarifier votre retraite"
-  → Subtitle: "Vous êtes on-track? À 38+, on sait."
-  → CTA: "Projection 65"
-
-ELSE IF protectionGapsScore > 3:
-  CAP: "Audit protection: filet vs réalité"
-  → Subtitle: "IJM? Assurances privées? Revoyons."
-  → CTA: "Audit 20 min"
-
-ELSE IF age >= 45 && 3aBalance < 100_000:
-  CAP: "Booster votre 3a avant 50"
-  → Subtitle: "CHF X/an de déduction + rendement"
-  → CTA: "Plan boost"
-
-ELSE:
-  CAP: "Densification sans surcharge"
-  → Subtitle: "Priorisez ce qui compte vraiment"
-  → CTA: "Audit complet"
-```
+Ensuite, des signaux de contexte raffinent le rendu:
+- `profile.isCouple`
+- `profile.employmentStatus`
+- `profile.patrimoine`
+- `profile.dettes`
+- `profile.targetRetirementAge`
+- signaux de vie deja detectes ou connus par le systeme
 
 ---
 
-### Cohort 4: **53-64 (Pre-Retirement)**
+## 4. Regles d'implementation
 
-**Definition**: Final working decade. Urgency to optimize. Clear retirement horizon (5-12 years). Often complex: inheritance, adult children, parent care, debt payoff timing.
+## 4.1 Ce qu'on NE fait PAS en Phase 6A
 
-**Detection Logic**:
-```dart
-age >= 53 && age <= 64 &&
-  (profile.monthlyIncome > 0 || retired == false) &&
-  (retirementAge != null && retirementAge <= age + 12)
-  → Cohort4_PreRetirement
-```
+- pas de `CohortDetectionService` declare comme nouvelle source de verite
+- pas de pseudo-code base sur des champs `CoachProfile` inexistants
+- pas de nouvel `ExplorerHubController` tant qu'il n'existe pas
+- pas de gating lourd de tout le produit d'un coup
+- pas de refonte visuelle majeure
 
-**Archetype**: `swiss_native`, often `independant_with_lpp` or widened `couple_mode`. Profile completeness 80-90%.
+## 4.2 Ce qu'on fait en Phase 6A
 
-**Cap typique**: "Préparer la transition" / "Optimiser les derniers leviers"
+On adapte 3 surfaces seulement:
 
-#### 4.1 Top 3 Guided Sequences
+1. `ResponseCardService.suggestedPrompts()`
+2. `CoachContextInjectorService`
+3. la priorisation Pulse / Cap a petite echelle
 
-| Journey | Coach Opening | Flow | ARB Key | Why |
-|---------|--------------|------|---------|-----|
-| **J1: Retraite Optimisée (Full)** | "Dans [X] ans, vous arrêtez. Regardons l'ordre optimal des 11 étapes." | Phase 1 (Clarify, 12 mois): 1. Scanner LPP → 2. Extrait AVS → 3. Recenser 3a → Phase 2 (Arbitrate, 6 mois avant): 4. Rente vs capital → 5. Timing 3a retrait → 6. Hypothèque: rembourser? → Phase 3 (Prepare, 3-6 mois): 7. Rachat LPP art. 79b → 8. LAMal adjustment → 9. Testament → 10. Budget post-retraite → Phase 4 (Act, 1-3 mois): 11. Retrait notification → 12. AVS anticipé→ Final: "Plan retraite signé, confiance 90%+" | `journey_retirement_full_phased_*` | Only cohort where retraite is IMMINENT. 11-step sequence is NOT overwhelming here—it's relief (finally a plan!). Each step = visible progress. TAO sequence champion. |
-| **J2: Décaissement Retraite** | "À la retraite, c'est le grand arbitrage: capital, rente, ou mixte? Les chiffres changent tout." | 1. LPP rente vs capital scenario (lifetime income projections) → 2. Tax impact LPP capital → 3. 3a decaissement strategy (LIFO = max tax optimization) → 4. SWR simulation (can I live 40 years on portfolio?) → 5. EPL impact (if mortage) → 6. Summary: "Net monthly income: CHF X (vs CHF Y if rente)" | `journey_withdrawal_strategy_*` | Suisse-specific complexity: rente = taxed income, capital = one-time tax. Most don't understand. Delta easily CHF 500k+ over lifetime. |
-| **J3: Succession & Testament** | "4 mois avant retraite, clarifier l'héritage: qui reçoit quoi, testamentaire vs légal." | 1. What if you die before/after retrait → 2. Current marital regime impact → 3. Enfants: part obligatoire? → 4. Donation now (tax-smart) vs testament → 5. Mandat pour inaptitude (often forgotten!) → 6. Notaire next steps → Summary: "Testament drafted, mandat signed" | `journey_succession_protection_*` | Emotional wall most hit at 55-60. Cohort ready (mortality real now). Suisse-specific (forced heirship, mandat inaptitude critical). |
-
-**Wording/Tone for Cohort 4**:
-- **Vocab**: Assume full literacy. All technical terms + legal references OK.
-- **Tone**: Respectful, calm, authoritative. "Vous avez travaillé 40+ ans. Maintenant, une vraie stratégie." No hype. No "best case scenario"—only realistic ranges.
-- **Reassurance**: Maturity. "À ce stade, on sait ce qui compte. Zéro fluff."
-- **Avoid**: "You've earned it" (lifestyle aspirational), "make the most of it" (YOLO), "finally rest" (depressing); instead: "secure your independence".
-
-**Explorer Tab Priorities (Cohort 4)**:
-
-Hub order:
-1. **Retraite** (40%) — the entire phased sequence, every depth level
-2. **Fiscalité** (20%) — capital tax, progression, last years optimizations
-3. **Patrimoine & Succession** (20%) — testament, heritage, donations
-4. **Santé & Protection** (15%) — LAMal post-retirement adjustments, long-term care
-5. **Logement** (5%) — EPL payoff timing, downsizing option
-6. Hide: Travail, Famille (unless adult children financial entanglement)
-
-**Screens to Prioritize**:
-- `retirement_dashboard_screen` (full phased view) — ★★★★★
-- `rente_vs_capital_screen` (LPP + 3a combined) — ★★★★★
-- `staggered_withdrawal_screen` (3a + SWR sequences) — ★★★★★
-- `succession_planner_screen` — ★★★★★ (refocus, lift from Tier B)
-- `testament_guide_screen` (new) — simple, not legal, but clear
-- `monte_carlo_screen` (portfolio longevity) — ★★★★★
-- `tax_withdrawal_optimizer_screen` — ★★★★★
-- Hide: `first_job`, `unemployment`, `birth_costs`, `couple_setup` (archived)
-
-**CTA Chips (Coach) for Cohort 4**:
-
-```
-// ARB: ctaChip_cohort4_*
-"📊 Plan retraite: les 11 étapes"
-"🎯 Rente ou capital? Simulation"
-"📋 Défiscaliser le retrait 3a"
-"⚖️ Testament & donations"
-"🏦 AVS: anticipé ou repoussé?"
-"💤 Budget post-retraite: vivable?"
-```
-
-**Pulse Cap for Cohort 4**:
-
-```
-IF retirementDate within 12 months:
-  CAP: "Retraite prévue [Date]: plan final"
-  → Subtitle: "11 étapes, timeline claire"
-  → CTA: "Phased plan"
-
-ELSE IF retirementDate within 2-5 years:
-  CAP: "Préparer votre transition ([X] ans)"
-  → Subtitle: "Clarify phase: données manquantes?"
-  → CTA: "Checklist"
-
-ELSE IF lppCertificate == nil OR lastUpdate > 1 year:
-  CAP: "Certificat LPP: obligatoire avant 55"
-  → Subtitle: "Rachat LPP bloqué sans lui"
-  → CTA: "Scanner urgent"
-
-ELSE IF testamentStatus == nil:
-  CAP: "Testament & mandat pour inaptitude"
-  → Subtitle: "Ne pas oublier avant retraite"
-  → CTA: "Guide simple"
-
-ELSE:
-  CAP: "Décaissement: rente vs capital?"
-  → Subtitle: "Impact CHF 500k+ à vie"
-  → CTA: "Simuler"
-```
+Objectif:
+- prouver qu'une experience differenciee par cohorte cree une meilleure valeur
+- sans re-architecturer tout le produit
 
 ---
 
-### Cohort 5: **65-74 (Active Retirement)**
+## 5. Champs reels a utiliser
 
-**Definition**: Recently retired (0-9 years). Active, managing consumption rhythm, succession planning, possible inheritance management. Tax-conscious (capital draw-down now visible).
+La spec doit s'exprimer avec des champs qui existent reellement dans
+[coach_profile.dart](/Users/julienbattaglia/Desktop/MINT/apps/mobile/lib/models/coach_profile.dart).
 
-**Detection Logic**:
-```dart
-age >= 65 && age <= 74 &&
-  (retiredEvent != null || avsSalarieStatus == false) &&
-  profile.lppCapital > 0 // still in capital phase or rente being received
-  → Cohort5_ActiveRetirement
-```
+### Champs OK
 
-**Archetype**: `swiss_native` (mostly), sometimes `returning_swiss` (expats back). Profile completeness 85-95% (retired = clearer picture).
+- `profile.birthYear`
+- `profile.age`
+- `profile.salaireBrutMensuel`
+- `profile.employmentStatus`
+- `profile.isCouple`
+- `profile.targetRetirementAge`
+- `profile.patrimoine`
+- `profile.dettes`
+- `profile.prevoyance`
+- `profile.nombreEnfants`
 
-**Cap typique**: "Protéger et piloter" / "Vivre sereinement ma retraite"
+### Equivalents a calculer explicitement
 
-#### 5.1 Top 3 Guided Sequences
+Au lieu de champs inexistants, utiliser:
 
-| Journey | Coach Opening | Flow | ARB Key | Why |
-|---------|--------------|------|---------|-----|
-| **J1: Rythme de Consommation** | "Retraité maintenant. Question réelle: à ce rythme, l'argent dure jusqu'à 95?" | 1. Current annual draw-down (from rente + capital + SWR) → 2. Inflation scenario (basic + 2%+ scenario) → 3. Longevity test (to age 90 vs 100) → 4. Lifestyle flexibility (what could we cut if needed?) → 5. Reassurance: "Your reserves last to [age]" | `journey_retirement_consumption_*` | Retirees NEED certainty (or honest uncertainty). Monte Carlo rerun each year. Emotional: "Will I run out?" is #1 fear. Low jargon, high reassurance. |
-| **J2: Impôt & Succession vivante** | "Vous êtes riche maintenant (capital + rente). Succession: que laisser, comment optimiser?" | 1. Current assets (rente, capital, real estate, inheritance pending) → 2. Estate plan review (testament up to date?) → 3. Donation now (tax-smart, no risk of neediness) vs later (estate) → 4. Enfants & small gifts → 5. Mandat pour inaptitude: is it still valid? → 6. Summary: "Plan protège CHF X, clarifies CHF Y for heirs" | `journey_succession_active_*` | Active retirees often inherit (parents 85+). New wealth needs planning. Suisse-specific: donation strategies, forced heirship updates, mandat refresh crucial. Different from 55 (now wealth is real, not theoretical). |
-| **J3: Protection Longévité** | "À 70, santé compte. Couverture santé post-65: revue-t-elle régulièrement?" | 1. Current LAMal franchise/couverture → 2. Private insurer changes post-65 → 3. Soins de longue durée (maison, aide home?) → 4. Costs: CHF X/month plausible? → 5. Assurance vs self-insurance → 6. Mandat pour inaptitude: power of attorney still designates right person? | `journey_longevity_protection_*` | Age 65-74 = last chance to plan pre-decline. LAMal changes, costs rise. Not about fear—about clarity. Suisse-specific: franchise, mandatory coverage, home care costs vary canton. |
-
-**Wording/Tone for Cohort 5**:
-- **Vocab**: Full financial + legal. "Succession", "donation", "usufruit", "tenure", "rente viagère", "longévité".
-- **Tone**: Calm, reassuring, respectful of mortality. "You've built well. Now protect it wisely."
-- **Reassurance**: Abundance (not scarcity). "You can afford to be generous and still be secure."
-- **Avoid**: Lifestyle aspirational (you're done working), fear-based language, overly complex scenarios.
-
-**Explorer Tab Priorities (Cohort 5)**:
-
-Hub order:
-1. **Retraite** (30%) — consumption, withdrawals, SWR refresh, longevity
-2. **Patrimoine & Succession** (30%) — active succession management, donations, heritage
-3. **Fiscalité** (20%) — capital gains from withdrawal, donation tax, canton rules
-4. **Santé & Protection** (15%) — LAMal, long-term care, protection
-5. **Logement** (5%) — downsizing option, second home, transfer
-6. Hide: Travail, Famille (unless adult children needing financial help)
-
-**Screens to Prioritize**:
-- `consumption_longevity_screen` (new) — "Will CHF last to 95/100?"
-- `active_succession_manager_screen` (new) — simple donation/estate tracker
-- `monte_carlo_refresh_screen` (annual rerun for retirees) — ★★★★★
-- `withdrawal_optimization_screen` (refined for retirees, focus on SWR + tax) — ★★★★★
-- `lpp_decaissement_tracking_screen` (are we taking the right amount each month?) — ★★★★
-- `protection_longevity_screen` (LAMal, long-term care costs) — ★★★★
-- `mandat_inaptitude_screen` (review if still valid) — ★★★★ (lifted from docs)
-
-**CTA Chips (Coach) for Cohort 5**:
-
-```
-// ARB: ctaChip_cohort5_*
-"💰 L'argent dure jusqu'à 95?"
-"📊 Retraite: bilan 5 ans"
-"📋 Succession: donations malignes?"
-"🏥 LAMal & soins longévité"
-"🎁 Aider mes enfants (et rester sûr)"
-"⚖️ Mandat pour inaptitude: à jour?"
-```
-
-**Pulse Cap for Cohort 5**:
-
-```
-IF retiredLessThan2Years:
-  CAP: "Retraite: bilan 1er année"
-  → Subtitle: "Rythme sustainable? Adaptations?"
-  → CTA: "Refresh"
-
-ELSE IF age >= 70:
-  CAP: "Protection longévité: vérifier"
-  → Subtitle: "LAMal, soins, couverture: à jour?"
-  → CTA: "Audit"
-
-ELSE IF inheritancePending || parentAge > 80:
-  CAP: "Succession: donation maintenant?"
-  → Subtitle: "Tax-smart, et vous restez sûrs"
-  → CTA: "Planifier"
-
-ELSE IF yearsUntilAge95 < years_until_portfolio_depletion:
-  CAP: "Portfolio dure jusqu'à 95"
-  → Subtitle: "Vous êtes couvert. Sérénité."
-  → CTA: "Monte Carlo"
-
-ELSE:
-  CAP: "Vivre votre retraite sereinement"
-  → Subtitle: "Bilan annuel: tout OK?"
-  → CTA: "Refresh"
-```
+| Faux champ | Equivalent reel |
+|---|---|
+| `totalAssets` | derive de `profile.patrimoine` |
+| `monthlyDebt` | derive de `profile.dettes` |
+| `monthlyIncome` | derive de `salaireBrutMensuel` ou net calcule |
+| `salaryStatus` | `employmentStatus` |
+| `lppCapital` | `profile.prevoyance.avoirLppTotal` ou autre champ prevoyance reel |
+| `retirementDate` | derive de `targetRetirementAge` / goal |
+| `dependentAge` | signal explicite a definir; ne pas l'inventer |
+| `debtSource` | ne pas supposer; modeler plus tard si necessaire |
 
 ---
 
-### Cohort 6: **75+ (Simplification & Legacy)**
+## 6. Les 6 cohortes produit
 
-**Definition**: Late retirement (10+ years out), simplification focus, legacy clarity, succession close to action, possibly cognitive decline planning.
+## 6.1 Premier pas (18-27)
 
-**Detection Logic**:
-```dart
-age >= 75 &&
-  (retiredEvent != null && yearsRetired >= 10) &&
-  (testamentOrMandatStatus != complete || inheritancePassing)
-  → Cohort6_Simplification
-```
+Enjeux:
+- premier salaire
+- budget sous tension
+- comparaison d'offre
 
-**Archetype**: `swiss_native`, mostly widowed or single. Profile completeness 90%+ (very clear picture).
+Parcours phares:
+- premier salaire maitrise
+- tension budget simple
+- comparaison d'offre
 
-**Cap typique**: "Garder une vue claire et transmettre proprement"
+Ce qu'on pousse:
+- budget
+- fiche de paie
+- epargne de base
+- comparaison d'emploi
 
-#### 6.1 Top 3 Guided Sequences
+Ce qu'on evite par defaut:
+- succession
+- retirement deep
+- rachat LPP agressif
 
-| Journey | Coach Opening | Flow | ARB Key | Why |
-|---------|--------------|------|---------|-----|
-| **J1: Clarté Patrimoniale** | "À 75, c'est simple: qui possède quoi, et qui hériterait si?" | 1. Full asset map (real estate, bank, insurance, digital) → 2. Where are the docs (testament, will, assurances, mandates)? → 3. Who knows? (enfants, notaire, executor designé?) → 4. What if you become unfit? (mandat inaptitude designates WHO?) → 5. Summary: "Everything is clear and your family knows where to find docs" | `journey_clarity_documentary_*` | Cohort 75+ biggest fear: "Will they know what to do if I'm gone?" Suisse-specific: testament, mandat inaptitude, digital asset list. Non-financial but critical. |
-| **J2: Transmission Sereine** | "Succession: transmettre selon vos valeurs, pas par accident." | 1. Who gets what (marital regime impact) → 2. Any wishes beyond legal minimum? (donation now, specific gifts?) → 3. Tax impact for heirs (canton, timing) → 4. Clarity for executor (instructions clear?) → 5. Legacy: any messages? (éthique, valeurs, story) | `journey_transmission_values_*` | Emotional & practical. Not about optimizing (too late)—about clarity + meaning. Helps heirs psychologically (not just financially). Suisse-specific: forced heirship, mandat, notaire role. |
-| **J3: Santé & Fin de Vie** | "À 75, anticiper: couverture santé, soins, et si choses s'accélèrent?" | 1. Current LAMal (franchise, couverture, cost changes expected?) → 2. Home care cost projection (CHF X/month if needed) → 3. Insurance coverage review (still appropriate?) → 4. Mandat pour inaptitude: is it CURRENT and legal? → 5. End-of-life directive (if desired) → 6. Safety: family knows where docs? | `journey_health_eol_*` | Medical reality. Not morbid—practical. Suisse-specific: LAMal post-75, long-term care, mandat inaptitude crucial (cognitive decline plausible). This cohort gets it (not depressing, just honest). |
+Ton:
+- pedagogique
+- simple
+- non abstrait
 
-**Wording/Tone for Cohort 6**:
-- **Vocab**: Simple + formal. "Testament", "succession", "héritage", "mandat pour inaptitude". Avoid "legacy" (too English).
-- **Tone**: Dignified, clear, warm. "Vous avez construit une belle vie. Transmettez-la clairement à ceux que vous aimez."
-- **Reassurance**: Completeness. "Quand tout est documenté, vous (et votre famille) pouvez respirer."
-- **Avoid**: Mortality language ("When you're gone"), fear-based, overly technical legal jargon.
+## 6.2 Construction (28-37)
 
-**Explorer Tab Priorities (Cohort 6)**:
+Enjeux:
+- achat logement
+- couple
+- naissance et couts
+- premiers arbitrages 3a / fiscalite
 
-Hub order:
-1. **Patrimoine & Succession** (50%) — testament, transmission, mandat, heritage clarity
-2. **Santé & Protection** (30%) — LAMal, long-term care, end-of-life, mandat inaptitude
-3. **Fiscalité** (15%) — donation tax, inheritance tax for heirs
-4. **Retraite** (5%) — consumptions, consumption forecasting if extended longevity
-5. Hide everything else
+Parcours phares:
+- acheter sans se pieger
+- couple financier
+- naissance et couts
 
-**Screens to Prioritize**:
-- `documentary_clarity_screen` (new) — checklist: où sont les docs, qui sait?
-- `transmission_guide_screen` (new) — simple transmission planner (not legal, but clear)
-- `mandat_inaptitude_screen` (lifted, focus on validity + refresh)
-- `testament_simple_guide_screen` (educational, not legal)
-- `lamal_longterm_care_screen` (LAMal post-75, costs)
-- Hide: everything work/career/first-job/unemployment/job-comparison/birth/young-family
+Ce qu'on pousse:
+- logement
+- couple
+- enfants
+- fiscalite concrete
 
-**CTA Chips (Coach) for Cohort 6**:
+## 6.3 Densification (38-52)
 
-```
-// ARB: ctaChip_cohort6_*
-"📋 Où sont mes documents? Checklist"
-"👨‍👩‍👧 Héritage clair pour mes enfants"
-"🏥 LAMal & soins: couvert?"
-"⚖️ Mandat pour inaptitude: valid?"
-"💌 Message pour après (si je veux)"
-"✅ Transmettre proprement"
-```
+Enjeux:
+- arbitrages complexes
+- protection
+- retraite preview
+- priorisation de leviers
 
-**Pulse Cap for Cohort 6**:
+Parcours phares:
+- densifier sans se tendre
+- retraite preview
+- proteger la famille
 
-```
-IF documentaryStatus == nil OR incomplete:
-  CAP: "Clarité patrimoniale: checklist"
-  → Subtitle: "Docs, succession, mandat: où?"
-  → CTA: "Remplir"
+Ce qu'on pousse:
+- protection
+- retraite
+- fiscalite
+- clarification des priorites
 
-ELSE IF mandatInaptitudeStatus != valid:
-  CAP: "Mandat pour inaptitude: urgent"
-  → Subtitle: "Invalide si > 10 ans ou marital change"
-  → CTA: "Vérifier"
+## 6.4 Pre-retraite (53-64)
 
-ELSE IF age >= 78:
-  CAP: "Santé & fin de vie: anticiper"
-  → Subtitle: "LAMal, soins, couverture"
-  → CTA: "Réviser"
+Enjeux:
+- transition
+- decaissement
+- choix rente/capital
+- fiscalite de sortie
 
-ELSE:
-  CAP: "Transmission: léguer selon vos valeurs"
-  → Subtitle: "Clair pour votre famille"
-  → CTA: "Planifier"
-```
+Parcours phares:
+- retraite 11 etapes
+- decaissement
+- succession / testament
 
----
+## 6.5 Retraite active (65-74)
 
-## 2. COHORT DETECTION SERVICE (Implementation)
+Enjeux:
+- rythme de consommation
+- protection long terme
+- succession vivante
 
-This is the **single source of truth** for determining user cohort. Called on every app launch + life event trigger.
+Parcours phares:
+- rythme de consommation
+- succession vivante
+- protection longevite
 
-### 2.1 Location & Contract
+## 6.6 Transmission (75+)
 
-```dart
-// File: lib/services/cohort_detection_service.dart
-// Called by: CapEngine, ExplorerHubController, CoachContextInjectorService
-// Input: CoachProfile, List<LifeEvent>, EnhancedConfidence
-// Output: CohortId enum (or null if ambiguous)
+Enjeux:
+- simplification
+- clarte patrimoniale
+- transmission sereine
 
-enum CohortId {
-  cohort1_FirstSteps,        // 18-27
-  cohort2_BuildPhase,        // 28-37
-  cohort3_Densification,     // 38-52
-  cohort4_PreRetirement,     // 53-64
-  cohort5_ActiveRetirement,  // 65-74
-  cohort6_Simplification,    // 75+
-}
-
-class CohortDetectionService {
-  /// Main entry point: returns cohort for a user
-  CohortId? detectCohort(CoachProfile profile, List<LifeEvent> events) {
-    final age = profile.age;
-    
-    // Rule 1: Hard age bands (fallback)
-    if (age < 18) return null; // Pre-18 = not target
-    if (age >= 18 && age <= 27) return _analyzeCohort1(profile, events);
-    if (age >= 28 && age <= 37) return _analyzeCohort2(profile, events);
-    if (age >= 38 && age <= 52) return _analyzeCohort3(profile, events);
-    if (age >= 53 && age <= 64) return _analyzeCohort4(profile, events);
-    if (age >= 65 && age <= 74) return _analyzeCohort5(profile, events);
-    if (age >= 75) return _analyzeCohort6(profile, events);
-    
-    return null;
-  }
-  
-  /// Cohort 1 (18-27): First Steps
-  CohortId? _analyzeCohort1(CoachProfile profile, List<LifeEvent> events) {
-    final hasFirstJob = events.contains(LifeEvent.firstJob) || 
-                        events.contains(LifeEvent.newJob);
-    final lowAssets = profile.totalAssets < 50_000;
-    final lowDebt = (profile.monthlyDebt ?? 0) == 0 || 
-                    (profile.debtSource == 'student_loan');
-    
-    return (hasFirstJob && lowAssets && lowDebt)
-        ? CohortId.cohort1_FirstSteps
-        : null;
-  }
-  
-  /// Cohort 2 (28-37): Build Phase
-  CohortId? _analyzeCohort2(CoachProfile profile, List<LifeEvent> events) {
-    final hasMajorLifeEvent = events.contains(LifeEvent.marriage) ||
-                              events.contains(LifeEvent.concubinage) ||
-                              events.contains(LifeEvent.housingPurchase) ||
-                              events.contains(LifeEvent.birth);
-    final stableIncome = (profile.monthlyIncome ?? 0) >= 4_500;
-    final hasAssets = profile.totalAssets >= 10_000;
-    
-    return (hasMajorLifeEvent && stableIncome)
-        ? CohortId.cohort2_BuildPhase
-        : null;
-  }
-  
-  /// Cohort 3 (38-52): Densification
-  CohortId? _analyzeCohort3(CoachProfile profile, List<LifeEvent> events) {
-    final highIncome = (profile.monthlyIncome ?? 0) >= 6_000;
-    final hasSigDebt = (profile.monthlyDebt ?? 0) >= 2_000;
-    final hasComplexity = events.contains(LifeEvent.birth) ||
-                         events.contains(LifeEvent.newJob) ||
-                         profile.dependentAge != null; // children or elder care
-    final hasAssets = profile.totalAssets >= 100_000;
-    
-    return ((highIncome || hasSigDebt) && hasComplexity)
-        ? CohortId.cohort3_Densification
-        : null;
-  }
-  
-  /// Cohort 4 (53-64): Pre-Retirement
-  CohortId? _analyzeCohort4(CoachProfile profile, List<LifeEvent> events) {
-    final stillWorking = profile.salaryStatus == 'employed' || 
-                         profile.salaryStatus == 'self_employed';
-    final hasRetirementHorizon = profile.targetRetirementAge != null &&
-                                 profile.targetRetirementAge! <= profile.age + 12;
-    
-    return (stillWorking && hasRetirementHorizon)
-        ? CohortId.cohort4_PreRetirement
-        : null;
-  }
-  
-  /// Cohort 5 (65-74): Active Retirement
-  CohortId? _analyzeCohort5(CoachProfile profile, List<LifeEvent> events) {
-    final isRetired = events.contains(LifeEvent.retirement) ||
-                     profile.salaryStatus == 'retired';
-    final hasLppCapital = profile.lppCapital != null && profile.lppCapital! > 0;
-    
-    return (isRetired && hasLppCapital)
-        ? CohortId.cohort5_ActiveRetirement
-        : null;
-  }
-  
-  /// Cohort 6 (75+): Simplification & Legacy
-  CohortId? _analyzeCohort6(CoachProfile profile, List<LifeEvent> events) {
-    final isRetired = events.contains(LifeEvent.retirement) ||
-                     profile.salaryStatus == 'retired';
-    final longTimeRetired = profile.retirementDate != null &&
-        DateTime.now().difference(profile.retirementDate!).inDays > 365 * 10;
-    
-    return (isRetired && longTimeRetired)
-        ? CohortId.cohort6_Simplification
-        : null;
-  }
-}
-```
-
-### 2.2 Integration Points
-
-**CapEngine** (`lib/services/cap_engine.dart`):
-```dart
-// Before selecting a Cap, detect cohort
-final cohort = CohortDetectionService().detectCohort(profile, events);
-
-// Filter Caps based on cohort
-final eligibleCaps = allCaps.where((cap) {
-  // Cohort 1: exclude retirement, succession, advanced tax
-  if (cohort == CohortId.cohort1_FirstSteps) {
-    return cap.category != 'retirement' && 
-           cap.category != 'succession' &&
-           cap.complexity != 'advanced';
-  }
-  // Cohort 5/6: exclude unemployment, first job, birth planning
-  if (cohort == CohortId.cohort5_ActiveRetirement ||
-      cohort == CohortId.cohort6_Simplification) {
-    return cap.category != 'employment_early' &&
-           cap.category != 'family_young' &&
-           cap.complexity != 'beginner';
-  }
-  // ... etc for each cohort
-  return true;
-}).toList();
-```
-
-**ExplorerHubController** (`lib/controllers/explorer_hub_controller.dart`):
-```dart
-// Reorder hubs based on cohort
-final hubOrder = _hubOrderByCohort(cohort);
-// Dim/hide certain hubs
-final visibleHubs = allHubs.where((hub) {
-  return !_hiddenHubsByCohort(cohort).contains(hub);
-}).toList();
-```
-
-**CoachContextInjectorService** (`lib/services/coach_context_injector_service.dart`):
-```dart
-// Inject cohort into coach system prompt
-final coachSystemPrompt = '''
-You are MINT's financial coach.
-
-User Profile:
-- Age: ${profile.age}
-- Cohort: ${cohort.name}  // <-- NEW
-- Phase of life: ${_phaseDescription(cohort)}
-
-Tone Guidelines for this cohort:
-${_toneGuidelines(cohort)}
-
-Topics to prioritize:
-${_topicsByCohorta(cohort).join(', ')}
-
-Topics to AVOID:
-${_hiddenTopicsByCohort(cohort).join(', ')}
-
-Always use the CTA chips appropriate for this cohort.
-Never recommend advanced features unless user explicitly asks.
-''';
-```
+Parcours phares:
+- clarte patrimoniale
+- transmission sereine
+- sante / fin de vie
 
 ---
 
-## 3. UI/UX ADAPTATION (NOT Visual Changes, Logic Changes)
+## 7. Matrice d'adaptation Phase 6A
 
-### 3.1 Should the UI Visually Change?
+## 7.1 Suggestion chips
 
-**Answer: NO for colors/layout. YES for content density and microcopy.**
+Premiere surface cible.
 
-- **NOT changing**: Core design system, color palette, layout grid, navigation structure.
-- **ARE changing**: Hub visibility, screen priorities, CTA chip set, coach voice + tone, copy complexity, feature visibility.
+La logique doit etre:
+- lifecycle d'abord
+- contexte ensuite
+- zero contradiction metier
 
-This keeps engineering cost low while achieving major UX impact.
+Exemple de garde-fous:
+- ne jamais pousser `rachat LPP` si l'utilisateur n'a pas de LPP
+- ne jamais pousser retraite profonde a un 22 ans par defaut
+- ne jamais pousser succession en priorite a une cohorte Premier pas
 
-### 3.2 What Changes Per Cohort
+## 7.2 Coach context
 
-**Cohort 1 (18-27)**:
-- Explorer hubs: **4 visible** (Travail, Famille, Fiscalité, Logement), rest collapsed
-- Screen density: **Low** (3-5 key screens per hub, no "advanced" tabs)
-- Copy: **Simple** ("revenus" not "salaire brut", "impôt" not "fiscalité progressive")
-- Onboarding: **Minimal** (just age + salary)
+Injecter:
+- cohort label produit
+- ton attendu
+- sujets prioritaires
+- sujets a ne pas pousser spontanement
 
-**Cohort 2 (28-37)**:
-- Explorer hubs: **5 visible** (Logement, Famille, Fiscalité, Travail, Retraite intro)
-- Screen density: **Medium** (8-12 screens per hub, 1-2 "advanced" tabs)
-- Copy: **Balanced** (financial terms OK, but explained on first use)
-- Onboarding: **Moderate** (age, salary, partner, children, mortgage intent)
+Sans:
+- mentionner brutalement le nom de la cohorte a l'utilisateur
+- rigidifier le coach au point de le rendre idiot
 
-**Cohort 3 (38-52)**:
-- Explorer hubs: **All 6 visible**
-- Screen density: **High** (all screens visible, advanced tabs prominent)
-- Copy: **Technical** (all jargon, legal references)
-- Onboarding: **Rich** (full profile capture)
+## 7.3 Pulse / Cap
 
-**Cohort 4 (53-64)**:
-- Explorer hubs: **All 6 visible**, Retraite takes 40% space
-- Screen density: **Very high** (all phased retirement screens, calculators, scenarios)
-- Copy: **Very technical** (legal, tax, succession language)
-- Onboarding: **Mandatory complete** (LPP, AVS, 3a, inheritance details)
+Adapter:
+- l'ordre de priorite
+- la formulation du cap
+- la promesse d'impact
 
-**Cohort 5 (65-74)**:
-- Explorer hubs: **All 6**, Retraite + Patrimoine each 30%
-- Screen density: **High but curated** (focus on consumption, inheritance, longevity)
-- Copy: **Warm + technical** ("You've built this. Now protect it.")
-- Onboarding: **Complete** (full asset map required)
-
-**Cohort 6 (75+)**:
-- Explorer hubs: **Only Patrimoine & Succession + Santé + mini-Retraite** (hide Travail, Famille)
-- Screen density: **Low, focused** (checklist-driven, clarity-focused)
-- Copy: **Simple but respectful** ("Transmettre proprement", "Documenter")
-- Onboarding: **Minimal new** (profile already complete)
+Sans:
+- re-ecrire tout `CapEngine` en Phase 6A
 
 ---
 
-## 4. CONTENT SUPPRESSION RULES (Never Show)
+## 8. Golden personas obligatoires
 
-These rules are **non-negotiable** to prevent inappropriate advice.
+Chaque cohorte doit avoir au moins un persona golden teste.
 
-### 4.1 Suppression Matrix
+### P1 Premier pas
+- 24 ans
+- premier emploi
+- pas de LPP reel exploitable
+- budget serre
 
-| Content | Cohort 1 | Cohort 2 | Cohort 3 | Cohort 4 | Cohort 5 | Cohort 6 |
-|---------|----------|----------|----------|----------|----------|----------|
-| **Retirement deep dive** | ❌ Hide | ⚠️ Intro only | ⚠️ Preview | ✅ Full | ✅ Full | ✅ Full |
-| **Succession / Testament** | ❌ Hide | ❌ Hide | ⚠️ Intro | ✅ Full | ✅ Full | ✅ Full |
-| **LPP Rachat strategies** | ❌ Hide | ❌ Hide | ✅ Intro | ✅ Full | ✅ (monitoring) | ✅ (monitoring) |
-| **Estate donation tax** | ❌ Hide | ❌ Hide | ❌ Hide | ✅ Full | ✅ Full | ✅ Full |
-| **Long-term care planning** | ❌ Hide | ❌ Hide | ⚠️ Prevention | ⚠️ Start | ✅ Full | ✅ Full |
-| **End-of-life care** | ❌ Hide | ❌ Hide | ❌ Hide | ❌ Hide | ⚠️ Info | ✅ Full |
-| **First job / salary** | ✅ Full | ⚠️ Archived | ❌ Hide | ❌ Hide | ❌ Hide | ❌ Hide |
-| **Unemployment aid** | ✅ Full | ✅ Full | ⚠️ Basic | ❌ Hide | ❌ Hide | ❌ Hide |
-| **Birth costs** | ❌ Hide | ✅ Full | ✅ (aging parents instead) | ❌ Hide | ❌ Hide | ❌ Hide |
-| **Parenting tax deductions** | ❌ Hide | ✅ Full | ✅ Full | ⚠️ Archived | ❌ Hide | ❌ Hide |
-| **Job comparison** | ⚠️ Simple | ✅ Full | ✅ Full | ❌ Hide | ❌ Hide | ❌ Hide |
-| **Professional insurance (IJM)** | ❌ Hide | ⚠️ Intro | ✅ Full | ✅ Full | ⚠️ Monitoring | ❌ Hide |
-| **Investment/asset allocation** | ❌ Hide | ❌ Hide | ⚠️ Portfolio planning | ✅ Full | ✅ Full | ⚠️ Simplified |
-| **Expatriate taxation** | ❌ Hide | ❌ Hide | ⚠️ If applicable | ✅ Full (if applicable) | ✅ (monitoring) | ⚠️ (if applicable) |
-| **Business owner planning** | ❌ Hide | ❌ Hide | ✅ Full (if self-employed) | ✅ Full | ⚠️ Monitoring | ❌ Hide |
-| **Mortgage stress-test** | ❌ Hide | ✅ Full | ✅ (refinance) | ⚠️ Payoff timing | ⚠️ Downsizing option | ❌ Hide |
-| **FINMA/ASB rules** | ❌ Hide | ✅ Basic | ✅ Full | ✅ Full | ❌ Hide | ❌ Hide |
+### P2 Construction
+- 33 ans
+- en couple
+- projet logement
+- un enfant en route
 
-### 4.2 Implementation
+### P3 Densification
+- 46 ans
+- couple avec enfants
+- revenus confortables
+- protection et retraite preview
 
-```dart
-// File: lib/constants/cohort_content_rules.dart
+### P4 Pre-retraite
+- 59 ans
+- encore actif
+- choix rente/capital a venir
 
-class CohortContentRules {
-  static bool shouldShowContent(
-    String contentKey,
-    CohortId cohort,
-  ) {
-    final suppressionMatrix = {
-      'retirement_deep_dive': [
-        CohortId.cohort1_FirstSteps,
-        CohortId.cohort2_BuildPhase,
-      ],
-      'succession_full': [
-        CohortId.cohort1_FirstSteps,
-        CohortId.cohort2_BuildPhase,
-      ],
-      'endOfLifePlanninBudget': [
-        CohortId.cohort1_FirstSteps,
-        CohortId.cohort2_BuildPhase,
-        CohortId.cohort3_Densification,
-        CohortId.cohort4_PreRetirement,
-      ],
-      // ... more rules
-    };
-    
-    return !suppressionMatrix[contentKey]?.contains(cohort) ?? true;
-  }
-}
+### P5 Retraite active
+- 68 ans
+- deja retraite
+- consommation + succession
 
-// Usage in screens:
-if (CohortContentRules.shouldShowContent('succession_full', userCohort)) {
-  SuccessionPlanner();
-} else {
-  SizedBox.shrink();
-}
-```
+### P6 Transmission
+- 79 ans
+- retraite longue
+- clarte patrimoniale et transmission
 
 ---
 
-## 5. JOURNEY/SEQUENCES (Guided Flows)
+## 9. Assertions de comportement
 
-Each cohort has **3 flagship journeys** that open via coach chat.
+Avant toute generalisation, definir au minimum 18 assertions, 3 par cohorte.
 
-### 5.1 Journey Detection & Routing
-
-```dart
-// File: lib/services/journey_orchestration_service.dart
-
-class JourneyOrchestrationService {
-  /// Returns eligible journeys for user's cohort + current context
-  List<Journey> getEligibleJourneys(
-    CohortId cohort,
-    CoachProfile profile,
-    List<LifeEvent> recentEvents,
-  ) {
-    if (cohort == CohortId.cohort1_FirstSteps) {
-      return [
-        Journey(
-          id: 'j1_first_salary',
-          title: 'Premier Salaire Maîtrisé',
-          trigger: recentEvents.contains(LifeEvent.firstJob),
-          screens: [
-            'first_job_screen',
-            'budget_breakdown_screen',
-            'savings_goal_screen',
-          ],
-        ),
-        // ... J2, J3
-      ];
-    }
-    // ... other cohorts
-  }
-}
-
-// Coach chat routing:
-// User: "Je viens de recevoir ma première fiche de paie"
-// Coach detects: CohortId.cohort1_FirstSteps + LifeEvent.firstJob
-// Coach opens: Journey('j1_first_salary') -> starts screen sequence
-```
-
-### 5.2 ARB Keys for Journeys
-
-**Pattern**: `journey_<cohort>_<journey_name>_<screen>`
-
-Examples:
-- `journey_cohort1_first_salary_opening` — "Tu viens de recevoir ta première fiche de paie..."
-- `journey_cohort2_housing_affordability_opening` — "Vous songez à acheter?"
-- `journey_cohort4_retirement_phased_phase1_clarify` — "Dans [X] ans, vous arrêtez..."
-- `journey_cohort5_consumption_longevity_opening` — "À ce rythme, l'argent dure jusqu'à 95?"
+Exemples:
+- P1 ne voit pas `rachat LPP` dans ses suggestions par defaut
+- P2 voit logement et couple avant succession
+- P3 voit protection / retraite preview avant premier salaire
+- P4 voit decaissement et rente/capital avant budget debutant
+- P5 ne voit pas comparaison premier emploi comme CTA majeur
+- P6 voit transmission / simplification avant optimisation agressive
 
 ---
 
-## 6. COACHING TONE & VOCABULARY (Detailed)
+## 10. Plan d'implementation corrige
 
-### 6.1 Vocabulary Allowed by Cohort
+### Sprint 6A.1
+- corriger les suggestion chips lifecycle-aware existantes
+- verrouiller les tests metier de suggestions
 
-| Term | Cohort 1 | Cohort 2 | Cohort 3 | Cohort 4 | Cohort 5 | Cohort 6 |
-|------|----------|----------|----------|----------|----------|----------|
-| **Fiscalité** | ❌ Use "impôt" | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Coordination LPP** | ❌ | ❌ | ✅ | ✅ | ✅ | ⚠️ (avoid if possible) |
-| **Taux de remplacement** | ❌ | ❌ | ✅ | ✅ | ✅ | ⚠️ |
-| **Usufruit / tenure** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **Rachat LPP art. 79b** | ❌ | ❌ | ⚠️ | ✅ | ⚠️ (retired) | ❌ |
-| **Rente viagère** | ❌ | ❌ | ⚠️ | ✅ | ✅ | ✅ |
-| **Mandat pour inaptitude** | ❌ | ❌ | ⚠️ | ✅ | ✅ | ✅ |
-| **Imputation locative** | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| **SWR (Safe Withdrawal Rate)** | ❌ | ❌ | ⚠️ | ✅ | ✅ | ⚠️ (simplify) |
+### Sprint 6A.2
+- introduire une projection cohort produit basee sur `LifecyclePhaseService`
+- pas de nouvelle SOT
 
-### 6.2 Tone Prompts (for Coach System Prompt)
+### Sprint 6A.3
+- injecter les regles cohortes dans `CoachContextInjectorService`
 
-**Cohort 1 (18-27)**:
-```
-You are MINT's friend-mentor on financial independence.
-Tone: Supportive, demystifying, anti-jargon.
-Vocabulary: Simple, direct, avoid abstract concepts.
-Goals: Make them feel normal about learning, celebrate small wins.
-Example: "Cool! Tu viens de piger ta première fiche de paie. On la décortique ensemble—c'est plus simple qu'il n'y paraît."
-Forbidden: "optimal strategy", "maximise", patronizing ("even you can understand").
-```
+### Sprint 6A.4
+- adapter une priorisation Pulse / Cap minimale
 
-**Cohort 2 (28-37)**:
-```
-You are MINT's trusted guide through major life decisions.
-Tone: Pragmatic, supportive, acknowledging complexity.
-Vocabulary: Financial terms OK, always briefly explain first use.
-Goals: Help them navigate trade-offs, reduce overwhelm, build confidence.
-Example: "À deux, les règles changent—impôts, retraite, couple-mode. Voyons ça ensemble."
-Forbidden: "best choice", lifestyle aspirations, false precision.
-```
+### Sprint 6A.5
+- golden personas + assertions produit automatisees
 
-**Cohort 3 (38-52)**:
-```
-You are MINT's serious, efficient partner through high complexity.
-Tone: Direct, clear, no fluff. Acknowledge real constraints (career, family, money).
-Vocabulary: Full technical vocabulary OK; assume financial literacy.
-Goals: Prioritization, clarity, visible progress.
-Example: "Carrière, famille, dettes, assurances: on priorise ce qui compte vraiment."
-Forbidden: Cheerleading, oversimplification, false certainty.
-```
-
-**Cohort 4 (53-64)**:
-```
-You are MINT's expert guide to retirement planning.
-Tone: Authoritative, calm, respectful of their 40+ years of work.
-Vocabulary: Full legal, tax, actuarial terminology.
-Goals: Comprehensive plan, visible timeline, confidence in transition.
-Example: "À 55, on a encore le temps. À 60, c'est urgent. Voici les 11 étapes."
-Forbidden: Hype, lifestyle aspirations, vague promises.
-```
-
-**Cohort 5 (65-74)**:
-```
-You are MINT's calm, respectful guide to active retirement.
-Tone: Warm, reassuring, respectful of mortality; avoiding fear or condescension.
-Vocabulary: Technical OK, but warm phrasing. "You've built well. Now protect wisely."
-Goals: Consumption confidence, wealth protection, legacy clarity.
-Example: "Vous êtes retraité. Question réelle: à ce rythme, l'argent dure jusqu'à 95?"
-Forbidden: "Finally rest", lifestyle hype, fear-mongering.
-```
-
-**Cohort 6 (75+)**:
-```
-You are MINT's dignified guide to legacy and simplicity.
-Tone: Respectful, clear, warm, non-medical. Practical, not morbid.
-Vocabulary: Simple + formal. "Testament", "héritage", "mandat pour inaptitude".
-Goals: Documentary clarity, transmission peace, family protection.
-Example: "À 75, c'est simple: qui possède quoi, et qui hériterait si?"
-Forbidden: Medical language, death-focused framing, fear.
-```
+### Sprint 6B
+- seulement apres validation Phase 6A
+- envisager Explorer ordering
+- envisager suppression / dimming de surfaces
+- envisager parcours flagship par cohorte
 
 ---
 
-## 7. SCREENS BY COHORT (Prioritization Spec)
+## 11. Decision de gouvernance
 
-### 7.1 Tier A Screens (Must Migrate to New Standard)
+Cette spec ne doit pas etre lue comme:
+- “construisons un nouveau moteur cohortes”
 
-**Cohort 1**:
-```
-Priority 1 (Tier A — full migration):
-  - first_job_screen
-  - job_comparison_screen
-  - budget_breakdown_screen (new)
-  - unemployment_safety_net_screen
+Elle doit etre lue comme:
+- “projetons une experience produit cohorte-aware sur la base lifecycle deja existante”
 
-Priority 2 (Tier B → Tier A conversion):
-  - tax_declaration_simple_screen (new)
-  - savings_goal_screen (new)
-```
+La priorite immediate n'est donc pas d'implanter 18 journeys.
 
-**Cohort 2**:
-```
-Priority 1 (Tier A):
-  - affordability_screen (housing)
-  - couple_mode_setup_screen
-  - birth_costs_breakdown_screen (new)
-  - marriage_tax_impact_screen
-  - epl_combined_screen
-
-Priority 2 (Tier B → Tier A):
-  - tax_deductions_children_screen
-  - concubinage_screen (lift to parity with marriage)
-```
-
-**Cohort 3**:
-```
-Priority 1 (Tier A):
-  - retirement_dashboard_screen (with confidence band)
-  - lpp_deep_service (full suite)
-  - protection_audit_screen (new)
-  - tax_optimization_screen (focused on high earners)
-  - monte_carlo_screen (reintroduce)
-
-Priority 2 (Tier B → Tier A):
-  - 3a_deep_simulator
-  - debt_stress_test_screen
-```
-
-**Cohort 4**:
-```
-Priority 1 (Tier A):
-  - retirement_phased_dashboard (new, 11 steps)
-  - rente_vs_capital_screen (LPP + 3a combined)
-  - staggered_withdrawal_screen (3a + SWR sequences)
-  - succession_planner_screen
-  - testament_guide_screen (new)
-  - monte_carlo_screen (portfolio longevity)
-  - tax_withdrawal_optimizer_screen
-
-Priority 2 (Tier B → Tier A):
-  - avs_anticipation_screen
-  - lamal_post_retirement_screen
-```
-
-**Cohort 5**:
-```
-Priority 1 (Tier A):
-  - consumption_longevity_screen (new — "will CHF last to 95?")
-  - active_succession_manager_screen (new)
-  - monte_carlo_refresh_screen (annual rerun)
-  - withdrawal_optimization_screen (SWR + tax focused)
-  - lpp_decaissement_tracking_screen (new)
-  - protection_longevity_screen (LAMal + long-term care)
-
-Priority 2 (Tier B → Tier A):
-  - mandat_inaptitude_screen
-```
-
-**Cohort 6**:
-```
-Priority 1 (Tier A):
-  - documentary_clarity_screen (new — checklist: where are docs?)
-  - transmission_guide_screen (new — simple transmission planner)
-  - mandat_inaptitude_screen
-  - testament_simple_guide_screen
-  - lamal_longterm_care_screen
-
-Priority 2 (Hide/Archive):
-  - first_job_screen
-  - unemployment_screen
-  - birth_costs_screen
-  - job_comparison_screen
-```
+La priorite immediate est:
+1. corriger les erreurs cohort-aware deja live
+2. verrouiller la logique de suggestion / ton / priorite
+3. prouver la valeur sur 3 surfaces
 
 ---
 
-## 8. ANALYTICS & INSTRUMENTATION
+## 12. Definition of done
 
-Every cap, journey, and CTA chip should log:
-- User cohort at trigger time
-- Sequence progress (step 1 of 5, etc.)
-- CTA usage by cohort
-- Completion rates by cohort + journey
-- Dropout points
+La Phase 6A est reussie si:
+- aucune contradiction metier evidente ne subsiste dans les suggestions
+- le lifecycle reste la seule base canonique
+- 6 personas golden ont des comportements differencies credibles
+- coach + suggestions + Pulse ne donnent plus une impression d'app generique
+- aucun nouveau moteur parallele n'a ete introduit
 
-**ARB Key Pattern for Analytics**: `analytics_cohort<N>_<event_type>`
-
-Example:
-```dart
-analytics.logEvent(
-  'journey_started',
-  parameters: {
-    'journey_id': 'j1_first_salary',
-    'cohort': 'cohort1_FirstSteps',
-    'entry_point': 'coach_suggestion',
-  },
-);
-
-analytics.logEvent(
-  'cta_chip_tapped',
-  parameters: {
-    'chip_key': 'ctaChip_cohort1_see_monthly_budget',
-    'cohort': 'cohort1_FirstSteps',
-    'tap_position': 2, // second chip tapped
-  },
-);
-```
-
----
-
-## 9. TESTING & VALIDATION
-
-### 9.1 Golden Couples by Cohort
-
-Test at least one persona per cohort:
-
-| Cohort | Golden Couple | Age | Profile | Test Scenario |
-|--------|---------------|-----|---------|---------------|
-| 1 | Alex (Suisse native) | 24 | First job CHF 45k, VS, no debt | Sees J1_FirstSalary, CTA chips for budget + job comparison |
-| 2 | Julia + Marco (couple) | 32/33 | Married, 1 child, CHF 120k combined, buying CHF 600k apt, VS | Sees J1_Housing, J2_Couple, J3_Birth, CTA chips for EPL + couple tax |
-| 3 | Sabine (single, high earner) | 45 | CHF 140k, 2 kids, CHF 300k mortgage, CHF 500k 3a, VS | Sees densification journey, advanced LPP rachat, protection audit |
-| 4 | Jérôme (pre-retiree) | 58 | CHF 130k, married, CHF 1.2M LPP, CHF 150k 3a, 7 years to 65 | Sees 11-step phased retirement, rente vs capital, succession intro |
-| 5 | Christiane (active retiree) | 70 | Retired 5 years, CHF 45k AVS + CHF 60k capital, CHF 800k estate | Sees consumption longevity, active succession, LAMal update |
-| 6 | Margaret (late retiree) | 82 | Retired 15+ years, CHF 1.2M estate, widowed, 3 adult children | Sees documentary clarity, transmission guide, mandat inaptitude review |
-
-### 9.2 Test Matrix
-
-For each cohort:
-1. ✅ **Cohort detection** works (correct age + life events → correct cohort)
-2. ✅ **Explorer hubs** visible/hidden correctly
-3. ✅ **Caps** shown are age-appropriate (no retirement for 22yo)
-4. ✅ **CTAs** match cohort tone
-5. ✅ **Journey starts** with coach suggestion
-6. ✅ **Screens** load without regression
-7. ✅ **Copy** uses correct vocabulary (no "coordination" for cohort 1)
-8. ✅ **Suppression rules** enforced (no succession tab for 30yo)
-
----
-
-## 10. MIGRATION ROADMAP
-
-### Phase 1: Infrastructure (2 sprints)
-- [ ] Implement `CohortDetectionService`
-- [ ] Add cohort field to `CoachProfile`
-- [ ] Create `CohortContentRules` suppression matrix
-- [ ] Write unit tests for detection logic (10+ test cases)
-- [ ] Golden couple validation (pass detection for all 6 personas)
-
-### Phase 2: Explorer Tab Adaptation (2 sprints)
-- [ ] Implement `hubOrderByCohort()` in `ExplorerHubController`
-- [ ] Hide/show hubs per cohort
-- [ ] Update hub tiles to reflect cohort priorities
-- [ ] Test with golden couples (verify hub order correct)
-- [ ] Suppress screens per `CohortContentRules`
-
-### Phase 3: Coach Integration (2 sprints)
-- [ ] Inject cohort into coach system prompt
-- [ ] Create 6 tone prompt variants
-- [ ] Wire cohort into `CapEngine` (filter caps by cohort)
-- [ ] Test coach suggestions (verify age-appropriate)
-- [ ] Create CTA chip variants per cohort (6 × 6 = 36 ARB keys)
-
-### Phase 4: Journey/Sequence Implementation (3 sprints)
-- [ ] Implement `JourneyOrchestrationService`
-- [ ] Build cohort-specific journey flows (3 journeys × 6 cohorts = 18 flows)
-- [ ] Lift Tier B screens to Tier A (per cohort)
-- [ ] Add "phases" structure to retirement journey for cohort 4
-- [ ] Test end-to-end journey flows
-
-### Phase 5: Analytics & Monitoring (1 sprint)
-- [ ] Instrument all cohort events
-- [ ] Create dashboard (by cohort: cap impressions, CTA usage, journey completion)
-- [ ] Set baseline metrics (cohort 1: 80%+ budget completion, cohort 4: 60%+ phased retirement)
-- [ ] Monitor for anomalies (wrong cap shown to wrong cohort?)
-
-### Phase 6: Polish & Hardening (1 sprint)
-- [ ] Audit all copy for vocabulary compliance
-- [ ] Test suppression rules (adversarial: try to show forbidden screens)
-- [ ] UX pass (no hardcoded text, all ARB keys)
-- [ ] Performance (cohort detection should be <10ms)
-- [ ] i18n: translate all cohort-specific ARB keys to 6 languages
-
-**Total: 9-10 sprints** (~2.5 months for an experienced team)
-
----
-
-## 11. SUMMARY SPEC TABLE
-
-| Aspect | Cohort 1 | Cohort 2 | Cohort 3 | Cohort 4 | Cohort 5 | Cohort 6 |
-|--------|----------|----------|----------|----------|----------|----------|
-| **Age** | 18-27 | 28-37 | 38-52 | 53-64 | 65-74 | 75+ |
-| **Life Phase** | First Steps | Build | Densify | Prepare Transition | Active Retirement | Legacy & Simplicity |
-| **J1** | First Salary | Housing | Densify | Retirement Phased | Consumption | Documentary Clarity |
-| **J2** | Budget Tension | Couple Financial | Retirement Preview | Decaissement | Succession | Transmission |
-| **J3** | Job Comparison | Birth Costs | Protection | Succession | Longevity | Health & EOL |
-| **Explorer Hubs (Visible)** | 4 / 7 | 5 / 7 | 6 / 7 | 6 / 7 (Retraite 40%) | 6 / 7 (Retraite + Patrimoine 30% each) | 3 / 7 (Patrimoine, Santé, mini-Retraite) |
-| **Tone** | Supportive mentor | Pragmatic guide | Serious advisor | Expert planner | Warm caretaker | Dignified guide |
-| **Vocabulary Level** | Simple | Intermediate | Advanced | Expert | Expert | Simple + formal |
-| **Copy Complexity** | Beginner | Intermediate | Advanced | Advanced | Advanced | Beginner/formal |
-| **Retirement Content** | Hidden | Intro | Preview | Full | Full | Full |
-| **Succession Content** | Hidden | Hidden | Intro | Full | Full | Full |
-| **Profile Completeness** | 50-60% | 65-80% | 75-85% | 80-90% | 85-95% | 90%+ |
-| **Expected Cap Focus** | Income, budget | Logement, couple | Tax, protection, LPP | Retraite, décaissement | Consumption, legacy | Documentation, legacy |
-
----
-
-## 12. DONE CRITERIA
-
-This spec is **production-ready** when:
-
-- [ ] All 6 cohorts detect correctly on golden couples
-- [ ] Each cohort sees only age-appropriate screens (suppression rules enforced)
-- [ ] Each cohort receives cohort-specific CTAs (36 chip variants)
-- [ ] Each cohort hears cohort-appropriate coach voice (6 tone variants)
-- [ ] Each cohort has 3 flagshipjourneys implemented (18 flows)
-- [ ] Explorer hubs reorder per cohort (no hardcoded "Retraite" first for 22yo)
-- [ ] Analytics tracks cohort at every meaningful event
-- [ ] All ARB keys translated to 6 languages
-- [ ] `flutter analyze` = 0 issues, `flutter test` = 100% pass rate
-- [ ] Golden couples tested end-to-end (each cohort: detect → see caps → start journey → progress)
-- [ ] No hardcoded French strings (all via `AppLocalizations`)
-- [ ] Documentation updated (navigation, voice, caps systems)
-
----
-
-## Appendix: ARB Key Patterns
-
-All cohort-related keys follow this pattern:
-
-```
-journey_cohort<N>_<journey_slug>_<screen_position>
-  e.g., journey_cohort1_first_salary_opening, journey_cohort4_retirement_phase1_intro
-
-cap_cohort<N>_<cap_slug>
-  e.g., cap_cohort1_understand_salary, cap_cohort4_retirement_plan
-
-ctaChip_cohort<N>_<action>
-  e.g., ctaChip_cohort1_see_monthly_budget, ctaChip_cohort5_will_money_last
-
-coach_tone_cohort<N>_<context>
-  e.g., coach_tone_cohort1_intro, coach_tone_cohort4_phased_retirement
-
-explorer_hub_cohort<N>_<hub_name>_visibility
-  e.g., explorer_hub_cohort1_retraite_hidden, explorer_hub_cohort2_logement_priority
-
-screen_copy_cohort<N>_<screen>_<element>
-  e.g., screen_copy_cohort1_first_job_vocabulary, screen_copy_cohort5_consumption_reassurance
-
-suppression_cohort<N>_<content_key>
-  e.g., suppression_cohort1_succession_full, suppression_cohort3_endOfLife_intro
-```
-
----
-
-This spec is **concrete, testable, and directly implementable** by the Flutter + backend teams. It requires no major UI redesign—only logic adaptation, content filtering, and coaching tone variation. When implemented properly, each cohort will experience MINT as if it was designed specifically for their life phase, while the underlying system remains unified.

--- a/docs/MINT_ANTI_BULLSHIT_MANIFESTO.md
+++ b/docs/MINT_ANTI_BULLSHIT_MANIFESTO.md
@@ -1,0 +1,177 @@
+# MINT Anti-Bullshit Manifesto
+
+> Statut: garde-fou produit
+> Role: empecher MINT de produire des feedbacks absurdes, hors contexte, ou non credibles
+> Portee: coach, caps, suggestion chips, onboarding, sequences, scan, cohortes
+
+---
+
+## 1. Le vrai risque
+
+Le pire bug de MINT n'est pas un crash.
+
+Le pire bug de MINT, c'est un feedback qui donne a l'utilisateur l'impression que:
+- MINT ne comprend pas sa situation
+- MINT raconte n'importe quoi
+- MINT plaque une pseudo-personnalisation vide
+- MINT pousse une action incoherente
+
+En finance, une suggestion stupide detruit la confiance beaucoup plus vite qu'un bug discret.
+
+Règle:
+
+**Un feedback absurde est un release-blocker.**
+
+---
+
+## 2. Principe central
+
+**Mieux vaut moins de feedbacks, mais tres justes, que plus de feedbacks pseudo-smart mais fragiles.**
+
+MINT ne doit jamais donner l'impression:
+- d'improviser
+- de deviner agressivement
+- de plaquer un template sur tout le monde
+- de pousser une action sans base suffisante
+
+---
+
+## 3. Les 7 interdits absolus
+
+1. Ne jamais pousser un levier qui contredit les donnees connues
+2. Ne jamais donner un chiffre fort sur une base fragile sans le signaler
+3. Ne jamais utiliser un ton de certitude sur une estimation pedagogique
+4. Ne jamais proposer une etape incoherente avec la cohorte ou la phase de vie
+5. Ne jamais laisser un fallback legacy produire un message contradictoire
+6. Ne jamais presenter une personnalisation non prouvee comme intelligente
+7. Ne jamais shipper un feedback important sans test persona ou assertion comportementale
+
+---
+
+## 4. Les 5 questions obligatoires avant tout feedback
+
+Avant d'afficher un cap, un CTA, une suggestion coach, un delta, un chiffre choc ou un next step, il faut pouvoir repondre oui a ces 5 questions:
+
+1. Est-ce que ce feedback est coherent avec les donnees connues ?
+2. Est-ce qu'il est coherent avec la phase de vie / cohorte / parcours en cours ?
+3. Est-ce qu'il est honnete sur le niveau de confiance ?
+4. Est-ce qu'un humain normal le trouverait intelligent et credible ?
+5. Est-ce qu'on a un test ou une assertion qui verrouille ce comportement ?
+
+Si la reponse est non a une de ces questions:
+
+**on ne shippe pas**
+
+---
+
+## 5. Regles de formulation
+
+### Quand la confiance est forte
+
+On peut dire:
+- ce qu'on sait
+- ce que cela change
+- la prochaine etape
+
+### Quand la confiance est faible
+
+On doit dire:
+- ce qu'on sait vraiment
+- ce qu'on estime
+- ce qui manque
+- comment ameliorer la precision
+
+### On n'utilise jamais
+
+- “garanti”
+- “optimal”
+- “meilleur”
+- “parfait”
+- “c'est sur”
+- tout ton qui fait semblant d'etre plus precis que les donnees
+
+---
+
+## 6. Regles cohortes
+
+Une logique cohort-aware n'est acceptable que si:
+- elle repose sur une source canonique existante
+- elle n'introduit pas une seconde classification concurrente
+- elle ne pousse pas de feedback incoherent
+- elle est testee sur personas golden
+
+Exemples d'erreurs interdites:
+- pousser `rachat LPP` a quelqu'un sans LPP
+- pousser succession en priorite a un 22 ans
+- pousser premier salaire a un retraite de 72 ans
+- pousser retraite profonde en priorite a un profil demarrage sans contexte
+
+---
+
+## 7. Regles sequences
+
+Une sequence ne doit jamais donner l'impression:
+- d'avancer au hasard
+- de repeter une etape inutilement
+- de resumer quelque chose de faux
+- de celebrer un changement qui n'existe pas
+
+Donc:
+- pas de delta visible sans vrai delta
+- pas de resume final sans outputs fiables
+- pas de “Continue” si la prochaine etape n'est pas reelle
+- pas de message legacy contradictoire en parallele
+
+---
+
+## 8. Golden personas obligatoires
+
+Tout systeme de feedback personnalise doit etre verifie au minimum sur:
+
+- un 24 ans premier emploi
+- un 33 ans projet logement
+- un couple de 36 ans avec enfant
+- un independant de 47 ans
+- un pre-retraite de 59 ans
+- un retraite de 72 ans
+
+Question a poser pour chacun:
+
+**"Est-ce que cette personne aurait l'impression que MINT comprend vraiment sa situation ?"**
+
+Si non, il faut corriger.
+
+---
+
+## 9. Regle de release
+
+Un feedback personnalise est release-ready seulement si:
+- la source de verite est claire
+- les preconditions metier sont explicites
+- le chemin canonique est prouve
+- les fallbacks sont verifies
+- au moins un test persona ou une assertion comportementale existe
+
+Sinon:
+
+**le feedback est encore experimental, pas production-ready**
+
+---
+
+## 10. Règle finale
+
+MINT n'a pas le droit d'etre “a cote de la plaque”.
+
+Si MINT ne sait pas, il doit le dire proprement.
+Si MINT estime, il doit le signaler.
+Si MINT personnalise, il doit pouvoir le justifier.
+
+La bonne personnalisation n'est pas:
+- plus de texte
+- plus de suggestions
+- plus de sophistication apparente
+
+La bonne personnalisation, c'est:
+
+**la bonne chose, au bon moment, pour la bonne personne, avec le bon niveau de certitude.**
+

--- a/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+++ b/docs/MINT_FINAL_EXECUTION_SYSTEM.md
@@ -1,0 +1,913 @@
+# MINT Final Execution System
+
+> Statut: point d'entree unique pour les agents leaders
+> Role: transformer MINT en produit exceptionnel, production-ready, centre sur l'experience
+> Portee: vision cible, doctrine, priorites, regles d'execution, pack final de prompts
+> Principe: ce document orchestre. Les documents cites restent autoritatifs sur leur domaine.
+
+---
+
+## 1. Comment utiliser ce document
+
+Ce document sert de **single entry point** pour les agents leaders qui pilotent MINT.
+
+Il ne remplace pas les sources de verite existantes. Il les assemble en un systeme d'execution coherent.
+
+Ordre de lecture obligatoire:
+1. `CLAUDE.md`
+2. `AGENTS.md`
+3. ce document
+4. les documents autoritatifs references en section 2
+
+Règle:
+- si ce document donne un cap produit et qu'un document autoritatif donne une regle technique precise, la regle technique precise l'emporte
+- si une divergence apparait entre ce document et un document autoritatif, corriger ce document
+
+---
+
+## 2. Documents autoritatifs a respecter
+
+Ces documents restent la reference sur leur domaine:
+
+- [ROADMAP_V2.md](/Users/julienbattaglia/Desktop/MINT/docs/ROADMAP_V2.md)
+- [MINT_UX_GRAAL_MASTERPLAN.md](/Users/julienbattaglia/Desktop/MINT/docs/MINT_UX_GRAAL_MASTERPLAN.md)
+- [SOURCE_OF_TRUTH_MATRIX.md](/Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md)
+- [ONBOARDING_ARCHITECTURE.md](/Users/julienbattaglia/Desktop/MINT/docs/ONBOARDING_ARCHITECTURE.md)
+- [RFC_AGENT_LOOP_STATEFUL.md](/Users/julienbattaglia/Desktop/MINT/docs/RFC_AGENT_LOOP_STATEFUL.md)
+- [ROUTE_POLICY.md](/Users/julienbattaglia/Desktop/MINT/docs/ROUTE_POLICY.md)
+- [GLOSSAIRE_PRODUIT.md](/Users/julienbattaglia/Desktop/MINT/docs/GLOSSAIRE_PRODUIT.md)
+- [TOP_10_SWISS_CORE_JOURNEYS.md](/Users/julienbattaglia/Desktop/MINT/docs/TOP_10_SWISS_CORE_JOURNEYS.md)
+- [AGENTS.md](/Users/julienbattaglia/Desktop/MINT/AGENTS.md)
+
+---
+
+## 3. Thèse produit finale
+
+MINT ne doit plus etre une collection d'outils.
+
+MINT doit devenir un **compagnon suisse de clarte financiere**, qui:
+- comprend la situation d'une personne ou d'un couple
+- choisit la bonne prochaine etape
+- oriente vers le bon ecran ou la bonne question
+- montre ce qui a change
+- memorise la progression
+- revient avec le bon levier au bon moment
+
+Formule produit:
+
+```text
+Comprendre -> Agir -> Voir le delta -> Revenir
+```
+
+Formule de marque:
+
+```text
+Les chiffres -> Les leviers
+```
+
+Ce que MINT ne doit pas etre:
+- un dashboard de plus
+- une app chat-only
+- un catalogue de simulateurs
+- une IA qui explique sans faire agir
+
+Ce que MINT doit etre:
+- un systeme vivant
+- calme, suisse, credible
+- pedagogique sans etre mou
+- profond sans etre opaque
+
+---
+
+## 4. Changement de doctrine
+
+Jusqu'ici, MINT a beaucoup avance par:
+- moteurs
+- calculs
+- ecrans
+- couverture metier
+
+La suite doit se faire par:
+- douleurs majeures
+- parcours
+- delta visible
+- memoire de progression
+- experience adaptee par cohorte
+
+Nouvelle regle:
+
+**Un sprint est prioritaire seulement s'il rend une douleur majeure plus claire, plus actionnable, ou plus visible.**
+
+---
+
+## 5. Douleurs prioritaires et architecture de parcours
+
+### 5.1 Les 3 parcours flagship
+
+Ce sont les parcours qui doivent devenir irreprochables avant d'elargir davantage le catalogue.
+
+#### 1. Acheter sans se pieger
+
+Pourquoi:
+- projet tres emotionnel
+- forte valeur percue
+- tres demonstratif du moteur suisse de MINT
+
+Le parcours doit couvrir:
+- accessibilite logement
+- fonds propres
+- EPL si pertinent
+- fiscalite retrait si pertinente
+- resume clair
+- prochaine etape credible
+
+#### 2. Sortir d'une tension financiere
+
+Pourquoi:
+- grande douleur reelle
+- forte frequence
+- enorme potentiel de transformation visible
+
+Le parcours doit couvrir:
+- diagnostic tension
+- dettes / leasing / charges fixes
+- ratio de risque
+- arbitrage liquidite
+- plan de desencombrement
+- prochaine action unique
+
+#### 3. Preparer sa retraite sans angle mort
+
+Pourquoi:
+- differenciateur suisse majeur
+- forte profondeur metier
+- grande valeur pour 45+, 55+, 65+
+
+Le parcours doit couvrir:
+- revenu retraite projete
+- confiance / incertitude
+- leviers 3a / LPP / rachat / decaissement
+- arbitrages lisibles
+- resume final simple
+
+### 5.2 Les 2 couches de renfort
+
+#### Leviers
+
+Cette couche nourrit les 3 parcours flagship:
+- pilier 3a
+- rachat LPP
+- fiscalite
+- retroactif 3a
+- optimisation de retrait
+
+Règle:
+- ne pas traiter ces leviers comme des features isolees
+- les brancher dans des parcours humains
+
+#### Couple
+
+Cette couche devient centrale apres stabilisation des 3 parcours flagship.
+
+Elle doit couvrir:
+- decisions a deux
+- ordre des rachats
+- retraite decalée
+- asymetries de revenu / patrimoine / LPP
+- logement a deux
+
+---
+
+## 6. Cohortes cibles 18-99
+
+MINT ne doit pas penser seulement par age, mais par matrice:
+- phase de vie
+- structure de foyer
+- statut de travail
+- stress principal
+- confiance des donnees
+
+### Cohortes prioritaires
+
+#### 18-27
+- enjeu: premier salaire, premier budget, dette/leasing, education financiere simple
+- cap typique: comprendre mon premier vrai revenu
+- ton: pedagogique, direct, non abstrait
+
+#### 28-37
+- enjeu: logement, couple, enfants, 3a, comparaisons d'emploi
+- cap typique: construire sans me pieger
+- ton: concret, orienté arbitrages
+
+#### 38-52
+- enjeu: densification, famille, impots, prelevements, protection, rachats, projection
+- cap typique: prioriser les bons leviers
+- ton: serieux, efficace, sans surcharge
+
+#### 53-64
+- enjeu: pre-retraite, optimisation, risque de trou, fiscalite de sortie, decaissement
+- cap typique: preparer la transition
+- ton: maitrise, clarte, confiance
+
+#### 65-74
+- enjeu: retrait, rythme de consommation, succession, simplification
+- cap typique: proteger et piloter
+- ton: simple, rassurant, non technique
+
+#### 75+
+- enjeu: transmission, protection, simplicite, lisibilite dossier
+- cap typique: garder une vue claire et transmettre proprement
+- ton: sobre, accompagne, lisible
+
+Règle de conception:
+- un 22 ans, un couple de 36 ans avec projet immobilier, un independant de 47 ans, un pre-retraite de 59 ans et un retraite de 72 ans ne doivent jamais avoir l'impression d'utiliser la meme app generique
+
+---
+
+## 7. Architecture d'experience cible
+
+Boucle coeur:
+
+```text
+Dossier
+-> comprend la situation
+-> nourrit le coach et Aujourd'hui
+-> ouvre un parcours
+-> declenche une action ou un scan
+-> recalcule confiance + projections + caps
+-> montre le delta
+-> memoire de progression
+-> prochaine etape
+```
+
+Chaque action dans MINT doit produire au moins un des trois:
+- un chiffre qui change
+- une confiance qui monte
+- une decision qui devient plus claire
+
+Sans cela, MINT reste un calculateur.
+
+---
+
+## 8. Regles produit non negociables
+
+1. Pas de nouvelle feature hors parcours
+2. Pas de nouveau chantier catalogue sans douleur claire
+3. Pas de wording centre simulateur quand une formulation centree decision ou douleur est possible
+4. Pas de chiffre ultra-precis sur donnees faibles sans signal pedagogique
+5. Pas d'action sans delta visible
+6. Pas de nouvelle route legacy
+7. Pas de nouvelle double source de verite
+8. Pas de “done” si le chemin runtime critique n'est pas prouve
+
+---
+
+## 9. Regles techniques non negociables
+
+### 9.1 Source de verite
+
+Respecter [SOURCE_OF_TRUTH_MATRIX.md](/Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md).
+
+En particulier:
+- `CoachProfile` = modele maitre local
+- `MintUserState` = etat runtime unifie
+- `financial_core` = seule source de verite calculatoire
+- backend `EnhancedConfidence` = source de verite confiance
+- onboarding API = chemin primaire, local = fallback
+
+### 9.2 Routage
+
+Respecter [ROUTE_POLICY.md](/Users/julienbattaglia/Desktop/MINT/docs/ROUTE_POLICY.md).
+
+Regles rapides:
+- nouvelles routes en francais kebab-case
+- pas de nouvelles routes legacy
+- toute route coach-routable doit exister dans `ScreenRegistry`
+- migrations progressives, jamais big bang
+
+### 9.3 Orchestration coach -> ecran -> retour
+
+Respecter [RFC_AGENT_LOOP_STATEFUL.md](/Users/julienbattaglia/Desktop/MINT/docs/RFC_AGENT_LOOP_STATEFUL.md).
+
+Regles rapides:
+- `ScreenReturn` est le contrat central
+- realtime riche = chemin canonique
+- fallback route-return = exceptionnel / Tier B
+- pas de second plan parallele a `CapSequence`
+- pas de guard fragile si l'etat runtime persiste suffit
+
+### 9.4 Tier A / Tier B
+
+- Tier A = ecran migre au contrat riche sequence
+- Tier B = fallback legacy
+
+Un agent ne doit jamais presenter un ecran Tier B comme s'il etait Tier A.
+
+---
+
+## 10. Ordre d'execution recommande
+
+### Chantier 1
+Finir le parcours flagship `Acheter sans se pieger`
+
+### Chantier 2
+Construire le parcours flagship `Sortir d'une tension financiere`
+
+### Chantier 3
+Finir le parcours flagship `Preparer sa retraite sans angle mort`
+
+### Chantier 4
+Brancher la boucle `scan -> enrichissement -> delta visible -> coach explique`
+
+### Chantier 5
+Rendre visible `ce qui a change` dans Aujourd'hui et Dossier
+
+### Chantier 6
+Construire l'OS de cohortes
+
+### Chantier 7
+Hardening production: observabilite, tests runtime, audits de joints
+
+---
+
+## 11. Definition of done d'un parcours exceptionnel
+
+Un parcours n'est pas “fini” parce qu'il a plusieurs ecrans.
+
+Un parcours est fini si:
+- l'entree par chat est naturelle
+- le coach ouvre le bon flow
+- le flow orchestre plusieurs etapes de facon robuste
+- l'utilisateur comprend ce qu'il se passe
+- un delta visible apparait
+- la confiance ou la precision progresse
+- la prochaine etape est claire
+- le tout est memorise dans l'etat utilisateur
+- les tests couvrent le joint runtime principal
+
+---
+
+## 12. Workflow des agents leaders
+
+Le team lead doit suivre cette discipline:
+
+1. cadrer le chantier par douleur et parcours
+2. designer le contrat de verite
+3. demander spec si sujet metier / legal / suisse
+4. faire implementer backend si contrat traverse les couches
+5. faire implementer Flutter
+6. exiger un auto-audit
+7. faire un audit final
+8. merger seulement si le runtime principal est prouve
+
+Le team lead ne doit pas:
+- lancer plusieurs chantiers strategiques en meme temps
+- accepter une PR qui corrige seulement un service si le bug est runtime
+- accepter un “green CI” comme seule preuve
+
+---
+
+## 13. Pack final de prompts
+
+### 13.1 Prompt maitre Team Lead
+
+```text
+Tu es le team lead de Mint. Ta mission est de transformer Mint en produit exceptionnel, production-ready, centre sur l'experience et non sur l'accumulation de features.
+
+Lis et fais respecter:
+- /Users/julienbattaglia/Desktop/MINT/CLAUDE.md
+- /Users/julienbattaglia/Desktop/MINT/AGENTS.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+- /Users/julienbattaglia/Desktop/MINT/docs/ROADMAP_V2.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_UX_GRAAL_MASTERPLAN.md
+- /Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md
+- /Users/julienbattaglia/Desktop/MINT/docs/ONBOARDING_ARCHITECTURE.md
+- /Users/julienbattaglia/Desktop/MINT/docs/RFC_AGENT_LOOP_STATEFUL.md
+- /Users/julienbattaglia/Desktop/MINT/docs/ROUTE_POLICY.md
+- /Users/julienbattaglia/Desktop/MINT/docs/GLOSSAIRE_PRODUIT.md
+- /Users/julienbattaglia/Desktop/MINT/docs/TOP_10_SWISS_CORE_JOURNEYS.md
+
+Doctrine:
+- Mint n'est plus une collection d'outils
+- Mint doit devenir un systeme vivant: comprendre, agir, voir le delta, revenir
+- toute feature doit s'inserer dans un parcours
+- toute action doit produire un avant/apres visible
+- aucune nouvelle dette structurelle
+- aucune divergence mobile/backend/source de verite
+- aucun wording produit centre “simulateur” ou “outil” si une formulation centree douleur ou decision est possible
+
+Top priorites produit:
+1. Achat logement
+2. Dette / leasing / budget sous tension
+3. Retraite / pre-retraite / decaissement
+4. Scan -> enrichissement -> delta visible
+5. Ce qui a change
+6. Cohortes
+7. Hardening prod
+
+Ton travail:
+- decouper le chantier en PRs strictes, testables, ordonnees
+- assigner chaque PR a l'agent adapte
+- exiger un auto-audit avant chaque commit
+- refuser tout chantier hors priorite
+- verifier les joints runtime, pas seulement les services
+- fournir apres chaque etape:
+  1. diagnostic
+  2. changement
+  3. verification
+  4. residus
+  5. prochaine etape
+
+Definition of done globale:
+- les 3 parcours flagship fonctionnent de bout en bout
+- le coach orchestre reellement les ecrans
+- l'utilisateur voit ce qui a change
+- la confiance et les projections evoluent visiblement
+- les cohortes cles ont une experience credible
+- les flows critiques ont des tests d'integration runtime
+- observabilite minimale en place
+```
+
+### 13.2 Prompt Flutter implementation
+
+```text
+Tu es le dart-agent Mint. Scope strict: /Users/julienbattaglia/Desktop/MINT/apps/mobile/ uniquement.
+
+Lis:
+- /Users/julienbattaglia/Desktop/MINT/.claude/skills/mint-flutter-dev/SKILL.md
+- /Users/julienbattaglia/Desktop/MINT/.claude/skills/mint-test-suite/SKILL.md
+- /Users/julienbattaglia/Desktop/MINT/CLAUDE.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_UX_GRAAL_MASTERPLAN.md
+- /Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md
+- /Users/julienbattaglia/Desktop/MINT/docs/RFC_AGENT_LOOP_STATEFUL.md
+
+Mission:
+implementer le chantier demande sans deriver, avec priorite a l'experience utilisateur, au delta visible, a la robustesse runtime, et aux tests de joints.
+
+Regles:
+- avant toute modif: flutter analyze && flutter test cible
+- ne pas toucher backend
+- ne pas creer une nouvelle source de verite
+- ne pas laisser de TODO user-facing mort
+- si tu touches le coach, verifier:
+  - route payload
+  - ScreenReturn
+  - realtime
+  - fallback
+  - analytics
+  - tests widget/integration
+- si tu touches une cohorte, verifier:
+  - copy
+  - CTA
+  - delta visible
+  - absence de jargon inutile
+
+Sortie attendue:
+- diagnostic
+- fichiers touches
+- tests lances
+- findings restants
+```
+
+### 13.3 Prompt Backend implementation
+
+```text
+Tu es le python-agent Mint. Scope strict: /Users/julienbattaglia/Desktop/MINT/services/backend/ et si necessaire /Users/julienbattaglia/Desktop/MINT/tools/openapi/.
+
+Lis:
+- /Users/julienbattaglia/Desktop/MINT/.claude/skills/mint-backend-dev/SKILL.md
+- /Users/julienbattaglia/Desktop/MINT/.claude/skills/mint-test-suite/SKILL.md
+- /Users/julienbattaglia/Desktop/MINT/CLAUDE.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+- /Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md
+- /Users/julienbattaglia/Desktop/MINT/docs/ONBOARDING_ARCHITECTURE.md
+
+Mission:
+garantir que tout contrat utilise par les parcours flagship et le coach reste authoritative, non divergent, teste, et documente.
+
+Regles:
+- avant modifs: ruff check . && pytest -q
+- API change => update openapi + contrat
+- ne jamais laisser mobile et backend diverger sur:
+  - confidence
+  - onboarding
+  - profile minimal
+  - outputs structures des parcours
+  - analytics contract si expose
+- ajouter des tests de contrat, pas seulement des tests service
+
+Sortie attendue:
+- contrat modifie
+- non-divergence garantie
+- tests
+- residus
+```
+
+### 13.4 Prompt Swiss-Brain spec / compliance
+
+```text
+Tu es le swiss-brain de Mint. Scope strict: docs/, education/, decisions/, visions/. Pas de code.
+
+Lis:
+- /Users/julienbattaglia/Desktop/MINT/CLAUDE.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+- /Users/julienbattaglia/Desktop/MINT/docs/TOP_10_SWISS_CORE_JOURNEYS.md
+- /Users/julienbattaglia/Desktop/MINT/docs/MINT_UX_GRAAL_MASTERPLAN.md
+- /Users/julienbattaglia/Desktop/MINT/docs/SOURCE_OF_TRUTH_MATRIX.md
+
+Mission:
+produire la spec metier, suisse, fiscale, pedagogique et compliance avant implementation.
+
+Tu dois fournir:
+- hypotheses legales
+- zones d'incertitude
+- cas limites suisses
+- wording recommande
+- wording interdit
+- jeux de tests metiers
+- exigences de preuve documentaire
+
+Interdit:
+- ecrire du code
+- designer un flow qui ressemble a du conseil prescriptif
+- laisser des termes ambigus ou trop agressifs
+```
+
+### 13.5 Prompt review / audit
+
+```text
+Audit this change in code review mode.
+
+Priorite absolue:
+- bugs runtime
+- regressions
+- doubles sources de verite
+- side effects paralleles
+- tests manquants sur les joints
+- claims "done" non prouves
+
+Ne te contente pas des services isoles.
+Cherche les chemins reels:
+- UI -> navigation -> payload -> screen -> return -> handler -> store
+
+Reponds avec:
+1. Findings ordonnes par severite
+2. Ce qui est confirme correct
+3. Verification effectuee
+4. Verdict honnete
+```
+
+### 13.6 Prompt auto-audit obligatoire
+
+```text
+Avant de commit, fais ton auto-audit.
+
+Liste explicitement:
+- le bug le plus probable encore present
+- le joint le moins prouve
+- le fallback le plus risque
+- toute hypothese non demontree
+- si cette etape est vraiment committable ou non
+
+Si tu ne peux pas defendre le patch honnetement, ne commit pas.
+```
+
+### 13.7 Prompt implementation anti-bugs
+
+```text
+Mission:
+Fermer ce chantier proprement, sans creer de dette ni laisser de bug de joint d'integration.
+
+Tu dois travailler comme un engineer senior de production, pas comme un generateur de patchs.
+
+Obligations:
+- identifier la source de verite avant tout changement
+- lister les callsites et consommateurs avant implementation
+- corriger le chemin canonique d'abord
+- verifier explicitement les fallbacks et side effects legacy
+- ajouter ou ajuster les tests au niveau du joint reel
+- faire un auto-audit avant de declarer l'etape terminee
+
+Interdictions:
+- corriger seulement un service si le bug est dans le runtime path
+- laisser une double source de verite
+- laisser un fallback silencieux non verifie
+- declarer “done” sans preuve du flow complet
+- melanger plusieurs chantiers non necessaires dans la meme PR
+
+Format de travail:
+1. Reformule le probleme exact
+2. Identifie la source de verite
+3. Liste les fichiers et callsites a verifier
+4. Implemente le minimum necessaire
+5. Lance analyze + tests cibles + test du joint principal
+6. Fais un auto-audit:
+   - bugs possibles restants
+   - hypotheses faites
+   - ce qui n'a pas ete prouve
+   - pourquoi le patch reste acceptable ou non
+
+Definition of done:
+- le chemin canonique fonctionne
+- les fallbacks pertinents sont verifies
+- aucun side effect legacy parallele non voulu
+- les tests couvrent le joint critique
+- les residus sont explicitement listes
+```
+
+### 13.8 Prompt chantier 1 - Achat logement
+
+```text
+Chantier: rendre le parcours flagship "Acheter sans se pieger" exceptionnel.
+
+Objectif produit:
+l'utilisateur entre avec une intention logement et vit un parcours de bout en bout:
+- accessibilite
+- EPL / fonds propres
+- fiscalite retrait
+- resume clair
+- delta visible
+- prochaine etape credible
+
+A livrer:
+- sequence coach -> logement / accessibilite -> EPL -> fiscalite retrait -> resume
+- Tier A propre sur les ecrans du parcours
+- bouton Continuer reel
+- SequenceProgressCard utile
+- stepOutputs/prefill propres
+- resume final comprehensible
+- au moins un test d'integration runtime sur le parcours
+
+Definition of done:
+- parcours demo A a Z fonctionne
+- pas de double consommation
+- pas de side effects legacy paralleles
+- delta visible apres chaque etape
+- analytics de parcours presents
+```
+
+### 13.9 Prompt chantier 2 - Dette / leasing / budget sous tension
+
+```text
+Chantier: construire le parcours flagship "Sortir d'une tension financiere".
+
+Objectif produit:
+Mint doit aider un utilisateur en douleur reelle, pas seulement lui montrer un score.
+
+Parcours cible:
+- diagnostic tension
+- dette / leasing / charges fixes
+- ratio et risque
+- arbitrage realisable
+- plan de desencombrement
+- prochaine action unique
+
+Ce que tu dois concevoir et implementer:
+- entree coach centree douleur
+- route vers les bons ecrans existants ou nouveaux minimums necessaires
+- logique de parcours guide
+- wording non jugeant, non anxiogene, tres clair
+- avant/apres visible:
+  - charge mensuelle
+  - marge restante
+  - horizon de sortie
+- CTA simples et progressifs
+
+Regles:
+- ne pas transformer ca en simple simulateur de dette
+- ne pas diluer avec trop de choix
+- montrer un plan realiste, pas “optimal”
+- si leasing est traite, le faire comme un probleme de tension et d'engagement, pas comme un objet isole
+
+Definition of done:
+- un utilisateur sous tension comprend en 60 secondes sa situation
+- voit un plan concret
+- voit ce qui change s'il agit
+- peut revenir plus tard et retrouver son parcours
+```
+
+### 13.10 Prompt chantier 3 - Retraite / pre-retraite / decaissement
+
+```text
+Chantier: rendre le parcours flagship "Preparer sa retraite sans angle mort" irreprochable.
+
+Objectif produit:
+passer d'outils isoles a un vrai parcours de decision.
+
+Le parcours doit couvrir:
+- niveau de revenu retraite attendu
+- gaps et confiance
+- leviers disponibles (3a, rachat LPP, decaissement, EPL si pertinent)
+- arbitrages lisibles
+- resume final en francais simple
+
+Priorites UX:
+- pas de jargon inutile
+- pas de chiffres ultra-precis si confiance faible
+- toujours montrer:
+  - ce qu'on sait
+  - ce qu'on estime
+  - ce qui ameliorerait la precision
+
+A livrer:
+- sequence guidee retraite / pre-retraite
+- scan LPP integre comme accelerateur de precision
+- delta visible avant/apres scan ou simulation
+- message coach qui explique le changement
+
+Definition of done:
+- Mint donne une sensation de maitrise, pas de confusion
+- le parcours est utilisable pour 45+, 55+, 65+
+- la confiance gouverne le type de message
+```
+
+### 13.11 Prompt chantier 4 - Scan -> delta visible
+
+```text
+Chantier: transformer le scan documentaire en moment de verite.
+
+Objectif:
+quand l'utilisateur scanne un document, il doit immediatement ressentir:
+- ce qui a ete compris
+- ce qui a change
+- pourquoi c'est important
+
+Boucle a livrer:
+- coach recommande le meilleur document via EVI
+- user scanne
+- OCR extrait
+- profil enrichi
+- projections / confiance recalculees
+- delta visible dans le chat + Aujourd'hui + Dossier
+
+A montrer:
+- +X points de confiance
+- projection plus precise
+- nouvelle prochaine etape
+
+Regles:
+- pas de wording generique
+- pas de simple “scan reussi”
+- toujours verbaliser l'impact metier
+
+Definition of done:
+- le scan devient un moteur de conversion, pas une fonction utilitaire
+```
+
+### 13.12 Prompt chantier 5 - Ce qui a change
+
+```text
+Chantier: rendre Mint vivant entre deux sessions.
+
+Objectif:
+l'utilisateur qui revient doit voir en quelques secondes:
+- ce qui a change
+- pourquoi ca a change
+- ce qu'il peut faire maintenant
+
+A livrer:
+- section "Depuis ta derniere visite"
+- Pulse: avant/apres visible
+- Dossier: historique de parcours et enrichissements
+- coach: message bref expliquant le delta
+
+Exemples:
+- confiance +12
+- projection retraite resserree
+- nouvelle etape debloquee
+- budget ou cap modifie
+
+Definition of done:
+- chaque enrichissement important laisse une trace visible
+- Mint ressemble a un film, pas a une photo
+```
+
+### 13.13 Prompt chantier 6 - OS de cohortes
+
+```text
+Chantier: rendre l'experience reellement adaptee aux cohortes Mint, de 18 a 99 ans.
+
+Ne raisonne pas seulement par age.
+Utilise la matrice:
+- phase de vie
+- structure de foyer
+- statut de travail
+- stress principal
+- confiance des donnees
+
+Travail demande:
+- formaliser les cohortes prioritaires
+- definir pour chacune:
+  - le cap principal
+  - les parcours prioritaires
+  - le ton
+  - les CTA
+  - les ecrans a privilegier
+- brancher cette logique dans le coach, Aujourd'hui, et les next steps
+
+Definition of done:
+- un 22 ans, un couple de 38 ans avec projet immo, un independant de 47 ans, un pre-retraite de 59 ans et un retraite de 72 ans n'ont pas l'impression d'utiliser la meme app generique
+```
+
+### 13.14 Prompt chantier 7 - Hardening production
+
+```text
+Chantier: rendre les parcours flagship launch-ready.
+
+A livrer:
+- observabilite minimale:
+  - erreurs coach
+  - erreurs OCR
+  - erreurs sequence
+  - latence provider
+  - completion rates parcours
+- tests runtime:
+  - CoachChatScreen
+  - RouteSuggestionCard
+  - GoRouter.extra
+  - ScreenCompletionTracker
+  - Tier A / Tier B
+- audit des side effects
+- audit des fallbacks
+- audit de non-divergence mobile/backend
+
+Definition of done:
+- les parcours critiques sont mesurables
+- les erreurs sont visibles
+- les regressions critiques cassent des tests
+```
+
+---
+
+## 14. Regles de qualite pour eviter un maximum de bugs
+
+Les prompts doivent toujours forcer ces verifications:
+
+1. source de verite
+2. callsites
+3. chemin canonique
+4. fallbacks
+5. side effects legacy
+6. joint runtime
+7. auto-audit
+
+Les bugs les plus frequents dans MINT viennent de:
+- patch local alors que le bug est dans le runtime path
+- tests service sans preuve de joint
+- fallback encore vivant en parallele
+- code “done” alors qu'un flow critique n'est pas prouve
+- seconde verite introduite sans l'assumer
+
+---
+
+## 15. Checklists finales
+
+### 15.1 Checklist Team Lead
+
+- [ ] Le chantier correspond a une douleur majeure ou un parcours prioritaire
+- [ ] La source de verite est claire
+- [ ] Le contrat backend/mobile est coherent
+- [ ] Le chemin canonique est explicite
+- [ ] Les fallbacks sont verifies
+- [ ] L'agent a fait un auto-audit honnete
+- [ ] Les residus sont listes
+- [ ] La PR ne melange pas des sujets inutiles
+
+### 15.2 Checklist Implementation
+
+- [ ] J'ai liste les callsites
+- [ ] J'ai corrige le bon endroit
+- [ ] J'ai verifie les side effects legacy
+- [ ] J'ai teste le joint principal
+- [ ] Je sais ce qui reste non prouve
+
+### 15.3 Checklist Produit
+
+- [ ] L'utilisateur comprend sa situation plus vite
+- [ ] Une prochaine etape est claire
+- [ ] Quelque chose change visiblement
+- [ ] Le langage n'est pas jargonneux
+- [ ] Le parcours parait vivant, pas bureaucratique
+
+---
+
+## 16. Verdict strategique
+
+MINT n'a plus besoin prioritairement de plus de profondeur.
+
+MINT a besoin de transformer la profondeur deja la en:
+- parcours impeccables
+- moments de clarte
+- deltas visibles
+- experiences adaptees aux cohortes
+
+Le bon cap n'est pas:
+- plus d'outils
+- plus de coverage
+- plus de sophistication abstraite
+
+Le bon cap est:
+
+**faire passer MINT d'un systeme riche a un systeme transformant.**
+


### PR DESCRIPTION
## Summary
2 critical user-facing bugs + anti-bullshit doctrine.

### Bugs fixed
1. **Rachat LPP inversé** — suggested buyback to users WITHOUT LPP
2. **Ratio 4200%** — double multiplication in tension summary

### Docs added
- COHORT_OS_SPEC V2 (aligned with existing LifecyclePhaseService)
- Anti-Bullshit Manifesto (7 interdits for feedback quality)
- Phase 6A fix plan

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8310 passed (2 pre-existing LPP golden failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)