### PR TITLE
feat: Phase 6A complete — coach + Cap cohort-aware

### DIFF
--- a/apps/mobile/lib/services/cap_engine.dart
+++ b/apps/mobile/lib/services/cap_engine.dart
@@ -5,6 +5,7 @@ import 'package:mint_mobile/models/response_card.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
 import 'package:mint_mobile/services/financial_core/confidence_scorer.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+import 'package:mint_mobile/services/product_cohort_service.dart';
 import 'package:mint_mobile/services/response_card_service.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -385,6 +386,14 @@ class CapEngine {
         captureType: 'profile',
         confidenceLabel: l.capMissingPieceConfidenceLabel(confidence.score.round().toString()),
       );
+    }
+
+    // Filter out caps that conflict with the user's cohort (Anti-Bullshit §6).
+    // A 22yo should never see succession as a priority cap.
+    final cohortResult = ProductCohortService.resolve(profile);
+    if (cohortResult.suppressedTopics.isNotEmpty) {
+      candidates.removeWhere((c) =>
+          cohortResult.suppressedTopics.any((topic) => c.id.contains(topic)));
     }
 
     // Sort by priority and return the winner.

--- a/apps/mobile/lib/services/coach/context_injector_service.dart
+++ b/apps/mobile/lib/services/coach/context_injector_service.dart
@@ -7,6 +7,7 @@ import 'package:mint_mobile/services/cap_memory_store.dart';
 import 'package:mint_mobile/services/cap_sequence_engine.dart';
 import 'package:mint_mobile/services/goal_selection_service.dart';
 import 'package:mint_mobile/services/lifecycle_phase_service.dart';
+import 'package:mint_mobile/services/product_cohort_service.dart';
 import 'package:mint_mobile/services/lifecycle/lifecycle_detector.dart';
 import 'package:mint_mobile/services/lifecycle/lifecycle_phase.dart'
     as lifecycle_v2;
@@ -161,6 +162,16 @@ class ContextInjectorService {
       final literacyDirective = _literacyDirective(profile.financialLiteracyLevel);
       lifecycleBlock = adaptation.coachSystemPromptAddition +
           (literacyDirective.isNotEmpty ? '\n$literacyDirective' : '');
+
+      // Product cohort: suppressed topics (Anti-Bullshit Manifesto §6).
+      // Tells the LLM which subjects to NEVER suggest for this user.
+      final cohortResult = ProductCohortService.resolve(profile);
+      if (cohortResult.suppressedTopics.isNotEmpty) {
+        lifecycleBlock += '\n\nSUJETS INTERDITS pour cet utilisateur '
+            '(cohorte ${cohortResult.cohort.name}):\n'
+            '${cohortResult.suppressedTopics.map((t) => '- $t').join('\n')}\n'
+            'Ne JAMAIS suggérer ces sujets, même si l\'utilisateur demande.';
+      }
     }
 
     // Load cross-session insights from the new CoachMemoryService (S58).

--- a/apps/mobile/test/services/product_cohort_service_test.dart
+++ b/apps/mobile/test/services/product_cohort_service_test.dart
@@ -199,5 +199,14 @@ void main() {
       expect(result.suppressedTopics, contains('lpp_buyback'));
       expect(result.lifecycle.tone, LifecycleTone.simple);
     });
+
+    // 18th assertion: cross-cohort consistency check
+    test('densification has NO suppressed topics (full access to all tools)', () {
+      final fullAccess = _persona(birthYear: 1984, salaire: 10000);
+      final result = ProductCohortService.resolve(fullAccess);
+      expect(result.cohort, ProductCohort.densification);
+      expect(result.suppressedTopics, isEmpty,
+          reason: 'Densification (38-52) should have unrestricted access');
+    });
   });
 }


### PR DESCRIPTION
## Summary
Final 2 PRs of Phase 6A: coach context injection + Cap filtering by cohort.

- Coach LLM now knows which topics are FORBIDDEN for each user's cohort
- CapEngine filters candidates by suppression matrix before scoring
- 18th assertion added (densification = full access)

**Phase 6A is COMPLETE.** All 6 PRs delivered.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8331 passed
- [x] 18 behavioral assertions on 6 golden personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)