### PR TITLE
feat: LAMal franchise seasonal trigger (Oct-Nov)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11415,5 +11415,6 @@
   "chatDocExtractionFailed": "Ich konnte keine Daten aus diesem Dokument extrahieren. Versuche es mit einem schärferen Foto.",
   "chatDocError": "Fehler bei der Dokumentenanalyse. Bitte erneut versuchen.",
   "chatDocAttachTooltip": "Dokument scannen",
-  "proactiveContractDeadline": "Erinnerung: {label} läuft in {days} Tagen ab. Plane voraus."
+  "seasonalLamalTitle": "Neue KVG-Prämien",
+  "seasonalLamalDesc": "Die Prämien 2027 sind veröffentlicht. Prüfe, ob deine Franchise noch optimal ist."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11443,5 +11443,6 @@
   "chatDocExtractionFailed": "I couldn't extract data from this document. Try with a clearer photo or different format.",
   "chatDocError": "Error analyzing document. Please try again.",
   "chatDocAttachTooltip": "Scan a document",
-  "proactiveContractDeadline": "Reminder: {label} is due in {days} days. Plan ahead."
+  "seasonalLamalTitle": "New LAMal premiums",
+  "seasonalLamalDesc": "2027 premiums are published. Check if your franchise is still optimal."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11408,5 +11408,6 @@
   "chatDocExtractionFailed": "No pude extraer datos de este documento. Intenta con una foto más nítida.",
   "chatDocError": "Error al analizar el documento. Inténtalo de nuevo.",
   "chatDocAttachTooltip": "Escanear un documento",
-  "proactiveContractDeadline": "Recordatorio: {label} vence en {days} días. Planifica con anticipación."
+  "seasonalLamalTitle": "Nuevas primas LAMal",
+  "seasonalLamalDesc": "Las primas 2027 están publicadas. Verifica si tu franquicia sigue siendo óptima."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11890,5 +11890,6 @@
   "chatDocExtractionFailed": "Je n'ai pas pu extraire de données de ce document. Essaie avec une photo plus nette ou un autre format.",
   "chatDocError": "Erreur lors de l'analyse du document. Réessaie.",
   "chatDocAttachTooltip": "Scanner un document",
-  "proactiveContractDeadline": "Rappel : {label} arrive dans {days} jours. Pense à anticiper."
+  "seasonalLamalTitle": "Nouvelles primes LAMal",
+  "seasonalLamalDesc": "Les primes 2027 sont publiées. Vérifie si ta franchise est toujours optimale."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11408,5 +11408,6 @@
   "chatDocExtractionFailed": "Non sono riuscito a estrarre dati da questo documento. Prova con una foto più nitida.",
   "chatDocError": "Errore nell'analisi del documento. Riprova.",
   "chatDocAttachTooltip": "Scansionare un documento",
-  "proactiveContractDeadline": "Promemoria: {label} scade tra {days} giorni. Pianifica in anticipo."
+  "seasonalLamalTitle": "Nuovi premi LAMal",
+  "seasonalLamalDesc": "I premi 2027 sono pubblicati. Verifica se la tua franchigia è ancora ottimale."
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11409,5 +11409,6 @@
   "chatDocExtractionFailed": "Não consegui extrair dados deste documento. Tenta com uma foto mais nítida.",
   "chatDocError": "Erro ao analisar o documento. Tenta novamente.",
   "chatDocAttachTooltip": "Digitalizar um documento",
-  "proactiveContractDeadline": "Lembrete: {label} vence em {days} dias. Planeia com antecedência."
+  "seasonalLamalTitle": "Novos prémios LAMal",
+  "seasonalLamalDesc": "Os prémios 2027 foram publicados. Verifica se a tua franquia ainda é ótima."
 }

--- a/apps/mobile/lib/services/gamification/seasonal_event_service.dart
+++ b/apps/mobile/lib/services/gamification/seasonal_event_service.dart
@@ -31,6 +31,9 @@ enum SeasonalEventType {
 
   /// Oct : mois de la prevoyance (campagne suisse annuelle).
   retirementMonth,
+
+  /// Oct-Nov : changement de franchise LAMal (nouvelles primes publiees).
+  lamalFranchiseReview,
 }
 
 /// Evenement saisonnier actif sur une periode donnee.
@@ -199,6 +202,17 @@ class SeasonalEventService {
         startDate: DateTime(year, 11, 1),
         endDate: DateTime(year, 11, 30),
         intentTag: '3a-deep',
+      ),
+
+      // ── Octobre : LAMal franchise review (nouvelles primes) ──
+      SeasonalEvent(
+        id: '$year-lamal-franchise-oct',
+        titleKey: 'seasonalLamalTitle',
+        descriptionKey: 'seasonalLamalDesc',
+        type: SeasonalEventType.lamalFranchiseReview,
+        startDate: DateTime(year, 10, 1),
+        endDate: DateTime(year, 11, 30),
+        intentTag: 'lamal_franchise',
       ),
 
       // ── Decembre : deadline 3a (31 dec) ──────────────────────


### PR DESCRIPTION
## Summary
Seasonal proactive trigger for LAMal franchise optimization.
Active Oct-Nov when new premiums are published.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8321 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)