### PR TITLE
fix: 7-pass audit — couple UI + AVS credits + actualRate tests

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11416,5 +11416,9 @@
   "chatDocError": "Fehler bei der Dokumentenanalyse. Bitte erneut versuchen.",
   "chatDocAttachTooltip": "Dokument scannen",
   "seasonalLamalTitle": "Neue KVG-Prämien",
-  "seasonalLamalDesc": "Die Prämien 2027 sind veröffentlicht. Prüfe, ob deine Franchise noch optimal ist."
+  "seasonalLamalDesc": "Die Prämien 2027 sind veröffentlicht. Prüfe, ob deine Franchise noch optimal ist.",
+  "extractionWhoseDocument": "Wessen Dokument ist das?",
+  "extractionWhoseDocumentBody": "Du hast ein Paar-Profil. Gehört dieses Dokument dir oder deinem Partner?",
+  "extractionDocMine": "Es ist meins",
+  "extractionDocPartner": "Es gehört meinem Partner"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11444,5 +11444,9 @@
   "chatDocError": "Error analyzing document. Please try again.",
   "chatDocAttachTooltip": "Scan a document",
   "seasonalLamalTitle": "New LAMal premiums",
-  "seasonalLamalDesc": "2027 premiums are published. Check if your franchise is still optimal."
+  "seasonalLamalDesc": "2027 premiums are published. Check if your franchise is still optimal.",
+  "extractionWhoseDocument": "Whose document is this?",
+  "extractionWhoseDocumentBody": "You have a couple profile. Is this document yours or your partner's?",
+  "extractionDocMine": "It's mine",
+  "extractionDocPartner": "It's my partner's"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11409,5 +11409,9 @@
   "chatDocError": "Error al analizar el documento. Inténtalo de nuevo.",
   "chatDocAttachTooltip": "Escanear un documento",
   "seasonalLamalTitle": "Nuevas primas LAMal",
-  "seasonalLamalDesc": "Las primas 2027 están publicadas. Verifica si tu franquicia sigue siendo óptima."
+  "seasonalLamalDesc": "Las primas 2027 están publicadas. Verifica si tu franquicia sigue siendo óptima.",
+  "extractionWhoseDocument": "¿De quién es este documento?",
+  "extractionWhoseDocumentBody": "Tienes un perfil de pareja. ¿Este documento es tuyo o de tu pareja?",
+  "extractionDocMine": "Es mío",
+  "extractionDocPartner": "Es de mi pareja"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11891,5 +11891,9 @@
   "chatDocError": "Erreur lors de l'analyse du document. Réessaie.",
   "chatDocAttachTooltip": "Scanner un document",
   "seasonalLamalTitle": "Nouvelles primes LAMal",
-  "seasonalLamalDesc": "Les primes 2027 sont publiées. Vérifie si ta franchise est toujours optimale."
+  "seasonalLamalDesc": "Les primes 2027 sont publiées. Vérifie si ta franchise est toujours optimale.",
+  "extractionWhoseDocument": "À qui est ce document ?",
+  "extractionWhoseDocumentBody": "Tu as un profil couple. Ce document est pour toi ou ton/ta partenaire ?",
+  "extractionDocMine": "C'est le mien",
+  "extractionDocPartner": "C'est celui de mon/ma partenaire"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11409,5 +11409,9 @@
   "chatDocError": "Errore nell'analisi del documento. Riprova.",
   "chatDocAttachTooltip": "Scansionare un documento",
   "seasonalLamalTitle": "Nuovi premi LAMal",
-  "seasonalLamalDesc": "I premi 2027 sono pubblicati. Verifica se la tua franchigia è ancora ottimale."
+  "seasonalLamalDesc": "I premi 2027 sono pubblicati. Verifica se la tua franchigia è ancora ottimale.",
+  "extractionWhoseDocument": "Di chi è questo documento?",
+  "extractionWhoseDocumentBody": "Hai un profilo di coppia. Questo documento è tuo o del tuo partner?",
+  "extractionDocMine": "È mio",
+  "extractionDocPartner": "È del mio partner"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -17557,6 +17557,10 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'De retour. Tes chiffres sont à jour.'**
   String get shellWelcomeBack;
+  String get extractionWhoseDocument;
+  String get extractionWhoseDocumentBody;
+  String get extractionDocMine;
+  String get extractionDocPartner;
   String get chatPickPhoto;
   String get chatPickGallery;
   String get chatPickFile;

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -9788,6 +9788,18 @@ class SDe extends S {
   String get shellWelcomeBack => 'Wieder da. Deine Zahlen sind aktuell.';
 
   @override
+  String get extractionWhoseDocument => 'Wessen Dokument ist das?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'Du hast ein Paar-Profil. Gehört dieses Dokument dir oder deinem Partner?';
+
+  @override
+  String get extractionDocMine => 'Es ist meins';
+
+  @override
+  String get extractionDocPartner => 'Es gehört meinem Partner';
+
+  @override
   String get chatPickPhoto => 'Foto aufnehmen';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -9722,6 +9722,18 @@ class SEn extends S {
   String get shellWelcomeBack => 'Back. Your numbers are up to date.';
 
   @override
+  String get extractionWhoseDocument => 'Whose document is this?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'You have a couple profile. Is this document yours or your partner\'s?';
+
+  @override
+  String get extractionDocMine => 'It\'s mine';
+
+  @override
+  String get extractionDocPartner => 'It\'s my partner\'s';
+
+  @override
   String get chatPickPhoto => 'Take a photo';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -9781,6 +9781,18 @@ class SEs extends S {
   String get shellWelcomeBack => 'De vuelta. Tus números están al día.';
 
   @override
+  String get extractionWhoseDocument => '¿De quién es este documento?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'Tienes un perfil de pareja. ¿Este documento es tuyo o de tu pareja?';
+
+  @override
+  String get extractionDocMine => 'Es mío';
+
+  @override
+  String get extractionDocPartner => 'Es de mi pareja';
+
+  @override
   String get chatPickPhoto => 'Tomar una foto';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -9777,6 +9777,18 @@ class SFr extends S {
   String get shellWelcomeBack => 'De retour. Tes chiffres sont à jour.';
 
   @override
+  String get extractionWhoseDocument => 'À qui est ce document ?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'Tu as un profil couple. Ce document est pour toi ou ton/ta partenaire ?';
+
+  @override
+  String get extractionDocMine => 'C\'est le mien';
+
+  @override
+  String get extractionDocPartner => 'C\'est celui de mon/ma partenaire';
+
+  @override
   String get chatPickPhoto => 'Prendre une photo';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -9807,6 +9807,18 @@ class SIt extends S {
   String get shellWelcomeBack => 'Bentornato. I tuoi numeri sono aggiornati.';
 
   @override
+  String get extractionWhoseDocument => 'Di chi è questo documento?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'Hai un profilo di coppia. Questo documento è tuo o del tuo partner?';
+
+  @override
+  String get extractionDocMine => 'È mio';
+
+  @override
+  String get extractionDocPartner => 'È del mio partner';
+
+  @override
   String get chatPickPhoto => 'Scattare una foto';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -9781,6 +9781,18 @@ class SPt extends S {
   String get shellWelcomeBack => 'De volta. Os teus números estão atualizados.';
 
   @override
+  String get extractionWhoseDocument => 'De quem é este documento?';
+
+  @override
+  String get extractionWhoseDocumentBody => 'Tens um perfil de casal. Este documento é teu ou do teu parceiro?';
+
+  @override
+  String get extractionDocMine => 'É meu';
+
+  @override
+  String get extractionDocPartner => 'É do meu parceiro';
+
+  @override
   String get chatPickPhoto => 'Tirar uma foto';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11410,5 +11410,9 @@
   "chatDocError": "Erro ao analisar o documento. Tenta novamente.",
   "chatDocAttachTooltip": "Digitalizar um documento",
   "seasonalLamalTitle": "Novos prémios LAMal",
-  "seasonalLamalDesc": "Os prémios 2027 foram publicados. Verifica se a tua franquia ainda é ótima."
+  "seasonalLamalDesc": "Os prémios 2027 foram publicados. Verifica se a tua franquia ainda é ótima.",
+  "extractionWhoseDocument": "De quem é este documento?",
+  "extractionWhoseDocumentBody": "Tens um perfil de casal. Este documento é teu ou do teu parceiro?",
+  "extractionDocMine": "É meu",
+  "extractionDocPartner": "É do meu parceiro"
 }

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -1129,6 +1129,7 @@ class CoachProfileProvider extends ChangeNotifier {
     int? lacunesCotisation;
     double? renteEstimee;
     double? ramd;
+    int? bonificationsEduc;
 
     for (final field in fields) {
       if (field.profileField == null) continue;
@@ -1151,6 +1152,10 @@ class CoachProfileProvider extends ChangeNotifier {
         case 'avsRamd':
           if (value is double) ramd = value;
           if (value is int) ramd = value.toDouble();
+        case 'bonificationsEducatives':
+        case 'avsEducationCredits':
+          if (value is double) bonificationsEduc = value.round();
+          if (value is int) bonificationsEduc = value;
       }
     }
 
@@ -1176,10 +1181,20 @@ class CoachProfileProvider extends ChangeNotifier {
       comptes3a: p.prevoyance.comptes3a,
       canContribute3a: p.prevoyance.canContribute3a,
       librePassage: p.prevoyance.librePassage,
+      bonificationsEducatives:
+          bonificationsEduc ?? p.prevoyance.bonificationsEducatives,
+      projectedRenteLpp: p.prevoyance.projectedRenteLpp,
+      projectedCapital65: p.prevoyance.projectedCapital65,
+      disabilityCoverage: p.prevoyance.disabilityCoverage,
+      deathCoverage: p.prevoyance.deathCoverage,
     );
 
     // Tag data sources as certificate-confirmed
     final updatedSources = Map<String, ProfileDataSource>.from(p.dataSources);
+    if (bonificationsEduc != null) {
+      updatedSources['prevoyance.bonificationsEducatives'] =
+          ProfileDataSource.certificate;
+    }
     if (anneesContrib != null) {
       updatedSources['prevoyance.anneesContribuees'] =
           ProfileDataSource.certificate;

--- a/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/extraction_review_screen.dart
@@ -466,6 +466,29 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
             _fields.length;
   }
 
+  /// Ask user whose document this is (for couple profiles).
+  /// Returns true if this is the partner's document.
+  Future<bool> _askWhoseDocument() async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(S.of(ctx)!.extractionWhoseDocument),
+        content: Text(S.of(ctx)!.extractionWhoseDocumentBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(S.of(ctx)!.extractionDocMine),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(S.of(ctx)!.extractionDocPartner),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
   // ── Confirm and navigate ─────────────────────────────────
 
   Future<void> _onConfirmAll() async {
@@ -493,10 +516,22 @@ class _ExtractionReviewScreenState extends State<ExtractionReviewScreen> {
       previousConfidence = currentConfidence.score.round();
     }
 
+    // For couple profiles: ask whose document this is before injecting.
+    final isCouple = coachProvider.hasProfile &&
+        coachProvider.profile!.conjoint != null;
+    final isPartnerDoc = isCouple &&
+        (widget.result.documentType == DocumentType.lppCertificate ||
+         widget.result.documentType == DocumentType.salaryCertificate) &&
+        await _askWhoseDocument();
+
     // Inject extracted data and AWAIT persistence before navigating
     switch (widget.result.documentType) {
       case DocumentType.lppCertificate:
-        await coachProvider.updateFromLppExtraction(_fields);
+        if (isPartnerDoc) {
+          await coachProvider.updateFromPartnerLppExtraction(_fields);
+        } else {
+          await coachProvider.updateFromLppExtraction(_fields);
+        }
       case DocumentType.avsExtract:
         await coachProvider.updateFromAvsExtraction(_fields);
       case DocumentType.taxDeclaration:

--- a/apps/mobile/test/providers/extraction_injection_test.dart
+++ b/apps/mobile/test/providers/extraction_injection_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  // ═══════════════════════════════════════════════════════════
+  //  actualRate parameter on estimateMarginalRate
+  // ═══════════════════════════════════════════════════════════
+
+  group('RetirementTaxCalculator.estimateMarginalRate — actualRate', () {
+    test('actualRate overrides estimation when valid', () {
+      final estimated = RetirementTaxCalculator.estimateMarginalRate(
+        120000, 'ZH',
+      );
+      final withActual = RetirementTaxCalculator.estimateMarginalRate(
+        120000, 'ZH',
+        actualRate: 0.275,
+      );
+      expect(withActual, equals(0.275));
+      expect(withActual, isNot(equals(estimated)));
+    });
+
+    test('actualRate 0.0 falls back to estimation', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+        actualRate: 0.0,
+      );
+      // Should NOT be 0.0 — should be the estimate
+      expect(result, greaterThan(0.05));
+    });
+
+    test('actualRate negative falls back to estimation', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+        actualRate: -0.10,
+      );
+      expect(result, greaterThan(0.05));
+    });
+
+    test('actualRate > 0.5 falls back to estimation', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+        actualRate: 0.60,
+      );
+      expect(result, lessThan(0.5));
+    });
+
+    test('actualRate null uses estimation (backward-compatible)', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+      );
+      expect(result, greaterThan(0.05));
+      expect(result, lessThan(0.5));
+    });
+
+    test('actualRate boundary 0.001 is accepted', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+        actualRate: 0.001,
+      );
+      expect(result, equals(0.001));
+    });
+
+    test('actualRate boundary 0.499 is accepted', () {
+      final result = RetirementTaxCalculator.estimateMarginalRate(
+        100000, 'ZH',
+        actualRate: 0.499,
+      );
+      expect(result, equals(0.499));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
3 critical findings from 7-pass audit methodology:
1. AVS education credits never extracted (field existed but wasn't populated)
2. Partner LPP extraction unreachable (no UI to select "whose cert?")
3. PrevoyanceProfile rebuild lost new fields in AVS extraction

+7 boundary tests for actualRate parameter.

## Test plan
- [x] flutter analyze: 0 errors (2 info warnings)
- [x] flutter test: 8328 passed
- [x] 7 actualRate tests covering all boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)