### PR TITLE
fix: 2 P0 release blockers — tension template + ARB crash

### DIFF
--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -17557,6 +17557,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'De retour. Tes chiffres sont à jour.'**
   String get shellWelcomeBack;
+  String proactiveContractDeadline(String label, String days);
   String get extractionWhoseDocument;
   String get extractionWhoseDocumentBody;
   String get extractionDocMine;

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -9788,6 +9788,15 @@ class SDe extends S {
   String get shellWelcomeBack => 'Wieder da. Deine Zahlen sind aktuell.';
 
   @override
+  String get seasonalLamalTitle => 'Neue KVG-Prämien';
+
+  @override
+  String get seasonalLamalDesc => 'Die Prämien 2027 sind veröffentlicht. Prüfe, ob deine Franchise noch optimal ist.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Erinnerung: \$label läuft in \$days Tagen ab. Plane voraus.';
+
+  @override
   String get extractionWhoseDocument => 'Wessen Dokument ist das?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -9722,6 +9722,15 @@ class SEn extends S {
   String get shellWelcomeBack => 'Back. Your numbers are up to date.';
 
   @override
+  String get seasonalLamalTitle => 'New LAMal premiums';
+
+  @override
+  String get seasonalLamalDesc => '2027 premiums are published. Check if your franchise is still optimal.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Reminder: \$label is due in \$days days. Plan ahead.';
+
+  @override
   String get extractionWhoseDocument => 'Whose document is this?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -9781,6 +9781,15 @@ class SEs extends S {
   String get shellWelcomeBack => 'De vuelta. Tus números están al día.';
 
   @override
+  String get seasonalLamalTitle => 'Nuevas primas LAMal';
+
+  @override
+  String get seasonalLamalDesc => 'Las primas 2027 están publicadas. Verifica si tu franquicia sigue siendo óptima.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Recordatorio: \$label vence en \$days días. Planifica con anticipación.';
+
+  @override
   String get extractionWhoseDocument => '¿De quién es este documento?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -9777,6 +9777,15 @@ class SFr extends S {
   String get shellWelcomeBack => 'De retour. Tes chiffres sont à jour.';
 
   @override
+  String get seasonalLamalTitle => 'Nouvelles primes LAMal';
+
+  @override
+  String get seasonalLamalDesc => 'Les primes 2027 sont publiées. Vérifie si ta franchise est toujours optimale.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Rappel : \$label arrive dans \$days jours. Pense à anticiper.';
+
+  @override
   String get extractionWhoseDocument => 'À qui est ce document ?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -9807,6 +9807,15 @@ class SIt extends S {
   String get shellWelcomeBack => 'Bentornato. I tuoi numeri sono aggiornati.';
 
   @override
+  String get seasonalLamalTitle => 'Nuovi premi LAMal';
+
+  @override
+  String get seasonalLamalDesc => 'I premi 2027 sono pubblicati. Verifica se la tua franchigia è ancora ottimale.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Promemoria: \$label scade tra \$days giorni. Pianifica in anticipo.';
+
+  @override
   String get extractionWhoseDocument => 'Di chi è questo documento?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -9781,6 +9781,15 @@ class SPt extends S {
   String get shellWelcomeBack => 'De volta. Os teus números estão atualizados.';
 
   @override
+  String get seasonalLamalTitle => 'Novos prémios LAMal';
+
+  @override
+  String get seasonalLamalDesc => 'Os prémios 2027 foram publicados. Verifica se a tua franquia ainda é ótima.';
+
+  @override
+  String proactiveContractDeadline(String label, String days) => 'Lembrete: \$label vence em \$days dias. Planeia com antecedência.';
+
+  @override
   String get extractionWhoseDocument => 'De quem é este documento?';
 
   @override

--- a/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
+++ b/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
@@ -301,6 +301,7 @@ class SequenceChatHandler {
       SequenceTemplate.housingPurchase,
       SequenceTemplate.optimize3a,
       SequenceTemplate.retirementPrep,
+      SequenceTemplate.financialTension,
     ];
     for (final t in templates) {
       if (t.id == id) return t;


### PR DESCRIPTION
## Summary
2 release-blocking bugs from external 5-team audit:
1. financial_tension template unreachable in _templateById()
2. proactiveContractDeadline/seasonalLamal missing in generated locales

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8328 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)