### PR TITLE
fix: P1 audit — age boundary + quitSequence + PII logs

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -3241,8 +3241,8 @@ class _CoachChatScreenState extends State<CoachChatScreen>
       onAdvance: (payload.canAdvance && payload.nextRoute != null) ? () {
         _navigateToSequenceStep(payload);
       } : null,
-      onQuit: payload.canQuit ? () {
-        SequenceChatHandler.quitSequence();
+      onQuit: payload.canQuit ? () async {
+        await SequenceChatHandler.quitSequence();
         if (mounted) {
           setState(() {
             _messages.add(ChatMessage(

--- a/apps/mobile/lib/services/lifecycle_phase_service.dart
+++ b/apps/mobile/lib/services/lifecycle_phase_service.dart
@@ -165,7 +165,7 @@ class LifecyclePhaseService {
 
     // Standard age-based detection
     if (age < 28) return LifecyclePhase.demarrage;
-    if (age < 35) return LifecyclePhase.construction;
+    if (age < 38) return LifecyclePhase.construction;  // Spec: 28-37 (§6)
     if (age < 45) return LifecyclePhase.acceleration;
     if (age < 55) return LifecyclePhase.consolidation;
     if (age < reg('avs.reference_age_men', avsAgeReferenceHomme.toDouble()).toInt()) return LifecyclePhase.transition;

--- a/apps/mobile/test/services/adaptive_challenge_service_test.dart
+++ b/apps/mobile/test/services/adaptive_challenge_service_test.dart
@@ -63,7 +63,7 @@ void main() {
   group('AdaptiveChallengeService', () {
     // ── Test 1: returns challenge matching user's phase ──
     test('getWeeklyChallenge returns challenge matching user phase', () async {
-      final profile = _makeProfile(birthYear: 1990); // age ~36 → acceleration
+      final profile = _makeProfile(birthYear: 1986); // age ~40 → acceleration
       final lifecycle = _lifecycle(profile, now: testDate);
       expect(lifecycle.phase, LifecyclePhase.acceleration);
 

--- a/apps/mobile/test/services/lifecycle_phase_service_test.dart
+++ b/apps/mobile/test/services/lifecycle_phase_service_test.dart
@@ -117,7 +117,7 @@ void main() {
       expect(result.tone, equals(LifecycleTone.encouraging));
     });
 
-    // ── Phase 3: Accélération (35-44) ───────────────────────────
+    // ── Phase 3: Accélération (38-44) ───────────────────────────
     test('age 40 → Accélération', () {
       final profile = makeProfile(birthYear: 1986);
       final result = LifecyclePhaseService.detect(profile, now: now);
@@ -177,8 +177,14 @@ void main() {
       expect(result.phase, equals(LifecyclePhase.construction));
     });
 
-    test('age 35 → Accélération (boundary)', () {
+    test('age 35 → Construction (spec §6: 28-37)', () {
       final profile = makeProfile(birthYear: 1991);
+      final result = LifecyclePhaseService.detect(profile, now: now);
+      expect(result.phase, equals(LifecyclePhase.construction));
+    });
+
+    test('age 38 → Accélération (boundary)', () {
+      final profile = makeProfile(birthYear: 1988);
       final result = LifecyclePhaseService.detect(profile, now: now);
       expect(result.phase, equals(LifecyclePhase.acceleration));
     });

--- a/services/backend/app/api/v1/endpoints/documents.py
+++ b/services/backend/app/api/v1/endpoints/documents.py
@@ -594,7 +594,7 @@ async def confirm_document_scan(
     """
     logger.info(
         "Scan confirmation: user=%s type=%s fields=%d confidence=%.2f method=%s",
-        current_user.id,
+        str(current_user.id)[:8] + "...",  # Truncate PII
         body.document_type.value,
         len(body.confirmed_fields),
         body.overall_confidence,
@@ -604,7 +604,7 @@ async def confirm_document_scan(
     # Store scan metadata for audit trail
     scan_record = {
         "id": str(uuid.uuid4()),
-        "user_id": str(current_user.id),
+        "user_id": str(current_user.id)[:8],  # Truncated for privacy
         "document_type": body.document_type.value,
         "fields": [f.model_dump() for f in body.confirmed_fields],
         "overall_confidence": body.overall_confidence,


### PR DESCRIPTION
## Summary
3 P1 fixes from external 5-team audit:
1. Age boundary construction aligned with spec (35→38)
2. quitSequence properly awaited
3. user.id truncated in backend logs

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8329 passed (+1 boundary test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)