### PR TITLE
feat: Phase 6B — 11-step pre-retirement journey

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11432,5 +11432,17 @@
   "capCoachPromptDivorce": "I'm divorced. Wie can I protect my financial situation?",
   "capCoachPromptCoupleOptim": "Wie can we optimize our pension planning as a couple?",
   "capCoachPromptCouple": "We're a couple. Wie should we coordinate our finances?",
-  "capCoachPromptMarried": "We're both working and married. Wie can we optimize?"
+  "capCoachPromptMarried": "We're both working and married. Wie can we optimize?",
+  "sequencePreretraiteGoal": "Prepare my retirement",
+  "sequencePreretraiteStep1": "Retirement projection",
+  "sequencePreretraiteStep2": "3a review",
+  "sequencePreretraiteStep3": "Annuity or capital",
+  "sequencePreretraiteStep4": "Optimal 3a withdrawal",
+  "sequencePreretraiteStep5": "Mortgage",
+  "sequencePreretraiteStep6": "LPP buyback",
+  "sequencePreretraiteStep7": "LAMal franchise",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Retirement budget",
+  "sequencePreretraiteStep10": "Withdrawal plan",
+  "sequencePreretraiteStep11": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11460,5 +11460,17 @@
   "capCoachPromptDivorce": "I'm divorced. How can I protect my financial situation?",
   "capCoachPromptCoupleOptim": "How can we optimize our pension planning as a couple?",
   "capCoachPromptCouple": "We're a couple. How should we coordinate our finances?",
-  "capCoachPromptMarried": "We're both working and married. How can we optimize?"
+  "capCoachPromptMarried": "We're both working and married. How can we optimize?",
+  "sequencePreretraiteGoal": "Prepare my retirement",
+  "sequencePreretraiteStep1": "Retirement projection",
+  "sequencePreretraiteStep2": "3a review",
+  "sequencePreretraiteStep3": "Annuity or capital",
+  "sequencePreretraiteStep4": "Optimal 3a withdrawal",
+  "sequencePreretraiteStep5": "Mortgage",
+  "sequencePreretraiteStep6": "LPP buyback",
+  "sequencePreretraiteStep7": "LAMal franchise",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Retirement budget",
+  "sequencePreretraiteStep10": "Withdrawal plan",
+  "sequencePreretraiteStep11": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11425,5 +11425,17 @@
   "capCoachPromptDivorce": "I'm divorced. Cómo can I protect my financial situation?",
   "capCoachPromptCoupleOptim": "Cómo can we optimize our pension planning as a couple?",
   "capCoachPromptCouple": "We're a couple. Cómo should we coordinate our finances?",
-  "capCoachPromptMarried": "We're both working and married. Cómo can we optimize?"
+  "capCoachPromptMarried": "We're both working and married. Cómo can we optimize?",
+  "sequencePreretraiteGoal": "Prepare my retirement",
+  "sequencePreretraiteStep1": "Retirement projection",
+  "sequencePreretraiteStep2": "3a review",
+  "sequencePreretraiteStep3": "Annuity or capital",
+  "sequencePreretraiteStep4": "Optimal 3a withdrawal",
+  "sequencePreretraiteStep5": "Mortgage",
+  "sequencePreretraiteStep6": "LPP buyback",
+  "sequencePreretraiteStep7": "LAMal franchise",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Retirement budget",
+  "sequencePreretraiteStep10": "Withdrawal plan",
+  "sequencePreretraiteStep11": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11907,5 +11907,17 @@
   "capCoachPromptDivorce": "Je suis divorcé·e. Comment protéger ma situation financière ?",
   "capCoachPromptCoupleOptim": "Comment optimiser notre prévoyance à deux ?",
   "capCoachPromptCouple": "Nous sommes en couple. Comment coordonner nos finances ?",
-  "capCoachPromptMarried": "Nous sommes mariés et nous travaillons tous les deux. Comment optimiser ?"
+  "capCoachPromptMarried": "Nous sommes mariés et nous travaillons tous les deux. Comment optimiser ?",
+  "sequencePreretraiteGoal": "Préparer ma retraite",
+  "sequencePreretraiteStep1": "Projection retraite",
+  "sequencePreretraiteStep2": "Bilan 3a",
+  "sequencePreretraiteStep3": "Rente ou capital",
+  "sequencePreretraiteStep4": "Retrait 3a optimal",
+  "sequencePreretraiteStep5": "Hypothèque",
+  "sequencePreretraiteStep6": "Rachat LPP",
+  "sequencePreretraiteStep7": "Franchise LAMal",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Budget retraite",
+  "sequencePreretraiteStep10": "Décaissement",
+  "sequencePreretraiteStep11": "Résumé"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11425,5 +11425,17 @@
   "capCoachPromptDivorce": "I'm divorced. Come can I protect my financial situation?",
   "capCoachPromptCoupleOptim": "Come can we optimize our pension planning as a couple?",
   "capCoachPromptCouple": "We're a couple. Come should we coordinate our finances?",
-  "capCoachPromptMarried": "We're both working and married. Come can we optimize?"
+  "capCoachPromptMarried": "We're both working and married. Come can we optimize?",
+  "sequencePreretraiteGoal": "Prepare my retirement",
+  "sequencePreretraiteStep1": "Retirement projection",
+  "sequencePreretraiteStep2": "3a review",
+  "sequencePreretraiteStep3": "Annuity or capital",
+  "sequencePreretraiteStep4": "Optimal 3a withdrawal",
+  "sequencePreretraiteStep5": "Mortgage",
+  "sequencePreretraiteStep6": "LPP buyback",
+  "sequencePreretraiteStep7": "LAMal franchise",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Retirement budget",
+  "sequencePreretraiteStep10": "Withdrawal plan",
+  "sequencePreretraiteStep11": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -17557,6 +17557,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'De retour. Tes chiffres sont à jour.'**
   String get shellWelcomeBack;
+  String get sequencePreretraiteGoal;
   String get capCoachPromptDebt;
   String get capCoachPromptIndepNoLpp;
   String get capCoachPrompt3a;

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -9788,6 +9788,9 @@ class SDe extends S {
   String get shellWelcomeBack => 'Wieder da. Deine Zahlen sind aktuell.';
 
   @override
+  String get sequencePreretraiteGoal => 'Prepare my retirement';
+
+  @override
   String get capCoachPromptDebt => 'Hilf mir prioritize my debt repayment. Where should I start?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -9722,6 +9722,9 @@ class SEn extends S {
   String get shellWelcomeBack => 'Back. Your numbers are up to date.';
 
   @override
+  String get sequencePreretraiteGoal => 'Prepare my retirement';
+
+  @override
   String get capCoachPromptDebt => 'Help me prioritize my debt repayment. Where should I start?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -9781,6 +9781,9 @@ class SEs extends S {
   String get shellWelcomeBack => 'De vuelta. Tus números están al día.';
 
   @override
+  String get sequencePreretraiteGoal => 'Prepare my retirement';
+
+  @override
   String get capCoachPromptDebt => 'Ayúdame prioritize my debt repayment. Where should I start?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -9777,6 +9777,9 @@ class SFr extends S {
   String get shellWelcomeBack => 'De retour. Tes chiffres sont à jour.';
 
   @override
+  String get sequencePreretraiteGoal => 'Préparer ma retraite';
+
+  @override
   String get capCoachPromptDebt => 'Aide-moi à prioriser le remboursement de mes dettes. Par quoi commencer\u00a0?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -9807,6 +9807,9 @@ class SIt extends S {
   String get shellWelcomeBack => 'Bentornato. I tuoi numeri sono aggiornati.';
 
   @override
+  String get sequencePreretraiteGoal => 'Prepare my retirement';
+
+  @override
   String get capCoachPromptDebt => 'Aiutami prioritize my debt repayment. Where should I start?';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -9781,6 +9781,9 @@ class SPt extends S {
   String get shellWelcomeBack => 'De volta. Os teus números estão atualizados.';
 
   @override
+  String get sequencePreretraiteGoal => 'Prepare my retirement';
+
+  @override
   String get capCoachPromptDebt => 'Ajuda-me prioritize my debt repayment. Where should I start?';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11426,5 +11426,17 @@
   "capCoachPromptDivorce": "I'm divorced. Como can I protect my financial situation?",
   "capCoachPromptCoupleOptim": "Como can we optimize our pension planning as a couple?",
   "capCoachPromptCouple": "We're a couple. Como should we coordinate our finances?",
-  "capCoachPromptMarried": "We're both working and married. Como can we optimize?"
+  "capCoachPromptMarried": "We're both working and married. Como can we optimize?",
+  "sequencePreretraiteGoal": "Prepare my retirement",
+  "sequencePreretraiteStep1": "Retirement projection",
+  "sequencePreretraiteStep2": "3a review",
+  "sequencePreretraiteStep3": "Annuity or capital",
+  "sequencePreretraiteStep4": "Optimal 3a withdrawal",
+  "sequencePreretraiteStep5": "Mortgage",
+  "sequencePreretraiteStep6": "LPP buyback",
+  "sequencePreretraiteStep7": "LAMal franchise",
+  "sequencePreretraiteStep8": "Succession",
+  "sequencePreretraiteStep9": "Retirement budget",
+  "sequencePreretraiteStep10": "Withdrawal plan",
+  "sequencePreretraiteStep11": "Summary"
 }

--- a/apps/mobile/lib/models/sequence_template.dart
+++ b/apps/mobile/lib/models/sequence_template.dart
@@ -198,6 +198,110 @@ class SequenceTemplate {
     ],
   );
 
+  /// Pré-retraite complète (11 étapes) — cohorte 53-64.
+  ///
+  /// Parcours flagship pré-retraite selon COHORT_OS_SPEC.md.
+  /// Phase 1: Clarifier (scan LPP, AVS, 3a recap)
+  /// Phase 2: Arbitrer (rente vs capital, 3a retrait, hypothèque)
+  /// Phase 3: Préparer (rachat LPP, LAMal, succession)
+  /// Phase 4: Agir (budget post-retraite, résumé)
+  static const preretraiteComplete = SequenceTemplate(
+    id: 'preretraite_complete',
+    goalLabelKey: 'sequencePreretraiteGoal',
+    steps: [
+      // Phase 1: Clarifier
+      SequenceStepDef(
+        id: 'pre_01_projection',
+        order: 1,
+        intentTag: 'retirement_projection',
+        titleKey: 'sequencePreretraiteStep1',
+        outputMapping: {
+          'taux_remplacement': 'taux_remplacement',
+          'gap_mensuel': 'gap_mensuel',
+        },
+      ),
+      SequenceStepDef(
+        id: 'pre_02_3a',
+        order: 2,
+        intentTag: 'simulator_3a',
+        titleKey: 'sequencePreretraiteStep2',
+        outputMapping: {
+          'contribution_annuelle': 'contribution_annuelle',
+          'economie_fiscale': 'economie_fiscale',
+        },
+      ),
+      // Phase 2: Arbitrer
+      SequenceStepDef(
+        id: 'pre_03_choice',
+        order: 3,
+        intentTag: 'retirement_choice',
+        titleKey: 'sequencePreretraiteStep3',
+        outputMapping: {'decision_mixte': 'decision_mixte'},
+      ),
+      SequenceStepDef(
+        id: 'pre_04_withdrawal',
+        order: 4,
+        intentTag: 'tax_optimization_3a',
+        titleKey: 'sequencePreretraiteStep4',
+        outputMapping: {'gain_echelonnement': 'gain_echelonnement'},
+      ),
+      SequenceStepDef(
+        id: 'pre_05_mortgage',
+        order: 5,
+        intentTag: 'mortgage_amortization',
+        titleKey: 'sequencePreretraiteStep5',
+        isOptional: true,
+      ),
+      // Phase 3: Préparer
+      SequenceStepDef(
+        id: 'pre_06_buyback',
+        order: 6,
+        intentTag: 'lpp_buyback',
+        titleKey: 'sequencePreretraiteStep6',
+        outputMapping: {'economie_rachat': 'economie_rachat'},
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'pre_07_lamal',
+        order: 7,
+        intentTag: 'lamal_franchise',
+        titleKey: 'sequencePreretraiteStep7',
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'pre_08_succession',
+        order: 8,
+        intentTag: 'succession_patrimoine',
+        titleKey: 'sequencePreretraiteStep8',
+        isOptional: true,
+      ),
+      // Phase 4: Agir
+      SequenceStepDef(
+        id: 'pre_09_budget',
+        order: 9,
+        intentTag: 'budget_overview',
+        titleKey: 'sequencePreretraiteStep9',
+        outputMapping: {
+          'revenu_net': 'revenu_net_retraite',
+          'charges_totales': 'charges_retraite',
+        },
+      ),
+      SequenceStepDef(
+        id: 'pre_10_decaissement',
+        order: 10,
+        intentTag: 'withdrawal_sequencing',
+        titleKey: 'sequencePreretraiteStep10',
+      ),
+      SequenceStepDef(
+        id: 'pre_11_summary',
+        order: 11,
+        intentTag: '_inline_summary',
+        titleKey: 'sequencePreretraiteStep11',
+        isOptional: true,
+      ),
+    ],
+  );
+
   /// Sortir d'une tension financière (4 étapes)
   ///
   /// Parcours flagship #2 — douleur réelle, forte fréquence.
@@ -256,6 +360,7 @@ class SequenceTemplate {
     return switch (intentTag) {
       'housing_purchase' => housingPurchase,
       'retirement_choice' || 'retirement_projection' => retirementPrep,
+      'preretraite_complete' => preretraiteComplete,
       'simulator_3a' || 'tax_optimization_3a' => optimize3a,
       'debt_ratio' || 'debt_repayment' || 'debt_risk_check' => financialTension,
       _ => null,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -3218,6 +3218,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
       'sequence3aGoal' => l.sequence3aGoal,
       'sequenceRetirementGoal' => l.sequenceRetirementGoal,
       'sequenceTensionGoal' => l.sequenceTensionGoal,
+      'sequencePreretraiteGoal' => l.sequencePreretraiteGoal,
       _ => key, // Fallback to raw key if unknown
     };
   }

--- a/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
+++ b/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
@@ -302,6 +302,7 @@ class SequenceChatHandler {
       SequenceTemplate.optimize3a,
       SequenceTemplate.retirementPrep,
       SequenceTemplate.financialTension,
+      SequenceTemplate.preretraiteComplete,
     ];
     for (final t in templates) {
       if (t.id == id) return t;

--- a/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
+++ b/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
@@ -31,6 +31,7 @@ List<SequenceSummaryItem> buildSequenceSummary({
     'optimize_3a' => _build3aSummary(allOutputs, loc),
     'retirement_prep' => _buildRetirementSummary(allOutputs, loc),
     'financial_tension' => _buildTensionSummary(allOutputs, loc),
+    'preretraite_complete' => _buildPreretraiteSummary(allOutputs, loc),
     _ => const [],
   };
 }
@@ -272,6 +273,77 @@ List<SequenceSummaryItem> _buildTensionSummary(
       icon: Icons.payments_outlined,
       label: l.summaryVersementMensuel,
       value: 'CHF\u00a0${formatChf(versement.toDouble())}',
+    ));
+  }
+
+  return items;
+}
+
+List<SequenceSummaryItem> _buildPreretraiteSummary(
+  Map<String, Map<String, dynamic>> outputs, S l,
+) {
+  final items = <SequenceSummaryItem>[];
+
+  // Step 1: Projection
+  final step1 = outputs['pre_01_projection'];
+  final taux = step1?['taux_remplacement'];
+  if (taux is num && taux > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.speed_outlined,
+      label: l.summaryTauxRemplacement,
+      value: '${taux.toStringAsFixed(0)}\u00a0%',
+    ));
+  }
+  final gap = step1?['gap_mensuel'];
+  if (gap is num && gap > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.warning_amber_outlined,
+      label: l.summaryEcartMensuel,
+      value: 'CHF\u00a0${formatChf(gap.toDouble())}',
+    ));
+  }
+
+  // Step 2: 3a
+  final step2 = outputs['pre_02_3a'];
+  final economieFiscale = step2?['economie_fiscale'];
+  if (economieFiscale is num && economieFiscale > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.discount_outlined,
+      label: l.summaryEconomieFiscale,
+      value: 'CHF\u00a0${formatChf(economieFiscale.toDouble())}',
+    ));
+  }
+
+  // Step 3: Rente vs Capital choice
+  final step3 = outputs['pre_03_choice'];
+  final decision = step3?['decision_mixte'];
+  if (decision is String && decision.isNotEmpty) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.check_circle_outline,
+      label: l.summaryChoixRenteCapital,
+      value: '✓',
+    ));
+  }
+
+  // Step 4: 3a withdrawal optimization
+  final step4 = outputs['pre_04_withdrawal'];
+  final gainEch = step4?['gain_echelonnement'];
+  if (gainEch is num && gainEch > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.timeline_outlined,
+      label: l.summaryGainEchelonnement,
+      value: 'CHF\u00a0${formatChf(gainEch.toDouble())}',
+    ));
+  }
+
+  // Step 6: LPP buyback (optional)
+  final step6 = outputs['pre_06_buyback'];
+  final economieRachat = step6?['economie_rachat'];
+  if (economieRachat is num && economieRachat > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.trending_up_outlined,
+      label: l.summaryEconomieRachat,
+      value: 'CHF\u00a0${formatChf(economieRachat.toDouble())}',
     ));
   }
 


### PR DESCRIPTION
## Summary
Flagship pre-retirement journey for 53-64 cohort: 11 steps across
4 phases (Clarifier → Arbitrer → Préparer → Agir).
Reuses all existing Tier A screens.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8329 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)