### PR TITLE
feat: RAG freshness boost + embedder tests

### DIFF
--- a/apps/mobile/lib/services/memory/coach_memory_service.dart
+++ b/apps/mobile/lib/services/memory/coach_memory_service.dart
@@ -76,7 +76,7 @@ class CoachMemoryService {
       if (token == null) return;
 
       await http.post(
-        Uri.parse('$baseUrl/api/v1/coach/chat/sync-insight'),
+        Uri.parse('$baseUrl/api/v1/coach/sync-insight'),
         headers: {
           'Authorization': 'Bearer $token',
           'Content-Type': 'application/json',

--- a/services/backend/app/services/rag/hybrid_search_service.py
+++ b/services/backend/app/services/rag/hybrid_search_service.py
@@ -80,7 +80,14 @@ SELECT COALESCE(v.doc_id, k.doc_id) AS doc_id,
        COALESCE(v.doc_type, k.doc_type) AS doc_type,
        COALESCE(v.vector_score, 0) AS vector_score,
        COALESCE(k.keyword_score, 0) AS keyword_score,
-       (0.7 * COALESCE(v.vector_score, 0) + 0.3 * COALESCE(k.keyword_score, 0)) AS fused_score
+       (0.7 * COALESCE(v.vector_score, 0) + 0.3 * COALESCE(k.keyword_score, 0))
+       * CASE
+           WHEN COALESCE(v.doc_type, k.doc_type) = 'memory'
+                AND COALESCE(v.metadata, k.metadata)::jsonb ? 'created_at'
+                AND (NOW() - (COALESCE(v.metadata, k.metadata)::jsonb->>'created_at')::timestamptz) < INTERVAL '30 days'
+           THEN 1.2  -- 20% freshness boost for recent memories
+           ELSE 1.0
+         END AS fused_score
 FROM vector_results v
 FULL OUTER JOIN keyword_results k ON v.doc_id = k.doc_id
 WHERE (0.7 * COALESCE(v.vector_score, 0) + 0.3 * COALESCE(k.keyword_score, 0)) >= %(min_score)s

--- a/services/backend/tests/test_insight_embedder.py
+++ b/services/backend/tests/test_insight_embedder.py
@@ -1,0 +1,92 @@
+"""Tests for insight_embedder — RAG memory embedding logic.
+
+Tests the pure logic (metadata building, validation) without requiring
+pgvector or OpenAI API. Integration tests would need a real database.
+"""
+
+import pytest
+import json
+from datetime import datetime, timezone
+
+from app.services.rag.insight_embedder import (
+    _build_metadata,
+    embed_insight,
+    remove_insight,
+)
+
+
+class TestBuildMetadata:
+    """Test metadata construction for pgvector storage."""
+
+    def test_basic_metadata(self):
+        result = _build_metadata("lpp", "fact", None, None)
+        data = json.loads(result)
+        assert data["topic"] == "lpp"
+        assert data["insight_type"] == "fact"
+        assert data["is_memory"] is True
+
+    def test_metadata_with_timestamp(self):
+        ts = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+        result = _build_metadata("retraite", "goal", None, ts)
+        data = json.loads(result)
+        assert "2026-03-28" in data["created_at"]
+
+    def test_metadata_filters_pii(self):
+        """Only safe keys from metadata are stored."""
+        meta = {
+            "templateId": "housing_purchase",
+            "stepCount": 4,
+            "documentType": "lpp_certificate",
+            "salary": 120000,  # PII — should be filtered
+            "employer": "ACME Corp",  # PII — should be filtered
+        }
+        result = _build_metadata("3a", "decision", meta, None)
+        data = json.loads(result)
+        assert data["templateId"] == "housing_purchase"
+        assert data["stepCount"] == 4
+        assert data["documentType"] == "lpp_certificate"
+        assert "salary" not in data
+        assert "employer" not in data
+
+    def test_metadata_empty_when_no_extras(self):
+        result = _build_metadata("budget", "concern", {}, None)
+        data = json.loads(result)
+        assert data["topic"] == "budget"
+        assert "salary" not in data
+
+
+class TestEmbedInsightWithoutDB:
+    """Test embed_insight behavior when no DATABASE_URL is set."""
+
+    @pytest.mark.asyncio
+    async def test_no_database_url_returns_false(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        result = await embed_insight(
+            insight_id="test-1",
+            topic="lpp",
+            summary="Avoir LPP de ~350k confirmé par certificat",
+            insight_type="fact",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_no_openai_key_returns_false(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = await embed_insight(
+            insight_id="test-2",
+            topic="retraite",
+            summary="Taux de remplacement ~65%, gap mensuel ~2500 CHF",
+            insight_type="fact",
+        )
+        assert result is False
+
+
+class TestRemoveInsightWithoutDB:
+    """Test remove_insight behavior when no DATABASE_URL is set."""
+
+    @pytest.mark.asyncio
+    async def test_no_database_returns_false(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        result = await remove_insight("nonexistent-id")
+        assert result is False


### PR DESCRIPTION
## Summary
- Memories < 30 days get 20% score boost in hybrid search
- 7 tests for insight_embedder (metadata, PII filter, fallbacks)
- Route fix: /coach/sync-insight

🤖 Generated with [Claude Code](https://claude.com/claude-code)