### PR TITLE
feat: Phase 6B — Couple Financier + Naissance (28-37)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11445,5 +11445,16 @@
   "sequencePreretraiteStep9": "Retirement budget",
   "sequencePreretraiteStep10": "Withdrawal plan",
   "sequencePreretraiteStep11": "Summary",
-  "proactiveContractDeadline": "Erinnerung: {label} läuft in {days} Tagen ab. Plane voraus."
+  "proactiveContractDeadline": "Erinnerung: {label} läuft in {days} Tagen ab. Plane voraus.",
+  "sequenceCoupleGoal": "Coordinate finances together",
+  "sequenceCoupleStep1": "Marriage or partnership",
+  "sequenceCoupleStep2": "Couple profile",
+  "sequenceCoupleStep3": "3a together",
+  "sequenceCoupleStep4": "Couple taxation",
+  "sequenceCoupleStep5": "Summary",
+  "sequenceNaissanceGoal": "Prepare for baby financially",
+  "sequenceNaissanceStep1": "Birth impact",
+  "sequenceNaissanceStep2": "Family budget",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11473,5 +11473,16 @@
   "sequencePreretraiteStep9": "Retirement budget",
   "sequencePreretraiteStep10": "Withdrawal plan",
   "sequencePreretraiteStep11": "Summary",
-  "proactiveContractDeadline": "Reminder: {label} is due in {days} days. Plan ahead."
+  "proactiveContractDeadline": "Reminder: {label} is due in {days} days. Plan ahead.",
+  "sequenceCoupleGoal": "Coordinate finances together",
+  "sequenceCoupleStep1": "Marriage or partnership",
+  "sequenceCoupleStep2": "Couple profile",
+  "sequenceCoupleStep3": "3a together",
+  "sequenceCoupleStep4": "Couple taxation",
+  "sequenceCoupleStep5": "Summary",
+  "sequenceNaissanceGoal": "Prepare for baby financially",
+  "sequenceNaissanceStep1": "Birth impact",
+  "sequenceNaissanceStep2": "Family budget",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11438,5 +11438,16 @@
   "sequencePreretraiteStep9": "Retirement budget",
   "sequencePreretraiteStep10": "Withdrawal plan",
   "sequencePreretraiteStep11": "Summary",
-  "proactiveContractDeadline": "Recordatorio: {label} vence en {days} días. Planifica con anticipación."
+  "proactiveContractDeadline": "Recordatorio: {label} vence en {days} días. Planifica con anticipación.",
+  "sequenceCoupleGoal": "Coordinate finances together",
+  "sequenceCoupleStep1": "Marriage or partnership",
+  "sequenceCoupleStep2": "Couple profile",
+  "sequenceCoupleStep3": "3a together",
+  "sequenceCoupleStep4": "Couple taxation",
+  "sequenceCoupleStep5": "Summary",
+  "sequenceNaissanceGoal": "Prepare for baby financially",
+  "sequenceNaissanceStep1": "Birth impact",
+  "sequenceNaissanceStep2": "Family budget",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11920,5 +11920,16 @@
   "sequencePreretraiteStep9": "Budget retraite",
   "sequencePreretraiteStep10": "Décaissement",
   "sequencePreretraiteStep11": "Résumé",
-  "proactiveContractDeadline": "Rappel : {label} arrive dans {days} jours. Pense à anticiper."
+  "proactiveContractDeadline": "Rappel : {label} arrive dans {days} jours. Pense à anticiper.",
+  "sequenceCoupleGoal": "Coordonner nos finances à deux",
+  "sequenceCoupleStep1": "Mariage ou concubinage",
+  "sequenceCoupleStep2": "Profil couple",
+  "sequenceCoupleStep3": "3a à deux",
+  "sequenceCoupleStep4": "Fiscalité couple",
+  "sequenceCoupleStep5": "Résumé",
+  "sequenceNaissanceGoal": "Préparer l'arrivée financièrement",
+  "sequenceNaissanceStep1": "Impact naissance",
+  "sequenceNaissanceStep2": "Budget famille",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Résumé"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11438,5 +11438,16 @@
   "sequencePreretraiteStep9": "Retirement budget",
   "sequencePreretraiteStep10": "Withdrawal plan",
   "sequencePreretraiteStep11": "Summary",
-  "proactiveContractDeadline": "Promemoria: {label} scade tra {days} giorni. Pianifica in anticipo."
+  "proactiveContractDeadline": "Promemoria: {label} scade tra {days} giorni. Pianifica in anticipo.",
+  "sequenceCoupleGoal": "Coordinate finances together",
+  "sequenceCoupleStep1": "Marriage or partnership",
+  "sequenceCoupleStep2": "Couple profile",
+  "sequenceCoupleStep3": "3a together",
+  "sequenceCoupleStep4": "Couple taxation",
+  "sequenceCoupleStep5": "Summary",
+  "sequenceNaissanceGoal": "Prepare for baby financially",
+  "sequenceNaissanceStep1": "Birth impact",
+  "sequenceNaissanceStep2": "Family budget",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -17557,6 +17557,8 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'De retour. Tes chiffres sont à jour.'**
   String get shellWelcomeBack;
+  String get sequenceCoupleGoal;
+  String get sequenceNaissanceGoal;
   String get sequencePreretraiteGoal;
   String get capCoachPromptDebt;
   String get capCoachPromptIndepNoLpp;

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -9788,6 +9788,12 @@ class SDe extends S {
   String get shellWelcomeBack => 'Wieder da. Deine Zahlen sind aktuell.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordinate finances together';
+
+  @override
+  String get sequenceNaissanceGoal => 'Prepare for baby financially';
+
+  @override
   String get sequencePreretraiteGoal => 'Prepare my retirement';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -9722,6 +9722,12 @@ class SEn extends S {
   String get shellWelcomeBack => 'Back. Your numbers are up to date.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordinate finances together';
+
+  @override
+  String get sequenceNaissanceGoal => 'Prepare for baby financially';
+
+  @override
   String get sequencePreretraiteGoal => 'Prepare my retirement';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -9781,6 +9781,12 @@ class SEs extends S {
   String get shellWelcomeBack => 'De vuelta. Tus números están al día.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordinate finances together';
+
+  @override
+  String get sequenceNaissanceGoal => 'Prepare for baby financially';
+
+  @override
   String get sequencePreretraiteGoal => 'Prepare my retirement';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -9777,6 +9777,12 @@ class SFr extends S {
   String get shellWelcomeBack => 'De retour. Tes chiffres sont à jour.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordonner nos finances à deux';
+
+  @override
+  String get sequenceNaissanceGoal => 'Préparer l\'arrivée financièrement';
+
+  @override
   String get sequencePreretraiteGoal => 'Préparer ma retraite';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -9807,6 +9807,12 @@ class SIt extends S {
   String get shellWelcomeBack => 'Bentornato. I tuoi numeri sono aggiornati.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordinate finances together';
+
+  @override
+  String get sequenceNaissanceGoal => 'Prepare for baby financially';
+
+  @override
   String get sequencePreretraiteGoal => 'Prepare my retirement';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -9781,6 +9781,12 @@ class SPt extends S {
   String get shellWelcomeBack => 'De volta. Os teus números estão atualizados.';
 
   @override
+  String get sequenceCoupleGoal => 'Coordinate finances together';
+
+  @override
+  String get sequenceNaissanceGoal => 'Prepare for baby financially';
+
+  @override
   String get sequencePreretraiteGoal => 'Prepare my retirement';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11439,5 +11439,16 @@
   "sequencePreretraiteStep9": "Retirement budget",
   "sequencePreretraiteStep10": "Withdrawal plan",
   "sequencePreretraiteStep11": "Summary",
-  "proactiveContractDeadline": "Lembrete: {label} vence em {days} dias. Planeia com antecedência."
+  "proactiveContractDeadline": "Lembrete: {label} vence em {days} dias. Planeia com antecedência.",
+  "sequenceCoupleGoal": "Coordinate finances together",
+  "sequenceCoupleStep1": "Marriage or partnership",
+  "sequenceCoupleStep2": "Couple profile",
+  "sequenceCoupleStep3": "3a together",
+  "sequenceCoupleStep4": "Couple taxation",
+  "sequenceCoupleStep5": "Summary",
+  "sequenceNaissanceGoal": "Prepare for baby financially",
+  "sequenceNaissanceStep1": "Birth impact",
+  "sequenceNaissanceStep2": "Family budget",
+  "sequenceNaissanceStep3": "3a parent",
+  "sequenceNaissanceStep4": "Summary"
 }

--- a/apps/mobile/lib/models/sequence_template.dart
+++ b/apps/mobile/lib/models/sequence_template.dart
@@ -351,6 +351,97 @@ class SequenceTemplate {
     ],
   );
 
+  /// Couple financier (5 étapes) — cohorte 28-37.
+  ///
+  /// Mariage vs concubinage, fiscalité couple, 3a couple,
+  /// coordination LPP, résumé.
+  static const coupleFinancier = SequenceTemplate(
+    id: 'couple_financier',
+    goalLabelKey: 'sequenceCoupleGoal',
+    steps: [
+      SequenceStepDef(
+        id: 'couple_01_status',
+        order: 1,
+        intentTag: 'life_event_marriage',
+        titleKey: 'sequenceCoupleStep1',
+        outputMapping: {'impact_fiscal_couple': 'impact_fiscal_couple'},
+      ),
+      SequenceStepDef(
+        id: 'couple_02_household',
+        order: 2,
+        intentTag: 'household_couple',
+        titleKey: 'sequenceCoupleStep2',
+      ),
+      SequenceStepDef(
+        id: 'couple_03_3a',
+        order: 3,
+        intentTag: 'simulator_3a',
+        titleKey: 'sequenceCoupleStep3',
+        outputMapping: {
+          'contribution_annuelle': 'contribution_couple',
+          'economie_fiscale': 'economie_couple',
+        },
+      ),
+      SequenceStepDef(
+        id: 'couple_04_fiscal',
+        order: 4,
+        intentTag: 'cantonal_fiscal_comparator',
+        titleKey: 'sequenceCoupleStep4',
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'couple_05_summary',
+        order: 5,
+        intentTag: '_inline_summary',
+        titleKey: 'sequenceCoupleStep5',
+        isOptional: true,
+      ),
+    ],
+  );
+
+  /// Naissance & coûts (4 étapes) — cohorte 28-37.
+  ///
+  /// Impact budget naissance, déductions enfants, 3a famille, résumé.
+  static const naissanceCouts = SequenceTemplate(
+    id: 'naissance_couts',
+    goalLabelKey: 'sequenceNaissanceGoal',
+    steps: [
+      SequenceStepDef(
+        id: 'naissance_01_impact',
+        order: 1,
+        intentTag: 'life_event_birth',
+        titleKey: 'sequenceNaissanceStep1',
+      ),
+      SequenceStepDef(
+        id: 'naissance_02_budget',
+        order: 2,
+        intentTag: 'budget_overview',
+        titleKey: 'sequenceNaissanceStep2',
+        outputMapping: {
+          'revenu_net': 'revenu_famille',
+          'charges_totales': 'charges_famille',
+        },
+      ),
+      SequenceStepDef(
+        id: 'naissance_03_3a',
+        order: 3,
+        intentTag: 'simulator_3a',
+        titleKey: 'sequenceNaissanceStep3',
+        outputMapping: {
+          'contribution_annuelle': 'contribution_parent',
+          'economie_fiscale': 'economie_parent',
+        },
+      ),
+      SequenceStepDef(
+        id: 'naissance_04_summary',
+        order: 4,
+        intentTag: '_inline_summary',
+        titleKey: 'sequenceNaissanceStep4',
+        isOptional: true,
+      ),
+    ],
+  );
+
   // ── INTENT → TEMPLATE MAPPING ─────────────────────────────────
 
   /// Maps a user intent to a guided sequence template.
@@ -361,6 +452,8 @@ class SequenceTemplate {
       'housing_purchase' => housingPurchase,
       'retirement_choice' || 'retirement_projection' => retirementPrep,
       'preretraite_complete' => preretraiteComplete,
+      'life_event_marriage' || 'life_event_concubinage' || 'household_couple' => coupleFinancier,
+      'life_event_birth' => naissanceCouts,
       'simulator_3a' || 'tax_optimization_3a' => optimize3a,
       'debt_ratio' || 'debt_repayment' || 'debt_risk_check' => financialTension,
       _ => null,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -3248,6 +3248,8 @@ class _CoachChatScreenState extends State<CoachChatScreen>
       'sequenceRetirementGoal' => l.sequenceRetirementGoal,
       'sequenceTensionGoal' => l.sequenceTensionGoal,
       'sequencePreretraiteGoal' => l.sequencePreretraiteGoal,
+      'sequenceCoupleGoal' => l.sequenceCoupleGoal,
+      'sequenceNaissanceGoal' => l.sequenceNaissanceGoal,
       _ => key, // Fallback to raw key if unknown
     };
   }

--- a/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
+++ b/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
@@ -303,6 +303,8 @@ class SequenceChatHandler {
       SequenceTemplate.retirementPrep,
       SequenceTemplate.financialTension,
       SequenceTemplate.preretraiteComplete,
+      SequenceTemplate.coupleFinancier,
+      SequenceTemplate.naissanceCouts,
     ];
     for (final t in templates) {
       if (t.id == id) return t;

--- a/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
+++ b/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
@@ -32,8 +32,56 @@ List<SequenceSummaryItem> buildSequenceSummary({
     'retirement_prep' => _buildRetirementSummary(allOutputs, loc),
     'financial_tension' => _buildTensionSummary(allOutputs, loc),
     'preretraite_complete' => _buildPreretraiteSummary(allOutputs, loc),
+    'couple_financier' => _buildCoupleSummary(allOutputs, loc),
+    'naissance_couts' => _buildNaissanceSummary(allOutputs, loc),
     _ => const [],
   };
+}
+
+List<SequenceSummaryItem> _buildCoupleSummary(
+  Map<String, Map<String, dynamic>> outputs, S l,
+) {
+  final items = <SequenceSummaryItem>[];
+
+  final step3 = outputs['couple_03_3a'];
+  final economieFiscale = step3?['economie_fiscale'];
+  if (economieFiscale is num && economieFiscale > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.discount_outlined,
+      label: l.summaryEconomieFiscale,
+      value: 'CHF\u00a0${formatChf(economieFiscale.toDouble())}',
+    ));
+  }
+
+  return items;
+}
+
+List<SequenceSummaryItem> _buildNaissanceSummary(
+  Map<String, Map<String, dynamic>> outputs, S l,
+) {
+  final items = <SequenceSummaryItem>[];
+
+  final step2 = outputs['naissance_02_budget'];
+  final charges = step2?['charges_totales'];
+  if (charges is num && charges > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.receipt_outlined,
+      label: l.summaryChargesFixes,
+      value: 'CHF\u00a0${formatChf(charges.toDouble())}',
+    ));
+  }
+
+  final step3 = outputs['naissance_03_3a'];
+  final economieFiscale = step3?['economie_fiscale'];
+  if (economieFiscale is num && economieFiscale > 0) {
+    items.add(SequenceSummaryItem(
+      icon: Icons.discount_outlined,
+      label: l.summaryEconomieFiscale,
+      value: 'CHF\u00a0${formatChf(economieFiscale.toDouble())}',
+    ));
+  }
+
+  return items;
 }
 
 /// Fallback labels (FR) for testing without a full localization context.


### PR DESCRIPTION
## Summary
2 new guided sequences for the 28-37 Construction cohort:
- couple_financier (5 steps): marriage/partnership → couple profile → 3a → fiscal → summary
- naissance_couts (4 steps): birth impact → family budget → 3a → summary

Total: 7 sequence templates across all cohorts.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8334 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)