### PR TITLE
feat: Phase 6B complete — 10 sequence templates, all cohorts

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11456,5 +11456,19 @@
   "sequenceNaissanceStep1": "Birth impact",
   "sequenceNaissanceStep2": "Family budget",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Summary"
+  "sequenceNaissanceStep4": "Summary",
+  "sequencePremiersPasGoal": "Understand my first salary",
+  "sequencePremiersPasStep1": "First job",
+  "sequencePremiersPasStep2": "My first budget",
+  "sequencePremiersPasStep3": "Discover 3a",
+  "sequenceDensificationGoal": "Protect and consolidate",
+  "sequenceDensificationStep1": "Retirement projection",
+  "sequenceDensificationStep2": "Disability protection",
+  "sequenceDensificationStep3": "LPP buyback",
+  "sequenceDensificationStep4": "Summary",
+  "sequenceRetraiteActiveGoal": "Manage my retirement",
+  "sequenceRetraiteActiveStep1": "Retirement budget",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "LAMal franchise",
+  "sequenceRetraiteActiveStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11484,5 +11484,19 @@
   "sequenceNaissanceStep1": "Birth impact",
   "sequenceNaissanceStep2": "Family budget",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Summary"
+  "sequenceNaissanceStep4": "Summary",
+  "sequencePremiersPasGoal": "Understand my first salary",
+  "sequencePremiersPasStep1": "First job",
+  "sequencePremiersPasStep2": "My first budget",
+  "sequencePremiersPasStep3": "Discover 3a",
+  "sequenceDensificationGoal": "Protect and consolidate",
+  "sequenceDensificationStep1": "Retirement projection",
+  "sequenceDensificationStep2": "Disability protection",
+  "sequenceDensificationStep3": "LPP buyback",
+  "sequenceDensificationStep4": "Summary",
+  "sequenceRetraiteActiveGoal": "Manage my retirement",
+  "sequenceRetraiteActiveStep1": "Retirement budget",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "LAMal franchise",
+  "sequenceRetraiteActiveStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11449,5 +11449,19 @@
   "sequenceNaissanceStep1": "Birth impact",
   "sequenceNaissanceStep2": "Family budget",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Summary"
+  "sequenceNaissanceStep4": "Summary",
+  "sequencePremiersPasGoal": "Understand my first salary",
+  "sequencePremiersPasStep1": "First job",
+  "sequencePremiersPasStep2": "My first budget",
+  "sequencePremiersPasStep3": "Discover 3a",
+  "sequenceDensificationGoal": "Protect and consolidate",
+  "sequenceDensificationStep1": "Retirement projection",
+  "sequenceDensificationStep2": "Disability protection",
+  "sequenceDensificationStep3": "LPP buyback",
+  "sequenceDensificationStep4": "Summary",
+  "sequenceRetraiteActiveGoal": "Manage my retirement",
+  "sequenceRetraiteActiveStep1": "Retirement budget",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "LAMal franchise",
+  "sequenceRetraiteActiveStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11931,5 +11931,19 @@
   "sequenceNaissanceStep1": "Impact naissance",
   "sequenceNaissanceStep2": "Budget famille",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Résumé"
+  "sequenceNaissanceStep4": "Résumé",
+  "sequencePremiersPasGoal": "Comprendre mon premier salaire",
+  "sequencePremiersPasStep1": "Premier emploi",
+  "sequencePremiersPasStep2": "Mon premier budget",
+  "sequencePremiersPasStep3": "Découvrir le 3a",
+  "sequenceDensificationGoal": "Protéger et densifier",
+  "sequenceDensificationStep1": "Projection retraite",
+  "sequenceDensificationStep2": "Protection invalidité",
+  "sequenceDensificationStep3": "Rachat LPP",
+  "sequenceDensificationStep4": "Résumé",
+  "sequenceRetraiteActiveGoal": "Piloter ma retraite",
+  "sequenceRetraiteActiveStep1": "Budget retraite",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "Franchise LAMal",
+  "sequenceRetraiteActiveStep4": "Résumé"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11449,5 +11449,19 @@
   "sequenceNaissanceStep1": "Birth impact",
   "sequenceNaissanceStep2": "Family budget",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Summary"
+  "sequenceNaissanceStep4": "Summary",
+  "sequencePremiersPasGoal": "Understand my first salary",
+  "sequencePremiersPasStep1": "First job",
+  "sequencePremiersPasStep2": "My first budget",
+  "sequencePremiersPasStep3": "Discover 3a",
+  "sequenceDensificationGoal": "Protect and consolidate",
+  "sequenceDensificationStep1": "Retirement projection",
+  "sequenceDensificationStep2": "Disability protection",
+  "sequenceDensificationStep3": "LPP buyback",
+  "sequenceDensificationStep4": "Summary",
+  "sequenceRetraiteActiveGoal": "Manage my retirement",
+  "sequenceRetraiteActiveStep1": "Retirement budget",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "LAMal franchise",
+  "sequenceRetraiteActiveStep4": "Summary"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -17557,6 +17557,9 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'De retour. Tes chiffres sont à jour.'**
   String get shellWelcomeBack;
+  String get sequenceRetraiteActiveGoal;
+  String get sequenceDensificationGoal;
+  String get sequencePremiersPasGoal;
   String get sequenceCoupleGoal;
   String get sequenceNaissanceGoal;
   String get sequencePreretraiteGoal;

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -9788,6 +9788,13 @@ class SDe extends S {
   String get shellWelcomeBack => 'Wieder da. Deine Zahlen sind aktuell.';
 
   @override
+  String get sequencePremiersPasGoal => 'Understand my first salary';
+  @override
+  String get sequenceDensificationGoal => 'Protect and consolidate';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Manage my retirement';
+
+  @override
   String get sequenceCoupleGoal => 'Coordinate finances together';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -9722,6 +9722,13 @@ class SEn extends S {
   String get shellWelcomeBack => 'Back. Your numbers are up to date.';
 
   @override
+  String get sequencePremiersPasGoal => 'Understand my first salary';
+  @override
+  String get sequenceDensificationGoal => 'Protect and consolidate';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Manage my retirement';
+
+  @override
   String get sequenceCoupleGoal => 'Coordinate finances together';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -9781,6 +9781,13 @@ class SEs extends S {
   String get shellWelcomeBack => 'De vuelta. Tus números están al día.';
 
   @override
+  String get sequencePremiersPasGoal => 'Understand my first salary';
+  @override
+  String get sequenceDensificationGoal => 'Protect and consolidate';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Manage my retirement';
+
+  @override
   String get sequenceCoupleGoal => 'Coordinate finances together';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -9777,6 +9777,13 @@ class SFr extends S {
   String get shellWelcomeBack => 'De retour. Tes chiffres sont à jour.';
 
   @override
+  String get sequencePremiersPasGoal => 'Comprendre mon premier salaire';
+  @override
+  String get sequenceDensificationGoal => 'Protéger et densifier';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Piloter ma retraite';
+
+  @override
   String get sequenceCoupleGoal => 'Coordonner nos finances à deux';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -9807,6 +9807,13 @@ class SIt extends S {
   String get shellWelcomeBack => 'Bentornato. I tuoi numeri sono aggiornati.';
 
   @override
+  String get sequencePremiersPasGoal => 'Understand my first salary';
+  @override
+  String get sequenceDensificationGoal => 'Protect and consolidate';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Manage my retirement';
+
+  @override
   String get sequenceCoupleGoal => 'Coordinate finances together';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -9781,6 +9781,13 @@ class SPt extends S {
   String get shellWelcomeBack => 'De volta. Os teus números estão atualizados.';
 
   @override
+  String get sequencePremiersPasGoal => 'Understand my first salary';
+  @override
+  String get sequenceDensificationGoal => 'Protect and consolidate';
+  @override
+  String get sequenceRetraiteActiveGoal => 'Manage my retirement';
+
+  @override
   String get sequenceCoupleGoal => 'Coordinate finances together';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11450,5 +11450,19 @@
   "sequenceNaissanceStep1": "Birth impact",
   "sequenceNaissanceStep2": "Family budget",
   "sequenceNaissanceStep3": "3a parent",
-  "sequenceNaissanceStep4": "Summary"
+  "sequenceNaissanceStep4": "Summary",
+  "sequencePremiersPasGoal": "Understand my first salary",
+  "sequencePremiersPasStep1": "First job",
+  "sequencePremiersPasStep2": "My first budget",
+  "sequencePremiersPasStep3": "Discover 3a",
+  "sequenceDensificationGoal": "Protect and consolidate",
+  "sequenceDensificationStep1": "Retirement projection",
+  "sequenceDensificationStep2": "Disability protection",
+  "sequenceDensificationStep3": "LPP buyback",
+  "sequenceDensificationStep4": "Summary",
+  "sequenceRetraiteActiveGoal": "Manage my retirement",
+  "sequenceRetraiteActiveStep1": "Retirement budget",
+  "sequenceRetraiteActiveStep2": "Succession",
+  "sequenceRetraiteActiveStep3": "LAMal franchise",
+  "sequenceRetraiteActiveStep4": "Summary"
 }

--- a/apps/mobile/lib/models/sequence_template.dart
+++ b/apps/mobile/lib/models/sequence_template.dart
@@ -351,6 +351,124 @@ class SequenceTemplate {
     ],
   );
 
+  /// Premiers pas financiers (3 étapes) — cohorte 18-27.
+  ///
+  /// Premier salaire → budget de base → 3a découverte.
+  static const premiersPas = SequenceTemplate(
+    id: 'premiers_pas',
+    goalLabelKey: 'sequencePremiersPasGoal',
+    steps: [
+      SequenceStepDef(
+        id: 'pp_01_first_job',
+        order: 1,
+        intentTag: 'life_event_first_job',
+        titleKey: 'sequencePremiersPasStep1',
+      ),
+      SequenceStepDef(
+        id: 'pp_02_budget',
+        order: 2,
+        intentTag: 'budget_overview',
+        titleKey: 'sequencePremiersPasStep2',
+        outputMapping: {
+          'revenu_net': 'revenu_net',
+          'charges_totales': 'charges_totales',
+        },
+      ),
+      SequenceStepDef(
+        id: 'pp_03_3a',
+        order: 3,
+        intentTag: 'simulator_3a',
+        titleKey: 'sequencePremiersPasStep3',
+        outputMapping: {
+          'contribution_annuelle': 'contribution_annuelle',
+          'economie_fiscale': 'economie_fiscale',
+        },
+      ),
+    ],
+  );
+
+  /// Densification & protection (4 étapes) — cohorte 38-52.
+  ///
+  /// Projection retraite → protection invalidité → rachat LPP → résumé.
+  static const densification = SequenceTemplate(
+    id: 'densification',
+    goalLabelKey: 'sequenceDensificationGoal',
+    steps: [
+      SequenceStepDef(
+        id: 'dens_01_projection',
+        order: 1,
+        intentTag: 'retirement_projection',
+        titleKey: 'sequenceDensificationStep1',
+        outputMapping: {
+          'taux_remplacement': 'taux_remplacement',
+          'gap_mensuel': 'gap_mensuel',
+        },
+      ),
+      SequenceStepDef(
+        id: 'dens_02_disability',
+        order: 2,
+        intentTag: 'disability_gap',
+        titleKey: 'sequenceDensificationStep2',
+      ),
+      SequenceStepDef(
+        id: 'dens_03_buyback',
+        order: 3,
+        intentTag: 'lpp_buyback',
+        titleKey: 'sequenceDensificationStep3',
+        outputMapping: {'economie_rachat': 'economie_rachat'},
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'dens_04_summary',
+        order: 4,
+        intentTag: '_inline_summary',
+        titleKey: 'sequenceDensificationStep4',
+        isOptional: true,
+      ),
+    ],
+  );
+
+  /// Retraite active (4 étapes) — cohorte 65-74.
+  ///
+  /// Budget retraite → succession → LAMal → résumé.
+  static const retraiteActive = SequenceTemplate(
+    id: 'retraite_active',
+    goalLabelKey: 'sequenceRetraiteActiveGoal',
+    steps: [
+      SequenceStepDef(
+        id: 'ra_01_budget',
+        order: 1,
+        intentTag: 'budget_overview',
+        titleKey: 'sequenceRetraiteActiveStep1',
+        outputMapping: {
+          'revenu_net': 'revenu_retraite',
+          'charges_totales': 'charges_retraite',
+        },
+      ),
+      SequenceStepDef(
+        id: 'ra_02_succession',
+        order: 2,
+        intentTag: 'succession_patrimoine',
+        titleKey: 'sequenceRetraiteActiveStep2',
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'ra_03_lamal',
+        order: 3,
+        intentTag: 'lamal_franchise',
+        titleKey: 'sequenceRetraiteActiveStep3',
+        isOptional: true,
+      ),
+      SequenceStepDef(
+        id: 'ra_04_summary',
+        order: 4,
+        intentTag: '_inline_summary',
+        titleKey: 'sequenceRetraiteActiveStep4',
+        isOptional: true,
+      ),
+    ],
+  );
+
   /// Couple financier (5 étapes) — cohorte 28-37.
   ///
   /// Mariage vs concubinage, fiscalité couple, 3a couple,
@@ -454,6 +572,9 @@ class SequenceTemplate {
       'preretraite_complete' => preretraiteComplete,
       'life_event_marriage' || 'life_event_concubinage' || 'household_couple' => coupleFinancier,
       'life_event_birth' => naissanceCouts,
+      'life_event_first_job' => premiersPas,
+      'disability_gap' || 'disability_insurance_flow' => densification,
+      'succession_patrimoine' => retraiteActive,
       'simulator_3a' || 'tax_optimization_3a' => optimize3a,
       'debt_ratio' || 'debt_repayment' || 'debt_risk_check' => financialTension,
       _ => null,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -3250,6 +3250,9 @@ class _CoachChatScreenState extends State<CoachChatScreen>
       'sequencePreretraiteGoal' => l.sequencePreretraiteGoal,
       'sequenceCoupleGoal' => l.sequenceCoupleGoal,
       'sequenceNaissanceGoal' => l.sequenceNaissanceGoal,
+      'sequencePremiersPasGoal' => l.sequencePremiersPasGoal,
+      'sequenceDensificationGoal' => l.sequenceDensificationGoal,
+      'sequenceRetraiteActiveGoal' => l.sequenceRetraiteActiveGoal,
       _ => key, // Fallback to raw key if unknown
     };
   }

--- a/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
+++ b/apps/mobile/lib/services/sequence/sequence_chat_handler.dart
@@ -305,6 +305,9 @@ class SequenceChatHandler {
       SequenceTemplate.preretraiteComplete,
       SequenceTemplate.coupleFinancier,
       SequenceTemplate.naissanceCouts,
+      SequenceTemplate.premiersPas,
+      SequenceTemplate.densification,
+      SequenceTemplate.retraiteActive,
     ];
     for (final t in templates) {
       if (t.id == id) return t;

--- a/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
+++ b/apps/mobile/lib/services/sequence/sequence_summary_builder.dart
@@ -34,6 +34,9 @@ List<SequenceSummaryItem> buildSequenceSummary({
     'preretraite_complete' => _buildPreretraiteSummary(allOutputs, loc),
     'couple_financier' => _buildCoupleSummary(allOutputs, loc),
     'naissance_couts' => _buildNaissanceSummary(allOutputs, loc),
+    'premiers_pas' => _build3aSummary(allOutputs, loc), // Reuses 3a summary
+    'densification' => _buildRetirementSummary(allOutputs, loc), // Reuses retirement
+    'retraite_active' => _buildTensionSummary(allOutputs, loc), // Reuses budget summary
     _ => const [],
   };
 }


### PR DESCRIPTION
## Summary
3 final templates complete Phase 6B: premiers_pas (18-27),
densification (38-52), retraite_active (65-74).

All 6 lifecycle cohorts now have guided journeys.
10 templates total, 36 steps across all sequences.

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8334 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)