### PR TITLE
feat: Haptic feedback + MintEmptyState standardisation (P2+P5)

### DIFF
--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -190,7 +191,12 @@ class _LoginScreenState extends State<LoginScreen> {
                   label: l10n.authLogin,
                   button: true,
                   child: FilledButton(
-                    onPressed: authProvider.isLoading ? null : _handleLogin,
+                    onPressed: authProvider.isLoading
+                        ? null
+                        : () {
+                            HapticFeedback.lightImpact();
+                            _handleLogin();
+                          },
                     child: authProvider.isLoading
                         ? const SizedBox(
                             height: 20,

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -554,7 +555,14 @@ class _RegisterScreenState extends State<RegisterScreen> {
                   label: l10n.authCreateAccount,
                   button: true,
                   child: FilledButton(
-                    onPressed: (_acceptedCgu && _confirmed18Plus && !authProvider.isLoading) ? _handleRegister : null,
+                    onPressed: (_acceptedCgu &&
+                            _confirmed18Plus &&
+                            !authProvider.isLoading)
+                        ? () {
+                            HapticFeedback.lightImpact();
+                            _handleRegister();
+                          }
+                        : null,
                     child: authProvider.isLoading
                         ? const SizedBox(
                             height: 20,

--- a/apps/mobile/lib/screens/byok_settings_screen.dart
+++ b/apps/mobile/lib/screens/byok_settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -346,6 +347,7 @@ class _ByokSettingsScreenState extends State<ByokSettingsScreen> {
             onPressed: byok.isLoading || _apiKeyController.text.isEmpty
                 ? null
                 : () async {
+                    HapticFeedback.lightImpact();
                     final messenger = ScaffoldMessenger.of(context);
                     await byok.saveKey(
                         _selectedProvider, _apiKeyController.text.trim());

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:provider/provider.dart';
@@ -3855,6 +3856,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
                     onPressed: _isBusy
                         ? null
                         : () {
+                            HapticFeedback.lightImpact();
                             // Typed send → deactivate voice mode.
                             _voiceModeActive = false;
                             _sendMessage(_controller.text);

--- a/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -1041,7 +1042,10 @@ Reponds uniquement avec le texte final.
       width: double.infinity,
       height: 56,
       child: ElevatedButton(
-        onPressed: _onSubmit,
+        onPressed: () {
+          HapticFeedback.lightImpact();
+          _onSubmit();
+        },
         style: ElevatedButton.styleFrom(
           backgroundColor: MintColors.primary,
           foregroundColor: MintColors.white,

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -254,7 +255,12 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
             width: double.infinity,
             height: 56,
             child: FilledButton.icon(
-              onPressed: _isProcessing ? null : _onCameraPressed,
+              onPressed: _isProcessing
+                  ? null
+                  : () {
+                      HapticFeedback.lightImpact();
+                      _onCameraPressed();
+                    },
             icon: const Icon(
               kIsWeb ? Icons.upload_file_outlined : Icons.camera_alt_outlined,
               size: 22,

--- a/apps/mobile/lib/screens/documents_screen.dart
+++ b/apps/mobile/lib/screens/documents_screen.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/coach_paywall_sheet.dart';
+import 'package:mint_mobile/widgets/common/mint_empty_state.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 
@@ -596,43 +597,12 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
   }
 
   Widget _buildEmptyState(S s) {
-    return MintSurface(
-      tone: MintSurfaceTone.porcelaine,
-      padding: const EdgeInsets.all(MintSpacing.xl),
-      child: Column(
-        children: [
-          Icon(Icons.folder_open_outlined,
-              size: 48, color: MintColors.textMuted.withValues(alpha: 0.4)),
-          const SizedBox(height: MintSpacing.md),
-          Text(
-            s.vaultEmptyTitle,
-            style: MintTextStyles.headlineMedium().copyWith(fontSize: 18),
-          ),
-          const SizedBox(height: MintSpacing.sm),
-          Text(
-            s.documentsEmptyVoice,
-            textAlign: TextAlign.center,
-            style: MintTextStyles.bodyMedium(),
-          ),
-          const SizedBox(height: MintSpacing.lg),
-          FilledButton.icon(
-            onPressed: () => _showUploadTypeSheet(s),
-            style: FilledButton.styleFrom(
-              backgroundColor: MintColors.primary,
-              foregroundColor: MintColors.white,
-              padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14),
-              ),
-            ),
-            icon: const Icon(Icons.add_rounded, size: 20),
-            label: Text(
-              s.vaultUploadButton,
-              style: MintTextStyles.titleMedium(color: MintColors.white).copyWith(fontSize: 14),
-            ),
-          ),
-        ],
-      ),
+    return MintEmptyState(
+      icon: Icons.folder_open_outlined,
+      title: s.vaultEmptyTitle,
+      subtitle: s.documentsEmptyVoice,
+      ctaLabel: s.vaultUploadButton,
+      onCta: () => _showUploadTypeSheet(s),
     );
   }
 

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -336,7 +337,10 @@ class _LandingScreenState extends State<LandingScreen>
         label: l10n.landingCtaCommencer,
         button: true,
         child: FilledButton(
-          onPressed: _onCtaTap,
+          onPressed: () {
+            HapticFeedback.lightImpact();
+            _onCtaTap();
+          },
           style: FilledButton.styleFrom(
             backgroundColor: MintColors.primary,
             shape: const StadiumBorder(),

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
@@ -194,7 +195,10 @@ class _SmartOnboardingScreenState extends State<SmartOnboardingScreen> {
                   child: SizedBox(
                     width: double.infinity,
                     child: FilledButton(
-                      onPressed: () => Navigator.of(ctx).pop(true),
+                      onPressed: () {
+                        HapticFeedback.lightImpact();
+                        Navigator.of(ctx).pop(true);
+                      },
                       child: Text(l.onboardingConsentAllow),
                     ),
                   ),

--- a/apps/mobile/lib/screens/open_banking/transaction_list_screen.dart
+++ b/apps/mobile/lib/screens/open_banking/transaction_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/services/open_banking_service.dart';
+import 'package:mint_mobile/widgets/common/mint_empty_state.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
@@ -403,19 +404,10 @@ class _TransactionListScreenState extends State<TransactionListScreen> {
   // ── Empty State ────────────────────────────────────────────
 
   Widget _buildEmptyState() {
-    return Container(
-      padding: const EdgeInsets.all(32),
-      child: Column(
-        children: [
-          Icon(Icons.receipt_long_outlined,
-              size: 48, color: MintColors.textMuted.withValues(alpha: 0.4)),
-          const SizedBox(height: 16),
-          Text(
-            S.of(context)!.transactionListNoTransaction,
-            style: MintTextStyles.titleMedium(color: MintColors.textMuted),
-          ),
-        ],
-      ),
+    return MintEmptyState(
+      icon: Icons.receipt_long_outlined,
+      title: S.of(context)!.transactionListNoTransaction,
+      subtitle: '', // No subtitle in original
     );
   }
 

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -17,6 +17,7 @@ import 'package:mint_mobile/widgets/profile/patrimoine_drawer_content.dart';
 import 'package:mint_mobile/widgets/profile/dettes_drawer_content.dart';
 import 'package:mint_mobile/widgets/profile/futur_drawer_content.dart';
 import 'package:mint_mobile/widgets/profile/enrichment_cta.dart';
+import 'package:mint_mobile/widgets/common/mint_empty_state.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 
 // NOTE: This screen is a deep-dive view. Primary display is now in PulseScreen
@@ -79,29 +80,12 @@ class FinancialSummaryScreen extends StatelessWidget {
 
   Widget _buildEmptyState(BuildContext context) {
     return SliverFillRemaining(
-      child: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.person_off_outlined,
-                size: 48, color: MintColors.textMuted),
-            const SizedBox(height: 16),
-            Text(
-              S.of(context)!.financialSummaryNoProfile,
-              style: MintTextStyles.bodyLarge(),
-            ),
-            const SizedBox(height: 12),
-            Semantics(
-              button: true,
-              label: S.of(context)!.financialSummaryStartDiagnostic,
-              child: FilledButton(
-                onPressed: () => context.push('/onboarding/quick'),
-                child:
-                    Text(S.of(context)!.financialSummaryStartDiagnostic),
-              ),
-            ),
-          ],
-        ),
+      child: MintEmptyState(
+        icon: Icons.person_off_outlined,
+        title: S.of(context)!.financialSummaryNoProfile,
+        subtitle: '', // No subtitle in original
+        ctaLabel: S.of(context)!.financialSummaryStartDiagnostic,
+        onCta: () => context.push('/onboarding/quick'),
       ),
     );
   }

--- a/apps/mobile/lib/widgets/coach/sequence_progress_card.dart
+++ b/apps/mobile/lib/widgets/coach/sequence_progress_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/models/sequence_message_payload.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -167,7 +168,12 @@ class SequenceProgressCard extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: onAdvance,
+                onPressed: onAdvance == null
+                    ? null
+                    : () {
+                        HapticFeedback.lightImpact();
+                        onAdvance!();
+                      },
                 style: FilledButton.styleFrom(
                   backgroundColor: MintColors.primary,
                   foregroundColor: MintColors.white,


### PR DESCRIPTION
## Summary

### P5 HapticFeedback (9 screens)
- `lightImpact()` on primary CTA buttons across 9 key screens
- Send message, continue sequence, camera scan, login, register, submit check-in, landing, save BYOK

### P2 MintEmptyState (3 migrated)
- transaction_list, documents, financial_summary → MintEmptyState

## Test plan
- [x] `flutter analyze` — 0 errors
- [x] `flutter test` — 8413 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)