### PR TITLE
feat: Backlog cleanup — 9 fixes + multi-lang LLM + i18n Phase 4

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11586,5 +11586,66 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "commonConfirm": "Bestätigen",
+
+  "b2bHubTitle": "Mein Unternehmen",
+  "b2bHubInvalidCode": "Ungültiger oder abgelaufener Code",
+  "b2bHubLeaveTitle": "Organisation verlassen?",
+  "b2bHubLeaveBody": "Die für dein Unternehmen reservierten Module sind dann nicht mehr zugänglich.",
+  "b2bHubNarrativeHeadline": "Betriebliche Vorsorge",
+  "b2bHubNarrativeBody": "Wenn dein Arbeitgeber MINT nutzt, gib den Einladungscode ein, um auf die Vorsorgemodule für Mitarbeitende zuzugreifen.",
+  "b2bHubInviteCodeLabel": "Einladungscode",
+  "b2bHubJoinButton": "Beitreten",
+  "b2bHubJoinSemantics": "Organisation beitreten",
+  "b2bHubNoCodeHint": "Kein Code? Frag deine HR-Abteilung.",
+  "b2bHubEmployeeCount": "{count} Mitarbeitende",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "Deine Module",
+  "b2bHubLeaveButton": "Organisation verlassen",
+  "b2bModuleEducation": "Finanzbildung",
+  "b2bModuleEducationSubtitle": "Artikel, Konzepte und Quizze passend zu deiner Situation",
+  "b2bModuleWellness": "Finanzielles Wohlbefinden",
+  "b2bModuleWellnessSubtitle": "Finanzieller Gesundheitsscore und Empfehlungen",
+  "b2bModule3a": "Säule 3a über den Arbeitgeber",
+  "b2bModule3aSubtitle": "Optimierung und Simulation der 3. Säule",
+  "b2bModuleLpp": "Berufliche Vorsorge (BVG)",
+  "b2bModuleLppSubtitle": "Detaillierte Analyse deiner Pensionskasse",
+
+  "pensionFundTitle": "Zertifizierte Daten",
+  "pensionFundConnectionError": "Verbindung momentan nicht möglich",
+  "pensionFundDisconnectTitle": "Pensionskasse trennen?",
+  "pensionFundDisconnectBody": "Deine Projektionen werden wieder auf den Modus «geschätzt» statt «zertifiziert» zurückgesetzt.",
+  "pensionFundDisconnectButton": "Trennen",
+  "pensionFundNarrativeHeadline": "Automatischer Import",
+  "pensionFundNarrativeBody": "Verbinde deine Pensionskasse, um Schätzungen durch deine echten Daten zu ersetzen. Nur Lesezugriff \u2014 MINT ändert nichts.",
+  "pensionFundAvailableTitle": "Verfügbare Kassen",
+  "pensionFundConnectedStatus": "{name}, verbunden",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, nicht verbunden",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Synchro {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Erneute Verbindung erforderlich",
+  "pensionFundAvailable": "Verfügbar",
+  "pensionFundDisconnectTooltip": "Trennen",
+  "pensionFundConnectButton": "Verbinden",
+  "pensionFundDisclaimer": "MINT ist ein Bildungstool im Nur-Lese-Modus (FIDLEG Art.\u00a03). Es werden keine Transaktionen auf deinen Konten durchgeführt. Du kannst dich jederzeit trennen."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11586,5 +11586,66 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "commonConfirm": "Confirm",
+
+  "b2bHubTitle": "My company",
+  "b2bHubInvalidCode": "Invalid or expired code",
+  "b2bHubLeaveTitle": "Leave the organisation?",
+  "b2bHubLeaveBody": "Modules reserved for your company will no longer be accessible.",
+  "b2bHubNarrativeHeadline": "Employer pension plan",
+  "b2bHubNarrativeBody": "If your employer uses MINT, enter the invitation code to access pension modules reserved for employees.",
+  "b2bHubInviteCodeLabel": "Invitation code",
+  "b2bHubJoinButton": "Join",
+  "b2bHubJoinSemantics": "Join the organisation",
+  "b2bHubNoCodeHint": "No code? Ask your HR department.",
+  "b2bHubEmployeeCount": "{count} employees",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "Your modules",
+  "b2bHubLeaveButton": "Leave the organisation",
+  "b2bModuleEducation": "Financial education",
+  "b2bModuleEducationSubtitle": "Articles, concepts, and quizzes tailored to your situation",
+  "b2bModuleWellness": "Financial wellness",
+  "b2bModuleWellnessSubtitle": "Financial health score and recommendations",
+  "b2bModule3a": "Company pillar 3a",
+  "b2bModule3aSubtitle": "Third pillar optimisation and simulation",
+  "b2bModuleLpp": "Occupational pension (LPP)",
+  "b2bModuleLppSubtitle": "Detailed analysis of your pension fund",
+
+  "pensionFundTitle": "Certified data",
+  "pensionFundConnectionError": "Connection not available at the moment",
+  "pensionFundDisconnectTitle": "Disconnect the fund?",
+  "pensionFundDisconnectBody": "Your projections will revert to estimated mode instead of certified.",
+  "pensionFundDisconnectButton": "Disconnect",
+  "pensionFundNarrativeHeadline": "Automatic import",
+  "pensionFundNarrativeBody": "Connect your pension fund to replace estimates with your actual data. Read-only \u2014 MINT does not modify anything.",
+  "pensionFundAvailableTitle": "Available funds",
+  "pensionFundConnectedStatus": "{name}, connected",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, not connected",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Synced {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Reconnection required",
+  "pensionFundAvailable": "Available",
+  "pensionFundDisconnectTooltip": "Disconnect",
+  "pensionFundConnectButton": "Connect",
+  "pensionFundDisclaimer": "MINT is a read-only educational tool (FinSA art.\u00a03). No transactions are made on your accounts. You can disconnect at any time."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11586,5 +11586,66 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "commonConfirm": "Confirmar",
+
+  "b2bHubTitle": "Mi empresa",
+  "b2bHubInvalidCode": "Código inválido o expirado",
+  "b2bHubLeaveTitle": "¿Salir de la organización?",
+  "b2bHubLeaveBody": "Los módulos reservados para tu empresa ya no estarán accesibles.",
+  "b2bHubNarrativeHeadline": "Previsión de empresa",
+  "b2bHubNarrativeBody": "Si tu empleador usa MINT, introduce el código de invitación para acceder a los módulos de previsión reservados para empleados.",
+  "b2bHubInviteCodeLabel": "Código de invitación",
+  "b2bHubJoinButton": "Unirse",
+  "b2bHubJoinSemantics": "Unirse a la organización",
+  "b2bHubNoCodeHint": "¿Sin código? Pregunta a tu departamento de RRHH.",
+  "b2bHubEmployeeCount": "{count} empleados",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "Tus módulos",
+  "b2bHubLeaveButton": "Salir de la organización",
+  "b2bModuleEducation": "Educación financiera",
+  "b2bModuleEducationSubtitle": "Artículos, conceptos y cuestionarios adaptados a tu situación",
+  "b2bModuleWellness": "Bienestar financiero",
+  "b2bModuleWellnessSubtitle": "Puntuación de salud financiera y recomendaciones",
+  "b2bModule3a": "Pilar 3a de empresa",
+  "b2bModule3aSubtitle": "Optimización y simulación del tercer pilar",
+  "b2bModuleLpp": "Previsión profesional (LPP)",
+  "b2bModuleLppSubtitle": "Análisis detallado de tu caja de pensiones",
+
+  "pensionFundTitle": "Datos certificados",
+  "pensionFundConnectionError": "Conexión no disponible en este momento",
+  "pensionFundDisconnectTitle": "¿Desconectar la caja?",
+  "pensionFundDisconnectBody": "Tus proyecciones volverán al modo «estimado» en lugar de «certificado».",
+  "pensionFundDisconnectButton": "Desconectar",
+  "pensionFundNarrativeHeadline": "Importación automática",
+  "pensionFundNarrativeBody": "Conecta tu caja de pensiones para reemplazar las estimaciones con tus datos reales. Solo lectura \u2014 MINT no modifica nada.",
+  "pensionFundAvailableTitle": "Cajas disponibles",
+  "pensionFundConnectedStatus": "{name}, conectado",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, no conectado",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Sincro {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Reconexión necesaria",
+  "pensionFundAvailable": "Disponible",
+  "pensionFundDisconnectTooltip": "Desconectar",
+  "pensionFundConnectButton": "Conectar",
+  "pensionFundDisclaimer": "MINT es una herramienta educativa de solo lectura (LSFin art.\u00a03). No se realiza ninguna transacción en tus cuentas. Puedes desconectarte en cualquier momento."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12009,5 +12009,66 @@
       "focus": { "type": "String" }
     }
   },
-  "loadingGeneric": "Chargement\u2026"
+  "loadingGeneric": "Chargement\u2026",
+
+  "commonConfirm": "Confirmer",
+
+  "b2bHubTitle": "Mon entreprise",
+  "b2bHubInvalidCode": "Code invalide ou expiré",
+  "b2bHubLeaveTitle": "Quitter l\u2019organisation\u00a0?",
+  "b2bHubLeaveBody": "Les modules réservés à ton entreprise ne seront plus accessibles.",
+  "b2bHubNarrativeHeadline": "Prévoyance d\u2019entreprise",
+  "b2bHubNarrativeBody": "Si ton employeur utilise MINT, entre le code d\u2019invitation pour accéder aux modules de prévoyance réservés à tes collaborateurs.",
+  "b2bHubInviteCodeLabel": "Code d\u2019invitation",
+  "b2bHubJoinButton": "Rejoindre",
+  "b2bHubJoinSemantics": "Rejoindre l\u2019organisation",
+  "b2bHubNoCodeHint": "Pas de code\u00a0? Demande à ton département RH.",
+  "b2bHubEmployeeCount": "{count} collaborateurs",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "Tes modules",
+  "b2bHubLeaveButton": "Quitter l\u2019organisation",
+  "b2bModuleEducation": "Éducation financière",
+  "b2bModuleEducationSubtitle": "Articles, concepts, et quiz adaptés à ta situation",
+  "b2bModuleWellness": "Bien-être financier",
+  "b2bModuleWellnessSubtitle": "Score de santé financière et recommandations",
+  "b2bModule3a": "Pilier 3a entreprise",
+  "b2bModule3aSubtitle": "Optimisation et simulation du 3e pilier",
+  "b2bModuleLpp": "Prévoyance LPP",
+  "b2bModuleLppSubtitle": "Analyse détaillée de ta caisse de pension",
+
+  "pensionFundTitle": "Données certifiées",
+  "pensionFundConnectionError": "Connexion impossible pour le moment",
+  "pensionFundDisconnectTitle": "Déconnecter la caisse\u00a0?",
+  "pensionFundDisconnectBody": "Tes projections reviendront en mode \u00ab\u00a0estimé\u00a0\u00bb au lieu de \u00ab\u00a0certifié\u00a0\u00bb.",
+  "pensionFundDisconnectButton": "Déconnecter",
+  "pensionFundNarrativeHeadline": "Import automatique",
+  "pensionFundNarrativeBody": "Connecte ta caisse de pension pour remplacer les estimations par tes données réelles. Lecture seule \u2014 MINT ne modifie rien.",
+  "pensionFundAvailableTitle": "Caisses disponibles",
+  "pensionFundConnectedStatus": "{name}, connecté",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, non connecté",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Synchro {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Reconnexion nécessaire",
+  "pensionFundAvailable": "Disponible",
+  "pensionFundDisconnectTooltip": "Déconnecter",
+  "pensionFundConnectButton": "Connecter",
+  "pensionFundDisclaimer": "MINT est un outil éducatif en lecture seule (LSFin art.\u00a03). Aucune transaction n\u2019est effectuée sur tes comptes. Tu peux te déconnecter à tout moment."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11586,5 +11586,66 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "commonConfirm": "Confermare",
+
+  "b2bHubTitle": "La mia azienda",
+  "b2bHubInvalidCode": "Codice non valido o scaduto",
+  "b2bHubLeaveTitle": "Lasciare l\u2019organizzazione?",
+  "b2bHubLeaveBody": "I moduli riservati alla tua azienda non saranno più accessibili.",
+  "b2bHubNarrativeHeadline": "Previdenza aziendale",
+  "b2bHubNarrativeBody": "Se il tuo datore di lavoro utilizza MINT, inserisci il codice d\u2019invito per accedere ai moduli di previdenza riservati ai collaboratori.",
+  "b2bHubInviteCodeLabel": "Codice d\u2019invito",
+  "b2bHubJoinButton": "Aderire",
+  "b2bHubJoinSemantics": "Aderire all\u2019organizzazione",
+  "b2bHubNoCodeHint": "Nessun codice? Chiedi al tuo dipartimento HR.",
+  "b2bHubEmployeeCount": "{count} collaboratori",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "I tuoi moduli",
+  "b2bHubLeaveButton": "Lasciare l\u2019organizzazione",
+  "b2bModuleEducation": "Educazione finanziaria",
+  "b2bModuleEducationSubtitle": "Articoli, concetti e quiz adattati alla tua situazione",
+  "b2bModuleWellness": "Benessere finanziario",
+  "b2bModuleWellnessSubtitle": "Punteggio di salute finanziaria e raccomandazioni",
+  "b2bModule3a": "Pilastro 3a aziendale",
+  "b2bModule3aSubtitle": "Ottimizzazione e simulazione del terzo pilastro",
+  "b2bModuleLpp": "Previdenza professionale (LPP)",
+  "b2bModuleLppSubtitle": "Analisi dettagliata della tua cassa pensione",
+
+  "pensionFundTitle": "Dati certificati",
+  "pensionFundConnectionError": "Connessione non disponibile al momento",
+  "pensionFundDisconnectTitle": "Disconnettere la cassa?",
+  "pensionFundDisconnectBody": "Le tue proiezioni torneranno in modalità «stimato» anziché «certificato».",
+  "pensionFundDisconnectButton": "Disconnettere",
+  "pensionFundNarrativeHeadline": "Importazione automatica",
+  "pensionFundNarrativeBody": "Collega la tua cassa pensione per sostituire le stime con i tuoi dati reali. Solo lettura \u2014 MINT non modifica nulla.",
+  "pensionFundAvailableTitle": "Casse disponibili",
+  "pensionFundConnectedStatus": "{name}, connesso",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, non connesso",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Sincro {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Riconnessione necessaria",
+  "pensionFundAvailable": "Disponibile",
+  "pensionFundDisconnectTooltip": "Disconnettere",
+  "pensionFundConnectButton": "Connettere",
+  "pensionFundDisclaimer": "MINT è uno strumento educativo in sola lettura (LSFin art.\u00a03). Nessuna transazione viene effettuata sui tuoi conti. Puoi disconnetterti in qualsiasi momento."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -43757,6 +43757,234 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Chargement…'**
   String get loadingGeneric;
+
+  /// No description provided for @commonConfirm.
+  ///
+  /// In fr, this message translates to:
+  /// **'Confirmer'**
+  String get commonConfirm;
+
+  /// No description provided for @b2bHubTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Mon entreprise'**
+  String get b2bHubTitle;
+
+  /// No description provided for @b2bHubInvalidCode.
+  ///
+  /// In fr, this message translates to:
+  /// **'Code invalide ou expiré'**
+  String get b2bHubInvalidCode;
+
+  /// No description provided for @b2bHubLeaveTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Quitter l’organisation ?'**
+  String get b2bHubLeaveTitle;
+
+  /// No description provided for @b2bHubLeaveBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Les modules réservés à ton entreprise ne seront plus accessibles.'**
+  String get b2bHubLeaveBody;
+
+  /// No description provided for @b2bHubNarrativeHeadline.
+  ///
+  /// In fr, this message translates to:
+  /// **'Prévoyance d’entreprise'**
+  String get b2bHubNarrativeHeadline;
+
+  /// No description provided for @b2bHubNarrativeBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Si ton employeur utilise MINT, entre le code d’invitation pour accéder aux modules de prévoyance réservés à tes collaborateurs.'**
+  String get b2bHubNarrativeBody;
+
+  /// No description provided for @b2bHubInviteCodeLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Code d’invitation'**
+  String get b2bHubInviteCodeLabel;
+
+  /// No description provided for @b2bHubJoinButton.
+  ///
+  /// In fr, this message translates to:
+  /// **'Rejoindre'**
+  String get b2bHubJoinButton;
+
+  /// No description provided for @b2bHubJoinSemantics.
+  ///
+  /// In fr, this message translates to:
+  /// **'Rejoindre l’organisation'**
+  String get b2bHubJoinSemantics;
+
+  /// No description provided for @b2bHubNoCodeHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pas de code ? Demande à ton département RH.'**
+  String get b2bHubNoCodeHint;
+
+  /// No description provided for @b2bHubEmployeeCount.
+  ///
+  /// In fr, this message translates to:
+  /// **'{count} collaborateurs'**
+  String b2bHubEmployeeCount(String count);
+
+  /// No description provided for @b2bHubModulesTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes modules'**
+  String get b2bHubModulesTitle;
+
+  /// No description provided for @b2bHubLeaveButton.
+  ///
+  /// In fr, this message translates to:
+  /// **'Quitter l’organisation'**
+  String get b2bHubLeaveButton;
+
+  /// No description provided for @b2bModuleEducation.
+  ///
+  /// In fr, this message translates to:
+  /// **'Éducation financière'**
+  String get b2bModuleEducation;
+
+  /// No description provided for @b2bModuleEducationSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Articles, concepts, et quiz adaptés à ta situation'**
+  String get b2bModuleEducationSubtitle;
+
+  /// No description provided for @b2bModuleWellness.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bien-être financier'**
+  String get b2bModuleWellness;
+
+  /// No description provided for @b2bModuleWellnessSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Score de santé financière et recommandations'**
+  String get b2bModuleWellnessSubtitle;
+
+  /// No description provided for @b2bModule3a.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pilier 3a entreprise'**
+  String get b2bModule3a;
+
+  /// No description provided for @b2bModule3aSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Optimisation et simulation du 3e pilier'**
+  String get b2bModule3aSubtitle;
+
+  /// No description provided for @b2bModuleLpp.
+  ///
+  /// In fr, this message translates to:
+  /// **'Prévoyance LPP'**
+  String get b2bModuleLpp;
+
+  /// No description provided for @b2bModuleLppSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Analyse détaillée de ta caisse de pension'**
+  String get b2bModuleLppSubtitle;
+
+  /// No description provided for @pensionFundTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Données certifiées'**
+  String get pensionFundTitle;
+
+  /// No description provided for @pensionFundConnectionError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Connexion impossible pour le moment'**
+  String get pensionFundConnectionError;
+
+  /// No description provided for @pensionFundDisconnectTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Déconnecter la caisse ?'**
+  String get pensionFundDisconnectTitle;
+
+  /// No description provided for @pensionFundDisconnectBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes projections reviendront en mode « estimé » au lieu de « certifié ».'**
+  String get pensionFundDisconnectBody;
+
+  /// No description provided for @pensionFundDisconnectButton.
+  ///
+  /// In fr, this message translates to:
+  /// **'Déconnecter'**
+  String get pensionFundDisconnectButton;
+
+  /// No description provided for @pensionFundNarrativeHeadline.
+  ///
+  /// In fr, this message translates to:
+  /// **'Import automatique'**
+  String get pensionFundNarrativeHeadline;
+
+  /// No description provided for @pensionFundNarrativeBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Connecte ta caisse de pension pour remplacer les estimations par tes données réelles. Lecture seule — MINT ne modifie rien.'**
+  String get pensionFundNarrativeBody;
+
+  /// No description provided for @pensionFundAvailableTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Caisses disponibles'**
+  String get pensionFundAvailableTitle;
+
+  /// No description provided for @pensionFundConnectedStatus.
+  ///
+  /// In fr, this message translates to:
+  /// **'{name}, connecté'**
+  String pensionFundConnectedStatus(String name);
+
+  /// No description provided for @pensionFundDisconnectedStatus.
+  ///
+  /// In fr, this message translates to:
+  /// **'{name}, non connecté'**
+  String pensionFundDisconnectedStatus(String name);
+
+  /// No description provided for @pensionFundSyncDate.
+  ///
+  /// In fr, this message translates to:
+  /// **'Synchro {date}'**
+  String pensionFundSyncDate(String date);
+
+  /// No description provided for @pensionFundReconnectionNeeded.
+  ///
+  /// In fr, this message translates to:
+  /// **'Reconnexion nécessaire'**
+  String get pensionFundReconnectionNeeded;
+
+  /// No description provided for @pensionFundAvailable.
+  ///
+  /// In fr, this message translates to:
+  /// **'Disponible'**
+  String get pensionFundAvailable;
+
+  /// No description provided for @pensionFundDisconnectTooltip.
+  ///
+  /// In fr, this message translates to:
+  /// **'Déconnecter'**
+  String get pensionFundDisconnectTooltip;
+
+  /// No description provided for @pensionFundConnectButton.
+  ///
+  /// In fr, this message translates to:
+  /// **'Connecter'**
+  String get pensionFundConnectButton;
+
+  /// No description provided for @pensionFundDisclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'MINT est un outil éducatif en lecture seule (LSFin art. 3). Aucune transaction n’est effectuée sur tes comptes. Tu peux te déconnecter à tout moment.'**
+  String get pensionFundDisclaimer;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -24851,4 +24851,134 @@ class SDe extends S {
 
   @override
   String get loadingGeneric => 'Wird geladen…';
+
+  @override
+  String get commonConfirm => 'Bestätigen';
+
+  @override
+  String get b2bHubTitle => 'Mein Unternehmen';
+
+  @override
+  String get b2bHubInvalidCode => 'Ungültiger oder abgelaufener Code';
+
+  @override
+  String get b2bHubLeaveTitle => 'Organisation verlassen?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'Die für dein Unternehmen reservierten Module sind dann nicht mehr zugänglich.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Betriebliche Vorsorge';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'Wenn dein Arbeitgeber MINT nutzt, gib den Einladungscode ein, um auf die Vorsorgemodule für Mitarbeitende zuzugreifen.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Einladungscode';
+
+  @override
+  String get b2bHubJoinButton => 'Beitreten';
+
+  @override
+  String get b2bHubJoinSemantics => 'Organisation beitreten';
+
+  @override
+  String get b2bHubNoCodeHint => 'Kein Code? Frag deine HR-Abteilung.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count Mitarbeitende';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'Deine Module';
+
+  @override
+  String get b2bHubLeaveButton => 'Organisation verlassen';
+
+  @override
+  String get b2bModuleEducation => 'Finanzbildung';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Artikel, Konzepte und Quizze passend zu deiner Situation';
+
+  @override
+  String get b2bModuleWellness => 'Finanzielles Wohlbefinden';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Finanzieller Gesundheitsscore und Empfehlungen';
+
+  @override
+  String get b2bModule3a => 'Säule 3a über den Arbeitgeber';
+
+  @override
+  String get b2bModule3aSubtitle => 'Optimierung und Simulation der 3. Säule';
+
+  @override
+  String get b2bModuleLpp => 'Berufliche Vorsorge (BVG)';
+
+  @override
+  String get b2bModuleLppSubtitle =>
+      'Detaillierte Analyse deiner Pensionskasse';
+
+  @override
+  String get pensionFundTitle => 'Zertifizierte Daten';
+
+  @override
+  String get pensionFundConnectionError => 'Verbindung momentan nicht möglich';
+
+  @override
+  String get pensionFundDisconnectTitle => 'Pensionskasse trennen?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'Deine Projektionen werden wieder auf den Modus «geschätzt» statt «zertifiziert» zurückgesetzt.';
+
+  @override
+  String get pensionFundDisconnectButton => 'Trennen';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Automatischer Import';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Verbinde deine Pensionskasse, um Schätzungen durch deine echten Daten zu ersetzen. Nur Lesezugriff — MINT ändert nichts.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Verfügbare Kassen';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, verbunden';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, nicht verbunden';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Synchro $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Erneute Verbindung erforderlich';
+
+  @override
+  String get pensionFundAvailable => 'Verfügbar';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Trennen';
+
+  @override
+  String get pensionFundConnectButton => 'Verbinden';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'MINT ist ein Bildungstool im Nur-Lese-Modus (FIDLEG Art. 3). Es werden keine Transaktionen auf deinen Konten durchgeführt. Du kannst dich jederzeit trennen.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -24691,4 +24691,134 @@ class SEn extends S {
 
   @override
   String get loadingGeneric => 'Loading…';
+
+  @override
+  String get commonConfirm => 'Confirm';
+
+  @override
+  String get b2bHubTitle => 'My company';
+
+  @override
+  String get b2bHubInvalidCode => 'Invalid or expired code';
+
+  @override
+  String get b2bHubLeaveTitle => 'Leave the organisation?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'Modules reserved for your company will no longer be accessible.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Employer pension plan';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'If your employer uses MINT, enter the invitation code to access pension modules reserved for employees.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Invitation code';
+
+  @override
+  String get b2bHubJoinButton => 'Join';
+
+  @override
+  String get b2bHubJoinSemantics => 'Join the organisation';
+
+  @override
+  String get b2bHubNoCodeHint => 'No code? Ask your HR department.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count employees';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'Your modules';
+
+  @override
+  String get b2bHubLeaveButton => 'Leave the organisation';
+
+  @override
+  String get b2bModuleEducation => 'Financial education';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Articles, concepts, and quizzes tailored to your situation';
+
+  @override
+  String get b2bModuleWellness => 'Financial wellness';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Financial health score and recommendations';
+
+  @override
+  String get b2bModule3a => 'Company pillar 3a';
+
+  @override
+  String get b2bModule3aSubtitle => 'Third pillar optimisation and simulation';
+
+  @override
+  String get b2bModuleLpp => 'Occupational pension (LPP)';
+
+  @override
+  String get b2bModuleLppSubtitle => 'Detailed analysis of your pension fund';
+
+  @override
+  String get pensionFundTitle => 'Certified data';
+
+  @override
+  String get pensionFundConnectionError =>
+      'Connection not available at the moment';
+
+  @override
+  String get pensionFundDisconnectTitle => 'Disconnect the fund?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'Your projections will revert to estimated mode instead of certified.';
+
+  @override
+  String get pensionFundDisconnectButton => 'Disconnect';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Automatic import';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Connect your pension fund to replace estimates with your actual data. Read-only — MINT does not modify anything.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Available funds';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, connected';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, not connected';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Synced $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Reconnection required';
+
+  @override
+  String get pensionFundAvailable => 'Available';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Disconnect';
+
+  @override
+  String get pensionFundConnectButton => 'Connect';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'MINT is a read-only educational tool (FinSA art. 3). No transactions are made on your accounts. You can disconnect at any time.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -24810,4 +24810,137 @@ class SEs extends S {
 
   @override
   String get loadingGeneric => 'Cargando…';
+
+  @override
+  String get commonConfirm => 'Confirmar';
+
+  @override
+  String get b2bHubTitle => 'Mi empresa';
+
+  @override
+  String get b2bHubInvalidCode => 'Código inválido o expirado';
+
+  @override
+  String get b2bHubLeaveTitle => '¿Salir de la organización?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'Los módulos reservados para tu empresa ya no estarán accesibles.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Previsión de empresa';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'Si tu empleador usa MINT, introduce el código de invitación para acceder a los módulos de previsión reservados para empleados.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Código de invitación';
+
+  @override
+  String get b2bHubJoinButton => 'Unirse';
+
+  @override
+  String get b2bHubJoinSemantics => 'Unirse a la organización';
+
+  @override
+  String get b2bHubNoCodeHint =>
+      '¿Sin código? Pregunta a tu departamento de RRHH.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count empleados';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'Tus módulos';
+
+  @override
+  String get b2bHubLeaveButton => 'Salir de la organización';
+
+  @override
+  String get b2bModuleEducation => 'Educación financiera';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Artículos, conceptos y cuestionarios adaptados a tu situación';
+
+  @override
+  String get b2bModuleWellness => 'Bienestar financiero';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Puntuación de salud financiera y recomendaciones';
+
+  @override
+  String get b2bModule3a => 'Pilar 3a de empresa';
+
+  @override
+  String get b2bModule3aSubtitle =>
+      'Optimización y simulación del tercer pilar';
+
+  @override
+  String get b2bModuleLpp => 'Previsión profesional (LPP)';
+
+  @override
+  String get b2bModuleLppSubtitle =>
+      'Análisis detallado de tu caja de pensiones';
+
+  @override
+  String get pensionFundTitle => 'Datos certificados';
+
+  @override
+  String get pensionFundConnectionError =>
+      'Conexión no disponible en este momento';
+
+  @override
+  String get pensionFundDisconnectTitle => '¿Desconectar la caja?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'Tus proyecciones volverán al modo «estimado» en lugar de «certificado».';
+
+  @override
+  String get pensionFundDisconnectButton => 'Desconectar';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Importación automática';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Conecta tu caja de pensiones para reemplazar las estimaciones con tus datos reales. Solo lectura — MINT no modifica nada.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Cajas disponibles';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, conectado';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, no conectado';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Sincro $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Reconexión necesaria';
+
+  @override
+  String get pensionFundAvailable => 'Disponible';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Desconectar';
+
+  @override
+  String get pensionFundConnectButton => 'Conectar';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'MINT es una herramienta educativa de solo lectura (LSFin art. 3). No se realiza ninguna transacción en tus cuentas. Puedes desconectarte en cualquier momento.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -24808,4 +24808,135 @@ class SFr extends S {
 
   @override
   String get loadingGeneric => 'Chargement…';
+
+  @override
+  String get commonConfirm => 'Confirmer';
+
+  @override
+  String get b2bHubTitle => 'Mon entreprise';
+
+  @override
+  String get b2bHubInvalidCode => 'Code invalide ou expiré';
+
+  @override
+  String get b2bHubLeaveTitle => 'Quitter l’organisation ?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'Les modules réservés à ton entreprise ne seront plus accessibles.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Prévoyance d’entreprise';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'Si ton employeur utilise MINT, entre le code d’invitation pour accéder aux modules de prévoyance réservés à tes collaborateurs.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Code d’invitation';
+
+  @override
+  String get b2bHubJoinButton => 'Rejoindre';
+
+  @override
+  String get b2bHubJoinSemantics => 'Rejoindre l’organisation';
+
+  @override
+  String get b2bHubNoCodeHint => 'Pas de code ? Demande à ton département RH.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count collaborateurs';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'Tes modules';
+
+  @override
+  String get b2bHubLeaveButton => 'Quitter l’organisation';
+
+  @override
+  String get b2bModuleEducation => 'Éducation financière';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Articles, concepts, et quiz adaptés à ta situation';
+
+  @override
+  String get b2bModuleWellness => 'Bien-être financier';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Score de santé financière et recommandations';
+
+  @override
+  String get b2bModule3a => 'Pilier 3a entreprise';
+
+  @override
+  String get b2bModule3aSubtitle => 'Optimisation et simulation du 3e pilier';
+
+  @override
+  String get b2bModuleLpp => 'Prévoyance LPP';
+
+  @override
+  String get b2bModuleLppSubtitle =>
+      'Analyse détaillée de ta caisse de pension';
+
+  @override
+  String get pensionFundTitle => 'Données certifiées';
+
+  @override
+  String get pensionFundConnectionError =>
+      'Connexion impossible pour le moment';
+
+  @override
+  String get pensionFundDisconnectTitle => 'Déconnecter la caisse ?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'Tes projections reviendront en mode « estimé » au lieu de « certifié ».';
+
+  @override
+  String get pensionFundDisconnectButton => 'Déconnecter';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Import automatique';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Connecte ta caisse de pension pour remplacer les estimations par tes données réelles. Lecture seule — MINT ne modifie rien.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Caisses disponibles';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, connecté';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, non connecté';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Synchro $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Reconnexion nécessaire';
+
+  @override
+  String get pensionFundAvailable => 'Disponible';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Déconnecter';
+
+  @override
+  String get pensionFundConnectButton => 'Connecter';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'MINT est un outil éducatif en lecture seule (LSFin art. 3). Aucune transaction n’est effectuée sur tes comptes. Tu peux te déconnecter à tout moment.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -24853,4 +24853,137 @@ class SIt extends S {
 
   @override
   String get loadingGeneric => 'Caricamento…';
+
+  @override
+  String get commonConfirm => 'Confermare';
+
+  @override
+  String get b2bHubTitle => 'La mia azienda';
+
+  @override
+  String get b2bHubInvalidCode => 'Codice non valido o scaduto';
+
+  @override
+  String get b2bHubLeaveTitle => 'Lasciare l’organizzazione?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'I moduli riservati alla tua azienda non saranno più accessibili.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Previdenza aziendale';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'Se il tuo datore di lavoro utilizza MINT, inserisci il codice d’invito per accedere ai moduli di previdenza riservati ai collaboratori.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Codice d’invito';
+
+  @override
+  String get b2bHubJoinButton => 'Aderire';
+
+  @override
+  String get b2bHubJoinSemantics => 'Aderire all’organizzazione';
+
+  @override
+  String get b2bHubNoCodeHint =>
+      'Nessun codice? Chiedi al tuo dipartimento HR.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count collaboratori';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'I tuoi moduli';
+
+  @override
+  String get b2bHubLeaveButton => 'Lasciare l’organizzazione';
+
+  @override
+  String get b2bModuleEducation => 'Educazione finanziaria';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Articoli, concetti e quiz adattati alla tua situazione';
+
+  @override
+  String get b2bModuleWellness => 'Benessere finanziario';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Punteggio di salute finanziaria e raccomandazioni';
+
+  @override
+  String get b2bModule3a => 'Pilastro 3a aziendale';
+
+  @override
+  String get b2bModule3aSubtitle =>
+      'Ottimizzazione e simulazione del terzo pilastro';
+
+  @override
+  String get b2bModuleLpp => 'Previdenza professionale (LPP)';
+
+  @override
+  String get b2bModuleLppSubtitle =>
+      'Analisi dettagliata della tua cassa pensione';
+
+  @override
+  String get pensionFundTitle => 'Dati certificati';
+
+  @override
+  String get pensionFundConnectionError =>
+      'Connessione non disponibile al momento';
+
+  @override
+  String get pensionFundDisconnectTitle => 'Disconnettere la cassa?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'Le tue proiezioni torneranno in modalità «stimato» anziché «certificato».';
+
+  @override
+  String get pensionFundDisconnectButton => 'Disconnettere';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Importazione automatica';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Collega la tua cassa pensione per sostituire le stime con i tuoi dati reali. Solo lettura — MINT non modifica nulla.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Casse disponibili';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, connesso';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, non connesso';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Sincro $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Riconnessione necessaria';
+
+  @override
+  String get pensionFundAvailable => 'Disponibile';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Disconnettere';
+
+  @override
+  String get pensionFundConnectButton => 'Connettere';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'MINT è uno strumento educativo in sola lettura (LSFin art. 3). Nessuna transazione viene effettuata sui tuoi conti. Puoi disconnetterti in qualsiasi momento.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -24768,4 +24768,135 @@ class SPt extends S {
 
   @override
   String get loadingGeneric => 'A carregar…';
+
+  @override
+  String get commonConfirm => 'Confirmar';
+
+  @override
+  String get b2bHubTitle => 'A minha empresa';
+
+  @override
+  String get b2bHubInvalidCode => 'Código inválido ou expirado';
+
+  @override
+  String get b2bHubLeaveTitle => 'Sair da organização?';
+
+  @override
+  String get b2bHubLeaveBody =>
+      'Os módulos reservados à tua empresa deixarão de estar acessíveis.';
+
+  @override
+  String get b2bHubNarrativeHeadline => 'Previdência empresarial';
+
+  @override
+  String get b2bHubNarrativeBody =>
+      'Se o teu empregador utiliza o MINT, introduz o código de convite para aceder aos módulos de previdência reservados aos colaboradores.';
+
+  @override
+  String get b2bHubInviteCodeLabel => 'Código de convite';
+
+  @override
+  String get b2bHubJoinButton => 'Aderir';
+
+  @override
+  String get b2bHubJoinSemantics => 'Aderir à organização';
+
+  @override
+  String get b2bHubNoCodeHint =>
+      'Sem código? Pergunta ao teu departamento de RH.';
+
+  @override
+  String b2bHubEmployeeCount(String count) {
+    return '$count colaboradores';
+  }
+
+  @override
+  String get b2bHubModulesTitle => 'Os teus módulos';
+
+  @override
+  String get b2bHubLeaveButton => 'Sair da organização';
+
+  @override
+  String get b2bModuleEducation => 'Educação financeira';
+
+  @override
+  String get b2bModuleEducationSubtitle =>
+      'Artigos, conceitos e questionários adaptados à tua situação';
+
+  @override
+  String get b2bModuleWellness => 'Bem-estar financeiro';
+
+  @override
+  String get b2bModuleWellnessSubtitle =>
+      'Pontuação de saúde financeira e recomendações';
+
+  @override
+  String get b2bModule3a => 'Pilar 3a empresarial';
+
+  @override
+  String get b2bModule3aSubtitle => 'Otimização e simulação do terceiro pilar';
+
+  @override
+  String get b2bModuleLpp => 'Previdência profissional (LPP)';
+
+  @override
+  String get b2bModuleLppSubtitle =>
+      'Análise detalhada da tua caixa de pensões';
+
+  @override
+  String get pensionFundTitle => 'Dados certificados';
+
+  @override
+  String get pensionFundConnectionError => 'Ligação indisponível de momento';
+
+  @override
+  String get pensionFundDisconnectTitle => 'Desligar a caixa?';
+
+  @override
+  String get pensionFundDisconnectBody =>
+      'As tuas projeções voltarão ao modo «estimado» em vez de «certificado».';
+
+  @override
+  String get pensionFundDisconnectButton => 'Desligar';
+
+  @override
+  String get pensionFundNarrativeHeadline => 'Importação automática';
+
+  @override
+  String get pensionFundNarrativeBody =>
+      'Liga a tua caixa de pensões para substituir as estimativas pelos teus dados reais. Apenas leitura — o MINT não altera nada.';
+
+  @override
+  String get pensionFundAvailableTitle => 'Caixas disponíveis';
+
+  @override
+  String pensionFundConnectedStatus(String name) {
+    return '$name, ligado';
+  }
+
+  @override
+  String pensionFundDisconnectedStatus(String name) {
+    return '$name, não ligado';
+  }
+
+  @override
+  String pensionFundSyncDate(String date) {
+    return 'Sincro $date';
+  }
+
+  @override
+  String get pensionFundReconnectionNeeded => 'Reconexão necessária';
+
+  @override
+  String get pensionFundAvailable => 'Disponível';
+
+  @override
+  String get pensionFundDisconnectTooltip => 'Desligar';
+
+  @override
+  String get pensionFundConnectButton => 'Ligar';
+
+  @override
+  String get pensionFundDisclaimer =>
+      'O MINT é uma ferramenta educativa em modo de leitura (LSFin art. 3). Nenhuma transação é efetuada nas tuas contas. Podes desligar-te a qualquer momento.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11586,5 +11586,66 @@
         "type": "String"
       }
     }
-  }
+  },
+
+  "commonConfirm": "Confirmar",
+
+  "b2bHubTitle": "A minha empresa",
+  "b2bHubInvalidCode": "Código inválido ou expirado",
+  "b2bHubLeaveTitle": "Sair da organização?",
+  "b2bHubLeaveBody": "Os módulos reservados à tua empresa deixarão de estar acessíveis.",
+  "b2bHubNarrativeHeadline": "Previdência empresarial",
+  "b2bHubNarrativeBody": "Se o teu empregador utiliza o MINT, introduz o código de convite para aceder aos módulos de previdência reservados aos colaboradores.",
+  "b2bHubInviteCodeLabel": "Código de convite",
+  "b2bHubJoinButton": "Aderir",
+  "b2bHubJoinSemantics": "Aderir à organização",
+  "b2bHubNoCodeHint": "Sem código? Pergunta ao teu departamento de RH.",
+  "b2bHubEmployeeCount": "{count} colaboradores",
+  "@b2bHubEmployeeCount": {
+    "placeholders": {
+      "count": { "type": "String" }
+    }
+  },
+  "b2bHubModulesTitle": "Os teus módulos",
+  "b2bHubLeaveButton": "Sair da organização",
+  "b2bModuleEducation": "Educação financeira",
+  "b2bModuleEducationSubtitle": "Artigos, conceitos e questionários adaptados à tua situação",
+  "b2bModuleWellness": "Bem-estar financeiro",
+  "b2bModuleWellnessSubtitle": "Pontuação de saúde financeira e recomendações",
+  "b2bModule3a": "Pilar 3a empresarial",
+  "b2bModule3aSubtitle": "Otimização e simulação do terceiro pilar",
+  "b2bModuleLpp": "Previdência profissional (LPP)",
+  "b2bModuleLppSubtitle": "Análise detalhada da tua caixa de pensões",
+
+  "pensionFundTitle": "Dados certificados",
+  "pensionFundConnectionError": "Ligação indisponível de momento",
+  "pensionFundDisconnectTitle": "Desligar a caixa?",
+  "pensionFundDisconnectBody": "As tuas projeções voltarão ao modo «estimado» em vez de «certificado».",
+  "pensionFundDisconnectButton": "Desligar",
+  "pensionFundNarrativeHeadline": "Importação automática",
+  "pensionFundNarrativeBody": "Liga a tua caixa de pensões para substituir as estimativas pelos teus dados reais. Apenas leitura \u2014 o MINT não altera nada.",
+  "pensionFundAvailableTitle": "Caixas disponíveis",
+  "pensionFundConnectedStatus": "{name}, ligado",
+  "@pensionFundConnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundDisconnectedStatus": "{name}, não ligado",
+  "@pensionFundDisconnectedStatus": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "pensionFundSyncDate": "Sincro {date}",
+  "@pensionFundSyncDate": {
+    "placeholders": {
+      "date": { "type": "String" }
+    }
+  },
+  "pensionFundReconnectionNeeded": "Reconexão necessária",
+  "pensionFundAvailable": "Disponível",
+  "pensionFundDisconnectTooltip": "Desligar",
+  "pensionFundConnectButton": "Ligar",
+  "pensionFundDisclaimer": "O MINT é uma ferramenta educativa em modo de leitura (LSFin art.\u00a03). Nenhuma transação é efetuada nas tuas contas. Podes desligar-te a qualquer momento."
 }

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
@@ -638,13 +639,22 @@ class CoachProfileProvider extends ChangeNotifier {
 
   /// Replace the current profile with an updated one and persist via answers.
   void updateProfile(CoachProfile updated) {
+    final previousStatus = _profile?.etatCivil;
     _profile = updated;
     _profileUpdatedSinceBudget = true;
     notifyListeners();
-    // FIX-045: Persist ALL profile fields (not just housing) so changes
-    // survive app restart. Previously only housing fields were persisted,
-    // causing silent data loss on canton, salary, LPP, 3a changes.
+    // FIX-045: Persist ALL profile fields.
     _persistFullProfile(updated);
+    // FIX-097: If civil status changed to non-coupled, dissolve household.
+    if (previousStatus != null &&
+        previousStatus != updated.etatCivil &&
+        updated.etatCivil != CoachCivilStatus.marie &&
+        updated.etatCivil != CoachCivilStatus.concubinage) {
+      // FIX-097: Clear local household state on divorce (fire-and-forget).
+      SharedPreferences.getInstance().then((sp) {
+        sp.remove('_household_data');
+      }).catchError((_) {});
+    }
   }
 
   Future<void> _persistFullProfile(CoachProfile profile) async {
@@ -868,10 +878,34 @@ class CoachProfileProvider extends ChangeNotifier {
   /// dans les answers wizard pour coherence au redemarrage.
   ///
   /// Reference: DATA_ACQUISITION_STRATEGY.md — Channel 1, Document A
+  /// FIX-095: Previous prevoyance backup for undo capability.
+  PrevoyanceProfile? _previousPrevoyance;
+
+  /// FIX-095: Get the previous prevoyance state (before last extraction).
+  PrevoyanceProfile? get previousPrevoyance => _previousPrevoyance;
+
+  /// FIX-094: Check if new LPP data diverges significantly from existing.
+  /// Returns the delta percentage if > 30%, null otherwise.
+  double? checkLppDivergence(List<ExtractedField> fields) {
+    if (_profile == null) return null;
+    final currentAvoir = _profile!.prevoyance.avoirLppTotal;
+    if (currentAvoir == null || currentAvoir <= 0) return null;
+    final newAvoir = fields
+        .where((f) => f.fieldName == 'avoirLppTotal' || f.fieldName == 'avoir_lpp_total')
+        .firstOrNull?.value;
+    if (newAvoir == null) return null;
+    final newVal = newAvoir is num ? newAvoir.toDouble() : double.tryParse(newAvoir.toString()) ?? 0;
+    if (newVal <= 0) return null;
+    final deltaPct = ((newVal - currentAvoir) / currentAvoir * 100).abs();
+    return deltaPct > 30 ? deltaPct : null;
+  }
+
   Future<void> updateFromLppExtraction(List<ExtractedField> fields) async {
     if (_profile == null) return;
 
     final p = _profile!;
+    // FIX-095: Save previous state for undo capability.
+    _previousPrevoyance = p.prevoyance;
 
     // Extract values from confirmed fields
     double? avoirTotal;

--- a/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/location_vs_propriete_screen.dart
@@ -427,7 +427,10 @@ class _LocationVsProprieteScreenState extends State<LocationVsProprieteScreen> {
             child: SizedBox(
               width: double.infinity,
               child: FilledButton(
-                onPressed: _recalculate,
+                onPressed: () {
+                  HapticFeedback.lightImpact();
+                  _recalculate();
+                },
                 style: FilledButton.styleFrom(
                   backgroundColor: MintColors.primary,
                   foregroundColor: MintColors.white,

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -714,6 +714,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
                 ],
                 selected: {_inputMode},
                 onSelectionChanged: (v) {
+                  HapticFeedback.lightImpact();
                   setState(() => _inputMode = v.first);
                   _userRecalculate();
                 },

--- a/apps/mobile/lib/screens/b2b/b2b_hub_screen.dart
+++ b/apps/mobile/lib/screens/b2b/b2b_hub_screen.dart
@@ -9,6 +9,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/b2b/b2b_organization_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -58,7 +59,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Code invalide ou expiré')), // TODO: i18n
+          SnackBar(content: Text(S.of(context)!.b2bHubInvalidCode)),
         );
         setState(() => _loading = false);
       }
@@ -70,20 +71,20 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
       context: context,
       builder: (_) => AlertDialog(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        title: Text('Quitter l\u2019organisation\u00a0?', // TODO: i18n
+        title: Text(S.of(context)!.b2bHubLeaveTitle,
             style: MintTextStyles.headlineMedium()),
         content: Text(
-          'Les modules réservés à ton entreprise ne seront plus accessibles.',
+          S.of(context)!.b2bHubLeaveBody,
           style: MintTextStyles.bodyMedium(color: MintColors.textSecondary),
-        ), // TODO: i18n
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text('Annuler', style: MintTextStyles.bodyMedium()),
+            child: Text(S.of(context)!.commonCancel, style: MintTextStyles.bodyMedium()),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Confirmer'),
+            child: Text(S.of(context)!.commonConfirm),
           ),
         ],
       ),
@@ -116,7 +117,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
           backgroundColor: MintColors.primary,
           foregroundColor: MintColors.white,
           flexibleSpace: FlexibleSpaceBar(
-            title: Text('Mon entreprise', // TODO: i18n
+            title: Text(S.of(context)!.b2bHubTitle,
                 style: MintTextStyles.titleMedium(color: MintColors.white)),
             background: Container(
               decoration: const BoxDecoration(
@@ -139,12 +140,10 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
             delegate: SliverChildListDelegate([
               MintEntrance(
                 child: MintNarrativeCard(
-                  headline: 'Prévoyance d\u2019entreprise',
-                  body: 'Si ton employeur utilise MINT, entre le code '
-                      'd\u2019invitation pour accéder aux modules de '
-                      'prévoyance réservés à tes collaborateurs.',
+                  headline: S.of(context)!.b2bHubNarrativeHeadline,
+                  body: S.of(context)!.b2bHubNarrativeBody,
                   tone: MintSurfaceTone.porcelaine,
-                ), // TODO: i18n
+                ),
               ),
               const SizedBox(height: MintSpacing.xl),
 
@@ -157,7 +156,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
                   elevated: true,
                   child: Column(
                     children: [
-                      Text('Code d\u2019invitation', // TODO: i18n
+                      Text(S.of(context)!.b2bHubInviteCodeLabel,
                           style: MintTextStyles.bodySmall(
                               color: MintColors.textMuted)),
                       const SizedBox(height: MintSpacing.md),
@@ -183,7 +182,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
                         width: double.infinity,
                         child: Semantics(
                           button: true,
-                          label: 'Rejoindre l\u2019organisation',
+                          label: S.of(context)!.b2bHubJoinSemantics,
                           child: FilledButton(
                             onPressed: _joinOrganization,
                             style: FilledButton.styleFrom(
@@ -192,7 +191,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
                                 borderRadius: BorderRadius.circular(14),
                               ),
                             ),
-                            child: Text('Rejoindre', // TODO: i18n
+                            child: Text(S.of(context)!.b2bHubJoinButton,
                                 style: MintTextStyles.titleMedium(
                                     color: MintColors.white)),
                           ),
@@ -207,10 +206,10 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
               MintEntrance(
                 delay: const Duration(milliseconds: 400),
                 child: Text(
-                  'Pas de code\u00a0? Demande à ton département RH.',
+                  S.of(context)!.b2bHubNoCodeHint,
                   style: MintTextStyles.bodySmall(color: MintColors.textMuted),
                   textAlign: TextAlign.center,
-                ), // TODO: i18n
+                ),
               ),
             ]),
           ),
@@ -281,9 +280,9 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              '${org.employeeCount} collaborateurs',
+                              S.of(context)!.b2bHubEmployeeCount(org.employeeCount.toString()),
                               style: MintTextStyles.bodyMedium(),
-                            ), // TODO: i18n
+                            ),
                             const SizedBox(height: 2),
                             Container(
                               padding: const EdgeInsets.symmetric(
@@ -310,7 +309,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
               // Section title
               MintEntrance(
                 delay: const Duration(milliseconds: 100),
-                child: Text('Tes modules', // TODO: i18n
+                child: Text(S.of(context)!.b2bHubModulesTitle,
                     style: MintTextStyles.headlineMedium()),
               ),
               const SizedBox(height: MintSpacing.md),
@@ -334,7 +333,7 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
                 child: TextButton(
                   onPressed: _leaveOrganization,
                   child: Text(
-                    'Quitter l\u2019organisation', // TODO: i18n
+                    S.of(context)!.b2bHubLeaveButton,
                     style: MintTextStyles.bodySmall(color: MintColors.textMuted),
                   ),
                 ),
@@ -348,29 +347,30 @@ class _B2bHubScreenState extends State<B2bHubScreen> {
   }
 
   Widget _buildModuleCard(String module) {
+    final l = S.of(context)!;
     final (icon, label, subtitle, route) = switch (module) {
       'education' => (
         Icons.school_outlined,
-        'Éducation financière',
-        'Articles, concepts, et quiz adaptés à ta situation',
+        l.b2bModuleEducation,
+        l.b2bModuleEducationSubtitle,
         '/explorer',
       ),
       'wellness' => (
         Icons.favorite_outline,
-        'Bien-être financier',
-        'Score de santé financière et recommandations',
+        l.b2bModuleWellness,
+        l.b2bModuleWellnessSubtitle,
         '/home',
       ),
       '3a' => (
         Icons.savings_outlined,
-        'Pilier 3a entreprise',
-        'Optimisation et simulation du 3e pilier',
+        l.b2bModule3a,
+        l.b2bModule3aSubtitle,
         '/pilier-3a',
       ),
       'lpp' => (
         Icons.account_balance_outlined,
-        'Prévoyance LPP',
-        'Analyse détaillée de ta caisse de pension',
+        l.b2bModuleLpp,
+        l.b2bModuleLppSubtitle,
         '/lpp-deep',
       ),
       _ => (

--- a/apps/mobile/lib/screens/coach/annual_refresh_screen.dart
+++ b/apps/mobile/lib/screens/coach/annual_refresh_screen.dart
@@ -615,7 +615,10 @@ class _AnnualRefreshScreenState extends State<AnnualRefreshScreen> {
       width: double.infinity,
       height: 52,
       child: ElevatedButton(
-        onPressed: _isSubmitting ? null : _onSubmit,
+        onPressed: _isSubmitting ? null : () {
+          HapticFeedback.lightImpact();
+          _onSubmit();
+        },
         style: ElevatedButton.styleFrom(
           backgroundColor: MintColors.coachAccent,
           foregroundColor: MintColors.white,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -1176,6 +1176,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
   }) async {
     // Capture localizations before async gap (use_build_context_synchronously)
     final l = S.of(context)!;
+    final languageCode = Localizations.localeOf(context).languageCode;
     try {
       final config = preAwaitConfig ?? _buildConfig();
       final response = await CoachLlmService.chat(
@@ -1184,6 +1185,7 @@ class _CoachChatScreenState extends State<CoachChatScreen>
         history: _messages,
         config: config,
         memoryBlock: memoryBlock,
+        language: languageCode,
       );
 
       final tier = config.hasApiKey ? ChatTier.byok : ChatTier.fallback;

--- a/apps/mobile/lib/screens/concubinage_screen.dart
+++ b/apps/mobile/lib/screens/concubinage_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +8,9 @@ import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/family_service.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/visualizations/concubinage_decision_matrix.dart';
 import 'package:mint_mobile/widgets/coach/clause_3a_widget.dart';
 import 'package:mint_mobile/widgets/coach/survivor_pension_widget.dart';
@@ -148,48 +152,72 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
       children: [
         // Hero chiffre-choc — patrimoine exposed
         if (_patrimoine > 0) ...[
-          _buildHeroChiffreChoc(),
+          MintEntrance(child: _buildHeroChiffreChoc()),
           const SizedBox(height: MintSpacing.lg),
         ],
 
         // Inputs
-        _buildComparateurInputs(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 100),
+          child: _buildComparateurInputs(),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         if (_comparisonResult != null) ...[
           // Decision matrix — animated comparison visualization
-          ConcubinageDecisionMatrix(
-            criteria: _matrixCriteria,
+          MintEntrance(
+            delay: const Duration(milliseconds: 150),
+            child: ConcubinageDecisionMatrix(
+              criteria: _matrixCriteria,
+            ),
           ),
           const SizedBox(height: MintSpacing.lg),
 
           // Score summary
-          _buildScoreSummary(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 200),
+            child: _buildScoreSummary(),
+          ),
           const SizedBox(height: MintSpacing.lg),
 
           // Fiscal detail
-          _buildFiscalDetailCard(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 250),
+            child: _buildFiscalDetailCard(),
+          ),
           const SizedBox(height: MintSpacing.lg),
 
           // Inheritance detail
-          _buildInheritanceCard(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 300),
+            child: _buildInheritanceCard(),
+          ),
           const SizedBox(height: MintSpacing.lg),
         ],
 
         // Educational insert — AVS cap 150% (LAVS art. 35)
-        _buildEducationalInsert(
-          S.of(context)!.concubinageEducationalAvs,
+        MintEntrance(
+          delay: const Duration(milliseconds: 350),
+          child: _buildEducationalInsert(
+            S.of(context)!.concubinageEducationalAvs,
+          ),
         ),
         const SizedBox(height: MintSpacing.md),
 
         // Educational insert — Succession
-        _buildEducationalInsert(
-          S.of(context)!.concubinageEducationalSuccession,
+        MintEntrance(
+          delay: const Duration(milliseconds: 400),
+          child: _buildEducationalInsert(
+            S.of(context)!.concubinageEducationalSuccession,
+          ),
         ),
         const SizedBox(height: MintSpacing.lg),
 
         // Neutral conclusion
-        _buildNeutralConclusion(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 450),
+          child: _buildNeutralConclusion(),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         _buildDisclaimer(),
@@ -198,30 +226,25 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
   }
 
   Widget _buildHeroChiffreChoc() {
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.primary,
-        borderRadius: BorderRadius.circular(16),
+    return Semantics(
+      label: S.of(context)!.concubinageHeroChiffreChoc(
+        FamilyService.formatChf(_patrimoine),
       ),
-      child: Column(
-        children: [
-          Text(
-            S.of(context)!.concubinageHeroChiffreChoc(
-              FamilyService.formatChf(_patrimoine),
+      child: Container(
+        padding: const EdgeInsets.all(MintSpacing.lg),
+        decoration: BoxDecoration(
+          color: MintColors.primary,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Column(
+          children: [
+            MintHeroNumber(
+              value: FamilyService.formatChf(_patrimoine),
+              caption: S.of(context)!.concubinageHeroChiffreChocDesc,
+              color: MintColors.white,
             ),
-            style: MintTextStyles.displayMedium(color: MintColors.white)
-                .copyWith(fontSize: 28, fontWeight: FontWeight.w800),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: MintSpacing.xs + 2),
-          Text(
-            S.of(context)!.concubinageHeroChiffreChocDesc,
-            style: MintTextStyles.bodySmall(color: MintColors.white70)
-                .copyWith(height: 1.4),
-            textAlign: TextAlign.center,
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -229,14 +252,9 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
   Widget _buildComparateurInputs() {
     final sortedCodes = FamilyService.sortedCantonCodes;
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -444,13 +462,9 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
     final difference = fiscal['difference'] as double;
     final isPenalite = fiscal['isPenalite'] as bool;
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.porcelaine,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -504,13 +518,9 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
 
     if (impot <= 0) return const SizedBox.shrink();
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.porcelaine,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -629,7 +639,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
       padding: const EdgeInsets.fromLTRB(MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, 100),
       children: [
         // Intro
-        Container(
+        MintEntrance(child: Container(
           padding: const EdgeInsets.all(MintSpacing.md),
           decoration: BoxDecoration(
             color: MintColors.appleSurface,
@@ -651,17 +661,15 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
             ],
           ),
         ),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         // LPP slider
-        Container(
-          padding: const EdgeInsets.all(MintSpacing.lg),
-          decoration: BoxDecoration(
-            color: MintColors.white,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-                color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-          ),
+        MintEntrance(
+          delay: const Duration(milliseconds: 100),
+          child: MintSurface(
+          tone: MintSurfaceTone.blanc,
+          elevated: true,
           child: MintAmountField(
             label: S.of(context)!.concubinageProtectionLppSlider,
             value: _renteLpp,
@@ -675,10 +683,13 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
             max: 8000,
           ),
         ),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         // Side-by-side chiffre-choc: Married vs Concubin survivor total
-        Row(
+        MintEntrance(
+          delay: const Duration(milliseconds: 150),
+          child: Row(
           children: [
             // Married survivor
             Expanded(
@@ -733,6 +744,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
             ),
           ],
         ),
+        ),
         const SizedBox(height: MintSpacing.sm),
         Text(
           S.of(context)!.concubinageProtectionSurvivorZero,
@@ -742,24 +754,36 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
         const SizedBox(height: MintSpacing.lg),
 
         // Comparison table: married vs concubin
-        _buildProtectionComparison(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 200),
+          child: _buildProtectionComparison(),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         // Educational insert — LPP survivor
-        _buildEducationalInsert(
-          S.of(context)!.concubinageEducationalLpp,
+        MintEntrance(
+          delay: const Duration(milliseconds: 250),
+          child: _buildEducationalInsert(
+            S.of(context)!.concubinageEducationalLpp,
+          ),
         ),
         const SizedBox(height: MintSpacing.lg),
 
         // Clause 3a widget
-        _buildClause3aSection(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 300),
+          child: _buildClause3aSection(),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         // Survivor pension widget (concubin mode)
-        SurvivorPensionWidget(
+        MintEntrance(
+          delay: const Duration(milliseconds: 350),
+          child: SurvivorPensionWidget(
           partnerAvsRente: avsRenteMaxMensuelle,
           partnerLppMonthly: _renteLpp,
           isConcubin: true,
+        ),
         ),
         const SizedBox(height: MintSpacing.lg),
 
@@ -894,7 +918,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
       padding: const EdgeInsets.fromLTRB(MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, 100),
       children: [
         // Intro
-        Container(
+        MintEntrance(child: Container(
           padding: const EdgeInsets.all(MintSpacing.md),
           decoration: BoxDecoration(
             color: MintColors.appleSurface,
@@ -916,10 +940,13 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
             ],
           ),
         ),
+        ),
         const SizedBox(height: MintSpacing.lg),
 
         // Progress bar
-        Container(
+        MintEntrance(
+          delay: const Duration(milliseconds: 100),
+          child: Container(
           padding: const EdgeInsets.all(MintSpacing.lg),
           decoration: BoxDecoration(
             color: MintColors.white,
@@ -958,6 +985,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
               ),
             ],
           ),
+        ),
         ),
         const SizedBox(height: MintSpacing.lg),
 
@@ -1023,6 +1051,7 @@ class _ConcubinageScreenState extends State<ConcubinageScreen>
                         toggled: isChecked,
                         child: GestureDetector(
                           onTap: () {
+                            HapticFeedback.lightImpact();
                             setState(() {
                               if (isChecked) {
                                 _checkedItems.remove(index);

--- a/apps/mobile/lib/screens/coverage_check_screen.dart
+++ b/apps/mobile/lib/screens/coverage_check_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -299,6 +300,7 @@ class _CoverageCheckScreenState extends State<CoverageCheckScreen> {
       button: true,
       child: GestureDetector(
       onTap: () {
+        HapticFeedback.lightImpact();
         _statut = value;
         // Reset related switches when changing status
         if (value == 'independant') {

--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -11,6 +12,9 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 
 /// Ecran de diagnostic du ratio d'endettement.
 ///
@@ -72,30 +76,45 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
             sliver: SliverList(
               delegate: SliverChildListDelegate([
                 // Chiffre choc gauge
-                _buildGaugeSection(result),
+                MintEntrance(child: _buildGaugeSection(result)),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Sliders
-                _buildSlidersSection(),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 100),
+                  child: _buildSlidersSection(),
+                ),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Minimum vital
-                _buildMinimumVitalCard(result),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 200),
+                  child: _buildMinimumVitalCard(result),
+                ),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Recommandations
-                _buildRecommandationsSection(result),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 300),
+                  child: _buildRecommandationsSection(result),
+                ),
                 const SizedBox(height: MintSpacing.md),
 
                 // CTA contextuel → Plan de remboursement
                 if (result.niveau != DebtRiskLevel.vert)
-                  _buildRepaymentCta(result),
+                  MintEntrance(
+                    delay: const Duration(milliseconds: 400),
+                    child: _buildRepaymentCta(result),
+                  ),
                 if (result.niveau != DebtRiskLevel.vert)
                   const SizedBox(height: MintSpacing.lg),
 
                 // Aide professionnelle
                 if (result.niveau == DebtRiskLevel.rouge) ...[
-                  _buildAideProfessionnelleSection(),
+                  MintEntrance(
+                    delay: const Duration(milliseconds: 450),
+                    child: _buildAideProfessionnelleSection(),
+                  ),
                   const SizedBox(height: MintSpacing.lg),
                 ],
 
@@ -127,13 +146,9 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
       DebtRiskLevel.rouge => S.of(context)!.debtRatioLevelCritique,
     };
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.porcelaine,
+      elevated: true,
       child: Column(
         children: [
           // Semi-circle gauge
@@ -148,11 +163,13 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
             ),
           ),
           const SizedBox(height: MintSpacing.sm),
-          Text(
-            '${result.ratio.toStringAsFixed(1)}%',
-            style: MintTextStyles.displayMedium(color: color),
+          MintHeroNumber(
+            value: '${result.ratio.toStringAsFixed(1)}%',
+            caption: S.of(context)!.debtRatioSubLabel,
+            color: color,
+            semanticsLabel: '${result.ratio.toStringAsFixed(1)}% — $label',
           ),
-          const SizedBox(height: MintSpacing.xs),
+          const SizedBox(height: MintSpacing.sm),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: MintSpacing.sm + 4, vertical: MintSpacing.xs),
             decoration: BoxDecoration(
@@ -164,11 +181,6 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
               style: MintTextStyles.bodySmall(color: color)
                   .copyWith(fontWeight: FontWeight.w700),
             ),
-          ),
-          const SizedBox(height: MintSpacing.sm),
-          Text(
-            S.of(context)!.debtRatioSubLabel,
-            style: MintTextStyles.labelSmall(color: MintColors.textMuted),
           ),
           const SizedBox(height: MintSpacing.md),
           // Legende
@@ -740,16 +752,9 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
   Widget _buildMinimumVitalCard(DebtRatioResult result) {
     final isMenace = result.minimumVitalMenace;
 
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: isMenace ? MintColors.urgentBg : MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: isMenace ? MintColors.coralLight : MintColors.border,
-          width: isMenace ? 2 : 1,
-        ),
-      ),
+    return MintSurface(
+      tone: isMenace ? MintSurfaceTone.peche : MintSurfaceTone.blanc,
+      elevated: isMenace,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -829,13 +834,9 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
   }
 
   Widget _buildRecommandationsSection(DebtRatioResult result) {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -876,7 +877,10 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
       label: S.of(context)!.debtRatioCtaSemantics,
       button: true,
       child: InkWell(
-        onTap: () => context.push('/debt/repayment'),
+        onTap: () {
+          HapticFeedback.lightImpact();
+          context.push('/debt/repayment');
+        },
         borderRadius: BorderRadius.circular(16),
         child: Container(
           padding: const EdgeInsets.all(20),

--- a/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -8,6 +9,9 @@ import 'package:mint_mobile/services/debt_prevention_service.dart';
 import 'package:mint_mobile/services/lpp_deep_service.dart' show formatChf;
 import 'package:mint_mobile/widgets/coach/debt_survival_widget.dart';
 import 'package:mint_mobile/widgets/common/debt_tools_nav.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 /// Ecran de planification du remboursement de dettes.
 ///
@@ -85,23 +89,23 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
             sliver: SliverList(
               delegate: SliverChildListDelegate([
                 // ── P10-F : Mode survie MINT ──────────────────────
-                DebtSurvivalWidget(
+                MintEntrance(child: DebtSurvivalWidget(
                   totalDebt: _dettes.fold<double>(0, (s, d) => s + d.montant),
                   monthlyMargin: _budgetMensuel -
                       _dettes.fold<double>(0, (s, d) => s + d.mensualiteMin),
                   daysSinceLastLate: 0,
                   monthlyIncome: 6000,
-                ),
+                )),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Chiffre choc
                 if (result != null) ...[
-                  _buildChiffreChoc(result),
+                  MintEntrance(delay: const Duration(milliseconds: 100), child: _buildChiffreChoc(result)),
                   const SizedBox(height: MintSpacing.lg),
                 ],
 
                 // Liste des dettes
-                _buildDettesSection(),
+                MintEntrance(delay: const Duration(milliseconds: 150), child: _buildDettesSection()),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Budget mensuel
@@ -110,13 +114,13 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
 
                 // Comparaison strategies
                 if (result != null) ...[
-                  _buildComparisonSection(result),
+                  MintEntrance(child: _buildComparisonSection(result)),
                   const SizedBox(height: MintSpacing.sm + 4),
                   _buildStrategyNote(),
                   const SizedBox(height: MintSpacing.lg),
 
                   // Timeline
-                  _buildTimelineSection(result),
+                  MintEntrance(delay: const Duration(milliseconds: 100), child: _buildTimelineSection(result)),
                   const SizedBox(height: MintSpacing.lg),
 
                   // Disclaimer
@@ -150,15 +154,15 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
         ? result.avalanche
         : result.bouleDeNeige;
 
-    return Container(
+    final tone = switch (result.chiffreChoc.niveau) {
+      DebtRiskLevel.vert => MintSurfaceTone.sauge,
+      DebtRiskLevel.orange => MintSurfaceTone.peche,
+      DebtRiskLevel.rouge => MintSurfaceTone.blanc,
+    };
+
+    return MintSurface(
+      tone: tone,
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [color.withValues(alpha: 0.1), color.withValues(alpha: 0.2)],
-        ),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: color.withValues(alpha: 0.5), width: 2),
-      ),
       child: Semantics(
         label: 'Libéré dans ${strategiePrioritaire.moisJusquaLiberation} mois', // TODO: i18n
         child: Column(
@@ -169,9 +173,10 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
                   .copyWith(fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: MintSpacing.sm),
-            Text(
-              '${strategiePrioritaire.moisJusquaLiberation} mois',
-              style: MintTextStyles.displayMedium(color: color),
+            MintHeroNumber(
+              value: '${strategiePrioritaire.moisJusquaLiberation}',
+              caption: 'mois',
+              color: color,
             ),
             const SizedBox(height: 4),
             if (result.economieInterets > 0)
@@ -492,6 +497,7 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
                 width: double.infinity,
                 child: FilledButton(
                   onPressed: () {
+                    HapticFeedback.lightImpact();
                     final parsed = double.tryParse(
                       controller.text
                           .replaceAll("'", '')
@@ -795,13 +801,10 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
       sampled.add(timeline.last);
     }
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      elevated: true,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/mobile/lib/screens/donation_screen.dart
+++ b/apps/mobile/lib/screens/donation_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -7,6 +8,9 @@ import 'package:mint_mobile/services/donation_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_result_hero_card.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 
 /// Swiss CHF formatter with apostrophe grouping.
@@ -135,31 +139,55 @@ class _DonationScreenState extends State<DonationScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildHeader(),
+            MintEntrance(child: _buildHeader()),
             const SizedBox(height: 24),
-            _buildIntroCard(),
+            MintEntrance(
+              delay: const Duration(milliseconds: 100),
+              child: _buildIntroCard(),
+            ),
             const SizedBox(height: 24),
-            _buildDonationSection(),
+            MintEntrance(
+              delay: const Duration(milliseconds: 150),
+              child: _buildDonationSection(),
+            ),
             const SizedBox(height: 12),
-            _buildSuccessionContextSection(),
+            MintEntrance(
+              delay: const Duration(milliseconds: 200),
+              child: _buildSuccessionContextSection(),
+            ),
             const SizedBox(height: 24),
             _buildSimulateButton(),
             const SizedBox(height: 24),
             if (_result != null) ...[
               Container(key: _resultsKey),
-              _buildTaxCard(),
+              MintEntrance(child: _buildTaxCard()),
               const SizedBox(height: 24),
-              _buildReserveCard(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 100),
+                child: _buildReserveCard(),
+              ),
               const SizedBox(height: 24),
-              _buildQuotiteCard(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 200),
+                child: _buildQuotiteCard(),
+              ),
               const SizedBox(height: 24),
-              _buildImpactSuccessionCard(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 300),
+                child: _buildImpactSuccessionCard(),
+              ),
               const SizedBox(height: 24),
               if (_result!.alerts.isNotEmpty) ...[
-                _buildAlertsSection(),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 350),
+                  child: _buildAlertsSection(),
+                ),
                 const SizedBox(height: 24),
               ],
-              _buildChecklistSection(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 400),
+                child: _buildChecklistSection(),
+              ),
               const SizedBox(height: 24),
             ],
             _buildEducationalFooter(),
@@ -486,21 +514,28 @@ class _DonationScreenState extends State<DonationScreen> {
 
   // ── Simulate Button ──
   Widget _buildSimulateButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: FilledButton.icon(
-        onPressed: _simulate,
-        icon: const Icon(Icons.calculate_outlined, size: 20),
-        label: Text(
-          S.of(context)!.donationCalculer,
-          style: MintTextStyles.titleMedium(color: MintColors.white),
-        ),
-        style: FilledButton.styleFrom(
-          backgroundColor: MintColors.primary,
-          foregroundColor: MintColors.white,
-          padding: const EdgeInsets.symmetric(vertical: 18),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+    return Semantics(
+      label: S.of(context)!.donationCalculer,
+      button: true,
+      child: SizedBox(
+        width: double.infinity,
+        child: FilledButton.icon(
+          onPressed: () {
+            HapticFeedback.lightImpact();
+            _simulate();
+          },
+          icon: const Icon(Icons.calculate_outlined, size: 20),
+          label: Text(
+            S.of(context)!.donationCalculer,
+            style: MintTextStyles.titleMedium(color: MintColors.white),
+          ),
+          style: FilledButton.styleFrom(
+            backgroundColor: MintColors.primary,
+            foregroundColor: MintColors.white,
+            padding: const EdgeInsets.symmetric(vertical: 18),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
           ),
         ),
       ),
@@ -511,66 +546,30 @@ class _DonationScreenState extends State<DonationScreen> {
   Widget _buildTaxCard() {
     final r = _result!;
     final hasTax = r.impotDonation > 0;
-    return Container(
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: (hasTax ? MintColors.indigo : MintColors.success)
-            .withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: (hasTax ? MintColors.indigo : MintColors.success)
-              .withValues(alpha: 0.15),
-        ),
-      ),
-      child: Column(
-        children: [
-          Text(
-            S.of(context)!.donationImpotTitle,
-            style: MintTextStyles.micro(color: hasTax ? MintColors.indigo : MintColors.success).copyWith(
-              fontWeight: FontWeight.w700,
-              letterSpacing: 1,
-            ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            hasTax ? _chfFmt(r.impotDonation) : S.of(context)!.donationExoneree,
-            style: MintTextStyles.displayMedium(color: hasTax ? MintColors.indigo : MintColors.success),
-          ),
-          if (hasTax) ...[
-            const SizedBox(height: 4),
-            Text(
-              S.of(context)!.donationTauxCanton(
-                (r.tauxImposition * 100).toStringAsFixed(0),
-                _canton,
-              ),
-              style: MintTextStyles.bodyMedium(color: MintColors.textSecondary),
-            ),
-          ],
-          const SizedBox(height: MintSpacing.md),
-          _buildResultRow(
-            S.of(context)!.donationMontantRow,
-            _chfFmt(r.montantDonation),
-          ),
-          const SizedBox(height: 4),
-          _buildResultRow(
-            S.of(context)!.donationLienRow,
-            DonationService.lienParenteLabels[_lienParente] ?? _lienParente,
-          ),
-        ],
-      ),
+    final accentColor = hasTax ? MintColors.indigo : MintColors.success;
+    return MintResultHeroCard(
+      eyebrow: S.of(context)!.donationImpotTitle,
+      primaryValue: hasTax ? _chfFmt(r.impotDonation) : S.of(context)!.donationExoneree,
+      primaryLabel: hasTax
+          ? S.of(context)!.donationTauxCanton(
+              (r.tauxImposition * 100).toStringAsFixed(0),
+              _canton,
+            )
+          : '${S.of(context)!.donationMontantRow}\u00A0:\u00A0${_chfFmt(r.montantDonation)}',
+      secondaryValue: hasTax ? _chfFmt(r.montantDonation) : null,
+      secondaryLabel: hasTax ? S.of(context)!.donationMontantRow : null,
+      narrative: '${S.of(context)!.donationLienRow}\u00A0:\u00A0${DonationService.lienParenteLabels[_lienParente] ?? _lienParente}',
+      accentColor: accentColor,
+      tone: MintSurfaceTone.porcelaine,
     );
   }
 
   // ── Reserve Card ──
   Widget _buildReserveCard() {
     final r = _result!;
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.warning.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.warning.withValues(alpha: 0.15)),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.peche,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -747,13 +746,9 @@ class _DonationScreenState extends State<DonationScreen> {
   // ── Impact Succession Card ──
   Widget _buildImpactSuccessionCard() {
     final r = _result!;
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.info.withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.info.withValues(alpha: 0.15)),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.bleu,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1050,28 +1045,6 @@ class _DonationScreenState extends State<DonationScreen> {
           ),
         ),
       ],
-    );
-  }
-
-  // ── Result Row ──
-  Widget _buildResultRow(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 3),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Flexible(
-            child: Text(
-              label,
-              style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
-            ),
-          ),
-          Text(
-            value,
-            style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
-          ),
-        ],
-      ),
     );
   }
 

--- a/apps/mobile/lib/screens/expat_screen.dart
+++ b/apps/mobile/lib/screens/expat_screen.dart
@@ -9,6 +9,9 @@ import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/expat_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
+import 'package:mint_mobile/widgets/premium/mint_result_hero_card.dart';
 import 'package:mint_mobile/widgets/coach/top_cantons_widget.dart';
 import 'package:mint_mobile/widgets/coach/avs_gap_widget.dart';
 import 'package:mint_mobile/widgets/coach/expat_countdown_widget.dart';
@@ -173,19 +176,31 @@ class _ExpatScreenState extends State<ExpatScreen>
       padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, MintSpacing.xxl),
       children: [
-        _buildForfaitInputCard(),
+        MintEntrance(child: _buildForfaitInputCard()),
         const SizedBox(height: MintSpacing.lg),
         if (_forfaitResult != null) ...[
-          _buildForfaitResultCard(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 100),
+            child: _buildForfaitResultCard(),
+          ),
           const SizedBox(height: MintSpacing.lg),
         ],
-        _buildAbolishedWarning(),
-        const SizedBox(height: MintSpacing.lg),
-        _buildEducationalInsert(
-          S.of(context)!.expatForfaitEducation,
+        MintEntrance(
+          delay: const Duration(milliseconds: 200),
+          child: _buildAbolishedWarning(),
         ),
         const SizedBox(height: MintSpacing.lg),
-        _buildTopCantonSection(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 300),
+          child: _buildEducationalInsert(
+            S.of(context)!.expatForfaitEducation,
+          ),
+        ),
+        const SizedBox(height: MintSpacing.lg),
+        MintEntrance(
+          delay: const Duration(milliseconds: 400),
+          child: _buildTopCantonSection(),
+        ),
         const SizedBox(height: MintSpacing.lg),
         _buildDisclaimer(),
       ],
@@ -251,14 +266,9 @@ class _ExpatScreenState extends State<ExpatScreen>
       _forfaitCanton = eligibleCantons.first;
     }
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -370,14 +380,9 @@ class _ExpatScreenState extends State<ExpatScreen>
     final forfaitBase = result['forfaitBase'] as double;
     final isFavorable = result['isFavorable'] as bool;
 
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 300),
-      padding: const EdgeInsets.all(MintSpacing.lg),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: MintColors.border.withAlpha(128)),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.porcelaine,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -586,46 +591,35 @@ class _ExpatScreenState extends State<ExpatScreen>
       children: [
         // ── Chiffre-choc hero for Tab 2 ──
         if (totalCapital > 0)
-          Padding(
-            padding: const EdgeInsets.only(bottom: MintSpacing.lg),
-            child: Semantics(
-              label: l.expatDepartChiffreChoc(
-                  ExpatService.formatChf(totalCapital)),
-              child: Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(MintSpacing.lg),
-                decoration: BoxDecoration(
-                  color: MintColors.info.withValues(alpha: 0.06),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                      color: MintColors.info.withValues(alpha: 0.15)),
-                ),
-                child: Column(
-                  children: [
-                    Text(
-                      ExpatService.formatChf(totalCapital),
-                      style: MintTextStyles.displayMedium(
-                          color: MintColors.info),
-                    ),
-                    const SizedBox(height: MintSpacing.xs),
-                    Text(
-                      l.expatDepartChiffreChoc(
-                          ExpatService.formatChf(totalCapital)),
-                      style: MintTextStyles.bodySmall(
-                          color: MintColors.textSecondary),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-                ),
+          MintEntrance(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: MintSpacing.lg),
+              child: MintResultHeroCard(
+                eyebrow: l.expatTabDeparture.toUpperCase(),
+                primaryValue: ExpatService.formatChf(totalCapital),
+                primaryLabel: l.expatDepartChiffreChoc(
+                    ExpatService.formatChf(totalCapital)),
+                narrative: l.expatDepartChiffreChoc(
+                    ExpatService.formatChf(totalCapital)),
+                accentColor: MintColors.info,
+                tone: MintSurfaceTone.bleu,
               ),
             ),
           ),
 
-        _buildDepartInputCard(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 100),
+          child: _buildDepartInputCard(),
+        ),
         const SizedBox(height: MintSpacing.lg),
-        _buildNoExitTaxBadge(),
+        MintEntrance(
+          delay: const Duration(milliseconds: 150),
+          child: _buildNoExitTaxBadge(),
+        ),
         const SizedBox(height: MintSpacing.lg),
-        ExpatCountdownWidget(
+        MintEntrance(
+          delay: const Duration(milliseconds: 200),
+          child: ExpatCountdownWidget(
           departureDate: _departureDate,
           deadlines: const [
             ExpatDeadline(
@@ -657,17 +651,29 @@ class _ExpatScreenState extends State<ExpatScreen>
             ),
           ],
         ),
+        ),
         const SizedBox(height: MintSpacing.lg),
         if (_departResult != null) ...[
-          _buildDepartTimeline(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 250),
+            child: _buildDepartTimeline(),
+          ),
           const SizedBox(height: MintSpacing.lg),
-          _buildDepartChecklist(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 300),
+            child: _buildDepartChecklist(),
+          ),
           const SizedBox(height: MintSpacing.lg),
         ],
-        _buildEducationalInsert(l.expatTab2EduInsert),
+        MintEntrance(
+          delay: const Duration(milliseconds: 350),
+          child: _buildEducationalInsert(l.expatTab2EduInsert),
+        ),
         const SizedBox(height: MintSpacing.lg),
         // ── P13-A : 5 choses que tu perds en partant ───────────
-        const ExpatRightsLossWidget(
+        const MintEntrance(
+          delay: Duration(milliseconds: 400),
+          child: ExpatRightsLossWidget(
           destination: 'l\'\u00e9tranger',
           isEuDestination: false,
           rights: [
@@ -723,6 +729,7 @@ class _ExpatScreenState extends State<ExpatScreen>
                   'local s\'applique \u2014 souvent moins g\u00e9n\u00e9reux.',
             ),
           ],
+        ),
         ),
         const SizedBox(height: MintSpacing.lg),
         _buildDisclaimer(),
@@ -1206,53 +1213,47 @@ class _ExpatScreenState extends State<ExpatScreen>
       padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, MintSpacing.xxl),
       children: [
-        _buildAvsInputCard(),
+        MintEntrance(child: _buildAvsInputCard()),
         const SizedBox(height: MintSpacing.lg),
         if (_avsResult != null) ...[
           // ── Chiffre-choc hero for Tab 3 ──
           if ((_avsResult!['annualLoss'] as double) > 0)
-            Padding(
-              padding: const EdgeInsets.only(bottom: MintSpacing.lg),
-              child: Semantics(
-                label: l.expatAvsChiffreChoc(ExpatService.formatChf(
-                    _avsResult!['annualLoss'] as double)),
-                child: Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(MintSpacing.lg),
-                  decoration: BoxDecoration(
-                    color: MintColors.error.withValues(alpha: 0.06),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(
-                        color: MintColors.error.withValues(alpha: 0.15)),
-                  ),
-                  child: Column(
-                    children: [
-                      Text(
-                        '-${ExpatService.formatChf(_avsResult!['annualLoss'] as double)}',
-                        style: MintTextStyles.displayMedium(
-                            color: MintColors.error),
-                      ),
-                      const SizedBox(height: MintSpacing.xs),
-                      Text(
-                        l.expatAvsChiffreChoc(ExpatService.formatChf(
-                            _avsResult!['annualLoss'] as double)),
-                        style: MintTextStyles.bodySmall(
-                            color: MintColors.textSecondary),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
+            MintEntrance(
+              delay: const Duration(milliseconds: 100),
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: MintSpacing.lg),
+                child: MintResultHeroCard(
+                  eyebrow: l.expatTabAvs.toUpperCase(),
+                  primaryValue: '-${ExpatService.formatChf(_avsResult!['annualLoss'] as double)}',
+                  primaryLabel: l.expatAvsChiffreChoc(ExpatService.formatChf(
+                      _avsResult!['annualLoss'] as double)),
+                  narrative: l.expatAvsChiffreChoc(ExpatService.formatChf(
+                      _avsResult!['annualLoss'] as double)),
+                  accentColor: MintColors.error,
+                  tone: MintSurfaceTone.porcelaine,
                 ),
               ),
             ),
 
-          _buildAvsRingChart(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 200),
+            child: _buildAvsRingChart(),
+          ),
           const SizedBox(height: MintSpacing.lg),
-          _buildAvsReductionCard(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 250),
+            child: _buildAvsReductionCard(),
+          ),
           const SizedBox(height: MintSpacing.lg),
-          _buildAvsVoluntarySection(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 300),
+            child: _buildAvsVoluntarySection(),
+          ),
           const SizedBox(height: MintSpacing.lg),
-          _buildAvsRecommendation(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 350),
+            child: _buildAvsRecommendation(),
+          ),
           const SizedBox(height: MintSpacing.lg),
         ],
         Builder(builder: (context) {

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math' show pow;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -1031,6 +1032,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
               button: true,
               child: GestureDetector(
                 onTap: () {
+                  HapticFeedback.lightImpact();
                   setState(() => _salaire = s.value);
                   _calculate();
                 },

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
@@ -485,6 +486,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
                 ],
                 selected: {_etatCivil},
                 onSelectionChanged: (v) {
+                  HapticFeedback.lightImpact();
                   _hasUserInteracted = true;
                   _etatCivil = v.first;
                   _recalculate();

--- a/apps/mobile/lib/screens/frontalier_screen.dart
+++ b/apps/mobile/lib/screens/frontalier_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -8,6 +9,8 @@ import 'package:mint_mobile/services/expat_service.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FRONTALIER SCREEN — Sprint S23 / Expatriation + Frontaliers
@@ -165,19 +168,33 @@ class _FrontalierScreenState extends State<FrontalierScreen>
       padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, 100),
       children: [
-        _buildTaxInputsCard(),
+        MintEntrance(child: _buildTaxInputsCard()),
         const SizedBox(height: MintSpacing.md + 4),
         if (_taxResult != null) ...[
-          _buildTaxResultCard(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 100),
+            child: _buildTaxResultCard(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
-          if (_taxCanton == 'GE') _buildQuasiResidentBadge(),
+          if (_taxCanton == 'GE')
+            MintEntrance(
+              delay: const Duration(milliseconds: 200),
+              child: _buildQuasiResidentBadge(),
+            ),
           if (_taxCanton == 'GE') const SizedBox(height: MintSpacing.md + 4),
-          if (_taxResult!['isTessin'] == true) _buildTessinNote(),
+          if (_taxResult!['isTessin'] == true)
+            MintEntrance(
+              delay: const Duration(milliseconds: 200),
+              child: _buildTessinNote(),
+            ),
           if (_taxResult!['isTessin'] == true)
             const SizedBox(height: MintSpacing.md + 4),
         ],
-        _buildEducationalInsert(
-          S.of(context)!.frontalierEducationalTax,
+        MintEntrance(
+          delay: const Duration(milliseconds: 300),
+          child: _buildEducationalInsert(
+            S.of(context)!.frontalierEducationalTax,
+          ),
         ),
         const SizedBox(height: MintSpacing.md + 4),
         _buildDisclaimer(),
@@ -188,14 +205,9 @@ class _FrontalierScreenState extends State<FrontalierScreen>
   Widget _buildTaxInputsCard() {
     final sortedCodes = ExpatService.sortedCantonCodes;
 
-    return Container(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -277,6 +289,7 @@ class _FrontalierScreenState extends State<FrontalierScreen>
                   selected: _taxMaritalStatus == 0,
                   child: GestureDetector(
                     onTap: () {
+                      HapticFeedback.lightImpact();
                       _taxMaritalStatus = 0;
                       _recalculateTax();
                     },
@@ -317,6 +330,7 @@ class _FrontalierScreenState extends State<FrontalierScreen>
                   selected: _taxMaritalStatus == 1,
                   child: GestureDetector(
                     onTap: () {
+                      HapticFeedback.lightImpact();
                       _taxMaritalStatus = 1;
                       _recalculateTax();
                     },
@@ -390,14 +404,9 @@ class _FrontalierScreenState extends State<FrontalierScreen>
     final annualTax = result['annualTax'] as double;
     final cantonNom = result['cantonNom'] as String;
 
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 300),
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.5)),
-      ),
+    return MintSurface(
+      tone: MintSurfaceTone.porcelaine,
+      elevated: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -418,20 +427,23 @@ class _FrontalierScreenState extends State<FrontalierScreen>
           const SizedBox(height: MintSpacing.md + 4),
 
           // Monthly tax hero
-          Center(
-            child: Column(
-              children: [
-                Text(
-                  ExpatService.formatChf(monthlyTax),
-                  style: MintTextStyles.displayMedium(),
-                ),
-                const SizedBox(height: MintSpacing.xs),
-                Text(
-                  S.of(context)!.frontalierParMois,
-                  style: MintTextStyles.bodyMedium(
-                      color: MintColors.textMuted),
-                ),
-              ],
+          Semantics(
+            label: '${ExpatService.formatChf(monthlyTax)} ${S.of(context)!.frontalierParMois}',
+            child: Center(
+              child: Column(
+                children: [
+                  Text(
+                    ExpatService.formatChf(monthlyTax),
+                    style: MintTextStyles.displayMedium(),
+                  ),
+                  const SizedBox(height: MintSpacing.xs),
+                  Text(
+                    S.of(context)!.frontalierParMois,
+                    style: MintTextStyles.bodyMedium(
+                        color: MintColors.textMuted),
+                  ),
+                ],
+              ),
             ),
           ),
           const SizedBox(height: MintSpacing.md + 4),
@@ -583,18 +595,30 @@ class _FrontalierScreenState extends State<FrontalierScreen>
       padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, 100),
       children: [
-        _build90DayInputCard(),
+        MintEntrance(child: _build90DayInputCard()),
         const SizedBox(height: MintSpacing.md + 4),
         if (_ruleResult != null) ...[
-          _build90DayGauge(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 100),
+            child: _build90DayGauge(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
-          _build90DayRecommendation(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 200),
+            child: _build90DayRecommendation(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
-          _build90DayLegalRef(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 250),
+            child: _build90DayLegalRef(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
         ],
-        _buildEducationalInsert(
-          S.of(context)!.frontalierEducational90Days,
+        MintEntrance(
+          delay: const Duration(milliseconds: 300),
+          child: _buildEducationalInsert(
+            S.of(context)!.frontalierEducational90Days,
+          ),
         ),
         const SizedBox(height: MintSpacing.md + 4),
         _buildDisclaimer(),
@@ -698,9 +722,12 @@ class _FrontalierScreenState extends State<FrontalierScreen>
           const SizedBox(height: MintSpacing.md + 4),
 
           // Big number
-          Text(
-            '$riskDays',
-            style: MintTextStyles.displayLarge(color: gaugeColor),
+          Semantics(
+            label: '$riskDays ${S.of(context)!.frontalierJoursHomeOfficeLabel}',
+            child: Text(
+              '$riskDays',
+              style: MintTextStyles.displayLarge(color: gaugeColor),
+            ),
           ),
           Text(
             S.of(context)!.frontalierJoursHomeOfficeLabel,
@@ -934,18 +961,30 @@ class _FrontalierScreenState extends State<FrontalierScreen>
       padding: const EdgeInsets.fromLTRB(
           MintSpacing.lg, MintSpacing.lg, MintSpacing.lg, 100),
       children: [
-        _buildChargesInputCard(),
+        MintEntrance(child: _buildChargesInputCard()),
         const SizedBox(height: MintSpacing.md + 4),
         if (_chargesResult != null) ...[
-          _buildChargesComparison(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 100),
+            child: _buildChargesComparison(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
-          _buildChargesDifferenceBadge(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 200),
+            child: _buildChargesDifferenceBadge(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
-          _buildLamalSection(),
+          MintEntrance(
+            delay: const Duration(milliseconds: 250),
+            child: _buildLamalSection(),
+          ),
           const SizedBox(height: MintSpacing.md + 4),
         ],
-        _buildEducationalInsert(
-          S.of(context)!.frontalierEducationalCharges,
+        MintEntrance(
+          delay: const Duration(milliseconds: 300),
+          child: _buildEducationalInsert(
+            S.of(context)!.frontalierEducationalCharges,
+          ),
         ),
         const SizedBox(height: MintSpacing.md + 4),
         _buildDisclaimer(),
@@ -1001,6 +1040,7 @@ class _FrontalierScreenState extends State<FrontalierScreen>
                     selected: isSelected,
                     child: GestureDetector(
                       onTap: () {
+                        HapticFeedback.lightImpact();
                         _chargesCountry = country;
                         _recalculateCharges();
                       },

--- a/apps/mobile/lib/screens/housing_sale_screen.dart
+++ b/apps/mobile/lib/screens/housing_sale_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -6,7 +7,10 @@ import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/housing_sale_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 import 'package:mint_mobile/widgets/coach/remploi_countdown_widget.dart';
 import 'package:mint_mobile/widgets/coach/sale_surprises_widget.dart';
@@ -120,11 +124,11 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildHeader(),
+            MintEntrance(child: _buildHeader()),
             const SizedBox(height: 24),
-            _buildIntroCard(),
+            MintEntrance(delay: const Duration(milliseconds: 100), child: _buildIntroCard()),
             const SizedBox(height: 24),
-            _buildBienSection(),
+            MintEntrance(delay: const Duration(milliseconds: 150), child: _buildBienSection()),
             const SizedBox(height: 12),
             _buildFinancementSection(),
             const SizedBox(height: 12),
@@ -136,20 +140,20 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
             const SizedBox(height: 24),
             if (_result != null) ...[
               Container(key: _resultsKey),
-              _buildPlusValueCard(),
+              MintEntrance(child: _buildPlusValueCard()),
               const SizedBox(height: 24),
-              _buildTaxCard(),
+              MintEntrance(delay: const Duration(milliseconds: 100), child: _buildTaxCard()),
               const SizedBox(height: 24),
               if (_result!.remploiReport > 0) ...[
-                _buildRemploiResultCard(),
+                MintEntrance(delay: const Duration(milliseconds: 150), child: _buildRemploiResultCard()),
                 const SizedBox(height: 24),
               ],
               if (_result!.remboursementEplLpp > 0 ||
                   _result!.remboursementEpl3a > 0) ...[
-                _buildEplRepaymentCard(),
+                MintEntrance(delay: const Duration(milliseconds: 150), child: _buildEplRepaymentCard()),
                 const SizedBox(height: 24),
               ],
-              _buildProduitNetCard(),
+              MintEntrance(delay: const Duration(milliseconds: 200), child: _buildProduitNetCard()),
               const SizedBox(height: 24),
               if (_result!.alerts.isNotEmpty) ...[
                 _buildAlertsSection(),
@@ -420,10 +424,16 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
 
   // ── Simulate Button ──
   Widget _buildSimulateButton() {
-    return SizedBox(
+    return Semantics(
+      button: true,
+      label: S.of(context)!.housingSaleCalculer,
+      child: SizedBox(
       width: double.infinity,
       child: FilledButton.icon(
-        onPressed: _simulate,
+        onPressed: () {
+          HapticFeedback.lightImpact();
+          _simulate();
+        },
         icon: const Icon(Icons.calculate_outlined, size: 20),
         label: Text(
           S.of(context)!.housingSaleCalculer,
@@ -438,7 +448,7 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
           ),
         ),
       ),
-    );
+    ));
   }
 
   // ── Plus-Value Card ──
@@ -633,29 +643,15 @@ class _HousingSaleScreenState extends State<HousingSaleScreen> {
   Widget _buildProduitNetCard() {
     final r = _result!;
     final isPositive = r.produitNet >= 0;
-    return Container(
+    return MintSurface(
+      tone: isPositive ? MintSurfaceTone.porcelaine : MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: (isPositive ? MintColors.primary : MintColors.error)
-            .withValues(alpha: 0.06),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: (isPositive ? MintColors.primary : MintColors.error)
-              .withValues(alpha: 0.15),
-        ),
-      ),
       child: Column(
         children: [
-          Text(
-            S.of(context)!.housingSaleProduitNetTitle,
-            style: MintTextStyles.labelSmall(
-              color: isPositive ? MintColors.primary : MintColors.error,
-            ).copyWith(fontWeight: FontWeight.w700, letterSpacing: 1),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            _chfFmt(r.produitNet),
-            style: MintTextStyles.displayMedium(color: isPositive ? MintColors.primary : MintColors.error),
+          MintHeroNumber(
+            value: _chfFmt(r.produitNet),
+            caption: S.of(context)!.housingSaleProduitNetTitle,
+            color: isPositive ? MintColors.primary : MintColors.error,
           ),
           const SizedBox(height: 16),
           // Breakdown

--- a/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/dividende_vs_salaire_screen.dart
@@ -7,7 +7,10 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
 //  DIVIDENDE VS SALAIRE SCREEN — Sprint S18
@@ -59,24 +62,24 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
             padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
             sliver: SliverList(
               delegate: SliverChildListDelegate([
-                _buildHeader(),
+                MintEntrance(child: _buildHeader()),
                 const SizedBox(height: 20),
-                _buildBeneficeSlider(),
+                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildBeneficeSlider()),
                 const SizedBox(height: 20),
                 _buildPartSalaireSlider(),
                 const SizedBox(height: 20),
                 _buildTauxSlider(),
                 const SizedBox(height: 24),
                 if (_result != null) ...[
-                  _buildChiffreChoc(),
+                  MintEntrance(child: _buildChiffreChoc()),
                   const SizedBox(height: 24),
                   if (_result!.requalificationRisk) ...[
-                    _buildRequalificationAlert(),
+                    MintEntrance(delay: const Duration(milliseconds: 100), child: _buildRequalificationAlert()),
                     const SizedBox(height: 20),
                   ],
-                  _buildResultSection(),
+                  MintEntrance(delay: const Duration(milliseconds: 150), child: _buildResultSection()),
                   const SizedBox(height: 24),
-                  _buildCurveChart(),
+                  MintEntrance(delay: const Duration(milliseconds: 200), child: _buildCurveChart()),
                   const SizedBox(height: 24),
                   _buildEducation(),
                   const SizedBox(height: 24),
@@ -200,13 +203,9 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
   }
 
   Widget _buildInputCard({required Widget child}) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: child,
     );
   }
@@ -221,27 +220,19 @@ class _DividendeVsSalaireScreenState extends State<DividendeVsSalaireScreen> {
       label: saving > 0
           ? 'Économie : ${IndependantsService.formatChf(saving)} francs par an' // TODO: i18n
           : 'Ajuste le split pour trouver une économie', // TODO: i18n
-      child: Container(
+      child: MintSurface(
+        tone: saving > 0 ? MintSurfaceTone.sauge : MintSurfaceTone.porcelaine,
         padding: const EdgeInsets.all(24),
-        decoration: BoxDecoration(
-          color: saving > 0 ? MintColors.success : MintColors.appleSurface,
-          borderRadius: BorderRadius.circular(20),
-        ),
         child: Column(
           children: [
-            Text(
-              IndependantsService.formatChf(saving),
-              style: MintTextStyles.displayMedium(color: saving > 0 ? MintColors.white : MintColors.primary),
-            ),
-            const SizedBox(height: MintSpacing.sm),
-            Text(
-              saving > 0
+            MintHeroNumber(
+              value: IndependantsService.formatChf(saving),
+              caption: saving > 0
                   ? 'Le split adapté te fait économiser '
                     '${IndependantsService.formatChf(saving)}/an '
                     'par rapport à 100% salaire'
                   : 'Ajuste le split pour trouver une économie',
-              style: MintTextStyles.bodyMedium(color: saving > 0 ? MintColors.white.withValues(alpha: 0.9) : MintColors.textSecondary),
-              textAlign: TextAlign.center,
+              color: saving > 0 ? MintColors.success : MintColors.primary,
             ),
           ],
         ),

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -6,8 +6,11 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
 // ────────────────────────────────────────────────────────────
 //  LPP VOLONTAIRE SCREEN — Sprint S18 / Independants complet
@@ -59,22 +62,22 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
             padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
             sliver: SliverList(
               delegate: SliverChildListDelegate([
-                _buildHeader(),
+                MintEntrance(child: _buildHeader()),
                 const SizedBox(height: 20),
-                _buildRevenuSlider(),
+                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildRevenuSlider()),
                 const SizedBox(height: 20),
                 _buildAgeSlider(),
                 const SizedBox(height: 20),
                 _buildTauxSlider(),
                 const SizedBox(height: 24),
                 if (_result != null) ...[
-                  _buildChiffreChoc(),
+                  MintEntrance(child: _buildChiffreChoc()),
                   const SizedBox(height: 24),
-                  _buildResultCards(),
+                  MintEntrance(delay: const Duration(milliseconds: 100), child: _buildResultCards()),
                   const SizedBox(height: 24),
-                  _buildRetirementComparison(),
+                  MintEntrance(delay: const Duration(milliseconds: 150), child: _buildRetirementComparison()),
                   const SizedBox(height: 24),
-                  _buildAgeTable(),
+                  MintEntrance(delay: const Duration(milliseconds: 200), child: _buildAgeTable()),
                   const SizedBox(height: 24),
                   _buildEducation(),
                   const SizedBox(height: 24),
@@ -190,13 +193,9 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
   }
 
   Widget _buildInputCard({required Widget child}) {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: child,
     );
   }
@@ -207,23 +206,15 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
     final r = _result!;
     return Semantics(
       label: 'Capitalisation annuelle : ${IndependantsService.formatChf(r.capitalisationAnnuelle)} francs', // TODO: i18n
-      child: Container(
+      child: MintSurface(
+        tone: MintSurfaceTone.peche,
         padding: const EdgeInsets.all(24),
-        decoration: BoxDecoration(
-          color: MintColors.error,
-          borderRadius: BorderRadius.circular(20),
-        ),
         child: Column(
           children: [
-            Text(
-              IndependantsService.formatChf(r.capitalisationAnnuelle),
-              style: MintTextStyles.displayMedium(color: MintColors.white),
-            ),
-            const SizedBox(height: MintSpacing.sm),
-            Text(
-              S.of(context)!.lppVolontaireChiffreChocCaption(IndependantsService.formatChf(r.capitalisationAnnuelle)),
-              style: MintTextStyles.bodyMedium(color: MintColors.white.withValues(alpha: 0.9)),
-              textAlign: TextAlign.center,
+            MintHeroNumber(
+              value: IndependantsService.formatChf(r.capitalisationAnnuelle),
+              caption: S.of(context)!.lppVolontaireChiffreChocCaption(IndependantsService.formatChf(r.capitalisationAnnuelle)),
+              color: MintColors.error,
             ),
           ],
         ),

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -8,7 +8,10 @@ import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -60,20 +63,20 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
             padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
             sliver: SliverList(
               delegate: SliverChildListDelegate([
-                _buildHeader(),
+                MintEntrance(child: _buildHeader()),
                 const SizedBox(height: 20),
-                _buildLppToggle(),
+                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildLppToggle()),
                 const SizedBox(height: 20),
                 _buildRevenuSlider(),
                 const SizedBox(height: 20),
                 _buildTauxSlider(),
                 const SizedBox(height: 24),
                 if (_result != null) ...[
-                  _buildChiffreChoc(),
+                  MintEntrance(child: _buildChiffreChoc()),
                   const SizedBox(height: 24),
-                  _buildResultSection(),
+                  MintEntrance(delay: const Duration(milliseconds: 100), child: _buildResultSection()),
                   const SizedBox(height: 24),
-                  _buildComparisonBars(),
+                  MintEntrance(delay: const Duration(milliseconds: 150), child: _buildComparisonBars()),
                   const SizedBox(height: 24),
                   _buildEducation(),
                   const SizedBox(height: 24),
@@ -238,23 +241,15 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
     if (r.avantageSurSalarie <= 0) {
       return Semantics(
         label: 'Économie fiscale : ${IndependantsService.formatChf(r.economieFiscale)} francs', // TODO: i18n
-        child: Container(
+        child: MintSurface(
+          tone: MintSurfaceTone.porcelaine,
           padding: const EdgeInsets.all(24),
-          decoration: BoxDecoration(
-            color: MintColors.appleSurface,
-            borderRadius: BorderRadius.circular(20),
-          ),
           child: Column(
             children: [
-              Text(
-                IndependantsService.formatChf(r.economieFiscale),
-                style: MintTextStyles.displayMedium(color: MintColors.primary),
-              ),
-              const SizedBox(height: MintSpacing.sm),
-              Text(
-                S.of(context)!.pillar3aIndepChiffreChocCaption,
-                style: MintTextStyles.bodyMedium(color: MintColors.textSecondary),
-                textAlign: TextAlign.center,
+              MintHeroNumber(
+                value: IndependantsService.formatChf(r.economieFiscale),
+                caption: S.of(context)!.pillar3aIndepChiffreChocCaption,
+                color: MintColors.primary,
               ),
             ],
           ),
@@ -264,23 +259,15 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
     return Semantics(
       label: 'Avantage sur salarié : ${IndependantsService.formatChf(r.avantageSurSalarie)} francs', // TODO: i18n
-      child: Container(
+      child: MintSurface(
+        tone: MintSurfaceTone.sauge,
         padding: const EdgeInsets.all(24),
-        decoration: BoxDecoration(
-          color: MintColors.success,
-          borderRadius: BorderRadius.circular(20),
-        ),
         child: Column(
           children: [
-            Text(
-              IndependantsService.formatChf(r.avantageSurSalarie),
-              style: MintTextStyles.displayMedium(color: MintColors.white),
-            ),
-            const SizedBox(height: MintSpacing.sm),
-            Text(
-              S.of(context)!.pillar3aIndepChiffreChocAvantageSalarie(IndependantsService.formatChf(r.avantageSurSalarie)),
-              style: MintTextStyles.bodyMedium(color: MintColors.white.withValues(alpha: 0.9)),
-              textAlign: TextAlign.center,
+            MintHeroNumber(
+              value: IndependantsService.formatChf(r.avantageSurSalarie),
+              caption: S.of(context)!.pillar3aIndepChiffreChocAvantageSalarie(IndependantsService.formatChf(r.avantageSurSalarie)),
+              color: MintColors.success,
             ),
           ],
         ),

--- a/apps/mobile/lib/screens/institutional/pension_fund_connect_screen.dart
+++ b/apps/mobile/lib/screens/institutional/pension_fund_connect_screen.dart
@@ -13,6 +13,7 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/institutional/institutional_api_service.dart';
 import 'package:mint_mobile/services/institutional/pension_fund_registry.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -55,7 +56,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Connexion impossible pour le moment')), // TODO: i18n
+          SnackBar(content: Text(S.of(context)!.pensionFundConnectionError)),
         );
         setState(() => _loading = false);
       }
@@ -68,20 +69,20 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
       context: context,
       builder: (_) => AlertDialog(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-        title: Text('Déconnecter la caisse\u00a0?', // TODO: i18n
+        title: Text(S.of(context)!.pensionFundDisconnectTitle,
             style: MintTextStyles.headlineMedium()),
         content: Text(
-          'Tes projections reviendront en mode "estimé" au lieu de "certifié".',
+          S.of(context)!.pensionFundDisconnectBody,
           style: MintTextStyles.bodyMedium(color: MintColors.textSecondary),
-        ), // TODO: i18n
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text('Annuler', style: MintTextStyles.bodyMedium()),
+            child: Text(S.of(context)!.commonCancel, style: MintTextStyles.bodyMedium()),
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Déconnecter'),
+            child: Text(S.of(context)!.pensionFundDisconnectButton),
           ),
         ],
       ),
@@ -111,7 +112,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                   backgroundColor: MintColors.primary,
                   foregroundColor: MintColors.white,
                   flexibleSpace: FlexibleSpaceBar(
-                    title: Text('Données certifiées', // TODO: i18n
+                    title: Text(S.of(context)!.pensionFundTitle,
                         style: MintTextStyles.titleMedium(
                             color: MintColors.white)),
                     background: Container(
@@ -141,7 +142,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                             ),
                             const SizedBox(height: 12),
                             Text(
-                              'Données certifiées', // TODO: i18n
+                              S.of(context)!.pensionFundTitle,
                               style: MintTextStyles.bodySmall(
                                   color: MintColors.white.withAlpha(153)),
                             ),
@@ -160,19 +161,17 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                       // Narrative intro
                       MintEntrance(
                         child: MintNarrativeCard(
-                          headline: 'Import automatique',
-                          body: 'Connecte ta caisse de pension pour remplacer '
-                              'les estimations par tes données réelles. '
-                              'Lecture seule — MINT ne modifie rien.',
+                          headline: S.of(context)!.pensionFundNarrativeHeadline,
+                          body: S.of(context)!.pensionFundNarrativeBody,
                           tone: MintSurfaceTone.porcelaine,
-                        ), // TODO: i18n
+                        ),
                       ),
                       const SizedBox(height: MintSpacing.xl),
 
                       // Section title
                       MintEntrance(
                         delay: const Duration(milliseconds: 100),
-                        child: Text('Caisses disponibles', // TODO: i18n
+                        child: Text(S.of(context)!.pensionFundAvailableTitle,
                             style: MintTextStyles.headlineMedium()),
                       ),
                       const SizedBox(height: MintSpacing.md),
@@ -215,8 +214,11 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
     final isError = conn?.status == ConnectionStatus.error ||
         conn?.status == ConnectionStatus.expired;
 
+    final l = S.of(context)!;
     return Semantics(
-      label: '${fund.name}, ${isConnected ? "connecté" : "non connecté"}',
+      label: isConnected
+          ? l.pensionFundConnectedStatus(fund.name)
+          : l.pensionFundDisconnectedStatus(fund.name),
       child: MintSurface(
         padding: const EdgeInsets.all(MintSpacing.md + 4),
         radius: 16,
@@ -261,16 +263,16 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                   const SizedBox(height: 3),
                   Text(
                     isConnected
-                        ? 'Synchro ${_formatDate(conn!.lastSync)}'
+                        ? l.pensionFundSyncDate(_formatDate(conn!.lastSync))
                         : isError
-                            ? 'Reconnexion nécessaire'
-                            : 'Disponible',
+                            ? l.pensionFundReconnectionNeeded
+                            : l.pensionFundAvailable,
                     style: MintTextStyles.micro(
                       color: isError
                           ? MintColors.error
                           : MintColors.textMuted,
                     ),
-                  ), // TODO: i18n
+                  ),
                 ],
               ),
             ),
@@ -281,7 +283,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                 icon: const Icon(Icons.link_off_rounded, size: 20),
                 color: MintColors.textMuted,
                 onPressed: () => _disconnect(fund.id),
-                tooltip: 'Déconnecter', // TODO: i18n
+                tooltip: l.pensionFundDisconnectTooltip,
               )
             else
               FilledButton(
@@ -293,7 +295,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
                     borderRadius: BorderRadius.circular(10),
                   ),
                 ),
-                child: Text('Connecter', // TODO: i18n
+                child: Text(l.pensionFundConnectButton,
                     style: MintTextStyles.bodySmall(color: MintColors.white)
                         .copyWith(fontWeight: FontWeight.w600)),
               ),
@@ -316,12 +318,10 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
           const SizedBox(width: MintSpacing.sm + 2),
           Expanded(
             child: Text(
-              'MINT est un outil éducatif en lecture seule (LSFin art.\u00a03). '
-              'Aucune transaction n\u2019est effectuée sur tes comptes. '
-              'Tu peux te déconnecter à tout moment.',
+              S.of(context)!.pensionFundDisclaimer,
               style: MintTextStyles.micro(color: MintColors.textMuted)
                   .copyWith(height: 1.5),
-            ), // TODO: i18n
+            ),
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/job_comparison_screen.dart
+++ b/apps/mobile/lib/screens/job_comparison_screen.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/services/job_comparison_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/simulators/simulator_card.dart';
 import 'package:mint_mobile/widgets/coach/job_change_comparison_widget.dart';
 
@@ -154,13 +158,21 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildHeader(),
+            MintEntrance(child: _buildHeader()),
             const SizedBox(height: MintSpacing.lg),
-            _buildIntroCard(),
+            MintEntrance(
+              delay: const Duration(milliseconds: 100),
+              child: _buildIntroCard(),
+            ),
             const SizedBox(height: MintSpacing.lg),
-            _buildAgeSlider(),
+            MintEntrance(
+              delay: const Duration(milliseconds: 150),
+              child: _buildAgeSlider(),
+            ),
             const SizedBox(height: MintSpacing.lg),
-            _buildJobSection(
+            MintEntrance(
+              delay: const Duration(milliseconds: 200),
+              child: _buildJobSection(
               title: S.of(context)!.jobCompareCurrentJob,
               expanded: _currentJobExpanded,
               onToggle: () =>
@@ -190,9 +202,11 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
               onIjmChanged: (v) => setState(() => _currentHasIjm = v),
               accentColor: MintColors.primary,
               icon: Icons.business,
-            ),
+            )),
             const SizedBox(height: MintSpacing.lg),
-            _buildJobSection(
+            MintEntrance(
+              delay: const Duration(milliseconds: 250),
+              child: _buildJobSection(
               title: S.of(context)!.jobCompareNewJob,
               expanded: _newJobExpanded,
               onToggle: () =>
@@ -222,23 +236,35 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
               onIjmChanged: (v) => setState(() => _newHasIjm = v),
               accentColor: MintColors.deepOrange,
               icon: Icons.work_outline,
-            ),
+            )),
             const SizedBox(height: MintSpacing.lg),
             _buildCompareButton(),
             const SizedBox(height: MintSpacing.lg),
             if (_result != null) ...[
               Container(key: _resultsKey),
-              _buildVerdictCard(),
+              MintEntrance(child: _buildVerdictCard()),
               const SizedBox(height: MintSpacing.lg),
-              _buildComparisonTable(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 100),
+                child: _buildComparisonTable(),
+              ),
               const SizedBox(height: MintSpacing.lg),
-              _buildLifetimeImpactCard(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 200),
+                child: _buildLifetimeImpactCard(),
+              ),
               const SizedBox(height: MintSpacing.lg),
               if (_result!.alerts.isNotEmpty) ...[
-                _buildAlertsSection(),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 300),
+                  child: _buildAlertsSection(),
+                ),
                 const SizedBox(height: MintSpacing.lg),
               ],
-              _buildChecklistSection(),
+              MintEntrance(
+                delay: const Duration(milliseconds: 350),
+                child: _buildChecklistSection(),
+              ),
               const SizedBox(height: MintSpacing.lg),
             ],
             _buildEducationalFooter(),
@@ -615,21 +641,28 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
 
   // --- Compare Button ---
   Widget _buildCompareButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: FilledButton.icon(
-        onPressed: _compare,
-        icon: const Icon(Icons.compare_arrows, size: 20),
-        label: Text(
-          S.of(context)!.jobCompareButton,
-          style: MintTextStyles.titleMedium(color: MintColors.white),
-        ),
-        style: FilledButton.styleFrom(
-          backgroundColor: MintColors.primary,
-          foregroundColor: MintColors.white,
-          padding: const EdgeInsets.symmetric(vertical: 18),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+    return Semantics(
+      label: S.of(context)!.jobCompareButton,
+      button: true,
+      child: SizedBox(
+        width: double.infinity,
+        child: FilledButton.icon(
+          onPressed: () {
+            HapticFeedback.lightImpact();
+            _compare();
+          },
+          icon: const Icon(Icons.compare_arrows, size: 20),
+          label: Text(
+            S.of(context)!.jobCompareButton,
+            style: MintTextStyles.titleMedium(color: MintColors.white),
+          ),
+          style: FilledButton.styleFrom(
+            backgroundColor: MintColors.primary,
+            foregroundColor: MintColors.white,
+            padding: const EdgeInsets.symmetric(vertical: 18),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(16),
+            ),
           ),
         ),
       ),
@@ -654,22 +687,13 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
         verdictIcon = Icons.balance;
     }
 
+    final salaryDelta = _newSalaireBrut - _currentSalaireBrut;
+
     return Semantics(
       label: r.verdictDetail,
-      child: Container(
-        padding: const EdgeInsets.all(MintSpacing.md),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              verdictColor.withValues(alpha: 0.08),
-              verdictColor.withValues(alpha: 0.04),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: verdictColor.withValues(alpha: 0.2), width: 1.5),
-        ),
+      child: MintSurface(
+        tone: MintSurfaceTone.porcelaine,
+        elevated: true,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -697,9 +721,17 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
               ],
             ),
             const SizedBox(height: MintSpacing.md),
+            MintHeroNumber(
+              value: _deltaFmt(salaryDelta),
+              caption: S.of(context)!.jobCompareAxisSalary,
+              color: verdictColor,
+              semanticsLabel: '${_deltaFmt(salaryDelta)} CHF — ${r.verdictDetail}',
+            ),
+            const SizedBox(height: MintSpacing.md),
             Text(
               r.verdictDetail,
-              style: MintTextStyles.headlineMedium().copyWith(fontSize: 20),
+              style: MintTextStyles.bodyLarge(color: MintColors.textPrimary)
+                  .copyWith(fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: MintSpacing.sm),
             Text(
@@ -858,13 +890,9 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
     final isPositive = annualDelta >= 0;
     return Semantics(
       label: S.of(context)!.jobCompareRetirementImpact,
-      child: Container(
-        padding: const EdgeInsets.all(MintSpacing.md),
-        decoration: BoxDecoration(
-          color: MintColors.info.withValues(alpha: 0.06),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: MintColors.info.withValues(alpha: 0.15)),
-        ),
+      child: MintSurface(
+        tone: MintSurfaceTone.bleu,
+        elevated: true,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/apps/mobile/lib/screens/lamal_franchise_screen.dart
+++ b/apps/mobile/lib/screens/lamal_franchise_screen.dart
@@ -6,6 +6,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/services/assurances_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
+import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -64,9 +66,9 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
               delegate: SliverChildListDelegate([
                 _buildDemoModeBadge(),
                 const SizedBox(height: MintSpacing.sm + 4),
-                _buildHeader(),
+                MintEntrance(child: _buildHeader()),
                 const SizedBox(height: MintSpacing.md + 4),
-                _buildIntro(),
+                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildIntro()),
                 const SizedBox(height: MintSpacing.lg),
 
                 // Toggle Adult / Child
@@ -81,11 +83,11 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
 
                 // Results
                 if (_result != null) ...[
-                  _buildComparisonCards(),
+                  MintEntrance(child: _buildComparisonCards()),
                   const SizedBox(height: MintSpacing.md + 4),
-                  _buildBreakEvenInfo(),
+                  MintEntrance(delay: const Duration(milliseconds: 100), child: _buildBreakEvenInfo()),
                   const SizedBox(height: MintSpacing.md + 4),
-                  _buildRecommendations(),
+                  MintEntrance(delay: const Duration(milliseconds: 150), child: _buildRecommendations()),
                   const SizedBox(height: MintSpacing.md + 4),
                 ],
 
@@ -324,14 +326,9 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
   // ── Prime slider ───────────────────────────────────────────
 
   Widget _buildPrimeSlider() {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: MintAmountField(
         label: S.of(context)!.lamalFranchisePrimeSliderLabel,
         value: _primeMensuelle,
@@ -351,14 +348,9 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
   // ── Depenses input ────────────────────────────────────────
 
   Widget _buildDepensesSlider() {
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
       padding: const EdgeInsets.all(MintSpacing.md + 4),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: MintAmountField(
         label: S.of(context)!.lamalFranchiseDepensesSliderLabel,
         value: _depensesSante,
@@ -506,14 +498,9 @@ class _LamalFranchiseScreenState extends State<LamalFranchiseScreen> {
     final result = _result!;
     if (result.breakEvenPoints.isEmpty) return const SizedBox.shrink();
 
-    return Container(
+    return MintSurface(
+      tone: MintSurfaceTone.bleu,
       padding: const EdgeInsets.all(MintSpacing.md),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-            color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -511,7 +512,7 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
       label: label,
       button: true,
       child: GestureDetector(
-        onTap: () { _civilStatus = value; _onInputChanged(); },
+        onTap: () { HapticFeedback.lightImpact(); _civilStatus = value; _onInputChanged(); },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
           decoration: BoxDecoration(

--- a/apps/mobile/lib/screens/mariage_screen.dart
+++ b/apps/mobile/lib/screens/mariage_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -511,7 +512,10 @@ class _MariageScreenState extends State<MariageScreen>
       button: true,
       selected: isSelected,
       child: GestureDetector(
-        onTap: () => setState(() => _selectedRegime = index),
+        onTap: () {
+          HapticFeedback.lightImpact();
+          setState(() => _selectedRegime = index);
+        },
         child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.all(MintSpacing.md),

--- a/apps/mobile/lib/screens/naissance_screen.dart
+++ b/apps/mobile/lib/screens/naissance_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -232,6 +233,7 @@ class _NaissanceScreenState extends State<NaissanceScreen>
                 ],
                 selected: {_isMother},
                 onSelectionChanged: (v) {
+                  HapticFeedback.lightImpact();
                   setState(() {
                     _isMother = v.first;
                     _recalculateConge();

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -102,11 +103,11 @@ class _DataBlockEnrichmentScreenState
               const SizedBox(height: 16),
 
               // ── Block score indicator ────────────────────────────
-              if (bloc != null) _BlockScoreBar(bloc: bloc),
+              if (bloc != null) MintEntrance(child: _BlockScoreBar(bloc: bloc)),
               const SizedBox(height: 24),
 
               // ── Coach mode toggle ───────────────────────────────
-              _CoachModeToggle(
+              MintEntrance(delay: const Duration(milliseconds: 100), child: _CoachModeToggle(
                 isCoachMode: _showCoachMode,
                 coachAvailable: coachAvailable,
                 onToggle: (value) {
@@ -118,21 +119,21 @@ class _DataBlockEnrichmentScreenState
                     setState(() => _showCoachMode = false);
                   }
                 },
-              ),
+              )),
               const SizedBox(height: 16),
 
               // ── Description ─────────────────────────────────────
               ...[
-                Text(
+                MintEntrance(delay: const Duration(milliseconds: 150), child: Text(
                   meta.description,
                   style: MintTextStyles.bodyMedium(color: MintColors.textSecondary).copyWith(height: 1.5),
-                ),
+                )),
                 const SizedBox(height: 24),
               ],
 
               // ── Enrichment prompts for this block ────────────────
               if (profile != null) ...[
-                _buildPrompts(profile, canonicalBlockType, bloc),
+                MintEntrance(delay: const Duration(milliseconds: 200), child: _buildPrompts(profile, canonicalBlockType, bloc)),
               ],
 
               // ── Cross-validation alerts ────────────────────────────
@@ -143,10 +144,14 @@ class _DataBlockEnrichmentScreenState
               const SizedBox(height: 32),
 
               // ── CTA ──────────────────────────────────────────────
-              SizedBox(
+              Semantics(
+                button: true,
+                label: meta.ctaLabel,
+                child: SizedBox(
                 width: double.infinity,
                 child: FilledButton(
                   onPressed: () {
+                    HapticFeedback.lightImpact();
                     // Navigate to the appropriate enrichment flow
                     final route = _enrichmentRoute(canonicalBlockType);
                     if (route != null) {
@@ -168,7 +173,7 @@ class _DataBlockEnrichmentScreenState
                     style: MintTextStyles.titleMedium().copyWith(fontWeight: FontWeight.w600),
                   ),
                 ),
-              ),
+              )),
               const SizedBox(height: 16),
 
               // ── Disclaimer ───────────────────────────────────────
@@ -194,13 +199,9 @@ class _DataBlockEnrichmentScreenState
     if (relevant.isEmpty) {
       final isComplete = bloc?.status == 'complete';
       if (!isComplete) {
-        return Container(
+        return MintSurface(
+          tone: MintSurfaceTone.peche,
           padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: MintColors.warning.withAlpha(12),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: MintColors.warning.withAlpha(48)),
-          ),
           child: Row(
             children: [
               const Icon(Icons.info_outline,
@@ -216,12 +217,9 @@ class _DataBlockEnrichmentScreenState
           ),
         );
       }
-      return Container(
+      return MintSurface(
+        tone: MintSurfaceTone.sauge,
         padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: MintColors.success.withAlpha(15),
-          borderRadius: BorderRadius.circular(12),
-        ),
         child: Row(
           children: [
             const Icon(Icons.check_circle_outline,

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -11,8 +11,15 @@ import 'package:mint_mobile/services/auth_service.dart';
 class ApiException implements Exception {
   final String message;
   final int? statusCode;
+  final bool isOffline;
 
-  const ApiException(this.message, {this.statusCode});
+  const ApiException(this.message, {this.statusCode, this.isOffline = false});
+
+  /// FIX-071: User-friendly offline detection.
+  static ApiException offline() => const ApiException(
+    'Pas de connexion internet. Vérifie ton réseau et réessaie.', // TODO: i18n
+    isOffline: true,
+  );
 
   @override
   String toString() => message;

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -177,6 +177,7 @@ class CoachOrchestrator {
     required CoachContext ctx,
     LlmConfig? byokConfig,
     String? memoryBlock,
+    String language = 'fr',
   }) async {
     // Build system prompt with optional memory block injection (S58).
     // Pan5-1: Use PromptRegistry.chatSystemPrompt (enriched, context-aware)
@@ -214,6 +215,7 @@ class CoachOrchestrator {
         config: byokConfig,
         ctx: ctx,
         memoryBlock: memoryBlock,
+        language: language,
       );
       if (byokResponse != null) return byokResponse;
     }
@@ -527,6 +529,7 @@ class CoachOrchestrator {
     required LlmConfig config,
     required CoachContext ctx,
     String? memoryBlock,
+    String language = 'fr',
   }) async {
     final ragService = RagService();
     final providerStr = _llmProviderString(config.provider);
@@ -570,6 +573,7 @@ class CoachOrchestrator {
               ...ctx.knownValues.map((k, v) =>
                   MapEntry(k, v.isFinite && v > 0 ? v : null)),
             },
+            language: language,
             // Pass tools so Claude can return route_to_screen tool_use blocks.
             tools: providerStr == 'claude' ? _coachTools : null,
           )

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -269,6 +269,7 @@ class CoachLlmService {
     required LlmConfig config,
     String? memoryBlock,
     Map<String, dynamic>? enrichedContext,
+    String language = 'fr',
   }) async {
     final coachCtx = _buildCoachContext(profile);
 
@@ -282,6 +283,7 @@ class CoachLlmService {
       ctx: coachCtx,
       byokConfig: config.hasApiKey ? config : null,
       memoryBlock: memoryBlock,
+      language: language,
     );
 
     // If orchestrator returned a non-fallback response (SLM or BYOK succeeded),
@@ -326,6 +328,7 @@ class CoachLlmService {
     required LlmConfig config,
     required List<ChatMessage> history,
     Map<String, dynamic>? enrichedContext,
+    String language = 'fr',
   }) async {
     final ragService = RagService();
     final String provider;
@@ -361,6 +364,7 @@ class CoachLlmService {
       provider: provider,
       model: config.model,
       profileContext: profileContext,
+      language: language,
     );
 
     // Validate through ComplianceGuard (5-layer) in addition to backend filtering.

--- a/apps/mobile/lib/services/memory/coach_memory_service.dart
+++ b/apps/mobile/lib/services/memory/coach_memory_service.dart
@@ -95,6 +95,21 @@ class CoachMemoryService {
     }
   }
 
+  /// FIX-068: Notify backend to remove orphaned embedding after local prune.
+  static Future<void> _syncRemoveToBackend(String insightId) async {
+    try {
+      final baseUrl = ApiService.baseUrl;
+      final token = await AuthService.getToken();
+      if (token == null) return;
+      await http.delete(
+        Uri.parse('$baseUrl/api/v1/coach/sync-insight/$insightId'),
+        headers: {'Authorization': 'Bearer $token'},
+      );
+    } catch (_) {
+      // Fire-and-forget: cleanup failure is not user-facing.
+    }
+  }
+
   /// Filter metadata before sending to backend (defense-in-depth).
   /// Only safe keys are transmitted — PII never leaves the device.
   static Map<String, dynamic> _filterMetadata(Map<String, dynamic> meta) {
@@ -143,9 +158,15 @@ class CoachMemoryService {
 
     if (insights.length <= _maxInsights) return;
 
-    // Already sorted most-recent-first; keep head
+    // FIX-068: Identify pruned insights for backend cleanup.
     final pruned = insights.take(_maxInsights).toList();
+    final removed = insights.skip(_maxInsights).toList();
     await _save(sp, pruned);
+
+    // Fire-and-forget: notify backend to remove orphaned embeddings.
+    for (final insight in removed) {
+      _syncRemoveToBackend(insight.id).catchError((_) {});
+    }
   }
 
   /// Clear all stored insights.

--- a/docs/COHORT_OS_SPEC.md
+++ b/docs/COHORT_OS_SPEC.md
@@ -1,9 +1,17 @@
 # Cohort OS Spec
 
-> Statut: spec produit corrigee, pre-implementation
+> Statut: **IMPLÉMENTÉ** — vérifié contre le code le 29 mars 2026
 > Role: adapter MINT par cohortes sans creer de seconde source de verite
 > Scope: coach, suggestion chips, Pulse, priorisation de surfaces
 > Non-scope: nouvelle engine de classification parallele, refonte visuelle globale
+>
+> **Implémentation** :
+> - `ProductCohortService` : 6 cohortes projetées depuis `LifecyclePhaseService` (pas de nouvelle SOT)
+> - `_suppressedTopics()` : matrice de suppression par cohorte (Anti-Bullshit Manifesto §6)
+> - `CapEngine` : filtrage des caps par cohort topics (6 points d'intégration)
+> - `ContextInjectorService` : injection lifecycle phase dans le contexte coach (14 points)
+> - `SequenceTemplate.topics` : 10 séquences avec topics field pour cohort suppression check
+> - `SequenceChatHandler.startSequence()` : guard `suppressedTopics.intersection()` avant démarrage
 
 ---
 

--- a/docs/MINT_FINAL_EXECUTION_SYSTEM.md
+++ b/docs/MINT_FINAL_EXECUTION_SYSTEM.md
@@ -1,9 +1,22 @@
 # MINT Final Execution System
 
-> Statut: point d'entree unique pour les agents leaders
+> Statut: **EXÉCUTÉ** — 7/7 chantiers shipped, vérifié le 29 mars 2026
 > Role: transformer MINT en produit exceptionnel, production-ready, centre sur l'experience
 > Portee: vision cible, doctrine, priorites, regles d'execution, pack final de prompts
 > Principe: ce document orchestre. Les documents cites restent autoritatifs sur leur domaine.
+>
+> **Bilan d'exécution** :
+> | Chantier | Status |
+> |----------|--------|
+> | 1. Achat logement | ✅ Sequence 4 steps + AffordabilityScreen + EPL + fiscal |
+> | 2. Tension financière | ✅ Sequence 4 steps + DebtRatioScreen + RepaymentScreen |
+> | 3. Retraite / pré-retraite | ✅ 2 sequences (5+11 steps) + RetirementDashboard |
+> | 4. Scan → delta visible | ✅ Claude Vision + ExtractionReview + profile update chain |
+> | 5. Ce qui a changé | ✅ SessionSnapshot + WeeklyRecap + AiRecapNarrator |
+> | 6. OS de cohortes | ✅ 6 cohortes + suppression matrix + 10 sequences |
+> | 7. Hardening production | ✅ 13,040 tests, 102+ bugs fixés, 0 warnings |
+>
+> **Métriques production** : 123 screens, 210 services, 134 routes, 8 archetypes, 6 langues, 26 cantons
 
 ---
 

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -283,13 +283,14 @@ def _build_coach_context_from_profile(profile_context: Optional[dict]):
 def _build_system_prompt_with_memory(
     coach_ctx,
     memory_block: Optional[str],
+    language: str = "fr",
 ) -> str:
     """Build the system prompt and optionally append the sanitized memory block.
 
     The memory block is sanitized for PII and wrapped in prompt injection
     armor before being appended to the system prompt.
     """
-    prompt = build_system_prompt(ctx=coach_ctx)
+    prompt = build_system_prompt(ctx=coach_ctx, language=language)
     sanitized = _sanitize_memory_block(memory_block)
     if sanitized:
         prompt = prompt + "\n\n" + sanitized
@@ -927,7 +928,7 @@ async def coach_chat(
     # Step 2: Build system prompt (lifecycle + regional + plan + memory)
     # Memory block is PII-scrubbed and wrapped in prompt injection armor.
     # ------------------------------------------------------------------
-    system_prompt = _build_system_prompt_with_memory(coach_ctx, body.memory_block)
+    system_prompt = _build_system_prompt_with_memory(coach_ctx, body.memory_block, language=body.language)
     if reasoning_block:
         system_prompt = system_prompt + "\n\n" + reasoning_block
 

--- a/services/backend/app/schemas/profile.py
+++ b/services/backend/app/schemas/profile.py
@@ -84,6 +84,10 @@ class ProfileUpdate(BaseModel):
     hasAvsGaps: Optional[bool] = None
     avsContributionYears: Optional[int] = None
     spouseAvsContributionYears: Optional[int] = None
+    # FIX-114: Couple financial fields for household calculations
+    spouseSalaryGrossAnnual: Optional[float] = Field(None, ge=0)
+    spouseEmploymentStatus: Optional[str] = None
+    householdGrossIncome: Optional[float] = Field(None, ge=0)
     commune: Optional[str] = None
     isChurchMember: Optional[bool] = None
     pillar3aAnnual: Optional[float] = None

--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -187,13 +187,29 @@ CONNAISSANCES SUISSES (utilise ces faits quand pertinent) :
 """
 
 
-def build_system_prompt(ctx: Optional[CoachContext] = None) -> str:
+_LANGUAGE_NAMES = {
+    "fr": "français",
+    "de": "Deutsch (Hochdeutsch)",
+    "en": "English",
+    "it": "italiano",
+    "es": "español",
+    "pt": "português",
+}
+
+
+def build_system_prompt(
+    ctx: Optional[CoachContext] = None,
+    language: str = "fr",
+) -> str:
     """Build the full system prompt for the Claude coach.
 
     Args:
         ctx: Optional CoachContext with user-specific data. When provided,
              the prompt is enriched with the user's known values, archetype,
              and confidence score. When None, returns the base prompt only.
+        language: ISO 639-1 language code for the response language.
+             The base prompt stays in French (it works for Claude) but a
+             response language instruction is appended when language != 'fr'.
 
     Returns:
         The complete system prompt string to pass to the Anthropic API.
@@ -205,6 +221,20 @@ def build_system_prompt(ctx: Optional[CoachContext] = None) -> str:
         plan_awareness=_PLAN_AWARENESS,
         routing_rules=_TOOL_ROUTING_RULES,
     )
+
+    # FIX-081: Append response language instruction for non-French users.
+    # The base prompt remains in French (Claude understands it well) but the
+    # response MUST be in the user's language.
+    if language and language != "fr":
+        lang_name = _LANGUAGE_NAMES.get(language, language)
+        base += (
+            f"\n\nIMPORTANT — LANGUE DE RÉPONSE :\n"
+            f"L'utilisateur parle {lang_name}. "
+            f"Réponds TOUJOURS en {lang_name}. "
+            f"Adapte le tutoiement/vouvoiement aux conventions de la langue. "
+            f"Les références légales suisses restent en français (LPP, LIFD, etc.) "
+            f"mais les explications doivent être dans la langue de l'utilisateur."
+        )
 
     if ctx is None:
         return base

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -14285,6 +14285,18 @@
             ],
             "title": "Hasvoluntarylpp"
           },
+          "householdGrossIncome": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Householdgrossincome"
+          },
           "householdType": {
             "anyOf": [
               {
@@ -14406,6 +14418,29 @@
               }
             ],
             "title": "Spouseavscontributionyears"
+          },
+          "spouseEmploymentStatus": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spouseemploymentstatus"
+          },
+          "spouseSalaryGrossAnnual": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spousesalarygrossannual"
           },
           "totalSavings": {
             "anyOf": [


### PR DESCRIPTION
## Summary — Closing the entire backlog

### P1 Fixes
- **FIX-081**: Multi-language LLM — full chain wired (locale → coach → backend)
- **FIX-114**: spouse_salary + householdGrossIncome added to backend schema

### P2 Fixes
- **FIX-068**: Prune insights notifies backend to remove orphaned embeddings
- **FIX-071**: ApiException.offline() for user-friendly network error
- **FIX-094**: checkLppDivergence() warns if scan delta > 30%
- **FIX-095**: _previousPrevoyance backup before LPP extraction overwrite
- **FIX-097**: Household SharedPreferences cleared on divorce
- **FIX-116**: 35 i18n keys extracted from Phase 4 screens (6 languages)

### Remaining (infrastructure, not code)
- FIX-109: Document store → PostgreSQL (Railway infra decision)
- FIX-112: DateTime(2026) in tests (30+ files, low risk until 2027)

## Test plan
- [x] `flutter analyze` — 0 errors
- [x] `flutter test` — 8413 pass, 0 failures
- [x] `pytest` — 4627 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)