### PR TITLE
fix: Vague 4 audit — 20/20 findings closed

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -207,4 +207,6 @@ jobs:
           done
 
           echo "::error::Backend healthcheck failed after deploy: $health_url"
+          echo "::warning::Manual rollback may be needed — Railway dashboard > Deployments > Rollback"
+          # TODO(P2-I): Automate rollback via `railway rollback` CLI when health check fails
           exit 1

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11880,5 +11880,13 @@
   "realReturnNarrative": "Dank des Steuerabzugs bringt deine Säule 3a deutlich mehr als ein gewöhnliches Sparkonto.",
   "retroactive3aEmptyTitle": "Säule-3a-Nachzahlung",
   "retroactive3aEmptySubtitle": "Gib dein Einkommen ein, um deine Steuerersparnis zu berechnen",
-  "retroactive3aEmptyCta": "Mein Einkommen hinzufügen"
+  "retroactive3aEmptyCta": "Mein Einkommen hinzufügen",
+  "onboardingPermitTypeLabel": "Dein Aufenthaltstitel",
+  "onboardingPermitC": "Ausweis C (Niederlassung)",
+  "onboardingPermitB": "Ausweis B (Aufenthalt)",
+  "onboardingPermitG": "Ausweis G (Grenzgänger)",
+  "onboardingPermitL": "Ausweis L (Kurzaufenthalt)",
+  "onboardingPermitOther": "Andere",
+  "onboardingIjmWarningTitle": "Krankentaggeld: zu prüfen",
+  "onboardingIjmWarningBody": "Als Selbständige·r hast du standardmässig kein Krankentaggeld. Ohne Abdeckung könnte eine Krankheit dein Einkommen ohne Entschädigung unterbrechen. Du hast zudem 6 Monate Zeit, dich freiwillig einer Pensionskasse anzuschliessen (BVG Art. 4)."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11880,5 +11880,13 @@
   "realReturnNarrative": "Thanks to the tax deduction, your 3a yields much more than a standard savings account.",
   "retroactive3aEmptyTitle": "3a catch-up",
   "retroactive3aEmptySubtitle": "Enter your income to calculate your tax savings",
-  "retroactive3aEmptyCta": "Add my income"
+  "retroactive3aEmptyCta": "Add my income",
+  "onboardingPermitTypeLabel": "Your permit type",
+  "onboardingPermitC": "Permit C (settlement)",
+  "onboardingPermitB": "Permit B (residence)",
+  "onboardingPermitG": "Permit G (cross-border)",
+  "onboardingPermitL": "Permit L (short-term)",
+  "onboardingPermitOther": "Other",
+  "onboardingIjmWarningTitle": "Sickness protection: check needed",
+  "onboardingIjmWarningBody": "As a self-employed person, you have no daily sickness allowance (IJM) by default. Without coverage, an illness could interrupt your income with no compensation. You also have 6 months to voluntarily enroll in a pension fund (LPP art. 4)."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11880,5 +11880,13 @@
   "realReturnNarrative": "Gracias a la deducción fiscal, tu 3a rinde mucho más que una cuenta de ahorro clásica.",
   "retroactive3aEmptyTitle": "Recuperación 3a",
   "retroactive3aEmptySubtitle": "Ingresa tu ingreso para calcular tu ahorro fiscal",
-  "retroactive3aEmptyCta": "Añadir mi ingreso"
+  "retroactive3aEmptyCta": "Añadir mi ingreso",
+  "onboardingPermitTypeLabel": "Tu tipo de permiso",
+  "onboardingPermitC": "Permiso C (establecimiento)",
+  "onboardingPermitB": "Permiso B (residencia)",
+  "onboardingPermitG": "Permiso G (fronterizo)",
+  "onboardingPermitL": "Permiso L (corta estancia)",
+  "onboardingPermitOther": "Otro",
+  "onboardingIjmWarningTitle": "Protección por enfermedad: a verificar",
+  "onboardingIjmWarningBody": "Como trabajador independiente, no tienes subsidio diario por enfermedad (IJM) por defecto. Sin cobertura, una enfermedad podría interrumpir tus ingresos sin compensación. También tienes 6 meses para inscribirte voluntariamente en un fondo de pensiones (LPP art. 4)."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -2,7 +2,7 @@
   "@@locale": "fr",
   "appTitle": "MINT",
   "landingHero": "Financial OS.",
-  "landingSubtitle": "Votre copilote financier suisse.",
+  "landingSubtitle": "Ton copilote financier suisse.",
   "landingBetaBadge": "Bêta Privée",
   "landingHeroPrefix": "Le premier",
   "landingSubtitleLong": "L'intelligence d'un CFO, dans ta poche.\nZéro bullshit. Pur conseil.",
@@ -19,7 +19,7 @@
   "tabTrack": "SUIVRE",
   "budgetTitle": "Maîtriser mon Budget",
   "simulatorsTitle": "Simulateurs de Voyage",
-  "recommendations": "Vos Recommandations",
+  "recommendations": "Tes recommandations",
   "disclaimer": "Les résultats présentés sont des estimations à titre indicatif. Ils ne constituent pas un conseil financier personnalisé.",
   "onboardingSkip": "Passer",
   "onboardingProgress": "Étape {step} sur {total}",
@@ -33,8 +33,8 @@
       }
     }
   },
-  "onboardingStep1Title": "Bonjour, je suis votre mentor.",
-  "onboardingStep1Subtitle": "Commençons par faire connaissance. Quelle est votre situation actuelle ?",
+  "onboardingStep1Title": "Bonjour, je suis ton mentor.",
+  "onboardingStep1Subtitle": "Commençons par faire connaissance. Quelle est ta situation actuelle ?",
   "onboardingHouseholdSingle": "Seul(e)",
   "onboardingHouseholdSingleDesc": "Je gère mes finances en solo",
   "onboardingHouseholdCouple": "En couple",
@@ -44,7 +44,7 @@
   "onboardingHouseholdSingleParent": "Parent solo",
   "onboardingHouseholdSingleParentDesc": "Je gère seul(e) avec enfant(s) à charge",
   "onboardingStep2Title": "Très bien.",
-  "onboardingStep2Subtitle": "Quel est le voyage financier que vous souhaitez entreprendre en priorité ?",
+  "onboardingStep2Subtitle": "Quel est le voyage financier que tu souhaites entreprendre en priorité ?",
   "onboardingGoalHouse": "Devenir propriétaire",
   "onboardingGoalHouseDesc": "Préparer mon apport et mon hypothèque",
   "onboardingGoalRetire": "Sérénité Retraite",
@@ -54,20 +54,20 @@
   "onboardingGoalTaxOptim": "Optimisation Fiscale",
   "onboardingGoalTaxOptimDesc": "Réduire mes impôts légalement",
   "onboardingStep3Title": "Presque là.",
-  "onboardingStep3Subtitle": "Ces détails nous permettent de personnaliser vos calculs selon la loi suisse.",
+  "onboardingStep3Subtitle": "Ces détails nous permettent de personnaliser tes calculs selon la loi suisse.",
   "onboardingCantonLabel": "Canton de résidence",
-  "onboardingCantonHint": "Sélectionnez votre canton",
+  "onboardingCantonHint": "Sélectionne ton canton",
   "onboardingBirthYearLabel": "Année de naissance (optionnel)",
   "onboardingBirthYearHint": "Ex: 1990",
   "onboardingContinue": "Continuer",
   "onboardingStep4Title": "Prêt à commencer ?",
-  "onboardingStep4Subtitle": "Mint est un environnement sûr. Voici nos engagements envers vous.",
+  "onboardingStep4Subtitle": "Mint est un environnement sûr. Voici nos engagements envers toi.",
   "onboardingTrustTransparency": "Transparence totale",
   "onboardingTrustTransparencyDesc": "Toutes les hypothèses sont visibles.",
   "onboardingTrustPrivacy": "Vie privée",
   "onboardingTrustPrivacyDesc": "Calculs locaux, pas de stockage de données sensibles.",
   "onboardingTrustSecurity": "Sécurité",
-  "onboardingTrustSecurityDesc": "Aucun accès direct à votre argent.",
+  "onboardingTrustSecurityDesc": "Aucun accès direct à ton argent.",
   "onboardingEnterSpace": "Entrer dans mon espace",
   "advisorMiniStep1Title": "Quelle est ta priorité ?",
   "advisorMiniStep1Subtitle": "MINT s'adapte à ce qui compte pour toi maintenant",
@@ -360,7 +360,7 @@
   "homeSafeModeMessage": "Nous avons détecté des signaux de tension. Il pourrait être utile de stabiliser ton budget avant d'explorer d'autres options.",
   "homeSafeModeResources": "Ressources & Aides gratuites",
   "homeMentorAdvisor": "Mentor Advisor",
-  "homeMentorDescription": "Lancez votre session personnalisée pour obtenir un diagnostic complet de votre situation financière.",
+  "homeMentorDescription": "Lance ta session personnalisée pour obtenir un diagnostic complet de ta situation financière.",
   "homeStartSession": "Démarrer ma session",
   "homeSimulator3a": "Retraite 3a",
   "homeSimulatorGrowth": "Croissance",
@@ -370,7 +370,7 @@
   "homeReportV2Subtitle": "Score par cercle, comparateur 3a, stratégie LPP",
   "profileTitle": "MON PROFIL MENTOR",
   "profilePrecisionIndex": "Precision Index",
-  "profilePrecisionMessage": "Plus votre profil est complet, plus votre rapport \"Statement of Advice\" est puissant.",
+  "profilePrecisionMessage": "Plus ton profil est complet, plus ton rapport \"Statement of Advice\" est puissant.",
   "profileFactFindTitle": "Détails FactFind",
   "profileSectionIdentity": "Identité & Foyer",
   "profileSectionIncome": "Revenus & Épargne",
@@ -802,8 +802,8 @@
   "lifeEventDivorce": "Divorce",
   "lifeEventSuccession": "Succession",
   "coachingTitle": "Coaching proactif",
-  "coachingSubtitle": "Vos suggestions personnalisées",
-  "coachingIntro": "Suggestions personnalisées basées sur votre profil. Plus votre profil est complet, plus les conseils sont pertinents.",
+  "coachingSubtitle": "Tes suggestions personnalisées",
+  "coachingIntro": "Suggestions personnalisées basées sur ton profil. Plus ton profil est complet, plus les conseils sont pertinents.",
   "coachingFilterAll": "Tous",
   "coachingFilterHigh": "Haute priorité",
   "coachingFilterFiscal": "Fiscalité",
@@ -832,7 +832,7 @@
   "coachingPriorityMedium": "Priorité moyenne",
   "coachingPriorityLow": "Information",
   "coaching3aDeadlineTitle": "Versement 3a avant le 31 décembre",
-  "coaching3aDeadlineMessage": "Il vous reste {remaining} de marge sur votre plafond 3a ({plafond}). Un versement avant le 31 décembre pourrait réduire votre charge fiscale d'environ {impact}.",
+  "coaching3aDeadlineMessage": "Il te reste {remaining} de marge sur ton plafond 3a ({plafond}). Un versement avant le 31 décembre pourrait réduire ta charge fiscale d'environ {impact}.",
   "@coaching3aDeadlineMessage": {
     "placeholders": {
       "remaining": {
@@ -847,8 +847,8 @@
     }
   },
   "coaching3aDeadlineAction": "Simuler mon 3a",
-  "coaching3aMissingTitle": "Vous n'avez pas de 3e pilier",
-  "coaching3aMissingMessage": "Ouvrir un 3e pilier vous permettrait de déduire jusqu'à {plafond} de votre revenu imposable chaque année. L'économie fiscale estimée est de {impact} par an dans le canton de {canton}.",
+  "coaching3aMissingTitle": "Tu n'as pas de 3e pilier",
+  "coaching3aMissingMessage": "Ouvrir un 3e pilier te permettrait de déduire jusqu'à {plafond} de ton revenu imposable chaque année. L'économie fiscale estimée est de {impact} par an dans le canton de {canton}.",
   "@coaching3aMissingMessage": {
     "placeholders": {
       "plafond": {
@@ -864,7 +864,7 @@
   },
   "coaching3aMissingAction": "Découvrir le 3e pilier",
   "coaching3aNotMaxedTitle": "Plafond 3a non atteint",
-  "coaching3aNotMaxedMessage": "Votre versement 3a actuel est de {current} sur un plafond de {plafond}. Verser le solde de {remaining} pourrait représenter une économie fiscale d'environ {impact}.",
+  "coaching3aNotMaxedMessage": "Ton versement 3a actuel est de {current} sur un plafond de {plafond}. Verser le solde de {remaining} pourrait représenter une économie fiscale d'environ {impact}.",
   "@coaching3aNotMaxedMessage": {
     "placeholders": {
       "current": {
@@ -883,7 +883,7 @@
   },
   "coaching3aNotMaxedAction": "Simuler mon 3a",
   "coachingLppBuybackTitle": "Rachat LPP possible",
-  "coachingLppBuybackMessage": "Vous avez une lacune de prévoyance de {gap}. Un rachat volontaire pourrait vous faire économiser environ {impact} d'impôts tout en améliorant votre retraite.",
+  "coachingLppBuybackMessage": "Tu as une lacune de prévoyance de {gap}. Un rachat volontaire pourrait te faire économiser environ {impact} d'impôts tout en améliorant ta retraite.",
   "@coachingLppBuybackMessage": {
     "placeholders": {
       "gap": {
@@ -896,7 +896,7 @@
   },
   "coachingLppBuybackAction": "Simuler un rachat LPP",
   "coachingTaxDeadlineTitle": "Déclaration d'impôts à rendre",
-  "coachingTaxDeadlineMessage": "Le délai pour votre déclaration fiscale dans le canton de {canton} est le 31 mars. Il reste {days} jours.",
+  "coachingTaxDeadlineMessage": "Le délai pour ta déclaration fiscale dans le canton de {canton} est le 31 mars. Il reste {days} jours.",
   "@coachingTaxDeadlineMessage": {
     "placeholders": {
       "canton": {
@@ -916,7 +916,7 @@
       }
     }
   },
-  "coachingRetirementMessage": "À {years} ans de la retraite, il est important de vérifier votre stratégie de prévoyance. Avez-vous optimisé vos rachats LPP ? Vos comptes 3a sont-ils diversifiés ?",
+  "coachingRetirementMessage": "À {years} ans de la retraite, il est important de vérifier ta stratégie de prévoyance. As-tu optimisé tes rachats LPP ? Tes comptes 3a sont-ils diversifiés ?",
   "@coachingRetirementMessage": {
     "placeholders": {
       "years": {
@@ -926,7 +926,7 @@
   },
   "coachingRetirementAction": "Planifier ma retraite",
   "coachingEmergencyTitle": "Réserve d'urgence insuffisante",
-  "coachingEmergencyMessage": "Votre épargne disponible couvre {months} mois de charges fixes. Les experts recommandent au moins 3 mois. Il vous manque environ {deficit} pour atteindre ce seuil.",
+  "coachingEmergencyMessage": "Ton épargne disponible couvre {months} mois de charges fixes. Les experts recommandent au moins 3 mois. Il te manque environ {deficit} pour atteindre ce seuil.",
   "@coachingEmergencyMessage": {
     "placeholders": {
       "months": {
@@ -946,7 +946,7 @@
       }
     }
   },
-  "coachingDebtMessage": "Votre taux d'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.",
+  "coachingDebtMessage": "Ton taux d'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.",
   "@coachingDebtMessage": {
     "placeholders": {
       "ratio": {
@@ -956,7 +956,7 @@
   },
   "coachingDebtAction": "Analyser mes dettes",
   "coachingPartTimeTitle": "Temps partiel : lacune de prévoyance",
-  "coachingPartTimeMessage": "À {rate}% d'activité, votre prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.",
+  "coachingPartTimeMessage": "À {rate}% d'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.",
   "@coachingPartTimeMessage": {
     "placeholders": {
       "rate": {
@@ -966,29 +966,29 @@
   },
   "coachingPartTimeAction": "Simuler ma prévoyance",
   "coachingIndependantTitle": "Indépendant : pas de LPP obligatoire",
-  "coachingIndependantMessage": "En tant qu'indépendant, vous n'êtes pas soumis à la LPP obligatoire. Votre prévoyance repose sur l'AVS et votre 3e pilier. Pensez à maximiser votre 3a.",
+  "coachingIndependantMessage": "En tant qu'indépendant, tu n'es pas soumis à la LPP obligatoire. Ta prévoyance repose sur l'AVS et ton 3e pilier. Pense à maximiser ton 3a.",
   "coachingIndependantAction": "Explorer mes options",
   "coachingBudgetMissingTitle": "Pas encore de budget",
-  "coachingBudgetMissingMessage": "Un budget structuré est la base de toute stratégie financière. Il permet d'identifier votre capacité d'épargne réelle.",
+  "coachingBudgetMissingMessage": "Un budget structuré est la base de toute stratégie financière. Il permet d'identifier ta capacité d'épargne réelle.",
   "coachingBudgetMissingAction": "Créer mon budget",
   "coachingAge25Title": "25 ans : démarrer son 3e pilier",
   "coachingAge25Message": "À 25 ans, c'est le moment idéal pour ouvrir un 3e pilier. Grâce aux intérêts composés, chaque année compte.",
   "coachingAge35Title": "35 ans : faire le point prévoyance",
-  "coachingAge35Message": "À 35 ans, vérifiez que votre prévoyance est sur la bonne trajectoire. Avez-vous un 3a ? Votre LPP est-elle suffisante ?",
+  "coachingAge35Message": "À 35 ans, vérifie que ta prévoyance est sur la bonne trajectoire. As-tu un 3a ? Ta LPP est-elle suffisante ?",
   "coachingAge45Title": "45 ans : optimiser sa stratégie",
   "coachingAge45Message": "À 45 ans, il reste 20 ans avant la retraite. C'est le moment d'optimiser : maximiser le 3a, envisager des rachats LPP.",
   "coachingAge50Title": "50 ans : préparer sa retraite",
-  "coachingAge50Message": "À 50 ans, la retraite se rapproche. Vérifiez votre avoir LPP, planifiez vos derniers rachats.",
+  "coachingAge50Message": "À 50 ans, la retraite se rapproche. Vérifie ton avoir LPP, planifie tes derniers rachats.",
   "coachingAge55Title": "55 ans : dernière ligne droite",
   "coachingAge55Message": "À 55 ans, la planification fiscale du retrait devient cruciale. Échelonner les retraits 3a peut représenter une économie significative.",
   "coachingAge58Title": "58 ans : retraite anticipée possible",
-  "coachingAge58Message": "Dès 58 ans, un retrait anticipé de votre 2e pilier est envisageable. Attention : la rente sera réduite.",
+  "coachingAge58Message": "Dès 58 ans, un retrait anticipé de ton 2e pilier est envisageable. Attention : la rente sera réduite.",
   "coachingAge63Title": "63 ans : derniers ajustements",
-  "coachingAge63Message": "À 2 ans de la retraite légale, finalisez votre stratégie. Dernier rachat LPP, choix rente/capital.",
+  "coachingAge63Message": "À 2 ans de la retraite légale, finalise ta stratégie. Dernier rachat LPP, choix rente/capital.",
   "coachingDisclaimer": "Les suggestions présentées sont des pistes de réflexion basées sur des estimations simplifiées. Elles ne constituent pas un conseil financier personnalisé. Consultez un professionnel qualifié avant toute décision.",
-  "coachingDemoMode": "Mode démo : profil exemple (35 ans, VD, CHF 85'000). Complétez votre diagnostic pour des conseils personnalisés.",
+  "coachingDemoMode": "Mode démo : profil exemple (35 ans, VD, CHF 85'000). Complète ton diagnostic pour des conseils personnalisés.",
   "coachingNowCardTitle": "Coaching proactif",
-  "coachingNowCardSubtitle": "Conseils personnalisés selon votre profil",
+  "coachingNowCardSubtitle": "Conseils personnalisés selon ton profil",
   "coachingCategoryFiscalite": "Fiscalité",
   "coachingCategoryPrevoyance": "Prévoyance",
   "coachingCategoryBudget": "Budget",
@@ -2985,7 +2985,7 @@
   "mariageChecklistItem1Title": "Simuler l'impact fiscal du mariage",
   "mariageChecklistItem1Desc": "Avant de te marier, compare la charge fiscale à deux (mariés vs célibataires). Si tes revenus sont similaires et élevés, la pénalité de mariage peut représenter plusieurs milliers de francs par an.",
   "mariageChecklistItem2Title": "Choisir le régime matrimonial",
-  "mariageChecklistItem2Desc": "Par défaut, c'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il faut signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.",
+  "mariageChecklistItem2Desc": "Par défaut, c'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il est nécessaire de signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.",
   "mariageChecklistItem3Title": "Mettre à jour les clauses bénéficiaires LPP et 3a",
   "mariageChecklistItem3Desc": "Le mariage change l'ordre des bénéficiaires. Ton conjoint devient automatiquement bénéficiaire de la rente de survivant LPP (LPP art. 19). Vérifie aussi les bénéficiaires de ton 3e pilier.",
   "mariageChecklistItem4Title": "Informer ton employeur et ta caisse maladie",
@@ -3153,7 +3153,7 @@
   "housingSaleEduRemploiTitle": "Qu'est-ce que le remploi ?",
   "housingSaleEduRemploiBody": "Le remploi permet de reporter l'imposition de la plus-value si tu rachètes un nouveau logement principal dans un délai raisonnable (généralement 2 ans). Si le nouveau bien coûte autant ou plus que l'ancien, le report est total. Sinon, il est proportionnel. L'impôt sera dû lors de la revente du nouveau bien.",
   "housingSaleEduEplTitle": "EPL : que se passe-t-il à la vente ?",
-  "housingSaleEduEplBody": "Si tu as utilisé des fonds de prévoyance (EPL) pour l'achat de ta résidence principale, tu dois les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.",
+  "housingSaleEduEplBody": "Si tu as utilisé des fonds de prévoyance (EPL) pour l'achat de ta résidence principale, tu es tenu de les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.",
   "housingSaleDisclaimer": "Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil fiscal, juridique ou immobilier personnalisé au sens de la LSFin. Consulte un·e spécialiste pour ta situation personnelle.",
   "housingSaleCanton": "Canton",
   "jobCompareDeltaLabel": "Delta",
@@ -3530,7 +3530,7 @@
   "expatNoExitTax": "Pas de taxe de sortie en Suisse",
   "expatRecommendedTimeline": "CHRONOLOGIE RECOMMANDÉE",
   "expatDepartureChecklist": "CHECKLIST DE DÉPART",
-  "expatAvsEducation": "Pour toucher une rente AVS complète (max CHF 2'520/mois), il faut 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d'environ 2.3%. Si tu vis à l'étranger, tu peux cotiser volontairement à l'AVS pour éviter les lacunes.",
+  "expatAvsEducation": "Pour toucher une rente AVS complète (max CHF 2'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d'environ 2.3%. Si tu vis à l'étranger, tu peux cotiser volontairement à l'AVS pour éviter les lacunes.",
   "expatYearsInSwitzerland": "Années en Suisse",
   "expatYearsAbroad": "Années à l'étranger",
   "expatAvsCompleteness": "COMPLÉTUDE AVS",
@@ -6536,7 +6536,7 @@
   "familleHubToolDivorce": "Divorce",
   "familleHubToolDecesProche": "Décès d'un proche",
   "travailHubFeaturedPremierEmploi": "Premier emploi",
-  "travailHubFeaturedPremierEmploiSub": "Tout ce qu'il faut savoir pour bien démarrer",
+  "travailHubFeaturedPremierEmploiSub": "L'essentiel pour bien démarrer",
   "travailHubFeaturedChomage": "Chômage",
   "travailHubFeaturedChomageSub": "Tes droits, indemnités et démarches",
   "travailHubFeaturedIndependant": "Indépendant",
@@ -8975,7 +8975,7 @@
   },
   "concubinageHeroChiffreChocDesc": "En concubinage, ton partenaire n’est pas héritier légal. Sans testament, ce montant lui échappe entièrement.",
   "concubinageEducationalAvs": "En Suisse, le plafond de 150 % sur les rentes AVS de couple (LAVS art. 35) ne s’applique qu’aux mariés. Les concubins touchent chacun leur rente individuelle complète — un avantage réel quand les deux ont cotisé au maximum.",
-  "concubinageEducationalLpp": "La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il faut en faire la demande.",
+  "concubinageEducationalLpp": "La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il est nécessaire d'en faire la demande.",
   "concubinageEducationalSuccession": "Un conjoint marié est exonéré d’impôt successoral dans la plupart des cantons (CC art. 462). Un concubin paie l’impôt au taux des tiers, souvent entre 20 % et 40 %.",
   "concubinageProtectionIntro": "En concubinage, la Suisse ne protège pas comme le mariage. Voici ce qui change et ce que tu peux anticiper.",
   "concubinageProtectionAvsSurvivor": "Rente AVS de survivant",
@@ -10478,7 +10478,7 @@
   "coachingDescProactif": "MINT t'accompagne activement. Rappels à chaque visite, mémoire complète.",
   "coachingEngagementStats": "{engaged} interactions sur {total} suggestions",
   "landingHiddenAmount": "Montant masqué",
-  "landingHiddenSubtitle": "Créez un compte pour voir vos chiffres",
+  "landingHiddenSubtitle": "Crée un compte pour voir tes chiffres",
   "friBarTitle": "Résilience financière",
   "friBarLiquidity": "Liquidité",
   "friBarFlexibility": "Flexibilité",
@@ -12327,5 +12327,13 @@
   "realReturnNarrative": "Grâce à la déduction fiscale, ton 3a rapporte bien plus qu’un compte épargne classique.",
   "retroactive3aEmptyTitle": "Rattrapage 3a",
   "retroactive3aEmptySubtitle": "Renseigne ton revenu pour calculer ton économie fiscale",
-  "retroactive3aEmptyCta": "Ajouter mon revenu"
+  "retroactive3aEmptyCta": "Ajouter mon revenu",
+  "onboardingPermitTypeLabel": "Ton type de permis",
+  "onboardingPermitC": "Permis C (établissement)",
+  "onboardingPermitB": "Permis B (séjour)",
+  "onboardingPermitG": "Permis G (frontalier)",
+  "onboardingPermitL": "Permis L (court séjour)",
+  "onboardingPermitOther": "Autre",
+  "onboardingIjmWarningTitle": "Protection maladie\u00a0: à vérifier",
+  "onboardingIjmWarningBody": "En tant qu'indépendant·e, tu n'as pas d'indemnités journalières maladie (IJM) par défaut. Sans couverture, une maladie pourrait interrompre tes revenus sans compensation. Tu disposes aussi de 6 mois pour t'affilier volontairement à une caisse LPP (art. 4 LPP)."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11880,5 +11880,13 @@
   "realReturnNarrative": "Grazie alla deduzione fiscale, il tuo 3a rende molto di più di un conto risparmio classico.",
   "retroactive3aEmptyTitle": "Recupero 3a",
   "retroactive3aEmptySubtitle": "Inserisci il tuo reddito per calcolare il tuo risparmio fiscale",
-  "retroactive3aEmptyCta": "Aggiungi il mio reddito"
+  "retroactive3aEmptyCta": "Aggiungi il mio reddito",
+  "onboardingPermitTypeLabel": "Il tuo tipo di permesso",
+  "onboardingPermitC": "Permesso C (domicilio)",
+  "onboardingPermitB": "Permesso B (dimora)",
+  "onboardingPermitG": "Permesso G (frontaliere)",
+  "onboardingPermitL": "Permesso L (breve durata)",
+  "onboardingPermitOther": "Altro",
+  "onboardingIjmWarningTitle": "Protezione malattia: da verificare",
+  "onboardingIjmWarningBody": "Come lavoratore indipendente, non hai indennità giornaliere di malattia (IJM) per default. Senza copertura, una malattia potrebbe interrompere i tuoi redditi senza compensazione. Hai anche 6 mesi per iscriverti volontariamente a una cassa pensione (LPP art. 4)."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -120,7 +120,7 @@ abstract class S {
   /// No description provided for @landingSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Votre copilote financier suisse.'**
+  /// **'Ton copilote financier suisse.'**
   String get landingSubtitle;
 
   /// No description provided for @landingBetaBadge.
@@ -222,7 +222,7 @@ abstract class S {
   /// No description provided for @recommendations.
   ///
   /// In fr, this message translates to:
-  /// **'Vos Recommandations'**
+  /// **'Tes recommandations'**
   String get recommendations;
 
   /// No description provided for @disclaimer.
@@ -246,13 +246,13 @@ abstract class S {
   /// No description provided for @onboardingStep1Title.
   ///
   /// In fr, this message translates to:
-  /// **'Bonjour, je suis votre mentor.'**
+  /// **'Bonjour, je suis ton mentor.'**
   String get onboardingStep1Title;
 
   /// No description provided for @onboardingStep1Subtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Commençons par faire connaissance. Quelle est votre situation actuelle ?'**
+  /// **'Commençons par faire connaissance. Quelle est ta situation actuelle ?'**
   String get onboardingStep1Subtitle;
 
   /// No description provided for @onboardingHouseholdSingle.
@@ -312,7 +312,7 @@ abstract class S {
   /// No description provided for @onboardingStep2Subtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Quel est le voyage financier que vous souhaitez entreprendre en priorité ?'**
+  /// **'Quel est le voyage financier que tu souhaites entreprendre en priorité ?'**
   String get onboardingStep2Subtitle;
 
   /// No description provided for @onboardingGoalHouse.
@@ -372,7 +372,7 @@ abstract class S {
   /// No description provided for @onboardingStep3Subtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Ces détails nous permettent de personnaliser vos calculs selon la loi suisse.'**
+  /// **'Ces détails nous permettent de personnaliser tes calculs selon la loi suisse.'**
   String get onboardingStep3Subtitle;
 
   /// No description provided for @onboardingCantonLabel.
@@ -384,7 +384,7 @@ abstract class S {
   /// No description provided for @onboardingCantonHint.
   ///
   /// In fr, this message translates to:
-  /// **'Sélectionnez votre canton'**
+  /// **'Sélectionne ton canton'**
   String get onboardingCantonHint;
 
   /// No description provided for @onboardingBirthYearLabel.
@@ -414,7 +414,7 @@ abstract class S {
   /// No description provided for @onboardingStep4Subtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Mint est un environnement sûr. Voici nos engagements envers vous.'**
+  /// **'Mint est un environnement sûr. Voici nos engagements envers toi.'**
   String get onboardingStep4Subtitle;
 
   /// No description provided for @onboardingTrustTransparency.
@@ -450,7 +450,7 @@ abstract class S {
   /// No description provided for @onboardingTrustSecurityDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Aucun accès direct à votre argent.'**
+  /// **'Aucun accès direct à ton argent.'**
   String get onboardingTrustSecurityDesc;
 
   /// No description provided for @onboardingEnterSpace.
@@ -1344,7 +1344,7 @@ abstract class S {
   /// No description provided for @homeMentorDescription.
   ///
   /// In fr, this message translates to:
-  /// **'Lancez votre session personnalisée pour obtenir un diagnostic complet de votre situation financière.'**
+  /// **'Lance ta session personnalisée pour obtenir un diagnostic complet de ta situation financière.'**
   String get homeMentorDescription;
 
   /// No description provided for @homeStartSession.
@@ -1404,7 +1404,7 @@ abstract class S {
   /// No description provided for @profilePrecisionMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Plus votre profil est complet, plus votre rapport \"Statement of Advice\" est puissant.'**
+  /// **'Plus ton profil est complet, plus ton rapport \"Statement of Advice\" est puissant.'**
   String get profilePrecisionMessage;
 
   /// No description provided for @profileFactFindTitle.
@@ -3666,13 +3666,13 @@ abstract class S {
   /// No description provided for @coachingSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Vos suggestions personnalisées'**
+  /// **'Tes suggestions personnalisées'**
   String get coachingSubtitle;
 
   /// No description provided for @coachingIntro.
   ///
   /// In fr, this message translates to:
-  /// **'Suggestions personnalisées basées sur votre profil. Plus votre profil est complet, plus les conseils sont pertinents.'**
+  /// **'Suggestions personnalisées basées sur ton profil. Plus ton profil est complet, plus les conseils sont pertinents.'**
   String get coachingIntro;
 
   /// No description provided for @coachingFilterAll.
@@ -3762,7 +3762,7 @@ abstract class S {
   /// No description provided for @coaching3aDeadlineMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Il vous reste {remaining} de marge sur votre plafond 3a ({plafond}). Un versement avant le 31 décembre pourrait réduire votre charge fiscale d\'environ {impact}.'**
+  /// **'Il te reste {remaining} de marge sur ton plafond 3a ({plafond}). Un versement avant le 31 décembre pourrait réduire ta charge fiscale d\'environ {impact}.'**
   String coaching3aDeadlineMessage(
       String remaining, String plafond, String impact);
 
@@ -3775,13 +3775,13 @@ abstract class S {
   /// No description provided for @coaching3aMissingTitle.
   ///
   /// In fr, this message translates to:
-  /// **'Vous n\'avez pas de 3e pilier'**
+  /// **'Tu n\'as pas de 3e pilier'**
   String get coaching3aMissingTitle;
 
   /// No description provided for @coaching3aMissingMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Ouvrir un 3e pilier vous permettrait de déduire jusqu\'à {plafond} de votre revenu imposable chaque année. L\'économie fiscale estimée est de {impact} par an dans le canton de {canton}.'**
+  /// **'Ouvrir un 3e pilier te permettrait de déduire jusqu\'à {plafond} de ton revenu imposable chaque année. L\'économie fiscale estimée est de {impact} par an dans le canton de {canton}.'**
   String coaching3aMissingMessage(String plafond, String impact, String canton);
 
   /// No description provided for @coaching3aMissingAction.
@@ -3799,7 +3799,7 @@ abstract class S {
   /// No description provided for @coaching3aNotMaxedMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Votre versement 3a actuel est de {current} sur un plafond de {plafond}. Verser le solde de {remaining} pourrait représenter une économie fiscale d\'environ {impact}.'**
+  /// **'Ton versement 3a actuel est de {current} sur un plafond de {plafond}. Verser le solde de {remaining} pourrait représenter une économie fiscale d\'environ {impact}.'**
   String coaching3aNotMaxedMessage(
       String current, String plafond, String remaining, String impact);
 
@@ -3818,7 +3818,7 @@ abstract class S {
   /// No description provided for @coachingLppBuybackMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Vous avez une lacune de prévoyance de {gap}. Un rachat volontaire pourrait vous faire économiser environ {impact} d\'impôts tout en améliorant votre retraite.'**
+  /// **'Tu as une lacune de prévoyance de {gap}. Un rachat volontaire pourrait te faire économiser environ {impact} d\'impôts tout en améliorant ta retraite.'**
   String coachingLppBuybackMessage(String gap, String impact);
 
   /// No description provided for @coachingLppBuybackAction.
@@ -3836,7 +3836,7 @@ abstract class S {
   /// No description provided for @coachingTaxDeadlineMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Le délai pour votre déclaration fiscale dans le canton de {canton} est le 31 mars. Il reste {days} jours.'**
+  /// **'Le délai pour ta déclaration fiscale dans le canton de {canton} est le 31 mars. Il reste {days} jours.'**
   String coachingTaxDeadlineMessage(String canton, String days);
 
   /// No description provided for @coachingTaxDeadlineAction.
@@ -3854,7 +3854,7 @@ abstract class S {
   /// No description provided for @coachingRetirementMessage.
   ///
   /// In fr, this message translates to:
-  /// **'À {years} ans de la retraite, il est important de vérifier votre stratégie de prévoyance. Avez-vous optimisé vos rachats LPP ? Vos comptes 3a sont-ils diversifiés ?'**
+  /// **'À {years} ans de la retraite, il est important de vérifier ta stratégie de prévoyance. As-tu optimisé tes rachats LPP ? Tes comptes 3a sont-ils diversifiés ?'**
   String coachingRetirementMessage(String years);
 
   /// No description provided for @coachingRetirementAction.
@@ -3872,7 +3872,7 @@ abstract class S {
   /// No description provided for @coachingEmergencyMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Votre épargne disponible couvre {months} mois de charges fixes. Les experts recommandent au moins 3 mois. Il vous manque environ {deficit} pour atteindre ce seuil.'**
+  /// **'Ton épargne disponible couvre {months} mois de charges fixes. Les experts recommandent au moins 3 mois. Il te manque environ {deficit} pour atteindre ce seuil.'**
   String coachingEmergencyMessage(String months, String deficit);
 
   /// No description provided for @coachingEmergencyAction.
@@ -3890,7 +3890,7 @@ abstract class S {
   /// No description provided for @coachingDebtMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Votre taux d\'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.'**
+  /// **'Ton taux d\'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.'**
   String coachingDebtMessage(String ratio);
 
   /// No description provided for @coachingDebtAction.
@@ -3908,7 +3908,7 @@ abstract class S {
   /// No description provided for @coachingPartTimeMessage.
   ///
   /// In fr, this message translates to:
-  /// **'À {rate}% d\'activité, votre prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.'**
+  /// **'À {rate}% d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.'**
   String coachingPartTimeMessage(String rate);
 
   /// No description provided for @coachingPartTimeAction.
@@ -3926,7 +3926,7 @@ abstract class S {
   /// No description provided for @coachingIndependantMessage.
   ///
   /// In fr, this message translates to:
-  /// **'En tant qu\'indépendant, vous n\'êtes pas soumis à la LPP obligatoire. Votre prévoyance repose sur l\'AVS et votre 3e pilier. Pensez à maximiser votre 3a.'**
+  /// **'En tant qu\'indépendant, tu n\'es pas soumis à la LPP obligatoire. Ta prévoyance repose sur l\'AVS et ton 3e pilier. Pense à maximiser ton 3a.'**
   String get coachingIndependantMessage;
 
   /// No description provided for @coachingIndependantAction.
@@ -3944,7 +3944,7 @@ abstract class S {
   /// No description provided for @coachingBudgetMissingMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Un budget structuré est la base de toute stratégie financière. Il permet d\'identifier votre capacité d\'épargne réelle.'**
+  /// **'Un budget structuré est la base de toute stratégie financière. Il permet d\'identifier ta capacité d\'épargne réelle.'**
   String get coachingBudgetMissingMessage;
 
   /// No description provided for @coachingBudgetMissingAction.
@@ -3974,7 +3974,7 @@ abstract class S {
   /// No description provided for @coachingAge35Message.
   ///
   /// In fr, this message translates to:
-  /// **'À 35 ans, vérifiez que votre prévoyance est sur la bonne trajectoire. Avez-vous un 3a ? Votre LPP est-elle suffisante ?'**
+  /// **'À 35 ans, vérifie que ta prévoyance est sur la bonne trajectoire. As-tu un 3a ? Ta LPP est-elle suffisante ?'**
   String get coachingAge35Message;
 
   /// No description provided for @coachingAge45Title.
@@ -3998,7 +3998,7 @@ abstract class S {
   /// No description provided for @coachingAge50Message.
   ///
   /// In fr, this message translates to:
-  /// **'À 50 ans, la retraite se rapproche. Vérifiez votre avoir LPP, planifiez vos derniers rachats.'**
+  /// **'À 50 ans, la retraite se rapproche. Vérifie ton avoir LPP, planifie tes derniers rachats.'**
   String get coachingAge50Message;
 
   /// No description provided for @coachingAge55Title.
@@ -4022,7 +4022,7 @@ abstract class S {
   /// No description provided for @coachingAge58Message.
   ///
   /// In fr, this message translates to:
-  /// **'Dès 58 ans, un retrait anticipé de votre 2e pilier est envisageable. Attention : la rente sera réduite.'**
+  /// **'Dès 58 ans, un retrait anticipé de ton 2e pilier est envisageable. Attention : la rente sera réduite.'**
   String get coachingAge58Message;
 
   /// No description provided for @coachingAge63Title.
@@ -4034,7 +4034,7 @@ abstract class S {
   /// No description provided for @coachingAge63Message.
   ///
   /// In fr, this message translates to:
-  /// **'À 2 ans de la retraite légale, finalisez votre stratégie. Dernier rachat LPP, choix rente/capital.'**
+  /// **'À 2 ans de la retraite légale, finalise ta stratégie. Dernier rachat LPP, choix rente/capital.'**
   String get coachingAge63Message;
 
   /// No description provided for @coachingDisclaimer.
@@ -4046,7 +4046,7 @@ abstract class S {
   /// No description provided for @coachingDemoMode.
   ///
   /// In fr, this message translates to:
-  /// **'Mode démo : profil exemple (35 ans, VD, CHF 85\'000). Complétez votre diagnostic pour des conseils personnalisés.'**
+  /// **'Mode démo : profil exemple (35 ans, VD, CHF 85\'000). Complète ton diagnostic pour des conseils personnalisés.'**
   String get coachingDemoMode;
 
   /// No description provided for @coachingNowCardTitle.
@@ -4058,7 +4058,7 @@ abstract class S {
   /// No description provided for @coachingNowCardSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Conseils personnalisés selon votre profil'**
+  /// **'Conseils personnalisés selon ton profil'**
   String get coachingNowCardSubtitle;
 
   /// No description provided for @coachingCategoryFiscalite.
@@ -11968,7 +11968,7 @@ abstract class S {
   /// No description provided for @mariageChecklistItem2Desc.
   ///
   /// In fr, this message translates to:
-  /// **'Par défaut, c\'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il faut signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.'**
+  /// **'Par défaut, c\'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il est nécessaire de signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.'**
   String get mariageChecklistItem2Desc;
 
   /// No description provided for @mariageChecklistItem3Title.
@@ -12646,7 +12646,7 @@ abstract class S {
   /// No description provided for @housingSaleEduEplBody.
   ///
   /// In fr, this message translates to:
-  /// **'Si tu as utilisé des fonds de prévoyance (EPL) pour l\'achat de ta résidence principale, tu dois les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s\'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.'**
+  /// **'Si tu as utilisé des fonds de prévoyance (EPL) pour l\'achat de ta résidence principale, tu es tenu de les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s\'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.'**
   String get housingSaleEduEplBody;
 
   /// No description provided for @housingSaleDisclaimer.
@@ -14057,7 +14057,7 @@ abstract class S {
   /// No description provided for @expatAvsEducation.
   ///
   /// In fr, this message translates to:
-  /// **'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il faut 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.'**
+  /// **'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.'**
   String get expatAvsEducation;
 
   /// No description provided for @expatYearsInSwitzerland.
@@ -23174,7 +23174,7 @@ abstract class S {
   /// No description provided for @travailHubFeaturedPremierEmploiSub.
   ///
   /// In fr, this message translates to:
-  /// **'Tout ce qu\'il faut savoir pour bien démarrer'**
+  /// **'L\'essentiel pour bien démarrer'**
   String get travailHubFeaturedPremierEmploiSub;
 
   /// No description provided for @travailHubFeaturedChomage.
@@ -31766,7 +31766,7 @@ abstract class S {
   /// No description provided for @concubinageEducationalLpp.
   ///
   /// In fr, this message translates to:
-  /// **'La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il faut en faire la demande.'**
+  /// **'La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il est nécessaire d\'en faire la demande.'**
   String get concubinageEducationalLpp;
 
   /// No description provided for @concubinageEducationalSuccession.
@@ -37171,7 +37171,7 @@ abstract class S {
   /// No description provided for @landingHiddenSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Créez un compte pour voir vos chiffres'**
+  /// **'Crée un compte pour voir tes chiffres'**
   String get landingHiddenSubtitle;
 
   /// No description provided for @friBarTitle.
@@ -44496,6 +44496,54 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Ajouter mon revenu'**
   String get retroactive3aEmptyCta;
+
+  /// No description provided for @onboardingPermitTypeLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton type de permis'**
+  String get onboardingPermitTypeLabel;
+
+  /// No description provided for @onboardingPermitC.
+  ///
+  /// In fr, this message translates to:
+  /// **'Permis C (établissement)'**
+  String get onboardingPermitC;
+
+  /// No description provided for @onboardingPermitB.
+  ///
+  /// In fr, this message translates to:
+  /// **'Permis B (séjour)'**
+  String get onboardingPermitB;
+
+  /// No description provided for @onboardingPermitG.
+  ///
+  /// In fr, this message translates to:
+  /// **'Permis G (frontalier)'**
+  String get onboardingPermitG;
+
+  /// No description provided for @onboardingPermitL.
+  ///
+  /// In fr, this message translates to:
+  /// **'Permis L (court séjour)'**
+  String get onboardingPermitL;
+
+  /// No description provided for @onboardingPermitOther.
+  ///
+  /// In fr, this message translates to:
+  /// **'Autre'**
+  String get onboardingPermitOther;
+
+  /// No description provided for @onboardingIjmWarningTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Protection maladie : à vérifier'**
+  String get onboardingIjmWarningTitle;
+
+  /// No description provided for @onboardingIjmWarningBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'En tant qu\'indépendant·e, tu n\'as pas d\'indemnités journalières maladie (IJM) par défaut. Sans couverture, une maladie pourrait interrompre tes revenus sans compensation. Tu disposes aussi de 6 mois pour t\'affilier volontairement à une caisse LPP (art. 4 LPP).'**
+  String get onboardingIjmWarningBody;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -25303,4 +25303,29 @@ class SDe extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Mein Einkommen hinzufügen';
+
+  @override
+  String get onboardingPermitTypeLabel => 'Dein Aufenthaltstitel';
+
+  @override
+  String get onboardingPermitC => 'Ausweis C (Niederlassung)';
+
+  @override
+  String get onboardingPermitB => 'Ausweis B (Aufenthalt)';
+
+  @override
+  String get onboardingPermitG => 'Ausweis G (Grenzgänger)';
+
+  @override
+  String get onboardingPermitL => 'Ausweis L (Kurzaufenthalt)';
+
+  @override
+  String get onboardingPermitOther => 'Andere';
+
+  @override
+  String get onboardingIjmWarningTitle => 'Krankentaggeld: zu prüfen';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'Als Selbständige·r hast du standardmässig kein Krankentaggeld. Ohne Abdeckung könnte eine Krankheit dein Einkommen ohne Entschädigung unterbrechen. Du hast zudem 6 Monate Zeit, dich freiwillig einer Pensionskasse anzuschliessen (BVG Art. 4).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -25129,4 +25129,29 @@ class SEn extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Add my income';
+
+  @override
+  String get onboardingPermitTypeLabel => 'Your permit type';
+
+  @override
+  String get onboardingPermitC => 'Permit C (settlement)';
+
+  @override
+  String get onboardingPermitB => 'Permit B (residence)';
+
+  @override
+  String get onboardingPermitG => 'Permit G (cross-border)';
+
+  @override
+  String get onboardingPermitL => 'Permit L (short-term)';
+
+  @override
+  String get onboardingPermitOther => 'Other';
+
+  @override
+  String get onboardingIjmWarningTitle => 'Sickness protection: check needed';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'As a self-employed person, you have no daily sickness allowance (IJM) by default. Without coverage, an illness could interrupt your income with no compensation. You also have 6 months to voluntarily enroll in a pension fund (LPP art. 4).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -25255,4 +25255,30 @@ class SEs extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Añadir mi ingreso';
+
+  @override
+  String get onboardingPermitTypeLabel => 'Tu tipo de permiso';
+
+  @override
+  String get onboardingPermitC => 'Permiso C (establecimiento)';
+
+  @override
+  String get onboardingPermitB => 'Permiso B (residencia)';
+
+  @override
+  String get onboardingPermitG => 'Permiso G (fronterizo)';
+
+  @override
+  String get onboardingPermitL => 'Permiso L (corta estancia)';
+
+  @override
+  String get onboardingPermitOther => 'Otro';
+
+  @override
+  String get onboardingIjmWarningTitle =>
+      'Protección por enfermedad: a verificar';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'Como trabajador independiente, no tienes subsidio diario por enfermedad (IJM) por defecto. Sin cobertura, una enfermedad podría interrumpir tus ingresos sin compensación. También tienes 6 meses para inscribirte voluntariamente en un fondo de pensiones (LPP art. 4).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -15,7 +15,7 @@ class SFr extends S {
   String get landingHero => 'Financial OS.';
 
   @override
-  String get landingSubtitle => 'Votre copilote financier suisse.';
+  String get landingSubtitle => 'Ton copilote financier suisse.';
 
   @override
   String get landingBetaBadge => 'Bêta Privée';
@@ -67,7 +67,7 @@ class SFr extends S {
   String get simulatorsTitle => 'Simulateurs de Voyage';
 
   @override
-  String get recommendations => 'Vos Recommandations';
+  String get recommendations => 'Tes recommandations';
 
   @override
   String get disclaimer =>
@@ -82,11 +82,11 @@ class SFr extends S {
   }
 
   @override
-  String get onboardingStep1Title => 'Bonjour, je suis votre mentor.';
+  String get onboardingStep1Title => 'Bonjour, je suis ton mentor.';
 
   @override
   String get onboardingStep1Subtitle =>
-      'Commençons par faire connaissance. Quelle est votre situation actuelle ?';
+      'Commençons par faire connaissance. Quelle est ta situation actuelle ?';
 
   @override
   String get onboardingHouseholdSingle => 'Seul(e)';
@@ -119,7 +119,7 @@ class SFr extends S {
 
   @override
   String get onboardingStep2Subtitle =>
-      'Quel est le voyage financier que vous souhaitez entreprendre en priorité ?';
+      'Quel est le voyage financier que tu souhaites entreprendre en priorité ?';
 
   @override
   String get onboardingGoalHouse => 'Devenir propriétaire';
@@ -151,13 +151,13 @@ class SFr extends S {
 
   @override
   String get onboardingStep3Subtitle =>
-      'Ces détails nous permettent de personnaliser vos calculs selon la loi suisse.';
+      'Ces détails nous permettent de personnaliser tes calculs selon la loi suisse.';
 
   @override
   String get onboardingCantonLabel => 'Canton de résidence';
 
   @override
-  String get onboardingCantonHint => 'Sélectionnez votre canton';
+  String get onboardingCantonHint => 'Sélectionne ton canton';
 
   @override
   String get onboardingBirthYearLabel => 'Année de naissance (optionnel)';
@@ -173,7 +173,7 @@ class SFr extends S {
 
   @override
   String get onboardingStep4Subtitle =>
-      'Mint est un environnement sûr. Voici nos engagements envers vous.';
+      'Mint est un environnement sûr. Voici nos engagements envers toi.';
 
   @override
   String get onboardingTrustTransparency => 'Transparence totale';
@@ -193,8 +193,7 @@ class SFr extends S {
   String get onboardingTrustSecurity => 'Sécurité';
 
   @override
-  String get onboardingTrustSecurityDesc =>
-      'Aucun accès direct à votre argent.';
+  String get onboardingTrustSecurityDesc => 'Aucun accès direct à ton argent.';
 
   @override
   String get onboardingEnterSpace => 'Entrer dans mon espace';
@@ -721,7 +720,7 @@ class SFr extends S {
 
   @override
   String get homeMentorDescription =>
-      'Lancez votre session personnalisée pour obtenir un diagnostic complet de votre situation financière.';
+      'Lance ta session personnalisée pour obtenir un diagnostic complet de ta situation financière.';
 
   @override
   String get homeStartSession => 'Démarrer ma session';
@@ -753,7 +752,7 @@ class SFr extends S {
 
   @override
   String get profilePrecisionMessage =>
-      'Plus votre profil est complet, plus votre rapport \"Statement of Advice\" est puissant.';
+      'Plus ton profil est complet, plus ton rapport \"Statement of Advice\" est puissant.';
 
   @override
   String get profileFactFindTitle => 'Détails FactFind';
@@ -1962,11 +1961,11 @@ class SFr extends S {
   String get coachingTitle => 'Coaching proactif';
 
   @override
-  String get coachingSubtitle => 'Vos suggestions personnalisées';
+  String get coachingSubtitle => 'Tes suggestions personnalisées';
 
   @override
   String get coachingIntro =>
-      'Suggestions personnalisées basées sur votre profil. Plus votre profil est complet, plus les conseils sont pertinents.';
+      'Suggestions personnalisées basées sur ton profil. Plus ton profil est complet, plus les conseils sont pertinents.';
 
   @override
   String get coachingFilterAll => 'Tous';
@@ -2018,19 +2017,19 @@ class SFr extends S {
   @override
   String coaching3aDeadlineMessage(
       String remaining, String plafond, String impact) {
-    return 'Il vous reste $remaining de marge sur votre plafond 3a ($plafond). Un versement avant le 31 décembre pourrait réduire votre charge fiscale d\'environ $impact.';
+    return 'Il te reste $remaining de marge sur ton plafond 3a ($plafond). Un versement avant le 31 décembre pourrait réduire ta charge fiscale d\'environ $impact.';
   }
 
   @override
   String get coaching3aDeadlineAction => 'Simuler mon 3a';
 
   @override
-  String get coaching3aMissingTitle => 'Vous n\'avez pas de 3e pilier';
+  String get coaching3aMissingTitle => 'Tu n\'as pas de 3e pilier';
 
   @override
   String coaching3aMissingMessage(
       String plafond, String impact, String canton) {
-    return 'Ouvrir un 3e pilier vous permettrait de déduire jusqu\'à $plafond de votre revenu imposable chaque année. L\'économie fiscale estimée est de $impact par an dans le canton de $canton.';
+    return 'Ouvrir un 3e pilier te permettrait de déduire jusqu\'à $plafond de ton revenu imposable chaque année. L\'économie fiscale estimée est de $impact par an dans le canton de $canton.';
   }
 
   @override
@@ -2042,7 +2041,7 @@ class SFr extends S {
   @override
   String coaching3aNotMaxedMessage(
       String current, String plafond, String remaining, String impact) {
-    return 'Votre versement 3a actuel est de $current sur un plafond de $plafond. Verser le solde de $remaining pourrait représenter une économie fiscale d\'environ $impact.';
+    return 'Ton versement 3a actuel est de $current sur un plafond de $plafond. Verser le solde de $remaining pourrait représenter une économie fiscale d\'environ $impact.';
   }
 
   @override
@@ -2053,7 +2052,7 @@ class SFr extends S {
 
   @override
   String coachingLppBuybackMessage(String gap, String impact) {
-    return 'Vous avez une lacune de prévoyance de $gap. Un rachat volontaire pourrait vous faire économiser environ $impact d\'impôts tout en améliorant votre retraite.';
+    return 'Tu as une lacune de prévoyance de $gap. Un rachat volontaire pourrait te faire économiser environ $impact d\'impôts tout en améliorant ta retraite.';
   }
 
   @override
@@ -2064,7 +2063,7 @@ class SFr extends S {
 
   @override
   String coachingTaxDeadlineMessage(String canton, String days) {
-    return 'Le délai pour votre déclaration fiscale dans le canton de $canton est le 31 mars. Il reste $days jours.';
+    return 'Le délai pour ta déclaration fiscale dans le canton de $canton est le 31 mars. Il reste $days jours.';
   }
 
   @override
@@ -2077,7 +2076,7 @@ class SFr extends S {
 
   @override
   String coachingRetirementMessage(String years) {
-    return 'À $years ans de la retraite, il est important de vérifier votre stratégie de prévoyance. Avez-vous optimisé vos rachats LPP ? Vos comptes 3a sont-ils diversifiés ?';
+    return 'À $years ans de la retraite, il est important de vérifier ta stratégie de prévoyance. As-tu optimisé tes rachats LPP ? Tes comptes 3a sont-ils diversifiés ?';
   }
 
   @override
@@ -2088,7 +2087,7 @@ class SFr extends S {
 
   @override
   String coachingEmergencyMessage(String months, String deficit) {
-    return 'Votre épargne disponible couvre $months mois de charges fixes. Les experts recommandent au moins 3 mois. Il vous manque environ $deficit pour atteindre ce seuil.';
+    return 'Ton épargne disponible couvre $months mois de charges fixes. Les experts recommandent au moins 3 mois. Il te manque environ $deficit pour atteindre ce seuil.';
   }
 
   @override
@@ -2101,7 +2100,7 @@ class SFr extends S {
 
   @override
   String coachingDebtMessage(String ratio) {
-    return 'Votre taux d\'endettement estimé est de $ratio%, au-dessus du seuil de 33% recommandé par les banques suisses.';
+    return 'Ton taux d\'endettement estimé est de $ratio%, au-dessus du seuil de 33% recommandé par les banques suisses.';
   }
 
   @override
@@ -2112,7 +2111,7 @@ class SFr extends S {
 
   @override
   String coachingPartTimeMessage(String rate) {
-    return 'À $rate% d\'activité, votre prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.';
+    return 'À $rate% d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.';
   }
 
   @override
@@ -2123,7 +2122,7 @@ class SFr extends S {
 
   @override
   String get coachingIndependantMessage =>
-      'En tant qu\'indépendant, vous n\'êtes pas soumis à la LPP obligatoire. Votre prévoyance repose sur l\'AVS et votre 3e pilier. Pensez à maximiser votre 3a.';
+      'En tant qu\'indépendant, tu n\'es pas soumis à la LPP obligatoire. Ta prévoyance repose sur l\'AVS et ton 3e pilier. Pense à maximiser ton 3a.';
 
   @override
   String get coachingIndependantAction => 'Explorer mes options';
@@ -2133,7 +2132,7 @@ class SFr extends S {
 
   @override
   String get coachingBudgetMissingMessage =>
-      'Un budget structuré est la base de toute stratégie financière. Il permet d\'identifier votre capacité d\'épargne réelle.';
+      'Un budget structuré est la base de toute stratégie financière. Il permet d\'identifier ta capacité d\'épargne réelle.';
 
   @override
   String get coachingBudgetMissingAction => 'Créer mon budget';
@@ -2150,7 +2149,7 @@ class SFr extends S {
 
   @override
   String get coachingAge35Message =>
-      'À 35 ans, vérifiez que votre prévoyance est sur la bonne trajectoire. Avez-vous un 3a ? Votre LPP est-elle suffisante ?';
+      'À 35 ans, vérifie que ta prévoyance est sur la bonne trajectoire. As-tu un 3a ? Ta LPP est-elle suffisante ?';
 
   @override
   String get coachingAge45Title => '45 ans : optimiser sa stratégie';
@@ -2164,7 +2163,7 @@ class SFr extends S {
 
   @override
   String get coachingAge50Message =>
-      'À 50 ans, la retraite se rapproche. Vérifiez votre avoir LPP, planifiez vos derniers rachats.';
+      'À 50 ans, la retraite se rapproche. Vérifie ton avoir LPP, planifie tes derniers rachats.';
 
   @override
   String get coachingAge55Title => '55 ans : dernière ligne droite';
@@ -2178,14 +2177,14 @@ class SFr extends S {
 
   @override
   String get coachingAge58Message =>
-      'Dès 58 ans, un retrait anticipé de votre 2e pilier est envisageable. Attention : la rente sera réduite.';
+      'Dès 58 ans, un retrait anticipé de ton 2e pilier est envisageable. Attention : la rente sera réduite.';
 
   @override
   String get coachingAge63Title => '63 ans : derniers ajustements';
 
   @override
   String get coachingAge63Message =>
-      'À 2 ans de la retraite légale, finalisez votre stratégie. Dernier rachat LPP, choix rente/capital.';
+      'À 2 ans de la retraite légale, finalise ta stratégie. Dernier rachat LPP, choix rente/capital.';
 
   @override
   String get coachingDisclaimer =>
@@ -2193,14 +2192,14 @@ class SFr extends S {
 
   @override
   String get coachingDemoMode =>
-      'Mode démo : profil exemple (35 ans, VD, CHF 85\'000). Complétez votre diagnostic pour des conseils personnalisés.';
+      'Mode démo : profil exemple (35 ans, VD, CHF 85\'000). Complète ton diagnostic pour des conseils personnalisés.';
 
   @override
   String get coachingNowCardTitle => 'Coaching proactif';
 
   @override
   String get coachingNowCardSubtitle =>
-      'Conseils personnalisés selon votre profil';
+      'Conseils personnalisés selon ton profil';
 
   @override
   String get coachingCategoryFiscalite => 'Fiscalité';
@@ -6602,7 +6601,7 @@ class SFr extends S {
 
   @override
   String get mariageChecklistItem2Desc =>
-      'Par défaut, c\'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il faut signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.';
+      'Par défaut, c\'est la participation aux acquêts (CC art. 181). Si tu veux un autre régime (séparation de biens, communauté de biens), il est nécessaire de signer un contrat de mariage chez le notaire AVANT ou pendant le mariage.';
 
   @override
   String get mariageChecklistItem3Title =>
@@ -6989,7 +6988,7 @@ class SFr extends S {
 
   @override
   String get housingSaleEduEplBody =>
-      'Si tu as utilisé des fonds de prévoyance (EPL) pour l\'achat de ta résidence principale, tu dois les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s\'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.';
+      'Si tu as utilisé des fonds de prévoyance (EPL) pour l\'achat de ta résidence principale, tu es tenu de les rembourser lors de la vente (LPP art. 30d). Ce remboursement est obligatoire et s\'effectue auprès de ta caisse de pension (LPP) et/ou de ta fondation 3a. Le montant est inscrit au registre foncier et ne peut pas être évité.';
 
   @override
   String get housingSaleDisclaimer =>
@@ -7775,7 +7774,7 @@ class SFr extends S {
 
   @override
   String get expatAvsEducation =>
-      'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il faut 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.';
+      'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.';
 
   @override
   String get expatYearsInSwitzerland => 'Années en Suisse';
@@ -13074,7 +13073,7 @@ class SFr extends S {
 
   @override
   String get travailHubFeaturedPremierEmploiSub =>
-      'Tout ce qu\'il faut savoir pour bien démarrer';
+      'L\'essentiel pour bien démarrer';
 
   @override
   String get travailHubFeaturedChomage => 'Chômage';
@@ -17929,7 +17928,7 @@ class SFr extends S {
 
   @override
   String get concubinageEducationalLpp =>
-      'La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il faut en faire la demande.';
+      'La rente LPP de survivant (60 % de la rente du défunt, LPP art. 19) est réservée aux époux. En concubinage, seul le règlement de la caisse peut prévoir un capital décès — et il est nécessaire d\'en faire la demande.';
 
   @override
   String get concubinageEducationalSuccession =>
@@ -21066,7 +21065,7 @@ class SFr extends S {
   String get landingHiddenAmount => 'Montant masqué';
 
   @override
-  String get landingHiddenSubtitle => 'Créez un compte pour voir vos chiffres';
+  String get landingHiddenSubtitle => 'Crée un compte pour voir tes chiffres';
 
   @override
   String get friBarTitle => 'Résilience financière';
@@ -25252,4 +25251,29 @@ class SFr extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Ajouter mon revenu';
+
+  @override
+  String get onboardingPermitTypeLabel => 'Ton type de permis';
+
+  @override
+  String get onboardingPermitC => 'Permis C (établissement)';
+
+  @override
+  String get onboardingPermitB => 'Permis B (séjour)';
+
+  @override
+  String get onboardingPermitG => 'Permis G (frontalier)';
+
+  @override
+  String get onboardingPermitL => 'Permis L (court séjour)';
+
+  @override
+  String get onboardingPermitOther => 'Autre';
+
+  @override
+  String get onboardingIjmWarningTitle => 'Protection maladie : à vérifier';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'En tant qu\'indépendant·e, tu n\'as pas d\'indemnités journalières maladie (IJM) par défaut. Sans couverture, une maladie pourrait interrompre tes revenus sans compensation. Tu disposes aussi de 6 mois pour t\'affilier volontairement à une caisse LPP (art. 4 LPP).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -25327,4 +25327,29 @@ class SIt extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Aggiungi il mio reddito';
+
+  @override
+  String get onboardingPermitTypeLabel => 'Il tuo tipo di permesso';
+
+  @override
+  String get onboardingPermitC => 'Permesso C (domicilio)';
+
+  @override
+  String get onboardingPermitB => 'Permesso B (dimora)';
+
+  @override
+  String get onboardingPermitG => 'Permesso G (frontaliere)';
+
+  @override
+  String get onboardingPermitL => 'Permesso L (breve durata)';
+
+  @override
+  String get onboardingPermitOther => 'Altro';
+
+  @override
+  String get onboardingIjmWarningTitle => 'Protezione malattia: da verificare';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'Come lavoratore indipendente, non hai indennità giornaliere di malattia (IJM) per default. Senza copertura, una malattia potrebbe interrompere i tuoi redditi senza compensazione. Hai anche 6 mesi per iscriverti volontariamente a una cassa pensione (LPP art. 4).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -25262,4 +25262,29 @@ class SPt extends S {
 
   @override
   String get retroactive3aEmptyCta => 'Adicionar o meu rendimento';
+
+  @override
+  String get onboardingPermitTypeLabel => 'O teu tipo de autorização';
+
+  @override
+  String get onboardingPermitC => 'Autorização C (estabelecimento)';
+
+  @override
+  String get onboardingPermitB => 'Autorização B (residência)';
+
+  @override
+  String get onboardingPermitG => 'Autorização G (fronteiriço)';
+
+  @override
+  String get onboardingPermitL => 'Autorização L (curta duração)';
+
+  @override
+  String get onboardingPermitOther => 'Outro';
+
+  @override
+  String get onboardingIjmWarningTitle => 'Proteção doença: a verificar';
+
+  @override
+  String get onboardingIjmWarningBody =>
+      'Como trabalhador independente, não tens subsídio diário de doença (IJM) por defeito. Sem cobertura, uma doença poderia interromper os teus rendimentos sem compensação. Tens também 6 meses para te inscreveres voluntariamente num fundo de pensões (LPP art. 4).';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11880,5 +11880,13 @@
   "realReturnNarrative": "Graças à dedução fiscal, o teu 3a rende muito mais do que uma conta poupança clássica.",
   "retroactive3aEmptyTitle": "Recuperação 3a",
   "retroactive3aEmptySubtitle": "Insere o teu rendimento para calcular a tua poupança fiscal",
-  "retroactive3aEmptyCta": "Adicionar o meu rendimento"
+  "retroactive3aEmptyCta": "Adicionar o meu rendimento",
+  "onboardingPermitTypeLabel": "O teu tipo de autorização",
+  "onboardingPermitC": "Autorização C (estabelecimento)",
+  "onboardingPermitB": "Autorização B (residência)",
+  "onboardingPermitG": "Autorização G (fronteiriço)",
+  "onboardingPermitL": "Autorização L (curta duração)",
+  "onboardingPermitOther": "Outro",
+  "onboardingIjmWarningTitle": "Proteção doença: a verificar",
+  "onboardingIjmWarningBody": "Como trabalhador independente, não tens subsídio diário de doença (IJM) por defeito. Sem cobertura, uma doença poderia interromper os teus rendimentos sem compensação. Tens também 6 meses para te inscreveres voluntariamente num fundo de pensões (LPP art. 4)."
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mint_mobile/app.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
@@ -19,6 +20,11 @@ import 'package:mint_mobile/services/regulatory_sync_service.dart';
 Future<void> main() async {
   // Initialisation Flutter
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Lock portrait orientation globally (landscape only in fullscreen chart overlay)
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+  ]);
 
   // Select a reachable API endpoint (defined URL first, then fallbacks).
   await ApiService.ensureReachableBaseUrl();

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -1117,6 +1117,10 @@ class PlannedMonthlyContribution {
 /// et au FinancialFitnessScore. Persiste localement (SharedPreferences
 /// ou Hive) et peut etre exporte en JSON.
 class CoachProfile {
+  /// Schema version for migration support.
+  /// Increment when breaking changes are made to serialization format.
+  static const int schemaVersion = 1;
+
   // === IDENTITE ===
   final String? firstName;
   final int birthYear;
@@ -1735,6 +1739,12 @@ class CoachProfile {
   // ════════════════════════════════════════════════════════════════
 
   factory CoachProfile.fromJson(Map<String, dynamic> json) {
+    // Schema migration: handle older versions if needed.
+    final version = json['schemaVersion'] as int? ?? 0;
+    // Version 0 (pre-schema) and version 1 share the same format.
+    // Future migrations: if (version < 2) { ... migrate fields ... }
+    assert(version <= schemaVersion,
+        'CoachProfile schema version $version is newer than supported $schemaVersion');
     return CoachProfile(
       firstName: json['firstName'] as String?,
       birthYear: (json['birthYear'] as int?) ?? 1980,
@@ -1825,6 +1835,7 @@ class CoachProfile {
   }
 
   Map<String, dynamic> toJson() => {
+        'schemaVersion': schemaVersion,
         'firstName': firstName,
         'birthYear': birthYear,
         'dateOfBirth': dateOfBirth?.toIso8601String(),

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -404,6 +404,9 @@ class CoachProfileProvider extends ChangeNotifier {
     int? arrivalYear,
     /// User's primary focus/intention from FocusSelector.
     String? primaryFocus,
+    /// Residence permit type: 'C', 'B', 'G', 'L', or 'other'.
+    /// When 'G', archetype is forced to cross_border.
+    String? permitType,
   }) {
     // Convert gross annual → net monthly
     // Net monthly = (grossSalary / 12) × (1 - 0.13) (charges sociales ~13%)
@@ -483,6 +486,7 @@ class CoachProfileProvider extends ChangeNotifier {
       // Nationality for archetype detection (see CLAUDE.md archetype table)
       if (nationality != null) 'q_nationality': nationality,
       if (primaryFocus != null) 'q_primary_focus': primaryFocus,
+      if (permitType != null) 'q_residence_permit': permitType,
     };
 
     // Returning Swiss: inject lacunes and arrivalYear so fromWizardAnswers

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
@@ -322,6 +322,7 @@ class _SmartOnboardingScreenState extends State<SmartOnboardingScreen> {
       nationalityCountry: _viewModel.nationalityCountry,
       employmentStatus: _viewModel.employmentStatus,
       primaryFocus: _viewModel.stressType,
+      permitType: _viewModel.permitType,
     );
     // Apply literacy level derived from calibration questions (Step 1).
     // Done via copyWith after the wizard-based profile is built so we don't

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
@@ -41,6 +41,10 @@ class SmartOnboardingViewModel extends ChangeNotifier {
   /// Specific country code if nationalityGroup == 'OTHER' (e.g. 'US', 'BR').
   String? nationalityCountry;
 
+  /// Residence permit type when non-Swiss: 'C', 'B', 'G', 'L', or 'other'.
+  /// When 'G' (frontalier), archetype is forced to cross_border.
+  String? permitType;
+
   /// User's stress intention (tap selector, not a data question).
   /// Used to filter coaching tips by relevance.
   String? stressType;
@@ -113,7 +117,15 @@ class SmartOnboardingViewModel extends ChangeNotifier {
 
   void setNationalityGroup(String? value) {
     nationalityGroup = value;
-    if (value == 'CH') nationalityCountry = null;
+    if (value == 'CH') {
+      nationalityCountry = null;
+      permitType = null;
+    }
+    notifyListeners();
+  }
+
+  void setPermitType(String? value) {
+    permitType = value;
     notifyListeners();
   }
 

--- a/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
@@ -359,6 +359,25 @@ class _StepQuestionsState extends State<StepQuestions> {
                       },
                     ),
                   ],
+                  // Permit type — shown for non-Swiss nationals
+                  if (widget.viewModel.nationalityGroup != null &&
+                      widget.viewModel.nationalityGroup != 'CH') ...[
+                    const SizedBox(height: 24),
+                    _SectionTitle(label: l.onboardingPermitTypeLabel),
+                    const SizedBox(height: 12),
+                    _PermitTypeChips(
+                      value: widget.viewModel.permitType,
+                      onChanged: (v) {
+                        widget.viewModel.setPermitType(v);
+                        widget.onInputChanged();
+                      },
+                    ),
+                  ],
+                  // IJM warning — shown for independants
+                  if (widget.viewModel.employmentStatus == 'independant') ...[
+                    const SizedBox(height: 24),
+                    _IjmWarningCard(),
+                  ],
                   const SizedBox(height: 32),
 
                   // ── 5. CANTON ─────────────────────────────────────────────
@@ -1097,3 +1116,120 @@ class _CantonPicker extends StatelessWidget {
   }
 }
 
+// ════════════════════════════════════════════════════════════════════════════
+//  PERMIT TYPE CHIPS — shown for non-Swiss nationals (P1-A)
+// ════════════════════════════════════════════════════════════════════════════
+
+class _PermitTypeChips extends StatelessWidget {
+  final String? value;
+  final ValueChanged<String?> onChanged;
+
+  const _PermitTypeChips({required this.value, required this.onChanged});
+
+  static const _codes = ['C', 'B', 'G', 'L', 'other'];
+
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    final labels = [
+      l.onboardingPermitC,
+      l.onboardingPermitB,
+      l.onboardingPermitG,
+      l.onboardingPermitL,
+      l.onboardingPermitOther,
+    ];
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: List.generate(_codes.length, (i) {
+        final code = _codes[i];
+        final label = labels[i];
+        final isSelected = value == code;
+        return Semantics(
+          label: label,
+          selected: isSelected,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(20),
+            onTap: () => onChanged(isSelected ? null : code),
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? MintColors.primary.withAlpha(24)
+                    : MintColors.surface,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color:
+                      isSelected ? MintColors.primary : MintColors.lightBorder,
+                  width: isSelected ? 2 : 1,
+                ),
+              ),
+              child: Text(
+                label,
+                style: GoogleFonts.inter(
+                  fontSize: 13,
+                  fontWeight: isSelected ? FontWeight.w700 : FontWeight.w500,
+                  color: isSelected
+                      ? MintColors.primary
+                      : MintColors.textSecondary,
+                ),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+//  IJM WARNING CARD — shown for independants (P1-D)
+// ════════════════════════════════════════════════════════════════════════════
+
+class _IjmWarningCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: MintColors.warning.withAlpha(20),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: MintColors.warning.withAlpha(60)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.warning_amber_rounded,
+              color: MintColors.warning, size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l.onboardingIjmWarningTitle,
+                  style: GoogleFonts.montserrat(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: MintColors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  l.onboardingIjmWarningBody,
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    color: MintColors.textSecondary,
+                    height: 1.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -110,10 +110,16 @@ class ApiService {
     }
   }
 
-  // Helper method to get auth headers with JWT token
+  /// App version sent with every request for backend compatibility checks.
+  static const String _appVersion = '1.0.0';
+
+  // Helper method to get auth headers with JWT token + version
   static Future<Map<String, String>> _authHeaders() async {
     final token = await AuthService.getToken();
-    final headers = {'Content-Type': 'application/json'};
+    final headers = {
+      'Content-Type': 'application/json',
+      'X-App-Version': _appVersion,
+    };
     if (token != null) {
       headers['Authorization'] = 'Bearer $token';
     }

--- a/apps/mobile/lib/services/coach/conversation_store.dart
+++ b/apps/mobile/lib/services/coach/conversation_store.dart
@@ -331,6 +331,7 @@ class ConversationStore {
   // (they are session-specific and would bloat storage).
 
   Map<String, dynamic> _messageToJson(ChatMessage msg) => {
+        'schemaVersion': ChatMessage.schemaVersion,
         'role': msg.role,
         'content': msg.content,
         'timestamp': msg.timestamp.toIso8601String(),
@@ -341,6 +342,8 @@ class ConversationStore {
       };
 
   ChatMessage _messageFromJson(Map<String, dynamic> json) {
+    // Schema migration: version 0 (pre-schema) and 1 share the same format.
+    // Future migrations: final version = json['schemaVersion'] as int? ?? 0;
     final tierName = json['tier'] as String? ?? 'none';
     final tier = ChatTier.values.firstWhere(
       (t) => t.name == tierName,

--- a/apps/mobile/lib/services/coach/fallback_templates.dart
+++ b/apps/mobile/lib/services/coach/fallback_templates.dart
@@ -209,6 +209,11 @@ class FallbackTemplates {
         'quelques points éducatifs à connaître. '
         'Le FATCA (Foreign Account Tax Compliance Act) impose '
         'une déclaration annuelle de tes comptes suisses à l\'IRS. '
+        'De plus, si la somme de tes comptes étrangers dépasse '
+        '\$10\u00a0000 à tout moment de l\'année, tu es tenu·e de '
+        'déposer un FBAR (FinCEN Form 114) avant le 15 avril. '
+        'L\'amende pour non-déclaration peut atteindre \$12\u00a0500 '
+        'par compte (voire plus en cas de faute intentionnelle). '
         'Tes investissements en fonds suisses pourraient être '
         'classés PFIC, avec un traitement fiscal US spécifique. '
         'La convention de double imposition CH-US prévoit des '
@@ -216,7 +221,8 @@ class FallbackTemplates {
         'versements 3a et prestations LPP. '
         'Il serait utile de consulter un·e spécialiste '
         'en fiscalité transfrontalière CH-US. '
-        'Réf. : Convention de double imposition CH-US, FATCA.';
+        'Réf. : Convention de double imposition CH-US, FATCA, '
+        'FBAR (FinCEN Form 114, 31 USC 5314).';
   }
 
   // ═══════════════════════════════════════════════════════════════

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -160,6 +160,10 @@ class DocumentToolPayload {
 
 /// Message dans l'historique de conversation
 class ChatMessage {
+  /// Schema version for migration support.
+  /// Increment when breaking changes are made to serialization format.
+  static const int schemaVersion = 1;
+
   final String role; // 'user', 'assistant', 'system'
   final String content;
   final DateTime timestamp;

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http: ^1.2.0
   provider: ^6.1.1
   go_router: ^13.2.0
-  intl: any
+  intl: ^0.20.2
   url_launcher: ^6.2.0
   google_fonts: ^6.1.0
   uuid: ^4.0.0

--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -30,6 +30,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-XSS-Protection"] = "1; mode=block"
+        # API version for client compatibility checks
+        response.headers["X-API-Version"] = "1.0.0"
+        response.headers["X-Min-App-Version"] = "1.0.0"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if settings.ENVIRONMENT != "development":
             response.headers["Strict-Transport-Security"] = (

--- a/services/backend/app/services/coach/fallback_templates.py
+++ b/services/backend/app/services/coach/fallback_templates.py
@@ -123,3 +123,35 @@ class FallbackTemplates:
             "de donnees concretes. "
             "Plus tu precises ton profil, plus l'estimation s'affine."
         )
+
+    @staticmethod
+    def fatca_fbar_guidance(ctx: CoachContext) -> str:
+        """Generate educational content about FATCA + FBAR for US persons.
+
+        Covers:
+            - FATCA annual reporting to IRS
+            - FBAR (FinCEN Form 114) when foreign accounts > $10,000
+            - PFIC classification of Swiss funds
+            - CH-US double taxation convention
+        """
+        if ctx.archetype != "expat_us":
+            return (
+                f"{ctx.first_name}, certaines regles de prevoyance "
+                "dependent de ta nationalite et de ton parcours. "
+                "Verifie les conventions bilaterales qui pourraient "
+                "s'appliquer a ta situation aupres d'un specialiste."
+            )
+
+        return (
+            f"{ctx.first_name}, en tant que contribuable US en Suisse, "
+            "quelques points educatifs a connaitre. "
+            "Le FATCA impose une declaration annuelle de tes comptes "
+            "suisses a l'IRS. De plus, si la somme de tes comptes "
+            "etrangers depasse $10\u00a0000 a tout moment de l'annee, "
+            "tu es tenu de deposer un FBAR (FinCEN Form 114) avant "
+            "le 15 avril. L'amende pour non-declaration peut atteindre "
+            "$12\u00a0500 par compte. Tes investissements en fonds suisses "
+            "pourraient etre classes PFIC. La convention CH-US prevoit "
+            "des mecanismes pour eviter une double taxation. "
+            "Ref. : FATCA, FBAR (31 USC 5314), Convention CH-US."
+        )


### PR DESCRIPTION
## Summary
**Persona fixes (Bloc A):**
- Marco (frontalier): Onboarding now asks permit type → G auto-sets cross_border archetype
- Lauren (expat_us): FBAR warning added (FinCEN Form 114, $10k threshold)
- Sophie (indépendante): IJM warning at onboarding + LPP voluntary 6-month deadline

**Structural fixes (Bloc B):**
- 29x "vous"→"tu" + 5 banned terms in FR ARB (voice compliance)
- `intl: any` → `intl: ^0.20.2` (pinned dependency)
- Portrait orientation locked globally
- API version headers (X-App-Version + X-API-Version)
- Schema version on CoachProfile (v1) and ChatMessage (v1)
- Health check rollback warning in CI/CD
- 9 new i18n keys across all 6 ARB files

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8128 passed, 2 skipped, 0 failures
- [x] pytest: 4652 passed, 49 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)