### PR TITLE
feat: S60 — birthDate migration + responsive refactor

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -80,6 +80,7 @@ enum FinancialArchetype {
 class ConjointProfile {
   final String? firstName;
   final int? birthYear;
+  final DateTime? dateOfBirth;
   final String? gender; // 'M', 'F', or null (AVS21 reference age)
   final double? salaireBrutMensuel;
   final int nombreDeMois; // 12, 13, 13.5
@@ -112,6 +113,7 @@ class ConjointProfile {
   const ConjointProfile({
     this.firstName,
     this.birthYear,
+    this.dateOfBirth,
     this.gender,
     this.salaireBrutMensuel,
     this.nombreDeMois = 12,
@@ -135,8 +137,11 @@ class ConjointProfile {
     return base + bonus;
   }
 
-  /// Age actuel
+  /// Age actuel — prefers dateOfBirth (exact), falls back to birthYear.
   int? get age {
+    if (dateOfBirth != null) {
+      return DateTime.now().difference(dateOfBirth!).inDays ~/ 365;
+    }
     if (birthYear == null) return null;
     return DateTime.now().year - birthYear!;
   }
@@ -177,6 +182,9 @@ class ConjointProfile {
     return ConjointProfile(
       firstName: json['firstName'] as String?,
       birthYear: json['birthYear'] as int?,
+      dateOfBirth: json['dateOfBirth'] != null
+          ? DateTime.tryParse(json['dateOfBirth'] as String)
+          : null,
       gender: json['gender'] as String?,
       salaireBrutMensuel: (json['salaireBrutMensuel'] as num?)?.toDouble(),
       nombreDeMois: json['nombreDeMois'] ?? 12,
@@ -198,6 +206,7 @@ class ConjointProfile {
   Map<String, dynamic> toJson() => {
         'firstName': firstName,
         'birthYear': birthYear,
+        'dateOfBirth': dateOfBirth?.toIso8601String(),
         'gender': gender,
         'salaireBrutMensuel': salaireBrutMensuel,
         'nombreDeMois': nombreDeMois,
@@ -216,6 +225,7 @@ class ConjointProfile {
   ConjointProfile copyWith({
     String? firstName,
     int? birthYear,
+    DateTime? dateOfBirth,
     String? gender,
     double? salaireBrutMensuel,
     int? nombreDeMois,
@@ -241,6 +251,7 @@ class ConjointProfile {
     return ConjointProfile(
       firstName: firstName ?? this.firstName,
       birthYear: birthYear ?? this.birthYear,
+      dateOfBirth: dateOfBirth ?? this.dateOfBirth,
       gender: gender ?? this.gender,
       salaireBrutMensuel: salaireBrutMensuel ?? this.salaireBrutMensuel,
       nombreDeMois: nombreDeMois ?? this.nombreDeMois,

--- a/apps/mobile/lib/models/minimal_profile_models.dart
+++ b/apps/mobile/lib/models/minimal_profile_models.dart
@@ -56,6 +56,9 @@ class MinimalProfileResult {
   /// Age used for the computation.
   final int age;
 
+  /// Birth date (ISO 8601) — when available, age is computed from this.
+  final DateTime? birthDate;
+
   /// Gross annual salary used for the computation.
   final double grossAnnualSalary;
 
@@ -114,6 +117,7 @@ class MinimalProfileResult {
     required this.liquidityMonths,
     required this.canton,
     required this.age,
+    this.birthDate,
     required this.grossAnnualSalary,
     required this.householdType,
     required this.isPropertyOwner,

--- a/apps/mobile/lib/models/profile.dart
+++ b/apps/mobile/lib/models/profile.dart
@@ -53,6 +53,7 @@ extension EmploymentStatusExtension on EmploymentStatus {
 class Profile {
   final String id;
   final int? birthYear;
+  final DateTime? dateOfBirth;
   final String? canton;
   final HouseholdType householdType;
   final double? incomeNetMonthly;
@@ -73,6 +74,17 @@ class Profile {
   final bool? hasVoluntaryLpp; // Pour indépendants
   final String? primaryActivity; // Pour mixtes: 'employee' ou 'self_employed'
 
+  /// Computed age — prefers dateOfBirth (exact), falls back to birthYear.
+  int? get age {
+    if (dateOfBirth != null) {
+      return DateTime.now().difference(dateOfBirth!).inDays ~/ 365;
+    }
+    if (birthYear != null) {
+      return DateTime.now().year - birthYear!;
+    }
+    return null;
+  }
+
   // ⭐ Genre (AVS21 transitional reference age, LAVS art. 21 al. 1)
   final String? gender; // 'M', 'F', or null
 
@@ -90,6 +102,7 @@ class Profile {
   Profile({
     required this.id,
     this.birthYear,
+    this.dateOfBirth,
     this.canton,
     required this.householdType,
     this.incomeNetMonthly,
@@ -166,6 +179,9 @@ class Profile {
     return Profile(
       id: json['id'],
       birthYear: json['birthYear'],
+      dateOfBirth: json['dateOfBirth'] != null
+          ? DateTime.tryParse(json['dateOfBirth'])
+          : null,
       canton: json['canton'],
       householdType: HouseholdType.values.firstWhere(
         (e) => e.name == json['householdType'],
@@ -216,6 +232,7 @@ class Profile {
     return {
       'id': id,
       'birthYear': birthYear,
+      'dateOfBirth': dateOfBirth?.toIso8601String(),
       'canton': canton,
       'householdType': householdType.name,
       'incomeNetMonthly': incomeNetMonthly,
@@ -248,6 +265,7 @@ class Profile {
   Profile copyWith({
     String? id,
     int? birthYear,
+    DateTime? dateOfBirth,
     String? canton,
     HouseholdType? householdType,
     double? incomeNetMonthly,
@@ -278,6 +296,7 @@ class Profile {
     return Profile(
       id: id ?? this.id,
       birthYear: birthYear ?? this.birthYear,
+      dateOfBirth: dateOfBirth ?? this.dateOfBirth,
       canton: canton ?? this.canton,
       householdType: householdType ?? this.householdType,
       incomeNetMonthly: incomeNetMonthly ?? this.incomeNetMonthly,

--- a/apps/mobile/lib/screens/achievements_screen.dart
+++ b/apps/mobile/lib/screens/achievements_screen.dart
@@ -133,7 +133,9 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -182,7 +184,7 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             ],
           ],
         ),
-      ))),
+      )))),
     );
   }
 
@@ -325,9 +327,13 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
         children: [
           Icon(icon, size: 14, color: MintColors.textMuted),
           const SizedBox(width: 6),
-          Text(
-            label,
-            style: MintTextStyles.labelSmall(color: MintColors.textSecondary),
+          Flexible(
+            child: Text(
+              label,
+              style: MintTextStyles.labelSmall(color: MintColors.textSecondary),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),
@@ -534,6 +540,8 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                     ? MintColors.textPrimary
                     : MintColors.textMuted,
               ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
             ),
             const SizedBox(height: MintSpacing.xs),
             Text(
@@ -550,6 +558,10 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
   void _showBadgeDetail(_BadgeInfo badge) {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -711,9 +723,13 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             children: [
               Icon(category.icon, color: category.color, size: 20),
               const SizedBox(width: MintSpacing.sm),
-              Text(
-                category.title,
-                style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+              Flexible(
+                child: Text(
+                  category.title,
+                  style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             ],
           ),
@@ -760,6 +776,8 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                           ? MintColors.textPrimary
                           : MintColors.textMuted,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   Text(
                     milestone.description,
@@ -791,9 +809,13 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
             children: [
               Icon(category.icon, color: category.color, size: 20),
               const SizedBox(width: MintSpacing.sm),
-              Text(
-                category.title,
-                style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+              Flexible(
+                child: Text(
+                  category.title,
+                  style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             ],
           ),
@@ -830,6 +852,8 @@ class _AchievementsScreenState extends State<AchievementsScreen> {
                 Text(
                   info.label,
                   style: MintTextStyles.bodyMedium(color: MintColors.textMuted),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
                 Text(
                   info.description,

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -645,6 +645,10 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
   void _showExplanation(String term, String text) {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -224,7 +224,9 @@ class _BudgetScreenState extends State<BudgetScreen>
           style: MintTextStyles.headlineMedium(),
         ),
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: Consumer<BudgetProvider>(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
+        top: false,
+        child: Consumer<BudgetProvider>(
         builder: (context, provider, child) {
           if (_hasError) {
             return Center(
@@ -484,7 +486,7 @@ class _BudgetScreenState extends State<BudgetScreen>
             ),
           );
         },
-      )))),
+      ))))),
     );
   }
 

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -2773,11 +2773,15 @@ class _CoachChatScreenState extends State<CoachChatScreen>
           Icon(Icons.cloud_off,
               size: 12, color: MintColors.warning.withValues(alpha: 0.9)),
           const SizedBox(width: MintSpacing.xs),
-          Text(
-            s.llmAllProvidersDown,
-            style: MintTextStyles.labelSmall(
-              color: MintColors.warning.withValues(alpha: 0.9),
-            ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+          Flexible(
+            child: Text(
+              s.llmAllProvidersDown,
+              style: MintTextStyles.labelSmall(
+                color: MintColors.warning.withValues(alpha: 0.9),
+              ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       );
@@ -2789,11 +2793,15 @@ class _CoachChatScreenState extends State<CoachChatScreen>
           Icon(Icons.warning_amber_outlined,
               size: 12, color: MintColors.warning.withValues(alpha: 0.9)),
           const SizedBox(width: MintSpacing.xs),
-          Text(
-            s.llmCircuitOpen,
-            style: MintTextStyles.labelSmall(
-              color: MintColors.warning.withValues(alpha: 0.9),
-            ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+          Flexible(
+            child: Text(
+              s.llmCircuitOpen,
+              style: MintTextStyles.labelSmall(
+                color: MintColors.warning.withValues(alpha: 0.9),
+              ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       );
@@ -2819,11 +2827,15 @@ class _CoachChatScreenState extends State<CoachChatScreen>
       children: [
         Icon(icon, size: 12, color: MintColors.white.withValues(alpha: 0.7)),
         const SizedBox(width: MintSpacing.xs),
-        Text(
-          label,
-          style: MintTextStyles.labelSmall(
-            color: MintColors.white.withValues(alpha: 0.7),
-          ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+        Flexible(
+          child: Text(
+            label,
+            style: MintTextStyles.labelSmall(
+              color: MintColors.white.withValues(alpha: 0.7),
+            ).copyWith(fontSize: 12, fontWeight: FontWeight.w400),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
       ],
     );
@@ -3594,6 +3606,10 @@ class _CoachChatScreenState extends State<CoachChatScreen>
     // Show bottom sheet with options: camera, gallery, file
     final source = await showModalBottomSheet<String>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       builder: (ctx) => SafeArea(
         child: Wrap(
           children: [

--- a/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_checkin_screen.dart
@@ -306,6 +306,9 @@ class _CoachCheckinScreenState extends State<CoachCheckinScreen>
         await showModalBottomSheet(
           context: context,
           isScrollControlled: true,
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85,
+          ),
           backgroundColor: MintColors.transparent,
           builder: (_) => MilestoneCelebrationSheet(milestone: milestone),
         );
@@ -699,6 +702,9 @@ Reponds uniquement avec le texte final.
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.transparent,
       builder: (ctx) {
         return StatefulBuilder(

--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -707,6 +707,9 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.transparent,
       builder: (ctx) => Padding(
         padding: EdgeInsets.only(

--- a/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
@@ -477,6 +477,9 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.transparent,
       builder: (ctx) => Padding(
         padding: EdgeInsets.only(

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -620,6 +620,9 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
     final submitted = await showModalBottomSheet<bool>(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
@@ -731,6 +734,10 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
 
     await showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
@@ -790,6 +797,10 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
 
     await showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
@@ -850,6 +861,10 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
     final showVision = imageFile != null && _isVisionAvailable(context);
     await showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(18)),

--- a/apps/mobile/lib/screens/documents_screen.dart
+++ b/apps/mobile/lib/screens/documents_screen.dart
@@ -97,7 +97,9 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
           const SizedBox(width: MintSpacing.sm),
         ],
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
         padding: const EdgeInsets.all(MintSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -162,7 +164,7 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             const SizedBox(height: MintSpacing.xl),
           ],
         ),
-      ))),
+      )))),
     );
   }
 
@@ -226,9 +228,13 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                   const Icon(Icons.folder_outlined,
                       color: MintColors.info, size: 18),
                   const SizedBox(width: MintSpacing.sm),
-                  Text(
-                    s.documentsConfidenceChoc(totalDocs.toString(), confidencePct.toString()),
-                    style: MintTextStyles.bodySmall(color: MintColors.info),
+                  Flexible(
+                    child: Text(
+                      s.documentsConfidenceChoc(totalDocs.toString(), confidencePct.toString()),
+                      style: MintTextStyles.bodySmall(color: MintColors.info),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
                 ],
               ),
@@ -407,6 +413,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                 child: Text(
                   title,
                   style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],
@@ -553,6 +561,8 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
                       Text(
                         typeLabel,
                         style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: MintSpacing.xs),
                       Row(
@@ -695,9 +705,13 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
             ),
           ),
           const SizedBox(width: MintSpacing.md),
-          Text(
-            s.vaultAnalyzing,
-            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary),
+          Flexible(
+            child: Text(
+              s.vaultAnalyzing,
+              style: MintTextStyles.bodyMedium(color: MintColors.textPrimary),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),
@@ -1033,6 +1047,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
     if (!sub.isCoach && docProvider.documentCount >= _freeDocLimit) {
       showModalBottomSheet(
         context: context,
+        isScrollControlled: true,
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.85,
+        ),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
@@ -1061,6 +1079,10 @@ class _DocumentsScreenState extends State<DocumentsScreen> {
 
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -506,6 +506,10 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
   void _showTauxMarginalInfo(BuildContext context, S l) {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
       builder: (context) {

--- a/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
+++ b/apps/mobile/lib/screens/main_tabs/dossier_tab.dart
@@ -136,6 +136,9 @@ class _DossierTabState extends State<DossierTab> {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
@@ -221,6 +224,9 @@ class _DossierTabState extends State<DossierTab> {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
@@ -583,6 +589,8 @@ class _ProfileSection extends StatelessWidget {
                         style: MintTextStyles.titleMedium(
                           color: MintColors.textPrimary,
                         ).copyWith(fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                       if (age != null || canton.isNotEmpty)
                         Text(
@@ -1143,6 +1151,8 @@ class _PlanStepRow extends StatelessWidget {
                         ? MintColors.textPrimary
                         : MintColors.textSecondary,
                   ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ],
             ),
@@ -1230,11 +1240,15 @@ class _DataRow extends StatelessWidget {
                   ),
                 ),
                 cta != null
-                    ? Text(
-                        cta!,
-                        style: MintTextStyles.labelSmall(
-                          color: MintColors.primary,
-                        ).copyWith(fontWeight: FontWeight.w500),
+                    ? Flexible(
+                        child: Text(
+                          cta!,
+                          style: MintTextStyles.labelSmall(
+                            color: MintColors.primary,
+                          ).copyWith(fontWeight: FontWeight.w500),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       )
                     : Row(
                         mainAxisSize: MainAxisSize.min,
@@ -1244,6 +1258,8 @@ class _DataRow extends StatelessWidget {
                             style: MintTextStyles.titleMedium(
                               color: MintColors.textPrimary,
                             ).copyWith(fontSize: 14, fontWeight: FontWeight.w500),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                           if (delta != null) ...[
                             const SizedBox(width: MintSpacing.xs),
@@ -1392,6 +1408,8 @@ class _DossierRow extends StatelessWidget {
                           style: MintTextStyles.titleMedium(
                             color: MintColors.textPrimary,
                           ).copyWith(fontSize: 15, fontWeight: FontWeight.w500),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
                         const SizedBox(height: 2),
                         Text(
@@ -1399,6 +1417,8 @@ class _DossierRow extends StatelessWidget {
                           style: MintTextStyles.labelSmall(
                             color: MintColors.textMuted,
                           ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ],
                     ),

--- a/apps/mobile/lib/screens/main_tabs/explore_tab.dart
+++ b/apps/mobile/lib/screens/main_tabs/explore_tab.dart
@@ -180,6 +180,8 @@ class _ExploreHubCard extends StatelessWidget {
                 child: Text(
                   title,
                   style: MintTextStyles.headlineMedium(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               const SizedBox(height: MintSpacing.sm),

--- a/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/quick_start_screen.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
@@ -38,7 +40,7 @@ class QuickStartScreen extends StatefulWidget {
 class _QuickStartScreenState extends State<QuickStartScreen> {
   final _analytics = AnalyticsService();
   final _nameController = TextEditingController();
-  double _age = 45;
+  int _birthYear = 1981;
   double _salary = 85000;
   String _canton = 'ZH';
   bool _saving = false;
@@ -67,7 +69,11 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
       if (profile.firstName != null && profile.firstName!.isNotEmpty) {
         _nameController.text = profile.firstName!;
       }
-      _age = profile.age.toDouble().clamp(18, 75);
+      if (profile.dateOfBirth != null) {
+        _birthYear = profile.dateOfBirth!.year;
+      } else {
+        _birthYear = DateTime.now().year - profile.age;
+      }
       if (profile.canton.isNotEmpty) {
         _canton = profile.canton;
       }
@@ -117,8 +123,10 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
     return balance;
   }
 
+  int get _age => DateTime.now().year - _birthYear;
+
   Map<String, double> _estimate() {
-    final age = _age.round();
+    final age = _age;
     final gross = _salary;
     final avs = AvsCalculator.renteFromRAMD(gross);
     final lppBalance = _estimateLppBalance(age, gross);
@@ -143,7 +151,7 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
 
     final provider = context.read<CoachProfileProvider>();
     provider.updateFromSmartFlow(
-      age: _age.round(),
+      age: _age,
       grossSalary: _salary,
       canton: _canton,
       firstName: _nameController.text.trim().isNotEmpty
@@ -261,16 +269,65 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
                     ),
                     const SizedBox(height: 22),
 
-                    // ── Age slider ──
-                    MintPremiumSlider(
-                      label: l.quickStartAge,
-                      value: _age,
-                      min: 18,
-                      max: 75,
-                      divisions: 57,
-                      formatValue: (v) =>
-                          l.quickStartAgeValue(v.round().toString()),
-                      onChanged: (v) => setState(() => _age = v),
+                    // ── Birth year picker ──
+                    Text(
+                      l.quickStartAge,
+                      style: MintTextStyles.bodySmall(
+                        color: MintColors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    MintSurface(
+                      tone: MintSurfaceTone.porcelaine,
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      radius: 12,
+                      child: SizedBox(
+                        height: 120,
+                        child: CupertinoPicker(
+                          scrollController: FixedExtentScrollController(
+                            initialItem: _birthYear - 1940,
+                          ),
+                          itemExtent: 38,
+                          diameterRatio: 1.2,
+                          magnification: 1.1,
+                          squeeze: 1.0,
+                          selectionOverlay: Container(
+                            decoration: BoxDecoration(
+                              border: Border.symmetric(
+                                horizontal: BorderSide(
+                                  color: MintColors.primary.withAlpha(38),
+                                  width: 1,
+                                ),
+                              ),
+                            ),
+                          ),
+                          onSelectedItemChanged: (index) {
+                            setState(() => _birthYear = 1940 + index);
+                          },
+                          children: List.generate(
+                            DateTime.now().year - 18 - 1940 + 1,
+                            (index) {
+                              final year = 1940 + index;
+                              final age = DateTime.now().year - year;
+                              final isSelected = year == _birthYear;
+                              return Center(
+                                child: Text(
+                                  l.quickStartAgeValue('$year ($age ans)'),
+                                  style: GoogleFonts.montserrat(
+                                    fontSize: isSelected ? 18 : 14,
+                                    fontWeight: isSelected
+                                        ? FontWeight.w700
+                                        : FontWeight.w400,
+                                    color: isSelected
+                                        ? MintColors.textPrimary
+                                        : MintColors.textMuted,
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
                     ),
                     const SizedBox(height: MintSpacing.md),
 
@@ -417,13 +474,17 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
             children: [
               Icon(Icons.show_chart, size: 18, color: accentColor),
               const SizedBox(width: MintSpacing.sm),
-              Text(
-                l.quickStartPreviewTitle,
-                style: MintTextStyles.bodySmall(
-                  color: MintColors.textPrimary,
+              Flexible(
+                child: Text(
+                  l.quickStartPreviewTitle,
+                  style: MintTextStyles.bodySmall(
+                    color: MintColors.textPrimary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: MintSpacing.sm),
               Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
@@ -513,6 +574,8 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
             style: MintTextStyles.displayMedium(color: color).copyWith(
               fontSize: 20,
             ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ),
         Text(
@@ -527,15 +590,21 @@ class _QuickStartScreenState extends State<QuickStartScreen> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(
-          label,
-          style: MintTextStyles.bodySmall(color: MintColors.textPrimary),
+        Flexible(
+          child: Text(
+            label,
+            style: MintTextStyles.bodySmall(color: MintColors.textPrimary),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
         Text(
           value,
           style: MintTextStyles.bodySmall(color: MintColors.primary).copyWith(
             fontWeight: FontWeight.w700,
           ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ],
     );

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_screen.dart
@@ -169,6 +169,10 @@ class _SmartOnboardingScreenState extends State<SmartOnboardingScreen> {
     final l = S.of(context)!;
     final result = await showModalBottomSheet<bool>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       isDismissible: false,
       enableDrag: false,
       builder: (ctx) {

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
@@ -23,7 +23,7 @@ class SmartOnboardingViewModel extends ChangeNotifier {
   // ─── Step 1 data (3 required questions) ──────────────────────────────────
 
   double grossSalary = 80000;
-  int age = 35;
+  DateTime? birthDate;
   String? canton;
 
   /// Optional first name — personalises coach narrative ("Salut Julie").
@@ -78,6 +78,14 @@ class SmartOnboardingViewModel extends ChangeNotifier {
   /// Error message if computation failed.
   String? error;
 
+  /// Computed age from birthDate. Falls back to 35 if no birthDate set.
+  int get age {
+    if (birthDate != null) {
+      return DateTime.now().difference(birthDate!).inDays ~/ 365;
+    }
+    return 35;
+  }
+
   // ─── Setters with notification ────────────────────────────────────────────
 
   void setFirstName(String? value) {
@@ -90,8 +98,14 @@ class SmartOnboardingViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setBirthDate(DateTime value) {
+    birthDate = value;
+    notifyListeners();
+  }
+
+  /// Backward-compat setter: creates a birthDate from age (Jan 1 of birth year).
   void setAge(int value) {
-    age = value;
+    birthDate = DateTime(DateTime.now().year - value, 1, 1);
     notifyListeners();
   }
 

--- a/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_ocr_upload.dart
@@ -193,6 +193,10 @@ class _StepOcrUploadState extends State<StepOcrUpload> {
     final l = S.of(context)!;
     final result = await showModalBottomSheet<bool>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
+++ b/apps/mobile/lib/screens/onboarding/steps/step_questions.dart
@@ -41,7 +41,6 @@ class StepQuestions extends StatefulWidget {
 
 class _StepQuestionsState extends State<StepQuestions> {
   static const int _minAge = 18;
-  static const int _maxAge = 75;
 
   // Salary presets mirrored from onboarding_minimal_screen.dart
   static const List<double> _salaryPresets = [
@@ -61,47 +60,56 @@ class _StepQuestionsState extends State<StepQuestions> {
     '150k+',
   ];
 
-  late TextEditingController _ageController;
+  late TextEditingController _birthYearController;
   late TextEditingController _firstNameController;
   bool _didTrackStart = false;
 
   /// P3-23: Guard against double-tap on submit button.
   bool _isSubmitting = false;
 
+  /// Current birth year derived from viewModel.birthDate or default.
+  int get _currentBirthYear {
+    final bd = widget.viewModel.birthDate;
+    if (bd != null) return bd.year;
+    return DateTime.now().year - 35; // default ~1991
+  }
+
   @override
   void initState() {
     super.initState();
-    _ageController =
-        TextEditingController(text: widget.viewModel.age.toString());
+    _birthYearController =
+        TextEditingController(text: _currentBirthYear.toString());
     _firstNameController =
         TextEditingController(text: widget.viewModel.firstName ?? '');
   }
 
   @override
   void dispose() {
-    _ageController.dispose();
+    _birthYearController.dispose();
     _firstNameController.dispose();
     super.dispose();
   }
 
-  void _setAge(int value) {
-    final clamped = value.clamp(_minAge, _maxAge);
-    widget.viewModel.setAge(clamped);
+  void _setBirthYear(int year) {
+    const minYear = 1940;
+    final maxYear = DateTime.now().year - _minAge;
+    final clamped = year.clamp(minYear, maxYear);
+    widget.viewModel.setBirthDate(DateTime(clamped, 1, 1));
     widget.onInputChanged();
     final text = clamped.toString();
-    _ageController.value = TextEditingValue(
+    _birthYearController.value = TextEditingValue(
       text: text,
       selection: TextSelection.collapsed(offset: text.length),
     );
   }
 
-  void _applyAgeFromInput() {
-    final parsed = int.tryParse(_ageController.text.trim());
+  void _applyBirthYearFromInput() {
+    final parsed = int.tryParse(_birthYearController.text.trim());
     if (parsed == null) {
-      _ageController.text = widget.viewModel.age.toString();
+      _birthYearController.text = _currentBirthYear.toString();
       return;
     }
-    _setAge(parsed);
+    _setBirthYear(parsed);
   }
 
   void _onSubmit() {
@@ -267,32 +275,31 @@ class _StepQuestionsState extends State<StepQuestions> {
                   // ── 2. AGE ────────────────────────────────────────────────
                   _SectionTitle(label: l.onboardingSmartAgeLabel),
                   const SizedBox(height: 12),
-                  _AgePicker(
-                    value: widget.viewModel.age,
-                    onChanged: _setAge,
+                  _BirthYearPicker(
+                    value: _currentBirthYear,
+                    onChanged: _setBirthYear,
                   ),
                   const SizedBox(height: 12),
                   SizedBox(
                     width: 180,
                     child: TextFormField(
-                      controller: _ageController,
+                      controller: _birthYearController,
                       textAlign: TextAlign.center,
                       keyboardType: TextInputType.number,
                       inputFormatters: [
                         FilteringTextInputFormatter.digitsOnly,
-                        LengthLimitingTextInputFormatter(2),
+                        LengthLimitingTextInputFormatter(4),
                       ],
                       validator: (v) {
                         if (v == null || v.isEmpty) return null;
-                        final age = int.tryParse(v);
-                        if (age == null || age < 18 || age > 75) {
+                        final year = int.tryParse(v);
+                        if (year == null || year < 1940 || year > DateTime.now().year - 18) {
                           return l.onboardingAgeInvalid;
                         }
                         return null;
                       },
                       decoration: InputDecoration(
                         labelText: l.onboardingSmartAgeDirectInput,
-                        suffixText: 'ans',
                         filled: true,
                         fillColor: MintColors.background,
                         contentPadding: const EdgeInsets.symmetric(
@@ -318,10 +325,10 @@ class _StepQuestionsState extends State<StepQuestions> {
                           ),
                         ),
                       ),
-                      onFieldSubmitted: (_) => _applyAgeFromInput(),
+                      onFieldSubmitted: (_) => _applyBirthYearFromInput(),
                       onTapOutside: (_) {
                         FocusScope.of(context).unfocus();
-                        _applyAgeFromInput();
+                        _applyBirthYearFromInput();
                       },
                     ),
                   ),
@@ -566,23 +573,23 @@ class _SalarySelectorState extends State<_SalarySelector> {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-//  AGE PICKER — CupertinoPicker wheel + quick chips (18–75)
+//  BIRTH YEAR PICKER — CupertinoPicker wheel + quick chips (1940–now-18)
 // ════════════════════════════════════════════════════════════════════════════
 
-class _AgePicker extends StatefulWidget {
-  final int value;
+class _BirthYearPicker extends StatefulWidget {
+  final int value; // birth year
   final ValueChanged<int> onChanged;
 
-  const _AgePicker({required this.value, required this.onChanged});
+  const _BirthYearPicker({required this.value, required this.onChanged});
 
   @override
-  State<_AgePicker> createState() => _AgePickerState();
+  State<_BirthYearPicker> createState() => _BirthYearPickerState();
 }
 
-class _AgePickerState extends State<_AgePicker> {
-  static const int _minAge = 18;
-  static const int _maxAge = 75;
-  static const List<int> _quickAges = [25, 30, 35, 40, 45, 50, 55, 60, 65];
+class _BirthYearPickerState extends State<_BirthYearPicker> {
+  static const int _minYear = 1940;
+  static int get _maxYear => DateTime.now().year - 18;
+  static const List<int> _quickYears = [1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000];
 
   late FixedExtentScrollController _controller;
 
@@ -590,7 +597,7 @@ class _AgePickerState extends State<_AgePicker> {
   void initState() {
     super.initState();
     _controller = FixedExtentScrollController(
-      initialItem: widget.value - _minAge,
+      initialItem: widget.value - _minYear,
     );
   }
 
@@ -601,10 +608,10 @@ class _AgePickerState extends State<_AgePicker> {
   }
 
   @override
-  void didUpdateWidget(covariant _AgePicker oldWidget) {
+  void didUpdateWidget(covariant _BirthYearPicker oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.value != widget.value) {
-      final targetItem = widget.value - _minAge;
+      final targetItem = widget.value - _minYear;
       if (_controller.selectedItem != targetItem) {
         _controller.animateToItem(
           targetItem,
@@ -618,6 +625,7 @@ class _AgePickerState extends State<_AgePicker> {
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
+    final maxYear = _maxYear;
     return MintSurface(
       tone: MintSurfaceTone.porcelaine,
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 12),
@@ -645,18 +653,19 @@ class _AgePickerState extends State<_AgePicker> {
                 ),
               ),
               onSelectedItemChanged: (index) {
-                widget.onChanged(_minAge + index);
+                widget.onChanged(_minYear + index);
               },
               children: List.generate(
-                _maxAge - _minAge + 1,
+                maxYear - _minYear + 1,
                 (index) {
-                  final age = _minAge + index;
-                  final isSelected = age == widget.value;
+                  final year = _minYear + index;
+                  final isSelected = year == widget.value;
+                  final age = DateTime.now().year - year;
                   return Center(
                     child: Text(
-                      l.stepQuestionsAgeYears(age),
+                      '$year (${l.stepQuestionsAgeYears(age)})',
                       style: GoogleFonts.montserrat(
-                        fontSize: isSelected ? 24 : 18,
+                        fontSize: isSelected ? 22 : 16,
                         fontWeight:
                             isSelected ? FontWeight.w700 : FontWeight.w400,
                         color: isSelected
@@ -674,11 +683,12 @@ class _AgePickerState extends State<_AgePicker> {
           Wrap(
             spacing: 8,
             runSpacing: 8,
-            children: _quickAges.map((age) {
-              final isSelected = age == widget.value;
+            children: _quickYears.where((y) => y <= maxYear).map((year) {
+              final isSelected = year == widget.value;
+              final age = DateTime.now().year - year;
               return InkWell(
                 borderRadius: BorderRadius.circular(20),
-                onTap: () => widget.onChanged(age),
+                onTap: () => widget.onChanged(year),
                 child: Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 12,
@@ -696,7 +706,7 @@ class _AgePickerState extends State<_AgePicker> {
                     ),
                   ),
                   child: Text(
-                    l.stepQuestionsAgeYears(age),
+                    '$year (${l.stepQuestionsAgeYears(age)})',
                     style: GoogleFonts.inter(
                       fontSize: 12,
                       fontWeight:

--- a/apps/mobile/lib/screens/portfolio_screen.dart
+++ b/apps/mobile/lib/screens/portfolio_screen.dart
@@ -30,7 +30,9 @@ class PortfolioScreen extends StatelessWidget {
         backgroundColor: MintColors.white,
         surfaceTintColor: MintColors.white,
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
+      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
+        top: false,
+        child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -59,7 +61,7 @@ class PortfolioScreen extends StatelessWidget {
             const SizedBox(height: 100),
           ],
         ),
-      ))),
+      )))),
     );
   }
 
@@ -95,7 +97,7 @@ class PortfolioScreen extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(S.of(context)!.portfolioReadinessTitle, style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.bold)),
+          Text(S.of(context)!.portfolioReadinessTitle, style: MintTextStyles.bodyMedium().copyWith(fontWeight: FontWeight.bold), maxLines: 1, overflow: TextOverflow.ellipsis),
           const SizedBox(height: 16),
           Row(
             children: [
@@ -165,11 +167,15 @@ class PortfolioScreen extends StatelessWidget {
             child: Text(
               title,
               style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
           Text(
             balance,
             style: MintTextStyles.titleMedium().copyWith(fontSize: 15),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -385,6 +385,9 @@ class FinancialSummaryScreen extends StatelessWidget {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),

--- a/apps/mobile/lib/screens/profile_screen.dart
+++ b/apps/mobile/lib/screens/profile_screen.dart
@@ -398,6 +398,8 @@ class ProfileScreen extends StatelessWidget {
                     style: MintTextStyles.titleMedium(
                       color: MintColors.textPrimary,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 const SizedBox(height: 2),
                 Text(
@@ -407,6 +409,8 @@ class ProfileScreen extends StatelessWidget {
                   style: MintTextStyles.bodySmall(
                     color: MintColors.textSecondary,
                   ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ],
             ),
@@ -457,6 +461,8 @@ class ProfileScreen extends StatelessWidget {
                       style: MintTextStyles.bodySmall(
                         color: MintColors.white,
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                     const SizedBox(height: 2),
                     Text(
@@ -466,6 +472,8 @@ class ProfileScreen extends StatelessWidget {
                       style: MintTextStyles.labelSmall(
                         color: MintColors.white70,
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ],
                 ),
@@ -517,10 +525,14 @@ class ProfileScreen extends StatelessWidget {
               const Icon(Icons.update_outlined,
                   size: 16, color: MintColors.warning),
               const SizedBox(width: MintSpacing.sm),
-              Text(
-                l.profileAnnualRefreshTitle,
-                style: MintTextStyles.bodySmall(
-                  color: MintColors.textPrimary,
+              Flexible(
+                child: Text(
+                  l.profileAnnualRefreshTitle,
+                  style: MintTextStyles.bodySmall(
+                    color: MintColors.textPrimary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],
@@ -590,14 +602,18 @@ class ProfileScreen extends StatelessWidget {
                       Text(title,
                           style: MintTextStyles.bodySmall(
                             color: MintColors.textPrimary,
-                          )),
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
                       const SizedBox(height: 2),
                       Text(status,
                           style: MintTextStyles.labelSmall(
                             color: isComplete
                                 ? MintColors.success
                                 : MintColors.textMuted,
-                          )),
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
                     ],
                   ),
                 ),
@@ -662,6 +678,8 @@ class ProfileScreen extends StatelessWidget {
                       style: MintTextStyles.titleMedium(
                         color: MintColors.textPrimary,
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                     if (authProvider.displayName != null)
                       Text(
@@ -669,6 +687,8 @@ class ProfileScreen extends StatelessWidget {
                         style: MintTextStyles.labelSmall(
                           color: MintColors.textMuted,
                         ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
                   ],
                 ),

--- a/apps/mobile/lib/screens/pulse/pulse_screen.dart
+++ b/apps/mobile/lib/screens/pulse/pulse_screen.dart
@@ -839,6 +839,8 @@ class _PulseScreenState extends State<PulseScreen> {
           greeting,
           style: MintTextStyles.titleMedium(color: MintColors.textPrimary)
               .copyWith(fontSize: 20),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ),
       centerTitle: false,
@@ -1277,10 +1279,15 @@ class _SignalRow extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                label,
-                style: MintTextStyles.bodyMedium(),
+              Flexible(
+                child: Text(
+                  label,
+                  style: MintTextStyles.bodyMedium(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
+              const SizedBox(width: MintSpacing.sm),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -1288,6 +1295,8 @@ class _SignalRow extends StatelessWidget {
                     value,
                     style: MintTextStyles.titleMedium(color: color)
                         .copyWith(fontWeight: FontWeight.w700),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   if (onTap != null) ...[
                     const SizedBox(width: MintSpacing.xs),
@@ -1462,14 +1471,21 @@ class _BudgetLine extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(
-          label,
-          style: MintTextStyles.labelSmall(color: MintColors.textMuted),
+        Flexible(
+          child: Text(
+            label,
+            style: MintTextStyles.labelSmall(color: MintColors.textMuted),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
+        const SizedBox(width: MintSpacing.sm),
         Text(
           value,
           style: MintTextStyles.labelSmall(color: color)
               .copyWith(fontWeight: FontWeight.w600),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ],
     );

--- a/apps/mobile/lib/services/slm/slm_auto_prompt_service.dart
+++ b/apps/mobile/lib/services/slm/slm_auto_prompt_service.dart
@@ -76,6 +76,10 @@ class SlmAutoPromptService {
   static Future<void> _showDownloadSheet(BuildContext context) async {
     await showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       isDismissible: true,
       enableDrag: true,
       shape: const RoundedRectangleBorder(

--- a/apps/mobile/lib/widgets/coach/response_card_widget.dart
+++ b/apps/mobile/lib/widgets/coach/response_card_widget.dart
@@ -393,6 +393,10 @@ class ResponseCardWidget extends StatelessWidget {
   void _showProofSheet(BuildContext context) {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),

--- a/apps/mobile/lib/widgets/common/safe_mode_gate.dart
+++ b/apps/mobile/lib/widgets/common/safe_mode_gate.dart
@@ -91,6 +91,10 @@ class SafeModeGate extends StatelessWidget {
                     onTap: () {
                       showModalBottomSheet<void>(
                       context: context,
+                      isScrollControlled: true,
+                      constraints: BoxConstraints(
+                        maxHeight: MediaQuery.of(context).size.height * 0.85,
+                      ),
                       backgroundColor: MintColors.white,
                       shape: const RoundedRectangleBorder(
                         borderRadius:

--- a/apps/mobile/lib/widgets/info_tooltip.dart
+++ b/apps/mobile/lib/widgets/info_tooltip.dart
@@ -39,6 +39,10 @@ class InfoTooltip extends StatelessWidget {
   void _showDefinition(BuildContext context, GlossaryTerm term) {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),

--- a/apps/mobile/lib/widgets/precision/field_help_tooltip.dart
+++ b/apps/mobile/lib/widgets/precision/field_help_tooltip.dart
@@ -66,6 +66,9 @@ class FieldHelpTooltip extends StatelessWidget {
       context: context,
       backgroundColor: MintColors.white,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),

--- a/apps/mobile/lib/widgets/precision/smart_default_indicator.dart
+++ b/apps/mobile/lib/widgets/precision/smart_default_indicator.dart
@@ -77,6 +77,10 @@ class SmartDefaultIndicator extends StatelessWidget {
 
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/apps/mobile/lib/widgets/premium/mint_amount_field.dart
+++ b/apps/mobile/lib/widgets/premium/mint_amount_field.dart
@@ -38,6 +38,9 @@ class MintAmountField extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/apps/mobile/lib/widgets/premium/mint_picker_tile.dart
+++ b/apps/mobile/lib/widgets/premium/mint_picker_tile.dart
@@ -30,6 +30,10 @@ class MintPickerTile extends StatelessWidget {
     int selected = value;
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.background,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),

--- a/apps/mobile/lib/widgets/pulse/action_success_sheet.dart
+++ b/apps/mobile/lib/widgets/pulse/action_success_sheet.dart
@@ -70,6 +70,10 @@ Future<void> showActionSuccessSheet(
 ) {
   return showModalBottomSheet(
     context: context,
+    isScrollControlled: true,
+    constraints: BoxConstraints(
+      maxHeight: MediaQuery.of(context).size.height * 0.85,
+    ),
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
     ),

--- a/apps/mobile/lib/widgets/simulators/buyback_widget.dart
+++ b/apps/mobile/lib/widgets/simulators/buyback_widget.dart
@@ -162,6 +162,10 @@ class _BuybackWidgetState extends State<BuybackWidget> {
     final l = S.of(context)!;
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
       backgroundColor: MintColors.white,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http: ^1.2.0
   provider: ^6.1.1
   go_router: ^13.2.0
-  intl: ^0.20.2
+  intl: any  # Pinned by flutter_localizations SDK — do not constrain further
   url_launcher: ^6.2.0
   google_fonts: ^6.1.0
   uuid: ^4.0.0

--- a/services/backend/alembic/versions/p12_add_birth_date.py
+++ b/services/backend/alembic/versions/p12_add_birth_date.py
@@ -1,0 +1,19 @@
+"""Add birth_date column to snapshots table.
+
+Revision ID: p12_add_birth_date
+Revises: p11_profile_userid_idx
+"""
+
+revision = "p12_add_birth_date"
+down_revision = "p11_profile_userid_idx"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column("snapshots", sa.Column("birth_date", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("snapshots", "birth_date")

--- a/services/backend/app/models/snapshot.py
+++ b/services/backend/app/models/snapshot.py
@@ -23,6 +23,7 @@ class SnapshotModel(Base):
 
     # Core inputs
     age = Column(Integer, default=0)
+    birth_date = Column(String, nullable=True)  # ISO 8601 date string
     gross_income = Column(Float, default=0.0)
     canton = Column(String, default="VD")
     archetype = Column(String, default="swiss_native")

--- a/services/backend/app/schemas/onboarding.py
+++ b/services/backend/app/schemas/onboarding.py
@@ -39,6 +39,11 @@ class MinimalProfileRequest(OnboardingBaseModel):
         ..., ge=18, le=70,
         description="Age de l'utilisateur (18-70)",
     )
+    birth_date: Optional[str] = Field(
+        default=None,
+        pattern=r"^\d{4}-\d{2}-\d{2}",
+        description="Date de naissance ISO 8601 (ex: 1981-06-15). Si fourni, age est calcule automatiquement.",
+    )
     gross_salary: float = Field(
         ..., ge=0,
         description="Salaire brut annuel en CHF",

--- a/services/backend/app/schemas/profile.py
+++ b/services/backend/app/schemas/profile.py
@@ -22,6 +22,7 @@ class Goal(str, Enum):
 
 class ProfileBase(BaseModel):
     birthYear: Optional[int] = None
+    dateOfBirth: Optional[str] = None  # ISO 8601 date string (e.g. "1981-06-15")
     canton: Optional[str] = None
     householdType: HouseholdType
     incomeNetMonthly: Optional[float] = None
@@ -62,6 +63,11 @@ class ProfileCreate(ProfileBase):
 
 class ProfileUpdate(BaseModel):
     birthYear: Optional[int] = Field(None, ge=1900, le=2025)  # FIX-069
+    dateOfBirth: Optional[str] = Field(
+        None,
+        pattern=r"^\d{4}-\d{2}-\d{2}",
+        description="Date de naissance ISO 8601 (ex: 1981-06-15)",
+    )
     canton: Optional[str] = None
     householdType: Optional[HouseholdType] = None
     incomeNetMonthly: Optional[float] = Field(None, ge=0)  # FIX-069

--- a/services/backend/app/services/onboarding/minimal_profile_service.py
+++ b/services/backend/app/services/onboarding/minimal_profile_service.py
@@ -438,6 +438,37 @@ def compute_minimal_profile(input: MinimalProfileInput) -> MinimalProfileResult:
     Raises:
         ValueError: If age, salary, or canton are invalid.
     """
+    # ── Resolve age from birth_date when provided ────────────────────────────
+    if input.birth_date:
+        from datetime import date
+        try:
+            bd = date.fromisoformat(input.birth_date[:10])
+            today = date.today()
+            computed_age = today.year - bd.year - (
+                (today.month, today.day) < (bd.month, bd.day)
+            )
+            input = MinimalProfileInput(
+                age=computed_age,
+                gross_salary=input.gross_salary,
+                canton=input.canton,
+                birth_date=input.birth_date,
+                household_type=input.household_type,
+                current_savings=input.current_savings,
+                is_property_owner=input.is_property_owner,
+                existing_3a=input.existing_3a,
+                existing_lpp=input.existing_lpp,
+                lpp_caisse_type=input.lpp_caisse_type,
+                total_debts=input.total_debts,
+                monthly_debt_service=input.monthly_debt_service,
+                stress_type=input.stress_type,
+                gender=input.gender,
+                nationality_group=input.nationality_group,
+                nationality_country=input.nationality_country,
+                arrival_age=input.arrival_age,
+            )
+        except (ValueError, TypeError):
+            pass  # Invalid birth_date format — fall back to provided age
+
     # ── Validation ──────────────────────────────────────────────────────────
     if input.age < 18 or input.age > 70:
         raise ValueError(f"Age must be between 18 and 70, got {input.age}")

--- a/services/backend/app/services/onboarding/onboarding_models.py
+++ b/services/backend/app/services/onboarding/onboarding_models.py
@@ -31,6 +31,7 @@ class MinimalProfileInput:
     age: int
     gross_salary: float
     canton: str
+    birth_date: Optional[str] = None        # ISO 8601 date (e.g. "1981-06-15")
     household_type: Optional[str] = None        # default: "single"
     current_savings: Optional[float] = None      # default: estimated from age/salary
     is_property_owner: Optional[bool] = None     # default: False


### PR DESCRIPTION
## Summary

### Chantier 1: birthDate migration
- `dateOfBirth: DateTime?` added to Profile, ConjointProfile, MinimalProfileModels
- Onboarding: birth year picker (CupertinoPicker) replaces age slider
- Backend: `birth_date` (ISO 8601) accepted on onboarding + profile schemas
- Alembic migration p12: `birth_date` column on snapshots
- Full backward compatibility — `age` still accepted and computed dynamically

### Chantier 2: Responsive refactor
- 40+ TextOverflow protections on 9 highest-traffic screens
- 24 bottom sheet maxHeight constraints (85% viewport)
- 4 SafeArea additions on screens missing it

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8128 passed, 2 skipped, 0 failures
- [x] pytest: 4652 passed, 49 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)