### PR TITLE
fix: Vague 5+6 audit — 39 findings closed

### DIFF
--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -8,7 +8,7 @@
   "landingSubtitleLong": "L'intelligence d'un CFO, dans ta poche.\nZéro bullshit. Pur conseil.",
   "landingFeature1Title": "Diagnostic Instantané",
   "landingFeature1Desc": "Analyse 360° en 5 min chrono.",
-  "landingFeature2Title": "100% Privé & Local",
+  "landingFeature2Title": "100\u00a0% Privé & Local",
   "landingFeature2Desc": "Tes données restent sur ton device.",
   "landingFeature3Title": "Stratégie Neutre",
   "landingFeature3Desc": "Zéro commission. Zéro conflit.",
@@ -77,7 +77,7 @@
   "advisorMiniStressDebt": "Réduire mes dettes",
   "advisorMiniStressTax": "Optimiser mes impôts",
   "advisorMiniStressRetirement": "Sécuriser ma retraite",
-  "advisorMiniResumeDiagnostic": "Reprendre mon diagnostic ({progress}%)",
+  "advisorMiniResumeDiagnostic": "Reprendre mon diagnostic ({progress}\u00a0%)",
   "@advisorMiniResumeDiagnostic": {
     "placeholders": {
       "progress": {
@@ -379,8 +379,8 @@
   "profileStatusComplete": "Complet",
   "profileStatusPartial": "Partial (Net)",
   "profileStatusMissing": "Manquant",
-  "profileReward15": "+15% de précision",
-  "profileReward10": "+10% de précision",
+  "profileReward15": "+15\u00a0% de précision",
+  "profileReward10": "+10\u00a0% de précision",
   "profileSecurityTitle": "Sécurité & Data",
   "profileConsentControl": "Contrôle des Partages",
   "profileConsentManage": "Gérer mes accès bLink",
@@ -403,10 +403,10 @@
   "rentVsCapitalBreakEven": "Break-even",
   "rentVsCapitalCapitalA85": "Capital à 85 ans",
   "rentVsCapitalJamais": "Jamais",
-  "rentVsCapitalPrudent": "Prudent (1%)",
-  "rentVsCapitalCentral": "Central (3%)",
-  "rentVsCapitalOptimiste": "Optimiste (5%)",
-  "rentVsCapitalTauxConversionExpl": "Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3% et 6%.",
+  "rentVsCapitalPrudent": "Prudent (1\u00a0%)",
+  "rentVsCapitalCentral": "Central (3\u00a0%)",
+  "rentVsCapitalOptimiste": "Optimiste (5\u00a0%)",
+  "rentVsCapitalTauxConversionExpl": "Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8\u00a0% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3\u00a0% et 6\u00a0%.",
   "rentVsCapitalChoixExpl": "La rente offre un revenu régulier à vie, mais s'arrête au décès (avec éventuellement une rente de survivant réduite). Le capital donne plus de flexibilité, mais comporte un risque d'épuisement si les rendements sont faibles ou la longévité élevée.",
   "rentVsCapitalDisclaimer": "Les résultats présentés sont des estimations à titre indicatif. Ils ne constituent pas un conseil financier personnalisé. Consultez votre caisse de pension et un·e spécialiste qualifié·e avant toute décision.",
   "disabilityGapTitle": "Mon filet de sécurité",
@@ -429,7 +429,7 @@
   "disabilityGapRiskMedium": "Risque modéré",
   "disabilityGapRiskLow": "Risque faible",
   "disabilityGapDisclaimer": "Outil éducatif — ne constitue pas un conseil en assurance au sens de la LSFin. Tes couvertures réelles dépendent de ton contrat de travail et de ta caisse de pension.",
-  "disabilityGapIjmExpl": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de votre salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu'à l'éventuelle rente AI.",
+  "disabilityGapIjmExpl": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80\u00a0% de votre salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu'à l'éventuelle rente AI.",
   "disabilityGapCo324aExpl": "Selon l'art. 324a CO, l'employeur doit verser le salaire pendant une durée limitée en cas de maladie. Cette durée dépend des années de service et de l'échelle cantonale applicable (bernoise, zurichoise ou bâloise). Après cette période, seule l'IJM (si existante) prend le relais.",
   "authLogin": "Se connecter",
   "authRegister": "Créer un compte",
@@ -525,7 +525,7 @@
   "documentsUploadBody": "MINT extrait automatiquement tes données de prévoyance professionnelle",
   "documentsUploadButton": "Choisir un fichier PDF",
   "documentsAnalyzing": "Analyse en cours...",
-  "documentsConfidence": "Confiance : {confidence}%",
+  "documentsConfidence": "Confiance : {confidence}\u00a0%",
   "@documentsConfidence": {
     "placeholders": {
       "confidence": {
@@ -687,7 +687,7 @@
   "jobCompareChecklistRachat": "Vérifier le délai de carence pour le rachat",
   "jobCompareChecklistRisque": "Calculer l'impact sur les prestations de risque",
   "jobCompareChecklistLibrePassage": "Vérifier le libre passage : transfert en 30 jours max",
-  "jobCompareEducational": "Le salaire invisible représente 10-30% de ta rémunération totale.",
+  "jobCompareEducational": "Le salaire invisible représente 10-30\u00a0% de ta rémunération totale.",
   "jobCompareVerdictBetter": "Le nouveau poste est globalement plus avantageux",
   "jobCompareVerdictWorse": "Le poste actuel offre une protection plus solide",
   "jobCompareVerdictComparable": "Les deux postes sont comparables",
@@ -938,7 +938,7 @@
     }
   },
   "coachingEmergencyAction": "Voir mon budget",
-  "coachingDebtTitle": "Taux d'endettement élevé ({ratio}%)",
+  "coachingDebtTitle": "Taux d'endettement élevé ({ratio}\u00a0%)",
   "@coachingDebtTitle": {
     "placeholders": {
       "ratio": {
@@ -946,7 +946,7 @@
       }
     }
   },
-  "coachingDebtMessage": "Ton taux d'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.",
+  "coachingDebtMessage": "Ton taux d'endettement estimé est de {ratio}\u00a0%, au-dessus du seuil de 33\u00a0% recommandé par les banques suisses.",
   "@coachingDebtMessage": {
     "placeholders": {
       "ratio": {
@@ -956,7 +956,7 @@
   },
   "coachingDebtAction": "Analyser mes dettes",
   "coachingPartTimeTitle": "Temps partiel : lacune de prévoyance",
-  "coachingPartTimeMessage": "À {rate}% d'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.",
+  "coachingPartTimeMessage": "À {rate}\u00a0% d'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.",
   "@coachingPartTimeMessage": {
     "placeholders": {
       "rate": {
@@ -1002,7 +1002,7 @@
   "segmentsGenderGapIntro": "La déduction de coordination (CHF 25'725) n'est pas proratisée pour le temps partiel, ce qui pénalise davantage les personnes travaillant à temps réduit. Déplacez le curseur pour voir l'impact.",
   "segmentsGenderGapTauxLabel": "Taux d'activité",
   "segmentsGenderGapParams": "Paramètres",
-  "segmentsGenderGapRevenuLabel": "Revenu annuel brut (100%)",
+  "segmentsGenderGapRevenuLabel": "Revenu annuel brut (100\u00a0%)",
   "segmentsGenderGapAgeLabel": "Âge",
   "segmentsGenderGapAvoirLabel": "Avoir LPP actuel",
   "segmentsGenderGapAnneesCotisLabel": "Années de cotisation",
@@ -1016,8 +1016,8 @@
       }
     }
   },
-  "segmentsGenderGapAt100": "À 100%",
-  "segmentsGenderGapAtCurrent": "À {rate}%",
+  "segmentsGenderGapAt100": "À 100\u00a0%",
+  "segmentsGenderGapAtCurrent": "À {rate}\u00a0%",
   "@segmentsGenderGapAtCurrent": {
     "placeholders": {
       "rate": {
@@ -1028,10 +1028,10 @@
   "segmentsGenderGapLacuneAnnuelle": "Lacune annuelle",
   "segmentsGenderGapLacuneTotale": "Lacune totale (~20 ans)",
   "segmentsGenderGapCoordinationTitle": "Comprendre la déduction de coordination",
-  "segmentsGenderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 25'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100% ou à 50%.",
-  "segmentsGenderGapSalaireBrut100": "Salaire brut à 100%",
-  "segmentsGenderGapSalaireCoord100": "Salaire coordonné à 100%",
-  "segmentsGenderGapSalaireBrutCurrent": "Salaire brut à {rate}%",
+  "segmentsGenderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 25'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100\u00a0% ou à 50\u00a0%.",
+  "segmentsGenderGapSalaireBrut100": "Salaire brut à 100\u00a0%",
+  "segmentsGenderGapSalaireCoord100": "Salaire coordonné à 100\u00a0%",
+  "segmentsGenderGapSalaireBrutCurrent": "Salaire brut à {rate}\u00a0%",
   "@segmentsGenderGapSalaireBrutCurrent": {
     "placeholders": {
       "rate": {
@@ -1039,7 +1039,7 @@
       }
     }
   },
-  "segmentsGenderGapSalaireCoordCurrent": "Salaire coordonné à {rate}%",
+  "segmentsGenderGapSalaireCoordCurrent": "Salaire coordonné à {rate}\u00a0%",
   "@segmentsGenderGapSalaireCoordCurrent": {
     "placeholders": {
       "rate": {
@@ -1049,7 +1049,7 @@
   },
   "segmentsGenderGapDeductionFixe": "Déduction coordination (fixe)",
   "segmentsGenderGapOfsTitle": "Statistique OFS",
-  "segmentsGenderGapOfsStat": "En Suisse, les femmes touchent en moyenne 37% de rente de moins que les hommes (OFS 2024)",
+  "segmentsGenderGapOfsStat": "En Suisse, les femmes touchent en moyenne 37\u00a0% de rente de moins que les hommes (OFS 2024)",
   "segmentsGenderGapRecTitle": "RECOMMANDATIONS",
   "segmentsGenderGapRecRachat": "Rachat LPP volontaire",
   "segmentsGenderGapRecRachatDesc": "Un rachat volontaire permet de combler partiellement la lacune de prévoyance tout en bénéficiant d'une déduction fiscale.",
@@ -1075,8 +1075,8 @@
   "segmentsFrontalierCatLpp": "LPP / Libre passage",
   "segmentsFrontalierCatAvs": "AVS / Coordination",
   "segmentsFrontalierQuasiResidentTitle": "Statut quasi-résident (GE)",
-  "segmentsFrontalierQuasiResidentDesc": "Le statut de quasi-résident est accessible si au moins 90% des revenus de votre ménage proviennent de Suisse.",
-  "segmentsFrontalierQuasiResidentCondition": "Condition : >= 90% des revenus du ménage provenant de Suisse",
+  "segmentsFrontalierQuasiResidentDesc": "Le statut de quasi-résident est accessible si au moins 90\u00a0% des revenus de votre ménage proviennent de Suisse.",
+  "segmentsFrontalierQuasiResidentCondition": "Condition : >= 90\u00a0% des revenus du ménage provenant de Suisse",
   "segmentsFrontalierChecklist": "Checklist frontalier",
   "segmentsFrontalierPaysFR": "France",
   "segmentsFrontalierPaysDE": "Allemagne",
@@ -1120,7 +1120,7 @@
   },
   "segmentsIndependant3aTitle": "3e pilier — plafond indépendant",
   "segmentsIndependant3aWithLpp": "Avec LPP volontaire : plafond 3a standard de CHF 7'258/an.",
-  "segmentsIndependant3aWithoutLpp": "Sans LPP : plafond 3a 'grand' de 20% du revenu net, max CHF 36'288/an.",
+  "segmentsIndependant3aWithoutLpp": "Sans LPP : plafond 3a 'grand' de 20\u00a0% du revenu net, max CHF 36'288/an.",
   "segmentsIndependantRecTitle": "RECOMMANDATIONS",
   "segmentsIndependantDisclaimer": "Les montants présentés sont des estimations indicatives. Consultez un fiduciaire ou un assureur avant toute décision.",
   "segmentsIndependantSources": "Sources",
@@ -1142,7 +1142,7 @@
   "assurancesLamalOptimale": "Franchise recommandée",
   "assurancesLamalBreakEven": "Seuil de rentabilité",
   "assurancesLamalDelaiRappel": "Rappel : modification possible avant le 30 novembre",
-  "assurancesLamalQuotePart": "Quote-part (10%, max 700 CHF)",
+  "assurancesLamalQuotePart": "Quote-part (10\u00a0%, max 700 CHF)",
   "assurancesCoverageTitle": "Check-up couverture",
   "assurancesCoverageSubtitle": "Évaluez votre protection assurantielle",
   "assurancesCoverageScore": "Score de couverture",
@@ -1401,7 +1401,7 @@
   "coachDidYouKnow": "Le savais-tu ?",
   "coachFact3a": "Le 3e pilier peut te faire économiser jusqu'à CHF 2'500 d'impôts par an, selon ton canton et ton revenu.",
   "coachFact3aLink": "Simuler mon économie 3a",
-  "coachFactAvs": "En Suisse, chaque année AVS manquante = −2.3% de rente à vie. Un rattrapage est possible dans certains cas.",
+  "coachFactAvs": "En Suisse, chaque année AVS manquante = −2.3\u00a0% de rente à vie. Un rattrapage est possible dans certains cas.",
   "coachFactAvsLink": "Vérifier mes années AVS",
   "coachFactLpp": "Le rachat LPP est l'un des leviers fiscaux les plus puissants pour les salarié·es en Suisse. Il est intégralement déductible du revenu imposable.",
   "coachFactLppLink": "Explorer le rachat LPP",
@@ -1696,7 +1696,7 @@
   "vaultPremiumBody": "Passe à MINT Premium pour stocker un nombre illimité de documents et débloquer l'audit de couverture automatique",
   "vaultPremiumCta": "Découvrir Premium",
   "vaultDocListTitle": "Mes documents",
-  "vaultConfidence": "Confiance : {confidence}%",
+  "vaultConfidence": "Confiance : {confidence}\u00a0%",
   "@vaultConfidence": {
     "placeholders": {
       "confidence": {
@@ -1794,7 +1794,7 @@
   "soaRemainder": "Reste à vivre",
   "soaEstimatedTaxLabel": "Impôts Estimés",
   "soaSavingsRate": "Taux d'épargne",
-  "soaSavingsGoal": "Objectif: 20%",
+  "soaSavingsGoal": "Objectif: 20\u00a0%",
   "soaProtectionScore": "Score Protection",
   "soaActiveDebts": "Dettes actives",
   "soaSerene": "Serein",
@@ -1833,7 +1833,7 @@
     }
   },
   "agirScenarioBriefTitle": "Scénarios de retraite en bref",
-  "agirScenarioBriefSummary": "Dans ~{years} ans, ton scénario Base vise {baseCapital} (~{replacement}% de remplacement). L'écart Prudent vs Optimiste est {gapCapital}.",
+  "agirScenarioBriefSummary": "Dans ~{years} ans, ton scénario Base vise {baseCapital} (~{replacement}\u00a0% de remplacement). L'écart Prudent vs Optimiste est {gapCapital}.",
   "@agirScenarioBriefSummary": {
     "placeholders": {
       "years": {
@@ -1884,7 +1884,7 @@
   "checkinScoreReasonNegativeGeneral": "Baisse temporaire ce mois. On ajuste le plan au prochain check-in.",
   "checkinImpactPending": "Impact en cours de calcul",
   "coachDataQualityTitle": "Qualite des donnees",
-  "coachDataQualityBody": "Calcul actuel: {dataPoints} donnees saisies ({percentage}%). Les postes non renseignes restent en estimation jusqu au diagnostic complet.",
+  "coachDataQualityBody": "Calcul actuel: {dataPoints} donnees saisies ({percentage}\u00a0%). Les postes non renseignes restent en estimation jusqu au diagnostic complet.",
   "@coachDataQualityBody": {
     "placeholders": {
       "dataPoints": {
@@ -1905,7 +1905,7 @@
   "profileStateFull": "Profil complet",
   "profileStatePartial": "Profil partiel",
   "profileStateMissing": "Profil non renseigne",
-  "profileCoachKnowledgeSummary": "{profileState} • Precision {precision}% • Check-ins: {checkins}{scorePart}",
+  "profileCoachKnowledgeSummary": "{profileState} • Precision {precision}\u00a0% • Check-ins: {checkins}{scorePart}",
   "@profileCoachKnowledgeSummary": {
     "placeholders": {
       "profileState": {
@@ -2014,7 +2014,7 @@
       }
     }
   },
-  "coachEnrichTargetTitle": "Passe de {current}% a {target}% de precision",
+  "coachEnrichTargetTitle": "Passe de {current}\u00a0% a {target}\u00a0% de precision",
   "@coachEnrichTargetTitle": {
     "placeholders": {
       "current": {
@@ -2035,7 +2035,7 @@
   "coachEnrichActionPension": "Compléter Prévoyance",
   "coachEnrichActionProperty": "Completer Immobilier & dettes",
   "coachEnrichActionDefault": "Completer mon diagnostic",
-  "coachAgirPartialTitle": "Plan en construction ({quality}%)",
+  "coachAgirPartialTitle": "Plan en construction ({quality}\u00a0%)",
   "@coachAgirPartialTitle": {
     "placeholders": {
       "quality": {
@@ -2095,7 +2095,7 @@
   "landingToday": "Aujourd'hui",
   "landingChfPerMonth": "CHF/mois",
   "landingAtRetirement": "À la retraite*",
-  "landingDropPurchasingPower": "-{percent}% de pouvoir d'achat",
+  "landingDropPurchasingPower": "-{percent}\u00a0% de pouvoir d'achat",
   "@landingDropPurchasingPower": {
     "placeholders": {
       "percent": {
@@ -2126,10 +2126,10 @@
   "landingFeaturePillarsSubtitle": "AVS, LPP et 3a calculés selon ta situation réelle — pas des moyennes suisses.",
   "landingFeatureCoachTitle": "Coach adapté à ton stade de vie",
   "landingFeatureCoachSubtitle": "25 ans ou 60 ans, frontalier ou indépendant — les conseils changent selon qui tu es.",
-  "landingFeaturePrivacyTitle": "100% privé, données sur ton appareil",
+  "landingFeaturePrivacyTitle": "100\u00a0% privé, données sur ton appareil",
   "landingFeaturePrivacySubtitle": "Aucun partage, aucune pub. Ton profil reste local sauf si tu crées un compte.",
   "landingTrustSwiss": "Conçu en Suisse",
-  "landingTrustPrivate": "100% privé",
+  "landingTrustPrivate": "100\u00a0% privé",
   "landingTrustNoCommitment": "Sans engagement",
   "landingCtaTitle": "Ton plan en 30 secondes",
   "landingCtaSubtitle": "3 questions • Gratuit • Sans engagement",
@@ -2203,7 +2203,7 @@
   "dashboardMetricYears": "ans",
   "dashboardMetricLifeExpectancy": "Espérance de vie estimée : 85 ans",
   "dashboardMetricMonthlyGap": "Écart mensuel",
-  "dashboardMetricVsTarget": "Vs cible 70% du salaire brut",
+  "dashboardMetricVsTarget": "Vs cible 70\u00a0% du salaire brut",
   "dashboardNextActionLabel": "Améliorer ta précision",
   "dashboardNextActionDetail": "Scanne ton certificat LPP pour affiner tes projections.",
   "dashboardWeatherSunny": "Marchés favorables, épargne maximisée.",
@@ -2734,10 +2734,10 @@
   "mariageProtectionIntro": "Que se passe-t-il si l'un de vous deux décède ? Compare la protection légale entre mariés et concubins.",
   "mariageLppRenteLabel": "Rente LPP mensuelle du défunt",
   "mariageAvsSurvivor": "Rente AVS de survivant",
-  "mariageAvsSurvivorSub": "80% de la rente maximale du défunt",
+  "mariageAvsSurvivorSub": "80\u00a0% de la rente maximale du défunt",
   "mariageAvsSurvivorFootnote": "LAVS art. 35 — uniquement pour les mariés",
   "mariageLppSurvivor": "Rente LPP de survivant",
-  "mariageLppSurvivorSub": "60% de la rente assurée du défunt",
+  "mariageLppSurvivorSub": "60\u00a0% de la rente assurée du défunt",
   "mariageLppSurvivorFootnote": "LPP art. 19 — mariés (concubins : clause nécessaire)",
   "mariageSurvivorMonthly": "Revenu mensuel du survivant marié",
   "mariageVsConcubin": "MARIÉ VS CONCUBIN",
@@ -2815,13 +2815,13 @@
   },
   "unemploymentContribMax": "24 mois",
   "unemploymentSituationTitle": "Situation personnelle",
-  "unemploymentSituationSubtitle": "Influence le taux d'indemnisation (70% ou 80%)",
+  "unemploymentSituationSubtitle": "Influence le taux d'indemnisation (70\u00a0% ou 80\u00a0%)",
   "unemploymentChildrenToggle": "Obligation d'entretien (enfants)",
   "unemploymentDisabilityToggle": "Handicap reconnu",
   "unemploymentNotEligible": "Non éligible",
   "unemploymentCompensationRate": "Taux d'indemnisation",
-  "unemploymentRateEnhanced": "Taux majoré (80%) : obligation d'entretien, handicap, ou salaire < CHF 3'797",
-  "unemploymentRateStandard": "Taux standard (70%) : applicable dans les autres situations",
+  "unemploymentRateEnhanced": "Taux majoré (80\u00a0%) : obligation d'entretien, handicap, ou salaire < CHF 3'797",
+  "unemploymentRateStandard": "Taux standard (70\u00a0%) : applicable dans les autres situations",
   "unemploymentDailyBenefit": "Indemnité /jour",
   "unemploymentMonthlyBenefit": "Indemnité /mois",
   "unemploymentInsuredEarnings": "Gain assuré retenu",
@@ -2871,7 +2871,7 @@
   "firstJobEdu13Title": "13e salaire",
   "firstJobEdu13Body": "Si ton contrat prévoit un 13e salaire, celui-ci est aussi soumis aux déductions sociales. Ton salaire mensuel brut est alors le salaire annuel divisé par 13.",
   "firstJobEduBudgetTitle": "Règle du 50/30/20",
-  "firstJobEduBudgetBody": "Un bon réflexe pour ton premier salaire : 50% pour les dépenses fixes, 30% pour les loisirs, 20% pour l'épargne et la prévoyance (3a inclus).",
+  "firstJobEduBudgetBody": "Un bon réflexe pour ton premier salaire : 50\u00a0% pour les dépenses fixes, 30\u00a0% pour les loisirs, 20\u00a0% pour l'épargne et la prévoyance (3a inclus).",
   "firstJobEduTaxTitle": "Déclaration fiscale",
   "firstJobEduTaxBody": "Dès ton premier emploi, tu devras remplir une déclaration fiscale. Garde toutes tes attestations (salaire, 3a, frais professionnels).",
   "firstJobAnalysisHeader": "Analyse MINT — Le film de ton salaire",
@@ -2905,7 +2905,7 @@
   "independantRecommendationsHeader": "RECOMMANDATIONS",
   "independantAnalysisHeader": "Analyse MINT — Ton kit indépendant",
   "independantSourcesTitle": "Sources",
-  "independantSourcesBody": "LPP art. 4 (pas d'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20% du revenu net, max 36'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal",
+  "independantSourcesBody": "LPP art. 4 (pas d'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20\u00a0% du revenu net, max 36'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal",
   "independantDisclaimer": "Les montants présentés sont des estimations indicatives. Les cotisations réelles dépendent de ta situation personnelle et des offres d'assurance disponibles. Consulte un fiduciaire ou un assureur avant toute décision.",
   "jobCompareAgeTitle": "Ton âge",
   "jobCompareAgeSubtitle": "Utilisé pour projeter le capital retraite",
@@ -2923,7 +2923,7 @@
   "jobCompareChecklistTitle": "Avant de signer",
   "jobCompareUnderstandHeader": "COMPRENDRE",
   "jobCompareEduInvisibleTitle": "Qu'est-ce que le salaire invisible ?",
-  "jobCompareEduInvisibleBody": "Le \"salaire invisible\" représente 10-30% de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.",
+  "jobCompareEduInvisibleBody": "Le \"salaire invisible\" représente 10-30\u00a0% de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.",
   "jobCompareEduCertTitle": "Comment lire mon certificat de prévoyance ?",
   "jobCompareEduCertBody": "Ton certificat de prévoyance (LPP) contient toutes les informations nécessaires : salaire assuré, déduction de coordination, taux de cotisation, avoir de vieillesse, taux de conversion, prestations de risque (invalidité et décès), et rachat possible. Demande-le à ton RH ou à ta caisse de pension.",
   "jobCompareAxisLabel": "Axe",
@@ -2953,7 +2953,7 @@
   "disabilityGapIfYouAre": "SI TU ES...",
   "disabilityGapEduTitle": "COMPRENDRE",
   "disabilityGapEduIjmTitle": "IJM vs AI : quelle différence ?",
-  "disabilityGapEduIjmBody": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de ton salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu'à l'éventuelle rente AI.",
+  "disabilityGapEduIjmBody": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80\u00a0% de ton salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu'à l'éventuelle rente AI.",
   "disabilityGapEduCoTitle": "L'obligation de ton employeur (CO art. 324a)",
   "disabilityGapEduCoBody": "Selon l'art. 324a CO, l'employeur doit verser le salaire pendant une durée limitée en cas de maladie. Cette durée dépend des années de service et de l'échelle cantonale applicable (bernoise, zurichoise ou bâloise). Après cette période, seule l'IJM (si existante) prend le relais.",
   "successionIntroDesc": "Le nouveau droit successoral (2023) a élargi la quotité disponible. Tu as désormais plus de liberté pour avantager certains héritiers. Cet outil te montre la répartition légale et l'impact d'un testament.",
@@ -2993,7 +2993,7 @@
   "mariageChecklistItem5Title": "Préparer la première déclaration commune",
   "mariageChecklistItem5Desc": "Dès l'année du mariage, tu fais une seule déclaration fiscale commune. Rassemble les justificatifs des deux (certificats de salaire, 3a, LPP, etc.). Le passage à la déclaration commune peut changer ta tranche d'imposition.",
   "mariageChecklistItem6Title": "Vérifier les rentes AVS de couple",
-  "mariageChecklistItem6Desc": "La rente AVS maximale pour un couple est plafonnée à 150% de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.",
+  "mariageChecklistItem6Desc": "La rente AVS maximale pour un couple est plafonnée à 150\u00a0% de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.",
   "mariageChecklistItem7Title": "Adapter le testament",
   "mariageChecklistItem7Desc": "Le mariage modifie l'ordre de succession. Le conjoint devient héritier légal avec des droits importants (CC art. 462). Si tu avais un testament en faveur d'un tiers, il est peut-être à revoir.",
   "mariageChecklistProgress": "{done}/{total} démarches effectuées",
@@ -3018,7 +3018,7 @@
   "successionFortuneSubtitle2": "Patrimoine total, 3a, LPP",
   "successionTestamentTitle": "Testament",
   "successionTestamentSubtitle2": "Volontés testamentaires",
-  "successionQuotitePct": "soit {pct}% de la succession",
+  "successionQuotitePct": "soit {pct}\u00a0% de la succession",
   "@successionQuotitePct": {
     "placeholders": {
       "pct": {
@@ -3037,7 +3037,7 @@
   },
   "successionEduQuotiteBody2": "La quotité disponible est la part de ta succession que tu peux librement attribuer par testament. Depuis le 1er janvier 2023, la réserve des descendants a été réduite de 3/4 à 1/2 de leur part légale. Les parents n'ont plus de réserve. Cela te donne plus de liberté pour favoriser ton/ta conjoint·e, ton/ta concubin·e ou toute autre personne.",
   "successionEdu3aBody2": "Le 3e pilier (pilier 3a) n'entre PAS dans la masse successorale ordinaire. Il est versé directement aux bénéficiaires selon un ordre fixé par l'OPP3 (art. 2) : conjoint/partenaire enregistré, puis descendants, parents, fratrie. Le concubin peut être désigné comme bénéficiaire, mais uniquement par une clause explicite déposée auprès de la fondation. Sans cette démarche, le/la concubin(e) ne reçoit rien du 3a.",
-  "successionEduConcubinBody2": "En droit suisse, les concubins n'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25% au lieu de 0%). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d'envisager des assurances-vie.",
+  "successionEduConcubinBody2": "En droit suisse, les concubins n'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25\u00a0% au lieu de 0\u00a0%). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d'envisager des assurances-vie.",
   "successionDisclaimerText": "Les résultats présentés sont des estimations à titre indicatif et ne constituent pas un conseil juridique ou notarial personnalisé. Le droit successoral comporte de nombreuses subtilités. Consultez un notaire ou un avocat spécialisé avant toute décision.",
   "donationIntroText": "Les donations en Suisse sont soumises à un impôt cantonal qui varie selon le lien de parenté et le canton. Depuis 2023, la réserve héréditaire a été réduite, te donnant plus de liberté. Cet outil t'aide à estimer l'impôt et à vérifier la compatibilité avec les droits des héritiers.",
   "donationSectionTitle": "DONATION",
@@ -3056,7 +3056,7 @@
   "donationCalculer": "Calculer",
   "donationImpotTitle": "IMPÔT SUR LA DONATION",
   "donationExoneree": "Exonérée",
-  "donationTauxCanton": "Taux : {taux}% (canton {canton})",
+  "donationTauxCanton": "Taux : {taux}\u00a0% (canton {canton})",
   "@donationTauxCanton": {
     "placeholders": {
       "taux": {
@@ -3071,7 +3071,7 @@
   "donationLienRow": "Lien de parenté",
   "donationReserveTitle": "RÉSERVE HÉRÉDITAIRE (2023)",
   "donationReserveProtege": "montant protégé par la loi (intouchable)",
-  "donationReserveNote": "Depuis 2023, les parents n'ont plus de réserve. La réserve des descendants est de 50% de leur part légale (CC art. 471).",
+  "donationReserveNote": "Depuis 2023, les parents n'ont plus de réserve. La réserve des descendants est de 50\u00a0% de leur part légale (CC art. 471).",
   "donationQuotiteTitle": "QUOTITÉ DISPONIBLE",
   "donationQuotiteDesc": "montant que tu peux librement donner",
   "donationDepassement": "Dépassement de {amount} — risque d'action en réduction",
@@ -3090,7 +3090,7 @@
   "donationEduAvancementTitle": "Avancement d'hoirie vs donation hors part",
   "donationEduAvancementBody": "Une donation en avancement d'hoirie est une avance sur la part successorale du bénéficiaire. Elle sera rapportée à la masse successorale lors du décès. Une donation hors part (ou préciput) est imputée uniquement sur la quotité disponible et n'est pas rapportée. Le choix entre les deux a un impact majeur sur l'équilibre entre les héritiers.",
   "donationEduConcubinTitle": "Donations et concubins",
-  "donationEduConcubinBody": "Les concubins n'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l'impôt cantonal sur les donations entre concubins est généralement élevé (18-25% selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.",
+  "donationEduConcubinBody": "Les concubins n'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l'impôt cantonal sur les donations entre concubins est généralement élevé (18-25\u00a0% selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.",
   "donationDisclaimer": "Cet outil éducatif fournit des estimations indicatives et ne constitue pas un conseil juridique, fiscal ou notarial personnalisé au sens de la LSFin. Consulte un·e spécialiste (notaire) pour ta situation.",
   "donationCanton": "Canton",
   "housingSaleIntroText": "Vendre un bien immobilier en Suisse implique un impôt sur les gains immobiliers (LHID art. 12), le remboursement éventuel des fonds de prévoyance utilisés (EPL) et des frais de transaction. Cet outil t'aide à estimer le produit net de ta vente.",
@@ -3210,7 +3210,7 @@
       }
     }
   },
-  "independantAvsBody": "Ta cotisation AVS estimée : {amount}/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6% au-dessus).",
+  "independantAvsBody": "Ta cotisation AVS estimée : {amount}/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6\u00a0% au-dessus).",
   "@independantAvsBody": {
     "placeholders": {
       "amount": {
@@ -3220,7 +3220,7 @@
   },
   "independantAvsSource": "Source : LAVS art. 8 / Tables des cotisations AVS",
   "independant3aWithLpp": "Avec LPP volontaire : plafond 3a standard de CHF 7’258/an.",
-  "independant3aWithoutLpp": "Sans LPP : plafond 3a \"grand\" de 20% du revenu net, max {amount}/an (plafond légal CHF 36’288).",
+  "independant3aWithoutLpp": "Sans LPP : plafond 3a \"grand\" de 20\u00a0% du revenu net, max {amount}/an (plafond légal CHF 36’288).",
   "@independant3aWithoutLpp": {
     "placeholders": {
       "amount": {
@@ -3251,11 +3251,11 @@
       }
     }
   },
-  "disabilityGapPhase1Full": "100% du salaire",
+  "disabilityGapPhase1Full": "100\u00a0% du salaire",
   "disabilityGapNoCoverage": "Aucune couverture",
   "disabilityGapNone": "Aucune",
   "disabilityGapPhase2Duration": "Jusqu'à 24 mois",
-  "disabilityGapPhase2Coverage": "80% du salaire ({amount} CHF/mois)",
+  "disabilityGapPhase2Coverage": "80\u00a0% du salaire ({amount} CHF/mois)",
   "@disabilityGapPhase2Coverage": {
     "placeholders": {
       "amount": {
@@ -3364,11 +3364,11 @@
   "affordabilityPillar3a": "Avoir 3a",
   "affordabilityPillarLpp": "Avoir LPP",
   "affordabilityCalculationDetail": "Détail du calcul",
-  "affordabilityEquityRequired": "Fonds propres requis (20%)",
+  "affordabilityEquityRequired": "Fonds propres requis (20\u00a0%)",
   "affordabilitySavingsLabel": "Épargne",
-  "affordabilityLppMax10": "Avoir LPP (max 10% du prix)",
+  "affordabilityLppMax10": "Avoir LPP (max 10\u00a0% du prix)",
   "affordabilityTotalEquity": "Total fonds propres",
-  "affordabilityMortgagePercent": "Hypothèque ({percent}%)",
+  "affordabilityMortgagePercent": "Hypothèque ({percent}\u00a0%)",
   "@affordabilityMortgagePercent": {
     "placeholders": {
       "percent": {
@@ -3377,7 +3377,7 @@
     }
   },
   "affordabilityMonthlyCharges": "Charges mensuelles théoriques",
-  "affordabilityCalculationNote": "Calcul théorique : hypothèque x (5% intérêt imputé + 1% amortissement) + prix x 1% frais accessoires. Max 33% du revenu brut.",
+  "affordabilityCalculationNote": "Calcul théorique : hypothèque x (5\u00a0% intérêt imputé + 1\u00a0% amortissement) + prix x 1\u00a0% frais accessoires. Max 33\u00a0% du revenu brut.",
   "amortizationSource": "Source : OPP3 (pilier 3a), pratique hypothécaire suisse. Plafond 3a salarié 2026 : CHF 7'258.",
   "amortizationIntroTitle": "Amortissement : direct ou indirect ?",
   "amortizationIntroBody": "En Suisse, l'amortissement indirect est une spécificité unique : au lieu de rembourser directement la dette, tu verses dans un pilier 3a nanti. Tu bénéficies d'une double déduction fiscale (intérêts + versement 3a) et ton capital reste investi.",
@@ -3421,7 +3421,7 @@
   "fiscalChurchMember": "Membre d'une Église",
   "fiscalChurchTax": "Impôt ecclésiastique",
   "fiscalEffectiveRate": "Taux effectif estimé",
-  "fiscalBelowAverage": "Inférieur à la moyenne suisse (~{rate}%)",
+  "fiscalBelowAverage": "Inférieur à la moyenne suisse (~{rate}\u00a0%)",
   "@fiscalBelowAverage": {
     "placeholders": {
       "rate": {
@@ -3429,7 +3429,7 @@
       }
     }
   },
-  "fiscalAboveAverage": "Supérieur à la moyenne suisse (~{rate}%)",
+  "fiscalAboveAverage": "Supérieur à la moyenne suisse (~{rate}\u00a0%)",
   "@fiscalAboveAverage": {
     "placeholders": {
       "rate": {
@@ -3530,7 +3530,7 @@
   "expatNoExitTax": "Pas de taxe de sortie en Suisse",
   "expatRecommendedTimeline": "CHRONOLOGIE RECOMMANDÉE",
   "expatDepartureChecklist": "CHECKLIST DE DÉPART",
-  "expatAvsEducation": "Pour toucher une rente AVS complète (max CHF 2'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d'environ 2.3%. Si tu vis à l'étranger, tu peux cotiser volontairement à l'AVS pour éviter les lacunes.",
+  "expatAvsEducation": "Pour toucher une rente AVS complète (max CHF 2'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d'environ 2.3\u00a0%. Si tu vis à l'étranger, tu peux cotiser volontairement à l'AVS pour éviter les lacunes.",
   "expatYearsInSwitzerland": "Années en Suisse",
   "expatYearsAbroad": "Années à l'étranger",
   "expatAvsCompleteness": "COMPLÉTUDE AVS",
@@ -3560,7 +3560,7 @@
   "mariageTimelineAct2Insight": "Rachat LPP, 3a maximal, préparation retraite. Votre capital double.",
   "mariageTimelineAct3Title": "Retraite couple",
   "mariageTimelineAct3Period": "25+ ans",
-  "mariageTimelineAct3Insight": "Attention : plafond AVS couple (150% rente max). Planifier rente vs capital.",
+  "mariageTimelineAct3Insight": "Attention : plafond AVS couple (150\u00a0% rente max). Planifier rente vs capital.",
   "naissanceChecklistItem1Title": "Inscrire bébé à l'assurance maladie (3 mois)",
   "naissanceChecklistItem1Desc": "Tu as 3 mois après la naissance pour inscrire ton enfant auprès d'une caisse maladie. Si tu le fais dans ce délai, la couverture est rétroactive dès la naissance. Passé ce délai, l'enfant risque une interruption de couverture. Compare les primes enfants entre caisses — les écarts peuvent être significatifs.",
   "naissanceChecklistItem2Title": "Demander les allocations familiales",
@@ -3568,7 +3568,7 @@
   "naissanceChecklistItem3Title": "Annoncer la naissance à l'état civil",
   "naissanceChecklistItem3Desc": "L'hôpital transmet généralement l'annonce à l'office de l'état civil. Vérifie que l'acte de naissance est bien établi. Tu en auras besoin pour toutes les démarches administratives.",
   "naissanceChecklistItem4Title": "Organiser le congé parental (APG)",
-  "naissanceChecklistItem4Desc": "Congé maternité : 14 semaines à 80% du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.",
+  "naissanceChecklistItem4Desc": "Congé maternité : 14 semaines à 80\u00a0% du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.",
   "naissanceChecklistItem5Title": "Mettre à jour la déclaration fiscale",
   "naissanceChecklistItem5Desc": "Un enfant supplémentaire te donne droit à une déduction fiscale de CHF 6'700/an (LIFD art. 35). Si tu as des frais de garde, tu peux déduire jusqu'à CHF 25'500/an. Pense à adapter tes acomptes d'impôts pour l'année en cours.",
   "naissanceChecklistItem6Title": "Adapter le budget familial",
@@ -3675,7 +3675,7 @@
       }
     }
   },
-  "narrativeConfidenceLabel": "Confiance profil : {score}%",
+  "narrativeConfidenceLabel": "Confiance profil : {score}\u00a0%",
   "@narrativeConfidenceLabel": {
     "placeholders": {
       "score": {
@@ -3714,7 +3714,7 @@
   "patrimoineLtvSaine": "LTV saine",
   "patrimoineLtvAmortissement": "Amortissement recommandé",
   "patrimoineLtvElevee": "LTV élevée — amortir",
-  "patrimoineLtvDisplay": "LTV {percent}%",
+  "patrimoineLtvDisplay": "LTV {percent}\u00a0%",
   "@patrimoineLtvDisplay": {
     "placeholders": {
       "percent": {
@@ -3790,7 +3790,7 @@
   "futurRevenuMensuelProjection": "Revenu mensuel projeté à la retraite",
   "futurRenteAvs": "Rente AVS",
   "futurRenteLpp": "Rente LPP estimée",
-  "futurPilier3aSwr": "Pilier 3a (SWR 4%)",
+  "futurPilier3aSwr": "Pilier 3a (SWR 4\u00a0%)",
   "futurCapitalLabel": "Capital {amount}",
   "@futurCapitalLabel": {
     "placeholders": {
@@ -3799,14 +3799,14 @@
       }
     }
   },
-  "futurLibrePassageSwr": "Libre passage (SWR 4%)",
-  "futurInvestissementsSwr": "Investissements (SWR 4%)",
+  "futurLibrePassageSwr": "Libre passage (SWR 4\u00a0%)",
+  "futurInvestissementsSwr": "Investissements (SWR 4\u00a0%)",
   "futurTotalCoupleProjecte": "Total couple projeté",
   "futurTotalMensuelProjecte": "Total mensuel projeté",
   "futurCapitalRetraite": "Capital à la retraite",
   "futurCapitalTotal": "Capital total (LPP + 3a + LP + investissements)",
   "futurCapitalTaxHint": "Le retrait en capital est taxé séparément (LIFD art. 38). Le SWR n'est pas un revenu imposable.",
-  "futurMargeIncertitude": "Marge d'incertitude (± {pct}%)",
+  "futurMargeIncertitude": "Marge d'incertitude (± {pct}\u00a0%)",
   "@futurMargeIncertitude": {
     "placeholders": {
       "pct": {
@@ -3826,7 +3826,7 @@
     }
   },
   "futurCompleterProfil": "Complete ton profil pour affiner la projection.",
-  "futurDisclaimer": "Projection éducative — ne constitue pas un conseil (LSFin). SWR 4% = règle des 4%, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.",
+  "futurDisclaimer": "Projection éducative — ne constitue pas un conseil (LSFin). SWR 4\u00a0% = règle des 4\u00a0%, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.",
   "futurExplorerDetails": "Explorer les détails",
   "financialSummaryTitle": "APERÇU FINANCIER",
   "financialSummaryNoProfile": "Aucun profil renseigné",
@@ -3848,7 +3848,7 @@
       }
     }
   },
-  "financialSummaryBonusEstime": "Bonus estimé ({pct}%)",
+  "financialSummaryBonusEstime": "Bonus estimé ({pct}\u00a0%)",
   "@financialSummaryBonusEstime": {
     "placeholders": {
       "pct": {
@@ -3962,7 +3962,7 @@
   "financialSummaryValeurEstimee": "Valeur estimée",
   "financialSummaryHypothequeRestante": "Hypothèque restante",
   "financialSummaryValeurNetteImmobiliere": "Valeur nette immobilière",
-  "financialSummaryLtvAmortissement": "Ratio LTV : {pct}% — amortissement 2ème rang obligatoire",
+  "financialSummaryLtvAmortissement": "Ratio LTV : {pct}\u00a0% — amortissement 2ème rang obligatoire",
   "@financialSummaryLtvAmortissement": {
     "placeholders": {
       "pct": {
@@ -3970,7 +3970,7 @@
       }
     }
   },
-  "financialSummaryLtvBonneVoie": "Ratio LTV : {pct}% — en bonne voie",
+  "financialSummaryLtvBonneVoie": "Ratio LTV : {pct}\u00a0% — en bonne voie",
   "@financialSummaryLtvBonneVoie": {
     "placeholders": {
       "pct": {
@@ -3978,7 +3978,7 @@
       }
     }
   },
-  "financialSummaryLtvExcellent": "Ratio LTV : {pct}% — excellent",
+  "financialSummaryLtvExcellent": "Ratio LTV : {pct}\u00a0% — excellent",
   "@financialSummaryLtvExcellent": {
     "placeholders": {
       "pct": {
@@ -4061,7 +4061,7 @@
   "financialSummaryMensualite": "Mensualité",
   "financialSummaryLeasing": "Leasing",
   "financialSummaryAutresDettes": "Autres dettes",
-  "financialSummaryConseilRemboursement": "Rembourse d'abord la dette à {taux}% avant d'investir. Chaque CHF remboursé = {taux}% de rendement effectif.",
+  "financialSummaryConseilRemboursement": "Rembourse d'abord la dette à {taux}\u00a0% avant d'investir. Chaque CHF remboursé = {taux}\u00a0% de rendement effectif.",
   "@financialSummaryConseilRemboursement": {
     "placeholders": {
       "taux": {
@@ -4425,8 +4425,8 @@
   "pillar3aDisclaimer": "Hypothèses pédagogiques basées sur rendements historiques moyens. Rendements passés ne constituent pas une assurance de résultat pour les rendements futurs.",
   "pillar3aCapitalEvolution": "Évolution de ton capital 3a",
   "pillar3aYearLabel": "Année",
-  "pillar3aBank15": "Banque 1.5%",
-  "pillar3aViac45": "VIAC 4.5%",
+  "pillar3aBank15": "Banque 1.5\u00a0%",
+  "pillar3aViac45": "VIAC 4.5\u00a0%",
   "pillar3aYearN": "Année {n}",
   "@pillar3aYearN": {
     "placeholders": {
@@ -4435,7 +4435,7 @@
       }
     }
   },
-  "pillar3aCompoundTip": "Les dernières années font +50% du gain total grâce aux intérêts composés !",
+  "pillar3aCompoundTip": "Les dernières années font +50\u00a0% du gain total grâce aux intérêts composés !",
   "pillar3aRecommended": "RECOMMANDÉ",
   "pillar3aVsBank": "{amount} vs Banque",
   "@pillar3aVsBank": {
@@ -4481,7 +4481,7 @@
   "slmDownload": "Télécharger",
   "slmDelete": "Supprimer",
   "slmIaOnDevice": "IA on-device",
-  "slmPrivacyMessage": "Le modèle fonctionne 100% sur ton appareil. Aucune donnée ne quitte ton téléphone.",
+  "slmPrivacyMessage": "Le modèle fonctionne 100\u00a0% sur ton appareil. Aucune donnée ne quitte ton téléphone.",
   "slmDownloadModelTitle": "Télécharger le modèle ?",
   "slmDeleteModelTitle": "Supprimer le modèle ?",
   "slmDeleteModelContent": "Cela libérera {size} d'espace. Tu pourras le re-télécharger à tout moment.",
@@ -4515,7 +4515,7 @@
   "landingMintDoesIt": "MINT le fait.",
   "landingCtaCommencer": "Commencer",
   "landingLegalFooterShort": "Outil éducatif. Ne constitue pas un conseil financier (LSFin). Données sur ton appareil.",
-  "pulseDigitalTwinPct": "Jumeau numérique : {pct}%",
+  "pulseDigitalTwinPct": "Jumeau numérique : {pct}\u00a0%",
   "@pulseDigitalTwinPct": {
     "placeholders": {
       "pct": {
@@ -4937,7 +4937,7 @@
   "forfaitFiscalBaseLine": "Base forfaitaire",
   "spendingMeterBudgetUnavailable": "Budget non disponible",
   "spendingMeterDisponible": "Disponible",
-  "spendingMeterVariablesLegend": "Variables {percent}%",
+  "spendingMeterVariablesLegend": "Variables {percent}\u00a0%",
   "@spendingMeterVariablesLegend": {
     "placeholders": {
       "percent": {
@@ -4945,7 +4945,7 @@
       }
     }
   },
-  "spendingMeterFuturLegend": "Futur {percent}%",
+  "spendingMeterFuturLegend": "Futur {percent}\u00a0%",
   "@spendingMeterFuturLegend": {
     "placeholders": {
       "percent": {
@@ -5013,7 +5013,7 @@
   "dataBlockPatrimoineDesc": "Épargne libre, investissements, immobilier : ces données complètent ta projection et permettent de calculer ton Financial Resilience Index.",
   "dataBlockPatrimoineCta": "Renseigner mon patrimoine",
   "dataBlockFiscaliteTitle": "Fiscalité",
-  "dataBlockFiscaliteDesc": "Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu'estimé (coefficient communal 60%-130%).",
+  "dataBlockFiscaliteDesc": "Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu'estimé (coefficient communal 60\u00a0%-130\u00a0%).",
   "dataBlockFiscaliteCta": "Comparer ma fiscalité",
   "dataBlockObjectifTitle": "Objectif retraite",
   "dataBlockObjectifDesc": "À quel âge souhaites-tu arrêter de travailler ? Un objectif clair permet de calculer l'effort d'épargne nécessaire et les options (anticipation, retraite partielle).",
@@ -5277,9 +5277,9 @@
   "frontalierTotalAnnuel": "Total annuel",
   "frontalierParMois": "par mois",
   "frontalierQuasiResidentTitle": "Quasi-résident (Genève)",
-  "frontalierQuasiResidentDesc": "Si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.",
+  "frontalierQuasiResidentDesc": "Si plus de 90\u00a0% de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.",
   "frontalierTessinTitle": "Tessin — régime spécial",
-  "frontalierEducationalTax": "En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l'état civil et le nombre d'enfants. À Genève, si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.",
+  "frontalierEducationalTax": "En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l'état civil et le nombre d'enfants. À Genève, si plus de 90\u00a0% de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.",
   "frontalierJoursBureau": "Jours au bureau en Suisse",
   "frontalierJoursHomeOffice": "Jours en home office à l'étranger",
   "frontalierJaugeRisque": "JAUGE DE RISQUE",
@@ -5306,7 +5306,7 @@
       }
     }
   },
-  "frontalierDuSalaire": "{percent}% du salaire",
+  "frontalierDuSalaire": "{percent}\u00a0% du salaire",
   "@frontalierDuSalaire": {
     "placeholders": {
       "percent": {
@@ -5334,7 +5334,7 @@
   "frontalierLamalTitle": "LAMal (suisse)",
   "frontalierLamalDesc": "Obligatoire si tu travailles en CH. Prime individuelle (~CHF 300-500/mois).",
   "frontalierCmuTitle": "CMU/Sécu (France)",
-  "frontalierCmuDesc": "Droit d'option possible pour les frontaliers FR. Cotisation ~8% du revenu fiscal.",
+  "frontalierCmuDesc": "Droit d'option possible pour les frontaliers FR. Cotisation ~8\u00a0% du revenu fiscal.",
   "frontalierAssurancePriveeTitle": "Assurance privée (DE/IT/AT)",
   "frontalierAssurancePriveeDesc": "En Allemagne, option PKV pour hauts revenus. IT/AT : régime obligatoire du pays.",
   "frontalierEducationalCharges": "En tant que frontalier, tu cotises aux assurances sociales suisses (AVS/AI/APG, AC, LPP). Les taux sont généralement plus bas qu'en France ou en Allemagne — mais la LAMal est à ta charge individuellement, ce qui peut compenser l'avantage.",
@@ -5358,7 +5358,7 @@
   "concubinageImpotSuccession": "IMPÔT SUR LA SUCCESSION",
   "concubinagePatrimoineTransmis": "Patrimoine transmis",
   "concubinageMarieExonere": "CHF 0 (exonéré)",
-  "concubinageConcubinTaux": "Concubin-e (~{taux}%)",
+  "concubinageConcubinTaux": "Concubin-e (~{taux}\u00a0%)",
   "@concubinageConcubinTaux": {
     "placeholders": {
       "taux": {
@@ -5896,7 +5896,7 @@
       }
     }
   },
-  "docImpactRenteOblig": "Rente obligatoire à 6.8% : CHF {amount}/an",
+  "docImpactRenteOblig": "Rente obligatoire à 6.8\u00a0% : CHF {amount}/an",
   "@docImpactRenteOblig": {
     "placeholders": {
       "amount": {
@@ -5904,7 +5904,7 @@
       }
     }
   },
-  "docImpactSurobligWithRate": "Part surobligatoire (CHF {suroblig}) à {rate}% = CHF {rente}/an",
+  "docImpactSurobligWithRate": "Part surobligatoire (CHF {suroblig}) à {rate}\u00a0% = CHF {rente}/an",
   "@docImpactSurobligWithRate": {
     "placeholders": {
       "suroblig": {
@@ -5934,7 +5934,7 @@
       }
     }
   },
-  "docImpactAvsCompletion": "sur {maxYears} nécessaires pour une rente AVS complète ({pct}%)",
+  "docImpactAvsCompletion": "sur {maxYears} nécessaires pour une rente AVS complète ({pct}\u00a0%)",
   "@docImpactAvsCompletion": {
     "placeholders": {
       "maxYears": {
@@ -5970,7 +5970,7 @@
       }
     }
   },
-  "extractionReviewConfidence": "Confiance extraction : {pct}%",
+  "extractionReviewConfidence": "Confiance extraction : {pct}\u00a0%",
   "@extractionReviewConfidence": {
     "placeholders": {
       "pct": {
@@ -6046,7 +6046,7 @@
       }
     }
   },
-  "firstSalaryNetPercent": "{pct}% net",
+  "firstSalaryNetPercent": "{pct}\u00a0% net",
   "@firstSalaryNetPercent": {
     "placeholders": {
       "pct": {
@@ -6116,8 +6116,8 @@
   "firstSalaryTask4": "Vérifier ta RC privée (env. CHF 100/an)",
   "firstSalaryTask5": "Verser le maximum 3a avant le 31 décembre",
   "firstSalaryBadgeTitle": "Premier pas financier",
-  "firstSalaryBadgeSubtitle": "Tu sais maintenant ce que 90% des gens ne savent jamais.",
-  "firstSalaryDisclaimer": "Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4%/an.",
+  "firstSalaryBadgeSubtitle": "Tu sais maintenant ce que 90\u00a0% des gens ne savent jamais.",
+  "firstSalaryDisclaimer": "Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4\u00a0%/an.",
   "benchmarkAppBarTitle": "Repères cantonaux",
   "benchmarkOptInTitle": "Activer les comparaisons cantonales",
   "benchmarkOptInSubtitle": "Compare ta situation à des ordres de grandeur issus des statistiques fédérales (OFS).",
@@ -6701,7 +6701,7 @@
   "dashboardNextActionsTitle": "Tes prochaines actions",
   "dashboardExploreAlsoTitle": "Explorer aussi",
   "dashboardImproveAccuracyTitle": "Améliore ta précision",
-  "dashboardCurrentConfidence": "Confiance actuelle : {score}%",
+  "dashboardCurrentConfidence": "Confiance actuelle : {score}\u00a0%",
   "@dashboardCurrentConfidence": {
     "placeholders": {
       "score": {
@@ -6731,7 +6731,7 @@
   "dashboardRachatLppTitle": "Rachat LPP",
   "dashboardRachatLppSubtitle": "Simuler l’impact fiscal",
   "dashboardRachatLppCta": "Calculer",
-  "dashboardPrecisionGainPercent": "Précision +{percent}%",
+  "dashboardPrecisionGainPercent": "Précision +{percent}\u00a0%",
   "@dashboardPrecisionGainPercent": {
     "placeholders": {
       "percent": {
@@ -7106,7 +7106,7 @@
   "expatTimeline30AfterTiming": "Après le départ",
   "expatTimelineUrgent": "Urgent !",
   "expatTimelinePassed": "Passé",
-  "expatSavingsBadge": "Économie : {amount} (-{percent}%)",
+  "expatSavingsBadge": "Économie : {amount} (-{percent}\u00a0%)",
   "@expatSavingsBadge": {
     "placeholders": {
       "amount": {
@@ -7133,7 +7133,7 @@
       }
     }
   },
-  "expatAvsReductionExplain": "Chaque année manquante réduit ta rente d'environ {percent}%. La réduction est définitive et s'applique à vie.",
+  "expatAvsReductionExplain": "Chaque année manquante réduit ta rente d'environ {percent}\u00a0%. La réduction est définitive et s'applique à vie.",
   "@expatAvsReductionExplain": {
     "placeholders": {
       "percent": {
@@ -7307,7 +7307,7 @@
   "genderGapIntro": "La déduction de coordination (CHF 26'460) n'est pas proratisée pour le temps partiel, ce qui pénalise davantage les personnes travaillant à temps réduit. Déplace le curseur pour voir l'impact.",
   "genderGapTauxActivite": "Taux d'activité",
   "genderGapParametres": "Paramètres",
-  "genderGapRevenuAnnuel": "Revenu annuel brut (100%)",
+  "genderGapRevenuAnnuel": "Revenu annuel brut (100\u00a0%)",
   "genderGapAge": "Âge",
   "genderGapAgeValue": "{age} ans",
   "@genderGapAgeValue": {
@@ -7330,8 +7330,8 @@
       }
     }
   },
-  "genderGapAt100": "À 100%",
-  "genderGapAtTaux": "À {taux}%",
+  "genderGapAt100": "À 100\u00a0%",
+  "genderGapAtTaux": "À {taux}\u00a0%",
   "@genderGapAtTaux": {
     "placeholders": {
       "taux": {
@@ -7343,10 +7343,10 @@
   "genderGapLacuneAnnuelle": "Lacune annuelle",
   "genderGapLacuneTotale": "Lacune totale (~20 ans)",
   "genderGapCoordinationTitle": "Comprendre la déduction de coordination",
-  "genderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 26'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100% ou à 50%.",
-  "genderGapSalaireBrut100": "Salaire brut à 100%",
-  "genderGapSalaireCoordonne100": "Salaire coordonné à 100%",
-  "genderGapSalaireBrutTaux": "Salaire brut à {taux}%",
+  "genderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 26'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100\u00a0% ou à 50\u00a0%.",
+  "genderGapSalaireBrut100": "Salaire brut à 100\u00a0%",
+  "genderGapSalaireCoordonne100": "Salaire coordonné à 100\u00a0%",
+  "genderGapSalaireBrutTaux": "Salaire brut à {taux}\u00a0%",
   "@genderGapSalaireBrutTaux": {
     "placeholders": {
       "taux": {
@@ -7354,7 +7354,7 @@
       }
     }
   },
-  "genderGapSalaireCoordonneTaux": "Salaire coordonné à {taux}%",
+  "genderGapSalaireCoordonneTaux": "Salaire coordonné à {taux}\u00a0%",
   "@genderGapSalaireCoordonneTaux": {
     "placeholders": {
       "taux": {
@@ -7368,10 +7368,10 @@
   "genderGapRecommandations": "Recommandations",
   "genderGapDisclaimer": "Les résultats présentés sont des estimations simplifiées à titre indicatif. Ils ne constituent pas un conseil financier personnalisé. Consulte ta caisse de pension et un·e spécialiste qualifié·e avant toute décision.",
   "genderGapSources": "Sources",
-  "genderGapSourcesBody": "LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8%) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)",
+  "genderGapSourcesBody": "LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8\u00a0%) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)",
   "achievementsErrorMessage": "Le chargement a buté. On réessaie ?",
   "documentsEmptyVoice": "C'est vide pour l'instant. Un scan de certificat, et tout s'éclaire.",
-  "documentsConfidenceChoc": "{count} documents = {pct}% de confiance",
+  "documentsConfidenceChoc": "{count} documents = {pct}\u00a0% de confiance",
   "@documentsConfidenceChoc": {
     "placeholders": {
       "count": {
@@ -8023,7 +8023,7 @@
   "eplRenteSansEpl": "Rente sans EPL",
   "eplRenteAvecEpl": "Rente avec EPL",
   "eplPerteMensuelle": "Perte mensuelle",
-  "eplImpactRenteNote": "Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2%, taux de conversion 6.8%. Le montant réel dépend de ta situation.",
+  "eplImpactRenteNote": "Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2\u00a0%, taux de conversion 6.8\u00a0%. Le montant réel dépend de ta situation.",
   "eplSectionFiscale": "Estimation fiscale",
   "eplMontantRetire": "Montant retiré",
   "eplImpotEstime": "Impôt estimé sur le retrait",
@@ -8105,7 +8105,7 @@
     }
   },
   "providerComparatorAssuranceTitle": "Attention — Assurance 3a",
-  "providerComparatorAssuranceNote": "Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5%) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.",
+  "providerComparatorAssuranceNote": "Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5\u00a0%) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.",
   "documentDetailFieldsExtracted": "{found} champs extraits sur {total}",
   "@documentDetailFieldsExtracted": {
     "placeholders": {
@@ -8259,7 +8259,7 @@
   "compoundTauxRendement": "Taux (Rendement annuel)",
   "compoundHorizonTemps": "Horizon de temps",
   "compoundValeurFinale": "Valeur Finale Potentielle",
-  "compoundGainsPercent": "{percent}% de ce montant provient uniquement de tes gains de placement.",
+  "compoundGainsPercent": "{percent}\u00a0% de ce montant provient uniquement de tes gains de placement.",
   "@compoundGainsPercent": {
     "placeholders": {
       "percent": {
@@ -8302,14 +8302,14 @@
   "leasingDisclaimer": "Le leasing reste une option pour certains professionnels. Cette analyse vise à sensibiliser le particulier sur le coût à long terme.",
   "creditTitle": "Crédit à la Consommation",
   "creditMentorTitle": "Points d'attention du Mentor",
-  "creditMentorBody": "En Suisse, un crédit coûte entre 4% et 10%. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.",
+  "creditMentorBody": "En Suisse, un crédit coûte entre 4\u00a0% et 10\u00a0%. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.",
   "creditParametres": "Paramètres",
   "creditMontantEmprunter": "Montant à emprunter",
   "creditDureeRemboursement": "Durée du remboursement",
   "creditTauxAnnuel": "Taux annuel effectif",
   "creditTaMensualite": "Ta Mensualité",
   "creditCoutInterets": "Coût des intérêts :",
-  "creditRateWarning": "Attention : Ce taux dépasse le max légal suisse de 10%.",
+  "creditRateWarning": "Attention : Ce taux dépasse le max légal suisse de 10\u00a0%.",
   "creditConseilsTitle": "Conseils du Mentor",
   "creditEpargnerDabord": "Épargner d'abord",
   "creditEpargnerDabordBody": "En économisant pendant 12 mois au lieu d'emprunter, tu gardes {amount} dans ta poche.",
@@ -8321,7 +8321,7 @@
     }
   },
   "creditCercleConfiance": "Cercle de confiance",
-  "creditCercleConfianceBody": "Un prêt familial peut souvent être obtenu à 0% d'intérêt.",
+  "creditCercleConfianceBody": "Un prêt familial peut souvent être obtenu à 0\u00a0% d'intérêt.",
   "creditDettesConseils": "Dettes Conseils Suisse",
   "creditDettesConseilsBody": "Contacte-les AVANT de signer si ta situation est fragile.",
   "creditDisclaimer": "Information à but préventif. Ne constitue pas un conseil juridique ou financier. Loi suisse sur le crédit à la consommation (LCC) appliquée.",
@@ -8588,8 +8588,8 @@
   "portfolioProtectionFamille": "Protection Famille",
   "portfolioAllocationSaine": "Ton allocation est saine. Pense à rééquilibrer ton 3a prochainement.",
   "portfolioAlerteDettes": "Alerte Dettes : Ta priorité absolue est le désendettement avant tout réinvestissement.",
-  "dividendeSplitMin": "0% salaire",
-  "dividendeSplitMax": "100% salaire",
+  "dividendeSplitMin": "0\u00a0% salaire",
+  "dividendeSplitMax": "100\u00a0% salaire",
   "disabilityInsAppBarTitle": "Ma couverture",
   "disabilityInsTitle": "Ma couverture invalidité",
   "disabilityInsSubtitle": "Bulletin scolaire · Franchise LAMal · AI/APG",
@@ -9558,7 +9558,7 @@
       }
     }
   },
-  "benchmarkInsightSavings": "Un profil similaire épargne environ {rate}% de son revenu",
+  "benchmarkInsightSavings": "Un profil similaire épargne environ {rate}\u00a0% de son revenu",
   "@benchmarkInsightSavings": {
     "placeholders": {
       "rate": {
@@ -9585,7 +9585,7 @@
       }
     }
   },
-  "benchmarkInsight3a": "Environ {rate}% des actifs versent dans le 3a",
+  "benchmarkInsight3a": "Environ {rate}\u00a0% des actifs versent dans le 3a",
   "@benchmarkInsight3a": {
     "placeholders": {
       "rate": {
@@ -9593,7 +9593,7 @@
       }
     }
   },
-  "benchmarkInsightLpp": "Le taux de couverture LPP est de {rate}%",
+  "benchmarkInsightLpp": "Le taux de couverture LPP est de {rate}\u00a0%",
   "@benchmarkInsightLpp": {
     "placeholders": {
       "rate": {
@@ -10075,7 +10075,7 @@
   "notifProfileUpdatedTitle": "Profil mis à jour",
   "notifProfileUpdatedBody": "Ton profil a été mis à jour. Nouvelles projections disponibles.",
   "notifOffTrackTitle": "Tu t'éloignes de ton plan",
-  "notifOffTrackBody": "Adhérence à {adherence}% sur {total} actions. Indication linéaire (hors rendement/fiscalité) : ~CHF {impact}.",
+  "notifOffTrackBody": "Adhérence à {adherence}\u00a0% sur {total} actions. Indication linéaire (hors rendement/fiscalité) : ~CHF {impact}.",
   "@notifOffTrackBody": {
     "placeholders": {
       "adherence": {
@@ -10385,7 +10385,7 @@
   "semanticsIncrement": "Augmenter",
   "frontalierDisclaimer": "Estimations simplifiées à but éducatif — ne constitue pas un conseil fiscal ou juridique. Les montants dépendent de nombreux facteurs (déductions, commune, fortune, convention internationale, etc.). Consulte un·e spécialiste fiscal·e pour une analyse personnalisée. LSFin.",
   "firstJobPayslipAvsLabel": "AVS/AI/APG",
-  "firstJobPayslipAvsExplanation": "Cotisation salarié·e : 5.3% du brut. Ton employeur paie aussi 5.3% en plus.",
+  "firstJobPayslipAvsExplanation": "Cotisation salarié·e : 5.3\u00a0% du brut. Ton employeur paie aussi 5.3\u00a0% en plus.",
   "firstJobPayslipLppLabel": "LPP (2e pilier)",
   "firstJobPayslipLppExplanation": "Épargne vieillesse obligatoire dès 25 ans. Le taux exact dépend de ta caisse et ton âge.",
   "firstJobPayslipImpotLabel": "Impôt à la source (estimation)",
@@ -10395,7 +10395,7 @@
   "firstJobChecklistConsequence1": "Sans certificat, tu ne peux pas vérifier que le montant transféré est correct.",
   "firstJobChecklistDeadline2": "30 jours",
   "firstJobChecklistAction2": "Vérifie que ton avoir LPP a été transféré à la caisse de ton nouvel employeur.",
-  "firstJobChecklistConsequence2": "Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05%.",
+  "firstJobChecklistConsequence2": "Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05\u00a0%.",
   "firstJobChecklistDeadline3": "1 mois",
   "firstJobChecklistAction3": "Informe ton assurance-maladie LAMal du changement d'employeur si tu bénéficiais d'une couverture collective.",
   "firstJobChecklistDeadline4": "Dès le premier salaire",
@@ -10427,7 +10427,7 @@
   "firstJobScenarioMySalary": "Mon salaire",
   "firstJobScenarioDefault": "Défaut",
   "firstJobScenarioMedianCH": "Médian CH",
-  "firstJobScenarioBoosted": "+20%",
+  "firstJobScenarioBoosted": "+20\u00a0%",
   "firstJobScenarioSemantics": "Scénario salaire : {label}",
   "@firstJobScenarioSemantics": {
     "placeholders": {
@@ -10648,10 +10648,10 @@
   "disabilityGapAct1Duration": "Semaines 1-26",
   "disabilityGapAct2LabelIjm": "ACTE 2 · IJM (assurance maladie)",
   "disabilityGapAct2LabelNoIjm": "ACTE 2 · Pas d’IJM",
-  "disabilityGapAct2SubIjm": "Assurance collective — 80% pendant 720 jours max",
+  "disabilityGapAct2SubIjm": "Assurance collective — 80\u00a0% pendant 720 jours max",
   "disabilityGapAct2SubNoIjm": "Sans IJM, tu passes directement à l’AI après l’employeur",
   "disabilityGapAct2Duration": "Jusqu’à 24 mois",
-  "disabilityGapAct2DetailIjm": "80% du salaire assuré",
+  "disabilityGapAct2DetailIjm": "80\u00a0% du salaire assuré",
   "disabilityGapAct2DetailNoIjm": "Aucune couverture — délai AI en cours",
   "disabilityGapAct3Label": "ACTE 3 · AI + LPP (définitif)",
   "disabilityGapAct3Duration": "Après 24 mois",
@@ -10669,7 +10669,7 @@
       }
     }
   },
-  "disabilityGapIjmCoverage": "80% pendant 720 jours — assurance collective",
+  "disabilityGapIjmCoverage": "80\u00a0% pendant 720 jours — assurance collective",
   "disabilityGapNoIjmCoverage": "Aucune IJM souscrite — risque maximal",
   "disabilityGapAiDetail": "Max {amount} CHF/mois — délai ~14 mois",
   "@disabilityGapAiDetail": {
@@ -10679,7 +10679,7 @@
       }
     }
   },
-  "disabilityGapLppCovered": "Rente invalidité ≈ 40% salaire coordonné (LPP art. 23)",
+  "disabilityGapLppCovered": "Rente invalidité ≈ 40\u00a0% salaire coordonné (LPP art. 23)",
   "disabilityGapLppNotCovered": "Salaire sous le seuil LPP — pas de couverture 2e pilier",
   "disabilityGapSavingsLabel": "Réserve d’urgence",
   "disabilityGapSavingsDetail": "{months} mois de charges couverts",
@@ -10708,7 +10708,7 @@
   "documentDetailExplanationSalaireAssure": "Salaire sur lequel les cotisations sont calculées",
   "documentDetailExplanationSalaireAvs": "Salaire déterminant pour l’AVS",
   "documentDetailExplanationDeduction": "Montant déduit pour coordonner avec l’AVS",
-  "documentDetailExplanationTauxOblig": "Légal minimum : 6.8%",
+  "documentDetailExplanationTauxOblig": "Légal minimum : 6.8\u00a0%",
   "documentDetailExplanationTauxSurob": "Fixé par ta caisse de pension",
   "documentDetailExplanationTauxEnv": "Taux moyen pondéré",
   "documentDetailExplanationInvalidite": "Rente en cas d’incapacité de travail",
@@ -10727,7 +10727,7 @@
   "disabilitySelfEmployedInsuranceQuestion": "Tu as déjà une assurance perte de gain ?",
   "disabilitySelfEmployedYes": "Oui",
   "disabilitySelfEmployedNo": "Non / Je ne sais pas",
-  "disabilitySelfEmployedApgTip": "Une APG individuelle dès CHF 45/mois peut couvrir 80% de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.",
+  "disabilitySelfEmployedApgTip": "Une APG individuelle dès CHF 45/mois peut couvrir 80\u00a0% de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.",
   "disabilitySelfEmployedDisclaimer": "Outil éducatif — ne constitue pas un conseil en assurance. Un·e courtier·ère indépendant·e peut comparer les offres APG de différents assureurs selon ton activité et ton revenu réel.",
   "disabilitySelfEmployedSources": "• LAMal art. 67-77 (assurance maladie perte de gain)\n• CO art. 324a (obligation employeur)\n• LAI art. 28 (rente AI)\n• LAVS art. 2 al. 3 (cotisation depuis l’étranger)",
   "confidenceDashboardLevelExcellent": "Excellente",
@@ -11716,7 +11716,7 @@
   "indepLppProRente": "Rente prévue à la retraite",
   "indepLppConCotisations": "Cotisations obligatoires élevées",
   "indepLppConFlexible": "Moins flexible",
-  "indepGrand3aSub": "20% du revenu net, max CHF 36'288/an",
+  "indepGrand3aSub": "20\u00a0% du revenu net, max CHF 36'288/an",
   "indepGrand3aProFlexibilite": "Flexibilité totale",
   "indepGrand3aProDeduction": "Déduction fiscale maximale",
   "indepGrand3aProCapital": "Capital disponible à 60 ans",
@@ -11727,7 +11727,7 @@
   "indepLayerFraisPro": "Frais professionnels",
   "indepLayerJoursNonFact": "Jours non facturables",
   "indepFiscal3a": "Pilier 3a grand versement",
-  "indepFiscal3aNote": "Max 20% du revenu net, plafonné à CHF 36'288/an sans LPP",
+  "indepFiscal3aNote": "Max 20\u00a0% du revenu net, plafonné à CHF 36'288/an sans LPP",
   "indepFiscalFraisPro": "Frais professionnels effectifs",
   "indepFiscalFraisProNote": "Loyer bureau, matériel, formation — déductibles au réel",
   "indepFiscalPrimesLpp": "Primes assurance maladie (LPP vol.)",
@@ -11753,7 +11753,7 @@
   "donationRegimeParticipation": "Participation aux acquêts",
   "donationRegimeCommunaute": "Communauté de biens",
   "donationRegimeSeparation": "Séparation de biens",
-  "donationReserveBarLabel": "Réserve {pct}%",
+  "donationReserveBarLabel": "Réserve {pct}\u00a0%",
   "@donationReserveBarLabel": {
     "placeholders": {
       "pct": {
@@ -11761,7 +11761,7 @@
       }
     }
   },
-  "donationDisponibleBarLabel": "Disponible {pct}%",
+  "donationDisponibleBarLabel": "Disponible {pct}\u00a0%",
   "@donationDisponibleBarLabel": {
     "placeholders": {
       "pct": {
@@ -11917,7 +11917,7 @@
   "capCoachPrompt3a": "Combien je peux économiser avec un versement 3a cette année ?",
   "capCoachPromptRachat": "Aide-moi à comprendre si un rachat LPP est pertinent pour moi.",
   "capCoachPromptBudgetDeficit": "Mon budget est en déficit. Comment retrouver de l'air ?",
-  "capCoachPromptReplacement": "Mon taux de remplacement est de {rate}%. Est-ce suffisant pour ma retraite ?",
+  "capCoachPromptReplacement": "Mon taux de remplacement est de {rate}\u00a0%. Est-ce suffisant pour ma retraite ?",
   "capCoachPromptUnemployment": "Je suis en situation de chômage. Quelles sont mes options financières ?",
   "capCoachPromptDivorce": "Je suis divorcé·e. Comment protéger ma situation financière ?",
   "capCoachPromptCoupleOptim": "Comment optimiser notre prévoyance à deux ?",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -156,7 +156,7 @@ abstract class S {
   /// No description provided for @landingFeature2Title.
   ///
   /// In fr, this message translates to:
-  /// **'100% Privé & Local'**
+  /// **'100 % Privé & Local'**
   String get landingFeature2Title;
 
   /// No description provided for @landingFeature2Desc.
@@ -510,7 +510,7 @@ abstract class S {
   /// No description provided for @advisorMiniResumeDiagnostic.
   ///
   /// In fr, this message translates to:
-  /// **'Reprendre mon diagnostic ({progress}%)'**
+  /// **'Reprendre mon diagnostic ({progress} %)'**
   String advisorMiniResumeDiagnostic(String progress);
 
   /// No description provided for @advisorMiniFullDiagnostic.
@@ -1458,13 +1458,13 @@ abstract class S {
   /// No description provided for @profileReward15.
   ///
   /// In fr, this message translates to:
-  /// **'+15% de précision'**
+  /// **'+15 % de précision'**
   String get profileReward15;
 
   /// No description provided for @profileReward10.
   ///
   /// In fr, this message translates to:
-  /// **'+10% de précision'**
+  /// **'+10 % de précision'**
   String get profileReward10;
 
   /// No description provided for @profileSecurityTitle.
@@ -1602,25 +1602,25 @@ abstract class S {
   /// No description provided for @rentVsCapitalPrudent.
   ///
   /// In fr, this message translates to:
-  /// **'Prudent (1%)'**
+  /// **'Prudent (1 %)'**
   String get rentVsCapitalPrudent;
 
   /// No description provided for @rentVsCapitalCentral.
   ///
   /// In fr, this message translates to:
-  /// **'Central (3%)'**
+  /// **'Central (3 %)'**
   String get rentVsCapitalCentral;
 
   /// No description provided for @rentVsCapitalOptimiste.
   ///
   /// In fr, this message translates to:
-  /// **'Optimiste (5%)'**
+  /// **'Optimiste (5 %)'**
   String get rentVsCapitalOptimiste;
 
   /// No description provided for @rentVsCapitalTauxConversionExpl.
   ///
   /// In fr, this message translates to:
-  /// **'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3% et 6%.'**
+  /// **'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.'**
   String get rentVsCapitalTauxConversionExpl;
 
   /// No description provided for @rentVsCapitalChoixExpl.
@@ -1758,7 +1758,7 @@ abstract class S {
   /// No description provided for @disabilityGapIjmExpl.
   ///
   /// In fr, this message translates to:
-  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.'**
+  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.'**
   String get disabilityGapIjmExpl;
 
   /// No description provided for @disabilityGapCo324aExpl.
@@ -2334,7 +2334,7 @@ abstract class S {
   /// No description provided for @documentsConfidence.
   ///
   /// In fr, this message translates to:
-  /// **'Confiance : {confidence}%'**
+  /// **'Confiance : {confidence} %'**
   String documentsConfidence(String confidence);
 
   /// No description provided for @documentsFieldsFound.
@@ -2976,7 +2976,7 @@ abstract class S {
   /// No description provided for @jobCompareEducational.
   ///
   /// In fr, this message translates to:
-  /// **'Le salaire invisible représente 10-30% de ta rémunération totale.'**
+  /// **'Le salaire invisible représente 10-30 % de ta rémunération totale.'**
   String get jobCompareEducational;
 
   /// No description provided for @jobCompareVerdictBetter.
@@ -3884,13 +3884,13 @@ abstract class S {
   /// No description provided for @coachingDebtTitle.
   ///
   /// In fr, this message translates to:
-  /// **'Taux d\'endettement élevé ({ratio}%)'**
+  /// **'Taux d\'endettement élevé ({ratio} %)'**
   String coachingDebtTitle(String ratio);
 
   /// No description provided for @coachingDebtMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Ton taux d\'endettement estimé est de {ratio}%, au-dessus du seuil de 33% recommandé par les banques suisses.'**
+  /// **'Ton taux d\'endettement estimé est de {ratio} %, au-dessus du seuil de 33 % recommandé par les banques suisses.'**
   String coachingDebtMessage(String ratio);
 
   /// No description provided for @coachingDebtAction.
@@ -3908,7 +3908,7 @@ abstract class S {
   /// No description provided for @coachingPartTimeMessage.
   ///
   /// In fr, this message translates to:
-  /// **'À {rate}% d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.'**
+  /// **'À {rate} % d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.'**
   String coachingPartTimeMessage(String rate);
 
   /// No description provided for @coachingPartTimeAction.
@@ -4142,7 +4142,7 @@ abstract class S {
   /// No description provided for @segmentsGenderGapRevenuLabel.
   ///
   /// In fr, this message translates to:
-  /// **'Revenu annuel brut (100%)'**
+  /// **'Revenu annuel brut (100 %)'**
   String get segmentsGenderGapRevenuLabel;
 
   /// No description provided for @segmentsGenderGapAgeLabel.
@@ -4184,13 +4184,13 @@ abstract class S {
   /// No description provided for @segmentsGenderGapAt100.
   ///
   /// In fr, this message translates to:
-  /// **'À 100%'**
+  /// **'À 100 %'**
   String get segmentsGenderGapAt100;
 
   /// No description provided for @segmentsGenderGapAtCurrent.
   ///
   /// In fr, this message translates to:
-  /// **'À {rate}%'**
+  /// **'À {rate} %'**
   String segmentsGenderGapAtCurrent(String rate);
 
   /// No description provided for @segmentsGenderGapLacuneAnnuelle.
@@ -4214,31 +4214,31 @@ abstract class S {
   /// No description provided for @segmentsGenderGapCoordinationBody.
   ///
   /// In fr, this message translates to:
-  /// **'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100% ou à 50%.'**
+  /// **'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100 % ou à 50 %.'**
   String get segmentsGenderGapCoordinationBody;
 
   /// No description provided for @segmentsGenderGapSalaireBrut100.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire brut à 100%'**
+  /// **'Salaire brut à 100 %'**
   String get segmentsGenderGapSalaireBrut100;
 
   /// No description provided for @segmentsGenderGapSalaireCoord100.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire coordonné à 100%'**
+  /// **'Salaire coordonné à 100 %'**
   String get segmentsGenderGapSalaireCoord100;
 
   /// No description provided for @segmentsGenderGapSalaireBrutCurrent.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire brut à {rate}%'**
+  /// **'Salaire brut à {rate} %'**
   String segmentsGenderGapSalaireBrutCurrent(String rate);
 
   /// No description provided for @segmentsGenderGapSalaireCoordCurrent.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire coordonné à {rate}%'**
+  /// **'Salaire coordonné à {rate} %'**
   String segmentsGenderGapSalaireCoordCurrent(String rate);
 
   /// No description provided for @segmentsGenderGapDeductionFixe.
@@ -4256,7 +4256,7 @@ abstract class S {
   /// No description provided for @segmentsGenderGapOfsStat.
   ///
   /// In fr, this message translates to:
-  /// **'En Suisse, les femmes touchent en moyenne 37% de rente de moins que les hommes (OFS 2024)'**
+  /// **'En Suisse, les femmes touchent en moyenne 37 % de rente de moins que les hommes (OFS 2024)'**
   String get segmentsGenderGapOfsStat;
 
   /// No description provided for @segmentsGenderGapRecTitle.
@@ -4412,13 +4412,13 @@ abstract class S {
   /// No description provided for @segmentsFrontalierQuasiResidentDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Le statut de quasi-résident est accessible si au moins 90% des revenus de votre ménage proviennent de Suisse.'**
+  /// **'Le statut de quasi-résident est accessible si au moins 90 % des revenus de votre ménage proviennent de Suisse.'**
   String get segmentsFrontalierQuasiResidentDesc;
 
   /// No description provided for @segmentsFrontalierQuasiResidentCondition.
   ///
   /// In fr, this message translates to:
-  /// **'Condition : >= 90% des revenus du ménage provenant de Suisse'**
+  /// **'Condition : >= 90 % des revenus du ménage provenant de Suisse'**
   String get segmentsFrontalierQuasiResidentCondition;
 
   /// No description provided for @segmentsFrontalierChecklist.
@@ -4640,7 +4640,7 @@ abstract class S {
   /// No description provided for @segmentsIndependant3aWithoutLpp.
   ///
   /// In fr, this message translates to:
-  /// **'Sans LPP : plafond 3a \'grand\' de 20% du revenu net, max CHF 36\'288/an.'**
+  /// **'Sans LPP : plafond 3a \'grand\' de 20 % du revenu net, max CHF 36\'288/an.'**
   String get segmentsIndependant3aWithoutLpp;
 
   /// No description provided for @segmentsIndependantRecTitle.
@@ -4772,7 +4772,7 @@ abstract class S {
   /// No description provided for @assurancesLamalQuotePart.
   ///
   /// In fr, this message translates to:
-  /// **'Quote-part (10%, max 700 CHF)'**
+  /// **'Quote-part (10 %, max 700 CHF)'**
   String get assurancesLamalQuotePart;
 
   /// No description provided for @assurancesCoverageTitle.
@@ -6200,7 +6200,7 @@ abstract class S {
   /// No description provided for @coachFactAvs.
   ///
   /// In fr, this message translates to:
-  /// **'En Suisse, chaque année AVS manquante = −2.3% de rente à vie. Un rattrapage est possible dans certains cas.'**
+  /// **'En Suisse, chaque année AVS manquante = −2.3 % de rente à vie. Un rattrapage est possible dans certains cas.'**
   String get coachFactAvs;
 
   /// No description provided for @coachFactAvsLink.
@@ -7256,7 +7256,7 @@ abstract class S {
   /// No description provided for @vaultConfidence.
   ///
   /// In fr, this message translates to:
-  /// **'Confiance : {confidence}%'**
+  /// **'Confiance : {confidence} %'**
   String vaultConfidence(String confidence);
 
   /// No description provided for @vaultAnalyzing.
@@ -7550,7 +7550,7 @@ abstract class S {
   /// No description provided for @soaSavingsGoal.
   ///
   /// In fr, this message translates to:
-  /// **'Objectif: 20%'**
+  /// **'Objectif: 20 %'**
   String get soaSavingsGoal;
 
   /// No description provided for @soaProtectionScore.
@@ -7742,7 +7742,7 @@ abstract class S {
   /// No description provided for @agirScenarioBriefSummary.
   ///
   /// In fr, this message translates to:
-  /// **'Dans ~{years} ans, ton scénario Base vise {baseCapital} (~{replacement}% de remplacement). L\'écart Prudent vs Optimiste est {gapCapital}.'**
+  /// **'Dans ~{years} ans, ton scénario Base vise {baseCapital} (~{replacement} % de remplacement). L\'écart Prudent vs Optimiste est {gapCapital}.'**
   String agirScenarioBriefSummary(
       String years, String baseCapital, String replacement, String gapCapital);
 
@@ -7827,7 +7827,7 @@ abstract class S {
   /// No description provided for @coachDataQualityBody.
   ///
   /// In fr, this message translates to:
-  /// **'Calcul actuel: {dataPoints} donnees saisies ({percentage}%). Les postes non renseignes restent en estimation jusqu au diagnostic complet.'**
+  /// **'Calcul actuel: {dataPoints} donnees saisies ({percentage} %). Les postes non renseignes restent en estimation jusqu au diagnostic complet.'**
   String coachDataQualityBody(String dataPoints, String percentage);
 
   /// No description provided for @coachShockTitle.
@@ -7893,7 +7893,7 @@ abstract class S {
   /// No description provided for @profileCoachKnowledgeSummary.
   ///
   /// In fr, this message translates to:
-  /// **'{profileState} • Precision {precision}% • Check-ins: {checkins}{scorePart}'**
+  /// **'{profileState} • Precision {precision} % • Check-ins: {checkins}{scorePart}'**
   String profileCoachKnowledgeSummary(
       String profileState, String precision, String checkins, String scorePart);
 
@@ -8116,7 +8116,7 @@ abstract class S {
   /// No description provided for @coachEnrichTargetTitle.
   ///
   /// In fr, this message translates to:
-  /// **'Passe de {current}% a {target}% de precision'**
+  /// **'Passe de {current} % a {target} % de precision'**
   String coachEnrichTargetTitle(String current, String target);
 
   /// No description provided for @coachEnrichBodyIdentity.
@@ -8182,7 +8182,7 @@ abstract class S {
   /// No description provided for @coachAgirPartialTitle.
   ///
   /// In fr, this message translates to:
-  /// **'Plan en construction ({quality}%)'**
+  /// **'Plan en construction ({quality} %)'**
   String coachAgirPartialTitle(String quality);
 
   /// No description provided for @coachAgirPartialBody.
@@ -8290,7 +8290,7 @@ abstract class S {
   /// No description provided for @landingDropPurchasingPower.
   ///
   /// In fr, this message translates to:
-  /// **'-{percent}% de pouvoir d\'achat'**
+  /// **'-{percent} % de pouvoir d\'achat'**
   String landingDropPurchasingPower(String percent);
 
   /// No description provided for @landingLppCapNotice.
@@ -8350,7 +8350,7 @@ abstract class S {
   /// No description provided for @landingFeaturePrivacyTitle.
   ///
   /// In fr, this message translates to:
-  /// **'100% privé, données sur ton appareil'**
+  /// **'100 % privé, données sur ton appareil'**
   String get landingFeaturePrivacyTitle;
 
   /// No description provided for @landingFeaturePrivacySubtitle.
@@ -8368,7 +8368,7 @@ abstract class S {
   /// No description provided for @landingTrustPrivate.
   ///
   /// In fr, this message translates to:
-  /// **'100% privé'**
+  /// **'100 % privé'**
   String get landingTrustPrivate;
 
   /// No description provided for @landingTrustNoCommitment.
@@ -8728,7 +8728,7 @@ abstract class S {
   /// No description provided for @dashboardMetricVsTarget.
   ///
   /// In fr, this message translates to:
-  /// **'Vs cible 70% du salaire brut'**
+  /// **'Vs cible 70 % du salaire brut'**
   String get dashboardMetricVsTarget;
 
   /// No description provided for @dashboardNextActionLabel.
@@ -10672,7 +10672,7 @@ abstract class S {
   /// No description provided for @mariageAvsSurvivorSub.
   ///
   /// In fr, this message translates to:
-  /// **'80% de la rente maximale du défunt'**
+  /// **'80 % de la rente maximale du défunt'**
   String get mariageAvsSurvivorSub;
 
   /// No description provided for @mariageAvsSurvivorFootnote.
@@ -10690,7 +10690,7 @@ abstract class S {
   /// No description provided for @mariageLppSurvivorSub.
   ///
   /// In fr, this message translates to:
-  /// **'60% de la rente assurée du défunt'**
+  /// **'60 % de la rente assurée du défunt'**
   String get mariageLppSurvivorSub;
 
   /// No description provided for @mariageLppSurvivorFootnote.
@@ -11032,7 +11032,7 @@ abstract class S {
   /// No description provided for @unemploymentSituationSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Influence le taux d\'indemnisation (70% ou 80%)'**
+  /// **'Influence le taux d\'indemnisation (70 % ou 80 %)'**
   String get unemploymentSituationSubtitle;
 
   /// No description provided for @unemploymentChildrenToggle.
@@ -11062,13 +11062,13 @@ abstract class S {
   /// No description provided for @unemploymentRateEnhanced.
   ///
   /// In fr, this message translates to:
-  /// **'Taux majoré (80%) : obligation d\'entretien, handicap, ou salaire < CHF 3\'797'**
+  /// **'Taux majoré (80 %) : obligation d\'entretien, handicap, ou salaire < CHF 3\'797'**
   String get unemploymentRateEnhanced;
 
   /// No description provided for @unemploymentRateStandard.
   ///
   /// In fr, this message translates to:
-  /// **'Taux standard (70%) : applicable dans les autres situations'**
+  /// **'Taux standard (70 %) : applicable dans les autres situations'**
   String get unemploymentRateStandard;
 
   /// No description provided for @unemploymentDailyBenefit.
@@ -11326,7 +11326,7 @@ abstract class S {
   /// No description provided for @firstJobEduBudgetBody.
   ///
   /// In fr, this message translates to:
-  /// **'Un bon réflexe pour ton premier salaire : 50% pour les dépenses fixes, 30% pour les loisirs, 20% pour l\'épargne et la prévoyance (3a inclus).'**
+  /// **'Un bon réflexe pour ton premier salaire : 50 % pour les dépenses fixes, 30 % pour les loisirs, 20 % pour l\'épargne et la prévoyance (3a inclus).'**
   String get firstJobEduBudgetBody;
 
   /// No description provided for @firstJobEduTaxTitle.
@@ -11488,7 +11488,7 @@ abstract class S {
   /// No description provided for @independantSourcesBody.
   ///
   /// In fr, this message translates to:
-  /// **'LPP art. 4 (pas d\'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20% du revenu net, max 36\'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal'**
+  /// **'LPP art. 4 (pas d\'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20 % du revenu net, max 36\'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal'**
   String get independantSourcesBody;
 
   /// No description provided for @independantDisclaimer.
@@ -11596,7 +11596,7 @@ abstract class S {
   /// No description provided for @jobCompareEduInvisibleBody.
   ///
   /// In fr, this message translates to:
-  /// **'Le \"salaire invisible\" représente 10-30% de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.'**
+  /// **'Le \"salaire invisible\" représente 10-30 % de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.'**
   String get jobCompareEduInvisibleBody;
 
   /// No description provided for @jobCompareEduCertTitle.
@@ -11776,7 +11776,7 @@ abstract class S {
   /// No description provided for @disabilityGapEduIjmBody.
   ///
   /// In fr, this message translates to:
-  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu\'à l\'éventuelle rente AI.'**
+  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu\'à l\'éventuelle rente AI.'**
   String get disabilityGapEduIjmBody;
 
   /// No description provided for @disabilityGapEduCoTitle.
@@ -12016,7 +12016,7 @@ abstract class S {
   /// No description provided for @mariageChecklistItem6Desc.
   ///
   /// In fr, this message translates to:
-  /// **'La rente AVS maximale pour un couple est plafonnée à 150% de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.'**
+  /// **'La rente AVS maximale pour un couple est plafonnée à 150 % de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.'**
   String get mariageChecklistItem6Desc;
 
   /// No description provided for @mariageChecklistItem7Title.
@@ -12106,7 +12106,7 @@ abstract class S {
   /// No description provided for @successionQuotitePct.
   ///
   /// In fr, this message translates to:
-  /// **'soit {pct}% de la succession'**
+  /// **'soit {pct} % de la succession'**
   String successionQuotitePct(String pct);
 
   /// No description provided for @successionExonereLabel.
@@ -12136,7 +12136,7 @@ abstract class S {
   /// No description provided for @successionEduConcubinBody2.
   ///
   /// In fr, this message translates to:
-  /// **'En droit suisse, les concubins n\'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l\'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25% au lieu de 0%). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d\'envisager des assurances-vie.'**
+  /// **'En droit suisse, les concubins n\'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l\'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25 % au lieu de 0 %). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d\'envisager des assurances-vie.'**
   String get successionEduConcubinBody2;
 
   /// No description provided for @successionDisclaimerText.
@@ -12250,7 +12250,7 @@ abstract class S {
   /// No description provided for @donationTauxCanton.
   ///
   /// In fr, this message translates to:
-  /// **'Taux : {taux}% (canton {canton})'**
+  /// **'Taux : {taux} % (canton {canton})'**
   String donationTauxCanton(String taux, String canton);
 
   /// No description provided for @donationMontantRow.
@@ -12280,7 +12280,7 @@ abstract class S {
   /// No description provided for @donationReserveNote.
   ///
   /// In fr, this message translates to:
-  /// **'Depuis 2023, les parents n\'ont plus de réserve. La réserve des descendants est de 50% de leur part légale (CC art. 471).'**
+  /// **'Depuis 2023, les parents n\'ont plus de réserve. La réserve des descendants est de 50 % de leur part légale (CC art. 471).'**
   String get donationReserveNote;
 
   /// No description provided for @donationQuotiteTitle.
@@ -12352,7 +12352,7 @@ abstract class S {
   /// No description provided for @donationEduConcubinBody.
   ///
   /// In fr, this message translates to:
-  /// **'Les concubins n\'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l\'impôt cantonal sur les donations entre concubins est généralement élevé (18-25% selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.'**
+  /// **'Les concubins n\'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l\'impôt cantonal sur les donations entre concubins est généralement élevé (18-25 % selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.'**
   String get donationEduConcubinBody;
 
   /// No description provided for @donationDisclaimer.
@@ -12767,7 +12767,7 @@ abstract class S {
   /// No description provided for @independantAvsBody.
   ///
   /// In fr, this message translates to:
-  /// **'Ta cotisation AVS estimée : {amount}/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6% au-dessus).'**
+  /// **'Ta cotisation AVS estimée : {amount}/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6 % au-dessus).'**
   String independantAvsBody(String amount);
 
   /// No description provided for @independantAvsSource.
@@ -12785,7 +12785,7 @@ abstract class S {
   /// No description provided for @independant3aWithoutLpp.
   ///
   /// In fr, this message translates to:
-  /// **'Sans LPP : plafond 3a \"grand\" de 20% du revenu net, max {amount}/an (plafond légal CHF 36’288).'**
+  /// **'Sans LPP : plafond 3a \"grand\" de 20 % du revenu net, max {amount}/an (plafond légal CHF 36’288).'**
   String independant3aWithoutLpp(String amount);
 
   /// No description provided for @independant3aSource.
@@ -12845,7 +12845,7 @@ abstract class S {
   /// No description provided for @disabilityGapPhase1Full.
   ///
   /// In fr, this message translates to:
-  /// **'100% du salaire'**
+  /// **'100 % du salaire'**
   String get disabilityGapPhase1Full;
 
   /// No description provided for @disabilityGapNoCoverage.
@@ -12869,7 +12869,7 @@ abstract class S {
   /// No description provided for @disabilityGapPhase2Coverage.
   ///
   /// In fr, this message translates to:
-  /// **'80% du salaire ({amount} CHF/mois)'**
+  /// **'80 % du salaire ({amount} CHF/mois)'**
   String disabilityGapPhase2Coverage(String amount);
 
   /// No description provided for @disabilityGapCollectiveInsurance.
@@ -13397,7 +13397,7 @@ abstract class S {
   /// No description provided for @affordabilityEquityRequired.
   ///
   /// In fr, this message translates to:
-  /// **'Fonds propres requis (20%)'**
+  /// **'Fonds propres requis (20 %)'**
   String get affordabilityEquityRequired;
 
   /// No description provided for @affordabilitySavingsLabel.
@@ -13409,7 +13409,7 @@ abstract class S {
   /// No description provided for @affordabilityLppMax10.
   ///
   /// In fr, this message translates to:
-  /// **'Avoir LPP (max 10% du prix)'**
+  /// **'Avoir LPP (max 10 % du prix)'**
   String get affordabilityLppMax10;
 
   /// No description provided for @affordabilityTotalEquity.
@@ -13421,7 +13421,7 @@ abstract class S {
   /// No description provided for @affordabilityMortgagePercent.
   ///
   /// In fr, this message translates to:
-  /// **'Hypothèque ({percent}%)'**
+  /// **'Hypothèque ({percent} %)'**
   String affordabilityMortgagePercent(String percent);
 
   /// No description provided for @affordabilityMonthlyCharges.
@@ -13433,7 +13433,7 @@ abstract class S {
   /// No description provided for @affordabilityCalculationNote.
   ///
   /// In fr, this message translates to:
-  /// **'Calcul théorique : hypothèque x (5% intérêt imputé + 1% amortissement) + prix x 1% frais accessoires. Max 33% du revenu brut.'**
+  /// **'Calcul théorique : hypothèque x (5 % intérêt imputé + 1 % amortissement) + prix x 1 % frais accessoires. Max 33 % du revenu brut.'**
   String get affordabilityCalculationNote;
 
   /// No description provided for @amortizationSource.
@@ -13655,13 +13655,13 @@ abstract class S {
   /// No description provided for @fiscalBelowAverage.
   ///
   /// In fr, this message translates to:
-  /// **'Inférieur à la moyenne suisse (~{rate}%)'**
+  /// **'Inférieur à la moyenne suisse (~{rate} %)'**
   String fiscalBelowAverage(String rate);
 
   /// No description provided for @fiscalAboveAverage.
   ///
   /// In fr, this message translates to:
-  /// **'Supérieur à la moyenne suisse (~{rate}%)'**
+  /// **'Supérieur à la moyenne suisse (~{rate} %)'**
   String fiscalAboveAverage(String rate);
 
   /// No description provided for @fiscalBreakdownTitle.
@@ -14057,7 +14057,7 @@ abstract class S {
   /// No description provided for @expatAvsEducation.
   ///
   /// In fr, this message translates to:
-  /// **'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.'**
+  /// **'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3 %. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.'**
   String get expatAvsEducation;
 
   /// No description provided for @expatYearsInSwitzerland.
@@ -14237,7 +14237,7 @@ abstract class S {
   /// No description provided for @mariageTimelineAct3Insight.
   ///
   /// In fr, this message translates to:
-  /// **'Attention : plafond AVS couple (150% rente max). Planifier rente vs capital.'**
+  /// **'Attention : plafond AVS couple (150 % rente max). Planifier rente vs capital.'**
   String get mariageTimelineAct3Insight;
 
   /// No description provided for @naissanceChecklistItem1Title.
@@ -14285,7 +14285,7 @@ abstract class S {
   /// No description provided for @naissanceChecklistItem4Desc.
   ///
   /// In fr, this message translates to:
-  /// **'Congé maternité : 14 semaines à 80% du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L\'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.'**
+  /// **'Congé maternité : 14 semaines à 80 % du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L\'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.'**
   String get naissanceChecklistItem4Desc;
 
   /// No description provided for @naissanceChecklistItem5Title.
@@ -14549,7 +14549,7 @@ abstract class S {
   /// No description provided for @narrativeConfidenceLabel.
   ///
   /// In fr, this message translates to:
-  /// **'Confiance profil : {score}%'**
+  /// **'Confiance profil : {score} %'**
   String narrativeConfidenceLabel(String score);
 
   /// No description provided for @patrimoineCoupleTitleCouple.
@@ -14639,7 +14639,7 @@ abstract class S {
   /// No description provided for @patrimoineLtvDisplay.
   ///
   /// In fr, this message translates to:
-  /// **'LTV {percent}%'**
+  /// **'LTV {percent} %'**
   String patrimoineLtvDisplay(String percent);
 
   /// No description provided for @patrimoineLpp.
@@ -14825,7 +14825,7 @@ abstract class S {
   /// No description provided for @futurPilier3aSwr.
   ///
   /// In fr, this message translates to:
-  /// **'Pilier 3a (SWR 4%)'**
+  /// **'Pilier 3a (SWR 4 %)'**
   String get futurPilier3aSwr;
 
   /// No description provided for @futurCapitalLabel.
@@ -14837,13 +14837,13 @@ abstract class S {
   /// No description provided for @futurLibrePassageSwr.
   ///
   /// In fr, this message translates to:
-  /// **'Libre passage (SWR 4%)'**
+  /// **'Libre passage (SWR 4 %)'**
   String get futurLibrePassageSwr;
 
   /// No description provided for @futurInvestissementsSwr.
   ///
   /// In fr, this message translates to:
-  /// **'Investissements (SWR 4%)'**
+  /// **'Investissements (SWR 4 %)'**
   String get futurInvestissementsSwr;
 
   /// No description provided for @futurTotalCoupleProjecte.
@@ -14879,7 +14879,7 @@ abstract class S {
   /// No description provided for @futurMargeIncertitude.
   ///
   /// In fr, this message translates to:
-  /// **'Marge d\'incertitude (± {pct}%)'**
+  /// **'Marge d\'incertitude (± {pct} %)'**
   String futurMargeIncertitude(String pct);
 
   /// No description provided for @futurFourchette.
@@ -14897,7 +14897,7 @@ abstract class S {
   /// No description provided for @futurDisclaimer.
   ///
   /// In fr, this message translates to:
-  /// **'Projection éducative — ne constitue pas un conseil (LSFin). SWR 4% = règle des 4%, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.'**
+  /// **'Projection éducative — ne constitue pas un conseil (LSFin). SWR 4 % = règle des 4 %, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.'**
   String get futurDisclaimer;
 
   /// No description provided for @futurExplorerDetails.
@@ -14987,7 +14987,7 @@ abstract class S {
   /// No description provided for @financialSummaryBonusEstime.
   ///
   /// In fr, this message translates to:
-  /// **'Bonus estimé ({pct}%)'**
+  /// **'Bonus estimé ({pct} %)'**
   String financialSummaryBonusEstime(String pct);
 
   /// No description provided for @financialSummaryConjointBrutMensuel.
@@ -15317,19 +15317,19 @@ abstract class S {
   /// No description provided for @financialSummaryLtvAmortissement.
   ///
   /// In fr, this message translates to:
-  /// **'Ratio LTV : {pct}% — amortissement 2ème rang obligatoire'**
+  /// **'Ratio LTV : {pct} % — amortissement 2ème rang obligatoire'**
   String financialSummaryLtvAmortissement(String pct);
 
   /// No description provided for @financialSummaryLtvBonneVoie.
   ///
   /// In fr, this message translates to:
-  /// **'Ratio LTV : {pct}% — en bonne voie'**
+  /// **'Ratio LTV : {pct} % — en bonne voie'**
   String financialSummaryLtvBonneVoie(String pct);
 
   /// No description provided for @financialSummaryLtvExcellent.
   ///
   /// In fr, this message translates to:
-  /// **'Ratio LTV : {pct}% — excellent'**
+  /// **'Ratio LTV : {pct} % — excellent'**
   String financialSummaryLtvExcellent(String pct);
 
   /// No description provided for @financialSummaryPrevoyanceCapital.
@@ -15623,7 +15623,7 @@ abstract class S {
   /// No description provided for @financialSummaryConseilRemboursement.
   ///
   /// In fr, this message translates to:
-  /// **'Rembourse d\'abord la dette à {taux}% avant d\'investir. Chaque CHF remboursé = {taux}% de rendement effectif.'**
+  /// **'Rembourse d\'abord la dette à {taux} % avant d\'investir. Chaque CHF remboursé = {taux} % de rendement effectif.'**
   String financialSummaryConseilRemboursement(String taux);
 
   /// No description provided for @financialSummaryTotalDettes.
@@ -16889,13 +16889,13 @@ abstract class S {
   /// No description provided for @pillar3aBank15.
   ///
   /// In fr, this message translates to:
-  /// **'Banque 1.5%'**
+  /// **'Banque 1.5 %'**
   String get pillar3aBank15;
 
   /// No description provided for @pillar3aViac45.
   ///
   /// In fr, this message translates to:
-  /// **'VIAC 4.5%'**
+  /// **'VIAC 4.5 %'**
   String get pillar3aViac45;
 
   /// No description provided for @pillar3aYearN.
@@ -16907,7 +16907,7 @@ abstract class S {
   /// No description provided for @pillar3aCompoundTip.
   ///
   /// In fr, this message translates to:
-  /// **'Les dernières années font +50% du gain total grâce aux intérêts composés !'**
+  /// **'Les dernières années font +50 % du gain total grâce aux intérêts composés !'**
   String get pillar3aCompoundTip;
 
   /// No description provided for @pillar3aRecommended.
@@ -17015,7 +17015,7 @@ abstract class S {
   /// No description provided for @slmPrivacyMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Le modèle fonctionne 100% sur ton appareil. Aucune donnée ne quitte ton téléphone.'**
+  /// **'Le modèle fonctionne 100 % sur ton appareil. Aucune donnée ne quitte ton téléphone.'**
   String get slmPrivacyMessage;
 
   /// No description provided for @slmDownloadModelTitle.
@@ -17177,7 +17177,7 @@ abstract class S {
   /// No description provided for @pulseDigitalTwinPct.
   ///
   /// In fr, this message translates to:
-  /// **'Jumeau numérique : {pct}%'**
+  /// **'Jumeau numérique : {pct} %'**
   String pulseDigitalTwinPct(String pct);
 
   /// No description provided for @pulseDigitalTwinHint.
@@ -18277,13 +18277,13 @@ abstract class S {
   /// No description provided for @spendingMeterVariablesLegend.
   ///
   /// In fr, this message translates to:
-  /// **'Variables {percent}%'**
+  /// **'Variables {percent} %'**
   String spendingMeterVariablesLegend(int percent);
 
   /// No description provided for @spendingMeterFuturLegend.
   ///
   /// In fr, this message translates to:
-  /// **'Futur {percent}%'**
+  /// **'Futur {percent} %'**
   String spendingMeterFuturLegend(int percent);
 
   /// No description provided for @avsGuideAppBarTitle.
@@ -18565,7 +18565,7 @@ abstract class S {
   /// No description provided for @dataBlockFiscaliteDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d\'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu\'estimé (coefficient communal 60%-130%).'**
+  /// **'Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d\'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu\'estimé (coefficient communal 60 %-130 %).'**
   String get dataBlockFiscaliteDesc;
 
   /// No description provided for @dataBlockFiscaliteCta.
@@ -19297,7 +19297,7 @@ abstract class S {
   /// No description provided for @frontalierQuasiResidentDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.'**
+  /// **'Si plus de 90 % de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.'**
   String get frontalierQuasiResidentDesc;
 
   /// No description provided for @frontalierTessinTitle.
@@ -19309,7 +19309,7 @@ abstract class S {
   /// No description provided for @frontalierEducationalTax.
   ///
   /// In fr, this message translates to:
-  /// **'En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l\'état civil et le nombre d\'enfants. À Genève, si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.'**
+  /// **'En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l\'état civil et le nombre d\'enfants. À Genève, si plus de 90 % de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.'**
   String get frontalierEducationalTax;
 
   /// No description provided for @frontalierJoursBureau.
@@ -19387,7 +19387,7 @@ abstract class S {
   /// No description provided for @frontalierDuSalaire.
   ///
   /// In fr, this message translates to:
-  /// **'{percent}% du salaire'**
+  /// **'{percent} % du salaire'**
   String frontalierDuSalaire(String percent);
 
   /// No description provided for @frontalierChargesChMoins.
@@ -19429,7 +19429,7 @@ abstract class S {
   /// No description provided for @frontalierCmuDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Droit d\'option possible pour les frontaliers FR. Cotisation ~8% du revenu fiscal.'**
+  /// **'Droit d\'option possible pour les frontaliers FR. Cotisation ~8 % du revenu fiscal.'**
   String get frontalierCmuDesc;
 
   /// No description provided for @frontalierAssurancePriveeTitle.
@@ -19573,7 +19573,7 @@ abstract class S {
   /// No description provided for @concubinageConcubinTaux.
   ///
   /// In fr, this message translates to:
-  /// **'Concubin-e (~{taux}%)'**
+  /// **'Concubin-e (~{taux} %)'**
   String concubinageConcubinTaux(String taux);
 
   /// No description provided for @concubinageWarningSuccession.
@@ -21211,13 +21211,13 @@ abstract class S {
   /// No description provided for @docImpactRenteOblig.
   ///
   /// In fr, this message translates to:
-  /// **'Rente obligatoire à 6.8% : CHF {amount}/an'**
+  /// **'Rente obligatoire à 6.8 % : CHF {amount}/an'**
   String docImpactRenteOblig(String amount);
 
   /// No description provided for @docImpactSurobligWithRate.
   ///
   /// In fr, this message translates to:
-  /// **'Part surobligatoire (CHF {suroblig}) à {rate}% = CHF {rente}/an'**
+  /// **'Part surobligatoire (CHF {suroblig}) à {rate} % = CHF {rente}/an'**
   String docImpactSurobligWithRate(String suroblig, String rate, String rente);
 
   /// No description provided for @docImpactSurobligNoRate.
@@ -21235,7 +21235,7 @@ abstract class S {
   /// No description provided for @docImpactAvsCompletion.
   ///
   /// In fr, this message translates to:
-  /// **'sur {maxYears} nécessaires pour une rente AVS complète ({pct}%)'**
+  /// **'sur {maxYears} nécessaires pour une rente AVS complète ({pct} %)'**
   String docImpactAvsCompletion(int maxYears, int pct);
 
   /// No description provided for @docImpactGenericMessage.
@@ -21289,7 +21289,7 @@ abstract class S {
   /// No description provided for @extractionReviewConfidence.
   ///
   /// In fr, this message translates to:
-  /// **'Confiance extraction : {pct}%'**
+  /// **'Confiance extraction : {pct} %'**
   String extractionReviewConfidence(int pct);
 
   /// No description provided for @extractionReviewSourcePrefix.
@@ -21409,7 +21409,7 @@ abstract class S {
   /// No description provided for @firstSalaryNetPercent.
   ///
   /// In fr, this message translates to:
-  /// **'{pct}% net'**
+  /// **'{pct} % net'**
   String firstSalaryNetPercent(int pct);
 
   /// No description provided for @firstSalaryAct2Title.
@@ -21619,13 +21619,13 @@ abstract class S {
   /// No description provided for @firstSalaryBadgeSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Tu sais maintenant ce que 90% des gens ne savent jamais.'**
+  /// **'Tu sais maintenant ce que 90 % des gens ne savent jamais.'**
   String get firstSalaryBadgeSubtitle;
 
   /// No description provided for @firstSalaryDisclaimer.
   ///
   /// In fr, this message translates to:
-  /// **'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7\'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4%/an.'**
+  /// **'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7\'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4 %/an.'**
   String get firstSalaryDisclaimer;
 
   /// No description provided for @benchmarkAppBarTitle.
@@ -23816,7 +23816,7 @@ abstract class S {
   /// No description provided for @dashboardCurrentConfidence.
   ///
   /// In fr, this message translates to:
-  /// **'Confiance actuelle : {score}%'**
+  /// **'Confiance actuelle : {score} %'**
   String dashboardCurrentConfidence(int score);
 
   /// No description provided for @dashboardPrecisionPtsGain.
@@ -23912,7 +23912,7 @@ abstract class S {
   /// No description provided for @dashboardPrecisionGainPercent.
   ///
   /// In fr, this message translates to:
-  /// **'Précision +{percent}%'**
+  /// **'Précision +{percent} %'**
   String dashboardPrecisionGainPercent(int percent);
 
   /// No description provided for @dashboardImpactChf.
@@ -25238,7 +25238,7 @@ abstract class S {
   /// No description provided for @expatSavingsBadge.
   ///
   /// In fr, this message translates to:
-  /// **'Économie : {amount} (-{percent}%)'**
+  /// **'Économie : {amount} (-{percent} %)'**
   String expatSavingsBadge(String amount, String percent);
 
   /// No description provided for @expatForfaitMoreCostly.
@@ -25256,7 +25256,7 @@ abstract class S {
   /// No description provided for @expatAvsReductionExplain.
   ///
   /// In fr, this message translates to:
-  /// **'Chaque année manquante réduit ta rente d\'environ {percent}%. La réduction est définitive et s\'applique à vie.'**
+  /// **'Chaque année manquante réduit ta rente d\'environ {percent} %. La réduction est définitive et s\'applique à vie.'**
   String expatAvsReductionExplain(String percent);
 
   /// No description provided for @expatAvsChiffreChoc.
@@ -25742,7 +25742,7 @@ abstract class S {
   /// No description provided for @genderGapRevenuAnnuel.
   ///
   /// In fr, this message translates to:
-  /// **'Revenu annuel brut (100%)'**
+  /// **'Revenu annuel brut (100 %)'**
   String get genderGapRevenuAnnuel;
 
   /// No description provided for @genderGapAge.
@@ -25796,13 +25796,13 @@ abstract class S {
   /// No description provided for @genderGapAt100.
   ///
   /// In fr, this message translates to:
-  /// **'À 100%'**
+  /// **'À 100 %'**
   String get genderGapAt100;
 
   /// No description provided for @genderGapAtTaux.
   ///
   /// In fr, this message translates to:
-  /// **'À {taux}%'**
+  /// **'À {taux} %'**
   String genderGapAtTaux(String taux);
 
   /// No description provided for @genderGapPerYear.
@@ -25832,31 +25832,31 @@ abstract class S {
   /// No description provided for @genderGapCoordinationBody.
   ///
   /// In fr, this message translates to:
-  /// **'La déduction de coordination est un montant fixe de CHF 26\'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100% ou à 50%.'**
+  /// **'La déduction de coordination est un montant fixe de CHF 26\'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100 % ou à 50 %.'**
   String get genderGapCoordinationBody;
 
   /// No description provided for @genderGapSalaireBrut100.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire brut à 100%'**
+  /// **'Salaire brut à 100 %'**
   String get genderGapSalaireBrut100;
 
   /// No description provided for @genderGapSalaireCoordonne100.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire coordonné à 100%'**
+  /// **'Salaire coordonné à 100 %'**
   String get genderGapSalaireCoordonne100;
 
   /// No description provided for @genderGapSalaireBrutTaux.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire brut à {taux}%'**
+  /// **'Salaire brut à {taux} %'**
   String genderGapSalaireBrutTaux(String taux);
 
   /// No description provided for @genderGapSalaireCoordonneTaux.
   ///
   /// In fr, this message translates to:
-  /// **'Salaire coordonné à {taux}%'**
+  /// **'Salaire coordonné à {taux} %'**
   String genderGapSalaireCoordonneTaux(String taux);
 
   /// No description provided for @genderGapDeductionFixe.
@@ -25898,7 +25898,7 @@ abstract class S {
   /// No description provided for @genderGapSourcesBody.
   ///
   /// In fr, this message translates to:
-  /// **'LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8%) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)'**
+  /// **'LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8 %) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)'**
   String get genderGapSourcesBody;
 
   /// No description provided for @achievementsErrorMessage.
@@ -25916,7 +25916,7 @@ abstract class S {
   /// No description provided for @documentsConfidenceChoc.
   ///
   /// In fr, this message translates to:
-  /// **'{count} documents = {pct}% de confiance'**
+  /// **'{count} documents = {pct} % de confiance'**
   String documentsConfidenceChoc(String count, String pct);
 
   /// No description provided for @lamalFranchiseAppBarTitle.
@@ -28136,7 +28136,7 @@ abstract class S {
   /// No description provided for @eplImpactRenteNote.
   ///
   /// In fr, this message translates to:
-  /// **'Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2%, taux de conversion 6.8%. Le montant réel dépend de ta situation.'**
+  /// **'Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2 %, taux de conversion 6.8 %. Le montant réel dépend de ta situation.'**
   String get eplImpactRenteNote;
 
   /// No description provided for @eplSectionFiscale.
@@ -28418,7 +28418,7 @@ abstract class S {
   /// No description provided for @providerComparatorAssuranceNote.
   ///
   /// In fr, this message translates to:
-  /// **'Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5%) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.'**
+  /// **'Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5 %) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.'**
   String get providerComparatorAssuranceNote;
 
   /// No description provided for @documentDetailFieldsExtracted.
@@ -29240,7 +29240,7 @@ abstract class S {
   /// No description provided for @compoundGainsPercent.
   ///
   /// In fr, this message translates to:
-  /// **'{percent}% de ce montant provient uniquement de tes gains de placement.'**
+  /// **'{percent} % de ce montant provient uniquement de tes gains de placement.'**
   String compoundGainsPercent(String percent);
 
   /// No description provided for @compoundLeconsTitle.
@@ -29414,7 +29414,7 @@ abstract class S {
   /// No description provided for @creditMentorBody.
   ///
   /// In fr, this message translates to:
-  /// **'En Suisse, un crédit coûte entre 4% et 10%. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.'**
+  /// **'En Suisse, un crédit coûte entre 4 % et 10 %. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.'**
   String get creditMentorBody;
 
   /// No description provided for @creditParametres.
@@ -29456,7 +29456,7 @@ abstract class S {
   /// No description provided for @creditRateWarning.
   ///
   /// In fr, this message translates to:
-  /// **'Attention : Ce taux dépasse le max légal suisse de 10%.'**
+  /// **'Attention : Ce taux dépasse le max légal suisse de 10 %.'**
   String get creditRateWarning;
 
   /// No description provided for @creditConseilsTitle.
@@ -29486,7 +29486,7 @@ abstract class S {
   /// No description provided for @creditCercleConfianceBody.
   ///
   /// In fr, this message translates to:
-  /// **'Un prêt familial peut souvent être obtenu à 0% d\'intérêt.'**
+  /// **'Un prêt familial peut souvent être obtenu à 0 % d\'intérêt.'**
   String get creditCercleConfianceBody;
 
   /// No description provided for @creditDettesConseils.
@@ -30320,13 +30320,13 @@ abstract class S {
   /// No description provided for @dividendeSplitMin.
   ///
   /// In fr, this message translates to:
-  /// **'0% salaire'**
+  /// **'0 % salaire'**
   String get dividendeSplitMin;
 
   /// No description provided for @dividendeSplitMax.
   ///
   /// In fr, this message translates to:
-  /// **'100% salaire'**
+  /// **'100 % salaire'**
   String get dividendeSplitMax;
 
   /// No description provided for @disabilityInsAppBarTitle.
@@ -34071,7 +34071,7 @@ abstract class S {
   /// No description provided for @benchmarkInsightSavings.
   ///
   /// In fr, this message translates to:
-  /// **'Un profil similaire épargne environ {rate}% de son revenu'**
+  /// **'Un profil similaire épargne environ {rate} % de son revenu'**
   String benchmarkInsightSavings(String rate);
 
   /// No description provided for @benchmarkInsightTax.
@@ -34089,13 +34089,13 @@ abstract class S {
   /// No description provided for @benchmarkInsight3a.
   ///
   /// In fr, this message translates to:
-  /// **'Environ {rate}% des actifs versent dans le 3a'**
+  /// **'Environ {rate} % des actifs versent dans le 3a'**
   String benchmarkInsight3a(String rate);
 
   /// No description provided for @benchmarkInsightLpp.
   ///
   /// In fr, this message translates to:
-  /// **'Le taux de couverture LPP est de {rate}%'**
+  /// **'Le taux de couverture LPP est de {rate} %'**
   String benchmarkInsightLpp(String rate);
 
   /// No description provided for @benchmarkTaxLevelBelow.
@@ -35959,7 +35959,7 @@ abstract class S {
   /// No description provided for @notifOffTrackBody.
   ///
   /// In fr, this message translates to:
-  /// **'Adhérence à {adherence}% sur {total} actions. Indication linéaire (hors rendement/fiscalité) : ~CHF {impact}.'**
+  /// **'Adhérence à {adherence} % sur {total} actions. Indication linéaire (hors rendement/fiscalité) : ~CHF {impact}.'**
   String notifOffTrackBody(String adherence, String total, String impact);
 
   /// No description provided for @agentTaskTaxDeclarationTitle.
@@ -36817,7 +36817,7 @@ abstract class S {
   /// No description provided for @firstJobPayslipAvsExplanation.
   ///
   /// In fr, this message translates to:
-  /// **'Cotisation salarié·e : 5.3% du brut. Ton employeur paie aussi 5.3% en plus.'**
+  /// **'Cotisation salarié·e : 5.3 % du brut. Ton employeur paie aussi 5.3 % en plus.'**
   String get firstJobPayslipAvsExplanation;
 
   /// No description provided for @firstJobPayslipLppLabel.
@@ -36877,7 +36877,7 @@ abstract class S {
   /// No description provided for @firstJobChecklistConsequence2.
   ///
   /// In fr, this message translates to:
-  /// **'Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05%.'**
+  /// **'Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05 %.'**
   String get firstJobChecklistConsequence2;
 
   /// No description provided for @firstJobChecklistDeadline3.
@@ -37009,7 +37009,7 @@ abstract class S {
   /// No description provided for @firstJobScenarioBoosted.
   ///
   /// In fr, this message translates to:
-  /// **'+20%'**
+  /// **'+20 %'**
   String get firstJobScenarioBoosted;
 
   /// No description provided for @firstJobScenarioSemantics.
@@ -37777,7 +37777,7 @@ abstract class S {
   /// No description provided for @disabilityGapAct2SubIjm.
   ///
   /// In fr, this message translates to:
-  /// **'Assurance collective — 80% pendant 720 jours max'**
+  /// **'Assurance collective — 80 % pendant 720 jours max'**
   String get disabilityGapAct2SubIjm;
 
   /// No description provided for @disabilityGapAct2SubNoIjm.
@@ -37795,7 +37795,7 @@ abstract class S {
   /// No description provided for @disabilityGapAct2DetailIjm.
   ///
   /// In fr, this message translates to:
-  /// **'80% du salaire assuré'**
+  /// **'80 % du salaire assuré'**
   String get disabilityGapAct2DetailIjm;
 
   /// No description provided for @disabilityGapAct2DetailNoIjm.
@@ -37826,7 +37826,7 @@ abstract class S {
   /// No description provided for @disabilityGapIjmCoverage.
   ///
   /// In fr, this message translates to:
-  /// **'80% pendant 720 jours — assurance collective'**
+  /// **'80 % pendant 720 jours — assurance collective'**
   String get disabilityGapIjmCoverage;
 
   /// No description provided for @disabilityGapNoIjmCoverage.
@@ -37844,7 +37844,7 @@ abstract class S {
   /// No description provided for @disabilityGapLppCovered.
   ///
   /// In fr, this message translates to:
-  /// **'Rente invalidité ≈ 40% salaire coordonné (LPP art. 23)'**
+  /// **'Rente invalidité ≈ 40 % salaire coordonné (LPP art. 23)'**
   String get disabilityGapLppCovered;
 
   /// No description provided for @disabilityGapLppNotCovered.
@@ -37934,7 +37934,7 @@ abstract class S {
   /// No description provided for @documentDetailExplanationTauxOblig.
   ///
   /// In fr, this message translates to:
-  /// **'Légal minimum : 6.8%'**
+  /// **'Légal minimum : 6.8 %'**
   String get documentDetailExplanationTauxOblig;
 
   /// No description provided for @documentDetailExplanationTauxSurob.
@@ -38048,7 +38048,7 @@ abstract class S {
   /// No description provided for @disabilitySelfEmployedApgTip.
   ///
   /// In fr, this message translates to:
-  /// **'Une APG individuelle dès CHF 45/mois peut couvrir 80% de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.'**
+  /// **'Une APG individuelle dès CHF 45/mois peut couvrir 80 % de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.'**
   String get disabilitySelfEmployedApgTip;
 
   /// No description provided for @disabilitySelfEmployedDisclaimer.
@@ -42488,7 +42488,7 @@ abstract class S {
   /// No description provided for @indepGrand3aSub.
   ///
   /// In fr, this message translates to:
-  /// **'20% du revenu net, max CHF 36\'288/an'**
+  /// **'20 % du revenu net, max CHF 36\'288/an'**
   String get indepGrand3aSub;
 
   /// No description provided for @indepGrand3aProFlexibilite.
@@ -42554,7 +42554,7 @@ abstract class S {
   /// No description provided for @indepFiscal3aNote.
   ///
   /// In fr, this message translates to:
-  /// **'Max 20% du revenu net, plafonné à CHF 36\'288/an sans LPP'**
+  /// **'Max 20 % du revenu net, plafonné à CHF 36\'288/an sans LPP'**
   String get indepFiscal3aNote;
 
   /// No description provided for @indepFiscalFraisPro.
@@ -42710,13 +42710,13 @@ abstract class S {
   /// No description provided for @donationReserveBarLabel.
   ///
   /// In fr, this message translates to:
-  /// **'Réserve {pct}%'**
+  /// **'Réserve {pct} %'**
   String donationReserveBarLabel(String pct);
 
   /// No description provided for @donationDisponibleBarLabel.
   ///
   /// In fr, this message translates to:
-  /// **'Disponible {pct}%'**
+  /// **'Disponible {pct} %'**
   String donationDisponibleBarLabel(String pct);
 
   /// No description provided for @donationDisclaimerFallback.
@@ -43353,7 +43353,7 @@ abstract class S {
   /// No description provided for @capCoachPromptReplacement.
   ///
   /// In fr, this message translates to:
-  /// **'Mon taux de remplacement est de {rate}%. Est-ce suffisant pour ma retraite ?'**
+  /// **'Mon taux de remplacement est de {rate} %. Est-ce suffisant pour ma retraite ?'**
   String capCoachPromptReplacement(Object rate);
 
   /// No description provided for @capCoachPromptUnemployment.

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -34,7 +34,7 @@ class SFr extends S {
   String get landingFeature1Desc => 'Analyse 360° en 5 min chrono.';
 
   @override
-  String get landingFeature2Title => '100% Privé & Local';
+  String get landingFeature2Title => '100 % Privé & Local';
 
   @override
   String get landingFeature2Desc => 'Tes données restent sur ton device.';
@@ -225,7 +225,7 @@ class SFr extends S {
 
   @override
   String advisorMiniResumeDiagnostic(String progress) {
-    return 'Reprendre mon diagnostic ($progress%)';
+    return 'Reprendre mon diagnostic ($progress %)';
   }
 
   @override
@@ -779,10 +779,10 @@ class SFr extends S {
   String get profileStatusMissing => 'Manquant';
 
   @override
-  String get profileReward15 => '+15% de précision';
+  String get profileReward15 => '+15 % de précision';
 
   @override
-  String get profileReward10 => '+10% de précision';
+  String get profileReward10 => '+10 % de précision';
 
   @override
   String get profileSecurityTitle => 'Sécurité & Data';
@@ -852,17 +852,17 @@ class SFr extends S {
   String get rentVsCapitalJamais => 'Jamais';
 
   @override
-  String get rentVsCapitalPrudent => 'Prudent (1%)';
+  String get rentVsCapitalPrudent => 'Prudent (1 %)';
 
   @override
-  String get rentVsCapitalCentral => 'Central (3%)';
+  String get rentVsCapitalCentral => 'Central (3 %)';
 
   @override
-  String get rentVsCapitalOptimiste => 'Optimiste (5%)';
+  String get rentVsCapitalOptimiste => 'Optimiste (5 %)';
 
   @override
   String get rentVsCapitalTauxConversionExpl =>
-      'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3% et 6%.';
+      'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.';
 
   @override
   String get rentVsCapitalChoixExpl =>
@@ -936,7 +936,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapIjmExpl =>
-      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.';
+      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.';
 
   @override
   String get disabilityGapCo324aExpl =>
@@ -1248,7 +1248,7 @@ class SFr extends S {
 
   @override
   String documentsConfidence(String confidence) {
-    return 'Confiance : $confidence%';
+    return 'Confiance : $confidence %';
   }
 
   @override
@@ -1597,7 +1597,7 @@ class SFr extends S {
 
   @override
   String get jobCompareEducational =>
-      'Le salaire invisible représente 10-30% de ta rémunération totale.';
+      'Le salaire invisible représente 10-30 % de ta rémunération totale.';
 
   @override
   String get jobCompareVerdictBetter =>
@@ -2095,12 +2095,12 @@ class SFr extends S {
 
   @override
   String coachingDebtTitle(String ratio) {
-    return 'Taux d\'endettement élevé ($ratio%)';
+    return 'Taux d\'endettement élevé ($ratio %)';
   }
 
   @override
   String coachingDebtMessage(String ratio) {
-    return 'Ton taux d\'endettement estimé est de $ratio%, au-dessus du seuil de 33% recommandé par les banques suisses.';
+    return 'Ton taux d\'endettement estimé est de $ratio %, au-dessus du seuil de 33 % recommandé par les banques suisses.';
   }
 
   @override
@@ -2111,7 +2111,7 @@ class SFr extends S {
 
   @override
   String coachingPartTimeMessage(String rate) {
-    return 'À $rate% d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.';
+    return 'À $rate % d\'activité, ta prévoyance professionnelle est réduite. La déduction de coordination pénalise davantage les temps partiels.';
   }
 
   @override
@@ -2244,7 +2244,7 @@ class SFr extends S {
   String get segmentsGenderGapParams => 'Paramètres';
 
   @override
-  String get segmentsGenderGapRevenuLabel => 'Revenu annuel brut (100%)';
+  String get segmentsGenderGapRevenuLabel => 'Revenu annuel brut (100 %)';
 
   @override
   String get segmentsGenderGapAgeLabel => 'Âge';
@@ -2267,11 +2267,11 @@ class SFr extends S {
   }
 
   @override
-  String get segmentsGenderGapAt100 => 'À 100%';
+  String get segmentsGenderGapAt100 => 'À 100 %';
 
   @override
   String segmentsGenderGapAtCurrent(String rate) {
-    return 'À $rate%';
+    return 'À $rate %';
   }
 
   @override
@@ -2286,22 +2286,22 @@ class SFr extends S {
 
   @override
   String get segmentsGenderGapCoordinationBody =>
-      'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100% ou à 50%.';
+      'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100 % ou à 50 %.';
 
   @override
-  String get segmentsGenderGapSalaireBrut100 => 'Salaire brut à 100%';
+  String get segmentsGenderGapSalaireBrut100 => 'Salaire brut à 100 %';
 
   @override
-  String get segmentsGenderGapSalaireCoord100 => 'Salaire coordonné à 100%';
+  String get segmentsGenderGapSalaireCoord100 => 'Salaire coordonné à 100 %';
 
   @override
   String segmentsGenderGapSalaireBrutCurrent(String rate) {
-    return 'Salaire brut à $rate%';
+    return 'Salaire brut à $rate %';
   }
 
   @override
   String segmentsGenderGapSalaireCoordCurrent(String rate) {
-    return 'Salaire coordonné à $rate%';
+    return 'Salaire coordonné à $rate %';
   }
 
   @override
@@ -2312,7 +2312,7 @@ class SFr extends S {
 
   @override
   String get segmentsGenderGapOfsStat =>
-      'En Suisse, les femmes touchent en moyenne 37% de rente de moins que les hommes (OFS 2024)';
+      'En Suisse, les femmes touchent en moyenne 37 % de rente de moins que les hommes (OFS 2024)';
 
   @override
   String get segmentsGenderGapRecTitle => 'RECOMMANDATIONS';
@@ -2400,11 +2400,11 @@ class SFr extends S {
 
   @override
   String get segmentsFrontalierQuasiResidentDesc =>
-      'Le statut de quasi-résident est accessible si au moins 90% des revenus de votre ménage proviennent de Suisse.';
+      'Le statut de quasi-résident est accessible si au moins 90 % des revenus de votre ménage proviennent de Suisse.';
 
   @override
   String get segmentsFrontalierQuasiResidentCondition =>
-      'Condition : >= 90% des revenus du ménage provenant de Suisse';
+      'Condition : >= 90 % des revenus du ménage provenant de Suisse';
 
   @override
   String get segmentsFrontalierChecklist => 'Checklist frontalier';
@@ -2523,7 +2523,7 @@ class SFr extends S {
 
   @override
   String get segmentsIndependant3aWithoutLpp =>
-      'Sans LPP : plafond 3a \'grand\' de 20% du revenu net, max CHF 36\'288/an.';
+      'Sans LPP : plafond 3a \'grand\' de 20 % du revenu net, max CHF 36\'288/an.';
 
   @override
   String get segmentsIndependantRecTitle => 'RECOMMANDATIONS';
@@ -2597,7 +2597,7 @@ class SFr extends S {
       'Rappel : modification possible avant le 30 novembre';
 
   @override
-  String get assurancesLamalQuotePart => 'Quote-part (10%, max 700 CHF)';
+  String get assurancesLamalQuotePart => 'Quote-part (10 %, max 700 CHF)';
 
   @override
   String get assurancesCoverageTitle => 'Check-up couverture';
@@ -3354,7 +3354,7 @@ class SFr extends S {
 
   @override
   String get coachFactAvs =>
-      'En Suisse, chaque année AVS manquante = −2.3% de rente à vie. Un rattrapage est possible dans certains cas.';
+      'En Suisse, chaque année AVS manquante = −2.3 % de rente à vie. Un rattrapage est possible dans certains cas.';
 
   @override
   String get coachFactAvsLink => 'Vérifier mes années AVS';
@@ -3958,7 +3958,7 @@ class SFr extends S {
 
   @override
   String vaultConfidence(String confidence) {
-    return 'Confiance : $confidence%';
+    return 'Confiance : $confidence %';
   }
 
   @override
@@ -4123,7 +4123,7 @@ class SFr extends S {
   String get soaSavingsRate => 'Taux d\'épargne';
 
   @override
-  String get soaSavingsGoal => 'Objectif: 20%';
+  String get soaSavingsGoal => 'Objectif: 20 %';
 
   @override
   String get soaProtectionScore => 'Score Protection';
@@ -4233,7 +4233,7 @@ class SFr extends S {
   @override
   String agirScenarioBriefSummary(
       String years, String baseCapital, String replacement, String gapCapital) {
-    return 'Dans ~$years ans, ton scénario Base vise $baseCapital (~$replacement% de remplacement). L\'écart Prudent vs Optimiste est $gapCapital.';
+    return 'Dans ~$years ans, ton scénario Base vise $baseCapital (~$replacement % de remplacement). L\'écart Prudent vs Optimiste est $gapCapital.';
   }
 
   @override
@@ -4288,7 +4288,7 @@ class SFr extends S {
 
   @override
   String coachDataQualityBody(String dataPoints, String percentage) {
-    return 'Calcul actuel: $dataPoints donnees saisies ($percentage%). Les postes non renseignes restent en estimation jusqu au diagnostic complet.';
+    return 'Calcul actuel: $dataPoints donnees saisies ($percentage %). Les postes non renseignes restent en estimation jusqu au diagnostic complet.';
   }
 
   @override
@@ -4325,7 +4325,7 @@ class SFr extends S {
   @override
   String profileCoachKnowledgeSummary(String profileState, String precision,
       String checkins, String scorePart) {
-    return '$profileState • Precision $precision% • Check-ins: $checkins$scorePart';
+    return '$profileState • Precision $precision % • Check-ins: $checkins$scorePart';
   }
 
   @override
@@ -4460,7 +4460,7 @@ class SFr extends S {
 
   @override
   String coachEnrichTargetTitle(String current, String target) {
-    return 'Passe de $current% a $target% de precision';
+    return 'Passe de $current % a $target % de precision';
   }
 
   @override
@@ -4500,7 +4500,7 @@ class SFr extends S {
 
   @override
   String coachAgirPartialTitle(String quality) {
-    return 'Plan en construction ($quality%)';
+    return 'Plan en construction ($quality %)';
   }
 
   @override
@@ -4567,7 +4567,7 @@ class SFr extends S {
 
   @override
   String landingDropPurchasingPower(String percent) {
-    return '-$percent% de pouvoir d\'achat';
+    return '-$percent % de pouvoir d\'achat';
   }
 
   @override
@@ -4608,7 +4608,7 @@ class SFr extends S {
 
   @override
   String get landingFeaturePrivacyTitle =>
-      '100% privé, données sur ton appareil';
+      '100 % privé, données sur ton appareil';
 
   @override
   String get landingFeaturePrivacySubtitle =>
@@ -4618,7 +4618,7 @@ class SFr extends S {
   String get landingTrustSwiss => 'Conçu en Suisse';
 
   @override
-  String get landingTrustPrivate => '100% privé';
+  String get landingTrustPrivate => '100 % privé';
 
   @override
   String get landingTrustNoCommitment => 'Sans engagement';
@@ -4815,7 +4815,7 @@ class SFr extends S {
   String get dashboardMetricMonthlyGap => 'Écart mensuel';
 
   @override
-  String get dashboardMetricVsTarget => 'Vs cible 70% du salaire brut';
+  String get dashboardMetricVsTarget => 'Vs cible 70 % du salaire brut';
 
   @override
   String get dashboardNextActionLabel => 'Améliorer ta précision';
@@ -5888,7 +5888,7 @@ class SFr extends S {
   String get mariageAvsSurvivor => 'Rente AVS de survivant';
 
   @override
-  String get mariageAvsSurvivorSub => '80% de la rente maximale du défunt';
+  String get mariageAvsSurvivorSub => '80 % de la rente maximale du défunt';
 
   @override
   String get mariageAvsSurvivorFootnote =>
@@ -5898,7 +5898,7 @@ class SFr extends S {
   String get mariageLppSurvivor => 'Rente LPP de survivant';
 
   @override
-  String get mariageLppSurvivorSub => '60% de la rente assurée du défunt';
+  String get mariageLppSurvivorSub => '60 % de la rente assurée du défunt';
 
   @override
   String get mariageLppSurvivorFootnote =>
@@ -6090,7 +6090,7 @@ class SFr extends S {
 
   @override
   String get unemploymentSituationSubtitle =>
-      'Influence le taux d\'indemnisation (70% ou 80%)';
+      'Influence le taux d\'indemnisation (70 % ou 80 %)';
 
   @override
   String get unemploymentChildrenToggle => 'Obligation d\'entretien (enfants)';
@@ -6106,11 +6106,11 @@ class SFr extends S {
 
   @override
   String get unemploymentRateEnhanced =>
-      'Taux majoré (80%) : obligation d\'entretien, handicap, ou salaire < CHF 3\'797';
+      'Taux majoré (80 %) : obligation d\'entretien, handicap, ou salaire < CHF 3\'797';
 
   @override
   String get unemploymentRateStandard =>
-      'Taux standard (70%) : applicable dans les autres situations';
+      'Taux standard (70 %) : applicable dans les autres situations';
 
   @override
   String get unemploymentDailyBenefit => 'Indemnité /jour';
@@ -6255,7 +6255,7 @@ class SFr extends S {
 
   @override
   String get firstJobEduBudgetBody =>
-      'Un bon réflexe pour ton premier salaire : 50% pour les dépenses fixes, 30% pour les loisirs, 20% pour l\'épargne et la prévoyance (3a inclus).';
+      'Un bon réflexe pour ton premier salaire : 50 % pour les dépenses fixes, 30 % pour les loisirs, 20 % pour l\'épargne et la prévoyance (3a inclus).';
 
   @override
   String get firstJobEduTaxTitle => 'Déclaration fiscale';
@@ -6342,7 +6342,7 @@ class SFr extends S {
 
   @override
   String get independantSourcesBody =>
-      'LPP art. 4 (pas d\'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20% du revenu net, max 36\'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal';
+      'LPP art. 4 (pas d\'obligation pour indépendants) / LPP art. 44 (affiliation volontaire) / OPP3 art. 7 (3a grand : 20 % du revenu net, max 36\'288) / LAVS art. 8 (cotisations indépendants) / LAA art. 4 / LAMal';
 
   @override
   String get independantDisclaimer =>
@@ -6400,7 +6400,7 @@ class SFr extends S {
 
   @override
   String get jobCompareEduInvisibleBody =>
-      'Le \"salaire invisible\" représente 10-30% de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.';
+      'Le \"salaire invisible\" représente 10-30 % de ta rémunération totale. Il inclut la part employeur à la caisse de pension (LPP), les assurances (IJM, accident), et parfois des avantages complémentaires. Deux postes au même salaire brut peuvent offrir des protections très différentes.';
 
   @override
   String get jobCompareEduCertTitle =>
@@ -6493,7 +6493,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapEduIjmBody =>
-      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80% de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu\'à l\'éventuelle rente AI.';
+      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne recevez plus rien jusqu\'à l\'éventuelle rente AI.';
 
   @override
   String get disabilityGapEduCoTitle =>
@@ -6632,7 +6632,7 @@ class SFr extends S {
 
   @override
   String get mariageChecklistItem6Desc =>
-      'La rente AVS maximale pour un couple est plafonnée à 150% de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.';
+      'La rente AVS maximale pour un couple est plafonnée à 150 % de la rente individuelle maximale (LAVS art. 35). Si tu as droit à la rente max avec ton conjoint, le plafond peut réduire ton total.';
 
   @override
   String get mariageChecklistItem7Title => 'Adapter le testament';
@@ -6682,7 +6682,7 @@ class SFr extends S {
 
   @override
   String successionQuotitePct(String pct) {
-    return 'soit $pct% de la succession';
+    return 'soit $pct % de la succession';
   }
 
   @override
@@ -6703,7 +6703,7 @@ class SFr extends S {
 
   @override
   String get successionEduConcubinBody2 =>
-      'En droit suisse, les concubins n\'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l\'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25% au lieu de 0%). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d\'envisager des assurances-vie.';
+      'En droit suisse, les concubins n\'ont AUCUN droit successoral légal. Sans testament, un concubin ne reçoit rien. De plus, l\'impôt successoral pour les concubins est généralement bien plus élevé que pour les conjoints (souvent 20-25 % au lieu de 0 %). Pour protéger ton/ta concubin·e, il est essentiel de rédiger un testament, de vérifier les clauses bénéficiaires 3a/LPP et d\'envisager des assurances-vie.';
 
   @override
   String get successionDisclaimerText =>
@@ -6763,7 +6763,7 @@ class SFr extends S {
 
   @override
   String donationTauxCanton(String taux, String canton) {
-    return 'Taux : $taux% (canton $canton)';
+    return 'Taux : $taux % (canton $canton)';
   }
 
   @override
@@ -6781,7 +6781,7 @@ class SFr extends S {
 
   @override
   String get donationReserveNote =>
-      'Depuis 2023, les parents n\'ont plus de réserve. La réserve des descendants est de 50% de leur part légale (CC art. 471).';
+      'Depuis 2023, les parents n\'ont plus de réserve. La réserve des descendants est de 50 % de leur part légale (CC art. 471).';
 
   @override
   String get donationQuotiteTitle => 'QUOTITÉ DISPONIBLE';
@@ -6826,7 +6826,7 @@ class SFr extends S {
 
   @override
   String get donationEduConcubinBody =>
-      'Les concubins n\'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l\'impôt cantonal sur les donations entre concubins est généralement élevé (18-25% selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.';
+      'Les concubins n\'ont aucun droit successoral légal en Suisse. Une donation est le moyen le plus direct de les avantager. Cependant, l\'impôt cantonal sur les donations entre concubins est généralement élevé (18-25 % selon les cantons). Schwyz fait exception : aucun impôt sur les donations quel que soit le lien. Envisager un testament en complément pour une protection complète.';
 
   @override
   String get donationDisclaimer =>
@@ -7060,7 +7060,7 @@ class SFr extends S {
 
   @override
   String independantAvsBody(String amount) {
-    return 'Ta cotisation AVS estimée : $amount/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6% au-dessus).';
+    return 'Ta cotisation AVS estimée : $amount/an (taux dégressif pour les revenus inférieurs à CHF 58’800, puis ~10.6 % au-dessus).';
   }
 
   @override
@@ -7073,7 +7073,7 @@ class SFr extends S {
 
   @override
   String independant3aWithoutLpp(String amount) {
-    return 'Sans LPP : plafond 3a \"grand\" de 20% du revenu net, max $amount/an (plafond légal CHF 36’288).';
+    return 'Sans LPP : plafond 3a \"grand\" de 20 % du revenu net, max $amount/an (plafond légal CHF 36’288).';
   }
 
   @override
@@ -7108,7 +7108,7 @@ class SFr extends S {
   }
 
   @override
-  String get disabilityGapPhase1Full => '100% du salaire';
+  String get disabilityGapPhase1Full => '100 % du salaire';
 
   @override
   String get disabilityGapNoCoverage => 'Aucune couverture';
@@ -7121,7 +7121,7 @@ class SFr extends S {
 
   @override
   String disabilityGapPhase2Coverage(String amount) {
-    return '80% du salaire ($amount CHF/mois)';
+    return '80 % du salaire ($amount CHF/mois)';
   }
 
   @override
@@ -7410,20 +7410,20 @@ class SFr extends S {
   String get affordabilityCalculationDetail => 'Détail du calcul';
 
   @override
-  String get affordabilityEquityRequired => 'Fonds propres requis (20%)';
+  String get affordabilityEquityRequired => 'Fonds propres requis (20 %)';
 
   @override
   String get affordabilitySavingsLabel => 'Épargne';
 
   @override
-  String get affordabilityLppMax10 => 'Avoir LPP (max 10% du prix)';
+  String get affordabilityLppMax10 => 'Avoir LPP (max 10 % du prix)';
 
   @override
   String get affordabilityTotalEquity => 'Total fonds propres';
 
   @override
   String affordabilityMortgagePercent(String percent) {
-    return 'Hypothèque ($percent%)';
+    return 'Hypothèque ($percent %)';
   }
 
   @override
@@ -7431,7 +7431,7 @@ class SFr extends S {
 
   @override
   String get affordabilityCalculationNote =>
-      'Calcul théorique : hypothèque x (5% intérêt imputé + 1% amortissement) + prix x 1% frais accessoires. Max 33% du revenu brut.';
+      'Calcul théorique : hypothèque x (5 % intérêt imputé + 1 % amortissement) + prix x 1 % frais accessoires. Max 33 % du revenu brut.';
 
   @override
   String get amortizationSource =>
@@ -7549,12 +7549,12 @@ class SFr extends S {
 
   @override
   String fiscalBelowAverage(String rate) {
-    return 'Inférieur à la moyenne suisse (~$rate%)';
+    return 'Inférieur à la moyenne suisse (~$rate %)';
   }
 
   @override
   String fiscalAboveAverage(String rate) {
-    return 'Supérieur à la moyenne suisse (~$rate%)';
+    return 'Supérieur à la moyenne suisse (~$rate %)';
   }
 
   @override
@@ -7774,7 +7774,7 @@ class SFr extends S {
 
   @override
   String get expatAvsEducation =>
-      'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3%. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.';
+      'Pour toucher une rente AVS complète (max CHF 2\'520/mois), il est nécessaire de totaliser 44 années de cotisation sans lacune. Chaque année manquante réduit ta rente d\'environ 2.3 %. Si tu vis à l\'étranger, tu peux cotiser volontairement à l\'AVS pour éviter les lacunes.';
 
   @override
   String get expatYearsInSwitzerland => 'Années en Suisse';
@@ -7870,7 +7870,7 @@ class SFr extends S {
 
   @override
   String get mariageTimelineAct3Insight =>
-      'Attention : plafond AVS couple (150% rente max). Planifier rente vs capital.';
+      'Attention : plafond AVS couple (150 % rente max). Planifier rente vs capital.';
 
   @override
   String get naissanceChecklistItem1Title =>
@@ -7902,7 +7902,7 @@ class SFr extends S {
 
   @override
   String get naissanceChecklistItem4Desc =>
-      'Congé maternité : 14 semaines à 80% du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L\'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.';
+      'Congé maternité : 14 semaines à 80 % du salaire (max CHF 220/jour). Congé paternité : 2 semaines (10 jours), à prendre dans les 6 mois. L\'inscription APG se fait via ton employeur ou directement auprès de la caisse de compensation.';
 
   @override
   String get naissanceChecklistItem5Title =>
@@ -8064,7 +8064,7 @@ class SFr extends S {
 
   @override
   String narrativeConfidenceLabel(String score) {
-    return 'Confiance profil : $score%';
+    return 'Confiance profil : $score %';
   }
 
   @override
@@ -8115,7 +8115,7 @@ class SFr extends S {
 
   @override
   String patrimoineLtvDisplay(String percent) {
-    return 'LTV $percent%';
+    return 'LTV $percent %';
   }
 
   @override
@@ -8220,7 +8220,7 @@ class SFr extends S {
   String get futurRenteLpp => 'Rente LPP estimée';
 
   @override
-  String get futurPilier3aSwr => 'Pilier 3a (SWR 4%)';
+  String get futurPilier3aSwr => 'Pilier 3a (SWR 4 %)';
 
   @override
   String futurCapitalLabel(String amount) {
@@ -8228,10 +8228,10 @@ class SFr extends S {
   }
 
   @override
-  String get futurLibrePassageSwr => 'Libre passage (SWR 4%)';
+  String get futurLibrePassageSwr => 'Libre passage (SWR 4 %)';
 
   @override
-  String get futurInvestissementsSwr => 'Investissements (SWR 4%)';
+  String get futurInvestissementsSwr => 'Investissements (SWR 4 %)';
 
   @override
   String get futurTotalCoupleProjecte => 'Total couple projeté';
@@ -8252,7 +8252,7 @@ class SFr extends S {
 
   @override
   String futurMargeIncertitude(String pct) {
-    return 'Marge d\'incertitude (± $pct%)';
+    return 'Marge d\'incertitude (± $pct %)';
   }
 
   @override
@@ -8266,7 +8266,7 @@ class SFr extends S {
 
   @override
   String get futurDisclaimer =>
-      'Projection éducative — ne constitue pas un conseil (LSFin). SWR 4% = règle des 4%, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.';
+      'Projection éducative — ne constitue pas un conseil (LSFin). SWR 4 % = règle des 4 %, résultats non assurés. Rentes AVS/LPP estimées selon LAVS art. 21-40, LPP art. 14-16.';
 
   @override
   String get futurExplorerDetails => 'Explorer les détails';
@@ -8317,7 +8317,7 @@ class SFr extends S {
 
   @override
   String financialSummaryBonusEstime(String pct) {
-    return 'Bonus estimé ($pct%)';
+    return 'Bonus estimé ($pct %)';
   }
 
   @override
@@ -8505,17 +8505,17 @@ class SFr extends S {
 
   @override
   String financialSummaryLtvAmortissement(String pct) {
-    return 'Ratio LTV : $pct% — amortissement 2ème rang obligatoire';
+    return 'Ratio LTV : $pct % — amortissement 2ème rang obligatoire';
   }
 
   @override
   String financialSummaryLtvBonneVoie(String pct) {
-    return 'Ratio LTV : $pct% — en bonne voie';
+    return 'Ratio LTV : $pct % — en bonne voie';
   }
 
   @override
   String financialSummaryLtvExcellent(String pct) {
-    return 'Ratio LTV : $pct% — excellent';
+    return 'Ratio LTV : $pct % — excellent';
   }
 
   @override
@@ -8676,7 +8676,7 @@ class SFr extends S {
 
   @override
   String financialSummaryConseilRemboursement(String taux) {
-    return 'Rembourse d\'abord la dette à $taux% avant d\'investir. Chaque CHF remboursé = $taux% de rendement effectif.';
+    return 'Rembourse d\'abord la dette à $taux % avant d\'investir. Chaque CHF remboursé = $taux % de rendement effectif.';
   }
 
   @override
@@ -9396,10 +9396,10 @@ class SFr extends S {
   String get pillar3aYearLabel => 'Année';
 
   @override
-  String get pillar3aBank15 => 'Banque 1.5%';
+  String get pillar3aBank15 => 'Banque 1.5 %';
 
   @override
-  String get pillar3aViac45 => 'VIAC 4.5%';
+  String get pillar3aViac45 => 'VIAC 4.5 %';
 
   @override
   String pillar3aYearN(int n) {
@@ -9408,7 +9408,7 @@ class SFr extends S {
 
   @override
   String get pillar3aCompoundTip =>
-      'Les dernières années font +50% du gain total grâce aux intérêts composés !';
+      'Les dernières années font +50 % du gain total grâce aux intérêts composés !';
 
   @override
   String get pillar3aRecommended => 'RECOMMANDÉ';
@@ -9471,7 +9471,7 @@ class SFr extends S {
 
   @override
   String get slmPrivacyMessage =>
-      'Le modèle fonctionne 100% sur ton appareil. Aucune donnée ne quitte ton téléphone.';
+      'Le modèle fonctionne 100 % sur ton appareil. Aucune donnée ne quitte ton téléphone.';
 
   @override
   String get slmDownloadModelTitle => 'Télécharger le modèle ?';
@@ -9557,7 +9557,7 @@ class SFr extends S {
 
   @override
   String pulseDigitalTwinPct(String pct) {
-    return 'Jumeau numérique : $pct%';
+    return 'Jumeau numérique : $pct %';
   }
 
   @override
@@ -10198,12 +10198,12 @@ class SFr extends S {
 
   @override
   String spendingMeterVariablesLegend(int percent) {
-    return 'Variables $percent%';
+    return 'Variables $percent %';
   }
 
   @override
   String spendingMeterFuturLegend(int percent) {
-    return 'Futur $percent%';
+    return 'Futur $percent %';
   }
 
   @override
@@ -10368,7 +10368,7 @@ class SFr extends S {
 
   @override
   String get dataBlockFiscaliteDesc =>
-      'Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d\'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu\'estimé (coefficient communal 60%-130%).';
+      'Ta commune, ton revenu imposable et ta fortune déterminent ton taux marginal d\'imposition. Une déclaration fiscale ou un avis de taxation donne un taux réel plutôt qu\'estimé (coefficient communal 60 %-130 %).';
 
   @override
   String get dataBlockFiscaliteCta => 'Comparer ma fiscalité';
@@ -10799,14 +10799,14 @@ class SFr extends S {
 
   @override
   String get frontalierQuasiResidentDesc =>
-      'Si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.';
+      'Si plus de 90 % de tes revenus mondiaux proviennent de Suisse, tu peux demander la taxation ordinaire avec déductions (3a, frais effectifs, etc.). Cela peut réduire significativement ton impôt.';
 
   @override
   String get frontalierTessinTitle => 'Tessin — régime spécial';
 
   @override
   String get frontalierEducationalTax =>
-      'En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l\'état civil et le nombre d\'enfants. À Genève, si plus de 90% de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.';
+      'En Suisse, les frontaliers sont imposés à la source (barème C). Le taux varie selon le canton, l\'état civil et le nombre d\'enfants. À Genève, si plus de 90 % de tes revenus mondiaux proviennent de Suisse, tu peux demander le statut de quasi-résident pour bénéficier des déductions.';
 
   @override
   String get frontalierJoursBureau => 'Jours au bureau en Suisse';
@@ -10851,7 +10851,7 @@ class SFr extends S {
 
   @override
   String frontalierDuSalaire(String percent) {
-    return '$percent% du salaire';
+    return '$percent % du salaire';
   }
 
   @override
@@ -10879,7 +10879,7 @@ class SFr extends S {
 
   @override
   String get frontalierCmuDesc =>
-      'Droit d\'option possible pour les frontaliers FR. Cotisation ~8% du revenu fiscal.';
+      'Droit d\'option possible pour les frontaliers FR. Cotisation ~8 % du revenu fiscal.';
 
   @override
   String get frontalierAssurancePriveeTitle => 'Assurance privée (DE/IT/AT)';
@@ -10954,7 +10954,7 @@ class SFr extends S {
 
   @override
   String concubinageConcubinTaux(String taux) {
-    return 'Concubin-e (~$taux%)';
+    return 'Concubin-e (~$taux %)';
   }
 
   @override
@@ -11934,12 +11934,12 @@ class SFr extends S {
 
   @override
   String docImpactRenteOblig(String amount) {
-    return 'Rente obligatoire à 6.8% : CHF $amount/an';
+    return 'Rente obligatoire à 6.8 % : CHF $amount/an';
   }
 
   @override
   String docImpactSurobligWithRate(String suroblig, String rate, String rente) {
-    return 'Part surobligatoire (CHF $suroblig) à $rate% = CHF $rente/an';
+    return 'Part surobligatoire (CHF $suroblig) à $rate % = CHF $rente/an';
   }
 
   @override
@@ -11954,7 +11954,7 @@ class SFr extends S {
 
   @override
   String docImpactAvsCompletion(int maxYears, int pct) {
-    return 'sur $maxYears nécessaires pour une rente AVS complète ($pct%)';
+    return 'sur $maxYears nécessaires pour une rente AVS complète ($pct %)';
   }
 
   @override
@@ -11989,7 +11989,7 @@ class SFr extends S {
 
   @override
   String extractionReviewConfidence(int pct) {
-    return 'Confiance extraction : $pct%';
+    return 'Confiance extraction : $pct %';
   }
 
   @override
@@ -12065,7 +12065,7 @@ class SFr extends S {
 
   @override
   String firstSalaryNetPercent(int pct) {
-    return '$pct% net';
+    return '$pct % net';
   }
 
   @override
@@ -12188,11 +12188,11 @@ class SFr extends S {
 
   @override
   String get firstSalaryBadgeSubtitle =>
-      'Tu sais maintenant ce que 90% des gens ne savent jamais.';
+      'Tu sais maintenant ce que 90 % des gens ne savent jamais.';
 
   @override
   String get firstSalaryDisclaimer =>
-      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7\'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4%/an.';
+      'Outil éducatif · ne constitue pas un conseil financier au sens de la LSFin. Source : LAVS art. 3, LPP art. 7, LACI art. 3, OPP3 art. 7 (3a 7\'258 CHF/an). Taux cotisations indicatifs 2026. Projection 3a : rendement hypothétique 4 %/an.';
 
   @override
   String get benchmarkAppBarTitle => 'Repères cantonaux';
@@ -13434,7 +13434,7 @@ class SFr extends S {
 
   @override
   String dashboardCurrentConfidence(int score) {
-    return 'Confiance actuelle : $score%';
+    return 'Confiance actuelle : $score %';
   }
 
   @override
@@ -13489,7 +13489,7 @@ class SFr extends S {
 
   @override
   String dashboardPrecisionGainPercent(int percent) {
-    return 'Précision +$percent%';
+    return 'Précision +$percent %';
   }
 
   @override
@@ -14243,7 +14243,7 @@ class SFr extends S {
 
   @override
   String expatSavingsBadge(String amount, String percent) {
-    return 'Économie : $amount (-$percent%)';
+    return 'Économie : $amount (-$percent %)';
   }
 
   @override
@@ -14258,7 +14258,7 @@ class SFr extends S {
 
   @override
   String expatAvsReductionExplain(String percent) {
-    return 'Chaque année manquante réduit ta rente d\'environ $percent%. La réduction est définitive et s\'applique à vie.';
+    return 'Chaque année manquante réduit ta rente d\'environ $percent %. La réduction est définitive et s\'applique à vie.';
   }
 
   @override
@@ -14536,7 +14536,7 @@ class SFr extends S {
   String get genderGapParametres => 'Paramètres';
 
   @override
-  String get genderGapRevenuAnnuel => 'Revenu annuel brut (100%)';
+  String get genderGapRevenuAnnuel => 'Revenu annuel brut (100 %)';
 
   @override
   String get genderGapAge => 'Âge';
@@ -14568,11 +14568,11 @@ class SFr extends S {
   }
 
   @override
-  String get genderGapAt100 => 'À 100%';
+  String get genderGapAt100 => 'À 100 %';
 
   @override
   String genderGapAtTaux(String taux) {
-    return 'À $taux%';
+    return 'À $taux %';
   }
 
   @override
@@ -14590,22 +14590,22 @@ class SFr extends S {
 
   @override
   String get genderGapCoordinationBody =>
-      'La déduction de coordination est un montant fixe de CHF 26\'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100% ou à 50%.';
+      'La déduction de coordination est un montant fixe de CHF 26\'460 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100 % ou à 50 %.';
 
   @override
-  String get genderGapSalaireBrut100 => 'Salaire brut à 100%';
+  String get genderGapSalaireBrut100 => 'Salaire brut à 100 %';
 
   @override
-  String get genderGapSalaireCoordonne100 => 'Salaire coordonné à 100%';
+  String get genderGapSalaireCoordonne100 => 'Salaire coordonné à 100 %';
 
   @override
   String genderGapSalaireBrutTaux(String taux) {
-    return 'Salaire brut à $taux%';
+    return 'Salaire brut à $taux %';
   }
 
   @override
   String genderGapSalaireCoordonneTaux(String taux) {
-    return 'Salaire coordonné à $taux%';
+    return 'Salaire coordonné à $taux %';
   }
 
   @override
@@ -14629,7 +14629,7 @@ class SFr extends S {
 
   @override
   String get genderGapSourcesBody =>
-      'LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8%) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)';
+      'LPP art. 8 (déduction de coordination) / LPP art. 14 (taux de conversion 6.8 %) / OPP2 art. 5 / OPP3 art. 7 / LPP art. 79b (rachat volontaire) / OFS 2024 (statistiques gender gap)';
 
   @override
   String get achievementsErrorMessage => 'Le chargement a buté. On réessaie ?';
@@ -14640,7 +14640,7 @@ class SFr extends S {
 
   @override
   String documentsConfidenceChoc(String count, String pct) {
-    return '$count documents = $pct% de confiance';
+    return '$count documents = $pct % de confiance';
   }
 
   @override
@@ -15899,7 +15899,7 @@ class SFr extends S {
 
   @override
   String get eplImpactRenteNote =>
-      'Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2%, taux de conversion 6.8%. Le montant réel dépend de ta situation.';
+      'Estimation éducative basée sur un salaire de CHF 100’000, rendement caisse 2 %, taux de conversion 6.8 %. Le montant réel dépend de ta situation.';
 
   @override
   String get eplSectionFiscale => 'Estimation fiscale';
@@ -16056,7 +16056,7 @@ class SFr extends S {
 
   @override
   String get providerComparatorAssuranceNote =>
-      'Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5%) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.';
+      'Les assurances 3a combinent épargne et couverture risque, mais les frais élevés (souvent > 1.5 %) et la rigidité du contrat les rendent défavorables pour les jeunes épargnants.';
 
   @override
   String documentDetailFieldsExtracted(int found, int total) {
@@ -16495,7 +16495,7 @@ class SFr extends S {
 
   @override
   String compoundGainsPercent(String percent) {
-    return '$percent% de ce montant provient uniquement de tes gains de placement.';
+    return '$percent % de ce montant provient uniquement de tes gains de placement.';
   }
 
   @override
@@ -16596,7 +16596,7 @@ class SFr extends S {
 
   @override
   String get creditMentorBody =>
-      'En Suisse, un crédit coûte entre 4% et 10%. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.';
+      'En Suisse, un crédit coûte entre 4 % et 10 %. Cet argent \"perdu\" en intérêts pourrait être investi pour ton avenir.';
 
   @override
   String get creditParametres => 'Paramètres';
@@ -16618,7 +16618,7 @@ class SFr extends S {
 
   @override
   String get creditRateWarning =>
-      'Attention : Ce taux dépasse le max légal suisse de 10%.';
+      'Attention : Ce taux dépasse le max légal suisse de 10 %.';
 
   @override
   String get creditConseilsTitle => 'Conseils du Mentor';
@@ -16636,7 +16636,7 @@ class SFr extends S {
 
   @override
   String get creditCercleConfianceBody =>
-      'Un prêt familial peut souvent être obtenu à 0% d\'intérêt.';
+      'Un prêt familial peut souvent être obtenu à 0 % d\'intérêt.';
 
   @override
   String get creditDettesConseils => 'Dettes Conseils Suisse';
@@ -17117,10 +17117,10 @@ class SFr extends S {
       'Alerte Dettes : Ta priorité absolue est le désendettement avant tout réinvestissement.';
 
   @override
-  String get dividendeSplitMin => '0% salaire';
+  String get dividendeSplitMin => '0 % salaire';
 
   @override
-  String get dividendeSplitMax => '100% salaire';
+  String get dividendeSplitMax => '100 % salaire';
 
   @override
   String get disabilityInsAppBarTitle => 'Ma couverture';
@@ -19304,7 +19304,7 @@ class SFr extends S {
 
   @override
   String benchmarkInsightSavings(String rate) {
-    return 'Un profil similaire épargne environ $rate% de son revenu';
+    return 'Un profil similaire épargne environ $rate % de son revenu';
   }
 
   @override
@@ -19319,12 +19319,12 @@ class SFr extends S {
 
   @override
   String benchmarkInsight3a(String rate) {
-    return 'Environ $rate% des actifs versent dans le 3a';
+    return 'Environ $rate % des actifs versent dans le 3a';
   }
 
   @override
   String benchmarkInsightLpp(String rate) {
-    return 'Le taux de couverture LPP est de $rate%';
+    return 'Le taux de couverture LPP est de $rate %';
   }
 
   @override
@@ -20360,7 +20360,7 @@ class SFr extends S {
 
   @override
   String notifOffTrackBody(String adherence, String total, String impact) {
-    return 'Adhérence à $adherence% sur $total actions. Indication linéaire (hors rendement/fiscalité) : ~CHF $impact.';
+    return 'Adhérence à $adherence % sur $total actions. Indication linéaire (hors rendement/fiscalité) : ~CHF $impact.';
   }
 
   @override
@@ -20863,7 +20863,7 @@ class SFr extends S {
 
   @override
   String get firstJobPayslipAvsExplanation =>
-      'Cotisation salarié·e : 5.3% du brut. Ton employeur paie aussi 5.3% en plus.';
+      'Cotisation salarié·e : 5.3 % du brut. Ton employeur paie aussi 5.3 % en plus.';
 
   @override
   String get firstJobPayslipLppLabel => 'LPP (2e pilier)';
@@ -20899,7 +20899,7 @@ class SFr extends S {
 
   @override
   String get firstJobChecklistConsequence2 =>
-      'Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05%.';
+      'Sans transfert, ton capital va à la Fondation supplétive à un taux de 0.05 %.';
 
   @override
   String get firstJobChecklistDeadline3 => '1 mois';
@@ -20969,7 +20969,7 @@ class SFr extends S {
   String get firstJobScenarioMedianCH => 'Médian CH';
 
   @override
-  String get firstJobScenarioBoosted => '+20%';
+  String get firstJobScenarioBoosted => '+20 %';
 
   @override
   String firstJobScenarioSemantics(String label) {
@@ -21418,7 +21418,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapAct2SubIjm =>
-      'Assurance collective — 80% pendant 720 jours max';
+      'Assurance collective — 80 % pendant 720 jours max';
 
   @override
   String get disabilityGapAct2SubNoIjm =>
@@ -21428,7 +21428,7 @@ class SFr extends S {
   String get disabilityGapAct2Duration => 'Jusqu’à 24 mois';
 
   @override
-  String get disabilityGapAct2DetailIjm => '80% du salaire assuré';
+  String get disabilityGapAct2DetailIjm => '80 % du salaire assuré';
 
   @override
   String get disabilityGapAct2DetailNoIjm =>
@@ -21448,7 +21448,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapIjmCoverage =>
-      '80% pendant 720 jours — assurance collective';
+      '80 % pendant 720 jours — assurance collective';
 
   @override
   String get disabilityGapNoIjmCoverage =>
@@ -21461,7 +21461,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapLppCovered =>
-      'Rente invalidité ≈ 40% salaire coordonné (LPP art. 23)';
+      'Rente invalidité ≈ 40 % salaire coordonné (LPP art. 23)';
 
   @override
   String get disabilityGapLppNotCovered =>
@@ -21518,7 +21518,7 @@ class SFr extends S {
       'Montant déduit pour coordonner avec l’AVS';
 
   @override
-  String get documentDetailExplanationTauxOblig => 'Légal minimum : 6.8%';
+  String get documentDetailExplanationTauxOblig => 'Légal minimum : 6.8 %';
 
   @override
   String get documentDetailExplanationTauxSurob =>
@@ -21584,7 +21584,7 @@ class SFr extends S {
 
   @override
   String get disabilitySelfEmployedApgTip =>
-      'Une APG individuelle dès CHF 45/mois peut couvrir 80% de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.';
+      'Une APG individuelle dès CHF 45/mois peut couvrir 80 % de ton revenu pendant 720 jours. C’est le filet le plus efficace pour un·e indépendant·e.';
 
   @override
   String get disabilitySelfEmployedDisclaimer =>
@@ -24095,7 +24095,7 @@ class SFr extends S {
   String get indepLppConFlexible => 'Moins flexible';
 
   @override
-  String get indepGrand3aSub => '20% du revenu net, max CHF 36\'288/an';
+  String get indepGrand3aSub => '20 % du revenu net, max CHF 36\'288/an';
 
   @override
   String get indepGrand3aProFlexibilite => 'Flexibilité totale';
@@ -24129,7 +24129,7 @@ class SFr extends S {
 
   @override
   String get indepFiscal3aNote =>
-      'Max 20% du revenu net, plafonné à CHF 36\'288/an sans LPP';
+      'Max 20 % du revenu net, plafonné à CHF 36\'288/an sans LPP';
 
   @override
   String get indepFiscalFraisPro => 'Frais professionnels effectifs';
@@ -24213,12 +24213,12 @@ class SFr extends S {
 
   @override
   String donationReserveBarLabel(String pct) {
-    return 'Réserve $pct%';
+    return 'Réserve $pct %';
   }
 
   @override
   String donationDisponibleBarLabel(String pct) {
-    return 'Disponible $pct%';
+    return 'Disponible $pct %';
   }
 
   @override
@@ -24576,7 +24576,7 @@ class SFr extends S {
 
   @override
   String capCoachPromptReplacement(Object rate) {
-    return 'Mon taux de remplacement est de $rate%. Est-ce suffisant pour ma retraite ?';
+    return 'Mon taux de remplacement est de $rate %. Est-ce suffisant pour ma retraite ?';
   }
 
   @override

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mint_mobile/app.dart';
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/coach/coach_orchestrator.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/pillar_3a_calculator.dart';
 import 'package:mint_mobile/services/slm/slm_download_service.dart';
@@ -90,6 +92,10 @@ Future<void> main() async {
   // Periodic refresh of server-driven feature flags (every 6 hours).
   // Cancelled/restarted by WidgetsBindingObserver in app.dart on lifecycle changes.
   FeatureFlags.startPeriodicRefresh();
+
+  // FIX-P1-7: Register orchestrator chat function to break circular dependency
+  // (coach_llm_service ↔ coach_orchestrator). Must happen before first chat.
+  CoachLlmService.registerOrchestrator(CoachOrchestrator.generateChat);
 
   // Lancement immédiat de l'app (UX first!)
   runApp(const MintApp());

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -1926,7 +1926,10 @@ class CoachProfile {
     final nombreEnfants = _parseInt(childrenRaw) ?? 0;
 
     // ── Revenus ─────────────────────────────────────────────
-    final payFrequency = answers['q_pay_frequency'] as String? ?? 'monthly';
+    // FIX-P0-2: Normalize to lowercase — "Yearly" (capitalized) was not
+    // recognized, causing annual salary to be treated as monthly.
+    final payFrequency =
+        (answers['q_pay_frequency'] as String?)?.toLowerCase() ?? 'monthly';
     final netIncome = _parseDouble(answers['q_net_income_period_chf']) ?? 5000;
 
     // Convert to monthly net income based on pay frequency

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -451,19 +451,22 @@ class CoachProfileProvider extends ChangeNotifier {
     );
 
     // AVS contribution years (LAVS art. 29 — cotisations dès 21 ans).
-    final int avsContributionYears;
+    final int rawAvsYears;
     if (isReturningSwiss) {
       // Reduced by time abroad
-      avsContributionYears = ((age - 20) - (yearsAbroad ?? 0)).clamp(0, 44);
+      rawAvsYears = (age - 20) - (yearsAbroad ?? 0);
     } else if (isExpat) {
       // Contributions start from max(arrivalAge, 21)
       final arrivalAge = arrivalYear - birthYear;
       final startAge = arrivalAge > 21 ? arrivalAge : 21;
-      avsContributionYears = (age - startAge).clamp(0, 44);
+      rawAvsYears = age - startAge;
     } else {
       // Swiss native: cotisations since age 21
-      avsContributionYears = (age - 20).clamp(0, 44);
+      rawAvsYears = age - 20;
     }
+    final avsContributionYears = rawAvsYears.clamp(0, 44);
+    // Flag when the raw value was outside [0, 44] so UI can inform the user.
+    final bool avsYearsWereClamped = rawAvsYears != avsContributionYears;
 
     final answers = <String, dynamic>{
       if (firstName != null && firstName.isNotEmpty) 'q_firstname': firstName,
@@ -479,6 +482,8 @@ class CoachProfileProvider extends ChangeNotifier {
           grossSalary >= 22680 && effectiveEmployment != 'independant',
       // AVS years estimated from age and situation (LAVS art. 29)
       'q_avs_contribution_years': avsContributionYears,
+      // P2-15: Flag when AVS years were clamped to [0,44] so UI can warn user.
+      if (avsYearsWereClamped) '_avs_years_clamped': true,
       // AVS rente estimated via financial_core AvsCalculator
       '_coach_avs_rente_estimee': minimal.avsMonthlyRente,
       // Patrimoine: estimated savings = (age-25) × salary × 5%
@@ -655,8 +660,16 @@ class CoachProfileProvider extends ChangeNotifier {
         updated.etatCivil != CoachCivilStatus.marie &&
         updated.etatCivil != CoachCivilStatus.concubinage) {
       // FIX-097: Clear local household state on divorce (fire-and-forget).
+      // FIX-P0-1: Remove ALL partner/spouse keys to prevent ghost conjoint
+      // on app restart. Without this, fromWizardAnswers() recreates the spouse
+      // from stale SharedPreferences → AVS couple cap 150% applied to a single.
       SharedPreferences.getInstance().then((sp) {
         sp.remove('_household_data');
+        final keysToRemove = sp.getKeys().where(
+            (k) => k.startsWith('q_partner_') || k.startsWith('q_spouse_'));
+        for (final key in keysToRemove.toList()) {
+          sp.remove(key);
+        }
       }).catchError((_) {});
     }
   }

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -423,7 +423,10 @@ class _CoachChatScreenState extends State<CoachChatScreen>
     final p = _profile!;
     if (!mounted) return;
     final s = S.of(context)!;
-    final name = p.firstName ?? s.coachFallbackName;
+    // FIX-P1-6: Guard against null/empty firstName to avoid blank greeting.
+    final name = (p.firstName != null && p.firstName!.isNotEmpty)
+        ? p.firstName!
+        : s.coachFallbackName;
     final locale = Localizations.localeOf(context).languageCode;
 
     final tier = _currentTier();

--- a/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
+++ b/apps/mobile/lib/screens/demenagement_cantonal_screen.dart
@@ -190,8 +190,13 @@ class _DemenagementCantonalScreenState
     final idxDepart = _indiceFiscal[_cantonDepart] ?? 75;
     final idxArrivee = _indiceFiscal[_cantonArrivee] ?? 75;
     // Simplified: proportional to income and index difference
-    final tauxMoyenDepart = idxDepart / 100 * 0.22; // ~22% charge GE — TODO: use tax_calculator.dart for cantonal rates
-    final tauxMoyenArrivee = idxArrivee / 100 * 0.22; // TODO: use financial_core/tax_calculator.dart
+    // Simplified proportional model: 22% is the approximate average effective
+    // income tax rate for GE at median income (LIFD art. 36 + cantonal).
+    // TODO(MINT-201): Replace with TaxCalculator.estimateMonthlyIncomeTax()
+    // from financial_core/tax_calculator.dart for per-canton accuracy.
+    // Ref: financial_core/tax_calculator.dart — progressiveTax(), capitalWithdrawalTax()
+    final tauxMoyenDepart = idxDepart / 100 * 0.22;
+    final tauxMoyenArrivee = idxArrivee / 100 * 0.22;
     return _revenuBrut * (tauxMoyenDepart - tauxMoyenArrivee);
   }
 

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -107,6 +107,9 @@ class FinancialSummaryScreen extends StatelessWidget {
             grossSalary: gross,
             canton: profile.canton.isNotEmpty ? profile.canton : 'ZH',
             age: profile.age,
+            // FIX-P1-4: Pass etatCivil + nombreEnfants for correct tax calc.
+            etatCivil: profile.etatCivil.name,
+            nombreEnfants: profile.nombreEnfants,
           )
         : null;
 

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -27,7 +27,7 @@ class ApiException implements Exception {
   String toString() => message;
 }
 
-// TODO(security): Certificate pinning — P1-6 audit finding.
+// TODO(MINT-106): Certificate pinning — P1-6 audit finding.
 // Implement TLS certificate pinning for production domains once stable:
 //   - mint-production-3a41.up.railway.app
 //   - Expected: SHA-256 pin of Railway's leaf certificate

--- a/apps/mobile/lib/services/assurances_service.dart
+++ b/apps/mobile/lib/services/assurances_service.dart
@@ -235,7 +235,8 @@ class LamalFranchiseService {
         points.add(BreakEvenPoint(
           franchiseBasse: low,
           franchiseHaute: high,
-          seuilDepenses: seuil.clamp(0, 50000),
+          // Rough estimate — max 2M CHF covers high-deductible scenarios.
+          seuilDepenses: seuil.clamp(0, 2000000),
         ));
       }
     }

--- a/apps/mobile/lib/services/coach/conversation_store.dart
+++ b/apps/mobile/lib/services/coach/conversation_store.dart
@@ -98,6 +98,10 @@ class ConversationStore {
   /// Key for the conversation index (list of metadata).
   static const _indexKey = '_chat_conversation_index';
 
+  /// Maximum conversations retained in SharedPreferences.
+  /// Oldest conversations are pruned when this limit is exceeded.
+  static const _maxConversations = 50;
+
   /// Maximum title length (characters).
   static const _maxTitleLength = 50;
 
@@ -228,8 +232,8 @@ class ConversationStore {
     RegExp(r'\b[1-9]\d{3}\s+[A-Z]', caseSensitive: false),
     // Employer patterns: "je travaille chez X", "mon employeur X"
     RegExp(r'(travaille\s+chez|employeur\s+est|boîte|entreprise)\s+\S+', caseSensitive: false),
-    // IBAN
-    RegExp(r'CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d?', caseSensitive: false),
+    // IBAN (CH + 19 digits, with optional spaces)
+    RegExp(r'CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1,2}', caseSensitive: false),
     // Written-out amounts: "septante mille", "cent vingt mille"
     RegExp(r'(septante|huitante|nonante|cinquante|soixante|vingt|trente|quarante)\s+(mille|cents?)', caseSensitive: false),
   ];
@@ -314,11 +318,19 @@ class ConversationStore {
     }
   }
 
-  /// Persist the conversation index.
+  /// Persist the conversation index, pruning oldest if over limit.
   Future<void> _saveIndex(
     SharedPreferences prefs,
     List<ConversationMeta> index,
   ) async {
+    // Prune oldest conversations if over limit
+    if (index.length > _maxConversations) {
+      final toRemove = index.sublist(_maxConversations);
+      for (final meta in toRemove) {
+        await prefs.remove('$_messagesPrefix${meta.id}');
+      }
+      index = index.sublist(0, _maxConversations);
+    }
     final json = index.map((m) => m.toJson()).toList();
     await prefs.setString(_indexKey, jsonEncode(json));
   }

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -3,7 +3,9 @@ import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/models/response_card.dart';
 import 'package:mint_mobile/models/sequence_message_payload.dart';
 import 'package:mint_mobile/services/coach/coach_models.dart';
-import 'package:mint_mobile/services/coach/coach_orchestrator.dart';
+// FIX-P1-7: Removed direct import of coach_orchestrator.dart to break
+// circular dependency (coach_llm ↔ orchestrator). The orchestrator is
+// now resolved lazily at call time via _resolveOrchestrator().
 import 'package:mint_mobile/services/coach/compliance_guard.dart';
 import 'package:mint_mobile/services/financial_fitness_service.dart';
 import 'package:mint_mobile/services/forecaster_service.dart';
@@ -252,15 +254,36 @@ class CoachResponse {
   });
 }
 
+/// Signature for the orchestrator's generateChat, used to break the
+/// circular dependency between coach_llm_service ↔ coach_orchestrator.
+typedef OrchestratorChatFn = Future<CoachResponse> Function({
+  required String userMessage,
+  required List<ChatMessage> history,
+  required CoachContext ctx,
+  LlmConfig? byokConfig,
+  String? memoryBlock,
+  String language,
+});
+
 /// Service de chat LLM pour le Coach MINT
 class CoachLlmService {
   /// Disclaimer standard
   static const _disclaimer =
       'Outil educatif — ne constitue pas un conseil financier. LSFin.';
 
+  /// FIX-P1-7: Late-bound orchestrator function to break circular import.
+  /// Set once at app init by [CoachOrchestrator.init()] or by tests.
+  static OrchestratorChatFn? _orchestratorChatFn;
+
+  /// Register the orchestrator's generateChat function.
+  /// Called once at startup (e.g. from main.dart or CoachOrchestrator.init).
+  static void registerOrchestrator(OrchestratorChatFn fn) {
+    _orchestratorChatFn = fn;
+  }
+
   /// Envoie un message et recoit une reponse du coach
   ///
-  /// Délègue à [CoachOrchestrator] pour la chaîne SLM → BYOK → mock.
+  /// Delegates to the registered orchestrator for the SLM → BYOK → mock chain.
   /// ComplianceGuard est appliqué centralement dans l'orchestrateur.
   ///
   /// Si BYOK est configure (config.hasApiKey), route via le backend RAG
@@ -277,11 +300,16 @@ class CoachLlmService {
   }) async {
     final coachCtx = _buildCoachContext(profile);
 
-    // Delegate to CoachOrchestrator (SLM → BYOK → fallback chain).
-    // If SLM is available, it will be tried first (zero-network, privacy-first).
-    // BYOK is passed when config.hasApiKey, otherwise skipped.
-    // memoryBlock (S58) provides lifecycle, goals, and conversation history context.
-    final orchestratorResponse = await CoachOrchestrator.generateChat(
+    // FIX-P1-7: Use late-bound orchestrator instead of direct import.
+    if (_orchestratorChatFn == null) {
+      // Graceful fallback if orchestrator not yet registered.
+      return const CoachResponse(
+        message: 'Service en cours d\'initialisation. Reessaie dans un instant.',
+        disclaimer: 'Outil educatif — ne constitue pas un conseil financier. LSFin.',
+      );
+    }
+
+    final orchestratorResponse = await _orchestratorChatFn!(
       userMessage: userMessage,
       history: history,
       ctx: coachCtx,
@@ -290,11 +318,7 @@ class CoachLlmService {
       language: language,
     );
 
-    // If orchestrator returned a non-fallback response (SLM or BYOK succeeded),
-    // return it directly.
-    // The mock path is used as the final fallback by CoachOrchestrator itself,
-    // but we check here to add suggested actions via _inferSuggestedActions.
-    // Note: suggestedActions are resolved at the screen layer (CoachChatScreen)
+    // suggestedActions are resolved at the screen layer (CoachChatScreen)
     // using inferSuggestedActions(userMessage, l) with BuildContext localizations.
     return CoachResponse(
       message: orchestratorResponse.message,
@@ -308,7 +332,7 @@ class CoachLlmService {
 
   /// Mode RAG direct (BYOK configure) — conservé pour compatibilité.
   ///
-  /// Appelé par l'orchestrateur via [CoachOrchestrator._tryByokChat].
+  /// Appelé par l'orchestrateur via CoachOrchestrator._tryByokChat.
   /// Reste accessible pour les tests unitaires de la couche RAG.
   @Deprecated('Utilise CoachOrchestrator.generateChat() à la place.')
   static Future<CoachResponse> chatViaRagDirect({

--- a/apps/mobile/lib/services/forecaster_service.dart
+++ b/apps/mobile/lib/services/forecaster_service.dart
@@ -304,7 +304,7 @@ class ForecasterService {
     // Compare against GROSS household income for consistency.
     // Previously used householdNetAnnuel (NET) which inflated the ratio.
     final householdGrossAnnuel = profile.revenuBrutAnnuelCouple;
-    final tauxRemplacement = _safeReplacementRate(
+    final tauxRemplacement = safeReplacementRate(
       annualRetirementIncome: scenarioBase.revenuAnnuelRetraite,
       annualCurrentIncome: householdGrossAnnuel,
     );
@@ -444,7 +444,7 @@ class ForecasterService {
           ).monthlyNetPayslip
         : 0.0;
     final householdNetAnnuel = (revenuNetMensuel + partnerNetMensuel) * 12;
-    final tauxRemplacement = _safeReplacementRate(
+    final tauxRemplacement = safeReplacementRate(
       annualRetirementIncome: scenarioBase.revenuAnnuelRetraite,
       annualCurrentIncome: householdNetAnnuel,
     );
@@ -1001,7 +1001,12 @@ class ForecasterService {
     return (to.year - from.year) * 12 + (to.month - from.month);
   }
 
-  static double _safeReplacementRate({
+  /// Canonical replacement rate computation with safety guards.
+  ///
+  /// FIX-P1-3: Made public so [RetirementProjectionService] delegates here
+  /// instead of duplicating the formula (which lacked guards).
+  /// Clamps to 0-200%, rejects negative or absurdly low incomes.
+  static double safeReplacementRate({
     required double annualRetirementIncome,
     required double annualCurrentIncome,
   }) {

--- a/apps/mobile/lib/services/precision/precision_service.dart
+++ b/apps/mobile/lib/services/precision/precision_service.dart
@@ -463,21 +463,26 @@ class PrecisionService {
     ));
 
     // --- AVS contribution years ---
-    double avsYears;
+    final double rawAvsYears;
     if (archetype == 'swiss_native') {
-      avsYears = (age - 20).clamp(0, 44).toDouble();
+      rawAvsYears = (age - 20).toDouble();
     } else if (archetype.startsWith('expat')) {
       // Expat: assume arrival at ~30 on average
-      avsYears = (age - 30).clamp(0, 44).toDouble();
+      rawAvsYears = (age - 30).toDouble();
     } else if (archetype == 'cross_border') {
-      avsYears = (age - 25).clamp(0, 44).toDouble();
+      rawAvsYears = (age - 25).toDouble();
     } else {
-      avsYears = (age - 20).clamp(0, 44).toDouble();
+      rawAvsYears = (age - 20).toDouble();
     }
+    final double avsYears = rawAvsYears.clamp(0, 44).toDouble();
+    // P2-15: Flag when clamping occurred so consumers can warn the user.
+    final bool avsYearsClamped = rawAvsYears != avsYears;
     defaults.add(SmartDefault(
       fieldName: 'avs_contribution_years',
       value: avsYears,
-      source: 'Estimation pour archetype $archetype (sans lacunes)',
+      source: avsYearsClamped
+          ? 'Estimation pour archetype $archetype (ajustée au max légal 44 ans)'
+          : 'Estimation pour archetype $archetype (sans lacunes)',
       confidence: archetype == 'swiss_native' ? 0.55 : 0.30,
     ));
 

--- a/apps/mobile/lib/services/retirement_projection_service.dart
+++ b/apps/mobile/lib/services/retirement_projection_service.dart
@@ -5,6 +5,7 @@ import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/financial_core/financial_core.dart';
+import 'package:mint_mobile/services/forecaster_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 
 // ────────────────────────────────────────────────────────────
@@ -210,11 +211,13 @@ class RetirementProjectionService {
         incomes.fold(0.0, (sum, s) => sum + s.monthlyAmount);
 
     // FIX-074: Use GROSS income for taux de remplacement (standard suisse).
-    // Was using NET, causing 12-point discrepancy vs ForecasterService.
+    // FIX-P1-3: Delegate to ForecasterService.safeReplacementRate (canonical).
     final revenuBrutMensuel = profile.revenuBrutAnnuel / 12 +
         (profile.conjoint?.revenuBrutAnnuel ?? 0) / 12;
-    final tauxRemplacement =
-        revenuBrutMensuel > 0 ? revenuMensuel / revenuBrutMensuel * 100 : 0.0;
+    final tauxRemplacement = ForecasterService.safeReplacementRate(
+      annualRetirementIncome: revenuMensuel * 12,
+      annualCurrentIncome: revenuBrutMensuel * 12,
+    );
 
     // 2. Couple phases
     final phases = _computePhases(
@@ -1079,8 +1082,11 @@ class RetirementProjectionService {
         : null;
     final revenuPreRetraite =
         userBkdn.monthlyNetPayslip + (conjBkdn?.monthlyNetPayslip ?? 0);
-    final tauxRemplacement =
-        revenuPreRetraite > 0 ? totalRevenus / revenuPreRetraite * 100 : 0.0;
+    // FIX-P1-3: Delegate to ForecasterService.safeReplacementRate (canonical).
+    final tauxRemplacement = ForecasterService.safeReplacementRate(
+      annualRetirementIncome: totalRevenus * 12,
+      annualCurrentIncome: revenuPreRetraite * 12,
+    );
 
     final solde = totalRevenus - impotMensuel - depensesMensuelles;
 

--- a/apps/mobile/lib/services/subscription_service.dart
+++ b/apps/mobile/lib/services/subscription_service.dart
@@ -332,15 +332,14 @@ class SubscriptionService {
       return purchased;
     }
 
-    // V6-2 audit fix: non-iOS paid upgrades require backend verification
-    // in release mode. Local mock grants only allowed in debug mode.
-    if (tier.isPaid && !kDebugMode) {
+    // Non-iOS paid upgrades ALWAYS require backend verification.
+    // SECURITY: No local mock grants for paid tiers, even in debug.
+    if (tier.isPaid) {
       final refreshed = await refreshFromBackend();
       return refreshed.tier.rank >= tier.rank;
     }
 
-    await Future<void>.delayed(const Duration(milliseconds: 100));
-
+    // Free tier downgrade — always allowed
     if (tier == SubscriptionTier.free) {
       _state = const SubscriptionState(
         tier: SubscriptionTier.free,
@@ -350,7 +349,8 @@ class SubscriptionService {
       return true;
     }
 
-    // Debug-only mock grant (never reached in release builds)
+    // Unreachable for paid tiers (guarded above)
+    assert(false, 'Unexpected tier: $tier');
     _state = SubscriptionState(
       tier: tier,
       isTrialActive: false,

--- a/apps/mobile/lib/widgets/premium/mint_amount_field.dart
+++ b/apps/mobile/lib/widgets/premium/mint_amount_field.dart
@@ -129,7 +129,9 @@ class MintAmountField extends StatelessWidget {
   }
 
   void _applyValue(String text, BuildContext ctx) {
-    final parsed = double.tryParse(text) ?? value;
+    // Strip Swiss formatting: "1'234.50" → "1234.50", "1 234" → "1234"
+    final cleaned = text.replaceAll("'", '').replaceAll('\u00a0', '').replaceAll(' ', '').replaceAll(',', '.');
+    final parsed = double.tryParse(cleaned) ?? value;
     double clamped = parsed;
     if (min != null && clamped < min!) clamped = min!;
     if (max != null && clamped > max!) clamped = max!;

--- a/apps/mobile/test/screens/coach/coach_chat_test.dart
+++ b/apps/mobile/test/screens/coach/coach_chat_test.dart
@@ -7,6 +7,7 @@ import 'package:mint_mobile/providers/mint_state_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/providers/user_activity_provider.dart';
 import 'package:mint_mobile/screens/coach/coach_chat_screen.dart';
+import 'package:mint_mobile/services/coach/coach_orchestrator.dart';
 import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/navigation/route_planner.dart';
 import 'package:mint_mobile/services/navigation/screen_registry.dart';
@@ -19,6 +20,9 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 // ────────────────────────────────────────────────────────────
 
 void main() {
+  // FIX-P1-7: Register orchestrator (no longer auto-imported by coach_llm_service).
+  CoachLlmService.registerOrchestrator(CoachOrchestrator.generateChat);
+
   CoachProfileProvider buildProfileProvider() {
     final provider = CoachProfileProvider();
     provider.updateFromAnswers({

--- a/apps/mobile/test/services/coach_llm_service_test.dart
+++ b/apps/mobile/test/services/coach_llm_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/coach/coach_orchestrator.dart';
 import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/rag_service.dart';
 
@@ -13,6 +14,8 @@ void main() {
   late List<ChatMessage> emptyHistory;
 
   setUp(() {
+    // FIX-P1-7: Register orchestrator (no longer auto-imported).
+    CoachLlmService.registerOrchestrator(CoachOrchestrator.generateChat);
     profile = CoachProfile.buildDemo();
     config = LlmConfig.defaultOpenAI;
     emptyHistory = [];

--- a/apps/mobile/test/services/subscription_service_test.dart
+++ b/apps/mobile/test/services/subscription_service_test.dart
@@ -147,36 +147,30 @@ void main() {
   // ═══════════════════════════════════════════════════════════════════════
 
   group('Upgrade', () {
-    test('upgradeTo premium changes tier to premium', () async {
+    test('upgradeTo premium requires backend (returns false without API)', () async {
+      // SECURITY: paid upgrades always require backend verification.
+      // Without a backend, upgradeTo returns false.
       final success = await SubscriptionService.upgradeTo(
         SubscriptionTier.premium,
       );
 
-      expect(success, isTrue);
-
-      final state = SubscriptionService.currentState();
-      expect(state.tier, SubscriptionTier.premium);
+      expect(success, isFalse);
     });
 
-    test('upgradeTo starter changes tier to starter', () async {
+    test('upgradeTo starter requires backend (returns false without API)', () async {
       final success = await SubscriptionService.upgradeTo(
         SubscriptionTier.starter,
       );
 
-      expect(success, isTrue);
-
-      final state = SubscriptionService.currentState();
-      expect(state.tier, SubscriptionTier.starter);
+      expect(success, isFalse);
     });
 
-    test('upgrade sets 30-day expiry', () async {
+    test('upgrade without backend does not change state', () async {
       await SubscriptionService.upgradeTo(SubscriptionTier.premium);
 
       final state = SubscriptionService.currentState();
-      expect(state.expiresAt, isNotNull);
-      // Expiry should be approximately 30 days from now
-      final diff = state.expiresAt!.difference(DateTime.now()).inDays;
-      expect(diff, inInclusiveRange(29, 30));
+      // State unchanged — still free tier
+      expect(state.tier, SubscriptionTier.free);
     });
 
     test('upgrade does not set trial active', () async {

--- a/services/backend/app/api/v1/endpoints/billing.py
+++ b/services/backend/app/api/v1/endpoints/billing.py
@@ -102,7 +102,7 @@ async def stripe_webhook(
     return StripeWebhookAck(received=True, event_type=event.get("type", "unknown"))
 
 
-@router.post("/debug/activate", response_model=BillingDebugActivateResponse)
+@router.post("/debug/activate", response_model=BillingDebugActivateResponse, include_in_schema=False)
 def debug_activate_subscription(
     body: BillingDebugActivateRequest,
     db: Session = Depends(get_db),
@@ -110,8 +110,9 @@ def debug_activate_subscription(
 ) -> BillingDebugActivateResponse:
     """
     Internal/dev helper to activate subscription without store checkout.
+    SECURITY: Only available in development. Hidden from OpenAPI schema.
     """
-    if settings.ENVIRONMENT in {"production", "staging"}:
+    if settings.ENVIRONMENT != "development":
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Not found",

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -151,8 +151,8 @@ async def _get_orchestrator():
 
 # Patterns that indicate PII in memory_block content.
 _PII_PATTERNS = [
-    re.compile(r"CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1}", re.IGNORECASE),  # IBAN
-    re.compile(r"\b[1-9]\d{3}\b(?=\s+[A-Z]{2})"),  # NPA (Swiss postal code 1000-9999 before city name)
+    re.compile(r"CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1,2}", re.IGNORECASE),  # IBAN (CH + 19 digits, with optional spaces)
+    re.compile(r"\b[1-9]\d{3}\b(?=\s+[A-Za-zÀ-ÿ]{2})"),  # NPA (Swiss postal code 1000-9999 before city name, incl. accented)
     re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"),  # email
     re.compile(r"\+?\d[\d\s]{8,14}\d"),  # phone numbers
 ]

--- a/services/backend/app/models/billing.py
+++ b/services/backend/app/models/billing.py
@@ -21,6 +21,9 @@ from app.core.database import Base
 
 class SubscriptionModel(Base):
     __tablename__ = "subscriptions"
+    __table_args__ = (
+        UniqueConstraint("user_id", "source", name="uq_subscription_user_source"),
+    )
 
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     user_id = Column(String, ForeignKey("users.id"), nullable=False, index=True)


### PR DESCRIPTION
## Summary
**Vague 5 (17 findings):** Ghost spouse cleanup, pay frequency case fix, unified replacement rate, tax params, null guards, circular dep broken, FR typography, investment cap, AVS clamp warning

**Vague 6 (22 findings):** IBAN/NPA regex hardened, billing security (3 P0s), Swiss amount parsing, conversation pruning

## Test plan
- [x] flutter analyze: 0 errors
- [x] flutter test: 8128 passed, 2 skipped, 0 failures
- [x] pytest: 4652 passed, 49 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)