### PR TITLE
fix: audit final — 4 P1 compliance fixes

### DIFF
--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -201,7 +201,7 @@
       }
     }
   },
-  "advisorMiniStep2AhaTaxQualitative": "Fiscalité en {canton} : {pressure} par rapport à la moyenne suisse",
+  "advisorMiniStep2AhaTaxQualitative": "Fiscalité en {canton} : {pressure} par rapport à l’indice fédéral",
   "@advisorMiniStep2AhaTaxQualitative": {
     "placeholders": {
       "canton": {
@@ -388,8 +388,8 @@
   "profileUser": "Utilisateur",
   "profileDeleteData": "Supprimer mes données locales",
   "rentVsCapitalTitle": "Rente vs Capital",
-  "rentVsCapitalDescription": "Comparez la rente viagère et le retrait en capital de votre 2e pilier",
-  "rentVsCapitalSubtitle": "Simulez votre 2e pilier • LPP",
+  "rentVsCapitalDescription": "Compare la rente viagère et le retrait en capital de ton 2e pilier",
+  "rentVsCapitalSubtitle": "Simulez ton 2e pilier • LPP",
   "rentVsCapitalAvoirOblig": "Avoir obligatoire",
   "rentVsCapitalAvoirSurob": "Avoir surobligatoire",
   "rentVsCapitalTauxConversion": "Taux de conversion surobligatoire",
@@ -406,7 +406,7 @@
   "rentVsCapitalPrudent": "Prudent (1\u00a0%)",
   "rentVsCapitalCentral": "Central (3\u00a0%)",
   "rentVsCapitalOptimiste": "Optimiste (5\u00a0%)",
-  "rentVsCapitalTauxConversionExpl": "Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8\u00a0% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3\u00a0% et 6\u00a0%.",
+  "rentVsCapitalTauxConversionExpl": "Le taux de conversion détermine le montant de ta rente annuelle en fonction de ton avoir de vieillesse. Le taux légal minimum est de 6.8\u00a0% pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3\u00a0% et 6\u00a0%.",
   "rentVsCapitalChoixExpl": "La rente offre un revenu régulier à vie, mais s'arrête au décès (avec éventuellement une rente de survivant réduite). Le capital donne plus de flexibilité, mais comporte un risque d'épuisement si les rendements sont faibles ou la longévité élevée.",
   "rentVsCapitalDisclaimer": "Les résultats présentés sont des estimations à titre indicatif. Ils ne constituent pas un conseil financier personnalisé. Consultez votre caisse de pension et un·e spécialiste qualifié·e avant toute décision.",
   "disabilityGapTitle": "Mon filet de sécurité",
@@ -429,7 +429,7 @@
   "disabilityGapRiskMedium": "Risque modéré",
   "disabilityGapRiskLow": "Risque faible",
   "disabilityGapDisclaimer": "Outil éducatif — ne constitue pas un conseil en assurance au sens de la LSFin. Tes couvertures réelles dépendent de ton contrat de travail et de ta caisse de pension.",
-  "disabilityGapIjmExpl": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80\u00a0% de votre salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu'à l'éventuelle rente AI.",
+  "disabilityGapIjmExpl": "L'IJM (indemnité journalière maladie) est une assurance qui couvre 80\u00a0% de ton salaire pendant max. 720 jours en cas de maladie. L'employeur n'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne reçois plus rien jusqu'à l'éventuelle rente AI.",
   "disabilityGapCo324aExpl": "Selon l'art. 324a CO, l'employeur doit verser le salaire pendant une durée limitée en cas de maladie. Cette durée dépend des années de service et de l'échelle cantonale applicable (bernoise, zurichoise ou bâloise). Après cette période, seule l'IJM (si existante) prend le relais.",
   "authLogin": "Se connecter",
   "authRegister": "Créer un compte",
@@ -787,14 +787,14 @@
   "successionExonere": "Exonéré",
   "successionTotalImpot": "Total impôt successoral",
   "succession3aOpp3": "Bénéficiaires 3a (OPP3 art. 2)",
-  "succession3aNote": "Le 3e pilier ne suit PAS votre testament. L'ordre de bénéficiaires est fixé par la loi.",
+  "succession3aNote": "Le 3e pilier ne suit PAS ton testament. L'ordre de bénéficiaires est fixé par la loi.",
   "successionPointsAttention": "Points d'attention",
   "successionChecklist": "Protection de mes proches",
   "successionChecklistSubtitle": "Actions à entreprendre",
   "successionEduQuotite": "Qu'est-ce que la quotité disponible ?",
-  "successionEduQuotiteBody": "La quotité disponible est la part de votre succession que vous pouvez librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.",
+  "successionEduQuotiteBody": "La quotité disponible est la part de ta succession que tu peux librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.",
   "successionEdu3a": "Le 3a et la succession : attention !",
-  "successionEdu3aBody": "Le 3e pilier est versé directement selon l'OPP3, pas selon votre testament.",
+  "successionEdu3aBody": "Le 3e pilier est versé directement selon l'OPP3, pas selon ton testament.",
   "successionEduConcubin": "Les concubins et la succession",
   "successionEduConcubinBody": "Les concubins n'ont aucun droit successoral légal. Sans testament, ils ne reçoivent rien.",
   "successionDisclaimer": "Information à caractère éducatif, ne constitue pas un conseil juridique (LSFin/CC). Consulte un·e spécialiste pour ta situation.",
@@ -1028,7 +1028,7 @@
   "segmentsGenderGapLacuneAnnuelle": "Lacune annuelle",
   "segmentsGenderGapLacuneTotale": "Lacune totale (~20 ans)",
   "segmentsGenderGapCoordinationTitle": "Comprendre la déduction de coordination",
-  "segmentsGenderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 25'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100\u00a0% ou à 50\u00a0%.",
+  "segmentsGenderGapCoordinationBody": "La déduction de coordination est un montant fixe de CHF 25'725 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100\u00a0% ou à 50\u00a0%.",
   "segmentsGenderGapSalaireBrut100": "Salaire brut à 100\u00a0%",
   "segmentsGenderGapSalaireCoord100": "Salaire coordonné à 100\u00a0%",
   "segmentsGenderGapSalaireBrutCurrent": "Salaire brut à {rate}\u00a0%",
@@ -1066,7 +1066,7 @@
   "segmentsFrontalierAppBar": "PARCOURS FRONTALIER",
   "segmentsFrontalierHeader": "Travailleur frontalier",
   "segmentsFrontalierHeaderSub": "Droits et obligations par pays",
-  "segmentsFrontalierIntro": "Les règles fiscales, de prévoyance et d'assurance varient selon votre pays de résidence et votre canton de travail.",
+  "segmentsFrontalierIntro": "Les règles fiscales, de prévoyance et d'assurance varient selon ton pays de résidence et ton canton de travail.",
   "segmentsFrontalierPaysLabel": "Pays de résidence",
   "segmentsFrontalierCantonLabel": "Canton de travail",
   "segmentsFrontalierRulesTitle": "RÈGLES APPLICABLES",
@@ -1075,7 +1075,7 @@
   "segmentsFrontalierCatLpp": "LPP / Libre passage",
   "segmentsFrontalierCatAvs": "AVS / Coordination",
   "segmentsFrontalierQuasiResidentTitle": "Statut quasi-résident (GE)",
-  "segmentsFrontalierQuasiResidentDesc": "Le statut de quasi-résident est accessible si au moins 90\u00a0% des revenus de votre ménage proviennent de Suisse.",
+  "segmentsFrontalierQuasiResidentDesc": "Le statut de quasi-résident est accessible si au moins 90\u00a0% des revenus de ton ménage proviennent de Suisse.",
   "segmentsFrontalierQuasiResidentCondition": "Condition : >= 90\u00a0% des revenus du ménage provenant de Suisse",
   "segmentsFrontalierChecklist": "Checklist frontalier",
   "segmentsFrontalierPaysFR": "France",
@@ -1128,7 +1128,7 @@
   "segmentsIndependantAlertLaa": "IMPORTANT : Sans assurance accident individuelle (LAA), les frais médicaux en cas d'accident ne sont pas couverts.",
   "segmentsIndependantAlertLpp": "Votre prévoyance repose uniquement sur l'AVS et le 3e pilier.",
   "segmentsIndependantAlert3a": "Vous ne profitez pas du 3e pilier. Plafond indépendant : CHF 36'288/an.",
-  "segmentsDemoMode": "Mode démo : profil exemple. Complétez votre diagnostic pour des résultats personnalisés.",
+  "segmentsDemoMode": "Mode démo : profil exemple. Complète ton diagnostic pour des résultats personnalisés.",
   "assurancesLamalTitle": "Optimiseur franchise LAMal",
   "assurancesLamalSubtitle": "Trouvez la franchise idéale selon vos frais de santé",
   "assurancesLamalPrimeMensuelle": "Prime mensuelle (franchise 300)",
@@ -1144,7 +1144,7 @@
   "assurancesLamalDelaiRappel": "Rappel : modification possible avant le 30 novembre",
   "assurancesLamalQuotePart": "Quote-part (10\u00a0%, max 700 CHF)",
   "assurancesCoverageTitle": "Check-up couverture",
-  "assurancesCoverageSubtitle": "Évaluez votre protection assurantielle",
+  "assurancesCoverageSubtitle": "Évaluez ta protection assurantielle",
   "assurancesCoverageScore": "Score de couverture",
   "assurancesCoverageLacunes": "Lacunes identifiées",
   "assurancesCoverageStatut": "Statut professionnel",
@@ -1175,7 +1175,7 @@
   "assurancesLamalTile": "Franchise LAMal",
   "assurancesLamalTileSub": "Trouvez la franchise idéale",
   "assurancesCoverageTile": "Check-up couverture",
-  "assurancesCoverageTileSub": "Évaluez votre protection assurantielle",
+  "assurancesCoverageTileSub": "Évaluez ta protection assurantielle",
   "openBankingTitle": "Open Banking",
   "openBankingSubtitle": "Connectez vos comptes bancaires",
   "openBankingFinmaGate": "Fonctionnalité en préparation — consultation réglementaire FINMA en cours",
@@ -1312,10 +1312,10 @@
   "lppDeepLibrePassagePrivacy": "Vos données restent sur votre appareil. Aucune information n'est transmise à des tiers. Conforme à la nLPD.",
   "lppDeepLibrePassageDisclaimer": "Ces informations sont pédagogiques et ne constituent pas un conseil juridique ou financier personnalisé. Les règles dépendent de votre caisse de pension et de votre situation. Base légale : LFLP, OLP.",
   "lppDeepEplTitle": "Retrait EPL",
-  "lppDeepEplSubtitle": "Financer un logement avec votre 2e pilier",
+  "lppDeepEplSubtitle": "Financer un logement avec ton 2e pilier",
   "lppDeepEplAppBar": "RETRAIT EPL",
   "lppDeepEplIntroTitle": "Retrait EPL — Propriété du logement",
-  "lppDeepEplIntroBody": "L'EPL permet d'utiliser votre avoir LPP pour financer l'achat d'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20'000.",
+  "lppDeepEplIntroBody": "L'EPL permet d'utiliser ton avoir LPP pour financer l'achat d'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20'000.",
   "lppDeepEplParams": "Paramètres",
   "lppDeepEplAvoirTotal": "Avoir LPP total",
   "lppDeepEplAge": "Âge",
@@ -3421,7 +3421,7 @@
   "fiscalChurchMember": "Membre d'une Église",
   "fiscalChurchTax": "Impôt ecclésiastique",
   "fiscalEffectiveRate": "Taux effectif estimé",
-  "fiscalBelowAverage": "Inférieur à la moyenne suisse (~{rate}\u00a0%)",
+  "fiscalBelowAverage": "Inférieur à l’indice fédéral (~{rate}\u00a0%)",
   "@fiscalBelowAverage": {
     "placeholders": {
       "rate": {
@@ -3429,7 +3429,7 @@
       }
     }
   },
-  "fiscalAboveAverage": "Supérieur à la moyenne suisse (~{rate}\u00a0%)",
+  "fiscalAboveAverage": "Supérieur à l’indice fédéral (~{rate}\u00a0%)",
   "@fiscalAboveAverage": {
     "placeholders": {
       "rate": {
@@ -4644,7 +4644,7 @@
   "heroGapMetaphorSmall": "C'est un café par jour de différence",
   "drawerCeQueTuAs": "Ce que tu as",
   "drawerCeQueTuAsSubtitle": "Patrimoine net",
-  "drawerCeQueTuDois": "Ce que tu dois",
+  "drawerCeQueTuDois": "Tes engagements",
   "drawerCeQueTuDoisSubtitle": "Dettes totales",
   "drawerCeQueTuAuras": "Ce que tu auras",
   "drawerCeQueTuAurasSubtitle": "Revenu retraite projeté",
@@ -9566,7 +9566,7 @@
       }
     }
   },
-  "benchmarkInsightTax": "La charge fiscale dans {canton} est {level} par rapport à la moyenne suisse",
+  "benchmarkInsightTax": "La charge fiscale dans {canton} est {level} par rapport à l’indice fédéral",
   "@benchmarkInsightTax": {
     "placeholders": {
       "canton": {

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -942,7 +942,7 @@ abstract class S {
   /// No description provided for @advisorMiniStep2AhaTaxQualitative.
   ///
   /// In fr, this message translates to:
-  /// **'Fiscalité en {canton} : {pressure} par rapport à la moyenne suisse'**
+  /// **'Fiscalité en {canton} : {pressure} par rapport à l’indice fédéral'**
   String advisorMiniStep2AhaTaxQualitative(String canton, String pressure);
 
   /// No description provided for @advisorMiniStep2AhaPressureLow.
@@ -1512,13 +1512,13 @@ abstract class S {
   /// No description provided for @rentVsCapitalDescription.
   ///
   /// In fr, this message translates to:
-  /// **'Comparez la rente viagère et le retrait en capital de votre 2e pilier'**
+  /// **'Compare la rente viagère et le retrait en capital de ton 2e pilier'**
   String get rentVsCapitalDescription;
 
   /// No description provided for @rentVsCapitalSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Simulez votre 2e pilier • LPP'**
+  /// **'Simulez ton 2e pilier • LPP'**
   String get rentVsCapitalSubtitle;
 
   /// No description provided for @rentVsCapitalAvoirOblig.
@@ -1620,7 +1620,7 @@ abstract class S {
   /// No description provided for @rentVsCapitalTauxConversionExpl.
   ///
   /// In fr, this message translates to:
-  /// **'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.'**
+  /// **'Le taux de conversion détermine le montant de ta rente annuelle en fonction de ton avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.'**
   String get rentVsCapitalTauxConversionExpl;
 
   /// No description provided for @rentVsCapitalChoixExpl.
@@ -1758,7 +1758,7 @@ abstract class S {
   /// No description provided for @disabilityGapIjmExpl.
   ///
   /// In fr, this message translates to:
-  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.'**
+  /// **'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne reçois plus rien jusqu\'à l\'éventuelle rente AI.'**
   String get disabilityGapIjmExpl;
 
   /// No description provided for @disabilityGapCo324aExpl.
@@ -3576,7 +3576,7 @@ abstract class S {
   /// No description provided for @succession3aNote.
   ///
   /// In fr, this message translates to:
-  /// **'Le 3e pilier ne suit PAS votre testament. L\'ordre de bénéficiaires est fixé par la loi.'**
+  /// **'Le 3e pilier ne suit PAS ton testament. L\'ordre de bénéficiaires est fixé par la loi.'**
   String get succession3aNote;
 
   /// No description provided for @successionPointsAttention.
@@ -3606,7 +3606,7 @@ abstract class S {
   /// No description provided for @successionEduQuotiteBody.
   ///
   /// In fr, this message translates to:
-  /// **'La quotité disponible est la part de votre succession que vous pouvez librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.'**
+  /// **'La quotité disponible est la part de ta succession que tu peux librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.'**
   String get successionEduQuotiteBody;
 
   /// No description provided for @successionEdu3a.
@@ -3618,7 +3618,7 @@ abstract class S {
   /// No description provided for @successionEdu3aBody.
   ///
   /// In fr, this message translates to:
-  /// **'Le 3e pilier est versé directement selon l\'OPP3, pas selon votre testament.'**
+  /// **'Le 3e pilier est versé directement selon l\'OPP3, pas selon ton testament.'**
   String get successionEdu3aBody;
 
   /// No description provided for @successionEduConcubin.
@@ -4214,7 +4214,7 @@ abstract class S {
   /// No description provided for @segmentsGenderGapCoordinationBody.
   ///
   /// In fr, this message translates to:
-  /// **'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100 % ou à 50 %.'**
+  /// **'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100 % ou à 50 %.'**
   String get segmentsGenderGapCoordinationBody;
 
   /// No description provided for @segmentsGenderGapSalaireBrut100.
@@ -4358,7 +4358,7 @@ abstract class S {
   /// No description provided for @segmentsFrontalierIntro.
   ///
   /// In fr, this message translates to:
-  /// **'Les règles fiscales, de prévoyance et d\'assurance varient selon votre pays de résidence et votre canton de travail.'**
+  /// **'Les règles fiscales, de prévoyance et d\'assurance varient selon ton pays de résidence et ton canton de travail.'**
   String get segmentsFrontalierIntro;
 
   /// No description provided for @segmentsFrontalierPaysLabel.
@@ -4412,7 +4412,7 @@ abstract class S {
   /// No description provided for @segmentsFrontalierQuasiResidentDesc.
   ///
   /// In fr, this message translates to:
-  /// **'Le statut de quasi-résident est accessible si au moins 90 % des revenus de votre ménage proviennent de Suisse.'**
+  /// **'Le statut de quasi-résident est accessible si au moins 90 % des revenus de ton ménage proviennent de Suisse.'**
   String get segmentsFrontalierQuasiResidentDesc;
 
   /// No description provided for @segmentsFrontalierQuasiResidentCondition.
@@ -4688,7 +4688,7 @@ abstract class S {
   /// No description provided for @segmentsDemoMode.
   ///
   /// In fr, this message translates to:
-  /// **'Mode démo : profil exemple. Complétez votre diagnostic pour des résultats personnalisés.'**
+  /// **'Mode démo : profil exemple. Complète ton diagnostic pour des résultats personnalisés.'**
   String get segmentsDemoMode;
 
   /// No description provided for @assurancesLamalTitle.
@@ -4784,7 +4784,7 @@ abstract class S {
   /// No description provided for @assurancesCoverageSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Évaluez votre protection assurantielle'**
+  /// **'Évaluez ta protection assurantielle'**
   String get assurancesCoverageSubtitle;
 
   /// No description provided for @assurancesCoverageScore.
@@ -4970,7 +4970,7 @@ abstract class S {
   /// No description provided for @assurancesCoverageTileSub.
   ///
   /// In fr, this message translates to:
-  /// **'Évaluez votre protection assurantielle'**
+  /// **'Évaluez ta protection assurantielle'**
   String get assurancesCoverageTileSub;
 
   /// No description provided for @openBankingTitle.
@@ -5708,7 +5708,7 @@ abstract class S {
   /// No description provided for @lppDeepEplSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Financer un logement avec votre 2e pilier'**
+  /// **'Financer un logement avec ton 2e pilier'**
   String get lppDeepEplSubtitle;
 
   /// No description provided for @lppDeepEplAppBar.
@@ -5726,7 +5726,7 @@ abstract class S {
   /// No description provided for @lppDeepEplIntroBody.
   ///
   /// In fr, this message translates to:
-  /// **'L\'EPL permet d\'utiliser votre avoir LPP pour financer l\'achat d\'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20\'000.'**
+  /// **'L\'EPL permet d\'utiliser ton avoir LPP pour financer l\'achat d\'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20\'000.'**
   String get lppDeepEplIntroBody;
 
   /// No description provided for @lppDeepEplParams.
@@ -13655,13 +13655,13 @@ abstract class S {
   /// No description provided for @fiscalBelowAverage.
   ///
   /// In fr, this message translates to:
-  /// **'Inférieur à la moyenne suisse (~{rate} %)'**
+  /// **'Inférieur à l’indice fédéral (~{rate} %)'**
   String fiscalBelowAverage(String rate);
 
   /// No description provided for @fiscalAboveAverage.
   ///
   /// In fr, this message translates to:
-  /// **'Supérieur à la moyenne suisse (~{rate} %)'**
+  /// **'Supérieur à l’indice fédéral (~{rate} %)'**
   String fiscalAboveAverage(String rate);
 
   /// No description provided for @fiscalBreakdownTitle.
@@ -17531,7 +17531,7 @@ abstract class S {
   /// No description provided for @drawerCeQueTuDois.
   ///
   /// In fr, this message translates to:
-  /// **'Ce que tu dois'**
+  /// **'Tes engagements'**
   String get drawerCeQueTuDois;
 
   /// No description provided for @drawerCeQueTuDoisSubtitle.
@@ -34077,7 +34077,7 @@ abstract class S {
   /// No description provided for @benchmarkInsightTax.
   ///
   /// In fr, this message translates to:
-  /// **'La charge fiscale dans {canton} est {level} par rapport à la moyenne suisse'**
+  /// **'La charge fiscale dans {canton} est {level} par rapport à l’indice fédéral'**
   String benchmarkInsightTax(String canton, String level);
 
   /// No description provided for @benchmarkInsightHousing.

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -481,7 +481,7 @@ class SFr extends S {
 
   @override
   String advisorMiniStep2AhaTaxQualitative(String canton, String pressure) {
-    return 'Fiscalité en $canton : $pressure par rapport à la moyenne suisse';
+    return 'Fiscalité en $canton : $pressure par rapport à l’indice fédéral';
   }
 
   @override
@@ -807,10 +807,10 @@ class SFr extends S {
 
   @override
   String get rentVsCapitalDescription =>
-      'Comparez la rente viagère et le retrait en capital de votre 2e pilier';
+      'Compare la rente viagère et le retrait en capital de ton 2e pilier';
 
   @override
-  String get rentVsCapitalSubtitle => 'Simulez votre 2e pilier • LPP';
+  String get rentVsCapitalSubtitle => 'Simulez ton 2e pilier • LPP';
 
   @override
   String get rentVsCapitalAvoirOblig => 'Avoir obligatoire';
@@ -862,7 +862,7 @@ class SFr extends S {
 
   @override
   String get rentVsCapitalTauxConversionExpl =>
-      'Le taux de conversion détermine le montant de votre rente annuelle en fonction de votre avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.';
+      'Le taux de conversion détermine le montant de ta rente annuelle en fonction de ton avoir de vieillesse. Le taux légal minimum est de 6.8 % pour la part obligatoire (LPP art. 14). Pour la part surobligatoire, chaque caisse de pension fixe son propre taux, généralement entre 3 % et 6 %.';
 
   @override
   String get rentVsCapitalChoixExpl =>
@@ -936,7 +936,7 @@ class SFr extends S {
 
   @override
   String get disabilityGapIjmExpl =>
-      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de votre salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, vous ne recevez plus rien jusqu\'à l\'éventuelle rente AI.';
+      'L\'IJM (indemnité journalière maladie) est une assurance qui couvre 80 % de ton salaire pendant max. 720 jours en cas de maladie. L\'employeur n\'est pas obligé de la souscrire, mais beaucoup le font via une assurance collective. Sans IJM, après la période légale de maintien du salaire, tu ne reçois plus rien jusqu\'à l\'éventuelle rente AI.';
 
   @override
   String get disabilityGapCo324aExpl =>
@@ -1912,7 +1912,7 @@ class SFr extends S {
 
   @override
   String get succession3aNote =>
-      'Le 3e pilier ne suit PAS votre testament. L\'ordre de bénéficiaires est fixé par la loi.';
+      'Le 3e pilier ne suit PAS ton testament. L\'ordre de bénéficiaires est fixé par la loi.';
 
   @override
   String get successionPointsAttention => 'Points d\'attention';
@@ -1928,14 +1928,14 @@ class SFr extends S {
 
   @override
   String get successionEduQuotiteBody =>
-      'La quotité disponible est la part de votre succession que vous pouvez librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.';
+      'La quotité disponible est la part de ta succession que tu peux librement attribuer par testament. Depuis 2023, la réserve des descendants est de 1/2.';
 
   @override
   String get successionEdu3a => 'Le 3a et la succession : attention !';
 
   @override
   String get successionEdu3aBody =>
-      'Le 3e pilier est versé directement selon l\'OPP3, pas selon votre testament.';
+      'Le 3e pilier est versé directement selon l\'OPP3, pas selon ton testament.';
 
   @override
   String get successionEduConcubin => 'Les concubins et la succession';
@@ -2286,7 +2286,7 @@ class SFr extends S {
 
   @override
   String get segmentsGenderGapCoordinationBody =>
-      'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de votre salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que vous travailliez à 100 % ou à 50 %.';
+      'La déduction de coordination est un montant fixe de CHF 25\'725 soustrait de ton salaire brut pour calculer le salaire coordonné (base LPP). Ce montant est le même que tu travailles à 100 % ou à 50 %.';
 
   @override
   String get segmentsGenderGapSalaireBrut100 => 'Salaire brut à 100 %';
@@ -2371,7 +2371,7 @@ class SFr extends S {
 
   @override
   String get segmentsFrontalierIntro =>
-      'Les règles fiscales, de prévoyance et d\'assurance varient selon votre pays de résidence et votre canton de travail.';
+      'Les règles fiscales, de prévoyance et d\'assurance varient selon ton pays de résidence et ton canton de travail.';
 
   @override
   String get segmentsFrontalierPaysLabel => 'Pays de résidence';
@@ -2400,7 +2400,7 @@ class SFr extends S {
 
   @override
   String get segmentsFrontalierQuasiResidentDesc =>
-      'Le statut de quasi-résident est accessible si au moins 90 % des revenus de votre ménage proviennent de Suisse.';
+      'Le statut de quasi-résident est accessible si au moins 90 % des revenus de ton ménage proviennent de Suisse.';
 
   @override
   String get segmentsFrontalierQuasiResidentCondition =>
@@ -2553,7 +2553,7 @@ class SFr extends S {
 
   @override
   String get segmentsDemoMode =>
-      'Mode démo : profil exemple. Complétez votre diagnostic pour des résultats personnalisés.';
+      'Mode démo : profil exemple. Complète ton diagnostic pour des résultats personnalisés.';
 
   @override
   String get assurancesLamalTitle => 'Optimiseur franchise LAMal';
@@ -2604,7 +2604,7 @@ class SFr extends S {
 
   @override
   String get assurancesCoverageSubtitle =>
-      'Évaluez votre protection assurantielle';
+      'Évaluez ta protection assurantielle';
 
   @override
   String get assurancesCoverageScore => 'Score de couverture';
@@ -2698,8 +2698,7 @@ class SFr extends S {
   String get assurancesCoverageTile => 'Check-up couverture';
 
   @override
-  String get assurancesCoverageTileSub =>
-      'Évaluez votre protection assurantielle';
+  String get assurancesCoverageTileSub => 'Évaluez ta protection assurantielle';
 
   @override
   String get openBankingTitle => 'Open Banking';
@@ -3093,7 +3092,7 @@ class SFr extends S {
   String get lppDeepEplTitle => 'Retrait EPL';
 
   @override
-  String get lppDeepEplSubtitle => 'Financer un logement avec votre 2e pilier';
+  String get lppDeepEplSubtitle => 'Financer un logement avec ton 2e pilier';
 
   @override
   String get lppDeepEplAppBar => 'RETRAIT EPL';
@@ -3103,7 +3102,7 @@ class SFr extends S {
 
   @override
   String get lppDeepEplIntroBody =>
-      'L\'EPL permet d\'utiliser votre avoir LPP pour financer l\'achat d\'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20\'000.';
+      'L\'EPL permet d\'utiliser ton avoir LPP pour financer l\'achat d\'un logement en propriété, amortir une hypothèque ou financer des rénovations. Montant minimum : CHF 20\'000.';
 
   @override
   String get lppDeepEplParams => 'Paramètres';
@@ -7549,12 +7548,12 @@ class SFr extends S {
 
   @override
   String fiscalBelowAverage(String rate) {
-    return 'Inférieur à la moyenne suisse (~$rate %)';
+    return 'Inférieur à l’indice fédéral (~$rate %)';
   }
 
   @override
   String fiscalAboveAverage(String rate) {
-    return 'Supérieur à la moyenne suisse (~$rate %)';
+    return 'Supérieur à l’indice fédéral (~$rate %)';
   }
 
   @override
@@ -9761,7 +9760,7 @@ class SFr extends S {
   String get drawerCeQueTuAsSubtitle => 'Patrimoine net';
 
   @override
-  String get drawerCeQueTuDois => 'Ce que tu dois';
+  String get drawerCeQueTuDois => 'Tes engagements';
 
   @override
   String get drawerCeQueTuDoisSubtitle => 'Dettes totales';
@@ -19309,7 +19308,7 @@ class SFr extends S {
 
   @override
   String benchmarkInsightTax(String canton, String level) {
-    return 'La charge fiscale dans $canton est $level par rapport à la moyenne suisse';
+    return 'La charge fiscale dans $canton est $level par rapport à l’indice fédéral';
   }
 
   @override


### PR DESCRIPTION
## Summary
Fixes 4 P1 findings from 75-gate audit:
- "moyenne suisse" → "indice fédéral" (4 ARB keys, compliance J3)
- 17 "votre/vous" → "ton/ta/tu" in educational text (J14)
- "Ce que tu dois" → "Tes engagements" (J9)
- Secrets check: 0 real secrets found (D7 false positive confirmed)

## Test plan
- [x] flutter test: 8128 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)