### PR TITLE
fix: 7/7 production blockers — consent, DB, routes, lint, i18n

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -907,6 +907,8 @@ final _router = GoRouter(
     GoRoute(
       path: '/expert-tier',
       parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) =>
+          FeatureFlags.enableExpertTier ? null : '/',
       builder: (context, state) => const ExpertTierScreen(),
     ),
     GoRoute(
@@ -917,6 +919,8 @@ final _router = GoRouter(
     GoRoute(
       path: '/pension-fund-connect',
       parentNavigatorKey: _rootNavigatorKey,
+      redirect: (context, state) =>
+          FeatureFlags.enablePensionFundConnect ? null : '/',
       builder: (context, state) => const PensionFundConnectScreen(),
     ),
     GoRoute(path: '/advisor/plan-30-days', redirect: (_, __) => '/home'),

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11893,5 +11893,12 @@
   "apiErrorOffline": "Keine Internetverbindung. Überprüfe dein Netzwerk und versuche es erneut.",
   "apiErrorTimeout": "Der Server antwortet zu langsam. Versuche es erneut.",
   "apiErrorSessionExpired": "Sitzung abgelaufen — bitte melde dich erneut an.",
-  "apiErrorServer": "Serverfehler. Versuche es in einem Moment erneut."
+  "apiErrorServer": "Serverfehler. Versuche es in einem Moment erneut.",
+  "pensionFundConnectComingSoon": "Bald verfügbar — Pilotvereinbarungen ausstehend",
+  "greetingMorning": "Guten Morgen",
+  "greetingAfternoon": "Guten Nachmittag",
+  "greetingEvening": "Guten Abend",
+  "greetingNight": "Gute Nacht",
+  "onboardingCalculationError": "Berechnungsfehler. Überprüfe deine Daten und versuche es erneut.",
+  "onboardingRetirementAgeWarning": "Pensionierung vor 55? Überprüfe dein Alter oder deinen Beschäftigungsstatus."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11893,5 +11893,12 @@
   "apiErrorOffline": "No internet connection. Check your network and try again.",
   "apiErrorTimeout": "The server is taking too long to respond. Try again.",
   "apiErrorSessionExpired": "Session expired — please log in again.",
-  "apiErrorServer": "Server error. Try again in a moment."
+  "apiErrorServer": "Server error. Try again in a moment.",
+  "pensionFundConnectComingSoon": "Coming soon — awaiting pilot agreements",
+  "greetingMorning": "Good morning",
+  "greetingAfternoon": "Good afternoon",
+  "greetingEvening": "Good evening",
+  "greetingNight": "Good night",
+  "onboardingCalculationError": "Calculation error. Check your data and try again.",
+  "onboardingRetirementAgeWarning": "Retirement before 55? Check your age or employment status."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -1354,8 +1354,8 @@
   "exploreLearn3a": "Que es el pilar 3a?",
   "exploreLearnLpp": "LPP: Como funciona",
   "exploreLearnFiscal": "Fiscalidad suiza 101",
-  "coachWelcome": "Bienvenue sur MINT",
-  "coachHello": "Bonjour {firstName}",
+  "coachWelcome": "Bienvenido a MINT",
+  "coachHello": "Hola {firstName}",
   "@coachHello": {
     "placeholders": {
       "firstName": {
@@ -8498,16 +8498,16 @@
   "openBankingHubSubtitle": "Conecta tus cuentas bancarias",
   "openBankingHubConnectedAccounts": "CUENTAS CONECTADAS",
   "openBankingHubApercu": "PANORAMA FINANCIERO",
-  "openBankingHubNavigation": "NAVIGATION",
+  "openBankingHubNavigation": "NAVEGACIÓN",
   "openBankingHubViewTransactions": "Ver transacciones",
   "openBankingHubViewTransactionsDesc": "Historial detallado por categoría",
   "openBankingHubManageConsents": "Gestionar consentimientos",
   "openBankingHubManageConsentsDesc": "Derechos nLPD, revocación, permisos",
-  "openBankingHubSoldeTotal": "Solde total",
+  "openBankingHubSoldeTotal": "Saldo total",
   "openBankingHubComptesConnectes": "3 cuentas conectadas",
   "openBankingHubRevenus": "Ingresos",
   "openBankingHubDepenses": "Gastos",
-  "openBankingHubEpargneNette": "Épargne nette",
+  "openBankingHubEpargneNette": "Ahorro neto",
   "openBankingHubTop3Depenses": "Top 3 gastos",
   "openBankingHubAddBankLabel": "Añadir un banco",
   "openBankingHubSyncMinutes": "Hace {minutes} min",
@@ -11893,5 +11893,12 @@
   "apiErrorOffline": "Sin conexión a internet. Verifica tu red e inténtalo de nuevo.",
   "apiErrorTimeout": "El servidor tarda demasiado en responder. Inténtalo de nuevo.",
   "apiErrorSessionExpired": "Sesión expirada — vuelve a iniciar sesión.",
-  "apiErrorServer": "Error del servidor. Inténtalo de nuevo en un momento."
+  "apiErrorServer": "Error del servidor. Inténtalo de nuevo en un momento.",
+  "pensionFundConnectComingSoon": "Disponible pronto — a la espera de acuerdos piloto",
+  "greetingMorning": "Buenos días",
+  "greetingAfternoon": "Buenas tardes",
+  "greetingEvening": "Buenas noches",
+  "greetingNight": "Buenas noches",
+  "onboardingCalculationError": "Error de cálculo. Verifica tus datos e inténtalo de nuevo.",
+  "onboardingRetirementAgeWarning": "¿Jubilación antes de los 55? Verifica tu edad o tu situación laboral."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12340,5 +12340,12 @@
   "apiErrorOffline": "Pas de connexion internet. Vérifie ton réseau et réessaie.",
   "apiErrorTimeout": "Le serveur met trop de temps à répondre. Réessaie.",
   "apiErrorSessionExpired": "Session expirée\u00a0— reconnecte-toi.",
-  "apiErrorServer": "Erreur serveur. Réessaie dans quelques instants."
+  "apiErrorServer": "Erreur serveur. Réessaie dans quelques instants.",
+  "pensionFundConnectComingSoon": "Bientôt disponible\u00a0— en attente des accords pilotes",
+  "greetingMorning": "Bonjour",
+  "greetingAfternoon": "Bon après-midi",
+  "greetingEvening": "Bonsoir",
+  "greetingNight": "Bonne nuit",
+  "onboardingCalculationError": "Erreur de calcul. Vérifie tes données et réessaie.",
+  "onboardingRetirementAgeWarning": "Retraite avant 55 ans\u00a0? Vérifie ton âge ou ton statut."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -1354,8 +1354,8 @@
   "exploreLearn3a": "Cos'e il pilastro 3a?",
   "exploreLearnLpp": "LPP: Come funziona",
   "exploreLearnFiscal": "Fiscalita svizzera 101",
-  "coachWelcome": "Bienvenue sur MINT",
-  "coachHello": "Bonjour {firstName}",
+  "coachWelcome": "Benvenuto su MINT",
+  "coachHello": "Ciao {firstName}",
   "@coachHello": {
     "placeholders": {
       "firstName": {
@@ -8459,16 +8459,16 @@
   "openBankingHubSubtitle": "Collega i tuoi conti bancari",
   "openBankingHubConnectedAccounts": "CONTI COLLEGATI",
   "openBankingHubApercu": "PANORAMICA FINANZIARIA",
-  "openBankingHubNavigation": "NAVIGATION",
+  "openBankingHubNavigation": "NAVIGAZIONE",
   "openBankingHubViewTransactions": "Vedi le transazioni",
   "openBankingHubViewTransactionsDesc": "Storico dettagliato per categoria",
   "openBankingHubManageConsents": "Gestisci i consensi",
   "openBankingHubManageConsentsDesc": "Diritti nLPD, revoca, ambiti",
-  "openBankingHubSoldeTotal": "Solde total",
+  "openBankingHubSoldeTotal": "Saldo totale",
   "openBankingHubComptesConnectes": "3 conti collegati",
   "openBankingHubRevenus": "Entrate",
   "openBankingHubDepenses": "Spese",
-  "openBankingHubEpargneNette": "Épargne nette",
+  "openBankingHubEpargneNette": "Risparmio netto",
   "openBankingHubTop3Depenses": "Top 3 spese",
   "openBankingHubAddBankLabel": "Aggiungi una banca",
   "openBankingHubSyncMinutes": "{minutes} min fa",
@@ -11893,5 +11893,12 @@
   "apiErrorOffline": "Nessuna connessione internet. Verifica la tua rete e riprova.",
   "apiErrorTimeout": "Il server impiega troppo tempo a rispondere. Riprova.",
   "apiErrorSessionExpired": "Sessione scaduta — effettua nuovamente l'accesso.",
-  "apiErrorServer": "Errore del server. Riprova tra qualche istante."
+  "apiErrorServer": "Errore del server. Riprova tra qualche istante.",
+  "pensionFundConnectComingSoon": "Disponibile a breve — in attesa degli accordi pilota",
+  "greetingMorning": "Buongiorno",
+  "greetingAfternoon": "Buon pomeriggio",
+  "greetingEvening": "Buonasera",
+  "greetingNight": "Buonanotte",
+  "onboardingCalculationError": "Errore di calcolo. Verifica i tuoi dati e riprova.",
+  "onboardingRetirementAgeWarning": "Pensionamento prima dei 55? Verifica la tua età o il tuo stato lavorativo."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -41234,19 +41234,19 @@ abstract class S {
   /// No description provided for @greetingMorning.
   ///
   /// In fr, this message translates to:
-  /// **'matin'**
+  /// **'Bonjour'**
   String get greetingMorning;
 
   /// No description provided for @greetingAfternoon.
   ///
   /// In fr, this message translates to:
-  /// **'après-midi'**
+  /// **'Bon après-midi'**
   String get greetingAfternoon;
 
   /// No description provided for @greetingEvening.
   ///
   /// In fr, this message translates to:
-  /// **'soir'**
+  /// **'Bonsoir'**
   String get greetingEvening;
 
   /// No description provided for @authShowPassword.
@@ -44574,6 +44574,30 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Erreur serveur. Réessaie dans quelques instants.'**
   String get apiErrorServer;
+
+  /// No description provided for @pensionFundConnectComingSoon.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bientôt disponible — en attente des accords pilotes'**
+  String get pensionFundConnectComingSoon;
+
+  /// No description provided for @greetingNight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bonne nuit'**
+  String get greetingNight;
+
+  /// No description provided for @onboardingCalculationError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Erreur de calcul. Vérifie tes données et réessaie.'**
+  String get onboardingCalculationError;
+
+  /// No description provided for @onboardingRetirementAgeWarning.
+  ///
+  /// In fr, this message translates to:
+  /// **'Retraite avant 55 ans ? Vérifie ton âge ou ton statut.'**
+  String get onboardingRetirementAgeWarning;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23430,13 +23430,13 @@ class SDe extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/Jahr';
 
   @override
-  String get greetingMorning => 'Morgen';
+  String get greetingMorning => 'Guten Morgen';
 
   @override
-  String get greetingAfternoon => 'Nachmittag';
+  String get greetingAfternoon => 'Guten Nachmittag';
 
   @override
-  String get greetingEvening => 'Abend';
+  String get greetingEvening => 'Guten Abend';
 
   @override
   String get authShowPassword => 'Passwort anzeigen';
@@ -25348,4 +25348,19 @@ class SDe extends S {
   @override
   String get apiErrorServer =>
       'Serverfehler. Versuche es in einem Moment erneut.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Bald verfügbar — Pilotvereinbarungen ausstehend';
+
+  @override
+  String get greetingNight => 'Gute Nacht';
+
+  @override
+  String get onboardingCalculationError =>
+      'Berechnungsfehler. Überprüfe deine Daten und versuche es erneut.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      'Pensionierung vor 55? Überprüfe dein Alter oder deinen Beschäftigungsstatus.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23269,13 +23269,13 @@ class SEn extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/year';
 
   @override
-  String get greetingMorning => 'morning';
+  String get greetingMorning => 'Good morning';
 
   @override
-  String get greetingAfternoon => 'afternoon';
+  String get greetingAfternoon => 'Good afternoon';
 
   @override
-  String get greetingEvening => 'evening';
+  String get greetingEvening => 'Good evening';
 
   @override
   String get authShowPassword => 'Show password';
@@ -25172,4 +25172,19 @@ class SEn extends S {
 
   @override
   String get apiErrorServer => 'Server error. Try again in a moment.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Coming soon — awaiting pilot agreements';
+
+  @override
+  String get greetingNight => 'Good night';
+
+  @override
+  String get onboardingCalculationError =>
+      'Calculation error. Check your data and try again.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      'Retirement before 55? Check your age or employment status.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -3306,11 +3306,11 @@ class SEs extends S {
   String get exploreLearnFiscal => 'Fiscalidad suiza 101';
 
   @override
-  String get coachWelcome => 'Bienvenue sur MINT';
+  String get coachWelcome => 'Bienvenido a MINT';
 
   @override
   String coachHello(String firstName) {
-    return 'Bonjour $firstName';
+    return 'Hola $firstName';
   }
 
   @override
@@ -17658,7 +17658,7 @@ class SEs extends S {
   String get openBankingHubApercu => 'PANORAMA FINANCIERO';
 
   @override
-  String get openBankingHubNavigation => 'NAVIGATION';
+  String get openBankingHubNavigation => 'NAVEGACIÓN';
 
   @override
   String get openBankingHubViewTransactions => 'Ver transacciones';
@@ -17675,7 +17675,7 @@ class SEs extends S {
       'Derechos nLPD, revocación, permisos';
 
   @override
-  String get openBankingHubSoldeTotal => 'Solde total';
+  String get openBankingHubSoldeTotal => 'Saldo total';
 
   @override
   String get openBankingHubComptesConnectes => '3 cuentas conectadas';
@@ -17687,7 +17687,7 @@ class SEs extends S {
   String get openBankingHubDepenses => 'Gastos';
 
   @override
-  String get openBankingHubEpargneNette => 'Épargne nette';
+  String get openBankingHubEpargneNette => 'Ahorro neto';
 
   @override
   String get openBankingHubTop3Depenses => 'Top 3 gastos';
@@ -23387,13 +23387,13 @@ class SEs extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/año';
 
   @override
-  String get greetingMorning => 'mañana';
+  String get greetingMorning => 'Buenos días';
 
   @override
-  String get greetingAfternoon => 'tarde';
+  String get greetingAfternoon => 'Buenas tardes';
 
   @override
-  String get greetingEvening => 'noche';
+  String get greetingEvening => 'Buenas noches';
 
   @override
   String get authShowPassword => 'Mostrar contraseña';
@@ -25301,4 +25301,19 @@ class SEs extends S {
   @override
   String get apiErrorServer =>
       'Error del servidor. Inténtalo de nuevo en un momento.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Disponible pronto — a la espera de acuerdos piloto';
+
+  @override
+  String get greetingNight => 'Buenas noches';
+
+  @override
+  String get onboardingCalculationError =>
+      'Error de cálculo. Verifica tus datos e inténtalo de nuevo.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      '¿Jubilación antes de los 55? Verifica tu edad o tu situación laboral.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23383,13 +23383,13 @@ class SFr extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/an';
 
   @override
-  String get greetingMorning => 'matin';
+  String get greetingMorning => 'Bonjour';
 
   @override
-  String get greetingAfternoon => 'après-midi';
+  String get greetingAfternoon => 'Bon après-midi';
 
   @override
-  String get greetingEvening => 'soir';
+  String get greetingEvening => 'Bonsoir';
 
   @override
   String get authShowPassword => 'Afficher le mot de passe';
@@ -25294,4 +25294,19 @@ class SFr extends S {
   @override
   String get apiErrorServer =>
       'Erreur serveur. Réessaie dans quelques instants.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Bientôt disponible — en attente des accords pilotes';
+
+  @override
+  String get greetingNight => 'Bonne nuit';
+
+  @override
+  String get onboardingCalculationError =>
+      'Erreur de calcul. Vérifie tes données et réessaie.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      'Retraite avant 55 ans ? Vérifie ton âge ou ton statut.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -3316,11 +3316,11 @@ class SIt extends S {
   String get exploreLearnFiscal => 'Fiscalita svizzera 101';
 
   @override
-  String get coachWelcome => 'Bienvenue sur MINT';
+  String get coachWelcome => 'Benvenuto su MINT';
 
   @override
   String coachHello(String firstName) {
-    return 'Bonjour $firstName';
+    return 'Ciao $firstName';
   }
 
   @override
@@ -17691,7 +17691,7 @@ class SIt extends S {
   String get openBankingHubApercu => 'PANORAMICA FINANZIARIA';
 
   @override
-  String get openBankingHubNavigation => 'NAVIGATION';
+  String get openBankingHubNavigation => 'NAVIGAZIONE';
 
   @override
   String get openBankingHubViewTransactions => 'Vedi le transazioni';
@@ -17707,7 +17707,7 @@ class SIt extends S {
   String get openBankingHubManageConsentsDesc => 'Diritti nLPD, revoca, ambiti';
 
   @override
-  String get openBankingHubSoldeTotal => 'Solde total';
+  String get openBankingHubSoldeTotal => 'Saldo totale';
 
   @override
   String get openBankingHubComptesConnectes => '3 conti collegati';
@@ -17719,7 +17719,7 @@ class SIt extends S {
   String get openBankingHubDepenses => 'Spese';
 
   @override
-  String get openBankingHubEpargneNette => 'Épargne nette';
+  String get openBankingHubEpargneNette => 'Risparmio netto';
 
   @override
   String get openBankingHubTop3Depenses => 'Top 3 spese';
@@ -23449,13 +23449,13 @@ class SIt extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/anno';
 
   @override
-  String get greetingMorning => 'mattina';
+  String get greetingMorning => 'Buongiorno';
 
   @override
-  String get greetingAfternoon => 'pomeriggio';
+  String get greetingAfternoon => 'Buon pomeriggio';
 
   @override
-  String get greetingEvening => 'sera';
+  String get greetingEvening => 'Buonasera';
 
   @override
   String get authShowPassword => 'Mostra password';
@@ -25372,4 +25372,19 @@ class SIt extends S {
   @override
   String get apiErrorServer =>
       'Errore del server. Riprova tra qualche istante.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Disponibile a breve — in attesa degli accordi pilota';
+
+  @override
+  String get greetingNight => 'Buonanotte';
+
+  @override
+  String get onboardingCalculationError =>
+      'Errore di calcolo. Verifica i tuoi dati e riprova.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      'Pensionamento prima dei 55? Verifica la tua età o il tuo stato lavorativo.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -3301,11 +3301,11 @@ class SPt extends S {
   String get exploreLearnFiscal => 'Fiscalidade suica 101';
 
   @override
-  String get coachWelcome => 'Bienvenue sur MINT';
+  String get coachWelcome => 'Bem-vindo ao MINT';
 
   @override
   String coachHello(String firstName) {
-    return 'Bonjour $firstName';
+    return 'Olá $firstName';
   }
 
   @override
@@ -17653,7 +17653,7 @@ class SPt extends S {
   String get openBankingHubApercu => 'PANORAMA FINANCEIRO';
 
   @override
-  String get openBankingHubNavigation => 'NAVIGATION';
+  String get openBankingHubNavigation => 'NAVEGAÇÃO';
 
   @override
   String get openBankingHubViewTransactions => 'Ver transações';
@@ -17670,7 +17670,7 @@ class SPt extends S {
       'Direitos nLPD, revogação, permissões';
 
   @override
-  String get openBankingHubSoldeTotal => 'Solde total';
+  String get openBankingHubSoldeTotal => 'Saldo total';
 
   @override
   String get openBankingHubComptesConnectes => '3 contas conectadas';
@@ -17682,7 +17682,7 @@ class SPt extends S {
   String get openBankingHubDepenses => 'Despesas';
 
   @override
-  String get openBankingHubEpargneNette => 'Épargne nette';
+  String get openBankingHubEpargneNette => 'Poupança líquida';
 
   @override
   String get openBankingHubTop3Depenses => 'Top 3 despesas';
@@ -17702,7 +17702,7 @@ class SPt extends S {
 
   @override
   String openBankingHubSyncDays(int days) {
-    return 'Il y a ${days}j';
+    return 'Há $days dias';
   }
 
   @override
@@ -17713,28 +17713,28 @@ class SPt extends S {
       'Consulta regulatória FINMA em curso. Os dados apresentados são de demonstração.';
 
   @override
-  String get transactionListThisMonth => 'Ce mois';
+  String get transactionListThisMonth => 'Este mês';
 
   @override
-  String get transactionListLastMonth => 'Mois précédent';
+  String get transactionListLastMonth => 'Mês anterior';
 
   @override
   String get transactionListNoTransaction => 'Sem transações';
 
   @override
-  String get transactionListRevenus => 'Revenus';
+  String get transactionListRevenus => 'Receitas';
 
   @override
-  String get transactionListDepenses => 'Dépenses';
+  String get transactionListDepenses => 'Despesas';
 
   @override
-  String get transactionListEpargneNette => 'Épargne nette';
+  String get transactionListEpargneNette => 'Poupança líquida';
 
   @override
-  String get transactionListTauxEpargne => 'Taux d’épargne';
+  String get transactionListTauxEpargne => 'Taxa de poupança';
 
   @override
-  String get transactionListModeDemo => 'MODE DÉMO';
+  String get transactionListModeDemo => 'MODO DEMO';
 
   @override
   String get lppVolontaireRevenuMax250k => 'CHF 250’000';
@@ -23390,13 +23390,13 @@ class SPt extends S {
   String get onboardingSmartSalaryPerYear => 'CHF/ano';
 
   @override
-  String get greetingMorning => 'manhã';
+  String get greetingMorning => 'Bom dia';
 
   @override
-  String get greetingAfternoon => 'tarde';
+  String get greetingAfternoon => 'Boa tarde';
 
   @override
-  String get greetingEvening => 'noite';
+  String get greetingEvening => 'Boa noite';
 
   @override
   String get authShowPassword => 'Mostrar palavra-passe';
@@ -25307,4 +25307,19 @@ class SPt extends S {
   @override
   String get apiErrorServer =>
       'Erro do servidor. Tenta novamente dentro de momentos.';
+
+  @override
+  String get pensionFundConnectComingSoon =>
+      'Disponível em breve — a aguardar acordos-piloto';
+
+  @override
+  String get greetingNight => 'Boa noite';
+
+  @override
+  String get onboardingCalculationError =>
+      'Erro de cálculo. Verifica os teus dados e tenta novamente.';
+
+  @override
+  String get onboardingRetirementAgeWarning =>
+      'Reforma antes dos 55? Verifica a tua idade ou situação profissional.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -1354,8 +1354,8 @@
   "exploreLearn3a": "O que e o pilar 3a?",
   "exploreLearnLpp": "LPP: Como funciona",
   "exploreLearnFiscal": "Fiscalidade suica 101",
-  "coachWelcome": "Bienvenue sur MINT",
-  "coachHello": "Bonjour {firstName}",
+  "coachWelcome": "Bem-vindo ao MINT",
+  "coachHello": "Olá {firstName}",
   "@coachHello": {
     "placeholders": {
       "firstName": {
@@ -8459,16 +8459,16 @@
   "openBankingHubSubtitle": "Conecta as tuas contas bancárias",
   "openBankingHubConnectedAccounts": "CONTAS CONECTADAS",
   "openBankingHubApercu": "PANORAMA FINANCEIRO",
-  "openBankingHubNavigation": "NAVIGATION",
+  "openBankingHubNavigation": "NAVEGAÇÃO",
   "openBankingHubViewTransactions": "Ver transações",
   "openBankingHubViewTransactionsDesc": "Histórico detalhado por categoria",
   "openBankingHubManageConsents": "Gerir consentimentos",
   "openBankingHubManageConsentsDesc": "Direitos nLPD, revogação, permissões",
-  "openBankingHubSoldeTotal": "Solde total",
+  "openBankingHubSoldeTotal": "Saldo total",
   "openBankingHubComptesConnectes": "3 contas conectadas",
   "openBankingHubRevenus": "Receitas",
   "openBankingHubDepenses": "Despesas",
-  "openBankingHubEpargneNette": "Épargne nette",
+  "openBankingHubEpargneNette": "Poupança líquida",
   "openBankingHubTop3Depenses": "Top 3 despesas",
   "openBankingHubAddBankLabel": "Adicionar um banco",
   "openBankingHubSyncMinutes": "Há {minutes} min",
@@ -8487,7 +8487,7 @@
       }
     }
   },
-  "openBankingHubSyncDays": "Il y a {days}j",
+  "openBankingHubSyncDays": "Há {days} dias",
   "@openBankingHubSyncDays": {
     "placeholders": {
       "days": {
@@ -8497,14 +8497,14 @@
   },
   "transactionListFinmaTitle": "Funcionalidade em preparação",
   "transactionListFinmaDesc": "Consulta regulatória FINMA em curso. Os dados apresentados são de demonstração.",
-  "transactionListThisMonth": "Ce mois",
-  "transactionListLastMonth": "Mois précédent",
+  "transactionListThisMonth": "Este mês",
+  "transactionListLastMonth": "Mês anterior",
   "transactionListNoTransaction": "Sem transações",
-  "transactionListRevenus": "Revenus",
-  "transactionListDepenses": "Dépenses",
-  "transactionListEpargneNette": "Épargne nette",
-  "transactionListTauxEpargne": "Taux d’épargne",
-  "transactionListModeDemo": "MODE DÉMO",
+  "transactionListRevenus": "Receitas",
+  "transactionListDepenses": "Despesas",
+  "transactionListEpargneNette": "Poupança líquida",
+  "transactionListTauxEpargne": "Taxa de poupança",
+  "transactionListModeDemo": "MODO DEMO",
   "lppVolontaireRevenuMax250k": "CHF 250’000",
   "lppVolontaireSalaireCoordLabel": "Salário coordenado",
   "lppVolontaireTauxBonifLabel": "Taxa de bonificação",
@@ -11893,5 +11893,12 @@
   "apiErrorOffline": "Sem ligação à internet. Verifica a tua rede e tenta novamente.",
   "apiErrorTimeout": "O servidor está a demorar demasiado a responder. Tenta novamente.",
   "apiErrorSessionExpired": "Sessão expirada — inicia sessão novamente.",
-  "apiErrorServer": "Erro do servidor. Tenta novamente dentro de momentos."
+  "apiErrorServer": "Erro do servidor. Tenta novamente dentro de momentos.",
+  "pensionFundConnectComingSoon": "Disponível em breve — a aguardar acordos-piloto",
+  "greetingMorning": "Bom dia",
+  "greetingAfternoon": "Boa tarde",
+  "greetingEvening": "Boa noite",
+  "greetingNight": "Boa noite",
+  "onboardingCalculationError": "Erro de cálculo. Verifica os teus dados e tenta novamente.",
+  "onboardingRetirementAgeWarning": "Reforma antes dos 55? Verifica a tua idade ou situação profissional."
 }

--- a/apps/mobile/lib/screens/institutional/pension_fund_connect_screen.dart
+++ b/apps/mobile/lib/screens/institutional/pension_fund_connect_screen.dart
@@ -55,7 +55,7 @@ class _PensionFundConnectScreenState extends State<PensionFundConnectScreen> {
     if (!_isApiLive) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Bientôt disponible — en attente des accords pilotes')), // TODO: i18n
+          SnackBar(content: Text(S.of(context)!.pensionFundConnectComingSoon)),
         );
       }
       return;

--- a/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
+++ b/apps/mobile/lib/screens/onboarding/smart_onboarding_viewmodel.dart
@@ -17,6 +17,12 @@ import 'package:mint_mobile/services/chiffre_choc_selector.dart';
 /// AVS gaps / lacunes are NOT collected here — source of truth is the
 /// extrait AVS uploaded via StepOcrUpload (AvsExtractParser).
 ///
+/// Error types for the onboarding flow — resolved to i18n strings in the UI.
+enum OnboardingErrorType {
+  retirementAgeWarning,
+  calculationError,
+}
+
 /// Delegates all financial computation to the shared financial_core.
 /// NEVER duplicates calculation logic.
 class SmartOnboardingViewModel extends ChangeNotifier {
@@ -75,8 +81,8 @@ class SmartOnboardingViewModel extends ChangeNotifier {
   /// True when a result has been computed at least once.
   bool get hasResult => profile != null && chiffreChoc != null;
 
-  /// Error message if computation failed.
-  String? error;
+  /// Error type if computation failed — resolve to i18n string in the UI.
+  OnboardingErrorType? errorType;
 
   /// Computed age from birthDate. Falls back to 35 if no birthDate set.
   int get age {
@@ -117,9 +123,9 @@ class SmartOnboardingViewModel extends ChangeNotifier {
   void setEmploymentStatus(String? value) {
     // P3-22: Warn if age < 55 and status is 'retraite' — likely a data entry error.
     if (value == 'retraite' && age < 55) {
-      error = 'Retraite avant 55 ans\u00a0? Vérifie ton âge ou ton statut.'; // TODO: i18n
+      errorType = OnboardingErrorType.retirementAgeWarning;
     } else {
-      error = null;
+      errorType = null;
     }
     employmentStatus = value;
     if (hasResult) {
@@ -272,7 +278,7 @@ class SmartOnboardingViewModel extends ChangeNotifier {
     if (!canCompute) return;
 
     try {
-      error = null;
+      errorType = null;
 
       profile = MinimalProfileService.compute(
         age: age,
@@ -297,7 +303,7 @@ class SmartOnboardingViewModel extends ChangeNotifier {
       confidenceScore =
           (providedCount / totalFields * 100).clamp(0.0, 100.0);
     } catch (e) {
-      error = 'Erreur de calcul. Vérifie tes données et réessaie.'; // TODO: i18n — extract to ARB
+      errorType = OnboardingErrorType.calculationError;
       profile = null;
       chiffreChoc = null;
       confidenceScore = 0;

--- a/apps/mobile/lib/screens/pulse/pulse_screen.dart
+++ b/apps/mobile/lib/screens/pulse/pulse_screen.dart
@@ -821,18 +821,18 @@ class _PulseScreenState extends State<PulseScreen> {
   // ── APP BAR (white — consistent with all other screens) ──
 
   // P3-24: Time-aware greeting prefix
-  static String _greetingPrefix() {
+  static String _greetingPrefix(S l) {
     final hour = DateTime.now().hour;
-    if (hour >= 5 && hour < 12) return 'Bonjour'; // TODO: i18n
-    if (hour >= 12 && hour < 18) return 'Bon après-midi'; // TODO: i18n
-    if (hour >= 18 && hour < 22) return 'Bonsoir'; // TODO: i18n
-    return 'Bonne nuit'; // TODO: i18n
+    if (hour >= 5 && hour < 12) return l.greetingMorning;
+    if (hour >= 12 && hour < 18) return l.greetingAfternoon;
+    if (hour >= 18 && hour < 22) return l.greetingEvening;
+    return l.greetingNight;
   }
 
   SliverAppBar _buildAppBar(BuildContext context, CoachProfile profile) {
     final l = S.of(context)!;
     final firstName = profile.firstName ?? '';
-    final prefix = _greetingPrefix();
+    final prefix = _greetingPrefix(l);
     final greeting =
         firstName.isNotEmpty ? '$prefix $firstName' : l.tabToday;
 

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -71,13 +71,13 @@ class ApiException implements Exception {
   String toString() => message;
 }
 
-// TODO(MINT-106): Certificate pinning — P1-6 audit finding.
-// Implement TLS certificate pinning for production domains once stable:
-//   - mint-production-3a41.up.railway.app
-//   - Expected: SHA-256 pin of Railway's leaf certificate
-//   - Use package:http_certificate_pinning or custom SecurityContext
-//   - Rotate pins before certificate renewal (Railway auto-renew ~90 days)
-//   - Fallback: disable pinning in debug mode only
+// DECISION(2026-03-30): TLS certificate pinning DEFERRED for V1.
+// Rationale: Railway uses Let's Encrypt with 90-day auto-renewal.
+// Pinning would require rotating pins every 90 days — high risk of
+// bricking the app if a pin rotation is missed. Railway handles TLS
+// termination with HSTS (verified: Strict-Transport-Security header active).
+// Revisit when: custom domain with controlled certificate lifecycle.
+// Risk accepted: MITM via compromised CA (low probability, standard for fintech V1).
 class ApiService {
   /// P1-7: Global HTTP timeout for all API calls.
   static const Duration _httpTimeout = Duration(seconds: 30);

--- a/apps/mobile/lib/services/feature_flags.dart
+++ b/apps/mobile/lib/services/feature_flags.dart
@@ -69,6 +69,12 @@ class FeatureFlags {
   /// Open banking screens: hub, transactions, consents
   static bool enableOpenBanking = false;
 
+  /// Pension Fund Connect (institutional API pilot)
+  static bool enablePensionFundConnect = false;
+
+  /// Expert Tier (human specialist marketplace)
+  static bool enableExpertTier = false;
+
   /// Admin screens: observability, analytics
   static bool enableAdminScreens = false;
 
@@ -92,6 +98,12 @@ class FeatureFlags {
     // V1 screen gating flags — F7: 5 dead flags removed (always true, no consumers)
     if (data.containsKey('enableOpenBanking')) {
       enableOpenBanking = data['enableOpenBanking'] == true;
+    }
+    if (data.containsKey('enablePensionFundConnect')) {
+      enablePensionFundConnect = data['enablePensionFundConnect'] == true;
+    }
+    if (data.containsKey('enableExpertTier')) {
+      enableExpertTier = data['enableExpertTier'] == true;
     }
     if (data.containsKey('enableAdminScreens')) {
       enableAdminScreens = data['enableAdminScreens'] == true;

--- a/apps/mobile/test/screens/pillar_3a_deep/staggered_withdrawal_screen_test.dart
+++ b/apps/mobile/test/screens/pillar_3a_deep/staggered_withdrawal_screen_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';

--- a/services/backend/app/api/v1/endpoints/assurances.py
+++ b/services/backend/app/api/v1/endpoints/assurances.py
@@ -7,10 +7,9 @@ POST /api/v1/assurances/coverage/check — Coverage checklist
 Sprint S13, Chantier 7: Assurances completes.
 """
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 
 from app.core.auth import require_current_user
-from app.core.rate_limit import limiter
 from app.models.user import User
 from app.schemas.assurances import (
     LamalFranchiseRequest,

--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -39,6 +39,7 @@ from app.schemas.auth import (
     TokenResponse,
     UserResponse,
     RefreshTokenRequest,
+    LogoutRequest,
     LogoutResponse,
     EmailVerificationRequest,
     EmailVerificationConfirmRequest,
@@ -482,6 +483,7 @@ _security_scheme = HTTPBearer(auto_error=False)
 @limiter.limit("30/minute")
 def logout(
     request: Request,
+    body: LogoutRequest = None,
     credentials: HTTPAuthorizationCredentials = Depends(_security_scheme),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_current_user),
@@ -491,6 +493,8 @@ def logout(
 
     The token will be rejected on subsequent requests until it naturally expires,
     at which point the blacklist entry is eligible for cleanup.
+
+    Optionally accepts a LogoutRequest body with refresh_token to blacklist both tokens.
     """
     if credentials is None:
         raise HTTPException(
@@ -508,24 +512,18 @@ def logout(
     expires_at = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
     blacklist_token(db, payload["jti"], expires_at)
 
-    # SECURITY: Also blacklist the refresh token if provided.
+    # SECURITY: Also blacklist the refresh token if provided via typed schema.
     # This prevents the refresh token from being reused after logout.
-    from fastapi import Body
-    # Try to read optional refresh_token from body (non-breaking for existing clients)
-    try:
-        import json
-        raw_body = request._body if hasattr(request, '_body') else None
-        if raw_body:
-            body_data = json.loads(raw_body)  # pragma: no cover
-            refresh_str = body_data.get("refresh_token") or body_data.get("refreshToken")  # pragma: no cover
-            if refresh_str:  # pragma: no cover
-                refresh_payload = decode_refresh_token(refresh_str)  # pragma: no cover
-                if refresh_payload and refresh_payload.get("jti"):  # pragma: no cover
-                    r_exp = refresh_payload.get("exp")  # pragma: no cover
-                    r_exp_dt = datetime.fromtimestamp(r_exp, tz=timezone.utc) if r_exp else datetime.now(timezone.utc)  # pragma: no cover
-                    blacklist_token(db, refresh_payload["jti"], r_exp_dt)  # pragma: no cover
-    except Exception:  # pragma: no cover
-        pass  # Best-effort — access token is always blacklisted
+    if body and body.refresh_token:
+        refresh_payload = decode_refresh_token(body.refresh_token)
+        if refresh_payload and refresh_payload.get("jti"):
+            r_exp = refresh_payload.get("exp")
+            r_exp_dt = (
+                datetime.fromtimestamp(r_exp, tz=timezone.utc)
+                if r_exp
+                else datetime.now(timezone.utc)
+            )
+            blacklist_token(db, refresh_payload["jti"], r_exp_dt)
 
     log_audit_event(
         db,

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -38,16 +38,21 @@ import re
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
 
 from app.core.auth import require_current_user
+from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.models.user import User
+from app.services.reengagement.consent_manager import ConsentManager
+from app.services.reengagement.reengagement_models import ConsentType
 from app.schemas.coach_chat import CoachChatRequest, CoachChatResponse
 from app.services.coach.claude_coach_service import build_system_prompt
 from app.services.coach.coach_context_builder import build_coach_context
 from app.services.coach.coach_tools import INTERNAL_TOOL_NAMES, get_llm_tools
 from app.constants.social_insurance import PILIER_3A_PLAFOND_AVEC_LPP
 from app.services.coach.structured_reasoning import StructuredReasoningService
+from pydantic import BaseModel as _BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -650,7 +655,7 @@ def _format_couple_optimization(ctx: dict) -> str:
     if avs:
         if avs.get("cap_applied"):
             reduction = avs.get("monthly_reduction", 0)
-            lines.append(f"- AVS couple : plafonnement appliqué (LAVS art. 35)")
+            lines.append("- AVS couple : plafonnement appliqué (LAVS art. 35)")
             lines.append(f"  Réduction mensuelle : {_fmt_chf(reduction)}")
         else:
             lines.append("- AVS couple : pas de plafonnement (revenus sous le seuil)")
@@ -884,6 +889,7 @@ async def coach_chat(
     request: Request,
     body: CoachChatRequest,
     _user: User = Depends(require_current_user),
+    db: Session = Depends(get_db),
 ) -> CoachChatResponse:
     """Coach chat endpoint — tools + system prompt + RAG + agent loop.
 
@@ -911,10 +917,12 @@ async def coach_chat(
         502: LLM API call failed.
         503: RAG dependencies not installed.
     """
-    # TODO(nLPD art. 6 al. 7): Verify conversation_memory consent before
-    # persisting conversation history. Requires ConsentManager.is_consent_given(
-    # user_id, ConsentType.conversation_memory). Without consent, conversation
-    # should be stateless (no memory_block persistence between sessions).
+    # nLPD art. 6 al. 7: Check conversation_memory consent.
+    # Without consent, conversation is stateless (no memory_block persistence).
+    has_memory_consent = ConsentManager.is_consent_given(
+        str(_user.id), ConsentType.conversation_memory, db=db
+    )
+
     # ------------------------------------------------------------------
     # Step 0: Sanitize inputs (PII whitelist + memory scrubbing)
     # ------------------------------------------------------------------
@@ -949,10 +957,13 @@ async def coach_chat(
     # The LLM humanizes this pre-computed analysis rather than reasoning from scratch.
     # Uses sanitized profile to prevent PII leakage in reasoning_trace.
     # ------------------------------------------------------------------
+    # nLPD: strip memory_block when conversation_memory consent not granted
+    effective_memory_block = body.memory_block if has_memory_consent else None
+
     reasoning_output = StructuredReasoningService.reason(
         user_message=body.message,
         profile_context=safe_profile,
-        memory_block=body.memory_block,
+        memory_block=effective_memory_block,
     )
     reasoning_block = reasoning_output.as_system_prompt_block()
 
@@ -960,7 +971,7 @@ async def coach_chat(
     # Step 2: Build system prompt (lifecycle + regional + plan + memory)
     # Memory block is PII-scrubbed and wrapped in prompt injection armor.
     # ------------------------------------------------------------------
-    system_prompt = _build_system_prompt_with_memory(coach_ctx, body.memory_block, language=body.language)
+    system_prompt = _build_system_prompt_with_memory(coach_ctx, effective_memory_block, language=body.language)
     if reasoning_block:
         system_prompt = system_prompt + "\n\n" + reasoning_block
 
@@ -1000,7 +1011,7 @@ async def coach_chat(
             model=body.model,
             profile_context=safe_profile,
             language=body.language,
-            memory_block=body.memory_block,
+            memory_block=effective_memory_block,
             system_prompt=system_prompt,
             user_id=_user.id if _user else None,
         )
@@ -1059,9 +1070,6 @@ async def coach_chat(
 # ════════════════════════════════════════════════════════════
 #  INSIGHT SYNC — Mobile → Backend → pgvector
 # ════════════════════════════════════════════════════════════
-
-from pydantic import BaseModel as _BaseModel
-
 
 class _InsightSyncRequest(_BaseModel):
     """Payload to embed a CoachInsight into the RAG vector store."""

--- a/services/backend/app/api/v1/endpoints/documents.py
+++ b/services/backend/app/api/v1/endpoints/documents.py
@@ -24,6 +24,14 @@ from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.models.document import DocumentModel
 from app.models.user import User
+from app.schemas.document_scan import (
+    DocumentScanConfirmation,
+    DocumentScanResponse,
+    VisionExtractionRequest,
+    VisionExtractionResponse,
+)
+from app.services.reengagement.consent_manager import ConsentManager
+from app.services.reengagement.reengagement_models import ConsentType
 
 from app.schemas.document import (
     BankStatementUploadResponse,
@@ -187,9 +195,18 @@ async def upload_document(
 
     The raw PDF is never stored — only the extracted fields are kept.
     """
-    # TODO(nLPD art. 6 al. 7): Verify document_upload consent before persisting
-    # extracted fields. Requires ConsentManager.is_consent_given(user_id,
-    # ConsentType.document_upload). Block with HTTP 403 if not granted.
+    # nLPD art. 6 al. 7: Verify document_upload consent before persisting
+    if not ConsentManager.is_consent_given(
+        str(_user.id), ConsentType.document_upload, db=db
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Consentement 'document_upload' requis pour telecharger un document. "
+                "Active-le dans Profil > Consentements."
+            ),
+        )
+
     # Validate file type
     if file.content_type and file.content_type not in (
         "application/pdf",
@@ -211,7 +228,7 @@ async def upload_document(
     # Read file bytes
     try:
         file_bytes = await file.read()
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=400, detail="Invalid request parameters")
 
     if not file_bytes:
@@ -463,7 +480,7 @@ async def upload_bank_statement(
     # Read file bytes
     try:
         file_bytes = await file.read()
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=400, detail="Invalid request parameters")
 
     if not file_bytes:
@@ -576,7 +593,7 @@ async def preview_budget_import(
 
     try:
         file_bytes = await file.read()
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=400, detail="Invalid request parameters")
 
     if not file_bytes:
@@ -619,14 +636,6 @@ async def preview_budget_import(
 # ════════════════════════════════════════════════════════════
 #  SCAN CONFIRMATION + CLAUDE VISION EXTRACTION
 # ════════════════════════════════════════════════════════════
-
-from app.schemas.document_scan import (
-    DocumentScanConfirmation,
-    DocumentScanResponse,
-    VisionExtractionRequest,
-    VisionExtractionResponse,
-)
-
 
 @router.post("/scan-confirmation", response_model=DocumentScanResponse)
 @limiter.limit("30/minute")

--- a/services/backend/app/api/v1/endpoints/fri.py
+++ b/services/backend/app/api/v1/endpoints/fri.py
@@ -124,7 +124,7 @@ async def simulate_fri_action(request: Request, body: FriSimulateRequest) -> Fri
         result = FriDisplayService.simulate_action(
             inp, body.action_type, body.confidence_score,
         )
-    except ValueError as e:
+    except ValueError:
         raise HTTPException(status_code=422, detail="Unprocessable input")
 
     return FriSimulateResponse(

--- a/services/backend/app/api/v1/endpoints/open_banking.py
+++ b/services/backend/app/api/v1/endpoints/open_banking.py
@@ -24,11 +24,11 @@ import os
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session
 
 from app.core.auth import require_current_user
+from app.core.database import get_db
 from app.models.user import User
-
-logger = logging.getLogger(__name__)
 from app.schemas.open_banking import (
     OpenBankingStatusResponse,
     ConsentRequest,
@@ -47,6 +47,7 @@ from app.services.open_banking.consent_manager import ConsentManager
 from app.services.open_banking.transaction_categorizer import TransactionCategorizer
 from app.services.open_banking.account_aggregator import AccountAggregator
 
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -149,7 +150,7 @@ def get_status() -> OpenBankingStatusResponse:
 # ---------------------------------------------------------------------------
 
 @router.post("/consent", response_model=ConsentResponse)
-def create_consent(request: ConsentRequest, response: Response, current_user: User = Depends(require_current_user)) -> ConsentResponse:
+def create_consent(request: ConsentRequest, response: Response, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)) -> ConsentResponse:
     """Create a new banking consent (nLPD-compliant).
 
     Requires explicit opt-in. Scopes must be explicitly chosen.
@@ -164,6 +165,7 @@ def create_consent(request: ConsentRequest, response: Response, current_user: Us
             bank_id=request.bankId,
             bank_name=request.bankName,
             scopes=request.scopes,
+            db=db,
         )
     except ValueError:
         raise HTTPException(status_code=422, detail="Unprocessable input")
@@ -180,7 +182,7 @@ def create_consent(request: ConsentRequest, response: Response, current_user: Us
 
 
 @router.delete("/consent/{consent_id}")
-def revoke_consent(consent_id: str, response: Response, current_user: User = Depends(require_current_user)):
+def revoke_consent(consent_id: str, response: Response, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)):
     """Revoke a banking consent.
 
     The consent is immediately invalidated. All associated data access stops.
@@ -190,13 +192,13 @@ def revoke_consent(consent_id: str, response: Response, current_user: User = Dep
     response.headers[_IN_MEMORY_HEADER[0]] = _IN_MEMORY_HEADER[1]
 
     # V3-4: IDOR guard — verify consent belongs to the current user.
-    consent = _consent_manager.get_consent(consent_id)
+    consent = _consent_manager.get_consent(consent_id, db=db)
     if not consent:
         raise HTTPException(status_code=404, detail="Consentement non trouve.")
     if consent.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="Acces interdit.")
 
-    success = _consent_manager.revoke_consent(consent_id)
+    success = _consent_manager.revoke_consent(consent_id, db=db)
     if not success:
         raise HTTPException(status_code=404, detail="Consentement non trouve.")
 
@@ -208,12 +210,12 @@ def revoke_consent(consent_id: str, response: Response, current_user: User = Dep
 
 
 @router.get("/consents", response_model=List[ConsentResponse])
-def list_consents(response: Response, current_user: User = Depends(require_current_user)) -> List[ConsentResponse]:
+def list_consents(response: Response, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)) -> List[ConsentResponse]:
     """List active consents for the current person."""
     _check_open_banking_enabled()
     response.headers[_IN_MEMORY_HEADER[0]] = _IN_MEMORY_HEADER[1]
 
-    consents = _consent_manager.get_active_consents(current_user.id)
+    consents = _consent_manager.get_active_consents(current_user.id, db=db)
 
     return [
         ConsentResponse(

--- a/services/backend/app/api/v1/endpoints/rag.py
+++ b/services/backend/app/api/v1/endpoints/rag.py
@@ -10,10 +10,14 @@ import logging
 import os
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
 
 from app.core.auth import require_current_user
+from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.models.user import User
+from app.services.reengagement.consent_manager import ConsentManager
+from app.services.reengagement.reengagement_models import ConsentType
 
 from app.schemas.rag import (
     ExtractedDocumentField,
@@ -113,7 +117,7 @@ def _get_orchestrator():
 
 @router.post("/query", response_model=RAGQueryResponse)
 @limiter.limit("20/minute")
-async def rag_query(request: Request, body: RAGQueryRequest, _user: User = Depends(require_current_user)):
+async def rag_query(request: Request, body: RAGQueryRequest, _user: User = Depends(require_current_user), db: Session = Depends(get_db)):
     """
     Main RAG query endpoint.
 
@@ -122,10 +126,12 @@ async def rag_query(request: Request, body: RAGQueryRequest, _user: User = Depen
 
     The API key is used for a single request and never stored.
     """
-    # TODO(nLPD art. 6 al. 7): Verify byok_data_sharing consent before querying
-    # user-specific data in RAG. Requires ConsentManager.is_consent_given(
-    # user_id, ConsentType.byok_data_sharing). Without consent, RAG should only
-    # search the public MINT knowledge base, not user-uploaded documents.
+    # nLPD art. 6 al. 7: Without byok_data_sharing consent, RAG only searches
+    # the public MINT knowledge base — user-uploaded documents are excluded.
+    has_byok_consent = ConsentManager.is_consent_given(
+        str(_user.id), ConsentType.byok_data_sharing, db=db
+    )
+
     orchestrator = await _get_orchestrator_safe()
 
     # Build profile context dict if provided
@@ -133,15 +139,18 @@ async def rag_query(request: Request, body: RAGQueryRequest, _user: User = Depen
     if body.profile_context:
         profile_ctx = body.profile_context.model_dump(exclude_none=True)
 
+    # nLPD: only pass user_id (for user-doc retrieval) if consent granted
+    effective_user_id = _user.id if (_user and has_byok_consent) else None
+
     try:
         result = await orchestrator.query(
             question=body.question,
             api_key=body.api_key,
             provider=body.provider.value,
             model=body.model,
-            profile_context=profile_ctx,
+            profile_context=profile_ctx if has_byok_consent else None,
             language=body.language.value,
-            user_id=_user.id if _user else None,
+            user_id=effective_user_id,
         )
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request parameters")

--- a/services/backend/app/api/v1/endpoints/reengagement.py
+++ b/services/backend/app/api/v1/endpoints/reengagement.py
@@ -20,10 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.core.auth import require_current_user
 from app.core.rate_limit import limiter
-
-logger = logging.getLogger(__name__)
 from app.models.user import User
-
 from app.schemas.reengagement import (
     ByokDetailResponse,
     ConsentDashboardResponse,
@@ -36,6 +33,8 @@ from app.schemas.reengagement import (
 from app.services.reengagement.consent_manager import ConsentManager
 from app.services.reengagement.reengagement_engine import ReengagementEngine
 from app.services.reengagement.reengagement_models import ConsentType
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/services/backend/app/api/v1/endpoints/snapshots.py
+++ b/services/backend/app/api/v1/endpoints/snapshots.py
@@ -19,8 +19,10 @@ Sources:
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from sqlalchemy.orm import Session
 
 from app.core.auth import require_current_user
+from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.models.user import User
 
@@ -83,7 +85,7 @@ def _snapshot_to_response(snapshot) -> SnapshotResponse:
 
 @router.post("", response_model=SnapshotResponse)
 @limiter.limit("30/minute")
-def create_financial_snapshot(request: Request, body: CreateSnapshotRequest, response: Response, current_user: User = Depends(require_current_user)) -> SnapshotResponse:
+def create_financial_snapshot(request: Request, body: CreateSnapshotRequest, response: Response, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)) -> SnapshotResponse:
     """Creer un snapshot financier.
 
     Capture l'etat financier de l'utilisateur a un moment donne,
@@ -96,7 +98,7 @@ def create_financial_snapshot(request: Request, body: CreateSnapshotRequest, res
     response.headers[_IN_MEMORY_HEADER[0]] = _IN_MEMORY_HEADER[1]
 
     # Consent guard: snapshot_storage consent required (nLPD)
-    if not ConsentManager.is_consent_given(current_user.id, ConsentType.snapshot_storage):
+    if not ConsentManager.is_consent_given(current_user.id, ConsentType.snapshot_storage, db=db):
         raise HTTPException(
             status_code=403,
             detail=(
@@ -110,6 +112,7 @@ def create_financial_snapshot(request: Request, body: CreateSnapshotRequest, res
             user_id=current_user.id,
             trigger=body.trigger,
             profile_data=body.profile_data,
+            db=db,
         )
         return _snapshot_to_response(snapshot)
 

--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -9,7 +9,6 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
-from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from app.core.config import settings
 from app.core.database import Base, engine

--- a/services/backend/app/services/document_vision_service.py
+++ b/services/backend/app/services/document_vision_service.py
@@ -10,9 +10,8 @@ See: MINT_ANTI_BULLSHIT_MANIFESTO.md, MINT_FINAL_EXECUTION_SYSTEM.md §13.11
 """
 
 import json
-import base64
 import logging
-from typing import Optional
+from typing import Dict, List as TList, Optional
 
 from anthropic import Anthropic
 
@@ -27,7 +26,6 @@ from app.schemas.document_scan import (
 logger = logging.getLogger(__name__)
 
 # Field definitions per document type — what to extract and validate.
-from typing import Dict, List as TList
 
 DOCUMENT_FIELDS: Dict[DocumentType, TList[dict]] = {
     DocumentType.lpp_certificate: [

--- a/services/backend/app/services/rag/faq_service.py
+++ b/services/backend/app/services/rag/faq_service.py
@@ -21,9 +21,9 @@ import re
 from dataclasses import dataclass, field
 from typing import Optional
 
-logger = logging.getLogger(__name__)
-
 from app.services.rag.knowledge_catalog import KnowledgeCategory
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Compliance constants

--- a/services/backend/app/services/rag/insight_embedder.py
+++ b/services/backend/app/services/rag/insight_embedder.py
@@ -53,7 +53,6 @@ async def embed_insight(
 
     try:
         import asyncpg
-        import httpx
 
         # Truncate summary to 8000 chars (OpenAI embedding max ~8191 tokens)
         safe_summary = summary[:8000] if len(summary) > 8000 else summary

--- a/services/backend/app/services/rag/knowledge_catalog.py
+++ b/services/backend/app/services/rag/knowledge_catalog.py
@@ -16,7 +16,7 @@ Sprint S67 — RAG v2 Knowledge Pipeline.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from enum import Enum
 from typing import Optional

--- a/services/backend/app/services/rag/update_pipeline.py
+++ b/services/backend/app/services/rag/update_pipeline.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from typing import Optional
 
-from app.services.rag.knowledge_catalog import KnowledgeCatalog, KnowledgeCategory, KnowledgeSource
+from app.services.rag.knowledge_catalog import KnowledgeCategory, KnowledgeSource
 
 # ---------------------------------------------------------------------------
 # Threshold constants

--- a/services/backend/app/services/reengagement/consent_manager.py
+++ b/services/backend/app/services/reengagement/consent_manager.py
@@ -199,6 +199,34 @@ class ConsentManager:
                 ),
                 revocable=True,
             ),
+            ConsentState(
+                consent_type=ConsentType.document_upload,
+                enabled=False,
+                label="Telechargement de documents",
+                detail=(
+                    "Autorise l'extraction de donnees structurees depuis tes "
+                    "certificats LPP, fiches de salaire et releves bancaires."
+                ),
+                never_sent=(
+                    "Le fichier PDF original n'est jamais stocke. Seuls les "
+                    "champs extraits sont conserves dans ton dossier."
+                ),
+                revocable=True,
+            ),
+            ConsentState(
+                consent_type=ConsentType.conversation_memory,
+                enabled=False,
+                label="Memoire de conversation",
+                detail=(
+                    "Permet au coach de se souvenir du contexte entre tes "
+                    "sessions pour des reponses plus pertinentes."
+                ),
+                never_sent=(
+                    "Jamais stocke : contenu exact des messages, donnees "
+                    "financieres precises, informations d'identification."
+                ),
+                revocable=True,
+            ),
         ]
 
         return ConsentDashboard(consents=consents)

--- a/services/backend/app/services/reengagement/reengagement_models.py
+++ b/services/backend/app/services/reengagement/reengagement_models.py
@@ -55,6 +55,8 @@ class ConsentType(str, Enum):
     byok_data_sharing = "byok_data_sharing"
     snapshot_storage = "snapshot_storage"
     notifications = "notifications"
+    document_upload = "document_upload"
+    conversation_memory = "conversation_memory"
 
 
 @dataclass

--- a/services/backend/pyproject.toml
+++ b/services/backend/pyproject.toml
@@ -55,6 +55,9 @@ exclude = ["alembic*"]
 line-length = 88
 target-version = "py310"
 
+[tool.ruff.lint.per-file-ignores]
+"alembic/**" = ["E402"]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q"

--- a/services/backend/scripts/embed_corpus.py
+++ b/services/backend/scripts/embed_corpus.py
@@ -26,10 +26,8 @@ import argparse
 import json
 import logging
 import os
-import re
 import sys
 from pathlib import Path
-from typing import Optional
 
 # Add backend root to sys.path for imports
 _BACKEND_DIR = Path(__file__).resolve().parent.parent

--- a/services/backend/scripts/ingest_corpus.py
+++ b/services/backend/scripts/ingest_corpus.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
 from pathlib import Path
 

--- a/services/backend/tests/conftest.py
+++ b/services/backend/tests/conftest.py
@@ -54,30 +54,14 @@ def override_get_db():
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_database():
     """Create database tables once for all tests."""
-    # Import models to ensure they're registered before creating tables
-    from app.models import (
-        User,
-        ProfileModel,
-        SessionModel,
-        AnalyticsEvent,
-        AuditEventModel,
-        LoginSecurityStateModel,
-        PasswordResetTokenModel,
-        EmailVerificationTokenModel,
-        SubscriptionModel,
-        EntitlementModel,
-        BillingTransactionModel,
-        BillingWebhookEventModel,
-        HouseholdModel,
-        HouseholdMemberModel,
-        AdminAuditEventModel,
-        SnapshotModel,
-        ConsentModel,
-    )
-    from app.models.banking_consent import BankingConsentModel
-    from app.models.external_data_source import ExternalDataSourceModel
-    from app.models.token_blacklist import TokenBlacklist
-    from app.models.document import DocumentModel  # noqa: F811
+    # Import models to ensure they're registered with SQLAlchemy before create_all
+    import app.models.user  # noqa: F401
+    import app.models  # noqa: F401
+    from app.models.banking_consent import BankingConsentModel  # noqa: F401
+    from app.models.external_data_source import ExternalDataSourceModel  # noqa: F401
+    from app.models.token_blacklist import TokenBlacklist  # noqa: F401
+    from app.models.document import DocumentModel  # noqa: F401
+
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)

--- a/services/backend/tests/test_agent_loop.py
+++ b/services/backend/tests/test_agent_loop.py
@@ -31,13 +31,10 @@ import logging
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from app.api.v1.endpoints.coach_chat import (
     MAX_AGENT_LOOP_ITERATIONS,
-    MAX_AGENT_LOOP_TOKENS,
     _execute_internal_tool,
-    _handle_retrieve_memories,
     _run_agent_loop,
 )
 
@@ -188,7 +185,7 @@ class TestAgentLoopToolExecution:
             _make_orchestrator_result(answer="Voici le résultat combiné."),
         )
         kwargs = {**_BASE_KWARGS, "memory_block": memory_block}
-        result = _run(_run_agent_loop(orchestrator=orch, **kwargs))
+        _run(_run_agent_loop(orchestrator=orch, **kwargs))
         assert orch.query.call_count == 2
         second_question = orch.query.call_args_list[1].kwargs["question"]
         assert "retraite" in second_question
@@ -203,7 +200,7 @@ class TestAgentLoopToolExecution:
             ),
             _make_orchestrator_result(answer="Pas de données en mémoire."),
         )
-        result = _run(_run_agent_loop(orchestrator=orch, **_BASE_KWARGS))
+        _run(_run_agent_loop(orchestrator=orch, **_BASE_KWARGS))
         assert orch.query.call_count == 2
         second_question = orch.query.call_args_list[1].kwargs["question"]
         assert "Aucune mémoire" in second_question

--- a/services/backend/tests/test_analytics.py
+++ b/services/backend/tests/test_analytics.py
@@ -2,7 +2,6 @@
 Tests for analytics endpoints - event tracking and analytics queries.
 """
 
-import os
 import pytest
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4

--- a/services/backend/tests/test_archetype_detection.py
+++ b/services/backend/tests/test_archetype_detection.py
@@ -1,6 +1,5 @@
 """FIX-165: Direct unit tests for _detect_archetype() — 8 branches."""
 
-import pytest
 from app.services.onboarding.minimal_profile_service import _detect_archetype
 from app.services.onboarding.onboarding_models import MinimalProfileInput
 

--- a/services/backend/tests/test_cantonal_knowledge.py
+++ b/services/backend/tests/test_cantonal_knowledge.py
@@ -7,7 +7,6 @@ for the 11 major Swiss cantons.
 
 from __future__ import annotations
 
-import pytest
 
 from app.services.rag.cantonal_knowledge import CantonalKnowledge
 

--- a/services/backend/tests/test_coach_tools.py
+++ b/services/backend/tests/test_coach_tools.py
@@ -14,7 +14,6 @@ Run: cd services/backend && python3 -m pytest tests/test_coach_tools.py -v
 
 from typing import Optional
 
-import pytest
 from app.services.coach.coach_tools import (
     COACH_TOOLS,
     ROUTE_TO_SCREEN_INTENT_TAGS,

--- a/services/backend/tests/test_coach_tools_categories.py
+++ b/services/backend/tests/test_coach_tools_categories.py
@@ -18,7 +18,6 @@ Run: cd services/backend && python3 -m pytest tests/test_coach_tools_categories.
 
 from typing import Optional
 
-import pytest
 from app.services.coach.coach_tools import (
     COACH_TOOLS,
     ToolCategory,

--- a/services/backend/tests/test_consent.py
+++ b/services/backend/tests/test_consent.py
@@ -65,16 +65,16 @@ class TestOptInDefaults:
         assert ConsentManager.is_consent_given(USER_A, ConsentType.notifications) is False
 
     def test_default_dashboard_all_off(self, manager):
-        """Default dashboard returns 3 consents, all disabled."""
+        """Default dashboard returns 5 consents, all disabled."""
         dashboard = manager.get_default_dashboard()
-        assert len(dashboard.consents) == 3
+        assert len(dashboard.consents) == 5
         for c in dashboard.consents:
             assert c.enabled is False
 
     def test_user_dashboard_all_off_for_new_user(self, manager):
         """User dashboard for new user mirrors default (all OFF)."""
         dashboard = manager.get_user_dashboard(USER_A)
-        assert len(dashboard.consents) == 3
+        assert len(dashboard.consents) == 5
         for c in dashboard.consents:
             assert c.enabled is False
 
@@ -281,14 +281,16 @@ class TestByokFieldBoundaries:
 
 
 class TestConsentTypeEnum:
-    """ConsentType enum covers exactly the 3 required types."""
+    """ConsentType enum covers exactly the 5 required types."""
 
-    def test_exactly_three_consent_types(self):
-        """There are exactly 3 consent types."""
-        assert len(ConsentType) == 3
+    def test_exactly_five_consent_types(self):
+        """There are exactly 5 consent types."""
+        assert len(ConsentType) == 5
 
     def test_consent_type_values(self):
         """Consent type values match expected strings."""
         assert ConsentType.byok_data_sharing.value == "byok_data_sharing"
         assert ConsentType.snapshot_storage.value == "snapshot_storage"
         assert ConsentType.notifications.value == "notifications"
+        assert ConsentType.document_upload.value == "document_upload"
+        assert ConsentType.conversation_memory.value == "conversation_memory"

--- a/services/backend/tests/test_document_scan.py
+++ b/services/backend/tests/test_document_scan.py
@@ -10,13 +10,11 @@ Covers:
 """
 
 import pytest
-from datetime import datetime
 from app.schemas.document_scan import (
     DocumentType,
     ConfidenceLevel,
     ExtractedFieldConfirmation,
     DocumentScanConfirmation,
-    DocumentScanResponse,
     VisionExtractionRequest,
     VisionExtractionResponse,
 )

--- a/services/backend/tests/test_documents.py
+++ b/services/backend/tests/test_documents.py
@@ -49,6 +49,14 @@ def client():
     """Test client with test DB and auth override."""
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[require_current_user] = _fake_user
+
+    # Grant document_upload consent for the test user (nLPD opt-in model)
+    from app.services.reengagement.consent_manager import ConsentManager
+    from app.services.reengagement.reengagement_models import ConsentType
+    db = TestingSessionLocal()
+    ConsentManager.update_consent("test-user-id", ConsentType.document_upload, True, db=db)
+    db.close()
+
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.pop(require_current_user, None)

--- a/services/backend/tests/test_e2e_coach_pipeline.py
+++ b/services/backend/tests/test_e2e_coach_pipeline.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -47,8 +47,7 @@ from app.api.v1.endpoints.coach_chat import (
     _run_agent_loop,
     _sanitize_profile_context,
 )
-from app.services.coach.claude_coach_service import build_system_prompt
-from app.services.coach.coach_tools import COACH_TOOLS, get_llm_tools
+from app.services.coach.coach_tools import get_llm_tools
 from app.services.coach.structured_reasoning import (
     ReasoningOutput,
     StructuredReasoningService,

--- a/services/backend/tests/test_faq_service.py
+++ b/services/backend/tests/test_faq_service.py
@@ -6,6 +6,8 @@ Validates FAQ count, structure, search, and category filtering.
 
 from __future__ import annotations
 
+import re as _re
+
 import pytest
 
 from app.services.rag.faq_service import FaqEntry, FaqService
@@ -81,9 +83,6 @@ def test_faq_entries_are_faq_entry_instances(all_faqs):
 # ---------------------------------------------------------------------------
 # Compliance checks — no banned terms
 # ---------------------------------------------------------------------------
-
-
-import re as _re
 
 # Banned as absolute promises — checked as whole words to avoid false positives
 # (e.g. "certain" banned but not "certaines/certains" as adjectives)

--- a/services/backend/tests/test_memory_injection.py
+++ b/services/backend/tests/test_memory_injection.py
@@ -1,5 +1,4 @@
 """FIX-189: Test that prompt injection patterns are filtered from memory_block."""
-import pytest
 from app.api.v1.endpoints.coach_chat import _sanitize_memory_block
 
 

--- a/services/backend/tests/test_onboarding_contract.py
+++ b/services/backend/tests/test_onboarding_contract.py
@@ -17,7 +17,6 @@ Sources:
     - LAVS art. 21-29, LPP art. 15-16, OPP3 art. 7
 """
 
-import pytest
 
 
 BANNED_TERMS = [

--- a/services/backend/tests/test_pillar_3a_retroactive.py
+++ b/services/backend/tests/test_pillar_3a_retroactive.py
@@ -4,7 +4,6 @@ Validates the NEW 2026 law allowing up to 10 years of retroactive
 Pillar 3a contributions with full tax deductibility.
 """
 
-import pytest
 
 from app.services.pillar_3a_deep.retroactive_3a_service import (
     HISTORICAL_3A_LIMITS,

--- a/services/backend/tests/test_rate_limit.py
+++ b/services/backend/tests/test_rate_limit.py
@@ -283,9 +283,7 @@ class TestRefreshTokenTTL:
         import jwt
         from app.core.config import settings
 
-        before = datetime.now(timezone.utc)
         token = create_refresh_token(user_id="test-user-7d")
-        after = datetime.now(timezone.utc)
 
         payload = jwt.decode(
             token,

--- a/services/backend/tests/test_reengagement.py
+++ b/services/backend/tests/test_reengagement.py
@@ -238,9 +238,9 @@ class TestConsentDefaults:
     """All consents must be OFF by default and correctly structured."""
 
     def test_all_consents_off_by_default(self, consent_manager):
-        """All 3 consents must start disabled (opt-in model)."""
+        """All 5 consents must start disabled (opt-in model)."""
         dashboard = consent_manager.get_default_dashboard()
-        assert len(dashboard.consents) == 3
+        assert len(dashboard.consents) == 5
         for consent in dashboard.consents:
             assert consent.enabled is False, (
                 f"Consent {consent.consent_type.value} should be OFF by default"
@@ -434,14 +434,16 @@ class TestEdgeCases:
                     f"title too long ({len(msg.title)} chars): {msg.title}"
                 )
 
-    def test_consent_types_are_three_independent(self, consent_manager):
-        """Consent dashboard has exactly 3 independent consent types."""
+    def test_consent_types_are_five_independent(self, consent_manager):
+        """Consent dashboard has exactly 5 independent consent types."""
         dashboard = consent_manager.get_default_dashboard()
         types = {c.consent_type for c in dashboard.consents}
         assert types == {
             ConsentType.byok_data_sharing,
             ConsentType.snapshot_storage,
             ConsentType.notifications,
+            ConsentType.document_upload,
+            ConsentType.conversation_memory,
         }
 
     def test_byok_detail_has_disclaimer_and_sources(self, consent_manager):

--- a/services/backend/tests/test_retrieve_memories.py
+++ b/services/backend/tests/test_retrieve_memories.py
@@ -44,7 +44,6 @@ def _find_tool(name: str) -> Optional[dict]:
 
 def _fake_user():
     """Mock authenticated user for dependency override."""
-    from app.core.auth import require_current_user, get_current_user
 
     user = MagicMock()
     user.id = "test-user-id"
@@ -194,7 +193,7 @@ class TestHandleRetrieveMemories:
             memory_block=_MEMORY_BLOCK,
             max_results=2,
         )
-        returned_lines = [l for l in result.split("\n") if l.strip()]
+        returned_lines = [line for line in result.split("\n") if line.strip()]
         assert len(returned_lines) <= 2
 
     def test_case_insensitive_search(self):
@@ -208,7 +207,7 @@ class TestHandleRetrieveMemories:
         """When multiple lines match, they appear in document order."""
         memory = "Ligne A: retraite\nLigne B: autre\nLigne C: retraite aussi"
         result = _handle_retrieve_memories(topic="retraite", memory_block=memory, max_results=5)
-        lines = [l for l in result.split("\n") if l.strip()]
+        lines = [line for line in result.split("\n") if line.strip()]
         assert lines[0].startswith("Ligne A")
         assert lines[1].startswith("Ligne C")
 
@@ -217,7 +216,7 @@ class TestHandleRetrieveMemories:
         # Build a memory with 5 lines all matching "test"
         memory = "\n".join(f"test ligne {i}" for i in range(5))
         result = _handle_retrieve_memories(topic="test", memory_block=memory)
-        returned_lines = [l for l in result.split("\n") if l.strip()]
+        returned_lines = [line for line in result.split("\n") if line.strip()]
         assert len(returned_lines) == 3
 
     def test_max_results_1_returns_exactly_one_line(self):
@@ -225,14 +224,14 @@ class TestHandleRetrieveMemories:
         result = _handle_retrieve_memories(
             topic="retraite", memory_block=_MEMORY_BLOCK, max_results=1
         )
-        returned_lines = [l for l in result.split("\n") if l.strip()]
+        returned_lines = [line for line in result.split("\n") if line.strip()]
         assert len(returned_lines) == 1
 
     def test_max_results_capped_at_5(self):
         """max_results values above 5 must be capped at 5."""
         memory = "\n".join(f"item {i}" for i in range(10))
         result = _handle_retrieve_memories(topic="item", memory_block=memory, max_results=100)
-        returned_lines = [l for l in result.split("\n") if l.strip()]
+        returned_lines = [line for line in result.split("\n") if line.strip()]
         assert len(returned_lines) <= 5
 
 

--- a/services/backend/tests/test_structured_reasoning.py
+++ b/services/backend/tests/test_structured_reasoning.py
@@ -26,10 +26,7 @@ from app.services.coach.structured_reasoning import (
     ReasoningOutput,
     StructuredReasoningService,
     _3A_CEILING_SALARIED,
-    _DECEMBER_DEADLINE_DAYS,
     _REPLACEMENT_RATE_GAP_THRESHOLD,
-    _LPP_BUYBACK_MIN_CHF,
-    _LIQUIDITY_DEFICIT_MONTHS,
 )
 
 

--- a/services/backend/tests/test_token_blacklist.py
+++ b/services/backend/tests/test_token_blacklist.py
@@ -14,8 +14,6 @@ Covers:
 - Cleanup returns correct count
 """
 
-import os
-import pytest
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -25,7 +23,6 @@ from sqlalchemy.orm import Session
 from app.main import app
 from app.core.database import get_db
 from app.models.user import User
-from app.models.token_blacklist import TokenBlacklist
 from app.services.auth_service import (
     create_access_token,
     create_refresh_token,
@@ -235,7 +232,7 @@ class TestLogoutEndpoint:
         try:
             user = _create_test_user(db)
             token = create_access_token(user.id, user.email)
-            payload = decode_token(token)
+            decode_token(token)  # validate token is decodable
 
             client = _make_client_with_real_db()
 

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -1991,68 +1991,6 @@
         "title": "BankStatementUploadResponse",
         "type": "object"
       },
-      "BillingDebugActivateRequest": {
-        "properties": {
-          "is_trial": {
-            "default": false,
-            "title": "Is Trial",
-            "type": "boolean"
-          },
-          "period_days": {
-            "default": 30,
-            "title": "Period Days",
-            "type": "integer"
-          },
-          "status": {
-            "default": "active",
-            "title": "Status",
-            "type": "string"
-          },
-          "tier": {
-            "default": "coach",
-            "title": "Tier",
-            "type": "string"
-          }
-        },
-        "title": "BillingDebugActivateRequest",
-        "type": "object"
-      },
-      "BillingDebugActivateResponse": {
-        "properties": {
-          "created_subscription_id": {
-            "title": "Created Subscription Id",
-            "type": "string"
-          },
-          "features": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Features",
-            "type": "array"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "tier": {
-            "title": "Tier",
-            "type": "string"
-          },
-          "user_id": {
-            "title": "User Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "user_id",
-          "tier",
-          "status",
-          "features",
-          "created_subscription_id"
-        ],
-        "title": "BillingDebugActivateResponse",
-        "type": "object"
-      },
       "BillingEntitlementsResponse": {
         "properties": {
           "current_period_end": {
@@ -6404,6 +6342,24 @@
         "title": "DisabilityGapResponse",
         "type": "object"
       },
+      "DissolveResponse": {
+        "properties": {
+          "revoked_members": {
+            "title": "Revoked Members",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "revoked_members"
+        ],
+        "title": "DissolveResponse",
+        "type": "object"
+      },
       "DividendeVsSalaireRequest": {
         "description": "Request for dividend vs salary optimization.",
         "properties": {
@@ -6929,6 +6885,7 @@
           "lpp_plan",
           "insurance_contract",
           "pillar_3a_attestation",
+          "mortgage_attestation",
           "insurance_policy",
           "lease",
           "lamal_statement",
@@ -10400,6 +10357,7 @@
       "InviteRequest": {
         "properties": {
           "email": {
+            "format": "email",
             "title": "Email",
             "type": "string"
           }
@@ -11454,6 +11412,24 @@
         "title": "LocationVsProprieteResponse",
         "type": "object"
       },
+      "LogoutRequest": {
+        "description": "Optional body for logout — allows blacklisting the refresh token too.",
+        "properties": {
+          "refresh_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Token"
+          }
+        },
+        "title": "LogoutRequest",
+        "type": "object"
+      },
       "LogoutResponse": {
         "description": "Schema for logout response.",
         "properties": {
@@ -11949,6 +11925,19 @@
             ],
             "description": "Age d'arrivee en Suisse (None = ne en Suisse)",
             "title": "Arrivalage"
+          },
+          "birthDate": {
+            "anyOf": [
+              {
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Date de naissance ISO 8601 (ex: 1981-06-15). Si fourni, age est calcule automatiquement.",
+            "title": "Birthdate"
           },
           "canton": {
             "description": "Code canton (2 lettres majuscules, ex: ZH, VD, GE)",
@@ -13641,6 +13630,17 @@
             "title": "Createdat",
             "type": "string"
           },
+          "dateOfBirth": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dateofbirth"
+          },
           "employmentStatus": {
             "anyOf": [
               {
@@ -13969,6 +13969,17 @@
             ],
             "title": "Commune"
           },
+          "dateOfBirth": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dateofbirth"
+          },
           "employmentStatus": {
             "anyOf": [
               {
@@ -14221,6 +14232,19 @@
               }
             ],
             "title": "Commune"
+          },
+          "dateOfBirth": {
+            "anyOf": [
+              {
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Date de naissance ISO 8601 (ex: 1981-06-15)",
+            "title": "Dateofbirth"
           },
           "employmentStatus": {
             "anyOf": [
@@ -21648,8 +21672,17 @@
     },
     "/api/v1/auth/logout": {
       "post": {
-        "description": "Logout by blacklisting the current token's JTI.\n\nThe token will be rejected on subsequent requests until it naturally expires,\nat which point the blacklist entry is eligible for cleanup.",
+        "description": "Logout by blacklisting the current token's JTI.\n\nThe token will be rejected on subsequent requests until it naturally expires,\nat which point the blacklist entry is eligible for cleanup.\n\nOptionally accepts a LogoutRequest body with refresh_token to blacklist both tokens.",
         "operationId": "logout_api_v1_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoutRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "content": {
@@ -21660,6 +21693,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [
@@ -21955,53 +21998,6 @@
           }
         ],
         "summary": "Create Checkout",
-        "tags": [
-          "billing"
-        ]
-      }
-    },
-    "/api/v1/billing/debug/activate": {
-      "post": {
-        "description": "Internal/dev helper to activate subscription without store checkout.",
-        "operationId": "debug_activate_subscription_api_v1_billing_debug_activate_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BillingDebugActivateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BillingDebugActivateResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Debug Activate Subscription",
         "tags": [
           "billing"
         ]
@@ -25243,6 +25239,32 @@
         ]
       }
     },
+    "/api/v1/household/dissolve": {
+      "delete": {
+        "operationId": "dissolve_api_v1_household_dissolve_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DissolveResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dissolve",
+        "tags": [
+          "Household P6"
+        ]
+      }
+    },
     "/api/v1/household/invite": {
       "post": {
         "operationId": "invite_api_v1_household_invite_post",
@@ -27324,7 +27346,7 @@
     },
     "/api/v1/profiles/{profile_id}": {
       "get": {
-        "description": "Get a profile by ID.\nIf profile belongs to a user, verify ownership.",
+        "description": "Get a profile by ID.\nRequires authentication. Verifies ownership.",
         "operationId": "get_profile_api_v1_profiles__profile_id__get",
         "parameters": [
           {
@@ -27371,7 +27393,7 @@
         ]
       },
       "patch": {
-        "description": "Update an existing profile.\nIf profile belongs to a user, verify ownership.",
+        "description": "Update an existing profile.\nRequires authentication. Verifies ownership.",
         "operationId": "update_profile_api_v1_profiles__profile_id__patch",
         "parameters": [
           {


### PR DESCRIPTION
## Summary — External audit blockers closed
1. **nLPD consent**: Real guards on documents, RAG, coach_chat (not TODOs)
2. **DB sessions**: Snapshots + OpenBanking endpoints use real DB
3. **Routes**: Sandbox/coming-soon feature-gated (default off)
4. **Logout**: Proper OpenAPI schema with LogoutRequest
5. **i18n**: 8 hardcoded FR extracted, 20+ bad ES/PT/IT translations fixed
6. **Lint**: ruff 93→0, flutter analyze 0 warnings
7. **TLS**: Decision documented (deferred V1, HSTS active)

## Test plan
- [x] flutter test: 8126 passed, 0 failures
- [x] pytest: 4652 passed, 0 failures
- [x] ruff check: 0 errors
- [x] flutter analyze: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)