### PR TITLE
fix: definitive — dead routes, nav test, BuildContext, real tests

### DIFF
--- a/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart
@@ -64,7 +64,7 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
 
     if (!_hasUserInteracted) {
       final screenReturn = ScreenReturn.abandoned(
-        route: '/dette-ratio',
+        route: '/debt/ratio',
         runId: _seqRunId,
         stepId: _seqStepId,
         eventId: 'evt_${_seqRunId}_${DateTime.now().millisecondsSinceEpoch}',
@@ -75,7 +75,7 @@ class _DebtRatioScreenState extends State<DebtRatioScreen> {
 
     final result = _result;
     final screenReturn = ScreenReturn.completed(
-      route: '/dette-ratio',
+      route: '/debt/ratio',
       stepOutputs: {
         'ratio_endettement': result.ratio,
         'marge_mensuelle': result.margeDisponible,

--- a/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
+++ b/apps/mobile/lib/screens/debt_prevention/repayment_screen.dart
@@ -59,7 +59,7 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
 
     if (!_hasUserInteracted) {
       final screenReturn = ScreenReturn.abandoned(
-        route: '/dette-remboursement',
+        route: '/debt/repayment',
         runId: _seqRunId,
         stepId: _seqStepId,
         eventId: 'evt_${_seqRunId}_${DateTime.now().millisecondsSinceEpoch}',
@@ -70,7 +70,7 @@ class _RepaymentScreenState extends State<RepaymentScreen> {
 
     final result = _result;
     final screenReturn = ScreenReturn.completed(
-      route: '/dette-remboursement',
+      route: '/debt/repayment',
       stepOutputs: {
         'horizon_mois': result?.avalanche.moisJusquaLiberation ?? 0,
         'versement_mensuel': _budgetMensuel,

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -516,12 +516,12 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
   /// Try Claude Vision extraction via backend API.
   /// Returns ExtractionResult if successful, null otherwise.
   Future<ExtractionResult?> _tryVisionExtraction(XFile file) async {
+    // Read canton BEFORE async gap to avoid BuildContext across await
+    final canton = Provider.of<CoachProfileProvider>(context, listen: false)
+        .profile?.canton;
     try {
       final bytes = await file.readAsBytes();
       final base64Image = base64Encode(bytes);
-
-      final canton = Provider.of<CoachProfileProvider>(context, listen: false)
-          .profile?.canton;
 
       final response = await DocumentService.extractWithVision(
         imageBase64: base64Image,

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -89,7 +89,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
 
     if (!_hasUserInteracted) {
       final screenReturn = ScreenReturn.abandoned(
-        route: '/premier-emploi',
+        route: '/first-job',
         runId: _seqRunId,
         stepId: _seqStepId,
         eventId: 'evt_${_seqRunId}_${DateTime.now().millisecondsSinceEpoch}',
@@ -99,7 +99,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     }
 
     final screenReturn = ScreenReturn.completed(
-      route: '/premier-emploi',
+      route: '/first-job',
       stepOutputs: {},
       runId: _seqRunId,
       stepId: _seqStepId,

--- a/apps/mobile/lib/services/cap_engine.dart
+++ b/apps/mobile/lib/services/cap_engine.dart
@@ -719,7 +719,7 @@ class CapEngine {
           headline: l.capLeSelfEmploymentHeadline,
           whyNow: l.capLeSelfEmploymentWhyNow,
           ctaLabel: l.capLeSelfEmploymentCtaLabel,
-          route: '/independant',
+          route: '/segments/independant',
         ),
       'retirement' => _LifeEventMapping(
           headline: l.capLeRetirementHeadline,
@@ -737,19 +737,19 @@ class CapEngine {
           headline: l.capLeDeathOfRelativeHeadline,
           whyNow: l.capLeDeathOfRelativeWhyNow,
           ctaLabel: l.capLeDeathOfRelativeCtaLabel,
-          route: '/deces-proche',
+          route: '/life-event/deces-proche',
         ),
       'newJob' => _LifeEventMapping(
           headline: l.capLeNewJobHeadline,
           whyNow: l.capLeNewJobWhyNow,
           ctaLabel: l.capLeNewJobCtaLabel,
-          route: '/job-comparison',
+          route: '/simulator/job-comparison',
         ),
       'housingSale' => _LifeEventMapping(
           headline: l.capLeHousingSaleHeadline,
           whyNow: l.capLeHousingSaleWhyNow,
           ctaLabel: l.capLeHousingSaleCtaLabel,
-          route: '/housing-sale',
+          route: '/life-event/housing-sale',
         ),
       'inheritance' => _LifeEventMapping(
           headline: l.capLeInheritanceHeadline,
@@ -761,7 +761,7 @@ class CapEngine {
           headline: l.capLeDonationHeadline,
           whyNow: l.capLeDonationWhyNow,
           ctaLabel: l.capLeDonationCtaLabel,
-          route: '/donation',
+          route: '/life-event/donation',
         ),
       'disability' => _LifeEventMapping(
           headline: l.capLeDisabilityHeadline,
@@ -773,13 +773,13 @@ class CapEngine {
           headline: l.capLeCantonMoveHeadline,
           whyNow: l.capLeCantonMoveWhyNow,
           ctaLabel: l.capLeCantonMoveCtaLabel,
-          route: '/demenagement-cantonal',
+          route: '/life-event/demenagement-cantonal',
         ),
       'countryMove' => _LifeEventMapping(
           headline: l.capLeCountryMoveHeadline,
           whyNow: l.capLeCountryMoveWhyNow,
           ctaLabel: l.capLeCountryMoveCtaLabel,
-          route: '/expat',
+          route: '/expatriation',
         ),
       'debtCrisis' => _LifeEventMapping(
           headline: l.capLeDebtCrisisHeadline,

--- a/apps/mobile/lib/services/navigation/screen_registry.dart
+++ b/apps/mobile/lib/services/navigation/screen_registry.dart
@@ -1324,7 +1324,7 @@ class MintScreenRegistry extends ScreenRegistry {
   );
 
   static const ScreenEntry _coachWeeklyRecap = ScreenEntry(
-    route: '/coach/weekly-recap',
+    route: '/weekly-recap',
     intentTag: 'coach_weekly_recap',
     behavior: ScreenBehavior.conversationPure,
     requiredFields: [],

--- a/apps/mobile/lib/widgets/pulse/cap_card.dart
+++ b/apps/mobile/lib/widgets/pulse/cap_card.dart
@@ -167,8 +167,8 @@ class CapCard extends StatelessWidget {
       case CtaMode.capture:
         // Route to the specific capture flow based on captureType.
         final route = switch (cap.captureType) {
-          'lpp' => '/document-scan',
-          'avs' => '/document-scan/avs',
+          'lpp' => '/scan',
+          'avs' => '/scan/avs-guide',
           'profile' => '/onboarding/enrichment',
           _ => '/onboarding/enrichment',
         };

--- a/apps/mobile/test/navigation_route_integrity_test.dart
+++ b/apps/mobile/test/navigation_route_integrity_test.dart
@@ -13,23 +13,50 @@ void main() {
         .map((m) => m.group(1)!)
         .toSet();
 
-    // 2. Extract all STATIC context.push/context.go targets from screens
-    // Only match pure string literals (no interpolation)
-    final screenDir = Directory('lib/screens');
+    // 2. Extract all STATIC route targets from screens, widgets, services, data
+    // Scans: context.push/go, route: '/...' fields, and redirect patterns
+    final dirsToScan = [
+      Directory('lib/screens'),
+      Directory('lib/widgets'),
+      Directory('lib/services'),
+      Directory('lib/data'),
+    ];
     final pushPattern = RegExp(r"context\.(push|go)\('(/[a-z0-9\-/]+)'");
+    final routeFieldPattern = RegExp(r"route:\s*'(/[a-z0-9\-/]+)'");
     final brokenRoutes = <String>[];
 
-    for (final file in screenDir.listSync(recursive: true)) {
-      if (file is! File || !file.path.endsWith('.dart')) continue;
-      final content = file.readAsStringSync();
-      for (final match in pushPattern.allMatches(content)) {
-        final route = match.group(2)!;
-        final basePath = route.split('?').first;
-        // Match: exact, or parent path (child routes like /profile/byok)
-        final hasMatch = definedRoutes.contains(basePath) ||
-            definedRoutes.any((r) => basePath.startsWith('$r/'));
-        if (!hasMatch) {
-          brokenRoutes.add('${file.path.split('lib/').last}: $route');
+    for (final dir in dirsToScan) {
+      if (!dir.existsSync()) continue;
+      for (final file in dir.listSync(recursive: true)) {
+        if (file is! File || !file.path.endsWith('.dart')) continue;
+        final content = file.readAsStringSync();
+        // Check context.push/go patterns
+        final contentLines = content.split('\n');
+        for (final match in pushPattern.allMatches(content)) {
+          // Skip matches inside comments
+          final lineIdx = content.substring(0, match.start).split('\n').length - 1;
+          if (lineIdx < contentLines.length && contentLines[lineIdx].trimLeft().startsWith('//')) continue;
+          final route = match.group(2)!;
+          final basePath = route.split('?').first;
+          final hasMatch = definedRoutes.contains(basePath) ||
+              definedRoutes.any((r) => basePath.startsWith('$r/'));
+          if (!hasMatch) {
+            brokenRoutes.add('${file.path.split('lib/').last}: $route');
+          }
+        }
+        // Check route: '/...' field patterns (e.g. in cap_engine, screen_registry)
+        final lines = content.split('\n');
+        for (final match in routeFieldPattern.allMatches(content)) {
+          // Skip matches inside comments
+          final lineIdx = content.substring(0, match.start).split('\n').length - 1;
+          if (lineIdx < lines.length && lines[lineIdx].trimLeft().startsWith('//')) continue;
+          final route = match.group(1)!;
+          final basePath = route.split('?').first;
+          final hasMatch = definedRoutes.contains(basePath) ||
+              definedRoutes.any((r) => basePath.startsWith('$r/'));
+          if (!hasMatch) {
+            brokenRoutes.add('${file.path.split('lib/').last}: $route (field)');
+          }
         }
       }
     }

--- a/services/backend/tests/test_consent_guards.py
+++ b/services/backend/tests/test_consent_guards.py
@@ -1,0 +1,452 @@
+"""
+Tests for nLPD consent guards across endpoints + auth schema coverage.
+
+Verifies that:
+1. documents.py — upload blocked without document_upload consent (403)
+2. rag.py — query degrades without byok_data_sharing consent (no user context)
+3. coach_chat.py — stateless without conversation_memory consent (memory_block stripped)
+4. auth.py — logout accepts refresh_token in body
+
+Run: cd services/backend && python3 -m pytest tests/test_consent_guards.py -v
+"""
+
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.core.auth import require_current_user, get_current_user
+from app.core.database import get_db
+from app.services.reengagement.consent_manager import ConsentManager
+from app.services.reengagement.reengagement_models import ConsentType
+from tests.conftest import TestingSessionLocal, override_get_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_user():
+    """Mock authenticated user."""
+    user = MagicMock()
+    user.id = "test-user-id"
+    user.email = "test@mint.ch"
+    user.display_name = "Test User"
+    return user
+
+
+def _grant_consent(consent_type: ConsentType):
+    """Grant a specific consent for the test user in the test DB."""
+    db = TestingSessionLocal()
+    ConsentManager.update_consent("test-user-id", consent_type, True, db=db)
+    db.close()
+
+
+def _revoke_consent(consent_type: ConsentType):
+    """Revoke a specific consent for the test user in the test DB."""
+    db = TestingSessionLocal()
+    ConsentManager.update_consent("test-user-id", consent_type, False, db=db)
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    """Test client with test DB and auth override."""
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_current_user] = _fake_user
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_coach_orchestrator(result: dict):
+    """Patch coach chat orchestrator to avoid needing chromadb."""
+    mock_orch = MagicMock()
+    mock_orch.query = AsyncMock(return_value=result)
+    return patch(
+        "app.api.v1.endpoints.coach_chat._get_orchestrator",
+        return_value=mock_orch,
+    )
+
+
+_COACH_OK_RESULT = {
+    "answer": "Le 3a est un instrument puissant.",
+    "sources": [],
+    "disclaimers": ["Outil educatif (LSFin)."],
+    "tokens_used": 100,
+}
+
+
+def _mock_rag_orchestrator(result: dict):
+    """Patch RAG orchestrator to avoid needing chromadb."""
+    mock_orch = MagicMock()
+    mock_orch.query = AsyncMock(return_value=result)
+    return patch(
+        "app.api.v1.endpoints.rag._get_orchestrator_safe",
+        new_callable=AsyncMock,
+        return_value=mock_orch,
+    )
+
+
+_RAG_OK_RESULT = {
+    "answer": "Le pilier 3a permet de deduire les cotisations.",
+    "sources": [],
+    "disclaimers": ["Outil educatif (LSFin)."],
+    "tokens_used": 80,
+}
+
+
+# ===========================================================================
+# 1a. documents.py — upload blocked without document_upload consent
+# ===========================================================================
+
+
+class TestDocumentUploadConsentGuard:
+    """nLPD art. 6 al. 7: document upload requires document_upload consent."""
+
+    def test_upload_blocked_without_document_upload_consent(self, client):
+        """POST /documents/upload returns 403 when document_upload consent is not granted."""
+        # No consent granted — default is False (nLPD opt-in)
+        response = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("cert.pdf", b"%PDF-1.4 mock", "application/pdf")},
+        )
+        assert response.status_code == 403
+        assert "document_upload" in response.json()["detail"]
+
+    def test_upload_allowed_with_document_upload_consent(self, client):
+        """POST /documents/upload does NOT return 403 when consent is granted."""
+        _grant_consent(ConsentType.document_upload)
+
+        # We still expect a non-403 response (could be 200 or other error from
+        # mocked docling, but not a consent block).
+        from unittest.mock import patch as _patch
+        from tests.test_documents import _make_mock_parser, _make_mock_extractor
+        from tests.test_documents import PARSER_PATCH, LPP_EXTRACTOR_PATCH
+
+        with _patch(LPP_EXTRACTOR_PATCH, return_value=_make_mock_extractor()), \
+             _patch(PARSER_PATCH, return_value=_make_mock_parser()):
+            response = client.post(
+                "/api/v1/documents/upload",
+                files={"file": ("cert.pdf", b"%PDF-1.4 mock", "application/pdf")},
+            )
+        assert response.status_code != 403
+
+    def test_upload_blocked_returns_actionable_message(self, client):
+        """403 response tells the user how to enable consent."""
+        response = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("cert.pdf", b"%PDF-1.4 mock", "application/pdf")},
+        )
+        assert response.status_code == 403
+        detail = response.json()["detail"]
+        assert "Consentement" in detail
+        assert "Profil" in detail or "Consentements" in detail
+
+    def test_upload_blocked_after_consent_revoked(self, client):
+        """Upload blocked again after consent is revoked."""
+        _grant_consent(ConsentType.document_upload)
+        _revoke_consent(ConsentType.document_upload)
+
+        response = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("cert.pdf", b"%PDF-1.4 mock", "application/pdf")},
+        )
+        assert response.status_code == 403
+
+
+# ===========================================================================
+# 1b. rag.py — degrades without byok_data_sharing consent
+# ===========================================================================
+
+
+class TestRAGConsentGuard:
+    """nLPD art. 6 al. 7: RAG degrades without byok_data_sharing consent."""
+
+    def test_rag_query_succeeds_without_byok_consent(self, client):
+        """POST /rag/query returns 200 even without byok_data_sharing consent.
+
+        The query still works — it just excludes user-specific context.
+        """
+        with _mock_rag_orchestrator(_RAG_OK_RESULT):
+            response = client.post(
+                "/api/v1/rag/query",
+                json={
+                    "question": "Qu'est-ce que le pilier 3a ?",
+                    "api_key": "sk-test-12345",
+                    "provider": "claude",
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert "answer" in data
+
+    def test_rag_query_without_consent_excludes_user_context(self, client):
+        """Without byok_data_sharing consent, profile_context and user_id are None."""
+        captured_kwargs = {}
+
+        async def _capturing_orchestrator():
+            mock_orch = MagicMock()
+
+            async def _capture_query(**kwargs):
+                captured_kwargs.update(kwargs)
+                return _RAG_OK_RESULT
+
+            mock_orch.query = _capture_query
+            return mock_orch
+
+        with patch(
+            "app.api.v1.endpoints.rag._get_orchestrator_safe",
+            new_callable=AsyncMock,
+            side_effect=_capturing_orchestrator,
+        ):
+            response = client.post(
+                "/api/v1/rag/query",
+                json={
+                    "question": "Qu'est-ce que le pilier 3a ?",
+                    "api_key": "sk-test-12345",
+                    "provider": "claude",
+                    "profile_context": {"canton": "VD", "age": 45},
+                },
+            )
+
+        assert response.status_code == 200
+        # Without consent: user_id should be None and profile_context should be None
+        assert captured_kwargs.get("user_id") is None
+        assert captured_kwargs.get("profile_context") is None
+
+    def test_rag_query_with_byok_consent_includes_user_context(self, client):
+        """With byok_data_sharing consent, profile_context and user_id are passed."""
+        _grant_consent(ConsentType.byok_data_sharing)
+
+        captured_kwargs = {}
+
+        async def _capturing_orchestrator():
+            mock_orch = MagicMock()
+
+            async def _capture_query(**kwargs):
+                captured_kwargs.update(kwargs)
+                return _RAG_OK_RESULT
+
+            mock_orch.query = _capture_query
+            return mock_orch
+
+        with patch(
+            "app.api.v1.endpoints.rag._get_orchestrator_safe",
+            new_callable=AsyncMock,
+            side_effect=_capturing_orchestrator,
+        ):
+            response = client.post(
+                "/api/v1/rag/query",
+                json={
+                    "question": "Qu'est-ce que le pilier 3a ?",
+                    "api_key": "sk-test-12345",
+                    "provider": "claude",
+                    "profile_context": {"canton": "VD", "age": 45},
+                },
+            )
+
+        assert response.status_code == 200
+        # With consent: user_id and profile_context should be present
+        assert captured_kwargs.get("user_id") == "test-user-id"
+        assert captured_kwargs.get("profile_context") is not None
+        assert captured_kwargs["profile_context"]["canton"] == "VD"
+
+
+# ===========================================================================
+# 1c. coach_chat.py — stateless without conversation_memory consent
+# ===========================================================================
+
+
+class TestCoachChatMemoryConsentGuard:
+    """nLPD art. 6 al. 7: coach chat is stateless without conversation_memory consent."""
+
+    _COACH_BODY = {
+        "message": "Comment optimiser mon 3a ?",
+        "api_key": "sk-test-key-12345",
+        "provider": "claude",
+    }
+
+    _COACH_BODY_WITH_MEMORY = {
+        "message": "Comment optimiser mon 3a ?",
+        "api_key": "sk-test-key-12345",
+        "provider": "claude",
+        "memory_block": "User mentioned saving 500 CHF/month in pilier 3a.",
+    }
+
+    def test_coach_chat_works_without_memory_consent(self, client):
+        """POST /coach/chat returns 200 even without conversation_memory consent."""
+        with _mock_coach_orchestrator(_COACH_OK_RESULT):
+            response = client.post("/api/v1/coach/chat", json=self._COACH_BODY)
+        assert response.status_code == 200
+
+    def test_coach_chat_strips_memory_block_without_consent(self, client):
+        """Without conversation_memory consent, memory_block is stripped (set to None)."""
+        captured_memory = {"value": "SENTINEL"}
+
+        original_reason = None
+        try:
+            from app.services.coach.structured_reasoning_service import StructuredReasoningService
+            original_reason = StructuredReasoningService.reason
+        except ImportError:
+            pass
+
+        def _capture_reason(user_message, profile_context, memory_block=None, **kw):
+            captured_memory["value"] = memory_block
+            # Return a minimal reasoning output
+            result = MagicMock()
+            result.as_system_prompt_block.return_value = ""
+            return result
+
+        with _mock_coach_orchestrator(_COACH_OK_RESULT), \
+             patch(
+                 "app.api.v1.endpoints.coach_chat.StructuredReasoningService.reason",
+                 side_effect=_capture_reason,
+             ):
+            response = client.post(
+                "/api/v1/coach/chat", json=self._COACH_BODY_WITH_MEMORY
+            )
+
+        assert response.status_code == 200
+        # Without consent, memory_block should have been stripped to None
+        assert captured_memory["value"] is None
+
+    def test_coach_chat_preserves_memory_block_with_consent(self, client):
+        """With conversation_memory consent, memory_block is preserved."""
+        _grant_consent(ConsentType.conversation_memory)
+
+        captured_memory = {"value": "SENTINEL"}
+
+        def _capture_reason(user_message, profile_context, memory_block=None, **kw):
+            captured_memory["value"] = memory_block
+            result = MagicMock()
+            result.as_system_prompt_block.return_value = ""
+            return result
+
+        with _mock_coach_orchestrator(_COACH_OK_RESULT), \
+             patch(
+                 "app.api.v1.endpoints.coach_chat.StructuredReasoningService.reason",
+                 side_effect=_capture_reason,
+             ):
+            response = client.post(
+                "/api/v1/coach/chat", json=self._COACH_BODY_WITH_MEMORY
+            )
+
+        assert response.status_code == 200
+        # With consent, memory_block should be preserved (non-None)
+        assert captured_memory["value"] is not None
+        assert "pilier 3a" in captured_memory["value"]
+
+    def test_coach_chat_memory_consent_revoked_strips_block(self, client):
+        """After revoking conversation_memory consent, memory_block is stripped again."""
+        _grant_consent(ConsentType.conversation_memory)
+        _revoke_consent(ConsentType.conversation_memory)
+
+        captured_memory = {"value": "SENTINEL"}
+
+        def _capture_reason(user_message, profile_context, memory_block=None, **kw):
+            captured_memory["value"] = memory_block
+            result = MagicMock()
+            result.as_system_prompt_block.return_value = ""
+            return result
+
+        with _mock_coach_orchestrator(_COACH_OK_RESULT), \
+             patch(
+                 "app.api.v1.endpoints.coach_chat.StructuredReasoningService.reason",
+                 side_effect=_capture_reason,
+             ):
+            response = client.post(
+                "/api/v1/coach/chat", json=self._COACH_BODY_WITH_MEMORY
+            )
+
+        assert response.status_code == 200
+        assert captured_memory["value"] is None
+
+
+# ===========================================================================
+# 3. Logout schema — accepts refresh_token in body
+# ===========================================================================
+
+
+class TestLogoutRefreshToken:
+    """Verify POST /auth/logout accepts a refresh_token in the request body."""
+
+    def test_logout_accepts_refresh_token_in_body(self, client):
+        """POST /auth/logout with refresh_token in body should work (blacklist both tokens).
+
+        Register + login to get real tokens, then logout with refresh_token.
+        """
+        # Register a user to get real tokens
+        reg_resp = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "logout-test@mint.ch",
+                "password": "securepass123",
+                "display_name": "Logout Test",
+            },
+        )
+        assert reg_resp.status_code == 201
+        tokens = reg_resp.json()
+        access_token = tokens["access_token"]
+        refresh_token = tokens["refresh_token"]
+
+        # Logout with refresh_token in body — requires Bearer token header
+        logout_resp = client.post(
+            "/api/v1/auth/logout",
+            json={"refresh_token": refresh_token},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert logout_resp.status_code == 200
+        assert logout_resp.json()["status"] == "logged_out"
+
+    def test_logout_works_without_refresh_token_in_body(self, client):
+        """POST /auth/logout works even without refresh_token (only blacklists access token)."""
+        reg_resp = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "logout-norefresh@mint.ch",
+                "password": "securepass123",
+            },
+        )
+        assert reg_resp.status_code == 201
+        access_token = reg_resp.json()["access_token"]
+
+        logout_resp = client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert logout_resp.status_code == 200
+        assert logout_resp.json()["status"] == "logged_out"
+
+    def test_logout_with_empty_body(self, client):
+        """POST /auth/logout with empty JSON body should still work."""
+        reg_resp = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "logout-empty@mint.ch",
+                "password": "securepass123",
+            },
+        )
+        assert reg_resp.status_code == 201
+        access_token = reg_resp.json()["access_token"]
+
+        logout_resp = client.post(
+            "/api/v1/auth/logout",
+            json={},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )

--- a/services/backend/tests/test_snapshots_db.py
+++ b/services/backend/tests/test_snapshots_db.py
@@ -1,0 +1,299 @@
+"""
+Tests for Snapshots DB persistence + Open Banking consent DB via API endpoints.
+
+Verifies that:
+1. List snapshots returns DB results (not just in-memory)
+2. Delete snapshots clears DB and subsequent GET returns empty
+3. Open banking consent creates in DB
+
+Run: cd services/backend && python3 -m pytest tests/test_snapshots_db.py -v
+"""
+
+import os
+import pytest
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.core.auth import require_current_user, get_current_user
+from app.core.database import get_db
+from app.services.reengagement.consent_manager import ConsentManager
+from app.services.reengagement.reengagement_models import ConsentType
+from tests.conftest import TestingSessionLocal, override_get_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_user():
+    """Mock authenticated user."""
+    user = MagicMock()
+    user.id = "test-user-id"
+    user.email = "test@mint.ch"
+    user.display_name = "Test User"
+    return user
+
+
+def _grant_snapshot_consent():
+    """Grant snapshot_storage consent for the test user."""
+    db = TestingSessionLocal()
+    ConsentManager.update_consent(
+        "test-user-id", ConsentType.snapshot_storage, True, db=db
+    )
+    db.close()
+
+
+_VALID_SNAPSHOT_BODY = {
+    "userId": "test-user-id",
+    "trigger": "quarterly",
+    "profileData": {
+        "age": 49,
+        "gross_income": 122207,
+        "canton": "VS",
+        "archetype": "swiss_native",
+        "household_type": "couple",
+        "replacement_ratio": 0.655,
+        "months_liquidity": 6.0,
+        "tax_saving_potential": 7258,
+        "confidence_score": 0.72,
+        "enrichment_count": 3,
+        "fri_total": 68.5,
+        "fri_l": 72.0,
+        "fri_f": 65.0,
+        "fri_r": 70.0,
+        "fri_s": 66.0,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    """Test client with test DB and auth override."""
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_current_user] = _fake_user
+    app.dependency_overrides[get_current_user] = _fake_user
+
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ===========================================================================
+# 2a. List snapshots uses DB
+# ===========================================================================
+
+
+class TestListSnapshotsDB:
+    """Verify GET /snapshots returns data persisted in DB."""
+
+    def test_list_snapshots_empty_initially(self, client):
+        """GET /snapshots returns empty list when no snapshots exist."""
+        response = client.get("/api/v1/snapshots")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["snapshots"] == []
+        assert data["count"] == 0
+
+    def test_list_snapshots_returns_db_results(self, client):
+        """Create a snapshot via API, then GET /snapshots returns it."""
+        _grant_snapshot_consent()
+
+        # Create snapshot
+        create_resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+        assert create_resp.status_code == 200
+        created_id = create_resp.json()["id"]
+
+        # List snapshots
+        list_resp = client.get("/api/v1/snapshots")
+        assert list_resp.status_code == 200
+        data = list_resp.json()
+        assert data["count"] >= 1
+        ids = [s["id"] for s in data["snapshots"]]
+        assert created_id in ids
+
+    def test_list_snapshots_returns_multiple(self, client):
+        """Multiple snapshots are all returned."""
+        _grant_snapshot_consent()
+
+        created_ids = []
+        for _ in range(3):
+            resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+            assert resp.status_code == 200
+            created_ids.append(resp.json()["id"])
+
+        list_resp = client.get("/api/v1/snapshots")
+        assert list_resp.status_code == 200
+        data = list_resp.json()
+        assert data["count"] == 3
+        returned_ids = [s["id"] for s in data["snapshots"]]
+        for cid in created_ids:
+            assert cid in returned_ids
+
+    def test_list_snapshots_respects_limit(self, client):
+        """GET /snapshots?limit=2 returns at most 2 snapshots."""
+        _grant_snapshot_consent()
+
+        for _ in range(5):
+            resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+            assert resp.status_code == 200
+
+        list_resp = client.get("/api/v1/snapshots?limit=2")
+        assert list_resp.status_code == 200
+        data = list_resp.json()
+        assert len(data["snapshots"]) <= 2
+
+    def test_snapshot_fields_persisted(self, client):
+        """Snapshot fields are correctly persisted and returned."""
+        _grant_snapshot_consent()
+
+        create_resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+        assert create_resp.status_code == 200
+        snapshot = create_resp.json()
+
+        assert snapshot["trigger"] == "quarterly"
+        assert snapshot["canton"] == "VS"
+        assert snapshot["grossIncome"] == 122207
+        assert snapshot["archetype"] == "swiss_native"
+        assert snapshot["friTotal"] == 68.5
+
+
+# ===========================================================================
+# 2b. Delete snapshots uses DB
+# ===========================================================================
+
+
+class TestDeleteSnapshotsDB:
+    """Verify DELETE /snapshots clears DB data."""
+
+    def test_delete_snapshots_clears_db(self, client):
+        """DELETE /snapshots returns count=1 after creating 1 snapshot."""
+        _grant_snapshot_consent()
+
+        # Create one snapshot
+        create_resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+        assert create_resp.status_code == 200
+
+        # Delete all
+        del_resp = client.delete("/api/v1/snapshots")
+        assert del_resp.status_code == 200
+        data = del_resp.json()
+        assert data["deletedCount"] >= 1
+
+        # Verify empty
+        list_resp = client.get("/api/v1/snapshots")
+        assert list_resp.status_code == 200
+        assert list_resp.json()["count"] == 0
+        assert list_resp.json()["snapshots"] == []
+
+    def test_delete_multiple_snapshots(self, client):
+        """DELETE /snapshots clears all snapshots for the user."""
+        _grant_snapshot_consent()
+
+        for _ in range(3):
+            resp = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+            assert resp.status_code == 200
+
+        del_resp = client.delete("/api/v1/snapshots")
+        assert del_resp.status_code == 200
+        assert del_resp.json()["deletedCount"] == 3
+
+        list_resp = client.get("/api/v1/snapshots")
+        assert list_resp.json()["count"] == 0
+
+    def test_delete_on_empty_returns_zero(self, client):
+        """DELETE /snapshots when no snapshots exist returns count=0."""
+        del_resp = client.delete("/api/v1/snapshots")
+        assert del_resp.status_code == 200
+        assert del_resp.json()["deletedCount"] == 0
+
+    def test_create_snapshot_requires_consent(self, client):
+        """POST /snapshots returns 403 without snapshot_storage consent."""
+        # No consent granted
+        response = client.post("/api/v1/snapshots", json=_VALID_SNAPSHOT_BODY)
+        assert response.status_code == 403
+        assert "snapshot_storage" in response.json()["detail"]
+
+
+# ===========================================================================
+# 4. Open Banking consent creates in DB
+# ===========================================================================
+
+
+class TestOpenBankingConsentDB:
+    """Verify POST /open-banking/consent persists in DB."""
+
+    _CONSENT_BODY = {
+        "bankId": "ubs",
+        "bankName": "UBS",
+        "scopes": ["accounts", "balances", "transactions"],
+    }
+
+    @pytest.fixture(autouse=True)
+    def _enable_open_banking(self):
+        """Enable the OPEN_BANKING_ENABLED feature gate for these tests."""
+        original = os.environ.get("OPEN_BANKING_ENABLED")
+        os.environ["OPEN_BANKING_ENABLED"] = "true"
+        yield
+        if original is None:
+            os.environ.pop("OPEN_BANKING_ENABLED", None)
+        else:
+            os.environ["OPEN_BANKING_ENABLED"] = original
+
+    def test_open_banking_consent_creates_in_db(self, client):
+        """POST /open-banking/consent creates a consent and returns it."""
+        response = client.post(
+            "/api/v1/open-banking/consent", json=self._CONSENT_BODY
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["bankId"] == "ubs"
+        assert data["bankName"] == "UBS"
+        assert "consentId" in data
+        assert data["scopes"] == ["accounts", "balances", "transactions"]
+        assert "grantedAt" in data
+        assert "expiresAt" in data
+
+    def test_open_banking_consent_persists_and_listed(self, client):
+        """Created consent appears in GET /open-banking/consents."""
+        # Create consent
+        create_resp = client.post(
+            "/api/v1/open-banking/consent", json=self._CONSENT_BODY
+        )
+        assert create_resp.status_code == 200
+        consent_id = create_resp.json()["consentId"]
+
+        # List consents — returns List[ConsentResponse] directly
+        list_resp = client.get("/api/v1/open-banking/consents")
+        assert list_resp.status_code == 200
+        data = list_resp.json()
+        consent_ids = [c["consentId"] for c in data]
+        assert consent_id in consent_ids
+
+    def test_open_banking_consent_revocable(self, client):
+        """DELETE /open-banking/consent/{id} revokes the consent."""
+        # Create
+        create_resp = client.post(
+            "/api/v1/open-banking/consent", json=self._CONSENT_BODY
+        )
+        assert create_resp.status_code == 200
+        consent_id = create_resp.json()["consentId"]
+
+        # Revoke
+        del_resp = client.delete(f"/api/v1/open-banking/consent/{consent_id}")
+        assert del_resp.status_code == 200
+
+    def test_open_banking_blocked_when_disabled(self, client):
+        """POST /open-banking/consent returns 503 when feature is disabled."""
+        os.environ["OPEN_BANKING_ENABLED"] = "false"
+        response = client.post(
+            "/api/v1/open-banking/consent", json=self._CONSENT_BODY
+        )
+        assert response.status_code == 503


### PR DESCRIPTION
## What this PR fixes (verified line by line, no agents)

### 7 dead routes in cap_engine.dart
Users clicking Cap/Pulse CTA buttons were sent to non-existent routes.
All 7 fixed to canonical GoRouter paths.

### AVS capture route broken in cap_card.dart
/document-scan/avs → /scan/avs-guide (route didn't exist)

### 4 ScreenReturn metadata mismatched
/dette-ratio, /dette-remboursement, /premier-emploi, /coach/weekly-recap
→ aligned to canonical router paths

### Navigation integrity test extended
Now scans widgets/, services/, data/ (not just screens/).
Catches data-driven route references. Skips comments.

### BuildContext across async gap
document_scan_screen.dart: Provider read moved before await

### 27 new backend tests (real, no pragma)
test_consent_guards.py + test_snapshots_db.py

## Test plan
- [x] flutter test: 8126 passed, 0 failures
- [x] pytest: 4679 passed, 0 failures
- [x] flutter analyze: 0 errors, 0 warnings
- [x] navigation_route_integrity_test: PASS (0 broken routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)