### PR TITLE
fix(ci): bump Flutter 3.27.4 → 3.41.4 to match code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
       - name: Flesch–Kincaid (Kandel–Moles) French gate
         run: |
@@ -113,7 +113,7 @@ jobs:
         run: python3 tools/checks/wcag_aa_all_touched.py
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
       - name: Install Flutter dependencies
         working-directory: apps/mobile
@@ -310,7 +310,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'  # pinned — withOpacity migration pending
+          flutter-version: '3.41.4'  # matches local dev; AppDelegate.swift uses FlutterImplicitEngineDelegate (3.41+)
           cache: true
 
       - name: Flutter version

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -83,7 +83,7 @@ jobs:
       # ── Setup Flutter ──
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
+          flutter-version: "3.41.4"
           channel: stable
           cache: true
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -126,7 +126,7 @@ jobs:
       # ── Flutter setup ──
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
 
       - name: Install Flutter dependencies


### PR DESCRIPTION
Unblocks TestFlight staging build (run 24148176291 failed — AppDelegate.swift uses FlutterImplicitEngineDelegate, symbol introduced in Flutter 3.41+).

Workflow-only change. No code touched. Dart SDK ^3.6.0 in pubspec is compatible with Flutter 3.41 (bundles Dart 3.7+).

Bumped pins:
- .github/workflows/ci.yml (3 jobs)
- .github/workflows/testflight.yml
- .github/workflows/play-store.yml

web.yml left on 3.32.1 (separate pin, unrelated to iOS build).

See commit message for full rationale.