### PR TITLE
Staging to v2.2.0 + CI Flutter 3.41.4 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
       - name: Flesch–Kincaid (Kandel–Moles) French gate
         run: |
@@ -113,7 +113,7 @@ jobs:
         run: python3 tools/checks/wcag_aa_all_touched.py
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
       - name: Install Flutter dependencies
         working-directory: apps/mobile
@@ -310,7 +310,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'  # pinned — withOpacity migration pending
+          flutter-version: '3.41.4'  # matches local dev; AppDelegate.swift uses FlutterImplicitEngineDelegate (3.41+)
           cache: true
 
       - name: Flutter version

--- a/.github/workflows/play-store.yml
+++ b/.github/workflows/play-store.yml
@@ -83,7 +83,7 @@ jobs:
       # ── Setup Flutter ──
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.4"
+          flutter-version: "3.41.4"
           channel: stable
           cache: true
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -126,7 +126,7 @@ jobs:
       # ── Flutter setup ──
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.4'
+          flutter-version: '3.41.4'
           cache: true
 
       - name: Install Flutter dependencies


### PR DESCRIPTION
Roll-forward of dev into staging.

Includes:
- v2.2 La Beauté de Mint (already on staging as 8c47750c — will be no-op)
- fix(ci): Flutter 3.27.4 → 3.41.4 bump (PR #282, commit fdaeccab)

Rationale: unblocks TestFlight staging build. Previous run (24148176291) failed because AppDelegate.swift uses FlutterImplicitEngineDelegate, a symbol only available in Flutter 3.41+. CI was pinned to 3.27.4.

On merge, the updated testflight.yml will be on staging and a manual TestFlight dispatch should succeed.