### PR TITLE
fix(deps): bump google_fonts → ^6.3.3 for Dart 3.11

### DIFF
--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -355,10 +355,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: df9763500dadba0155373e9cb44e202ce21bd9ed5de6bdbd05c5854e86839cb8
+      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.3"
   google_mlkit_commons:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   go_router: ^13.2.0
   intl: any  # Pinned by flutter_localizations SDK — do not constrain further
   url_launcher: ^6.2.0
-  google_fonts: ^6.1.0
+  google_fonts: ^6.3.3  # 6.3.3+ required for Dart 3.11 / Flutter 3.41 (FontWeight const map fix)
   uuid: ^4.0.0
   pdf: ^3.10.8
   printing: ^5.12.0


### PR DESCRIPTION
Cascade from Flutter 3.41.4 bump (#282). google_fonts 6.3.0 had a const FontWeight-keyed map that breaks on Dart 3.11. 6.3.3 fixes it. Patch bump, same major, API stable.

TestFlight run 24149039981 failed at kernel_snapshot_program with this exact error — this unblocks TestFlight upload.