### PR TITLE
ci(temporary): match regen workflow for Sign In with Apple

### DIFF
--- a/.github/workflows/match-regen.yml
+++ b/.github/workflows/match-regen.yml
@@ -1,0 +1,63 @@
+# TEMPORARY workflow for v2.2 Sign In with Apple match regen
+# PURPOSE: Delete and recreate the AppStore provisioning profile in the
+#          mint-certificates private repo after enabling Sign In with Apple
+#          capability for ch.mint.app.
+# LIFETIME: This file will be deleted immediately after a successful run.
+
+name: Match Regen (TEMPORARY)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type REGEN to confirm"
+        required: true
+
+concurrency:
+  group: match-regen
+  cancel-in-progress: false
+
+jobs:
+  match-regen:
+    name: Fastlane Match Nuke + Regen
+    runs-on: macos-15
+    timeout-minutes: 20
+    environment:
+      name: staging
+    if: ${{ github.event.inputs.confirm == 'REGEN' }}
+
+    defaults:
+      run:
+        working-directory: apps/mobile/ios
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          working-directory: apps/mobile/ios
+
+      - name: Install Fastlane
+        run: bundle install
+
+      - name: Run match nuke + regen
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_KEY_ID: ${{ secrets.APP_STORE_KEY_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_ISSUER_ID: ${{ secrets.APP_STORE_ISSUER_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          ASC_API_KEY_CONTENT: ${{ secrets.ASC_API_KEY_CONTENT }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          CI: "true"
+        run: bundle exec fastlane nuke_and_regen

--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -131,6 +131,57 @@ platform :ios do
     )
   end
 
+  desc "TEMPORARY: Nuke + regenerate AppStore match profile (Sign In with Apple rollout)"
+  lane :nuke_and_regen do
+    key_id = ENV["APP_STORE_CONNECT_API_KEY_ID"] || ENV["APP_STORE_KEY_ID"] || ENV["ASC_KEY_ID"]
+    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"] || ENV["APP_STORE_ISSUER_ID"] || ENV["ASC_ISSUER_ID"]
+    raw_key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] || ENV["APP_STORE_CONNECT_API_KEY"] || ENV["APP_STORE_CONNECT_PRIVATE_KEY"] || ENV["ASC_API_KEY_CONTENT"]
+
+    UI.user_error!("Missing APP_STORE_CONNECT_API_KEY_ID") if key_id.to_s.strip.empty?
+    UI.user_error!("Missing APP_STORE_CONNECT_ISSUER_ID") if issuer_id.to_s.strip.empty?
+    UI.user_error!("Missing APP_STORE_CONNECT_API_KEY_CONTENT") if raw_key_content.to_s.strip.empty?
+
+    normalized_key_content = raw_key_content.gsub('\n', "\n")
+    unless normalized_key_content.include?("-----BEGIN PRIVATE KEY-----")
+      normalized_key_content = Base64.strict_decode64(normalized_key_content)
+    end
+
+    api_key = app_store_connect_api_key(
+      key_id: key_id,
+      issuer_id: issuer_id,
+      key_content: normalized_key_content,
+      is_key_content_base64: false,
+      in_house: false,
+    )
+
+    setup_ci if ENV["CI"]
+
+    # Nuke existing appstore certs + profiles from Apple + match repo
+    match_nuke(
+      type: "appstore",
+      app_identifier: "ch.mint.app",
+      team_id: "7F5UDGYS5H",
+      git_url: ENV["MATCH_GIT_URL"],
+      git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"],
+      api_key: api_key,
+      skip_confirmation: true,
+    )
+
+    # Regenerate fresh cert + profile (picks up Sign In with Apple entitlement)
+    match(
+      type: "appstore",
+      app_identifier: "ch.mint.app",
+      team_id: "7F5UDGYS5H",
+      git_url: ENV["MATCH_GIT_URL"],
+      git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"],
+      api_key: api_key,
+      readonly: false,
+      force: true,
+    )
+
+    UI.success("Match nuke + regen complete. mint-certificates now holds a fresh AppStore profile with Sign In with Apple.")
+  end
+
   desc "Initialize Match certificates (run once locally)"
   lane :setup_match do
     raw = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"]


### PR DESCRIPTION
Temporary workflow + Fastlane lane. Will be deleted after one successful run.

Enables `fastlane match nuke appstore` + `fastlane match appstore --readonly false --force` via a new `nuke_and_regen` lane, using the same auth pattern as the existing `beta` lane.

## Why
v2.2 AppDelegate requires the Sign In with Apple capability. Julien has enabled it in the Apple Developer Portal for `ch.mint.app`, but the provisioning profile stored in `mint-certificates` predates that change. TestFlight run 24150115112 failed at `fastlane build_app` on provisioning profile mismatch. Local match is blocked (no MATCH_PASSWORD in Julien's hands). This workflow unblocks the v2.2 TestFlight staging build.

## Scope
- `.github/workflows/match-regen.yml` — workflow_dispatch-only, requires typing REGEN to confirm, uses the staging environment to inherit CI secrets
- `apps/mobile/ios/fastlane/Fastfile` — new `nuke_and_regen` lane mirroring `beta`'s App Store Connect key handling

## Post-merge
1. `gh workflow run match-regen.yml --ref dev -f confirm=REGEN`
2. Verify mint-certificates repo has a fresh AppStore profile
3. Open cleanup PR removing both the workflow and the lane
4. Re-trigger TestFlight staging