### PR TITLE
ci(temporary): match-regen push trigger on throwaway branch

### DIFF
--- a/.github/workflows/match-regen.yml
+++ b/.github/workflows/match-regen.yml
@@ -7,11 +7,9 @@
 name: Match Regen (TEMPORARY)
 
 on:
-  workflow_dispatch:
-    inputs:
-      confirm:
-        description: "Type REGEN to confirm"
-        required: true
+  push:
+    branches:
+      - ci/match-regen-run
 
 concurrency:
   group: match-regen
@@ -24,7 +22,7 @@ jobs:
     timeout-minutes: 20
     environment:
       name: staging
-    if: ${{ github.event.inputs.confirm == 'REGEN' }}
+    if: ${{ contains(github.event.head_commit.message, '[regen-ok]') }}
 
     defaults:
       run:


### PR DESCRIPTION
Follow-up to #286. Switches the match-regen workflow from `workflow_dispatch` to `push` on a throwaway branch `ci/match-regen-run`, gated by a `[regen-ok]` tag in the commit message.

## Why
`workflow_dispatch` workflows are only registered if they exist on the default branch (main). We do not want to touch main. A push trigger on a dedicated throwaway branch bypasses this entirely: we create the branch, the workflow auto-runs, we delete the branch afterward.

## Safety
- Trigger is scoped to branch `ci/match-regen-run` only
- Job only runs if head commit message contains `[regen-ok]`
- Concurrency group prevents double runs
- Branch is deleted immediately after the regen job completes