### PR TITLE
fix(ci): unblock nuke_and_regen lane (UI.confirm stub)

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -156,7 +156,19 @@ platform :ios do
 
     setup_ci if ENV["CI"]
 
-    # Nuke existing appstore certs + profiles from Apple + match repo
+    # Force auto-confirmation: match_nuke calls UI.confirm regardless of
+    # skip_confirmation in non-TTY CI contexts, and without a TTY it
+    # returns false → nuke bails → the misleading "readonly" error fires.
+    # Stub UI.confirm to always return true for this lane.
+    module FastlaneCore
+      class UI
+        def self.confirm(_message)
+          true
+        end
+      end
+    end
+
+    # Nuke existing appstore certs + profiles from Apple + match repo.
     match_nuke(
       type: "appstore",
       app_identifier: "ch.mint.app",
@@ -165,6 +177,7 @@ platform :ios do
       git_basic_authorization: ENV["MATCH_GIT_BASIC_AUTHORIZATION"],
       api_key: api_key,
       skip_confirmation: true,
+      readonly: false,
     )
 
     # Regenerate fresh cert + profile (picks up Sign In with Apple entitlement)


### PR DESCRIPTION
First match-regen run (24152659432) failed at match_nuke with: `fastlane match nuke doesn't delete anything when running with --readonly enabled`. That error message is misleading — the real cause is that match_nuke internally calls UI.confirm even when skip_confirmation: true is passed, and in non-TTY CI UI.confirm returns false, so nuke bails out before deleting anything.

Fix: stub FastlaneCore::UI.confirm to return true inside the nuke_and_regen lane, and explicitly pass readonly: false. Scoped to this lane only, zero impact on the beta lane.