### PR TITLE
fix(ci): embed match credentials in URL, bypass credential helper

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -242,21 +242,6 @@ jobs:
           [[ -n "$key_content" ]] || { echo "::error::Missing secret: APP_STORE_CONNECT_API_KEY_CONTENT (or APP_STORE_CONNECT_API_KEY/APP_STORE_CONNECT_PRIVATE_KEY/ASC_API_KEY_CONTENT)"; exit 1; }
           echo "App Store secrets precheck: OK"
 
-      # ── Fix GitHub Actions credential helper (interferes with match git_basic_authorization) ──
-      - name: Configure git credentials for match
-        env:
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-        run: |
-          # GitHub Actions sets a credential helper that overrides match's Authorization header.
-          # Remove ALL extraheaders and credential helpers at every level, then set our own.
-          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
-          git config --system --unset-all http.https://github.com/.extraheader 2>/dev/null || true
-          git config --local --unset-all http.https://github.com/.extraheader 2>/dev/null || true
-          git config --global --unset-all credential.helper 2>/dev/null || true
-          git config --system --unset-all credential.helper 2>/dev/null || true
-          # Set our authorization header explicitly for the certificates repo
-          git config --global http.https://github.com/Julienbatt/mint-certificates.git.extraheader "Authorization: Basic ${MATCH_GIT_BASIC_AUTHORIZATION}"
-
       # ── Fastlane: sign + upload ──
       - name: "Build & Upload to TestFlight (${{ steps.env-config.outputs.env_label }})"
         working-directory: apps/mobile/ios

--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -77,9 +77,10 @@ platform :ios do
       api_key: api_key,
       readonly: true,
     }
-    if ENV["CI"] && ENV["MATCH_GIT_BASIC_AUTHORIZATION"]
-      match_params[:git_basic_authorization] = ENV["MATCH_GIT_BASIC_AUTHORIZATION"]
-    end
+    # NOTE: git_basic_authorization is NOT used because GitHub Actions macOS
+    # runners have a credential helper that overrides the Authorization header.
+    # Instead, credentials are embedded directly in MATCH_GIT_URL (as a secret).
+    # See: fix(ci) commit for details on the credential helper conflict.
     match(match_params)
 
     # ── 4. Auto-increment build number ──


### PR DESCRIPTION
Drop git_basic_authorization, embed token in MATCH_GIT_URL. Bypasses macOS runner credential helper.