### PR TITLE
fix(ci): nuclear credential cleanup + match clone verification

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -108,20 +108,24 @@ jobs:
       #    certificates repo (different account). persist-credentials: false above
       #    prevents checkout from writing credentials, and we inject our own below.
       - name: Configure git credentials for certificates repo
-        env:
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
-          # Kill ALL credential helpers (osxkeychain, store, manager) at every level
-          git config --system --unset-all credential.helper 2>/dev/null || true
-          git config --global --unset-all credential.helper 2>/dev/null || true
-          # Set store as the ONLY helper
-          git config --global credential.helper store
-          # Write token for github.com
-          TOKEN=$(echo "$MATCH_GIT_BASIC_AUTHORIZATION" | base64 -d | cut -d: -f2)
-          echo "https://Julienbatt:${TOKEN}@github.com" > ~/.git-credentials
-          chmod 600 ~/.git-credentials
-          # Verify it works
-          git ls-remote https://github.com/Julienbatt/mint-certificates.git HEAD 2>&1 | head -1 && echo "✓ Certificates repo accessible" || echo "✗ FAILED"
+          # GitHub Actions macOS runners have osxkeychain + actions credential helpers
+          # that intercept ALL github.com HTTPS requests and override match's
+          # Authorization: Basic header. Nuclear option: blank the credential helper
+          # at EVERY level so nothing can intercept.
+          git config --system credential.helper "" 2>/dev/null || sudo git config --system credential.helper ""
+          git config --global credential.helper ""
+          # Also remove any extraheaders injected by actions/checkout
+          git config --global --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+          # Verify: git should now have NO credential helpers
+          echo "Credential helpers after cleanup:"
+          git config --list --show-scope | grep credential || echo "(none — good)"
+          # Verify access using the same method match will use
+          echo "Testing match-style clone..."
+          git clone https://github.com/Julienbatt/mint-certificates.git /tmp/test-match \
+            -c "http.extraheader=Authorization: Basic ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}" \
+            --depth 1 2>&1 | tail -3 && echo "✓ Match-style clone works" || echo "✗ FAILED"
+          rm -rf /tmp/test-match
 
       # ── Xcode / iOS SDK setup (App Store requirement) ──
       - name: Setup latest stable Xcode

--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -77,10 +77,9 @@ platform :ios do
       api_key: api_key,
       readonly: true,
     }
-    # NOTE: git_basic_authorization is NOT used because GitHub Actions macOS
-    # runners have a credential helper that overrides the Authorization header.
-    # Instead, credentials are embedded directly in MATCH_GIT_URL (as a secret).
-    # See: fix(ci) commit for details on the credential helper conflict.
+    if ENV["CI"] && ENV["MATCH_GIT_BASIC_AUTHORIZATION"]
+      match_params[:git_basic_authorization] = ENV["MATCH_GIT_BASIC_AUTHORIZATION"]
+    end
     match(match_params)
 
     # ── 4. Auto-increment build number ──


### PR DESCRIPTION
Blanks credential.helper at system+global, adds match-style clone test.