### PR TITLE
fix(ci): match auth via env var

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -108,6 +108,8 @@ jobs:
       #    certificates repo (different account). persist-credentials: false above
       #    prevents checkout from writing credentials, and we inject our own below.
       - name: Configure git credentials for certificates repo
+        env:
+          MATCH_AUTH: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
           # GitHub Actions macOS runners have osxkeychain + actions credential helpers
           # that intercept ALL github.com HTTPS requests and override match's
@@ -120,11 +122,11 @@ jobs:
           # Verify: git should now have NO credential helpers
           echo "Credential helpers after cleanup:"
           git config --list --show-scope | grep credential || echo "(none — good)"
-          # Verify access using the same method match will use
+          # Verify access using the same method match will use (via env var, not inline secret)
           echo "Testing match-style clone..."
           git clone https://github.com/Julienbatt/mint-certificates.git /tmp/test-match \
-            -c "http.extraheader=Authorization: Basic ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}" \
-            --depth 1 2>&1 | tail -3 && echo "✓ Match-style clone works" || echo "✗ FAILED"
+            -c "http.extraheader=Authorization: Basic ${MATCH_AUTH}" \
+            --depth 1 2>&1 && echo "✓ Match-style clone works" || echo "✗ Match-style clone FAILED"
           rm -rf /tmp/test-match
 
       # ── Xcode / iOS SDK setup (App Store requirement) ──


### PR DESCRIPTION
Pass secret via env var to avoid GitHub masking corruption.