### PR TITLE
docs: anonymous coach hook milestone brief

### DIFF
--- a/.planning/briefs/anonymous-coach-hook/01-PRODUCT-BRIEF.md
+++ b/.planning/briefs/anonymous-coach-hook/01-PRODUCT-BRIEF.md
@@ -1,0 +1,169 @@
+# Product Brief — Anonymous Coach Hook
+
+**Milestone name:** Anonymous Coach Hook (3 free messages)
+**Date:** 2026-04-11
+**Author:** Julien (creator) + Claude (recovery session)
+**Status:** Ready for GSD new-milestone
+
+---
+
+## The Problem
+
+**Current broken flow:**
+1. User opens MINT for the first time from TestFlight
+2. Sees landing page "On éclaire. Tu décides." → taps "Parle à Mint"
+3. Arrives on empty coach chat screen with "Tu veux en parler ?"
+4. Types their question
+5. **Waits 25 seconds, sees "Le coach IA n'est pas disponible pour le moment"**
+6. **Closes the app. Never comes back.**
+
+**Root cause (confirmed 2026-04-11 during recovery session):**
+The backend `/api/v1/coach/chat` endpoint (and also `/rag/query`) requires JWT authentication via `require_current_user`. But the Flutter app marks `/coach/chat` as `RouteScope.public` (KILL-05 decision) — users can reach the chat without logging in. Contradiction: Flutter says "chat is public", backend says "chat requires auth". Result: anonymous users always hit the static fallback template.
+
+**Why this matters:**
+MINT's core hook is the AI coach. It's the reason someone downloads the app. If the first interaction fails, we lose the user forever. Current conversion to "I'll install MINT" → "I'll use MINT" is effectively 0% for unauthenticated users, which is 100% of new installs.
+
+---
+
+## The Solution
+
+**Give every new user 3 real AI conversations before asking them to sign in.**
+
+After 3 messages of genuine, RAG-backed, Claude-powered responses, surface a soft paywall: "MINT can keep learning your situation if you sign in — 1 tap with Apple ID". The user has already experienced the value; now they have a reason to commit.
+
+---
+
+## Design Principles
+
+1. **Zero friction on first contact.** No account, no email, no wizard. Tap → chat → answer.
+2. **Real quality, not a demo.** The 3 free messages must use the full RAG + Claude pipeline. No downgraded model, no canned responses. If we give them a cheap taste, we lose them.
+3. **Never frustrate.** The 4th message doesn't say "blocked" — it says "you've had 3 great conversations, want to keep them? Sign in."
+4. **Economically sustainable.** 3 messages × Claude Sonnet 4.5 = ~$0.05-0.15 per anonymous user. Acceptable cost per lead if conversion to signup is >10%.
+5. **Abuse-resistant.** Device-ID based with IP-level fallback. Not NSA-proof, but stops casual scraping.
+
+---
+
+## User Flow (desired)
+
+```
+COLD START (new user, TestFlight install)
+  ↓
+Landing screen: "On éclaire. Tu décides." + "Parle à Mint" button
+  ↓
+Coach chat screen (no login required)
+  ↓
+User types: "C'est quoi les 3 piliers suisses ?"
+  ↓
+[TYPING INDICATOR ~3s]
+  ↓
+Real Claude response with RAG sources + compliance disclaimer
+  [Message 1/3 used — displayed subtly in the UI, not anxiety-inducing]
+  ↓
+User types: "Comment optimiser mon 3e pilier ?"
+  ↓
+Real answer
+  [Message 2/3]
+  ↓
+User types: "Je gagne 80k, je dois cotiser combien ?"
+  ↓
+Real answer + soft nudge at the end:
+  "Tu as 1 conversation restante. Pour que Mint se souvienne de toi
+   et personnalise ses conseils, sauve ta conversation en 1 tap."
+  [Inline CTA: "Sauver avec Apple" | "Sauver avec email"]
+  ↓
+If user types a 4th message:
+  Response arrives → ends with firmer CTA:
+  "Cette conversation restera ici si tu la sauves maintenant.
+   Sinon Mint oubliera tout à la fermeture de l'app."
+  [Full-width CTA button: "Sauver mes 4 conversations"]
+  ↓
+If user ignores and types 5th message:
+  NO response. Bottom sheet appears:
+  "Pour continuer avec Mint, crée ton espace gratuit.
+   Apple Sign-In • Magic link • Mot de passe"
+  [Primary CTA: "Sign in with Apple"]
+```
+
+---
+
+## Scope
+
+### In scope (v1 of this milestone)
+
+- [ ] Backend: anonymous coach endpoint (same RAG + Claude pipeline as authenticated)
+- [ ] Backend: device_id-based rate limiting (3 messages per device, persistent counter)
+- [ ] Backend: IP-level rate limiting (abuse protection)
+- [ ] Backend: migration table for anonymous usage tracking
+- [ ] Flutter: send device_id header on coach requests when no JWT
+- [ ] Flutter: UI for "X messages remaining" counter (subtle, not anxious)
+- [ ] Flutter: inline CTA at message 3 (soft prompt)
+- [ ] Flutter: blocking bottom sheet at message 4+ (hard stop)
+- [ ] Flutter: merge anonymous conversation into account on login
+- [ ] End-to-end test on TestFlight (creator verifies on iPhone)
+
+### Out of scope (defer to later)
+
+- Multi-device conversation sync
+- Anonymous conversation persistence across app kill (v1 is in-memory only — if they close the app, conversations are lost AND this is intentional to push signup)
+- Referral / invite codes
+- A/B testing of different paywall copy
+- Analytics funnel dashboard (track signup conversion rate) — we'll add this after we see the flow works
+- GDPR consent for anonymous device tracking — needs compliance review separately
+
+---
+
+## Success Criteria
+
+**Technical:**
+- New user on TestFlight can send 3 messages and get real Claude responses
+- 4th message attempt triggers the upgrade flow
+- After Apple Sign-In, the 3 previous messages persist in the account
+- Rate limiting prevents >3 messages per device (verified by resetting and retrying)
+- Backend handles 10 concurrent anonymous users without errors
+
+**Product:**
+- Creator (Julien) cold-starts the app on iPhone and feels the flow "just works"
+- Copy at each stage doesn't feel like a paywall — feels like "MINT wants to remember you"
+- Transition to signup is 1 tap (Apple Sign-In) or 2 taps (magic link)
+
+**Economic:**
+- Cost per anonymous user < $0.20 (3 messages max, short responses, no image generation)
+- Rate limit prevents any single IP from burning >100 requests/day
+
+---
+
+## Explicit Non-Goals
+
+1. **Not an onboarding flow.** We don't ask for age/canton/salary before the first chat. That's the previous failed approach.
+2. **Not a demo mode.** Anonymous coach has access to the same RAG, the same Claude Sonnet model, the same compliance guard. The ONLY difference is persistence (in-memory) and count (3 messages).
+3. **Not a retirement framing.** Per CLAUDE.md rules, anonymous coach must handle all 18 life events — housing, career, tax, debt, family — not just retirement.
+4. **Not bypass-able by reinstalling.** IP-level rate limit means a motivated bad actor needs a new IP every 3 messages. That's expensive enough.
+
+---
+
+## Dependencies on Recovery Session
+
+This milestone depends on these already being deployed:
+- ✓ Phase 4 (coach AI server-key tier via /coach/chat) — already merged in PR #306/307
+- ✓ Railway staging properly connected to staging branch (fixed during recovery session)
+- ✓ Apple Sign-In endpoint working (`/auth/apple/verify` returns 400 not 404)
+- ✓ Magic link endpoints exist on backend
+
+Known issues NOT blocking this milestone (but affect UX):
+- Keyboard stuck at top of screen (separate bug)
+- Back button from coach doesn't return to landing (separate bug)
+- "Recevoir un lien magique" button text overflows (layout bug)
+- SMTP not configured on Railway staging (magic link will succeed-silently without sending email)
+
+These should be addressed in the next milestone after this one.
+
+---
+
+## Reference Documents (read these)
+
+- `CLAUDE.md` — MINT identity, compliance rules, 18 life events
+- `.planning/briefs/anonymous-coach-hook/02-TECHNICAL-SPEC.md` — detailed technical design
+- `.planning/briefs/anonymous-coach-hook/03-API-CONTRACT.md` — backend API changes
+- `.planning/briefs/anonymous-coach-hook/04-COPY-AND-UX.md` — exact copy for each UI state
+- `.planning/briefs/anonymous-coach-hook/05-OPEN-QUESTIONS.md` — decisions still pending
+- `.planning/INCIDENT_DIAGNOSTIC_2026-04-10.md` — full context of why we're here

--- a/.planning/briefs/anonymous-coach-hook/02-TECHNICAL-SPEC.md
+++ b/.planning/briefs/anonymous-coach-hook/02-TECHNICAL-SPEC.md
@@ -1,0 +1,469 @@
+# Technical Specification — Anonymous Coach Hook
+
+**Date:** 2026-04-11
+**Status:** Ready for implementation
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  FLUTTER (no JWT yet)                                       │
+│  ┌───────────────────────────────────────────┐             │
+│  │  device_id (UUID v4, persisted SharedPref)│             │
+│  │  counter: local mirror (authoritative = BE)│             │
+│  └───────────────────────────────────────────┘             │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         │ POST /api/v1/coach/chat/anonymous
+                         │ Headers: X-Device-Id: <uuid>
+                         │ Body: { message, language, cash_level }
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  BACKEND                                                    │
+│                                                              │
+│  1. Rate limit by IP (SlowAPI: 15/hour)                    │
+│  2. Validate X-Device-Id header                             │
+│  3. Lookup anonymous_usage WHERE device_id = ?              │
+│  4. If count >= 3 → return 200 with requires_auth=true     │
+│  5. If count < 3:                                           │
+│     a. Call RAG orchestrator (same as auth'd path)          │
+│     b. Use server-side ANTHROPIC_API_KEY                    │
+│     c. max_tokens=500 (shorter than auth'd = 2000)         │
+│     d. Apply ComplianceGuard                                │
+│     e. INSERT OR UPDATE anonymous_usage (count+1)          │
+│     f. Return 200 with response + remaining count           │
+│  6. Cleanup job: delete anonymous_usage rows > 90 days old  │
+└─────────────────────────────────────────────────────────────┘
+                         │
+                         │ After signup (Apple Sign-In or magic link)
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  MIGRATION PATH                                             │
+│                                                              │
+│  On successful login:                                       │
+│  1. Flutter reads device_id                                 │
+│  2. POST /api/v1/auth/claim-anonymous                       │
+│     { device_id } (JWT required)                            │
+│  3. Backend: UPDATE anonymous_usage SET user_id=? WHERE dev │
+│  4. Backend: marks device as "claimed" (no more anon use)   │
+│  5. Flutter: clears local "anonymous mode" flag             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Backend Changes
+
+### New endpoint: POST /api/v1/coach/chat/anonymous
+
+**Why a separate endpoint (not modifying existing `/coach/chat`):**
+- Clear separation of concerns — anonymous path has different rate limits, different max_tokens, different auth
+- Easier to disable/monitor independently
+- Existing authenticated endpoint stays untouched (no regression risk)
+
+**Request:**
+```json
+POST /api/v1/coach/chat/anonymous
+Headers:
+  Content-Type: application/json
+  X-Device-Id: <uuid-v4>
+Body:
+  {
+    "message": "C'est quoi les 3 piliers suisses ?",
+    "language": "fr",
+    "cash_level": 3
+  }
+```
+
+**Response (success, messages remaining):**
+```json
+200 OK
+{
+  "message": "Les 3 piliers suisses sont un système de prévoyance...",
+  "sources": [{"title": "LAVS art. 21", "file": "avs.md"}],
+  "disclaimers": ["Outil éducatif. Ne constitue pas un conseil financier."],
+  "tool_calls": [],
+  "tokens_used": 180,
+  "anonymous_usage": {
+    "used": 1,
+    "limit": 3,
+    "remaining": 2,
+    "requires_auth": false
+  }
+}
+```
+
+**Response (limit reached, soft paywall at message 3):**
+```json
+200 OK
+{
+  "message": "...real answer to their question...",
+  "sources": [...],
+  "disclaimers": [...],
+  "anonymous_usage": {
+    "used": 3,
+    "limit": 3,
+    "remaining": 0,
+    "requires_auth": true,
+    "paywall_message": "Tu as eu 3 conversations avec Mint. Sauve-les en te connectant — Mint se souviendra de toi."
+  }
+}
+```
+
+**Response (blocked, hard paywall at message 4+):**
+```json
+403 Forbidden
+{
+  "detail": "anonymous_limit_exceeded",
+  "paywall_message": "Pour continuer avec Mint, crée ton espace gratuit. 1 tap avec Apple.",
+  "upgrade_options": [
+    {"method": "apple_sign_in", "label": "Sign in with Apple", "primary": true},
+    {"method": "magic_link", "label": "Email magic link"},
+    {"method": "password", "label": "Mot de passe"}
+  ]
+}
+```
+
+**Rate limiting:**
+- **SlowAPI decorator**: `@limiter.limit("15/hour")` (per IP)
+- **Device-ID limit**: 3 messages lifetime per device_id (enforced in query logic)
+- **IP reasoning**: 15/hour lets a household share a WiFi. 3/device means max 5 devices per hour per IP before IP rate limit kicks in.
+
+**max_tokens:**
+- Anonymous: **500 tokens** (enough for a quality answer, not enough for essays)
+- Authenticated: **2000 tokens** (unchanged)
+
+**System prompt:**
+- Same as authenticated `/coach/chat`
+- MUST cover all 18 life events
+- MUST include compliance guard post-processing
+
+### New endpoint: POST /api/v1/auth/claim-anonymous
+
+**Purpose:** Migrate anonymous conversation to authenticated account after signup.
+
+**Request:**
+```json
+POST /api/v1/auth/claim-anonymous
+Headers:
+  Authorization: Bearer <jwt>
+  Content-Type: application/json
+Body:
+  { "device_id": "<uuid>" }
+```
+
+**Response:**
+```json
+200 OK
+{
+  "claimed": true,
+  "messages_migrated": 3
+}
+```
+
+**Logic:**
+- Verify JWT
+- Find `anonymous_usage` rows WHERE `device_id = ?`
+- Set `user_id = <jwt.user_id>` and `claimed_at = NOW()`
+- If the table also stores conversation snippets (see DB schema below), attach them to the user's conversation history
+
+### Database schema
+
+**New table: `anonymous_coach_usage`**
+
+```sql
+CREATE TABLE anonymous_coach_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id TEXT NOT NULL,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    first_message_at TIMESTAMP NOT NULL,
+    last_message_at TIMESTAMP NOT NULL,
+    ip_address_hash TEXT,  -- SHA-256 of IP for abuse tracking without storing raw IP
+    claimed_by_user_id TEXT,  -- NULL until user signs up
+    claimed_at TIMESTAMP,
+    UNIQUE(device_id)
+);
+
+CREATE INDEX idx_anon_device ON anonymous_coach_usage(device_id);
+CREATE INDEX idx_anon_claimed ON anonymous_coach_usage(claimed_by_user_id)
+  WHERE claimed_by_user_id IS NOT NULL;
+CREATE INDEX idx_anon_cleanup ON anonymous_coach_usage(last_message_at)
+  WHERE claimed_by_user_id IS NULL;
+```
+
+**Optional table (v2): `anonymous_messages` for conversation content**
+
+For v1, we DON'T persist actual message content in anonymous mode — only the counter. This is intentional:
+- Simpler (no text storage)
+- Privacy-friendly (nothing to leak)
+- Forces urgency ("sign in NOW or lose your conversation")
+
+If we later want to persist for migration purposes, add:
+```sql
+CREATE TABLE anonymous_messages (
+    id INTEGER PRIMARY KEY,
+    device_id TEXT NOT NULL,
+    role TEXT NOT NULL,  -- 'user' or 'assistant'
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    claimed_by_user_id TEXT,
+    FOREIGN KEY (device_id) REFERENCES anonymous_coach_usage(device_id)
+);
+```
+
+For now: **v1 does NOT persist messages**. The migration on signup just preserves the counter and marks the device as "claimed" so it can't be reused anonymously.
+
+### Cleanup job
+
+```python
+# scripts/cleanup_anonymous_usage.py
+# Run daily via cron or Railway scheduled job
+DELETE FROM anonymous_coach_usage
+WHERE claimed_by_user_id IS NULL
+  AND last_message_at < NOW() - INTERVAL '90 days';
+```
+
+Unclaimed records older than 90 days are deleted. Claimed records are kept for audit.
+
+---
+
+## Flutter Changes
+
+### Device ID handling
+
+**File:** `apps/mobile/lib/services/device_id_service.dart` (new)
+
+```dart
+class DeviceIdService {
+  static const _key = '_mint_device_id';
+  static String? _cached;
+
+  /// Returns a persistent device UUID. Generated on first call, reused after.
+  static Future<String> get() async {
+    if (_cached != null) return _cached!;
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_key);
+    if (id == null) {
+      id = const Uuid().v4();
+      await prefs.setString(_key, id);
+    }
+    _cached = id;
+    return id;
+  }
+
+  /// Called on logout to NOT reset (device stays the same).
+  /// But the anonymous flag on the account is cleared.
+  static Future<void> markClaimed() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('_mint_device_claimed', true);
+  }
+
+  static Future<bool> isClaimed() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('_mint_device_claimed') ?? false;
+  }
+}
+```
+
+**NOTE:** `_mint_device_id` already exists in the codebase (see audit data). Check if it's a UUID or something else and reuse if compatible. If not, add this service.
+
+### CoachOrchestrator changes
+
+**File:** `apps/mobile/lib/services/coach/coach_orchestrator.dart`
+
+Current chain: SLM → BYOK → Server-key (JWT required) → Fallback
+
+**New chain:**
+- If user is authenticated: SLM → BYOK → Server-key (JWT) → Fallback
+- If user is NOT authenticated: SLM → BYOK → **Anonymous Server-key (device_id)** → Fallback
+
+Add new method `_tryAnonymousServerKeyChat()`:
+
+```dart
+static Future<CoachResponse?> _tryAnonymousServerKeyChat({
+  required String userMessage,
+  required List<ChatMessage> history,
+  required CoachContext ctx,
+  String? memoryBlock,
+  String language = 'fr',
+  int cashLevel = 3,
+}) async {
+  final deviceId = await DeviceIdService.get();
+  final service = AnonymousCoachChatApiService();
+  
+  try {
+    final response = await service.chat(
+      deviceId: deviceId,
+      message: userMessage,
+      profileContext: {...},  // same as server-key path
+      language: language,
+      cashLevel: cashLevel,
+    ).timeout(_byokTimeout);
+
+    // If anonymous limit reached, attach paywall metadata to response
+    if (response.anonymousUsage.requiresAuth) {
+      return CoachResponse(
+        message: response.message,
+        disclaimer: ComplianceGuard.standardDisclaimer,
+        sources: response.sources,
+        disclaimers: response.disclaimers,
+        // NEW FIELD: signals UI to show paywall after this message
+        anonymousPaywall: AnonymousPaywallState(
+          remaining: response.anonymousUsage.remaining,
+          message: response.anonymousUsage.paywallMessage,
+        ),
+      );
+    }
+    
+    // Normal path (messages remaining)
+    return CoachResponse(
+      message: response.message,
+      ...
+    );
+  } on AnonymousLimitExceededException {
+    // 4th+ attempt: return a special response that triggers hard paywall UI
+    return CoachResponse(
+      message: '',
+      disclaimer: '',
+      anonymousPaywall: AnonymousPaywallState.blocked(),
+    );
+  } catch (e) {
+    debugPrint('[Orchestrator] Anonymous chat error: $e');
+    return null;
+  }
+}
+```
+
+### Logic change in generateChat
+
+```dart
+static Future<CoachResponse> generateChat({...}) async {
+  // 1. SLM (unchanged)
+  if (_slmEligible()) {...}
+
+  // 2. BYOK (unchanged)
+  if (byokConfig != null && byokConfig.hasApiKey) {...}
+
+  // 2.5. NEW: Server-key tier, branches on auth state
+  if (!FeatureFlags.safeModeDegraded) {
+    final isAuthenticated = await AuthService.getToken() != null;
+    
+    if (isAuthenticated) {
+      // Authenticated server-key (existing path)
+      final response = await _tryServerKeyChat(...);
+      if (response != null) return response;
+    } else {
+      // NEW: Anonymous server-key (device_id based)
+      final response = await _tryAnonymousServerKeyChat(...);
+      if (response != null) return response;
+    }
+  }
+
+  // 3. Fallback (unchanged, last resort)
+  return _chatFallback(language);
+}
+```
+
+### New service: AnonymousCoachChatApiService
+
+**File:** `apps/mobile/lib/services/coach/anonymous_coach_chat_api_service.dart` (new)
+
+Similar to `CoachChatApiService` but:
+- No JWT header
+- Sends `X-Device-Id` header
+- Calls `/coach/chat/anonymous` endpoint
+- Parses `anonymous_usage` metadata
+- Throws `AnonymousLimitExceededException` on 403
+
+### UI Changes
+
+**File:** `apps/mobile/lib/screens/coach/coach_chat_screen.dart`
+
+1. **Message counter display:**
+   - Show "3 messages restants" below input bar while anonymous
+   - Only visible if user is NOT authenticated
+   - Fades in subtly, not anxiety-inducing
+   - Updates after each successful response
+
+2. **Soft CTA at message 3:**
+   - Inline card below the 3rd assistant message
+   - Text: "Tu as eu 3 conversations avec Mint. Sauve-les pour qu'il se souvienne de toi."
+   - Two buttons: "Sign in with Apple" (primary) | "Plus tard" (dismiss)
+
+3. **Hard paywall at message 4+:**
+   - Modal bottom sheet, non-dismissible except via signup or "Close app"
+   - Full-screen-ish, dominant CTA
+   - Text: "Pour continuer avec Mint, crée ton espace gratuit. 1 tap avec Apple."
+
+4. **Post-signup confirmation:**
+   - Once user signs in, show a brief toast: "Bon retour. Mint se souvient de toi maintenant."
+   - Call `/auth/claim-anonymous` silently in background
+
+### New widget: AnonymousPaywallCard
+
+**File:** `apps/mobile/lib/widgets/coach/anonymous_paywall_card.dart` (new)
+
+Inline card rendered below an assistant message when `anonymousPaywall != null`.
+
+Two variants:
+- **Soft** (message 3): inline, dismissible, not modal
+- **Blocked** (message 4+): modal bottom sheet, forces action
+
+---
+
+## Security & Abuse Prevention
+
+1. **IP hashing**: Store SHA-256 of IP, not raw. Backend only reads first 8 chars for rate limit lookup.
+2. **Device ID is a hint, not identity**: Easy to reset by reinstall. That's OK because IP rate limit is the real protection.
+3. **No PII in anonymous state**: No email, no phone, no name. Only device_id (pseudo) and question content.
+4. **Logs**: Anonymous requests logged with device_id hash only. No question content in logs (privacy).
+5. **Shared WiFi scenario**: 15 requests/hour per IP = enough for a family of 5, not enough for scraping.
+6. **Token budget cap**: 500 max_tokens × 3 messages = ~$0.15 per anonymous user at Sonnet rates.
+
+---
+
+## Testing Strategy
+
+### Unit tests (backend)
+- `test_anonymous_coach_chat.py`
+- Test counter increments correctly
+- Test 403 at message 4
+- Test claim migration updates user_id
+- Test rate limit kicks in at 15/hour
+
+### Integration tests (backend)
+- Full HTTP POST flow: device_id → 3 messages → claim → 4th message as authenticated
+
+### Flutter tests
+- `test_anonymous_coach_chat_api_service_test.dart`
+- Test service sends device_id header
+- Test service parses paywall metadata
+- Test orchestrator routes to anonymous service when no JWT
+
+### End-to-end (manual, on device)
+1. Fresh install → 3 messages → real responses
+2. 4th message → hard paywall
+3. Apple Sign-In → claim → 5th message works as authenticated
+4. Reinstall app → new device_id → 3 more messages possible (expected behavior)
+
+---
+
+## Performance Targets
+
+- Response time (anonymous): ≤ 5s (same as authenticated path, no additional latency from counter lookup)
+- Counter lookup: single indexed query < 10ms
+- Migration (claim): < 100ms
+- Backend concurrent anonymous users: 10+ without degradation
+
+---
+
+## Rollout Plan
+
+1. Deploy backend to Railway staging
+2. Update Flutter to call new endpoint
+3. Build TestFlight staging
+4. Creator walks the flow end-to-end
+5. Fix discovered issues
+6. Deploy to production (after PR staging → main approval)

--- a/.planning/briefs/anonymous-coach-hook/03-API-CONTRACT.md
+++ b/.planning/briefs/anonymous-coach-hook/03-API-CONTRACT.md
@@ -1,0 +1,303 @@
+# API Contract — Anonymous Coach Hook
+
+**Date:** 2026-04-11
+**Version:** v1
+
+---
+
+## Endpoint 1: POST /api/v1/coach/chat/anonymous
+
+**Purpose:** Send a message to the coach without requiring authentication, limited to 3 messages per device.
+
+**Auth:** None (public endpoint)
+
+### Request
+
+```http
+POST /api/v1/coach/chat/anonymous HTTP/1.1
+Host: mint-staging.up.railway.app
+Content-Type: application/json
+X-Device-Id: 550e8400-e29b-41d4-a716-446655440000
+```
+
+**Body:**
+```json
+{
+  "message": "C'est quoi les 3 piliers suisses ?",
+  "language": "fr",
+  "cash_level": 3,
+  "profile_context": null
+}
+```
+
+**Required fields:**
+- `message` (string, 1-2000 chars)
+- `X-Device-Id` header (UUID v4)
+
+**Optional fields:**
+- `language` (default: "fr", allowed: "fr" | "de" | "en" | "it" | "es" | "pt")
+- `cash_level` (default: 3, range: 1-5 — voice intensity)
+- `profile_context` (default: null — anonymous users don't have profile data yet)
+
+### Response 200 — Success with messages remaining
+
+```json
+{
+  "message": "Les 3 piliers suisses sont un système de prévoyance articulé en trois niveaux :\n\n1. **1er pilier (AVS/AI)** : obligatoire, couvre les besoins vitaux\n2. **2e pilier (LPP)** : prévoyance professionnelle obligatoire dès 22'680 CHF/an\n3. **3e pilier** : épargne individuelle facultative, avantages fiscaux (3a)\n\n[... real Claude response ...]",
+  "sources": [
+    {
+      "title": "LAVS art. 21-40",
+      "file": "avs_system.md",
+      "section": "Régime des rentes"
+    }
+  ],
+  "disclaimers": [
+    "Outil éducatif. Ne constitue pas un conseil financier au sens de la LSFin."
+  ],
+  "tool_calls": [],
+  "tokens_used": 245,
+  "anonymous_usage": {
+    "used": 1,
+    "limit": 3,
+    "remaining": 2,
+    "requires_auth": false,
+    "paywall_message": null
+  }
+}
+```
+
+### Response 200 — Success at message 3 (soft paywall)
+
+```json
+{
+  "message": "[...real answer to user's 3rd question...]",
+  "sources": [...],
+  "disclaimers": [...],
+  "tool_calls": [],
+  "tokens_used": 198,
+  "anonymous_usage": {
+    "used": 3,
+    "limit": 3,
+    "remaining": 0,
+    "requires_auth": true,
+    "paywall_message": "Tu as eu 3 conversations avec Mint. Sauve-les en te connectant — Mint se souviendra de toi et personnalisera ses conseils."
+  }
+}
+```
+
+**UI interpretation:** Display the normal coach response. Then render the `AnonymousPaywallCard` (soft variant) inline below the message.
+
+### Response 403 — Hard paywall (message 4+)
+
+```json
+{
+  "detail": "anonymous_limit_exceeded",
+  "paywall_message": "Pour continuer avec Mint, crée ton espace gratuit. 1 tap avec Apple.",
+  "upgrade_options": [
+    {
+      "method": "apple_sign_in",
+      "label": "Sign in with Apple",
+      "primary": true
+    },
+    {
+      "method": "magic_link",
+      "label": "Email magic link",
+      "primary": false
+    },
+    {
+      "method": "password",
+      "label": "Mot de passe",
+      "primary": false
+    }
+  ],
+  "anonymous_usage": {
+    "used": 3,
+    "limit": 3,
+    "remaining": 0
+  }
+}
+```
+
+**UI interpretation:** No coach response to render. Immediately show modal bottom sheet with upgrade options.
+
+### Response 400 — Invalid request
+
+```json
+{
+  "detail": "Invalid X-Device-Id header: must be a valid UUID v4"
+}
+```
+
+### Response 429 — Rate limit (IP-level)
+
+```json
+{
+  "detail": "Rate limit exceeded: 15 requests per hour per IP"
+}
+```
+
+**Retry-After header:** included
+
+### Response 503 — Backend error
+
+```json
+{
+  "detail": "Coach AI temporarily unavailable. Please try again in a moment."
+}
+```
+
+---
+
+## Endpoint 2: POST /api/v1/auth/claim-anonymous
+
+**Purpose:** Migrate anonymous device usage to an authenticated user account after signup.
+
+**Auth:** JWT required
+
+### Request
+
+```http
+POST /api/v1/auth/claim-anonymous HTTP/1.1
+Authorization: Bearer eyJhbGc...
+Content-Type: application/json
+```
+
+**Body:**
+```json
+{
+  "device_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Response 200 — Successfully claimed
+
+```json
+{
+  "claimed": true,
+  "device_id": "550e8400-e29b-41d4-a716-446655440000",
+  "messages_migrated": 3,
+  "claimed_at": "2026-04-11T10:23:45Z"
+}
+```
+
+### Response 200 — Device not found (already claimed or never used)
+
+```json
+{
+  "claimed": false,
+  "reason": "device_not_found_or_already_claimed"
+}
+```
+
+**Note:** This is not an error. The Flutter app can call this on every login without checking state — the backend handles gracefully.
+
+### Response 409 — Device claimed by different user
+
+```json
+{
+  "detail": "Device already claimed by another account"
+}
+```
+
+**This prevents:** User A uses device anonymously → friend borrows phone → friend signs in as User B → User B tries to claim User A's device usage.
+
+---
+
+## Rate Limiting
+
+### IP-level (SlowAPI)
+- `/coach/chat/anonymous`: **15 requests per hour per IP**
+- Applies to ALL anonymous endpoints
+- Returns 429 with Retry-After header
+
+### Device-level (database logic)
+- **3 messages per device_id LIFETIME** (not per day, per lifetime)
+- Enforced by querying `anonymous_coach_usage.message_count`
+- At count = 3, returns success + `requires_auth: true`
+- At count >= 4, returns 403
+
+---
+
+## Backward Compatibility
+
+- Existing `/api/v1/coach/chat` (authenticated) is **unchanged**
+- Existing `/api/v1/rag/query` is **unchanged**
+- Flutter orchestrator adds new branch in `generateChat()`, doesn't modify existing paths
+- SLM + BYOK + authenticated server-key paths are untouched
+
+---
+
+## Security Notes
+
+1. **No PII stored.** Device_id is a pseudo-random UUID, not linked to identity.
+2. **IP is hashed before storage** (SHA-256, first 16 chars) for abuse tracking without privacy leak.
+3. **Messages are NOT persisted** in anonymous state (v1). The database stores only the counter.
+4. **Bearer JWT** never leaks to the anonymous endpoint (different route, different middleware).
+5. **CORS**: same policy as existing public endpoints (mobile app origins only).
+
+---
+
+## Monitoring
+
+Add these metrics:
+- `anonymous_coach_requests_total` (counter, by status_code)
+- `anonymous_coach_users_unique_daily` (gauge, count of distinct device_ids/day)
+- `anonymous_coach_converted_to_signup` (counter, device_ids that called /claim)
+- `anonymous_coach_abandoned_at_paywall` (counter, hit 403 then never claimed)
+
+Conversion rate = `converted / unique_daily`
+
+Target: >10% conversion at message 3.
+
+---
+
+## Example cURL Sequences
+
+### Happy path (3 messages then signup)
+
+```bash
+DEVICE=$(uuidgen)
+URL=https://mint-staging.up.railway.app/api/v1
+
+# Message 1
+curl -X POST $URL/coach/chat/anonymous \
+  -H "Content-Type: application/json" \
+  -H "X-Device-Id: $DEVICE" \
+  -d '{"message":"Hello Mint","language":"fr","cash_level":3}'
+
+# Message 2
+curl -X POST $URL/coach/chat/anonymous \
+  -H "Content-Type: application/json" \
+  -H "X-Device-Id: $DEVICE" \
+  -d '{"message":"Comment optimiser mon 3e pilier ?","language":"fr","cash_level":3}'
+
+# Message 3 (soft paywall returned alongside answer)
+curl -X POST $URL/coach/chat/anonymous \
+  -H "Content-Type: application/json" \
+  -H "X-Device-Id: $DEVICE" \
+  -d '{"message":"Je gagne 80k, je cotise combien ?","language":"fr","cash_level":3}'
+
+# Message 4 (hard paywall, 403)
+curl -X POST $URL/coach/chat/anonymous \
+  -H "Content-Type: application/json" \
+  -H "X-Device-Id: $DEVICE" \
+  -d '{"message":"Une autre question","language":"fr","cash_level":3}'
+# → 403
+
+# User signs up via Apple Sign-In → gets JWT
+JWT="eyJhbGc..."
+
+# Claim anonymous device
+curl -X POST $URL/auth/claim-anonymous \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d "{\"device_id\":\"$DEVICE\"}"
+# → {"claimed":true,"messages_migrated":3}
+
+# Now message 5 works via /coach/chat (authenticated)
+curl -X POST $URL/coach/chat \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Merci","language":"fr","cash_level":3}'
+# → 200 OK, authenticated response
+```

--- a/.planning/briefs/anonymous-coach-hook/04-COPY-AND-UX.md
+++ b/.planning/briefs/anonymous-coach-hook/04-COPY-AND-UX.md
@@ -1,0 +1,239 @@
+# Copy & UX — Anonymous Coach Hook
+
+**Date:** 2026-04-11
+**Voice reference:** `docs/VOICE_SYSTEM.md` — 5 pillars: calme, précis, fin, rassurant, net.
+
+---
+
+## Voice reminders (non-negotiable)
+
+- **Never** "vous" — always "tu"
+- **Never** "retirement" framing — Mint is for 18 life events
+- **Never** anxiety language ("Vous avez atteint votre limite", "Vous devez vous connecter")
+- **Always** soft, inviting, "viens avec moi" energy
+- **Never** the banned terms: garanti, optimal, meilleur, parfait, certain
+- **Regional**: default Suisse Romande voice (anonymous users don't have canton yet)
+
+---
+
+## Copy strings by UI state
+
+### State 1 — Initial coach screen (unchanged from current)
+
+Shows the current "silent opener" with the key number or intent text.
+No changes to this screen as part of this milestone.
+
+### State 2 — Messages remaining counter (new, subtle)
+
+**Location:** Just above the input bar, on the right side, 11pt italic, 50% opacity.
+
+```
+FR: "2 conversations avant que Mint te perde de vue"
+DE: "2 Gespräche, bevor Mint dich aus den Augen verliert"
+EN: "2 conversations before Mint loses track of you"
+IT: "2 conversazioni prima che Mint ti perda di vista"
+ES: "2 conversaciones antes de que Mint te pierda de vista"
+PT: "2 conversas antes de Mint te perder de vista"
+```
+
+**Countdown variants:**
+- 3 left: `"3 conversations avant que Mint te perde de vue"` (barely visible)
+- 2 left: same copy, slightly more visible
+- 1 left: `"Dernière conversation avant que Mint te perde de vue"` (warmer color, still soft)
+- 0 left (after message 3 sent): hide the counter — the inline paywall card takes over
+
+**Why this copy:** Frames the cost as "Mint will lose you" (emotional, relational) instead of "you will lose access" (transactional, aggressive).
+
+### State 3 — Inline soft paywall (after 3rd message)
+
+**Location:** Rendered inline below the 3rd assistant message, like a ResponseCard.
+
+**Card header:**
+```
+FR: "Garde-moi dans ta poche"
+```
+
+**Card body:**
+```
+FR: "On vient d'avoir 3 bonnes conversations, toi et moi. 
+     Si tu te connectes maintenant, je me souviens de tout : 
+     ce qu'on a dit, ce qui compte pour toi, ce qu'on doit creuser.
+     Sinon, tout repart à zéro à la prochaine ouverture."
+```
+
+**Primary button:** "Garde-les avec Apple" (Apple logo inline)
+**Secondary button:** "Email"
+**Tertiary (text link):** "Plus tard — je ferme l'app"
+
+**Why this copy:**
+- "Garde-moi dans ta poche" — intimate, ownership reversed (you own Mint, not the other way)
+- "toi et moi" — creates a we
+- "tout repart à zéro" — concrete consequence, not abstract
+- "Plus tard — je ferme l'app" — honest about the choice, not guilt-trippy
+
+### State 4 — Hard paywall (modal bottom sheet, message 4+ attempt)
+
+**Appears when:** user sends a 4th message. Bottom sheet slides up, can't be dismissed by swipe-down (only by "Close app" or signing in).
+
+**Header:**
+```
+FR: "On est rendus à un moment"
+```
+
+**Body:**
+```
+FR: "Tu as eu 3 conversations avec moi. Tu as vu ce que je peux faire.
+     Maintenant, soit tu me laisses te suivre vraiment (et je garde 
+     tout ce qu'on a dit), soit tu me laisses ici et je redeviens 
+     un inconnu à la prochaine ouverture.
+     
+     Aucune carte bancaire. Juste un nom pour que je sache à qui je parle."
+```
+
+**Primary button (dominant, 56px tall):**
+`"Sign in with Apple"` (Apple logo)
+
+**Secondary button:**
+`"Recevoir un lien par email"`
+
+**Text link (bottom):**
+`"Fermer l'app"` (dismisses the sheet and closes the coach screen)
+
+**Why this copy:**
+- "On est rendus à un moment" — marks a transition, not a block
+- "soit tu me laisses te suivre vraiment" — choice is about relationship, not access
+- "je redeviens un inconnu" — the consequence is mutual (Mint loses, you lose)
+- "Aucune carte bancaire" — removes the "is this paid?" anxiety
+
+### State 5 — Post-signup confirmation toast
+
+**Appears when:** User completes Apple Sign-In or magic link verification, and the silent `claim-anonymous` API call succeeds.
+
+**Toast (top of screen, 3 seconds):**
+```
+FR: "On se retrouve. Mint se souvient de toi maintenant."
+```
+
+**Why this copy:**
+- "On se retrouve" — celebration of reunion, not "success"
+- Present tense — Mint already remembers, it's not a promise
+
+### State 6 — Claim failure (silent, no UI)
+
+If `/auth/claim-anonymous` fails silently (404, 409, etc.), the Flutter app should **not** show an error. The user just signed in — don't ruin the moment. Log the failure for debugging, move on.
+
+The user will have a fresh conversation history in their account. The 3 anonymous messages are lost. Acceptable trade-off for not blocking signup.
+
+### State 7 — Error states
+
+**Network error during anonymous chat:**
+```
+FR: "On dirait que la connexion fait des siennes. 
+     Réessaie dans un instant."
+```
+
+**Rate limit (IP, 429):**
+```
+FR: "Trop de questions d'un coup. Laisse-moi respirer 
+     une minute et reviens."
+```
+
+**Backend down (503):**
+```
+FR: "Mint fait une petite pause technique. 
+     Reviens dans quelques minutes."
+```
+
+---
+
+## UX Patterns
+
+### Counter display timing
+
+- **Fade in** after the FIRST assistant message is rendered (not before — we don't want to scare them on arrival)
+- **Fade out** when the inline soft paywall appears (after 3rd message)
+- **Never** on screens other than coach chat
+- **Never** if user is authenticated (no counter for logged-in users)
+
+### Soft paywall card animation
+
+- Slide up from bottom of the message, 300ms ease-out
+- Appears ~500ms after the 3rd assistant message renders (let them read it first)
+- Inside the scrollable message list, not fixed (user can scroll past it)
+- Dismissing with "Plus tard" collapses the card, user can still scroll history
+
+### Hard paywall bottom sheet
+
+- Slides up from bottom, 400ms ease-in-out
+- Full width, ~60% screen height
+- Backdrop blur + 30% dark overlay
+- **No close button** — forces a choice (sign in or close app)
+- Apple button: 56px tall, full width, haptic feedback on tap
+- Close app link: very small, bottom, 12pt, text-muted
+- Background scroll locked
+
+### Post-signup flow
+
+1. User taps "Sign in with Apple"
+2. Native Apple Sign-In sheet opens (iOS native)
+3. User authenticates
+4. Apple returns JWT payload
+5. App sends `POST /auth/apple/verify` → gets backend JWT
+6. App sends `POST /auth/claim-anonymous` (silent, background)
+7. Toast "On se retrouve. Mint se souvient de toi maintenant."
+8. Bottom sheet dismisses
+9. Coach chat continues as authenticated (no page change)
+
+---
+
+## Accessibility
+
+- Counter text: 11pt minimum, contrast ratio 4.5:1 against background
+- Paywall card: keyboard focusable, screen reader announces "Inline suggestion: save your conversation with Apple Sign-In"
+- Bottom sheet: screen reader trap (TalkBack / VoiceOver) — focus stays inside until action taken
+- All buttons: minimum 44x44 hit target
+
+---
+
+## i18n keys to add (all 6 ARB files)
+
+```
+anonymousCoachCounter3: "3 conversations avant que Mint te perde de vue"
+anonymousCoachCounter2: "2 conversations avant que Mint te perde de vue"
+anonymousCoachCounter1: "Dernière conversation avant que Mint te perde de vue"
+anonymousCoachSoftPaywallHeader: "Garde-moi dans ta poche"
+anonymousCoachSoftPaywallBody: "On vient d'avoir 3 bonnes conversations..."
+anonymousCoachSoftPaywallApple: "Garde-les avec Apple"
+anonymousCoachSoftPaywallEmail: "Email"
+anonymousCoachSoftPaywallLater: "Plus tard — je ferme l'app"
+anonymousCoachHardPaywallHeader: "On est rendus à un moment"
+anonymousCoachHardPaywallBody: "Tu as eu 3 conversations avec moi..."
+anonymousCoachHardPaywallApple: "Sign in with Apple"
+anonymousCoachHardPaywallMagicLink: "Recevoir un lien par email"
+anonymousCoachHardPaywallCloseApp: "Fermer l'app"
+anonymousCoachReunionToast: "On se retrouve. Mint se souvient de toi maintenant."
+anonymousCoachNetworkError: "On dirait que la connexion fait des siennes. Réessaie dans un instant."
+anonymousCoachRateLimitError: "Trop de questions d'un coup. Laisse-moi respirer une minute et reviens."
+anonymousCoachBackendError: "Mint fait une petite pause technique. Reviens dans quelques minutes."
+```
+
+All keys must be translated to DE, EN, IT, ES, PT. Run `flutter gen-l10n` after adding.
+
+---
+
+## Compliance notes
+
+- **Disclaimer still shown** at the end of each anonymous response (same as authenticated path)
+- **Sources still displayed** (RAG citations visible to anonymous users)
+- **No guarantee language** in any copy
+- **No "meilleur", "optimal", "parfait"** in any copy
+- **No retirement framing** anywhere — the default assumption is "user has a life question"
+
+---
+
+## Out of scope for this milestone
+
+- A/B testing different counter/paywall copy (add measurement first, iterate later)
+- Localized paywall images or illustrations
+- Progress indicator ("conversation 2 of 3") visible during message 1 and 2 — we decided to only show counter passively, not actively
+- Allowing the user to pre-preview "what I'll get by signing in" — keep the magic, don't explain it

--- a/.planning/briefs/anonymous-coach-hook/05-OPEN-QUESTIONS.md
+++ b/.planning/briefs/anonymous-coach-hook/05-OPEN-QUESTIONS.md
@@ -1,0 +1,220 @@
+# Open Questions — Anonymous Coach Hook
+
+**Date:** 2026-04-11
+**Status:** These decisions need to be made (by Julien) before or during GSD new-milestone questioning phase.
+
+---
+
+## Q1 — How many free messages?
+
+**Current proposal:** 3
+
+**Alternatives:**
+- **1 message**: Maximum pressure to convert. Risk: user leaves without having tasted enough
+- **3 messages** (proposed): Enough to ask a question, follow-up, deep dive. Feels "complete"
+- **5 messages**: More generous. Better for complex topics but higher cost
+- **10 messages**: Cleo's approach. Feels like a real trial. Most expensive per user
+
+**Cost comparison (per anonymous user):**
+- 1 msg: ~$0.03
+- 3 msgs: ~$0.10
+- 5 msgs: ~$0.17
+- 10 msgs: ~$0.34
+
+**Decision needed:** Which number?
+
+---
+
+## Q2 — Lifetime limit or daily reset?
+
+**Option A — Lifetime per device (proposed):** 3 messages ever, then must signup
+- **Pro**: Forces conversion, clean signal
+- **Con**: User who tests on day 1 can't come back on day 5 without signing up
+
+**Option B — Daily reset:** 3 messages per day, resets at midnight UTC
+- **Pro**: User can return over multiple days before committing
+- **Con**: Less urgency to sign up, higher cost, no clean conversion signal
+
+**Option C — Weekly reset:** 3 per week
+- Middle ground
+
+**Decision needed:** A, B, or C?
+
+**Recommendation:** Start with **A (lifetime)**. If conversion is low, relax to weekly/daily.
+
+---
+
+## Q3 — Does anonymous coach have access to RAG?
+
+**Current proposal:** Yes, full RAG access
+
+**Alternative:** No RAG, pure LLM only (smaller system prompt, no vector retrieval)
+
+**Trade-off:**
+- With RAG: answers are grounded, cite Swiss law, more accurate. Cost: ~20% more compute (embedding lookups).
+- Without RAG: generic LLM answers, less impressive, risk of hallucination. Cheaper.
+
+**Julien's instinct from earlier conversation:** Keep RAG. Hallucinations lose users. Agreed.
+
+**Decision needed:** Confirm RAG = yes?
+
+---
+
+## Q4 — Does anonymous coach have tool calling?
+
+**Tools available:** `route_to_screen`, `generate_document`, `retrieve_memories`, etc.
+
+**Options:**
+- **All tools**: same as authenticated (but many tools don't make sense without profile/history)
+- **Subset**: only `route_to_screen` (Claude can suggest navigating to a simulator)
+- **None**: pure text response only
+
+**Recommendation:** **Subset — only `route_to_screen`**. An anonymous user hitting the coach can be routed to a simulator (e.g., "Want to see your retirement projection? Open the 3a simulator" → tap → they see a calculator they can play with without login). Other tools require profile data they don't have.
+
+**Decision needed:** Confirm subset?
+
+---
+
+## Q5 — Does anonymous coach have memory within the session?
+
+**Meaning:** Between message 1, 2, and 3, does Claude remember the previous exchanges in the conversation?
+
+**Options:**
+- **Yes, within session**: Pass conversation history to each `/coach/chat/anonymous` call. Claude has context.
+- **No, stateless**: Each message is independent. Cheaper, but feels broken.
+
+**Recommendation:** **Yes — full session context**. Anonymous users interact for maybe 5 minutes. Passing 3-5 messages of history costs ~$0.01 extra. Worth it for quality.
+
+**Decision needed:** Confirm yes?
+
+**How does Flutter handle this?** The orchestrator already passes `history: List<ChatMessage>` to the server. No change needed. Anonymous endpoint just receives the same list.
+
+---
+
+## Q6 — What about the 4th+ message after they've signed in?
+
+**Scenario:** User sends 3 anonymous messages → sees soft paywall → ignores it → sends 4th message → hard paywall → signs in with Apple → 5th message...
+
+**Current design:** After signin, the `claim-anonymous` call transitions the device. 5th message goes via `/coach/chat` (authenticated). Normal flow.
+
+**Edge case:** What if during the Apple Sign-In flow, they already had a draft of a 5th message in the input? After signin, do we auto-send it, or do they have to re-tap?
+
+**Recommendation:** **Auto-send after signin.** If the user was clearly trying to send a message before the paywall, honor their intent after they authenticate. Small UX win.
+
+**Decision needed:** Confirm auto-send?
+
+---
+
+## Q7 — What if magic link is used but email never arrives (SMTP not configured)?
+
+**Current state:** Railway staging has no SMTP variables set. Magic link endpoint returns 200 but no email is sent.
+
+**Options:**
+- **Block magic link for now**: UI shows "Coming soon" badge, only Apple Sign-In is active
+- **Hide magic link option**: Don't offer it, only Apple
+- **Fix SMTP on Railway**: Setup SMTP provider (SendGrid/Mailgun/AWS SES)
+
+**Recommendation:** **Fix SMTP.** Don't ship with a broken auth option. Either it works or it's hidden.
+
+**Decision needed:** Who fixes SMTP? Creator needs to provision a service.
+
+**Alternative for beta:** Show only Apple Sign-In, hide magic link until SMTP is live.
+
+---
+
+## Q8 — What happens on Android (no Apple Sign-In)?
+
+**Current state:** Apple Sign-In is iOS only. No Android build yet.
+
+**When Android ships:** The hard paywall shows only magic link + password options (no Apple button).
+
+**For this milestone:** iOS only. Android is out of scope.
+
+**Decision needed:** Confirm iOS-only scope for this milestone?
+
+---
+
+## Q9 — What do we show in the "silent opener" for anonymous users?
+
+**Current state:** The coach chat shows a "key financial number" from the profile (replacement rate, FRI score, capital).
+
+**Problem:** Anonymous users have no profile. What do we show?
+
+**Options:**
+- **Nothing**: Just a welcome message
+- **Generic example**: "Un Suisse sur 3 arrive à 65 ans avec moins que prévu" (a stat, not personal)
+- **Question**: "Qu'est-ce qui t'inquiète aujourd'hui ?" (opens the conversation)
+- **Voice cursor prompt**: "Tu veux en parler ?" (current fallback)
+
+**Recommendation:** **Question approach** — "Qu'est-ce qui t'inquiète aujourd'hui ?" or similar. Opens the dialogue, invites immediate typing.
+
+**Decision needed:** Which opener?
+
+---
+
+## Q10 — Observability and conversion tracking
+
+**Question:** Do we add analytics events for this flow in v1, or defer?
+
+**Events to track (if enabled):**
+- `anonymous_coach_message_sent` (count, by message_number)
+- `anonymous_coach_soft_paywall_shown`
+- `anonymous_coach_soft_paywall_dismissed`
+- `anonymous_coach_hard_paywall_shown`
+- `anonymous_coach_signed_up_from_paywall` (the conversion event)
+- `anonymous_coach_closed_app_from_paywall`
+
+**Privacy:** Already anonymous (device_id), add session_id, no PII.
+
+**Recommendation:** **Add events in v1.** Without them we can't measure if it works. But log them locally only for v1 (no backend aggregation yet). In v2, aggregate in dashboard.
+
+**Decision needed:** Events yes/no?
+
+---
+
+## Q11 — Migration of existing TestFlight users
+
+**Question:** Current TestFlight users who have been using the app without an account — what happens to them when this ships?
+
+**Answer:** They already don't have an account, so they'll hit the new flow on next app open. Their "conversation history" is already empty (coach was broken). They're effectively new users.
+
+**Action required:** None. Ship it.
+
+---
+
+## Q12 — What about existing anonymous patterns in the codebase?
+
+**Found during audit:** `coach_chat_screen.dart:342-347` has a "CHAT-01: Ensure a profile exists for the coach context. Anonymous users get a minimal profile on first message. (VD, 35 ans, 0 income)"
+
+**Conflict with new design:** This minimal profile was a workaround for the broken state. With the new anonymous flow, we should **remove** this fake profile creation. Anonymous users genuinely have no profile, and the backend handles this via `profile_context: null`.
+
+**Action:** Delete `CHAT-01` fake profile logic in `coach_chat_screen.dart:342-347` as part of this milestone.
+
+**Decision needed:** Confirm deletion?
+
+---
+
+## Summary of decisions required (before GSD milestone questioning)
+
+| # | Question | Recommended answer | Urgency |
+|---|----------|-------------------|---------|
+| 1 | Message count | 3 | Critical |
+| 2 | Lifetime vs reset | Lifetime (A) | Critical |
+| 3 | RAG access | Yes | Critical |
+| 4 | Tool calling | Subset (route_to_screen only) | Important |
+| 5 | Session memory | Yes | Important |
+| 6 | Auto-send after signin | Yes | Nice-to-have |
+| 7 | SMTP / magic link | Fix SMTP or hide option | Critical |
+| 8 | iOS-only scope | Yes | Confirm |
+| 9 | Silent opener copy | "Qu'est-ce qui t'inquiète aujourd'hui ?" | Important |
+| 10 | Analytics events | Yes, local only | Nice-to-have |
+| 11 | TestFlight migration | No action | Confirm |
+| 12 | Remove fake minimal profile | Yes | Critical |
+
+---
+
+## How to use this document in GSD new-milestone
+
+The new milestone's **questioning phase** (see `references/questioning.md`) should walk through these 12 questions with the user. Most have a clear recommendation — the user just needs to confirm or override.
+
+**Don't** ask them as a checklist. Weave them into natural conversation. Lead with the emotional framing ("we want to hook users without locking them in"), then dig into the specifics as they come up.

--- a/.planning/briefs/anonymous-coach-hook/README.md
+++ b/.planning/briefs/anonymous-coach-hook/README.md
@@ -1,0 +1,82 @@
+# Brief — Anonymous Coach Hook
+
+**For:** A new GSD session that will run `/gsd-new-milestone` in a separate window.
+**Goal:** This folder contains everything needed to start the milestone without any prior context.
+
+## How to use this in the new GSD window
+
+1. Open a fresh Claude Code session in `/Users/julienbattaglia/Desktop/MINT`
+2. Start with this command:
+   ```
+   /gsd-new-milestone @.planning/briefs/anonymous-coach-hook/
+   ```
+3. GSD will read all files in this folder and use them as context.
+4. The questioning phase will walk through `05-OPEN-QUESTIONS.md` decisions.
+5. Once questioning is complete, GSD generates milestone + phases + plans automatically.
+
+## Files in this brief
+
+| File | Purpose |
+|------|---------|
+| `README.md` (this file) | Entry point for new session |
+| `01-PRODUCT-BRIEF.md` | The why: problem, solution, user flow, scope, success criteria |
+| `02-TECHNICAL-SPEC.md` | Architecture, database schema, Flutter/backend changes |
+| `03-API-CONTRACT.md` | Exact endpoint signatures, request/response formats, cURL examples |
+| `04-COPY-AND-UX.md` | Exact UI copy for every state, animations, i18n keys |
+| `05-OPEN-QUESTIONS.md` | 12 decisions needed before implementation, with recommendations |
+
+## Read order
+
+1. `01-PRODUCT-BRIEF.md` — understand why we're doing this
+2. `05-OPEN-QUESTIONS.md` — see what's undecided
+3. `02-TECHNICAL-SPEC.md` — understand the technical shape
+4. `03-API-CONTRACT.md` — reference during implementation
+5. `04-COPY-AND-UX.md` — reference during implementation
+
+## Context that the new session will NOT have
+
+This brief was written at the end of a recovery session on 2026-04-11 that fixed several critical bugs in MINT:
+- Coach AI server-key tier (wired but auth-gated — this milestone removes the auth gate for 3 messages)
+- Auth fixes (logout purge, checkAuth at startup, visible login link)
+- LPP calculations fix (ForecasterService was ignoring certificate overrides)
+- 12 dead routes purged from navigation
+- Test suite cleanup (deleted 40+ change-detector tests)
+
+These fixes are in PR #306 (merged to dev) and PR #307 (merged to staging). TestFlight staging builds successfully. Backend is correctly deployed on Railway staging after fixing a misconfigured source branch.
+
+**Known bugs NOT fixed during recovery session** (may affect this milestone's TestFlight testing):
+- Keyboard stays at top of screen
+- Back button from coach doesn't return to landing (no real stack)
+- "Recevoir un lien magique" button text overflows
+- No SMTP configured on Railway staging (magic link succeeds silently without sending email)
+
+These are P2 bugs, not blockers for this milestone, but the user should know.
+
+**Reference documents to consult if stuck:**
+- `CLAUDE.md` — MINT identity, compliance, 18 life events
+- `.planning/INCIDENT_DIAGNOSTIC_2026-04-10.md` — full audit of pre-recovery state
+- `.planning/PROJECT.md` — current recovery project state
+- `docs/CICD_ARCHITECTURE.md` — deployment architecture (BUT note: doc says TestFlight only on main; reality is push-to-staging also triggers TestFlight staging)
+- `docs/VOICE_SYSTEM.md` — editorial voice rules
+
+## What to NOT do in the new session
+
+- Do not re-audit the app. The audit is done.
+- Do not re-plan the recovery project. It's done.
+- Do not touch any of the existing phases 1-8 in `.planning/phases/`. They are complete.
+- Do not merge this milestone's PRs to main without testing in TestFlight staging first.
+- Do not modify files outside the scope of this milestone without explicit approval.
+
+## Definition of Done for this milestone
+
+- [ ] Backend endpoint `/coach/chat/anonymous` deployed to Railway staging
+- [ ] Backend endpoint `/auth/claim-anonymous` deployed
+- [ ] Database migration applied
+- [ ] Flutter code sends device_id header, routes to anonymous endpoint when no JWT
+- [ ] UI displays message counter, soft paywall, hard paywall per `04-COPY-AND-UX.md`
+- [ ] All 6 ARB files updated with new i18n keys
+- [ ] Unit + integration tests pass
+- [ ] TestFlight staging build succeeds
+- [ ] Creator validates on iPhone: 3 messages → soft paywall → 4th blocked → signin → claim → authenticated chat works
+- [ ] PR merged to dev, then staging, verified green
+- [ ] Staging → main merge scheduled (not automatic, creator decides)


### PR DESCRIPTION
## Summary

Complete brief for the next milestone: anonymous coach access with 3 free messages, soft/hard paywall, and signin migration path.

Docs-only PR. No code changes.

## Why now

During the recovery session on 2026-04-11, we discovered the coach AI is gated behind JWT auth at the backend, but marked public on Flutter — anonymous users hit a fallback template. This milestone fixes that while preserving economic sustainability (rate-limited, capped at 3 free messages per device).

## Files added

- \`.planning/briefs/anonymous-coach-hook/README.md\` — entry point
- \`.planning/briefs/anonymous-coach-hook/01-PRODUCT-BRIEF.md\` — the why
- \`.planning/briefs/anonymous-coach-hook/02-TECHNICAL-SPEC.md\` — architecture
- \`.planning/briefs/anonymous-coach-hook/03-API-CONTRACT.md\` — endpoint contracts
- \`.planning/briefs/anonymous-coach-hook/04-COPY-AND-UX.md\` — exact copy for every UI state
- \`.planning/briefs/anonymous-coach-hook/05-OPEN-QUESTIONS.md\` — 12 decisions with recommendations

## Usage

Open a new Claude Code session in this repo and run:
\`\`\`
/gsd-new-milestone @.planning/briefs/anonymous-coach-hook/
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)