### PR TITLE
fix(coach): CRITICAL — resolve asyncio deadlock that hangs coach AI forever

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -86,29 +86,36 @@ _init_lock = asyncio.Lock()
 # ---------------------------------------------------------------------------
 
 
-async def _get_vector_store():
-    """Get or create the singleton vector store instance (async-safe)."""
+def _get_vector_store():
+    """Get or create the singleton vector store instance.
+
+    Synchronous to avoid deadlock with the shared _init_lock used by
+    _get_orchestrator. MintVectorStore.__init__ is sync anyway.
+
+    FIX (2026-04-11): Previously `async def` + `async with _init_lock`.
+    When `_get_orchestrator` held the lock and awaited this function,
+    this function tried to re-acquire the SAME (non-reentrant) asyncio.Lock,
+    causing an infinite deadlock. Every coach_chat request hung forever.
+    Coach AI has been broken in the app since 2026-03-22 because of this.
+    """
     global _vector_store
     if _vector_store is not None:
         return _vector_store
-    async with _init_lock:
-        if _vector_store is not None:
-            return _vector_store
-        try:
-            from app.services.rag.vector_store import MintVectorStore
+    try:
+        from app.services.rag.vector_store import MintVectorStore
 
-            backend_dir = os.path.dirname(
-                os.path.dirname(
-                    os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-                )
+        backend_dir = os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
             )
-            persist_dir = os.path.join(backend_dir, "data", "chromadb")
-            _vector_store = MintVectorStore(persist_directory=persist_dir)
-        except ImportError:
-            raise HTTPException(
-                status_code=503,
-                detail="RAG dependencies not installed. Install with: pip install -e '.[rag]'",
-            )
+        )
+        persist_dir = os.path.join(backend_dir, "data", "chromadb")
+        _vector_store = MintVectorStore(persist_directory=persist_dir)
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="RAG dependencies not installed. Install with: pip install -e '.[rag]'",
+        )
     return _vector_store
 
 
@@ -152,7 +159,7 @@ async def _get_orchestrator():
         try:
             from app.services.rag.orchestrator import RAGOrchestrator
 
-            vs = await _get_vector_store()
+            vs = _get_vector_store()
             hybrid = _get_hybrid_search()
             _orchestrator = RAGOrchestrator(vector_store=vs, hybrid_search=hybrid)
             if hybrid:


### PR DESCRIPTION
## Summary

**Critical bug fix**: Coach AI has been completely broken in the app since 2026-03-22 due to an asyncio deadlock in \`_get_vector_store()\`. Every \`/coach/chat\` request hangs forever, never returns HTTP response.

## Root Cause

\`\`\`
_get_orchestrator()                                    ← async function
  └── async with _init_lock:                           ← acquires lock A
        └── vs = await _get_vector_store()             ← calls async
              └── async with _init_lock:               ← tries to acquire SAME lock A
                    ← ∞ DEADLOCK (asyncio.Lock is NOT reentrant)
\`\`\`

## Evidence

Railway staging logs show the exact hang:
\`\`\`
coach_chat using server-side API key (beta mode)
system_prompt_length chars=14337 tokens_est=3584
[NO COMPLETION LOG — request hangs forever, Railway eventually returns 502]
\`\`\`

Direct cURL test confirms:
\`\`\`
$ curl -X POST /api/v1/coach/chat --max-time 120 ...
curl: (28) Operation timed out after 120001 milliseconds with 0 bytes received
\`\`\`

The backend never sends any HTTP headers — it's literally stuck waiting on a lock.

## Fix

Make \`_get_vector_store()\` synchronous (no lock needed). \`MintVectorStore.__init__\` is already sync, and \`rag.py\` uses the same pattern without async/lock.

**3 line change**:
- Remove \`async\` from function signature
- Remove \`async with _init_lock:\` block
- Remove \`await\` from caller in \`_get_orchestrator()\`

## Testing

- ✅ 5246 backend tests pass
- ✅ 0 regressions
- ✅ Linter clean
- ⏳ TestFlight device test after deploy

## Impact

**This is the fix that makes the coach AI actually work in the app for the first time since v2.2.** The creator has never been able to get a real Claude response in the app on TestFlight because of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)