### PR TITLE
fix(backend): CRITICAL — install [rag] extras in Docker image

### DIFF
--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -10,9 +10,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install deps from pyproject.toml (single source of truth)
+# CRITICAL: [rag] extra includes chromadb, openai, tiktoken which are required
+# by coach_chat.py / rag.py. Without this extra, the RAG orchestrator
+# cannot initialize and returns 503 "RAG dependencies not installed".
 COPY pyproject.toml .
 COPY app/ app/
-RUN pip install --no-cache-dir . && python -c "import anthropic; print('anthropic', anthropic.__version__)"
+RUN pip install --no-cache-dir ".[rag]" && python -c "import anthropic, chromadb; print('anthropic', anthropic.__version__, '/ chromadb', chromadb.__version__)"
 
 # --- Stage 2: Production ---
 FROM python:3.12-slim AS production


### PR DESCRIPTION
## Summary

**Second critical fix in the coach AI chain.** Paired with PR #309 (asyncio deadlock), this finally makes the coach work.

## The bug

\`\`\`dockerfile
RUN pip install --no-cache-dir .    ← only installs core deps
\`\`\`

But the RAG orchestrator needs \`chromadb\`, \`openai\`, \`tiktoken\` which are in the \`[rag]\` extra. Result: every coach request returns 503 "RAG dependencies not installed".

## Evidence (post-deadlock fix)

\`\`\`
$ curl -X POST /api/v1/coach/chat ...
HTTP 503 in 0.34s
{\"detail\":\"RAG dependencies not installed. Install with: pip install -e '.[rag]'\"}
\`\`\`

## Fix

\`\`\`dockerfile
RUN pip install --no-cache-dir \".[rag]\" && python -c \"import anthropic, chromadb; ...\"
\`\`\`

Also added chromadb to the smoke import check so the build fails loudly if the extra gets dropped again.

## Context

This is the **same bug class** as PR #309 — a fundamental piece of infrastructure that has been silently broken since v2.2. The coach AI has never worked in the app on TestFlight because of these two bugs stacked on top of each other:

1. **PR #309**: asyncio deadlock → every request hangs forever
2. **PR #310** (this one): chromadb missing → every request returns 503

Together these explain why the creator has been seeing \"Coach AI unavailable\" on every TestFlight build since March.

🤖 Generated with [Claude Code](https://claude.com/claude-code)