### PR TITLE
Staging deploy v3: fix language check fallback

### DIFF
--- a/services/backend/app/services/coach/compliance_guard.py
+++ b/services/backend/app/services/coach/compliance_guard.py
@@ -325,10 +325,12 @@ class ComplianceGuard:
         text = unicodedata.normalize("NFKC", text)
 
         # ── Pre-check: wrong language (basic heuristic) ──
+        # NOTE: log only, never fallback. Too many false positives with
+        # conversational French that uses English tech terms ("ETF", "cash",
+        # "score", etc.) or when Claude quotes the user's English words.
         language_violations = self._check_language(text)
         if language_violations:
             violations.extend(language_violations)
-            use_fallback = True
 
         # ── Layer 1: Banned terms ──
         # Strip negated guarantees (e.g. "rien n'est garanti") from the


### PR DESCRIPTION
## Summary
Third staging deploy. Fixes critical bug found in live test:

- ComplianceGuard language check was triggering fallback on 3+ English markers (the, this, with, you) — Claude naturally echoes English tech terms from conversation history, killing the second message in any conversation.

## Root cause
Same pattern as prescriptive check: post-hoc rejection kills substantive responses. Defense must be in the system prompt, not the guard.

## Test plan
- [ ] Railway deploy
- [ ] Sophie scenario: pave + follow-up + PDF
- [ ] Verify multi-turn conversations don't fallback