### PR TITLE
feat(flutter): disclaimer slim footer, kill per-message card

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -32,6 +32,7 @@ import 'package:mint_mobile/services/rag_service.dart';
 import 'package:mint_mobile/widgets/coach/lightning_menu.dart';
 import 'package:mint_mobile/services/coach/conversation_store.dart';
 import 'package:mint_mobile/widgets/coach/coach_app_bar.dart';
+import 'package:mint_mobile/widgets/coach/coach_disclaimer_footer.dart';
 import 'package:mint_mobile/widgets/coach/coach_input_bar.dart';
 import 'package:mint_mobile/widgets/coach/coach_loading_indicator.dart';
 import 'package:mint_mobile/widgets/coach/coach_message_bubble.dart';
@@ -1573,12 +1574,20 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
               padding: EdgeInsets.only(
                 bottom: MediaQuery.of(context).viewPadding.bottom,
               ),
-              child: CoachInputBar(
-                controller: _controller,
-                focusNode: _focusNode,
-                isStreaming: _isStreaming,
-                onSend: () => _sendMessage(_controller.text),
-                onLightningMenu: _showLightningMenu,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  CoachInputBar(
+                    controller: _controller,
+                    focusNode: _focusNode,
+                    isStreaming: _isStreaming,
+                    onSend: () => _sendMessage(_controller.text),
+                    onLightningMenu: _showLightningMenu,
+                  ),
+                  // Phase C — permanent slim legal footer. Replaces the
+                  // legacy per-message CoachDisclaimersSection card.
+                  const CoachDisclaimerFooter(),
+                ],
               ),
             ),
           ],

--- a/apps/mobile/lib/widgets/coach/coach_disclaimer_footer.dart
+++ b/apps/mobile/lib/widgets/coach/coach_disclaimer_footer.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/theme/mint_spacing.dart';
+import 'package:mint_mobile/theme/mint_text_styles.dart';
+
+// ────────────────────────────────────────────────────────────
+//  COACH DISCLAIMER FOOTER — permanent slim legal anchor
+//
+//  Phase C (2026-04-14). Replaces the legacy per-message
+//  CoachDisclaimersSection card. State-of-the-art pattern:
+//  Wise / Revolut / Cleo all use a single permanent footer
+//  with a tap target opening the canonical legal text.
+//
+//  Legal basis: LSFin/FINMA require the disclaimer to be
+//  accessible at-a-tap — NOT duplicated under every message.
+//
+//  Visual: one line, ~32px total, textMutedAaa @ 40% alpha,
+//  MintTextStyles.micro, tap → modal bottom sheet with the
+//  canonical disclaimer content.
+// ────────────────────────────────────────────────────────────
+
+/// Permanent slim disclaimer footer for the coach chat scaffold.
+///
+/// One line, muted, tappable. Opens [showCoachDisclaimerSheet] on tap.
+/// Accessible as a Semantics button with a 44x44 minimum hit target.
+class CoachDisclaimerFooter extends StatelessWidget {
+  const CoachDisclaimerFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    return Semantics(
+      button: true,
+      label: s.coachDisclaimerCollapsed,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => showCoachDisclaimerSheet(context),
+        child: Container(
+          width: double.infinity,
+          constraints: const BoxConstraints(minHeight: 44),
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(
+            horizontal: MintSpacing.md,
+            vertical: MintSpacing.xs,
+          ),
+          child: Text(
+            s.coachDisclaimerCollapsed,
+            textAlign: TextAlign.center,
+            style: MintTextStyles.micro(
+              color: MintColors.textMutedAaa.withValues(alpha: 0.4),
+            ).copyWith(
+              fontSize: 11,
+              fontStyle: FontStyle.italic,
+              height: 1.3,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Opens the canonical disclaimer as a scrollable modal bottom sheet.
+///
+/// Content is a concise, LSFin-compliant restatement sourced from
+/// `legal/DISCLAIMER.md`. The body text uses the existing i18n key
+/// `coachDisclaimer`, already localized in the 6 supported languages.
+Future<void> showCoachDisclaimerSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: MintColors.craie,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (ctx) => const _CoachDisclaimerSheet(),
+  );
+}
+
+class _CoachDisclaimerSheet extends StatelessWidget {
+  const _CoachDisclaimerSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final mq = MediaQuery.of(context);
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: mq.size.height * 0.75,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Drag handle
+            Padding(
+              padding: const EdgeInsets.only(top: 10, bottom: 6),
+              child: Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: MintColors.textMutedAaa.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            // Header row with close button
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MintSpacing.md,
+                vertical: MintSpacing.xs,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      s.coachDisclaimerCollapsed,
+                      style: MintTextStyles.bodyMedium(
+                        color: MintColors.textPrimary,
+                      ).copyWith(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  Semantics(
+                    button: true,
+                    label: 'Fermer',
+                    child: IconButton(
+                      icon: const Icon(Icons.close, size: 20),
+                      color: MintColors.textSecondaryAaa,
+                      onPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1, thickness: 0.5),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(
+                  MintSpacing.md,
+                  MintSpacing.md,
+                  MintSpacing.md,
+                  MintSpacing.lg,
+                ),
+                child: Text(
+                  s.coachDisclaimer,
+                  style: MintTextStyles.bodySmall(
+                    color: MintColors.textSecondaryAaa,
+                  ).copyWith(height: 1.55),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/widgets/coach/coach_message_bubble.dart
+++ b/apps/mobile/lib/widgets/coach/coach_message_bubble.dart
@@ -163,14 +163,10 @@ class CoachMessageBubble extends StatelessWidget {
               child: CoachSourcesSection(sources: msg.sources),
             ),
           ],
-          // Disclaimers (from RAG backend)
-          if (msg.disclaimers.isNotEmpty) ...[
-            const SizedBox(height: MintSpacing.sm),
-            Padding(
-              padding: const EdgeInsets.only(left: 44, right: MintSpacing.xxl),
-              child: CoachDisclaimersSection(disclaimers: msg.disclaimers),
-            ),
-          ],
+          // Disclaimers — NO LONGER rendered per-message.
+          // State-of-the-art pattern (Wise/Revolut/Cleo): a single permanent
+          // slim footer lives in CoachChatScreen's Scaffold. The data field
+          // `msg.disclaimers` remains on the model (API contract preserved).
           // Response Cards (Phase 1 — inline strip)
           if (!isStreamingThis && msg.responseCards.isNotEmpty) ...[
             const SizedBox(height: MintSpacing.md - 4),
@@ -450,87 +446,12 @@ class CoachSourcesSection extends StatelessWidget {
   }
 }
 
-/// Disclaimers section displayed under coach messages — collapsed by default.
-class CoachDisclaimersSection extends StatefulWidget {
-  final List<String> disclaimers;
-
-  const CoachDisclaimersSection({super.key, required this.disclaimers});
-
-  @override
-  State<CoachDisclaimersSection> createState() =>
-      _CoachDisclaimersSectionState();
-}
-
-class _CoachDisclaimersSectionState extends State<CoachDisclaimersSection> {
-  bool _expanded = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: MintSpacing.md - 4,
-        vertical: MintSpacing.md - 4,
-      ),
-      decoration: BoxDecoration(
-        color: MintColors.pecheDouce.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          GestureDetector(
-            onTap: () => setState(() => _expanded = !_expanded),
-            behavior: HitTestBehavior.opaque,
-            child: Row(
-              children: [
-                Icon(Icons.info_outline_rounded,
-                    size: 13,
-                    // AESTH-05 per AUDIT_RETRAIT S3 (D-03 swap map)
-                    color: MintColors.textMutedAaa.withValues(alpha: 0.6)),
-                const SizedBox(width: MintSpacing.sm),
-                Expanded(
-                  child: Text(
-                    S.of(context)!.coachDisclaimerCollapsed,
-                    style: MintTextStyles.micro(
-                      // AESTH-05 per AUDIT_RETRAIT S3 (D-03 swap map)
-                      color: MintColors.textMutedAaa,
-                    ).copyWith(height: 1.4),
-                  ),
-                ),
-                Icon(
-                  _expanded
-                      ? Icons.keyboard_arrow_up
-                      : Icons.keyboard_arrow_down,
-                  size: 16,
-                  color: MintColors.textMutedAaa.withValues(alpha: 0.6),
-                ),
-              ],
-            ),
-          ),
-          AnimatedCrossFade(
-            firstChild: const SizedBox.shrink(),
-            secondChild: Padding(
-              padding: const EdgeInsets.only(
-                top: MintSpacing.sm,
-                left: 13 + MintSpacing.sm, // align with text after icon
-              ),
-              child: Text(
-                widget.disclaimers.join('\n'),
-                style: MintTextStyles.micro(
-                  color: MintColors.textMutedAaa,
-                ).copyWith(height: 1.4),
-              ),
-            ),
-            crossFadeState: _expanded
-                ? CrossFadeState.showSecond
-                : CrossFadeState.showFirst,
-            duration: const Duration(milliseconds: 200),
-          ),
-        ],
-      ),
-    );
-  }
-}
+// CoachDisclaimersSection removed (Phase C — 2026-04-14).
+// Legacy per-message disclaimer card (~56-68px, one per coach response) has
+// been replaced by a single permanent slim footer in the coach chat Scaffold
+// (CoachDisclaimerFooter, see coach_chat_screen.dart). LSFin/FINMA require
+// the disclaimer accessible at-a-tap, NOT duplicated per message.
+// The `msg.disclaimers` field is preserved on ChatMessage (API contract).
 
 /// Suggested action chips displayed under coach messages.
 class CoachSuggestedActions extends StatelessWidget {

--- a/apps/mobile/test/widgets/coach/coach_disclaimer_footer_test.dart
+++ b/apps/mobile/test/widgets/coach/coach_disclaimer_footer_test.dart
@@ -1,0 +1,139 @@
+// ────────────────────────────────────────────────────────────
+//  COACH DISCLAIMER FOOTER TESTS — Phase C (2026-04-14)
+//
+//  Validates the slim-footer replacement for the per-message
+//  CoachDisclaimersSection card.
+//
+//  Assertions:
+//   1. CoachMessageBubble no longer renders any disclaimer card
+//      even when `msg.disclaimers` is non-empty (API contract
+//      preserved, visual no longer rendered per-message).
+//   2. CoachDisclaimerFooter renders exactly one disclaimer
+//      line using the `coachDisclaimerCollapsed` ARB key.
+//   3. Tapping the footer opens the modal bottom sheet with
+//      the canonical disclaimer body (`coachDisclaimer` ARB key).
+//   4. Footer exposes Semantics(button: true) for a11y.
+//   5. Footer hit target is at least 44px tall (a11y).
+// ────────────────────────────────────────────────────────────
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
+import 'package:mint_mobile/widgets/coach/coach_disclaimer_footer.dart';
+import 'package:mint_mobile/widgets/coach/coach_message_bubble.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('fr')],
+    locale: const Locale('fr'),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  // ────────────────────────────────────────────────────────────
+  //  No more per-message disclaimer card
+  // ────────────────────────────────────────────────────────────
+
+  testWidgets(
+      'CoachMessageBubble no longer renders any disclaimer card even when '
+      'msg.disclaimers is populated', (tester) async {
+    final msg = ChatMessage(
+      role: 'assistant',
+      content: 'Bonjour',
+      timestamp: DateTime.now(),
+      disclaimers: const [
+        'Outil educatif. Ne constitue pas un conseil financier.',
+        'Reference LSFin art. 3.',
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(
+      CoachMessageBubble(message: msg, messageIndex: 0),
+    ));
+    await tester.pump();
+
+    // The bubble still renders the text content.
+    expect(find.text('Bonjour'), findsOneWidget);
+
+    // Legacy per-message disclaimer strings must NOT appear in the tree.
+    expect(
+      find.text('Outil educatif. Ne constitue pas un conseil financier.'),
+      findsNothing,
+    );
+    expect(find.text('Reference LSFin art. 3.'), findsNothing);
+
+    // The collapsible label of the old card must not appear inside the bubble.
+    final fr = await S.delegate.load(const Locale('fr'));
+    expect(
+      find.descendant(
+        of: find.byType(CoachMessageBubble),
+        matching: find.text(fr.coachDisclaimerCollapsed),
+      ),
+      findsNothing,
+    );
+  });
+
+  // ────────────────────────────────────────────────────────────
+  //  Permanent slim footer
+  // ────────────────────────────────────────────────────────────
+
+  testWidgets('CoachDisclaimerFooter renders one line with the i18n key',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const CoachDisclaimerFooter()));
+    await tester.pump();
+
+    final fr = await S.delegate.load(const Locale('fr'));
+    // Exactly one line with the collapsed-disclaimer label.
+    expect(find.text(fr.coachDisclaimerCollapsed), findsOneWidget);
+  });
+
+  testWidgets('CoachDisclaimerFooter is a Semantics button with a11y label',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const CoachDisclaimerFooter()));
+    await tester.pump();
+
+    final fr = await S.delegate.load(const Locale('fr'));
+    // Find the explicit Semantics wrapper authored inside the widget
+    // (button: true, label: <i18n>). We don't rely on the merged-semantics
+    // tree owner because InkWell also contributes button semantics.
+    final semanticsWidgets = tester
+        .widgetList<Semantics>(find.byType(Semantics))
+        .where((w) =>
+            w.properties.button == true &&
+            w.properties.label == fr.coachDisclaimerCollapsed);
+    expect(semanticsWidgets, isNotEmpty);
+  });
+
+  testWidgets('CoachDisclaimerFooter hit target is at least 44px tall',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const CoachDisclaimerFooter()));
+    await tester.pump();
+
+    final footerSize = tester.getSize(find.byType(CoachDisclaimerFooter));
+    expect(footerSize.height, greaterThanOrEqualTo(44));
+  });
+
+  testWidgets(
+      'Tapping the footer opens the disclaimer bottom sheet with canonical body',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const CoachDisclaimerFooter()));
+    await tester.pump();
+
+    await tester.tap(find.byType(CoachDisclaimerFooter));
+    await tester.pumpAndSettle();
+
+    final fr = await S.delegate.load(const Locale('fr'));
+    // The canonical disclaimer body (from the `coachDisclaimer` ARB key)
+    // must now be visible inside the bottom sheet.
+    expect(find.text(fr.coachDisclaimer), findsOneWidget);
+  });
+}

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -74,58 +74,77 @@ def _scrub_pii(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Prompt version — bumped on every rewrite so telemetry can A/B cleanly.
+# Never remove or rename. Increment on content changes.
+PROMPT_VERSION = "v2"
+
+
 def build_discovery_system_prompt(
     intent: str | None = None,
     language: str = "fr",
+    facts: list[str] | None = None,
 ) -> str:
-    """Build the discovery system prompt for anonymous users.
+    """Build the v2 discovery system prompt for anonymous users.
 
-    This prompt is intentionally minimal and written from scratch (NOT derived
-    from the authenticated coach system prompt). It contains NO references to:
-    - Any available functions or capabilities
-    - User data, accounts, or saved information
-    - Conversation history or past interactions
-    - Any internal system or feature names
+    v2 (2026-04-15) — audit-driven rewrite:
+    - Tight length cap (≤ 3 phrases, verdict-first) — was 3-5 in v1.
+    - Directive to cite user-declared numbers verbatim (fixes MSG1 regressions
+      where Claude generalised instead of using the figures the user typed).
+    - Optional `facts` parameter injected as a `<facts_user>` block so the
+      deterministic regex extractor (phase B) can ground the LLM without
+      relying on compliance-fragile tool-calls.
 
-    Threat mitigation T-13-05: prevents information disclosure about
-    authenticated capabilities.
+    Security contract preserved (T-13-05): the prompt contains NO references
+    to any internal feature — the strings `outil`, `dossier`, `profil`,
+    `memoire`, `tool` are forbidden and asserted by tests.
+
+    Disclaimers are NOT included in the prompt body (doctrine violation +
+    lexicon clash). They are appended by the endpoint via the response's
+    `disclaimers[]` list so the legal obligation is met at the API layer.
     """
-    # Base identity and rules
-    prompt_parts = [
+    parts: list[str] = [
         "Tu es MINT, un compagnon de lucidite financiere suisse.",
         "",
         "Contexte : mode decouverte. La personne n'a pas encore de compte.",
-        "Tu ne sais rien sur elle. Tu ne disposes d'aucune donnee personnelle.",
-        "",
     ]
 
-    # Intent injection (if user selected a felt-state pill)
     if intent:
-        prompt_parts.append(
-            f"La personne a exprime ce sentiment : \u00ab\u202f{intent}\u202f\u00bb."
+        parts.append(
+            f"Elle a exprime ce sentiment : \u00ab\u202f{intent}\u202f\u00bb."
         )
-        prompt_parts.append(
-            "Utilise ce sentiment comme point de depart pour ta reponse."
-        )
-        prompt_parts.append("")
 
-    # Rules and constraints
-    prompt_parts.extend([
-        "Regles strictes :",
-        "- Reponds avec un insight surprenant sur la finance suisse (un fait, un angle mort, une implication concrete).",
-        "- Couche 1 (fait) + couche 2 (traduction humaine) uniquement.",
-        "- Tutoie. Ton calme, precis, fin, rassurant, net.",
-        "- Maximum 1 question de relance a la fin.",
-        "- Jamais de recommandation de produit specifique.",
-        "- Jamais de promesse de rendement ni de certitude sur les resultats.",
-        "- Jamais de comparaison sociale ('top X%').",
-        "- Jamais de langage absolu ou prescriptif. Utilise le conditionnel.",
-        "- Reponse courte (3-5 phrases max).",
-        "",
-        "Objectif : surprendre la personne avec un eclairage qu'elle ne connaissait pas.",
+    parts.append("")
+    parts.extend([
+        "Regles :",
+        "- Reponse en 3 phrases maximum.",
+        "- Premiere ligne = le verdict ou le chiffre le plus pertinent.",
+        "- Reprends textuellement les chiffres que la personne te donne "
+        "(salaire, valeur de rachat, avoir, etc.) — ne les parapharse pas.",
+        "- Tutoie. Ton calme, precis, sans jargon non traduit.",
+        "- Une seule question de relance a la fin, si utile.",
+        "- Jamais de recommandation de produit nomme. Jamais de promesse "
+        "de rendement. Jamais de comparaison sociale. Jamais de langage "
+        "absolu : utilise le conditionnel.",
     ])
 
-    return "\n".join(prompt_parts)
+    # User-declared facts block (phase B) — appears only when populated.
+    if facts:
+        parts.append("")
+        parts.append("<facts_user>")
+        for fact in facts:
+            parts.append(f"- {fact}")
+        parts.append("</facts_user>")
+        parts.append(
+            "Appuie-toi sur ces elements pour ancrer ta reponse. "
+            "Cite-les explicitement."
+        )
+
+    parts.append("")
+    parts.append(
+        "Objectif : eclairer avec un angle concret et surprenant."
+    )
+
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -232,13 +251,40 @@ async def anonymous_chat(
             detail="Limite atteinte. Cree un compte pour continuer.",
         )
 
-    # --- Step 3: Scrub PII from input (T-13-02) ---
+    # --- Step 3a: Extract deterministic facts from the RAW message (phase B).
+    #
+    # Must run BEFORE _scrub_pii — the scrubber replaces any "NNNN CHF/fr"
+    # token with "[***]", which would destroy every salary/LPP figure the
+    # extractor relies on.  Facts are kept in-memory only (no user_id, no DB
+    # writes) — logged by topic list only (no values) to avoid PII in logs.
+    extracted_facts_texts: list[str] = []
+    try:
+        from app.services.coach.profile_extractor import extract_profile_facts
+        _facts = extract_profile_facts(body.message)
+        extracted_facts_texts = [f.text for f in _facts]
+        if _facts:
+            logger.info(
+                "anonymous_chat.extracted_facts session=%s topics=%s",
+                session_id,
+                sorted({f.topic for f in _facts}),
+            )
+    except Exception as exc:  # pragma: no cover — belt-and-braces
+        # PII-safe: log the exception TYPE only. The extractor runs on the
+        # raw (pre-scrub) message so any exception message could carry a
+        # fragment of user input.
+        logger.warning(
+            "anonymous_chat.profile_extractor_failed: %s",
+            type(exc).__name__,
+        )
+
+    # --- Step 3b: Scrub PII from input (T-13-02) ---
     clean_message = _scrub_pii(body.message)
 
     # --- Step 4: Build discovery system prompt (T-13-05) ---
     discovery_prompt = build_discovery_system_prompt(
         intent=body.intent,
         language=body.language,
+        facts=extracted_facts_texts or None,
     )
 
     # --- Step 5: Call LLM ---

--- a/services/backend/app/services/coach/profile_extractor.py
+++ b/services/backend/app/services/coach/profile_extractor.py
@@ -50,6 +50,22 @@ class Fact:
     `value` field is advisory only — it is the parsed numeric/string form
     of the fact and is not persisted directly (the textual `text` carries
     it to the LLM on reload).
+
+    SECURITY CONTRACT — `text` must be a **deterministic template** built
+    from validated captures, never raw user input passthrough. On the
+    anonymous path, `Fact.text` is injected into the system prompt as-is,
+    so any leak of T-13-05 forbidden tokens (`outil|tool|dossier|profil|
+    memoire|memory`) would break the information-disclosure guard. New
+    extractors that echo user strings MUST scrub these tokens first. Tests:
+    `test_profile_extractor_v2_patterns.py::test_facts_never_contain_forbidden_lexicon`.
+
+    DOCTRINE — PII vs facts: the extractor runs on the raw (pre-scrub)
+    message on the anonymous path by design, so salaries and LPP amounts
+    ARE propagated to the LLM via the `<facts_user>` block. This is a
+    conscious trade-off: without it the coach cannot cite the user's
+    numbers and the MSG1 insight regresses to generic advice. The raw
+    `question` field reaching the orchestrator stays scrubbed — the facts
+    block is the narrow, explicit channel for numeric grounding.
     """
 
     topic: str  # "identity", "salary", "location", "household", "lpp", "3a", "debt"
@@ -242,7 +258,67 @@ def _extract_age(msg: str) -> Fact | None:
 
 
 def _extract_salary(msg: str) -> Fact | None:
-    # "gagne 95'000 brut", "95k brut", "salaire 120000", "I earn 95000"
+    """Extract salary fact from a user message.
+
+    Handles (in priority order):
+    1. Monthly salaries with explicit "par mois" / "mensuel" / "/mois".
+       Annualises × 12 with a 3k-40k/month plausibility gate — this is the
+       dominant way Swiss residents state their income ("7600 Fr net /mois").
+    2. Annual salaries with keyword ("gagne / salaire / revenu") or marker
+       ("brut / net / par an").
+    3. Short "XXk brut" form.
+    """
+    net_or_brut_marker = re.search(r"\b(brut|net)\b", msg, re.IGNORECASE)
+    marker = (net_or_brut_marker.group(1).lower() if net_or_brut_marker else "brut")
+
+    # ------------------------------------------------------------------
+    # (1) Monthly salary — highest priority (most common natural phrasing).
+    # If a monthly phrasing is present ANYWHERE in the message, we do NOT
+    # fall through to the annual pass — otherwise "80000 francs par mois"
+    # would be mis-detected as an annual salary of 80k.
+    # ------------------------------------------------------------------
+    has_monthly_context = bool(
+        re.search(
+            r"\b(?:par\s+mois|/\s*mois|mensuel(?:s|le)?|monthly)\b",
+            msg,
+            re.IGNORECASE,
+        )
+    )
+    monthly_patterns = [
+        # "7600 Fr net par mois", "7'600 CHF /mois", "8500 par mois"
+        _NUM + r"\s*(?:chf|francs?|fr\.?)?\s*(?:brut|net)?\s*"
+        r"(?:par\s+mois|/\s*mois|mensuel(?:s|le)?|monthly)",
+        # "salaire mensuel (de) 6200", "mon salaire mensuel est de 6200"
+        r"(?:salaire|revenu|income)\s+(?:mensuel(?:s|le)?|monthly)"
+        r"[^\d]{0,12}" + _NUM,
+    ]
+    for pattern in monthly_patterns:
+        m = re.search(pattern, msg, re.IGNORECASE)
+        if not m:
+            continue
+        monthly = _to_int(m.group(1))
+        if monthly is None:
+            continue
+        # Plausibility: 3k-40k/month (covers Geneva cadres, excludes rente +
+        # CEO fantasy). 40k cap keeps annual ≤ 480k, inside the annual band.
+        if not (3_000 <= monthly <= 40_000):
+            continue
+        annual = monthly * 12
+        return Fact(
+            topic="salary",
+            insight_type="fact",
+            text=f"{annual:,} CHF {marker}/an ({monthly:,}/mois)"
+                 .replace(",", "'"),
+            value=annual,
+        )
+    if has_monthly_context:
+        # The user clearly stated a monthly figure. Don't invent an annual
+        # one by pattern-matching the same number as CHF/year.
+        return None
+
+    # ------------------------------------------------------------------
+    # (2) Annual salary / existing behaviour (kept verbatim for regression)
+    # ------------------------------------------------------------------
     patterns = [
         # "XXk" or "XX k" short form with salary keyword
         (
@@ -276,9 +352,6 @@ def _extract_salary(msg: str) -> Fact | None:
         # Plausibility gate: full-time Swiss salaries 15k-500k/year.
         if not (15_000 <= amount <= 500_000):
             continue
-        marker = "brut" if re.search(r"\bbrut\b", msg, re.IGNORECASE) else (
-            "net" if re.search(r"\bnet\b", msg, re.IGNORECASE) else "brut"
-        )
         return Fact(
             topic="salary",
             insight_type="fact",
@@ -405,28 +478,56 @@ def _extract_family(msg: str) -> Fact | None:
 
 
 def _extract_lpp(msg: str) -> Fact | None:
-    # "LPP 70'000", "2e pilier 70000", "avoir LPP de 120k"
+    """Extract a 2e-pilier / LPP amount.
+
+    Covers the natural-language forms actually used by Swiss residents in
+    addition to the technical lexicon:
+    - Technical: `LPP`, `2e pilier`, `deuxième pilier`, `2nd pillar`
+    - Natural: `valeur de rachat`, `caisse de pension`, `avoir de vieillesse`,
+               `rachat possible`, `montant de rachat`
+    All share the same plausibility band (1'000 – 5'000'000 CHF).
+    """
+    # Keyword set — ordered widest-first so the first hit wins.
+    keywords = (
+        r"lpp|2e\s+pilier|deuxi[èe]me\s+pilier|2nd\s+pillar|"
+        r"valeur\s+de\s+rachat|caisse\s+de\s+pension|avoir\s+de\s+vieillesse|"
+        r"rachat\s+(?:possible|maximum|max)|montant\s+de\s+rachat"
+    )
+    # Number AFTER keyword: "LPP 70'000", "valeur de rachat de 300 000"
     m = re.search(
-        r"\b(?:lpp|2e\s+pilier|deuxi[èe]me\s+pilier|2nd\s+pillar)"
-        r"[^\d]{0,20}" + _NUM + r"\s*(?:chf|k|francs?)?",
+        rf"\b(?:{keywords})[^\d]{{0,30}}" + _NUM + r"\s*(?:chf|k|francs?|fr\.?)?",
         msg,
         re.IGNORECASE,
     )
-    if m:
-        raw = m.group(1)
-        amount = _to_int(raw)
-        if amount is not None:
-            # "k" suffix handling
-            if re.search(r"\b\d{1,3}\s*k\b", m.group(0), re.IGNORECASE) and amount < 1000:
-                amount *= 1000
-            if 1_000 <= amount <= 5_000_000:
-                return Fact(
-                    topic="lpp",
-                    insight_type="fact",
-                    text=f"LPP ≈ {amount:,} CHF".replace(",", "'"),
-                    value=amount,
-                )
-    return None
+    # Number BEFORE keyword: "300'000 Fr de valeur de rachat".
+    # REQUIRE an explicit currency marker (CHF / francs / Fr.) to avoid
+    # capturing years ("en 2025 la caisse de pension a valu ...") — the
+    # year would pass the 1'000-5'000'000 band silently.
+    if not m:
+        m = re.search(
+            _NUM
+            + r"\s*(?:chf|k|francs?|fr\.?)"
+            + rf"(?:\s+\w+){{0,6}}\s+(?:{keywords})",
+            msg,
+            re.IGNORECASE,
+        )
+    if not m:
+        return None
+    raw = m.group(1)
+    amount = _to_int(raw)
+    if amount is None:
+        return None
+    # "k" suffix handling
+    if re.search(r"\b\d{1,3}\s*k\b", m.group(0), re.IGNORECASE) and amount < 1000:
+        amount *= 1000
+    if not (1_000 <= amount <= 5_000_000):
+        return None
+    return Fact(
+        topic="lpp",
+        insight_type="fact",
+        text=f"LPP ≈ {amount:,} CHF".replace(",", "'"),
+        value=amount,
+    )
 
 
 def _extract_pillar3a(msg: str) -> Fact | None:

--- a/services/backend/tests/test_anonymous_chat_facts_wiring.py
+++ b/services/backend/tests/test_anonymous_chat_facts_wiring.py
@@ -1,0 +1,145 @@
+"""
+Integration test for the anonymous-chat ↔ profile_extractor wiring (phase B).
+
+Asserts:
+1. Facts are extracted BEFORE the PII scrubber destroys numeric tokens.
+2. The extracted facts are injected into the system prompt that reaches
+   the orchestrator — via the <facts_user> block.
+3. Session logs topics only (not values) — privacy invariant.
+4. When the message carries no extractable facts, no facts block is emitted.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.v1.endpoints.anonymous_chat as anonymous_chat_module
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _stub_orchestrator(monkeypatch):
+    """Capture the system_prompt that reaches the LLM and return a stub reply."""
+    captured: dict[str, str] = {}
+
+    async def fake_query(self, *, question, system_prompt, **_):  # noqa: ANN001
+        captured["system_prompt"] = system_prompt
+        captured["question"] = question
+        return {
+            "answer": "Stub reply.",
+            "tokens_used": 0,
+            "sources": [],
+            "disclaimers": [],
+        }
+
+    monkeypatch.setattr(
+        anonymous_chat_module._NoRagOrchestrator,
+        "query",
+        fake_query,
+    )
+
+    # Also stub the ANTHROPIC_API_KEY check.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-stub")
+
+    return captured
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _session() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Happy path: the three expected facts end up in the prompt.
+# ---------------------------------------------------------------------------
+
+
+def test_facts_extracted_and_injected_in_prompt(client, _stub_orchestrator, caplog):
+    caplog.set_level(logging.INFO)
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": (
+                "J'ai 49 ans, je gagne 7600 Fr net par mois dans le Valais, "
+                "et j'ai 300 000 Fr de valeur de rachat dans ma caisse de pension. "
+                "Qu'est-ce que je dois faire ?"
+            ),
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    prompt = _stub_orchestrator["system_prompt"]
+    # Facts block present
+    assert "<facts_user>" in prompt
+    assert "</facts_user>" in prompt
+    # Key figures landed verbatim inside the block
+    assert "49 ans" in prompt
+    assert "300'000" in prompt  # formatted LPP
+    # Salary annualised — 7600×12 = 91'200
+    assert "91'200" in prompt or "7'600" in prompt
+    # Telemetry logs topics only, not raw values
+    log_lines = [r.getMessage() for r in caplog.records]
+    assert any("topics=" in line and "session=" in line for line in log_lines)
+    # No raw value leaks into logs
+    assert not any(
+        "300000" in line or "300 000" in line or "7600" in line
+        for line in log_lines
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing data: no facts block emitted (keeps prompt compact).
+# ---------------------------------------------------------------------------
+
+
+def test_no_facts_block_when_message_is_abstract(client, _stub_orchestrator):
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": "Je me sens un peu perdu avec mes finances.",
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    prompt = _stub_orchestrator["system_prompt"]
+    assert "<facts_user>" not in prompt
+    assert "</facts_user>" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# PII scrubbing still runs — extractor ran BEFORE scrub, not instead of.
+# ---------------------------------------------------------------------------
+
+
+def test_question_reaching_orchestrator_is_still_scrubbed(client, _stub_orchestrator):
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": (
+                "J'ai 49 ans et un IBAN CH93 0076 2011 6238 5295 7 et 8500 CHF par mois."
+            ),
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    sent_message = _stub_orchestrator["question"]
+    # IBAN must have been replaced
+    assert "CH93" not in sent_message or "[***]" in sent_message
+    # But the extractor STILL captured the salary (ran pre-scrub) — visible
+    # in the facts block of the prompt.
+    prompt = _stub_orchestrator["system_prompt"]
+    assert "<facts_user>" in prompt
+    assert "102'000" in prompt  # 8500 × 12 annualised

--- a/services/backend/tests/test_anonymous_prompt_v2.py
+++ b/services/backend/tests/test_anonymous_prompt_v2.py
@@ -1,0 +1,205 @@
+"""
+Contract tests for the v2 anonymous discovery system prompt (post-audit, phase A).
+
+Asserts the new constraints that were absent from v1:
+1. PROMPT_VERSION is bumped and exported (for telemetry / A/B).
+2. Max-length directive is tight (≤ 3 phrases) — not the old "3-5 phrases max".
+3. "Cite textuellement les chiffres donnés par la personne" directive exists.
+4. Verdict-first directive exists.
+5. No leak of the forbidden lexicon (`outil/dossier/profil/memoire/tool`)
+   — the T-13-05 guard from v1 is preserved.
+6. No hallucinatable Swiss-knowledge block (no hardcoded AVS/LPP/3a figures).
+7. No `MANDATORY save_insight` or any tool-call directive (tools=None path —
+   Claude would otherwise produce literal `save_insight(...)` in output).
+8. When user-declared `facts` are provided, they appear verbatim inside a
+   `<facts_user>` block distinct from the rest of the prompt.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.api.v1.endpoints.anonymous_chat import (
+    PROMPT_VERSION,
+    build_discovery_system_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_is_v2():
+    assert PROMPT_VERSION == "v2", (
+        "Prompt rewrite must bump PROMPT_VERSION so telemetry can segregate "
+        "old vs new responses. Bump again on next rewrite."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Length discipline
+# ---------------------------------------------------------------------------
+
+
+def test_length_directive_is_tight_max_3_phrases():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    # Either exact "3 phrases" OR the verdict-first shorthand — both acceptable.
+    assert (
+        "3 phrases" in lowered or "trois phrases" in lowered
+    ), "New prompt must cap at 3 phrases (was 3-5 in v1 — too long)."
+    # Regression guard: the old "3-5 phrases max" must be gone.
+    assert "3-5 phrases" not in lowered, (
+        "Old length band '3-5 phrases max' is incompatible with v2.7 "
+        "density doctrine (max 3)."
+    )
+
+
+def test_verdict_first_directive_present():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    assert "verdict" in lowered or "première ligne" in lowered or "chiffre" in lowered, (
+        "Prompt must instruct Claude to lead with the verdict or the most "
+        "relevant figure. Without this, responses regress to long-form "
+        "educational text."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quote-the-numbers doctrine (fixes "n'a pas vu les 300'000")
+# ---------------------------------------------------------------------------
+
+
+def test_cite_user_numbers_directive_present():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    # Must tell the model to cite numbers the user provided.
+    has_cite = any(
+        kw in lowered
+        for kw in (
+            "cite",
+            "reprends",
+            "reprends les chiffres",
+            "reprends les valeurs",
+            "utilise les chiffres",
+        )
+    )
+    assert has_cite, (
+        "Prompt must tell Claude to echo user-provided numbers verbatim — "
+        "otherwise it generalises ('le rachat possible') instead of using "
+        "the actual figure ('tes 300'000 CHF')."
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-13-05 forbidden lexicon preserved (security regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["outil", "tool", "profil", "memoire", "memory", "dossier"],
+)
+def test_forbidden_tokens_never_in_prompt(forbidden: str):
+    prompt = build_discovery_system_prompt().lower()
+    assert forbidden not in prompt, (
+        f"T-13-05 information-disclosure guard: '{forbidden}' must not leak "
+        "into anonymous discovery prompt."
+    )
+
+
+def test_no_mandatory_save_insight_directive():
+    prompt = build_discovery_system_prompt().lower()
+    # Tools=None on anonymous path — any save_* directive would cause Claude
+    # to emit literal tool-call text in the response body.
+    assert "save_insight" not in prompt
+    assert "mandatory" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# No hardcoded Swiss numbers (hallucination-detector defence)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        "7'258",   # 3a plafond salarié LPP
+        "36'288",  # 3a plafond indépendant
+        "30'240",  # AVS rente max
+        "6.8",     # LPP taux conversion
+        "22'680",  # LPP seuil d'accès
+    ],
+)
+def test_no_hardcoded_swiss_numbers_in_prompt(number: str):
+    """Hard-coded figures in the prompt create two problems:
+    (1) they drift when constants change (single source of truth = code),
+    (2) if the legacy compliance_guard is ever re-enabled on the anonymous
+        path, known_values=None triggers false-positive hallucination hits.
+    """
+    assert number not in build_discovery_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# User-declared facts injection (fixes "n'a pas vu les 300'000")
+# ---------------------------------------------------------------------------
+
+
+def test_facts_block_absent_when_no_facts_supplied():
+    prompt = build_discovery_system_prompt(facts=None)
+    assert "<facts_user>" not in prompt
+    assert "</facts_user>" not in prompt
+
+
+def test_facts_block_included_verbatim_when_supplied():
+    prompt = build_discovery_system_prompt(
+        facts=[
+            "49 ans",
+            "salaire 7'600 CHF net/mois",
+            "LPP ≈ 300'000 CHF",
+        ],
+    )
+    assert "<facts_user>" in prompt
+    assert "</facts_user>" in prompt
+    # Each fact is quoted literally in the block.
+    assert "49 ans" in prompt
+    assert "7'600" in prompt
+    assert "300'000" in prompt
+
+
+def test_facts_block_tells_model_to_use_them():
+    prompt = build_discovery_system_prompt(facts=["49 ans"])
+    # The instruction must sit near the facts so Claude does not ignore them.
+    # Must not exceed prompt size: simple substring suffices.
+    lowered = prompt.lower()
+    assert "facts_user" in lowered
+    # Some directive to leverage the facts (either cite/reprends/utilise).
+    assert any(
+        kw in lowered
+        for kw in ("cite", "reprends", "utilise", "intègre", "appuie-toi")
+    )
+
+
+def test_intent_still_supported_alongside_facts():
+    prompt = build_discovery_system_prompt(
+        intent="Je me sens perdu",
+        facts=["49 ans"],
+    )
+    assert "Je me sens perdu" in prompt
+    assert "49 ans" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Shape invariants — keep the prompt short and readable
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_is_kept_compact():
+    prompt = build_discovery_system_prompt()
+    # v1 was ~900 chars. v2 should stay ≤ 1600 chars even with the new
+    # directives — if it balloons, Claude gets lost.
+    assert len(prompt) <= 1600, (
+        f"Prompt must stay compact; got {len(prompt)} chars. "
+        "Compactness is part of the contract — verbose prompts train verbose "
+        "responses."
+    )

--- a/services/backend/tests/test_profile_extractor_v2_patterns.py
+++ b/services/backend/tests/test_profile_extractor_v2_patterns.py
@@ -1,0 +1,222 @@
+"""
+v2 profile_extractor pattern tests (phase B).
+
+Expands anonymous-friendly patterns identified by the audit:
+- Monthly salary sentences ("7600 Fr net par mois") must be annualised ×12
+  with a plausibility gate (3k-40k/month ≈ 36k-480k/year).
+- "valeur de rachat" / "caisse de pension" / "avoir de vieillesse" map to
+  the LPP topic (user never says "LPP" explicitly in natural speech).
+- Existing patterns must keep working — regression guard.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.coach.profile_extractor import extract_profile_facts
+
+
+def _topics(message: str) -> set[str]:
+    return {f.topic for f in extract_profile_facts(message)}
+
+
+def _fact_by_topic(message: str, topic: str):
+    for f in extract_profile_facts(message):
+        if f.topic == topic:
+            return f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Monthly salary annualisation
+# ---------------------------------------------------------------------------
+
+
+def test_monthly_salary_fr_is_annualised():
+    fact = _fact_by_topic(
+        "je gagne 7600 Fr net par mois dans le Valais",
+        "salary",
+    )
+    assert fact is not None, "7600 CHF/mois must be captured — it's the "\
+        "commonest way Swiss residents state their salary."
+    # 7600 × 12 = 91'200 — within 15k-500k plausibility band.
+    assert fact.value == 7600 * 12
+    assert "net" in fact.text
+    assert "/an" in fact.text or "/mois" in fact.text
+
+
+def test_monthly_salary_without_net_brut_marker():
+    fact = _fact_by_topic("j'ai 8500 CHF par mois", "salary")
+    assert fact is not None
+    assert fact.value == 8500 * 12
+
+
+def test_monthly_salary_mensuel_variant():
+    fact = _fact_by_topic("mon salaire mensuel est de 6200 francs", "salary")
+    assert fact is not None
+    assert fact.value == 6200 * 12
+
+
+def test_monthly_salary_implausibly_low_rejected():
+    # 800/month × 12 = 9'600/year — below the 3k-40k/month band.
+    assert _fact_by_topic(
+        "je reçois 800 francs par mois de rente",
+        "salary",
+    ) is None
+
+
+def test_monthly_salary_implausibly_high_rejected():
+    # 80k/month × 12 = 960k/year — above 40k/month band.
+    assert _fact_by_topic(
+        "je gagne 80000 francs par mois",
+        "salary",
+    ) is None
+
+
+def test_annual_salary_still_works_after_monthly_patch():
+    """Regression guard — monthly pattern must not break existing annual
+    extraction."""
+    fact = _fact_by_topic("je gagne 95000 CHF brut par an", "salary")
+    assert fact is not None
+    assert fact.value == 95_000
+
+
+# ---------------------------------------------------------------------------
+# LPP natural language ("valeur de rachat", "caisse de pension")
+# ---------------------------------------------------------------------------
+
+
+def test_valeur_de_rachat_maps_to_lpp():
+    fact = _fact_by_topic(
+        "j'ai 300000 Fr de valeur de rachat dans ma caisse de pension",
+        "lpp",
+    )
+    assert fact is not None, (
+        "'valeur de rachat' is the dominant way Swiss residents refer to "
+        "their LPP — regex must match or MSG1 insights drop the number."
+    )
+    assert fact.value == 300_000
+
+
+def test_caisse_de_pension_alone_maps_to_lpp():
+    fact = _fact_by_topic(
+        "ma caisse de pension me verse 70377 CHF",
+        "lpp",
+    )
+    assert fact is not None
+    assert fact.value == 70_377
+
+
+def test_avoir_de_vieillesse_maps_to_lpp():
+    fact = _fact_by_topic(
+        "mon avoir de vieillesse est de 120'000 CHF",
+        "lpp",
+    )
+    assert fact is not None
+    assert fact.value == 120_000
+
+
+def test_lpp_explicit_keyword_still_works():
+    """Regression guard for existing LPP path."""
+    fact = _fact_by_topic("LPP 70'377 CHF", "lpp")
+    assert fact is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic first-message sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_full_first_message_all_topics_captured():
+    msg = (
+        "J'ai 49 ans, je gagne 7600 Fr net par mois dans le Valais, "
+        "et j'ai 300 000 Fr de valeur de rachat dans ma caisse de pension. "
+        "Qu'est-ce que je dois faire ?"
+    )
+    topics = _topics(msg)
+    assert "identity" in topics  # age 49
+    assert "salary" in topics    # 7600/mo × 12
+    assert "location" in topics  # Valais → VS
+    assert "lpp" in topics       # 300'000 via valeur de rachat
+
+    salary = _fact_by_topic(msg, "salary")
+    lpp = _fact_by_topic(msg, "lpp")
+    age = _fact_by_topic(msg, "identity")
+    assert salary.value == 7600 * 12
+    assert lpp.value == 300_000
+    assert age.value == 49
+
+
+# ---------------------------------------------------------------------------
+# Natural-language robustness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "valeur de rachat de 300000 CHF",
+        "j'ai 300'000 Fr de rachat possible",
+        "rachat possible de 539414 CHF",
+    ],
+)
+def test_rachat_variations(phrase: str):
+    fact = _fact_by_topic(phrase, "lpp")
+    assert fact is not None
+    # Accept a range — the detector should pick *some* valid LPP figure.
+    assert 70_000 <= fact.value <= 5_000_000
+
+
+# ---------------------------------------------------------------------------
+# Year-before-keyword collision (post-audit P2 #7)
+# ---------------------------------------------------------------------------
+
+
+def test_year_before_lpp_keyword_is_ignored():
+    """'en 2025 la caisse de pension a valu 70'000' must not extract 2025
+    as an LPP value. Require explicit currency marker on the BEFORE path."""
+    fact = _fact_by_topic(
+        "en 2025 la caisse de pension a valu 70'000",
+        "lpp",
+    )
+    # 2025 is NOT an LPP value. 70'000 may or may not be captured via the
+    # AFTER path (no keyword precedes it there) — either outcome is OK, as
+    # long as we don't return 2025.
+    if fact is not None:
+        assert fact.value != 2025
+
+
+def test_year_alone_never_captured_as_lpp():
+    assert _fact_by_topic("depuis 2020 dans la caisse de pension", "lpp") is None
+
+
+# ---------------------------------------------------------------------------
+# T-13-05 forbidden lexicon — facts must never leak the banned tokens into
+# the anonymous system prompt. Templated `text=` strings are the designed
+# defence — this test locks it in so a future `_extract_profession` that
+# emits "profil: cadre" or similar is caught at test time.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN = ("outil", "tool", "profil", "dossier", "memoire", "memory")
+
+
+@pytest.mark.parametrize(
+    "adversarial_message",
+    [
+        "j'utilise l'outil MINT pour mon dossier retraite",
+        "je veux un profil financier et une memoire durable",
+        "mon dossier est complet, memoire intacte, profil clair",
+        "my tool is my memory",
+        "49 ans, 7600 fr/mois, mon outil préféré c'est ce dossier",
+    ],
+)
+def test_facts_never_contain_forbidden_lexicon(adversarial_message: str):
+    facts = extract_profile_facts(adversarial_message)
+    for fact in facts:
+        lowered = fact.text.lower()
+        for banned in _FORBIDDEN:
+            assert banned not in lowered, (
+                f"Fact {fact!r} leaks T-13-05 forbidden token '{banned}'. "
+                f"Any future extractor that echoes user text into Fact.text "
+                f"must scrub or reject these tokens."
+            )

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -1249,6 +1249,79 @@
         "title": "AnomalyResponse",
         "type": "object"
       },
+      "AnonymousChatRequest": {
+        "description": "Request for anonymous discovery chat.\n\nNo authentication required. Limited to 3 messages per device token.",
+        "properties": {
+          "intent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Felt-state pill text selected by the user (e.g. 'Je me sens perdu').",
+            "title": "Intent"
+          },
+          "language": {
+            "default": "fr",
+            "description": "Langue de la reponse: 'fr', 'de', 'en', 'it'.",
+            "title": "Language",
+            "type": "string"
+          },
+          "message": {
+            "description": "Message de l'utilisateur anonyme.",
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "AnonymousChatRequest",
+        "type": "object"
+      },
+      "AnonymousChatResponse": {
+        "description": "Response for anonymous discovery chat.\n\nIncludes compliance disclaimers and remaining message count.",
+        "properties": {
+          "disclaimers": {
+            "description": "Disclaimers de conformite.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Disclaimers",
+            "type": "array"
+          },
+          "message": {
+            "description": "Reponse du coach en mode decouverte.",
+            "title": "Message",
+            "type": "string"
+          },
+          "messagesRemaining": {
+            "description": "Nombre de messages restants pour cette session anonyme.",
+            "maximum": 3.0,
+            "minimum": 0.0,
+            "title": "Messagesremaining",
+            "type": "integer"
+          },
+          "tokensUsed": {
+            "default": 0,
+            "description": "Estimation de l'utilisation de tokens.",
+            "minimum": 0.0,
+            "title": "Tokensused",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "message",
+          "messagesRemaining"
+        ],
+        "title": "AnonymousChatResponse",
+        "type": "object"
+      },
       "AppleVerifyPurchaseRequest": {
         "properties": {
           "expires_at": {
@@ -3698,6 +3771,25 @@
             "title": "Cashlevel",
             "type": "integer"
           },
+          "conversationHistory": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prior conversation messages for multi-turn context. Each item: {role: 'user'|'assistant', content: str}. Last 8 messages max. Sanitized client-side.",
+            "title": "Conversationhistory"
+          },
           "language": {
             "default": "fr",
             "description": "Langue de la reponse: 'fr', 'de', 'en', 'it'.",
@@ -4202,6 +4294,111 @@
           "icon"
         ],
         "title": "CoachingTipResponse",
+        "type": "object"
+      },
+      "CommitmentCreate": {
+        "description": "Request schema for creating a commitment device.",
+        "properties": {
+          "ifThenText": {
+            "maxLength": 500,
+            "title": "Ifthentext",
+            "type": "string"
+          },
+          "reminderAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderat"
+          },
+          "whenText": {
+            "maxLength": 500,
+            "title": "Whentext",
+            "type": "string"
+          },
+          "whereText": {
+            "maxLength": 500,
+            "title": "Wheretext",
+            "type": "string"
+          }
+        },
+        "required": [
+          "whenText",
+          "whereText",
+          "ifThenText"
+        ],
+        "title": "CommitmentCreate",
+        "type": "object"
+      },
+      "CommitmentResponse": {
+        "description": "Response schema for a commitment device.",
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "title": "Createdat",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "ifThenText": {
+            "title": "Ifthentext",
+            "type": "string"
+          },
+          "reminderAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderat"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "whenText": {
+            "title": "Whentext",
+            "type": "string"
+          },
+          "whereText": {
+            "title": "Wheretext",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "whenText",
+          "whereText",
+          "ifThenText",
+          "createdAt"
+        ],
+        "title": "CommitmentResponse",
+        "type": "object"
+      },
+      "CommitmentStatusUpdate": {
+        "description": "Request schema for updating commitment status.",
+        "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "CommitmentStatusUpdate",
         "type": "object"
       },
       "CommuneListResponse": {
@@ -9329,6 +9526,22 @@
         "title": "FranchiseOption",
         "type": "object"
       },
+      "FreshStartResponse": {
+        "properties": {
+          "landmarks": {
+            "items": {
+              "$ref": "#/components/schemas/LandmarkResponse"
+            },
+            "title": "Landmarks",
+            "type": "array"
+          }
+        },
+        "required": [
+          "landmarks"
+        ],
+        "title": "FreshStartResponse",
+        "type": "object"
+      },
       "FriBreakdownResponse": {
         "description": "FRI breakdown result — 4 components + total.",
         "properties": {
@@ -11940,6 +12153,39 @@
           "disclaimer"
         ],
         "title": "LamalOptionResponse",
+        "type": "object"
+      },
+      "LandmarkResponse": {
+        "properties": {
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "daysUntil": {
+            "title": "Daysuntil",
+            "type": "integer"
+          },
+          "intent": {
+            "title": "Intent",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "date",
+          "daysUntil",
+          "message",
+          "intent"
+        ],
+        "title": "LandmarkResponse",
         "type": "object"
       },
       "LibrePassageRequest": {
@@ -21065,7 +21311,7 @@
             "$ref": "#/components/schemas/DocumentType"
           },
           "imageBase64": {
-            "description": "Base64-encoded document image (JPEG/PNG)",
+            "description": "Base64-encoded document (JPEG, PNG, or PDF)",
             "maxLength": 5000000,
             "title": "Imagebase64",
             "type": "string"
@@ -21114,6 +21360,12 @@
           "extractionMethod": {
             "default": "claude_vision",
             "title": "Extractionmethod",
+            "type": "string"
+          },
+          "extractionStatus": {
+            "default": "success",
+            "description": "Extraction outcome: 'success' (fields extracted and validated), 'partial' (some fields extracted, some rejected by validation), 'no_fields_found' (Claude parsed OK but returned zero fields — document unreadable or empty), or 'parse_error' (Claude returned non-JSON). Flutter surfaces a targeted error for each status.",
+            "title": "Extractionstatus",
             "type": "string"
           },
           "overallConfidence": {
@@ -22755,6 +23007,48 @@
         ]
       }
     },
+    "/api/v1/anonymous/chat": {
+      "post": {
+        "description": "Anonymous discovery chat with device-scoped rate limiting.\n\nRequires X-Anonymous-Session header (UUID format).\nLimited to 3 messages per device token (lifetime).\nUses stripped-down discovery system prompt (no tools, no profile).",
+        "operationId": "anonymous_chat_api_v1_anonymous_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnonymousChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonymousChatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Anonymous Chat",
+        "tags": [
+          "Anonymous Chat P13"
+        ]
+      }
+    },
     "/api/v1/arbitrage/allocation-annuelle": {
       "post": {
         "description": "Compare les strategies d'allocation annuelle de l'epargne.\n\nSimule jusqu'a 4 options selon l'eligibilite:\n- 3a (si pas encore verse au max)\n- Rachat LPP (si potentiel de rachat > 0)\n- Amortissement indirect (si proprietaire)\n- Investissement libre (toujours disponible)\n\nReturns:\n    AllocationAnnuelleResponse avec trajectoires, breakeven, sensibilite,\n    disclaimer et sources legales.",
@@ -24254,6 +24548,209 @@
         "summary": "Coach Chat",
         "tags": [
           "Coach Chat S56"
+        ]
+      }
+    },
+    "/api/v1/coach/commitment/": {
+      "get": {
+        "description": "List user's commitments, optionally filtered by status.",
+        "operationId": "list_commitments_api_v1_coach_commitment__get",
+        "parameters": [
+          {
+            "description": "Filter by status (pending, completed, dismissed)",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by status (pending, completed, dismissed)",
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CommitmentResponse"
+                  },
+                  "title": "Response List Commitments Api V1 Coach Commitment  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Commitments",
+        "tags": [
+          "Commitment P14"
+        ]
+      },
+      "post": {
+        "description": "Create a new implementation intention commitment.\n\nT-14-08: Rate limit — max 50 pending commitments per user.\nT-14-07: Length validation enforced by Pydantic schema (500 char max).",
+        "operationId": "create_commitment_api_v1_coach_commitment__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitmentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Commitment",
+        "tags": [
+          "Commitment P14"
+        ]
+      }
+    },
+    "/api/v1/coach/commitment/{commitment_id}": {
+      "patch": {
+        "description": "Update commitment status (completed or dismissed).\n\nT-14-06: IDOR protection — query filters by BOTH commitment_id AND user_id.",
+        "operationId": "update_commitment_status_api_v1_coach_commitment__commitment_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "commitment_id",
+            "required": true,
+            "schema": {
+              "title": "Commitment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitmentStatusUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Commitment Status",
+        "tags": [
+          "Commitment P14"
+        ]
+      }
+    },
+    "/api/v1/coach/fresh-start/": {
+      "get": {
+        "description": "Return upcoming fresh-start landmarks with personalized messages.\n\nRate-limited to max 2 landmarks per calendar month (T-14-10).",
+        "operationId": "get_fresh_start_api_v1_coach_fresh_start__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FreshStartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Fresh Start",
+        "tags": [
+          "Fresh Start P14"
         ]
       }
     },
@@ -29631,7 +30128,7 @@
     },
     "/api/v1/profiles/me": {
       "get": {
-        "description": "Get the authenticated user's profile.\nReturns the most recently updated profile linked to the current user.",
+        "description": "Get the authenticated user's profile.\n\nGet-or-create semantics (FIX-B, 2026-04-13): if the authenticated user\nsomehow has no profile row (legacy account, partial migration, aborted\nbootstrap during auth), auto-create an empty one on the fly rather than\nreturning 404 forever. Every auth path SHOULD already call\n`ensure_empty_profile`, but this endpoint is the last line of defence\nfor the downstream screens that depend on a profile existing.",
         "operationId": "get_my_profile_api_v1_profiles_me_get",
         "responses": {
           "200": {


### PR DESCRIPTION
## Why

Pre-audit found the per-message disclaimer card was rendered after every coach reply (pecheDouce@15% container, ~56-68px), violating \`feedback_chat_must_be_silent.md\` and \`feedback_no_banality_wow.md\`. Zero LSFin/FINMA obligation to repeat per-message — obligation is "accessible at one tap".

State-of-the-art comparables (Cleo / Revolut / Wise / Stripe Atlas) : permanent slim footer, tap → modal canonical disclaimer.

## What

- Removed \`CoachDisclaimersSection\` widget + its per-message render in \`CoachMessageBubble\`. \`ChatMessage.disclaimers\` field preserved (API contract intact).
- Added \`CoachDisclaimerFooter\` — 1-line slim permanent footer in the chat Scaffold:
  - \`MintColors.textMutedAaa @ 40%\`, italic 11px micro text
  - Hit target ≥ 44×44pt, \`Semantics(button: true)\` for VoiceOver
  - Tap → modal bottom sheet with canonical disclaimer body (reuses existing \`coachDisclaimer\` ARB key — no i18n churn)

## Test plan

- [x] 5 new widget tests in \`coach_disclaimer_footer_test.dart\`: bubble no-longer-renders card, footer renders single line, semantic button label, 44pt hit target, tap opens sheet with canonical body
- [x] Existing \`coach_message_bubble_test.dart\` (9 tests) — still green
- [x] \`flutter analyze\` on 4 touched files → 0 new issues
- [ ] CI \`Flutter services\` + \`Flutter widgets\` green
- [ ] Post-merge on device: scroll chat — single slim footer at bottom, no red-pale card per-message

## Audit trail

Pre-audit (sector map, 4 parallel agents) confirmed: zero widget test asserted the removed card → no regression risk. Legal doctrine "effective disclosure" defends slim footer vs. cérémonial répété.

🤖 Generated with [Claude Code](https://claude.com/claude-code)