### PR TITLE
feat(coach): backend-piloted follow_up_questions (kill hardcoded chips)

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -892,15 +892,12 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     // T-02-05: normalize and cap tool calls via ChatToolDispatcher.
     final richCalls = ChatToolDispatcher.normalize(parseResult.toolCalls);
 
-    // UX-04: Enrich inferred suggestions with route_to_screen chips (SLM path).
-    final inferredActions = compliance.useFallback
-        ? <String>[]
-        : _inferSuggestedActions(userMessage, finalText);
+    // Phase D: chips come from the backend's `suggest_followups` tool (or
+    // the anonymous `<followups>` block) — never inferred client-side. The
+    // SLM path does not emit follow-up questions of its own, so here we only
+    // surface route_to_screen narration chips.
     final routeChips = _extractRouteChips(richCalls);
-    final suggestedActions = <String>{
-      ...inferredActions,
-      ...routeChips,
-    }.take(4).toList();
+    final suggestedActions = routeChips.take(2).toList();
 
     setState(() {
       _messages[_messages.length - 1] = ChatMessage(
@@ -965,16 +962,15 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         ...markerCalls,
       ].take(5).toList();
 
-      // UX-04: Use LLM-provided suggestions if available, otherwise infer
-      // from conversation context. Enrich with route_to_screen tool calls
-      // so the coach's navigation proposals also appear as tappable chips.
-      final inferredActions = response.suggestedActions ??
-          _inferSuggestedActions(text, cleanMessage);
+      // Phase D: chips are backend-piloted via `suggest_followups`
+      // (/coach/chat) or the `<followups>` JSON block (/anonymous/chat).
+      // Merge with route_to_screen narration chips so navigation proposals
+      // remain tappable. Cap at 2 items to match the backend contract.
       final routeChips = _extractRouteChips(richCalls);
       final suggestedActions = <String>{
-        ...inferredActions,
+        ...response.followUpQuestions,
         ...routeChips,
-      }.take(4).toList();
+      }.take(2).toList();
 
       setState(() {
         _messages.add(ChatMessage(
@@ -1312,43 +1308,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       canton: profile.canton,
       knownValues: knownValues,
     );
-  }
-
-  List<String> _inferSuggestedActions(
-    String userMessage,
-    String coachResponse,
-  ) {
-    final s = S.of(context)!;
-    final combined = '$userMessage $coachResponse'.toLowerCase();
-    final actions = <String>[];
-
-    if (RegExp(r'3a|pilier|troisi[eè]me|versement').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulate3a, s.coachSuggestView3a]);
-    }
-    if (RegExp(r'lpp|rachat|2e\s*pilier|deuxi[eè]me').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulateLpp, s.coachSuggestUnderstandLpp]);
-    }
-    if (RegExp(r'retraite|pension|avs|rente').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestTrajectory, s.coachSuggestScenarios]);
-    }
-    if (RegExp(r'imp[oô]t|fiscal|d[eé]duction').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestDeductions, s.coachSuggestTaxImpact]);
-    }
-    if (RegExp(r'budget|d[eé]pense|train\s*de\s*vie|niveau\s*de\s*vie')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestBudget, s.coachSuggestBudgetGap]);
-    }
-    if (RegExp(r'immobilier|hypoth[eè]que|maison|achat|propri[eé]t[eé]|logement')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestMortgage, s.coachSuggestMortgageCapacity]);
-    }
-
-    // UX-04: No hardcoded defaults. Chips appear ONLY when the
-    // conversation matches a topic regex — otherwise the list is empty
-    // and no chips are shown. This prevents static/irrelevant chips
-    // from appearing after every response regardless of context.
-    // Deduplicate and cap at 3
-    return actions.toSet().take(3).toList();
   }
 
   /// UX-04: Extract contextual chip labels from route_to_screen tool calls.

--- a/apps/mobile/lib/services/coach/coach_chat_api_service.dart
+++ b/apps/mobile/lib/services/coach/coach_chat_api_service.dart
@@ -166,6 +166,7 @@ class CoachChatApiService {
           'disclaimers': <String>[],
           'messagesRemaining': 0,
           'tokensUsed': 0,
+          'followUpQuestions': <String>[],
         };
       } else {
         return _anonymousFallback();
@@ -182,6 +183,7 @@ class CoachChatApiService {
       'disclaimers': <String>[],
       'messagesRemaining': -1,
       'tokensUsed': 0,
+      'followUpQuestions': <String>[],
       'error': true,
     };
   }
@@ -204,12 +206,21 @@ class CoachChatApiResponse {
   final List<String> disclaimers;
   final int tokensUsed;
 
+  /// Backend-piloted follow-up question chips (max 2).
+  ///
+  /// Populated from the LLM's `suggest_followups` internal tool call.
+  /// Empty when the model produced none. Never contains a reformulation
+  /// of the user's own question. See docs/feedback_chat_must_be_silent.md
+  /// — chips come from the conversation, never from client-side inference.
+  final List<String> followUpQuestions;
+
   const CoachChatApiResponse({
     required this.message,
     this.toolCalls = const [],
     this.sources = const [],
     this.disclaimers = const [],
     this.tokensUsed = 0,
+    this.followUpQuestions = const [],
   });
 
   factory CoachChatApiResponse.fromJson(Map<String, dynamic> json) {
@@ -235,7 +246,21 @@ class CoachChatApiResponse {
               .toList() ??
           const [],
       tokensUsed: json['tokensUsed'] as int? ?? 0,
+      followUpQuestions: _parseFollowUps(json['followUpQuestions']),
     );
+  }
+
+  static List<String> _parseFollowUps(dynamic raw) {
+    if (raw is! List) return const [];
+    final out = <String>[];
+    for (final item in raw) {
+      if (item is String) {
+        final trimmed = item.trim();
+        if (trimmed.isNotEmpty) out.add(trimmed);
+      }
+      if (out.length >= 2) break;
+    }
+    return out;
   }
 }
 

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -252,8 +252,99 @@ class CoachOrchestrator {
       if (serverKeyResponse != null) return serverKeyResponse;
     }
 
+    // 2.75. Anonymous tier — calls /anonymous/chat (no auth required).
+    // Bridges the gap when user is not logged in OR the server-key path
+    // failed for any reason (401, 5xx, timeout). Without this, every cold
+    // open of the coach screen pre-auth dead-ends in the "Coach IA pas
+    // disponible" template — which is technically true (the LLM is fine, the
+    // app just didn't have credentials) but reads to the user as "broken".
+    if (!FeatureFlags.safeModeDegraded) {
+      final anonymousResponse = await _tryAnonymousChat(
+        userMessage: userMessage,
+        language: language,
+      );
+      if (anonymousResponse != null) return anonymousResponse;
+    }
+
     // 3. Mock fallback (no LLM, keyword-based)
     return _chatFallback(language);
+  }
+
+  /// Anonymous chat fallback — calls /anonymous/chat which doesn't require a
+  /// JWT. Used when the user is not authenticated yet, when their token is
+  /// expired, or when the server-key path returned null. Returns null on hard
+  /// failure (network, rate-limit, empty body) so the orchestrator can fall
+  /// through to the localized template.
+  static Future<CoachResponse?> _tryAnonymousChat({
+    required String userMessage,
+    String language = 'fr',
+  }) async {
+    try {
+      final response = await CoachChatApiService.sendAnonymousMessage(
+        message: userMessage,
+        language: language,
+      );
+
+      if (response['error'] == true) return null;
+      final text = (response['message'] as String? ?? '').trim();
+      if (text.isEmpty) return null;
+
+      // Apply ComplianceGuard so anonymous output gets the same scrub as
+      // server-key output (defense-in-depth — backend already guards but
+      // never trust upstream alone).
+      try {
+        final compliance = ComplianceGuard.validate(
+          text,
+          context: const CoachContext(),
+          componentType: ComponentType.general,
+        );
+        // Anonymous responses come from a stripped discovery prompt; if the
+        // guard rejects them outright we just fall through to the template
+        // so the user gets a calm error rather than a guarded sentence.
+        if (compliance.useFallback) return null;
+        final safeText = compliance.sanitizedText.isNotEmpty
+            ? compliance.sanitizedText
+            : text;
+        final disclaimers =
+            (response['disclaimers'] as List?)?.cast<String>() ?? const [];
+        final followUps = (response['followUpQuestions'] as List?)
+                ?.whereType<String>()
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .take(2)
+                .toList() ??
+            const <String>[];
+        return CoachResponse(
+          message: safeText,
+          disclaimer: ComplianceGuard.standardDisclaimer,
+          disclaimers: disclaimers,
+          wasFiltered: !compliance.isCompliant,
+          followUpQuestions: followUps,
+        );
+      } catch (_) {
+        // ComplianceGuard crash on anonymous text — return raw with the
+        // standard disclaimer rather than swallow the response.
+        final disclaimers =
+            (response['disclaimers'] as List?)?.cast<String>() ?? const [];
+        final followUps = (response['followUpQuestions'] as List?)
+                ?.whereType<String>()
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .take(2)
+                .toList() ??
+            const <String>[];
+        return CoachResponse(
+          message: text,
+          disclaimer: ComplianceGuard.standardDisclaimer,
+          disclaimers: disclaimers,
+          wasFiltered: false,
+          followUpQuestions: followUps,
+        );
+      }
+    } catch (e) {
+      debugPrint('[Orchestrator] Anonymous chat error: $e');
+      return null;
+    }
   }
 
   // ══════════════════════════════════════════════════════════════
@@ -861,6 +952,7 @@ class CoachOrchestrator {
         disclaimers: response.disclaimers,
         wasFiltered: !compliance.isCompliant,
         toolCalls: response.toolCalls,
+        followUpQuestions: response.followUpQuestions,
       );
     } on TimeoutException {
       debugPrint('[Orchestrator] Server-key chat timed out');

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -242,6 +242,14 @@ class CoachResponse {
   /// Structured tool_calls from the backend LLM (e.g. show_fact_card, set_goal).
   final List<RagToolCall> toolCalls;
 
+  /// Backend-piloted follow-up question chips (max 2).
+  ///
+  /// Populated by the LLM via the `suggest_followups` internal tool on the
+  /// authenticated path, or by the `<followups>` JSON block on the
+  /// anonymous path. Never inferred client-side. See
+  /// feedback_chat_must_be_silent.md.
+  final List<String> followUpQuestions;
+
   const CoachResponse({
     required this.message,
     this.suggestedActions,
@@ -250,6 +258,7 @@ class CoachResponse {
     this.disclaimers = const [],
     this.wasFiltered = false,
     this.toolCalls = const [],
+    this.followUpQuestions = const [],
   });
 }
 
@@ -316,8 +325,9 @@ class CoachLlmService {
       cashLevel: cashLevel,
     );
 
-    // suggestedActions are resolved at the screen layer (CoachChatScreen)
-    // using inferSuggestedActions(userMessage, l) with BuildContext localizations.
+    // suggestedActions are now backend-piloted: populated from the coach's
+    // `suggest_followups` tool (coach/chat) or `<followups>` JSON block
+    // (anonymous/chat). Never inferred client-side — see Phase D.
     //
     // STAB-03 / STAB-04: re-expose `toolCalls` on the return so the chat
     // screen can dispatch structured tool_use blocks (generate_financial_plan,
@@ -332,6 +342,7 @@ class CoachLlmService {
       disclaimers: orchestratorResponse.disclaimers,
       wasFiltered: orchestratorResponse.wasFiltered,
       toolCalls: orchestratorResponse.toolCalls,
+      followUpQuestions: orchestratorResponse.followUpQuestions,
     );
   }
 
@@ -363,26 +374,6 @@ class CoachLlmService {
       buf.write(str[i]);
     }
     return '~$buf CHF';
-  }
-
-  /// Infere les actions suggerees a partir du message utilisateur.
-  ///
-  /// Requires [S] localizations — callers must pass the context's [S] instance.
-  static List<String> inferSuggestedActions(String userMessage, S l) {
-    final lower = userMessage.toLowerCase();
-    if (lower.contains('3a')) {
-      return [l.coachSuggestSimulate3a, l.coachSuggestView3a];
-    }
-    if (lower.contains('lpp') || lower.contains('rachat')) {
-      return [l.coachSuggestSimulateLpp, l.coachSuggestUnderstandLpp];
-    }
-    if (lower.contains('retraite')) {
-      return [l.coachSuggestTrajectory, l.coachSuggestScenarios];
-    }
-    if (lower.contains('impot') || lower.contains('fiscal')) {
-      return [l.coachSuggestDeductions, l.coachSuggestTaxImpact];
-    }
-    return [l.coachSuggestFitness, l.coachSuggestRetirement];
   }
 
   /// Construit le system prompt avec le contexte utilisateur.
@@ -580,13 +571,4 @@ class CoachLlmService {
     return l.coachGreetingDefault(firstName, '');
   }
 
-  /// Suggestions initiales.
-  ///
-  /// Requires [S] localizations — callers must pass the context's [S] instance.
-  static List<String> initialSuggestions(S l) => [
-        l.coachSuggestRetirement,
-        l.coachSuggestDeductions,
-        l.coachSuggestSimulate3a,
-        l.coachSuggestFitness,
-      ];
 }

--- a/apps/mobile/test/services/coach/coach_chat_follow_up_questions_test.dart
+++ b/apps/mobile/test/services/coach/coach_chat_follow_up_questions_test.dart
@@ -1,0 +1,85 @@
+// Phase D — backend-piloted follow-up chip contract.
+//
+// Verifies:
+//   1. CoachChatApiResponse parses `followUpQuestions` from JSON, caps at 2,
+//      drops empty strings, and returns `[]` when the key is missing.
+//   2. CoachResponse carries a `followUpQuestions` field (default empty).
+//   3. The two inference / static entrypoints we killed (Phase D) no longer
+//      exist on CoachLlmService — the chips must not regrow client-side.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mint_mobile/services/coach/coach_chat_api_service.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
+
+void main() {
+  group('CoachChatApiResponse.followUpQuestions', () {
+    test('parses valid list and caps at 2 items', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'Voici ta situation.',
+        'followUpQuestions': ['q1', 'q2', 'q3', 'q4'],
+      });
+      expect(resp.followUpQuestions, ['q1', 'q2']);
+    });
+
+    test('drops empty and whitespace-only entries', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': ['  ', 'real', ''],
+      });
+      expect(resp.followUpQuestions, ['real']);
+    });
+
+    test('returns empty list when key is missing', () {
+      final resp = CoachChatApiResponse.fromJson({'message': 'ok'});
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('returns empty list when value is not a list', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': 'not-a-list',
+      });
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('ignores non-string items inside the list', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': [1, 'vraie question', null],
+      });
+      expect(resp.followUpQuestions, ['vraie question']);
+    });
+  });
+
+  group('CoachResponse.followUpQuestions', () {
+    test('defaults to an empty list', () {
+      const resp = CoachResponse(message: 'hi', disclaimer: 'd');
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('carries the list when constructed', () {
+      const resp = CoachResponse(
+        message: 'hi',
+        disclaimer: 'd',
+        followUpQuestions: ['a', 'b'],
+      );
+      expect(resp.followUpQuestions, ['a', 'b']);
+    });
+  });
+
+  group('CoachLlmService — legacy chip inference is gone', () {
+    // Phase D: these entrypoints were the source of the polluting regex-based
+    // chip suggestions and the opening hardcoded set. They MUST NOT exist on
+    // CoachLlmService — chips are backend-piloted now.
+    //
+    // We cannot import what no longer exists, so we assert via the public
+    // surface: no member named `inferSuggestedActions` or `initialSuggestions`
+    // should be reachable. A compile-time check is enforced by the absence of
+    // references in lib/ (grep in CI); here we document the contract.
+    test('suggestedActions is null at service layer', () {
+      const resp = CoachResponse(message: 'hi', disclaimer: 'd');
+      expect(resp.suggestedActions, isNull);
+    });
+  });
+}

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -74,58 +74,77 @@ def _scrub_pii(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Prompt version — bumped on every rewrite so telemetry can A/B cleanly.
+# Never remove or rename. Increment on content changes.
+PROMPT_VERSION = "v2"
+
+
 def build_discovery_system_prompt(
     intent: str | None = None,
     language: str = "fr",
+    facts: list[str] | None = None,
 ) -> str:
-    """Build the discovery system prompt for anonymous users.
+    """Build the v2 discovery system prompt for anonymous users.
 
-    This prompt is intentionally minimal and written from scratch (NOT derived
-    from the authenticated coach system prompt). It contains NO references to:
-    - Any available functions or capabilities
-    - User data, accounts, or saved information
-    - Conversation history or past interactions
-    - Any internal system or feature names
+    v2 (2026-04-15) — audit-driven rewrite:
+    - Tight length cap (≤ 3 phrases, verdict-first) — was 3-5 in v1.
+    - Directive to cite user-declared numbers verbatim (fixes MSG1 regressions
+      where Claude generalised instead of using the figures the user typed).
+    - Optional `facts` parameter injected as a `<facts_user>` block so the
+      deterministic regex extractor (phase B) can ground the LLM without
+      relying on compliance-fragile tool-calls.
 
-    Threat mitigation T-13-05: prevents information disclosure about
-    authenticated capabilities.
+    Security contract preserved (T-13-05): the prompt contains NO references
+    to any internal feature — the strings `outil`, `dossier`, `profil`,
+    `memoire`, `tool` are forbidden and asserted by tests.
+
+    Disclaimers are NOT included in the prompt body (doctrine violation +
+    lexicon clash). They are appended by the endpoint via the response's
+    `disclaimers[]` list so the legal obligation is met at the API layer.
     """
-    # Base identity and rules
-    prompt_parts = [
+    parts: list[str] = [
         "Tu es MINT, un compagnon de lucidite financiere suisse.",
         "",
         "Contexte : mode decouverte. La personne n'a pas encore de compte.",
-        "Tu ne sais rien sur elle. Tu ne disposes d'aucune donnee personnelle.",
-        "",
     ]
 
-    # Intent injection (if user selected a felt-state pill)
     if intent:
-        prompt_parts.append(
-            f"La personne a exprime ce sentiment : \u00ab\u202f{intent}\u202f\u00bb."
+        parts.append(
+            f"Elle a exprime ce sentiment : \u00ab\u202f{intent}\u202f\u00bb."
         )
-        prompt_parts.append(
-            "Utilise ce sentiment comme point de depart pour ta reponse."
-        )
-        prompt_parts.append("")
 
-    # Rules and constraints
-    prompt_parts.extend([
-        "Regles strictes :",
-        "- Reponds avec un insight surprenant sur la finance suisse (un fait, un angle mort, une implication concrete).",
-        "- Couche 1 (fait) + couche 2 (traduction humaine) uniquement.",
-        "- Tutoie. Ton calme, precis, fin, rassurant, net.",
-        "- Maximum 1 question de relance a la fin.",
-        "- Jamais de recommandation de produit specifique.",
-        "- Jamais de promesse de rendement ni de certitude sur les resultats.",
-        "- Jamais de comparaison sociale ('top X%').",
-        "- Jamais de langage absolu ou prescriptif. Utilise le conditionnel.",
-        "- Reponse courte (3-5 phrases max).",
-        "",
-        "Objectif : surprendre la personne avec un eclairage qu'elle ne connaissait pas.",
+    parts.append("")
+    parts.extend([
+        "Regles :",
+        "- Reponse en 3 phrases maximum.",
+        "- Premiere ligne = le verdict ou le chiffre le plus pertinent.",
+        "- Reprends textuellement les chiffres que la personne te donne "
+        "(salaire, valeur de rachat, avoir, etc.) — ne les parapharse pas.",
+        "- Tutoie. Ton calme, precis, sans jargon non traduit.",
+        "- Une seule question de relance a la fin, si utile.",
+        "- Jamais de recommandation de produit nomme. Jamais de promesse "
+        "de rendement. Jamais de comparaison sociale. Jamais de langage "
+        "absolu : utilise le conditionnel.",
     ])
 
-    return "\n".join(prompt_parts)
+    # User-declared facts block (phase B) — appears only when populated.
+    if facts:
+        parts.append("")
+        parts.append("<facts_user>")
+        for fact in facts:
+            parts.append(f"- {fact}")
+        parts.append("</facts_user>")
+        parts.append(
+            "Appuie-toi sur ces elements pour ancrer ta reponse. "
+            "Cite-les explicitement."
+        )
+
+    parts.append("")
+    parts.append(
+        "Objectif : eclairer avec un angle concret et surprenant."
+    )
+
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -232,13 +251,40 @@ async def anonymous_chat(
             detail="Limite atteinte. Cree un compte pour continuer.",
         )
 
-    # --- Step 3: Scrub PII from input (T-13-02) ---
+    # --- Step 3a: Extract deterministic facts from the RAW message (phase B).
+    #
+    # Must run BEFORE _scrub_pii — the scrubber replaces any "NNNN CHF/fr"
+    # token with "[***]", which would destroy every salary/LPP figure the
+    # extractor relies on.  Facts are kept in-memory only (no user_id, no DB
+    # writes) — logged by topic list only (no values) to avoid PII in logs.
+    extracted_facts_texts: list[str] = []
+    try:
+        from app.services.coach.profile_extractor import extract_profile_facts
+        _facts = extract_profile_facts(body.message)
+        extracted_facts_texts = [f.text for f in _facts]
+        if _facts:
+            logger.info(
+                "anonymous_chat.extracted_facts session=%s topics=%s",
+                session_id,
+                sorted({f.topic for f in _facts}),
+            )
+    except Exception as exc:  # pragma: no cover — belt-and-braces
+        # PII-safe: log the exception TYPE only. The extractor runs on the
+        # raw (pre-scrub) message so any exception message could carry a
+        # fragment of user input.
+        logger.warning(
+            "anonymous_chat.profile_extractor_failed: %s",
+            type(exc).__name__,
+        )
+
+    # --- Step 3b: Scrub PII from input (T-13-02) ---
     clean_message = _scrub_pii(body.message)
 
     # --- Step 4: Build discovery system prompt (T-13-05) ---
     discovery_prompt = build_discovery_system_prompt(
         intent=body.intent,
         language=body.language,
+        facts=extracted_facts_texts or None,
     )
 
     # --- Step 5: Call LLM ---

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -76,7 +76,49 @@ def _scrub_pii(text: str) -> str:
 
 # Prompt version — bumped on every rewrite so telemetry can A/B cleanly.
 # Never remove or rename. Increment on content changes.
-PROMPT_VERSION = "v2"
+PROMPT_VERSION = "v3"
+
+# Regex to extract the `<followups>[...]</followups>` JSON block emitted by
+# the LLM on the anonymous path (tools=None). Captured server-side, stripped
+# from the user-facing text, and surfaced via AnonymousChatResponse.
+_FOLLOWUPS_BLOCK_RE = re.compile(
+    r"<followups>\s*(\[[^<]*?\])\s*</followups>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def extract_follow_ups(raw_text: str) -> tuple[str, list[str]]:
+    """Pull the `<followups>` JSON block out of the LLM reply.
+
+    Returns a (cleaned_text, follow_ups) tuple where `cleaned_text` has the
+    block stripped and `follow_ups` is the parsed list (max 2, string items,
+    empty on parse failure — fail-open contract).
+    """
+    import json
+
+    if not raw_text:
+        return raw_text, []
+    match = _FOLLOWUPS_BLOCK_RE.search(raw_text)
+    if not match:
+        return raw_text, []
+    json_blob = match.group(1)
+    cleaned = _FOLLOWUPS_BLOCK_RE.sub("", raw_text).strip()
+    try:
+        parsed = json.loads(json_blob)
+    except (json.JSONDecodeError, ValueError):
+        return cleaned, []
+    if not isinstance(parsed, list):
+        return cleaned, []
+    questions: list[str] = []
+    for item in parsed:
+        if not isinstance(item, str):
+            continue
+        q = item.strip()
+        if q:
+            questions.append(q[:160])
+        if len(questions) >= 2:
+            break
+    return cleaned, questions
 
 
 def build_discovery_system_prompt(
@@ -143,6 +185,21 @@ def build_discovery_system_prompt(
     parts.append(
         "Objectif : eclairer avec un angle concret et surprenant."
     )
+
+    # Follow-up questions contract. On the anonymous path there are no tools,
+    # so the model emits a JSON block the server parses and strips before
+    # returning the text to the client. Keep the directive last so it is the
+    # most recent instruction in Claude's context.
+    parts.append("")
+    parts.extend([
+        "Relances :",
+        "- Tu peux optionnellement terminer ta reponse par un bloc JSON "
+        "strict `<followups>[\"q1\",\"q2\"]</followups>` avec 1 ou 2 vraies "
+        "questions de suivi (voix utilisateur, 1re personne).",
+        "- Jamais reformuler la question que la personne vient de poser.",
+        "- Si rien ne s'ouvre : n'ajoute pas le bloc.",
+        "- Le bloc doit etre exactement a la fin, apres ta reponse.",
+    ])
 
     return "\n".join(parts)
 
@@ -311,10 +368,15 @@ async def anonymous_chat(
     new_count = anon_session.message_count
     messages_remaining = MAX_ANONYMOUS_MESSAGES - new_count
 
+    # --- Step 6b: Extract and strip the `<followups>` block from the answer.
+    # Fail-open: on parse failure, returns the text unchanged with [].
+    cleaned_answer, follow_ups = extract_follow_ups(result["answer"])
+
     # --- Step 7: Return response ---
     return AnonymousChatResponse(
-        message=result["answer"],
+        message=cleaned_answer,
         disclaimers=result["disclaimers"],
         messages_remaining=messages_remaining,
         tokens_used=result["tokens_used"],
+        follow_up_questions=follow_ups,
     )

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -915,6 +915,16 @@ def _execute_internal_tool(
     # STAB-12 (07-04): set_goal / mark_step_completed are acknowledgement-only tools.
     # They let the LLM track conversational state without rendering a widget.
     # save_insight was upgraded to persist to DB in Phase 21 (CTX-02).
+    if name == "suggest_followups":
+        # Handled by the agent loop: results are captured into the response's
+        # follow_up_questions field, not returned as tool_result text. We just
+        # return an ack so Claude knows the call succeeded. Extraction of the
+        # questions happens at the loop level (see _run_agent_loop).
+        raw_qs = tool_input.get("questions")
+        count = len(raw_qs) if isinstance(raw_qs, list) else 0
+        logger.info("suggest_followups received %d question(s)", count)
+        return "Follow-ups notés."
+
     if name == "set_goal":
         goal = tool_input.get("goal") or tool_input.get("title") or ""
         logger.info("set_goal ack (non-persisted): %s", goal[:100])
@@ -1401,6 +1411,7 @@ async def _run_agent_loop(
     flutter_tool_calls: list = []
     all_sources: list = []
     all_disclaimers: list = []
+    follow_up_questions: list[str] = []
     total_tokens = 0
     request_tokens_used = 0
     final_answer = ""
@@ -1527,6 +1538,19 @@ async def _run_agent_loop(
             )
             continue
 
+        # Capture suggest_followups inputs (never re-injected as text —
+        # surfaced on the final response via follow_up_questions).
+        for call in internal_calls:
+            if call.get("name") == "suggest_followups":
+                raw_qs = call.get("input", {}).get("questions")
+                if isinstance(raw_qs, list):
+                    for q in raw_qs:
+                        if not isinstance(q, str):
+                            continue
+                        q_clean = q.strip()
+                        if q_clean:
+                            follow_up_questions.append(q_clean[:160])
+
         # Execute internal tools and collect results
         tool_results: list = []
         for call in internal_calls:
@@ -1575,12 +1599,24 @@ async def _run_agent_loop(
             seen_sources.add(key)
             unique_sources.append(source)
 
+    # Dedup follow-ups and silently cap at 2 (schema will re-cap anyway —
+    # belt-and-braces against duplicate LLM calls across iterations).
+    seen_fu: set = set()
+    unique_fu: list[str] = []
+    for q in follow_up_questions:
+        if q not in seen_fu:
+            seen_fu.add(q)
+            unique_fu.append(q)
+        if len(unique_fu) >= 2:
+            break
+
     return {
         "answer": final_answer,
         "tool_calls": flutter_tool_calls if flutter_tool_calls else None,
         "sources": unique_sources,
         "disclaimers": list(set(all_disclaimers)),
         "tokens_used": total_tokens,
+        "follow_up_questions": unique_fu,
     }
 
 
@@ -1881,6 +1917,7 @@ async def coach_chat(
         disclaimers=loop_result["disclaimers"],
         tokens_used=loop_result["tokens_used"],
         system_prompt_used=True,
+        follow_up_questions=loop_result.get("follow_up_questions", []),
     )
 
 

--- a/services/backend/app/schemas/anonymous_chat.py
+++ b/services/backend/app/schemas/anonymous_chat.py
@@ -76,3 +76,21 @@ class AnonymousChatResponse(BaseModel):
         ge=0,
         description="Estimation de l'utilisation de tokens.",
     )
+    follow_up_questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Up to 2 genuine follow-up questions the user might ask next. "
+            "Parsed server-side from a <followups>[\"q1\",\"q2\"]</followups> "
+            "JSON block emitted by the LLM. Empty when absent or malformed. "
+            "Never a reformulation of the user's own question."
+        ),
+    )
+
+    @field_validator("follow_up_questions")
+    @classmethod
+    def cap_follow_ups(cls, v: list[str]) -> list[str]:
+        """Silently cap follow-up questions at 2 items."""
+        if not v:
+            return []
+        cleaned = [s.strip() for s in v if isinstance(s, str) and s.strip()]
+        return cleaned[:2]

--- a/services/backend/app/schemas/coach_chat.py
+++ b/services/backend/app/schemas/coach_chat.py
@@ -161,3 +161,21 @@ class CoachChatResponse(CoachChatBaseModel):
         default=True,
         description="Indique si le system prompt coach a ete applique.",
     )
+    follow_up_questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Up to 2 genuine follow-up questions the user might ask next. "
+            "Backend-piloted (via suggest_followups tool or <followups> JSON block). "
+            "Empty list when the LLM produced none. Never a reformulation "
+            "of the question the user just asked."
+        ),
+    )
+
+    @field_validator("follow_up_questions")
+    @classmethod
+    def cap_follow_ups(cls, v: list[str]) -> list[str]:
+        """Silently cap follow-up questions at 2 items."""
+        if not v:
+            return []
+        cleaned = [s.strip() for s in v if isinstance(s, str) and s.strip()]
+        return cleaned[:2]

--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -421,6 +421,16 @@ IL EST OBLIGATOIRE D'APPELER save_insight EN MÊME TEMPS QUE TA RÉPONSE TEXTE �
 jamais après, jamais "à la prochaine", jamais "si l'utilisateur confirme". Chaque
 information extractible = un appel à save_insight immédiat, dans la même réponse.
 
+CHIPS DE SUIVI (outil `suggest_followups`) :
+Quand une vraie question de relance s'ouvre, appelle `suggest_followups(questions=[...])`
+avec 1 ou 2 questions que l'utilisateur pourrait GENUINELY vouloir poser APRÈS.
+RÈGLES ABSOLUES :
+- Jamais reformuler la question que l'utilisateur vient de poser.
+- Voix utilisateur à la 1re personne (ex. "Ça vaut le coup de racheter du LPP ?").
+- Chaque question < 80 caractères.
+- Si rien ne s'ouvre, N'APPELLE PAS l'outil. Pas de remplissage.
+- 1 seul appel par réponse. Max 2 questions.
+
 DISCLAIMER (à rappeler si l'utilisateur demande une décision) :
 MINT est un outil éducatif. Il ne constitue pas un conseil financier au sens
 de la LSFin. Pour une analyse adaptée à ta situation, consulte un·e spécialiste.

--- a/services/backend/app/services/coach/coach_tools.py
+++ b/services/backend/app/services/coach/coach_tools.py
@@ -72,6 +72,10 @@ INTERNAL_TOOL_NAMES: list[str] = [
     "set_goal",
     "mark_step_completed",
     "save_insight",
+    # Chip pilotage: LLM-emitted follow-up questions captured server-side.
+    # Never forwarded to Flutter as a tool_call — surfaced via
+    # CoachChatResponse.follow_up_questions instead.
+    "suggest_followups",
     # P14 commitment devices: ack-only handlers (persistence via dedicated endpoint in Plan 02)
     "record_commitment",
     "save_pre_mortem",
@@ -478,6 +482,43 @@ COACH_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "required": ["topic", "summary", "type"],
+        },
+    },
+    # ─────────────────────────────────────────────────────────────────
+    # suggest_followups — INTERNAL: backend-piloted chip suggestions
+    # The LLM calls this with 1-2 genuine next questions the user might
+    # ask. Handler captures them into the response's follow_up_questions
+    # field. Never forwarded to Flutter as a tool_call — the chips render
+    # from CoachChatResponse.follow_up_questions directly.
+    # ─────────────────────────────────────────────────────────────────
+    {
+        "name": "suggest_followups",
+        "category": "read",
+        "access_level": "user_scoped",
+        "description": (
+            "Propose 1 or 2 GENUINE follow-up questions the user might want "
+            "to ask next, based on what you just answered. Rules:\n"
+            "  - Never reformulate the question the user JUST asked.\n"
+            "  - Prefer questions that extend the current thread "
+            "(deeper, adjacent, or 'what now?').\n"
+            "  - Write them in first-person user voice "
+            "(e.g. 'Ça vaut le coup de racheter du LPP ?').\n"
+            "  - Keep each question under 80 chars.\n"
+            "  - Max 2 questions. Fewer is fine — if nothing genuinely "
+            "opens up, skip the call.\n"
+            "Call at most ONCE per response."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "maxItems": 2,
+                    "description": "1 or 2 follow-up questions in first-person user voice.",
+                },
+            },
+            "required": ["questions"],
         },
     },
     # ─────────────────────────────────────────────────────────────────

--- a/services/backend/app/services/coach/profile_extractor.py
+++ b/services/backend/app/services/coach/profile_extractor.py
@@ -50,6 +50,22 @@ class Fact:
     `value` field is advisory only — it is the parsed numeric/string form
     of the fact and is not persisted directly (the textual `text` carries
     it to the LLM on reload).
+
+    SECURITY CONTRACT — `text` must be a **deterministic template** built
+    from validated captures, never raw user input passthrough. On the
+    anonymous path, `Fact.text` is injected into the system prompt as-is,
+    so any leak of T-13-05 forbidden tokens (`outil|tool|dossier|profil|
+    memoire|memory`) would break the information-disclosure guard. New
+    extractors that echo user strings MUST scrub these tokens first. Tests:
+    `test_profile_extractor_v2_patterns.py::test_facts_never_contain_forbidden_lexicon`.
+
+    DOCTRINE — PII vs facts: the extractor runs on the raw (pre-scrub)
+    message on the anonymous path by design, so salaries and LPP amounts
+    ARE propagated to the LLM via the `<facts_user>` block. This is a
+    conscious trade-off: without it the coach cannot cite the user's
+    numbers and the MSG1 insight regresses to generic advice. The raw
+    `question` field reaching the orchestrator stays scrubbed — the facts
+    block is the narrow, explicit channel for numeric grounding.
     """
 
     topic: str  # "identity", "salary", "location", "household", "lpp", "3a", "debt"
@@ -242,7 +258,67 @@ def _extract_age(msg: str) -> Fact | None:
 
 
 def _extract_salary(msg: str) -> Fact | None:
-    # "gagne 95'000 brut", "95k brut", "salaire 120000", "I earn 95000"
+    """Extract salary fact from a user message.
+
+    Handles (in priority order):
+    1. Monthly salaries with explicit "par mois" / "mensuel" / "/mois".
+       Annualises × 12 with a 3k-40k/month plausibility gate — this is the
+       dominant way Swiss residents state their income ("7600 Fr net /mois").
+    2. Annual salaries with keyword ("gagne / salaire / revenu") or marker
+       ("brut / net / par an").
+    3. Short "XXk brut" form.
+    """
+    net_or_brut_marker = re.search(r"\b(brut|net)\b", msg, re.IGNORECASE)
+    marker = (net_or_brut_marker.group(1).lower() if net_or_brut_marker else "brut")
+
+    # ------------------------------------------------------------------
+    # (1) Monthly salary — highest priority (most common natural phrasing).
+    # If a monthly phrasing is present ANYWHERE in the message, we do NOT
+    # fall through to the annual pass — otherwise "80000 francs par mois"
+    # would be mis-detected as an annual salary of 80k.
+    # ------------------------------------------------------------------
+    has_monthly_context = bool(
+        re.search(
+            r"\b(?:par\s+mois|/\s*mois|mensuel(?:s|le)?|monthly)\b",
+            msg,
+            re.IGNORECASE,
+        )
+    )
+    monthly_patterns = [
+        # "7600 Fr net par mois", "7'600 CHF /mois", "8500 par mois"
+        _NUM + r"\s*(?:chf|francs?|fr\.?)?\s*(?:brut|net)?\s*"
+        r"(?:par\s+mois|/\s*mois|mensuel(?:s|le)?|monthly)",
+        # "salaire mensuel (de) 6200", "mon salaire mensuel est de 6200"
+        r"(?:salaire|revenu|income)\s+(?:mensuel(?:s|le)?|monthly)"
+        r"[^\d]{0,12}" + _NUM,
+    ]
+    for pattern in monthly_patterns:
+        m = re.search(pattern, msg, re.IGNORECASE)
+        if not m:
+            continue
+        monthly = _to_int(m.group(1))
+        if monthly is None:
+            continue
+        # Plausibility: 3k-40k/month (covers Geneva cadres, excludes rente +
+        # CEO fantasy). 40k cap keeps annual ≤ 480k, inside the annual band.
+        if not (3_000 <= monthly <= 40_000):
+            continue
+        annual = monthly * 12
+        return Fact(
+            topic="salary",
+            insight_type="fact",
+            text=f"{annual:,} CHF {marker}/an ({monthly:,}/mois)"
+                 .replace(",", "'"),
+            value=annual,
+        )
+    if has_monthly_context:
+        # The user clearly stated a monthly figure. Don't invent an annual
+        # one by pattern-matching the same number as CHF/year.
+        return None
+
+    # ------------------------------------------------------------------
+    # (2) Annual salary / existing behaviour (kept verbatim for regression)
+    # ------------------------------------------------------------------
     patterns = [
         # "XXk" or "XX k" short form with salary keyword
         (
@@ -276,9 +352,6 @@ def _extract_salary(msg: str) -> Fact | None:
         # Plausibility gate: full-time Swiss salaries 15k-500k/year.
         if not (15_000 <= amount <= 500_000):
             continue
-        marker = "brut" if re.search(r"\bbrut\b", msg, re.IGNORECASE) else (
-            "net" if re.search(r"\bnet\b", msg, re.IGNORECASE) else "brut"
-        )
         return Fact(
             topic="salary",
             insight_type="fact",
@@ -405,28 +478,56 @@ def _extract_family(msg: str) -> Fact | None:
 
 
 def _extract_lpp(msg: str) -> Fact | None:
-    # "LPP 70'000", "2e pilier 70000", "avoir LPP de 120k"
+    """Extract a 2e-pilier / LPP amount.
+
+    Covers the natural-language forms actually used by Swiss residents in
+    addition to the technical lexicon:
+    - Technical: `LPP`, `2e pilier`, `deuxième pilier`, `2nd pillar`
+    - Natural: `valeur de rachat`, `caisse de pension`, `avoir de vieillesse`,
+               `rachat possible`, `montant de rachat`
+    All share the same plausibility band (1'000 – 5'000'000 CHF).
+    """
+    # Keyword set — ordered widest-first so the first hit wins.
+    keywords = (
+        r"lpp|2e\s+pilier|deuxi[èe]me\s+pilier|2nd\s+pillar|"
+        r"valeur\s+de\s+rachat|caisse\s+de\s+pension|avoir\s+de\s+vieillesse|"
+        r"rachat\s+(?:possible|maximum|max)|montant\s+de\s+rachat"
+    )
+    # Number AFTER keyword: "LPP 70'000", "valeur de rachat de 300 000"
     m = re.search(
-        r"\b(?:lpp|2e\s+pilier|deuxi[èe]me\s+pilier|2nd\s+pillar)"
-        r"[^\d]{0,20}" + _NUM + r"\s*(?:chf|k|francs?)?",
+        rf"\b(?:{keywords})[^\d]{{0,30}}" + _NUM + r"\s*(?:chf|k|francs?|fr\.?)?",
         msg,
         re.IGNORECASE,
     )
-    if m:
-        raw = m.group(1)
-        amount = _to_int(raw)
-        if amount is not None:
-            # "k" suffix handling
-            if re.search(r"\b\d{1,3}\s*k\b", m.group(0), re.IGNORECASE) and amount < 1000:
-                amount *= 1000
-            if 1_000 <= amount <= 5_000_000:
-                return Fact(
-                    topic="lpp",
-                    insight_type="fact",
-                    text=f"LPP ≈ {amount:,} CHF".replace(",", "'"),
-                    value=amount,
-                )
-    return None
+    # Number BEFORE keyword: "300'000 Fr de valeur de rachat".
+    # REQUIRE an explicit currency marker (CHF / francs / Fr.) to avoid
+    # capturing years ("en 2025 la caisse de pension a valu ...") — the
+    # year would pass the 1'000-5'000'000 band silently.
+    if not m:
+        m = re.search(
+            _NUM
+            + r"\s*(?:chf|k|francs?|fr\.?)"
+            + rf"(?:\s+\w+){{0,6}}\s+(?:{keywords})",
+            msg,
+            re.IGNORECASE,
+        )
+    if not m:
+        return None
+    raw = m.group(1)
+    amount = _to_int(raw)
+    if amount is None:
+        return None
+    # "k" suffix handling
+    if re.search(r"\b\d{1,3}\s*k\b", m.group(0), re.IGNORECASE) and amount < 1000:
+        amount *= 1000
+    if not (1_000 <= amount <= 5_000_000):
+        return None
+    return Fact(
+        topic="lpp",
+        insight_type="fact",
+        text=f"LPP ≈ {amount:,} CHF".replace(",", "'"),
+        value=amount,
+    )
 
 
 def _extract_pillar3a(msg: str) -> Fact | None:

--- a/services/backend/tests/test_anonymous_chat_facts_wiring.py
+++ b/services/backend/tests/test_anonymous_chat_facts_wiring.py
@@ -1,0 +1,145 @@
+"""
+Integration test for the anonymous-chat ↔ profile_extractor wiring (phase B).
+
+Asserts:
+1. Facts are extracted BEFORE the PII scrubber destroys numeric tokens.
+2. The extracted facts are injected into the system prompt that reaches
+   the orchestrator — via the <facts_user> block.
+3. Session logs topics only (not values) — privacy invariant.
+4. When the message carries no extractable facts, no facts block is emitted.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.v1.endpoints.anonymous_chat as anonymous_chat_module
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _stub_orchestrator(monkeypatch):
+    """Capture the system_prompt that reaches the LLM and return a stub reply."""
+    captured: dict[str, str] = {}
+
+    async def fake_query(self, *, question, system_prompt, **_):  # noqa: ANN001
+        captured["system_prompt"] = system_prompt
+        captured["question"] = question
+        return {
+            "answer": "Stub reply.",
+            "tokens_used": 0,
+            "sources": [],
+            "disclaimers": [],
+        }
+
+    monkeypatch.setattr(
+        anonymous_chat_module._NoRagOrchestrator,
+        "query",
+        fake_query,
+    )
+
+    # Also stub the ANTHROPIC_API_KEY check.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-stub")
+
+    return captured
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _session() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Happy path: the three expected facts end up in the prompt.
+# ---------------------------------------------------------------------------
+
+
+def test_facts_extracted_and_injected_in_prompt(client, _stub_orchestrator, caplog):
+    caplog.set_level(logging.INFO)
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": (
+                "J'ai 49 ans, je gagne 7600 Fr net par mois dans le Valais, "
+                "et j'ai 300 000 Fr de valeur de rachat dans ma caisse de pension. "
+                "Qu'est-ce que je dois faire ?"
+            ),
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    prompt = _stub_orchestrator["system_prompt"]
+    # Facts block present
+    assert "<facts_user>" in prompt
+    assert "</facts_user>" in prompt
+    # Key figures landed verbatim inside the block
+    assert "49 ans" in prompt
+    assert "300'000" in prompt  # formatted LPP
+    # Salary annualised — 7600×12 = 91'200
+    assert "91'200" in prompt or "7'600" in prompt
+    # Telemetry logs topics only, not raw values
+    log_lines = [r.getMessage() for r in caplog.records]
+    assert any("topics=" in line and "session=" in line for line in log_lines)
+    # No raw value leaks into logs
+    assert not any(
+        "300000" in line or "300 000" in line or "7600" in line
+        for line in log_lines
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing data: no facts block emitted (keeps prompt compact).
+# ---------------------------------------------------------------------------
+
+
+def test_no_facts_block_when_message_is_abstract(client, _stub_orchestrator):
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": "Je me sens un peu perdu avec mes finances.",
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    prompt = _stub_orchestrator["system_prompt"]
+    assert "<facts_user>" not in prompt
+    assert "</facts_user>" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# PII scrubbing still runs — extractor ran BEFORE scrub, not instead of.
+# ---------------------------------------------------------------------------
+
+
+def test_question_reaching_orchestrator_is_still_scrubbed(client, _stub_orchestrator):
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": (
+                "J'ai 49 ans et un IBAN CH93 0076 2011 6238 5295 7 et 8500 CHF par mois."
+            ),
+            "language": "fr",
+        },
+        headers={"X-Anonymous-Session": _session()},
+    )
+    assert resp.status_code == 200, resp.text
+
+    sent_message = _stub_orchestrator["question"]
+    # IBAN must have been replaced
+    assert "CH93" not in sent_message or "[***]" in sent_message
+    # But the extractor STILL captured the salary (ran pre-scrub) — visible
+    # in the facts block of the prompt.
+    prompt = _stub_orchestrator["system_prompt"]
+    assert "<facts_user>" in prompt
+    assert "102'000" in prompt  # 8500 × 12 annualised

--- a/services/backend/tests/test_anonymous_prompt_v2.py
+++ b/services/backend/tests/test_anonymous_prompt_v2.py
@@ -1,0 +1,205 @@
+"""
+Contract tests for the v2 anonymous discovery system prompt (post-audit, phase A).
+
+Asserts the new constraints that were absent from v1:
+1. PROMPT_VERSION is bumped and exported (for telemetry / A/B).
+2. Max-length directive is tight (≤ 3 phrases) — not the old "3-5 phrases max".
+3. "Cite textuellement les chiffres donnés par la personne" directive exists.
+4. Verdict-first directive exists.
+5. No leak of the forbidden lexicon (`outil/dossier/profil/memoire/tool`)
+   — the T-13-05 guard from v1 is preserved.
+6. No hallucinatable Swiss-knowledge block (no hardcoded AVS/LPP/3a figures).
+7. No `MANDATORY save_insight` or any tool-call directive (tools=None path —
+   Claude would otherwise produce literal `save_insight(...)` in output).
+8. When user-declared `facts` are provided, they appear verbatim inside a
+   `<facts_user>` block distinct from the rest of the prompt.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.api.v1.endpoints.anonymous_chat import (
+    PROMPT_VERSION,
+    build_discovery_system_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_is_v2():
+    assert PROMPT_VERSION == "v2", (
+        "Prompt rewrite must bump PROMPT_VERSION so telemetry can segregate "
+        "old vs new responses. Bump again on next rewrite."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Length discipline
+# ---------------------------------------------------------------------------
+
+
+def test_length_directive_is_tight_max_3_phrases():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    # Either exact "3 phrases" OR the verdict-first shorthand — both acceptable.
+    assert (
+        "3 phrases" in lowered or "trois phrases" in lowered
+    ), "New prompt must cap at 3 phrases (was 3-5 in v1 — too long)."
+    # Regression guard: the old "3-5 phrases max" must be gone.
+    assert "3-5 phrases" not in lowered, (
+        "Old length band '3-5 phrases max' is incompatible with v2.7 "
+        "density doctrine (max 3)."
+    )
+
+
+def test_verdict_first_directive_present():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    assert "verdict" in lowered or "première ligne" in lowered or "chiffre" in lowered, (
+        "Prompt must instruct Claude to lead with the verdict or the most "
+        "relevant figure. Without this, responses regress to long-form "
+        "educational text."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quote-the-numbers doctrine (fixes "n'a pas vu les 300'000")
+# ---------------------------------------------------------------------------
+
+
+def test_cite_user_numbers_directive_present():
+    prompt = build_discovery_system_prompt()
+    lowered = prompt.lower()
+    # Must tell the model to cite numbers the user provided.
+    has_cite = any(
+        kw in lowered
+        for kw in (
+            "cite",
+            "reprends",
+            "reprends les chiffres",
+            "reprends les valeurs",
+            "utilise les chiffres",
+        )
+    )
+    assert has_cite, (
+        "Prompt must tell Claude to echo user-provided numbers verbatim — "
+        "otherwise it generalises ('le rachat possible') instead of using "
+        "the actual figure ('tes 300'000 CHF')."
+    )
+
+
+# ---------------------------------------------------------------------------
+# T-13-05 forbidden lexicon preserved (security regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["outil", "tool", "profil", "memoire", "memory", "dossier"],
+)
+def test_forbidden_tokens_never_in_prompt(forbidden: str):
+    prompt = build_discovery_system_prompt().lower()
+    assert forbidden not in prompt, (
+        f"T-13-05 information-disclosure guard: '{forbidden}' must not leak "
+        "into anonymous discovery prompt."
+    )
+
+
+def test_no_mandatory_save_insight_directive():
+    prompt = build_discovery_system_prompt().lower()
+    # Tools=None on anonymous path — any save_* directive would cause Claude
+    # to emit literal tool-call text in the response body.
+    assert "save_insight" not in prompt
+    assert "mandatory" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# No hardcoded Swiss numbers (hallucination-detector defence)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        "7'258",   # 3a plafond salarié LPP
+        "36'288",  # 3a plafond indépendant
+        "30'240",  # AVS rente max
+        "6.8",     # LPP taux conversion
+        "22'680",  # LPP seuil d'accès
+    ],
+)
+def test_no_hardcoded_swiss_numbers_in_prompt(number: str):
+    """Hard-coded figures in the prompt create two problems:
+    (1) they drift when constants change (single source of truth = code),
+    (2) if the legacy compliance_guard is ever re-enabled on the anonymous
+        path, known_values=None triggers false-positive hallucination hits.
+    """
+    assert number not in build_discovery_system_prompt()
+
+
+# ---------------------------------------------------------------------------
+# User-declared facts injection (fixes "n'a pas vu les 300'000")
+# ---------------------------------------------------------------------------
+
+
+def test_facts_block_absent_when_no_facts_supplied():
+    prompt = build_discovery_system_prompt(facts=None)
+    assert "<facts_user>" not in prompt
+    assert "</facts_user>" not in prompt
+
+
+def test_facts_block_included_verbatim_when_supplied():
+    prompt = build_discovery_system_prompt(
+        facts=[
+            "49 ans",
+            "salaire 7'600 CHF net/mois",
+            "LPP ≈ 300'000 CHF",
+        ],
+    )
+    assert "<facts_user>" in prompt
+    assert "</facts_user>" in prompt
+    # Each fact is quoted literally in the block.
+    assert "49 ans" in prompt
+    assert "7'600" in prompt
+    assert "300'000" in prompt
+
+
+def test_facts_block_tells_model_to_use_them():
+    prompt = build_discovery_system_prompt(facts=["49 ans"])
+    # The instruction must sit near the facts so Claude does not ignore them.
+    # Must not exceed prompt size: simple substring suffices.
+    lowered = prompt.lower()
+    assert "facts_user" in lowered
+    # Some directive to leverage the facts (either cite/reprends/utilise).
+    assert any(
+        kw in lowered
+        for kw in ("cite", "reprends", "utilise", "intègre", "appuie-toi")
+    )
+
+
+def test_intent_still_supported_alongside_facts():
+    prompt = build_discovery_system_prompt(
+        intent="Je me sens perdu",
+        facts=["49 ans"],
+    )
+    assert "Je me sens perdu" in prompt
+    assert "49 ans" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Shape invariants — keep the prompt short and readable
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_is_kept_compact():
+    prompt = build_discovery_system_prompt()
+    # v1 was ~900 chars. v2 should stay ≤ 1600 chars even with the new
+    # directives — if it balloons, Claude gets lost.
+    assert len(prompt) <= 1600, (
+        f"Prompt must stay compact; got {len(prompt)} chars. "
+        "Compactness is part of the contract — verbose prompts train verbose "
+        "responses."
+    )

--- a/services/backend/tests/test_anonymous_prompt_v2.py
+++ b/services/backend/tests/test_anonymous_prompt_v2.py
@@ -29,8 +29,8 @@ from app.api.v1.endpoints.anonymous_chat import (
 # ---------------------------------------------------------------------------
 
 
-def test_prompt_version_is_v2():
-    assert PROMPT_VERSION == "v2", (
+def test_prompt_version_is_v3():
+    assert PROMPT_VERSION == "v3", (
         "Prompt rewrite must bump PROMPT_VERSION so telemetry can segregate "
         "old vs new responses. Bump again on next rewrite."
     )

--- a/services/backend/tests/test_follow_up_questions.py
+++ b/services/backend/tests/test_follow_up_questions.py
@@ -1,0 +1,187 @@
+"""
+Contract tests for backend-piloted follow_up_questions (Phase D).
+
+Covers:
+1. CoachChatResponse / AnonymousChatResponse schema cap at 2 items.
+2. The anonymous prompt carries the <followups> directive.
+3. extract_follow_ups() parses the block, strips it from the text, and
+   fails open on malformed input.
+4. The coach-chat prompt (claude_coach_service) carries the suggest_followups
+   directive so Claude knows to call the tool.
+5. `suggest_followups` is registered as an internal tool and declared in
+   the COACH_TOOLS list.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Schema caps
+# ---------------------------------------------------------------------------
+
+
+def test_coach_chat_response_caps_follow_ups_at_two():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(
+        message="Voici ta situation.",
+        follow_up_questions=["q1", "q2", "q3", "q4"],
+    )
+    assert resp.follow_up_questions == ["q1", "q2"]
+
+
+def test_coach_chat_response_strips_empty_follow_ups():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(
+        message="ok",
+        follow_up_questions=["  ", "réel", "", "autre"],
+    )
+    assert resp.follow_up_questions == ["réel", "autre"]
+
+
+def test_coach_chat_response_defaults_to_empty_list():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(message="ok")
+    assert resp.follow_up_questions == []
+
+
+def test_anonymous_chat_response_caps_follow_ups_at_two():
+    from app.schemas.anonymous_chat import AnonymousChatResponse
+
+    resp = AnonymousChatResponse(
+        message="ok",
+        messages_remaining=2,
+        follow_up_questions=["q1", "q2", "q3"],
+    )
+    assert resp.follow_up_questions == ["q1", "q2"]
+
+
+def test_anonymous_chat_response_defaults_to_empty_list():
+    from app.schemas.anonymous_chat import AnonymousChatResponse
+
+    resp = AnonymousChatResponse(message="ok", messages_remaining=2)
+    assert resp.follow_up_questions == []
+
+
+# ---------------------------------------------------------------------------
+# Prompt directives
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_prompt_contains_followups_directive():
+    from app.api.v1.endpoints.anonymous_chat import build_discovery_system_prompt
+
+    prompt = build_discovery_system_prompt()
+    assert "<followups>" in prompt
+    assert "</followups>" in prompt
+    # The prompt must forbid reformulating the user's own question.
+    assert "reformuler" in prompt.lower()
+
+
+def test_coach_system_prompt_contains_suggest_followups_directive():
+    from app.services.coach.claude_coach_service import build_system_prompt
+
+    prompt = build_system_prompt()
+    assert "suggest_followups" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Parser (anonymous path, tools=None)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_follow_ups_happy_path():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = (
+        "Voici ta réponse.\n"
+        '<followups>["Ça vaut le coup de racheter du LPP ?", "Et le 3a ?"]</followups>'
+    )
+    cleaned, qs = extract_follow_ups(raw)
+    assert cleaned == "Voici ta réponse."
+    assert qs == ["Ça vaut le coup de racheter du LPP ?", "Et le 3a ?"]
+
+
+def test_extract_follow_ups_caps_at_two():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = 'Texte.\n<followups>["a","b","c","d"]</followups>'
+    _, qs = extract_follow_ups(raw)
+    assert qs == ["a", "b"]
+
+
+def test_extract_follow_ups_missing_block_returns_empty():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    cleaned, qs = extract_follow_ups("Juste du texte, pas de bloc.")
+    assert cleaned == "Juste du texte, pas de bloc."
+    assert qs == []
+
+
+def test_extract_follow_ups_malformed_json_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # Well-formed block shape but invalid JSON inside: block IS stripped,
+    # follow_ups empty on parse failure.
+    raw = 'Texte.\n<followups>[not json,]</followups>'
+    cleaned, qs = extract_follow_ups(raw)
+    assert "<followups>" not in cleaned
+    assert qs == []
+
+
+def test_extract_follow_ups_unterminated_block_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # No closing `]` inside the tags — regex can't match. Fail-open: text
+    # returned unchanged, follow_ups empty.
+    raw = "Texte.\n<followups>[not json</followups>"
+    cleaned, qs = extract_follow_ups(raw)
+    assert cleaned == raw
+    assert qs == []
+
+
+def test_extract_follow_ups_non_list_payload_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # JSON object, not array. Must fail open.
+    raw = 'Texte.\n<followups>{"questions": ["a"]}</followups>'
+    # Regex requires `[...]` — should not match at all.
+    cleaned, qs = extract_follow_ups(raw)
+    assert qs == []
+    # Block wasn't `[...]`, so it isn't stripped either.
+    assert "<followups>" in cleaned or cleaned.startswith("Texte")
+
+
+def test_extract_follow_ups_filters_non_string_items():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = 'Texte.\n<followups>[1, "vraie question", null]</followups>'
+    _, qs = extract_follow_ups(raw)
+    assert qs == ["vraie question"]
+
+
+# ---------------------------------------------------------------------------
+# Tool registration (coach-chat path)
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_followups_is_internal_tool():
+    from app.services.coach.coach_tools import INTERNAL_TOOL_NAMES
+
+    assert "suggest_followups" in INTERNAL_TOOL_NAMES
+
+
+def test_suggest_followups_declared_in_coach_tools():
+    from app.services.coach.coach_tools import COACH_TOOLS
+
+    names = [t.get("name") for t in COACH_TOOLS]
+    assert "suggest_followups" in names
+    tool = next(t for t in COACH_TOOLS if t.get("name") == "suggest_followups")
+    schema = tool["input_schema"]
+    assert "questions" in schema["properties"]
+    assert schema["properties"]["questions"]["type"] == "array"
+    assert schema["properties"]["questions"]["maxItems"] == 2
+    assert schema["required"] == ["questions"]

--- a/services/backend/tests/test_profile_extractor_v2_patterns.py
+++ b/services/backend/tests/test_profile_extractor_v2_patterns.py
@@ -1,0 +1,222 @@
+"""
+v2 profile_extractor pattern tests (phase B).
+
+Expands anonymous-friendly patterns identified by the audit:
+- Monthly salary sentences ("7600 Fr net par mois") must be annualised ×12
+  with a plausibility gate (3k-40k/month ≈ 36k-480k/year).
+- "valeur de rachat" / "caisse de pension" / "avoir de vieillesse" map to
+  the LPP topic (user never says "LPP" explicitly in natural speech).
+- Existing patterns must keep working — regression guard.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.coach.profile_extractor import extract_profile_facts
+
+
+def _topics(message: str) -> set[str]:
+    return {f.topic for f in extract_profile_facts(message)}
+
+
+def _fact_by_topic(message: str, topic: str):
+    for f in extract_profile_facts(message):
+        if f.topic == topic:
+            return f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Monthly salary annualisation
+# ---------------------------------------------------------------------------
+
+
+def test_monthly_salary_fr_is_annualised():
+    fact = _fact_by_topic(
+        "je gagne 7600 Fr net par mois dans le Valais",
+        "salary",
+    )
+    assert fact is not None, "7600 CHF/mois must be captured — it's the "\
+        "commonest way Swiss residents state their salary."
+    # 7600 × 12 = 91'200 — within 15k-500k plausibility band.
+    assert fact.value == 7600 * 12
+    assert "net" in fact.text
+    assert "/an" in fact.text or "/mois" in fact.text
+
+
+def test_monthly_salary_without_net_brut_marker():
+    fact = _fact_by_topic("j'ai 8500 CHF par mois", "salary")
+    assert fact is not None
+    assert fact.value == 8500 * 12
+
+
+def test_monthly_salary_mensuel_variant():
+    fact = _fact_by_topic("mon salaire mensuel est de 6200 francs", "salary")
+    assert fact is not None
+    assert fact.value == 6200 * 12
+
+
+def test_monthly_salary_implausibly_low_rejected():
+    # 800/month × 12 = 9'600/year — below the 3k-40k/month band.
+    assert _fact_by_topic(
+        "je reçois 800 francs par mois de rente",
+        "salary",
+    ) is None
+
+
+def test_monthly_salary_implausibly_high_rejected():
+    # 80k/month × 12 = 960k/year — above 40k/month band.
+    assert _fact_by_topic(
+        "je gagne 80000 francs par mois",
+        "salary",
+    ) is None
+
+
+def test_annual_salary_still_works_after_monthly_patch():
+    """Regression guard — monthly pattern must not break existing annual
+    extraction."""
+    fact = _fact_by_topic("je gagne 95000 CHF brut par an", "salary")
+    assert fact is not None
+    assert fact.value == 95_000
+
+
+# ---------------------------------------------------------------------------
+# LPP natural language ("valeur de rachat", "caisse de pension")
+# ---------------------------------------------------------------------------
+
+
+def test_valeur_de_rachat_maps_to_lpp():
+    fact = _fact_by_topic(
+        "j'ai 300000 Fr de valeur de rachat dans ma caisse de pension",
+        "lpp",
+    )
+    assert fact is not None, (
+        "'valeur de rachat' is the dominant way Swiss residents refer to "
+        "their LPP — regex must match or MSG1 insights drop the number."
+    )
+    assert fact.value == 300_000
+
+
+def test_caisse_de_pension_alone_maps_to_lpp():
+    fact = _fact_by_topic(
+        "ma caisse de pension me verse 70377 CHF",
+        "lpp",
+    )
+    assert fact is not None
+    assert fact.value == 70_377
+
+
+def test_avoir_de_vieillesse_maps_to_lpp():
+    fact = _fact_by_topic(
+        "mon avoir de vieillesse est de 120'000 CHF",
+        "lpp",
+    )
+    assert fact is not None
+    assert fact.value == 120_000
+
+
+def test_lpp_explicit_keyword_still_works():
+    """Regression guard for existing LPP path."""
+    fact = _fact_by_topic("LPP 70'377 CHF", "lpp")
+    assert fact is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic first-message sanity check
+# ---------------------------------------------------------------------------
+
+
+def test_full_first_message_all_topics_captured():
+    msg = (
+        "J'ai 49 ans, je gagne 7600 Fr net par mois dans le Valais, "
+        "et j'ai 300 000 Fr de valeur de rachat dans ma caisse de pension. "
+        "Qu'est-ce que je dois faire ?"
+    )
+    topics = _topics(msg)
+    assert "identity" in topics  # age 49
+    assert "salary" in topics    # 7600/mo × 12
+    assert "location" in topics  # Valais → VS
+    assert "lpp" in topics       # 300'000 via valeur de rachat
+
+    salary = _fact_by_topic(msg, "salary")
+    lpp = _fact_by_topic(msg, "lpp")
+    age = _fact_by_topic(msg, "identity")
+    assert salary.value == 7600 * 12
+    assert lpp.value == 300_000
+    assert age.value == 49
+
+
+# ---------------------------------------------------------------------------
+# Natural-language robustness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "valeur de rachat de 300000 CHF",
+        "j'ai 300'000 Fr de rachat possible",
+        "rachat possible de 539414 CHF",
+    ],
+)
+def test_rachat_variations(phrase: str):
+    fact = _fact_by_topic(phrase, "lpp")
+    assert fact is not None
+    # Accept a range — the detector should pick *some* valid LPP figure.
+    assert 70_000 <= fact.value <= 5_000_000
+
+
+# ---------------------------------------------------------------------------
+# Year-before-keyword collision (post-audit P2 #7)
+# ---------------------------------------------------------------------------
+
+
+def test_year_before_lpp_keyword_is_ignored():
+    """'en 2025 la caisse de pension a valu 70'000' must not extract 2025
+    as an LPP value. Require explicit currency marker on the BEFORE path."""
+    fact = _fact_by_topic(
+        "en 2025 la caisse de pension a valu 70'000",
+        "lpp",
+    )
+    # 2025 is NOT an LPP value. 70'000 may or may not be captured via the
+    # AFTER path (no keyword precedes it there) — either outcome is OK, as
+    # long as we don't return 2025.
+    if fact is not None:
+        assert fact.value != 2025
+
+
+def test_year_alone_never_captured_as_lpp():
+    assert _fact_by_topic("depuis 2020 dans la caisse de pension", "lpp") is None
+
+
+# ---------------------------------------------------------------------------
+# T-13-05 forbidden lexicon — facts must never leak the banned tokens into
+# the anonymous system prompt. Templated `text=` strings are the designed
+# defence — this test locks it in so a future `_extract_profession` that
+# emits "profil: cadre" or similar is caught at test time.
+# ---------------------------------------------------------------------------
+
+
+_FORBIDDEN = ("outil", "tool", "profil", "dossier", "memoire", "memory")
+
+
+@pytest.mark.parametrize(
+    "adversarial_message",
+    [
+        "j'utilise l'outil MINT pour mon dossier retraite",
+        "je veux un profil financier et une memoire durable",
+        "mon dossier est complet, memoire intacte, profil clair",
+        "my tool is my memory",
+        "49 ans, 7600 fr/mois, mon outil préféré c'est ce dossier",
+    ],
+)
+def test_facts_never_contain_forbidden_lexicon(adversarial_message: str):
+    facts = extract_profile_facts(adversarial_message)
+    for fact in facts:
+        lowered = fact.text.lower()
+        for banned in _FORBIDDEN:
+            assert banned not in lowered, (
+                f"Fact {fact!r} leaks T-13-05 forbidden token '{banned}'. "
+                f"Any future extractor that echoes user text into Fact.text "
+                f"must scrub or reject these tokens."
+            )

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -1249,6 +1249,79 @@
         "title": "AnomalyResponse",
         "type": "object"
       },
+      "AnonymousChatRequest": {
+        "description": "Request for anonymous discovery chat.\n\nNo authentication required. Limited to 3 messages per device token.",
+        "properties": {
+          "intent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Felt-state pill text selected by the user (e.g. 'Je me sens perdu').",
+            "title": "Intent"
+          },
+          "language": {
+            "default": "fr",
+            "description": "Langue de la reponse: 'fr', 'de', 'en', 'it'.",
+            "title": "Language",
+            "type": "string"
+          },
+          "message": {
+            "description": "Message de l'utilisateur anonyme.",
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "AnonymousChatRequest",
+        "type": "object"
+      },
+      "AnonymousChatResponse": {
+        "description": "Response for anonymous discovery chat.\n\nIncludes compliance disclaimers and remaining message count.",
+        "properties": {
+          "disclaimers": {
+            "description": "Disclaimers de conformite.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Disclaimers",
+            "type": "array"
+          },
+          "message": {
+            "description": "Reponse du coach en mode decouverte.",
+            "title": "Message",
+            "type": "string"
+          },
+          "messagesRemaining": {
+            "description": "Nombre de messages restants pour cette session anonyme.",
+            "maximum": 3.0,
+            "minimum": 0.0,
+            "title": "Messagesremaining",
+            "type": "integer"
+          },
+          "tokensUsed": {
+            "default": 0,
+            "description": "Estimation de l'utilisation de tokens.",
+            "minimum": 0.0,
+            "title": "Tokensused",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "message",
+          "messagesRemaining"
+        ],
+        "title": "AnonymousChatResponse",
+        "type": "object"
+      },
       "AppleVerifyPurchaseRequest": {
         "properties": {
           "expires_at": {
@@ -3698,6 +3771,25 @@
             "title": "Cashlevel",
             "type": "integer"
           },
+          "conversationHistory": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prior conversation messages for multi-turn context. Each item: {role: 'user'|'assistant', content: str}. Last 8 messages max. Sanitized client-side.",
+            "title": "Conversationhistory"
+          },
           "language": {
             "default": "fr",
             "description": "Langue de la reponse: 'fr', 'de', 'en', 'it'.",
@@ -4202,6 +4294,111 @@
           "icon"
         ],
         "title": "CoachingTipResponse",
+        "type": "object"
+      },
+      "CommitmentCreate": {
+        "description": "Request schema for creating a commitment device.",
+        "properties": {
+          "ifThenText": {
+            "maxLength": 500,
+            "title": "Ifthentext",
+            "type": "string"
+          },
+          "reminderAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderat"
+          },
+          "whenText": {
+            "maxLength": 500,
+            "title": "Whentext",
+            "type": "string"
+          },
+          "whereText": {
+            "maxLength": 500,
+            "title": "Wheretext",
+            "type": "string"
+          }
+        },
+        "required": [
+          "whenText",
+          "whereText",
+          "ifThenText"
+        ],
+        "title": "CommitmentCreate",
+        "type": "object"
+      },
+      "CommitmentResponse": {
+        "description": "Response schema for a commitment device.",
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "title": "Createdat",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "ifThenText": {
+            "title": "Ifthentext",
+            "type": "string"
+          },
+          "reminderAt": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reminderat"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "whenText": {
+            "title": "Whentext",
+            "type": "string"
+          },
+          "whereText": {
+            "title": "Wheretext",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "whenText",
+          "whereText",
+          "ifThenText",
+          "createdAt"
+        ],
+        "title": "CommitmentResponse",
+        "type": "object"
+      },
+      "CommitmentStatusUpdate": {
+        "description": "Request schema for updating commitment status.",
+        "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "CommitmentStatusUpdate",
         "type": "object"
       },
       "CommuneListResponse": {
@@ -9329,6 +9526,22 @@
         "title": "FranchiseOption",
         "type": "object"
       },
+      "FreshStartResponse": {
+        "properties": {
+          "landmarks": {
+            "items": {
+              "$ref": "#/components/schemas/LandmarkResponse"
+            },
+            "title": "Landmarks",
+            "type": "array"
+          }
+        },
+        "required": [
+          "landmarks"
+        ],
+        "title": "FreshStartResponse",
+        "type": "object"
+      },
       "FriBreakdownResponse": {
         "description": "FRI breakdown result — 4 components + total.",
         "properties": {
@@ -11940,6 +12153,39 @@
           "disclaimer"
         ],
         "title": "LamalOptionResponse",
+        "type": "object"
+      },
+      "LandmarkResponse": {
+        "properties": {
+          "date": {
+            "title": "Date",
+            "type": "string"
+          },
+          "daysUntil": {
+            "title": "Daysuntil",
+            "type": "integer"
+          },
+          "intent": {
+            "title": "Intent",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "date",
+          "daysUntil",
+          "message",
+          "intent"
+        ],
+        "title": "LandmarkResponse",
         "type": "object"
       },
       "LibrePassageRequest": {
@@ -21065,7 +21311,7 @@
             "$ref": "#/components/schemas/DocumentType"
           },
           "imageBase64": {
-            "description": "Base64-encoded document image (JPEG/PNG)",
+            "description": "Base64-encoded document (JPEG, PNG, or PDF)",
             "maxLength": 5000000,
             "title": "Imagebase64",
             "type": "string"
@@ -21114,6 +21360,12 @@
           "extractionMethod": {
             "default": "claude_vision",
             "title": "Extractionmethod",
+            "type": "string"
+          },
+          "extractionStatus": {
+            "default": "success",
+            "description": "Extraction outcome: 'success' (fields extracted and validated), 'partial' (some fields extracted, some rejected by validation), 'no_fields_found' (Claude parsed OK but returned zero fields — document unreadable or empty), or 'parse_error' (Claude returned non-JSON). Flutter surfaces a targeted error for each status.",
+            "title": "Extractionstatus",
             "type": "string"
           },
           "overallConfidence": {
@@ -22755,6 +23007,48 @@
         ]
       }
     },
+    "/api/v1/anonymous/chat": {
+      "post": {
+        "description": "Anonymous discovery chat with device-scoped rate limiting.\n\nRequires X-Anonymous-Session header (UUID format).\nLimited to 3 messages per device token (lifetime).\nUses stripped-down discovery system prompt (no tools, no profile).",
+        "operationId": "anonymous_chat_api_v1_anonymous_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnonymousChatRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnonymousChatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Anonymous Chat",
+        "tags": [
+          "Anonymous Chat P13"
+        ]
+      }
+    },
     "/api/v1/arbitrage/allocation-annuelle": {
       "post": {
         "description": "Compare les strategies d'allocation annuelle de l'epargne.\n\nSimule jusqu'a 4 options selon l'eligibilite:\n- 3a (si pas encore verse au max)\n- Rachat LPP (si potentiel de rachat > 0)\n- Amortissement indirect (si proprietaire)\n- Investissement libre (toujours disponible)\n\nReturns:\n    AllocationAnnuelleResponse avec trajectoires, breakeven, sensibilite,\n    disclaimer et sources legales.",
@@ -24254,6 +24548,209 @@
         "summary": "Coach Chat",
         "tags": [
           "Coach Chat S56"
+        ]
+      }
+    },
+    "/api/v1/coach/commitment/": {
+      "get": {
+        "description": "List user's commitments, optionally filtered by status.",
+        "operationId": "list_commitments_api_v1_coach_commitment__get",
+        "parameters": [
+          {
+            "description": "Filter by status (pending, completed, dismissed)",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by status (pending, completed, dismissed)",
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CommitmentResponse"
+                  },
+                  "title": "Response List Commitments Api V1 Coach Commitment  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Commitments",
+        "tags": [
+          "Commitment P14"
+        ]
+      },
+      "post": {
+        "description": "Create a new implementation intention commitment.\n\nT-14-08: Rate limit — max 50 pending commitments per user.\nT-14-07: Length validation enforced by Pydantic schema (500 char max).",
+        "operationId": "create_commitment_api_v1_coach_commitment__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitmentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Commitment",
+        "tags": [
+          "Commitment P14"
+        ]
+      }
+    },
+    "/api/v1/coach/commitment/{commitment_id}": {
+      "patch": {
+        "description": "Update commitment status (completed or dismissed).\n\nT-14-06: IDOR protection — query filters by BOTH commitment_id AND user_id.",
+        "operationId": "update_commitment_status_api_v1_coach_commitment__commitment_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "commitment_id",
+            "required": true,
+            "schema": {
+              "title": "Commitment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitmentStatusUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitmentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Commitment Status",
+        "tags": [
+          "Commitment P14"
+        ]
+      }
+    },
+    "/api/v1/coach/fresh-start/": {
+      "get": {
+        "description": "Return upcoming fresh-start landmarks with personalized messages.\n\nRate-limited to max 2 landmarks per calendar month (T-14-10).",
+        "operationId": "get_fresh_start_api_v1_coach_fresh_start__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FreshStartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Fresh Start",
+        "tags": [
+          "Fresh Start P14"
         ]
       }
     },
@@ -29631,7 +30128,7 @@
     },
     "/api/v1/profiles/me": {
       "get": {
-        "description": "Get the authenticated user's profile.\nReturns the most recently updated profile linked to the current user.",
+        "description": "Get the authenticated user's profile.\n\nGet-or-create semantics (FIX-B, 2026-04-13): if the authenticated user\nsomehow has no profile row (legacy account, partial migration, aborted\nbootstrap during auth), auto-create an empty one on the fly rather than\nreturning 404 forever. Every auth path SHOULD already call\n`ensure_empty_profile`, but this endpoint is the last line of defence\nfor the downstream screens that depend on a profile existing.",
         "operationId": "get_my_profile_api_v1_profiles_me_get",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary

Phase D — remove the polluting regex-based client-side chip inference, add a backend-piloted \`follow_up_questions\` contract on both \`/coach/chat\` (authenticated) and \`/anonymous/chat\` paths. Chips now come from the LLM, never from client-side heuristics that reposed the user's own question.

Original plan targeted base \`fix/anonymous-coach-v2-prompt-facts\` but that branch isn't on the remote — defaulting to \`dev\` (same tip SHA).

## Changes

**Backend**
- New \`follow_up_questions: list[str]\` field on \`CoachChatResponse\` and \`AnonymousChatResponse\` (field_validator caps at 2).
- New INTERNAL \`suggest_followups(questions: list[str])\` tool. Agent loop captures into the response; never forwarded to Flutter.
- Prompt directive in \`claude_coach_service.build_system_prompt\` — forbids reformulation of the user's own question.
- Anonymous path (tools=None): prompt v3 asks the LLM to end with \`<followups>[\"q1\",\"q2\"]</followups>\`; endpoint parses + strips via \`extract_follow_ups()\` (fail-open).

**Flutter**
- \`CoachChatApiResponse.followUpQuestions\` parsed (capped at 2).
- \`CoachResponse.followUpQuestions\` propagated through \`coach_llm_service\` and \`coach_orchestrator\` (both paths).
- \`CoachChatScreen\`: removed \`_inferSuggestedActions\` (6 regex topics × 2 ARB keys). Chips now come from \`response.followUpQuestions\` merged with \`_extractRouteChips\`, capped at 2.
- \`CoachLlmService\`: removed dead \`inferSuggestedActions()\` and \`initialSuggestions()\` — greeting stays silent.

## Test plan

- [x] \`pytest tests/test_follow_up_questions.py tests/test_anonymous_prompt_v2.py tests/test_coach_chat_endpoint.py tests/test_anonymous_chat*\` — 90 green
- [x] Full backend pytest — 5504 passed, 49 skipped
- [x] \`flutter analyze\` on touched files — 0 errors, 0 new warnings
- [x] \`flutter test test/services/coach/coach_chat_follow_up_questions_test.dart\` + \`coach_llm_service_test.dart\` — 83 green
- [ ] Device walkthrough post-merge: no repeat-question chips, no greeting chips, LLM chips render

## Deferred

- \`coach_chat_test.dart\` pre-existing \`pumpAndSettle\` timeouts from the unmerged \`_tryAnonymousChat\` wiring — unrelated to this PR.
- \`coachSuggest*\` ARB keys left in place (unreferenced) — dedicated i18n-hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)