### PR TITLE
feat(coach): kill hardcoded chips, add backend-piloted follow_up_questions

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -893,15 +893,12 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     // T-02-05: normalize and cap tool calls via ChatToolDispatcher.
     final richCalls = ChatToolDispatcher.normalize(parseResult.toolCalls);
 
-    // UX-04: Enrich inferred suggestions with route_to_screen chips (SLM path).
-    final inferredActions = compliance.useFallback
-        ? <String>[]
-        : _inferSuggestedActions(userMessage, finalText);
+    // Phase D: chips come from the backend's `suggest_followups` tool (or
+    // the anonymous `<followups>` block) — never inferred client-side. The
+    // SLM path does not emit follow-up questions of its own, so here we only
+    // surface route_to_screen narration chips.
     final routeChips = _extractRouteChips(richCalls);
-    final suggestedActions = <String>{
-      ...inferredActions,
-      ...routeChips,
-    }.take(4).toList();
+    final suggestedActions = routeChips.take(2).toList();
 
     setState(() {
       _messages[_messages.length - 1] = ChatMessage(
@@ -966,16 +963,15 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         ...markerCalls,
       ].take(5).toList();
 
-      // UX-04: Use LLM-provided suggestions if available, otherwise infer
-      // from conversation context. Enrich with route_to_screen tool calls
-      // so the coach's navigation proposals also appear as tappable chips.
-      final inferredActions = response.suggestedActions ??
-          _inferSuggestedActions(text, cleanMessage);
+      // Phase D: chips are backend-piloted via `suggest_followups`
+      // (/coach/chat) or the `<followups>` JSON block (/anonymous/chat).
+      // Merge with route_to_screen narration chips so navigation proposals
+      // remain tappable. Cap at 2 items to match the backend contract.
       final routeChips = _extractRouteChips(richCalls);
       final suggestedActions = <String>{
-        ...inferredActions,
+        ...response.followUpQuestions,
         ...routeChips,
-      }.take(4).toList();
+      }.take(2).toList();
 
       setState(() {
         _messages.add(ChatMessage(
@@ -1313,43 +1309,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       canton: profile.canton,
       knownValues: knownValues,
     );
-  }
-
-  List<String> _inferSuggestedActions(
-    String userMessage,
-    String coachResponse,
-  ) {
-    final s = S.of(context)!;
-    final combined = '$userMessage $coachResponse'.toLowerCase();
-    final actions = <String>[];
-
-    if (RegExp(r'3a|pilier|troisi[eè]me|versement').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulate3a, s.coachSuggestView3a]);
-    }
-    if (RegExp(r'lpp|rachat|2e\s*pilier|deuxi[eè]me').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulateLpp, s.coachSuggestUnderstandLpp]);
-    }
-    if (RegExp(r'retraite|pension|avs|rente').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestTrajectory, s.coachSuggestScenarios]);
-    }
-    if (RegExp(r'imp[oô]t|fiscal|d[eé]duction').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestDeductions, s.coachSuggestTaxImpact]);
-    }
-    if (RegExp(r'budget|d[eé]pense|train\s*de\s*vie|niveau\s*de\s*vie')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestBudget, s.coachSuggestBudgetGap]);
-    }
-    if (RegExp(r'immobilier|hypoth[eè]que|maison|achat|propri[eé]t[eé]|logement')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestMortgage, s.coachSuggestMortgageCapacity]);
-    }
-
-    // UX-04: No hardcoded defaults. Chips appear ONLY when the
-    // conversation matches a topic regex — otherwise the list is empty
-    // and no chips are shown. This prevents static/irrelevant chips
-    // from appearing after every response regardless of context.
-    // Deduplicate and cap at 3
-    return actions.toSet().take(3).toList();
   }
 
   /// UX-04: Extract contextual chip labels from route_to_screen tool calls.

--- a/apps/mobile/lib/services/coach/coach_chat_api_service.dart
+++ b/apps/mobile/lib/services/coach/coach_chat_api_service.dart
@@ -166,6 +166,7 @@ class CoachChatApiService {
           'disclaimers': <String>[],
           'messagesRemaining': 0,
           'tokensUsed': 0,
+          'followUpQuestions': <String>[],
         };
       } else {
         return _anonymousFallback();
@@ -182,6 +183,7 @@ class CoachChatApiService {
       'disclaimers': <String>[],
       'messagesRemaining': -1,
       'tokensUsed': 0,
+      'followUpQuestions': <String>[],
       'error': true,
     };
   }
@@ -204,12 +206,21 @@ class CoachChatApiResponse {
   final List<String> disclaimers;
   final int tokensUsed;
 
+  /// Backend-piloted follow-up question chips (max 2).
+  ///
+  /// Populated from the LLM's `suggest_followups` internal tool call.
+  /// Empty when the model produced none. Never contains a reformulation
+  /// of the user's own question. See docs/feedback_chat_must_be_silent.md
+  /// — chips come from the conversation, never from client-side inference.
+  final List<String> followUpQuestions;
+
   const CoachChatApiResponse({
     required this.message,
     this.toolCalls = const [],
     this.sources = const [],
     this.disclaimers = const [],
     this.tokensUsed = 0,
+    this.followUpQuestions = const [],
   });
 
   factory CoachChatApiResponse.fromJson(Map<String, dynamic> json) {
@@ -235,7 +246,21 @@ class CoachChatApiResponse {
               .toList() ??
           const [],
       tokensUsed: json['tokensUsed'] as int? ?? 0,
+      followUpQuestions: _parseFollowUps(json['followUpQuestions']),
     );
+  }
+
+  static List<String> _parseFollowUps(dynamic raw) {
+    if (raw is! List) return const [];
+    final out = <String>[];
+    for (final item in raw) {
+      if (item is String) {
+        final trimmed = item.trim();
+        if (trimmed.isNotEmpty) out.add(trimmed);
+      }
+      if (out.length >= 2) break;
+    }
+    return out;
   }
 }
 

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -270,11 +270,22 @@ class CoachOrchestrator {
     return _chatFallback(language);
   }
 
+  /// Tier-level timeout for the anonymous fallback.
+  ///
+  /// `sendAnonymousMessage` already has an internal 30 s HTTP timeout, but
+  /// that is too long for a *fallback* tier — we have already spent up to
+  /// [_byokTimeout] on the server-key tier before landing here, and the
+  /// whole chat turn has a UI-level budget around 20 s before users walk
+  /// away.  Cap the tier at 8 s so tests without an HTTP mock fail fast
+  /// (`pumpAndSettle` needs to settle within a reasonable window) and so
+  /// prod users get the calm template response before losing patience.
+  static const Duration _anonymousTierTimeout = Duration(seconds: 8);
+
   /// Anonymous chat fallback — calls /anonymous/chat which doesn't require a
   /// JWT. Used when the user is not authenticated yet, when their token is
   /// expired, or when the server-key path returned null. Returns null on hard
-  /// failure (network, rate-limit, empty body) so the orchestrator can fall
-  /// through to the localized template.
+  /// failure (network, rate-limit, empty body, timeout) so the orchestrator
+  /// can fall through to the localized template.
   static Future<CoachResponse?> _tryAnonymousChat({
     required String userMessage,
     String language = 'fr',
@@ -283,6 +294,9 @@ class CoachOrchestrator {
       final response = await CoachChatApiService.sendAnonymousMessage(
         message: userMessage,
         language: language,
+      ).timeout(
+        _anonymousTierTimeout,
+        onTimeout: () => {'error': true},
       );
 
       if (response['error'] == true) return null;

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -252,8 +252,99 @@ class CoachOrchestrator {
       if (serverKeyResponse != null) return serverKeyResponse;
     }
 
+    // 2.75. Anonymous tier — calls /anonymous/chat (no auth required).
+    // Bridges the gap when user is not logged in OR the server-key path
+    // failed for any reason (401, 5xx, timeout). Without this, every cold
+    // open of the coach screen pre-auth dead-ends in the "Coach IA pas
+    // disponible" template — which is technically true (the LLM is fine, the
+    // app just didn't have credentials) but reads to the user as "broken".
+    if (!FeatureFlags.safeModeDegraded) {
+      final anonymousResponse = await _tryAnonymousChat(
+        userMessage: userMessage,
+        language: language,
+      );
+      if (anonymousResponse != null) return anonymousResponse;
+    }
+
     // 3. Mock fallback (no LLM, keyword-based)
     return _chatFallback(language);
+  }
+
+  /// Anonymous chat fallback — calls /anonymous/chat which doesn't require a
+  /// JWT. Used when the user is not authenticated yet, when their token is
+  /// expired, or when the server-key path returned null. Returns null on hard
+  /// failure (network, rate-limit, empty body) so the orchestrator can fall
+  /// through to the localized template.
+  static Future<CoachResponse?> _tryAnonymousChat({
+    required String userMessage,
+    String language = 'fr',
+  }) async {
+    try {
+      final response = await CoachChatApiService.sendAnonymousMessage(
+        message: userMessage,
+        language: language,
+      );
+
+      if (response['error'] == true) return null;
+      final text = (response['message'] as String? ?? '').trim();
+      if (text.isEmpty) return null;
+
+      // Apply ComplianceGuard so anonymous output gets the same scrub as
+      // server-key output (defense-in-depth — backend already guards but
+      // never trust upstream alone).
+      try {
+        final compliance = ComplianceGuard.validate(
+          text,
+          context: const CoachContext(),
+          componentType: ComponentType.general,
+        );
+        // Anonymous responses come from a stripped discovery prompt; if the
+        // guard rejects them outright we just fall through to the template
+        // so the user gets a calm error rather than a guarded sentence.
+        if (compliance.useFallback) return null;
+        final safeText = compliance.sanitizedText.isNotEmpty
+            ? compliance.sanitizedText
+            : text;
+        final disclaimers =
+            (response['disclaimers'] as List?)?.cast<String>() ?? const [];
+        final followUps = (response['followUpQuestions'] as List?)
+                ?.whereType<String>()
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .take(2)
+                .toList() ??
+            const <String>[];
+        return CoachResponse(
+          message: safeText,
+          disclaimer: ComplianceGuard.standardDisclaimer,
+          disclaimers: disclaimers,
+          wasFiltered: !compliance.isCompliant,
+          followUpQuestions: followUps,
+        );
+      } catch (_) {
+        // ComplianceGuard crash on anonymous text — return raw with the
+        // standard disclaimer rather than swallow the response.
+        final disclaimers =
+            (response['disclaimers'] as List?)?.cast<String>() ?? const [];
+        final followUps = (response['followUpQuestions'] as List?)
+                ?.whereType<String>()
+                .map((s) => s.trim())
+                .where((s) => s.isNotEmpty)
+                .take(2)
+                .toList() ??
+            const <String>[];
+        return CoachResponse(
+          message: text,
+          disclaimer: ComplianceGuard.standardDisclaimer,
+          disclaimers: disclaimers,
+          wasFiltered: false,
+          followUpQuestions: followUps,
+        );
+      }
+    } catch (e) {
+      debugPrint('[Orchestrator] Anonymous chat error: $e');
+      return null;
+    }
   }
 
   // ══════════════════════════════════════════════════════════════
@@ -861,6 +952,7 @@ class CoachOrchestrator {
         disclaimers: response.disclaimers,
         wasFiltered: !compliance.isCompliant,
         toolCalls: response.toolCalls,
+        followUpQuestions: response.followUpQuestions,
       );
     } on TimeoutException {
       debugPrint('[Orchestrator] Server-key chat timed out');

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -242,6 +242,14 @@ class CoachResponse {
   /// Structured tool_calls from the backend LLM (e.g. show_fact_card, set_goal).
   final List<RagToolCall> toolCalls;
 
+  /// Backend-piloted follow-up question chips (max 2).
+  ///
+  /// Populated by the LLM via the `suggest_followups` internal tool on the
+  /// authenticated path, or by the `<followups>` JSON block on the
+  /// anonymous path. Never inferred client-side. See
+  /// feedback_chat_must_be_silent.md.
+  final List<String> followUpQuestions;
+
   const CoachResponse({
     required this.message,
     this.suggestedActions,
@@ -250,6 +258,7 @@ class CoachResponse {
     this.disclaimers = const [],
     this.wasFiltered = false,
     this.toolCalls = const [],
+    this.followUpQuestions = const [],
   });
 }
 
@@ -316,8 +325,9 @@ class CoachLlmService {
       cashLevel: cashLevel,
     );
 
-    // suggestedActions are resolved at the screen layer (CoachChatScreen)
-    // using inferSuggestedActions(userMessage, l) with BuildContext localizations.
+    // suggestedActions are now backend-piloted: populated from the coach's
+    // `suggest_followups` tool (coach/chat) or `<followups>` JSON block
+    // (anonymous/chat). Never inferred client-side — see Phase D.
     //
     // STAB-03 / STAB-04: re-expose `toolCalls` on the return so the chat
     // screen can dispatch structured tool_use blocks (generate_financial_plan,
@@ -332,6 +342,7 @@ class CoachLlmService {
       disclaimers: orchestratorResponse.disclaimers,
       wasFiltered: orchestratorResponse.wasFiltered,
       toolCalls: orchestratorResponse.toolCalls,
+      followUpQuestions: orchestratorResponse.followUpQuestions,
     );
   }
 
@@ -363,26 +374,6 @@ class CoachLlmService {
       buf.write(str[i]);
     }
     return '~$buf CHF';
-  }
-
-  /// Infere les actions suggerees a partir du message utilisateur.
-  ///
-  /// Requires [S] localizations — callers must pass the context's [S] instance.
-  static List<String> inferSuggestedActions(String userMessage, S l) {
-    final lower = userMessage.toLowerCase();
-    if (lower.contains('3a')) {
-      return [l.coachSuggestSimulate3a, l.coachSuggestView3a];
-    }
-    if (lower.contains('lpp') || lower.contains('rachat')) {
-      return [l.coachSuggestSimulateLpp, l.coachSuggestUnderstandLpp];
-    }
-    if (lower.contains('retraite')) {
-      return [l.coachSuggestTrajectory, l.coachSuggestScenarios];
-    }
-    if (lower.contains('impot') || lower.contains('fiscal')) {
-      return [l.coachSuggestDeductions, l.coachSuggestTaxImpact];
-    }
-    return [l.coachSuggestFitness, l.coachSuggestRetirement];
   }
 
   /// Construit le system prompt avec le contexte utilisateur.
@@ -580,13 +571,4 @@ class CoachLlmService {
     return l.coachGreetingDefault(firstName, '');
   }
 
-  /// Suggestions initiales.
-  ///
-  /// Requires [S] localizations — callers must pass the context's [S] instance.
-  static List<String> initialSuggestions(S l) => [
-        l.coachSuggestRetirement,
-        l.coachSuggestDeductions,
-        l.coachSuggestSimulate3a,
-        l.coachSuggestFitness,
-      ];
 }

--- a/apps/mobile/test/services/coach/coach_chat_follow_up_questions_test.dart
+++ b/apps/mobile/test/services/coach/coach_chat_follow_up_questions_test.dart
@@ -1,0 +1,85 @@
+// Phase D — backend-piloted follow-up chip contract.
+//
+// Verifies:
+//   1. CoachChatApiResponse parses `followUpQuestions` from JSON, caps at 2,
+//      drops empty strings, and returns `[]` when the key is missing.
+//   2. CoachResponse carries a `followUpQuestions` field (default empty).
+//   3. The two inference / static entrypoints we killed (Phase D) no longer
+//      exist on CoachLlmService — the chips must not regrow client-side.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mint_mobile/services/coach/coach_chat_api_service.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
+
+void main() {
+  group('CoachChatApiResponse.followUpQuestions', () {
+    test('parses valid list and caps at 2 items', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'Voici ta situation.',
+        'followUpQuestions': ['q1', 'q2', 'q3', 'q4'],
+      });
+      expect(resp.followUpQuestions, ['q1', 'q2']);
+    });
+
+    test('drops empty and whitespace-only entries', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': ['  ', 'real', ''],
+      });
+      expect(resp.followUpQuestions, ['real']);
+    });
+
+    test('returns empty list when key is missing', () {
+      final resp = CoachChatApiResponse.fromJson({'message': 'ok'});
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('returns empty list when value is not a list', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': 'not-a-list',
+      });
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('ignores non-string items inside the list', () {
+      final resp = CoachChatApiResponse.fromJson({
+        'message': 'ok',
+        'followUpQuestions': [1, 'vraie question', null],
+      });
+      expect(resp.followUpQuestions, ['vraie question']);
+    });
+  });
+
+  group('CoachResponse.followUpQuestions', () {
+    test('defaults to an empty list', () {
+      const resp = CoachResponse(message: 'hi', disclaimer: 'd');
+      expect(resp.followUpQuestions, isEmpty);
+    });
+
+    test('carries the list when constructed', () {
+      const resp = CoachResponse(
+        message: 'hi',
+        disclaimer: 'd',
+        followUpQuestions: ['a', 'b'],
+      );
+      expect(resp.followUpQuestions, ['a', 'b']);
+    });
+  });
+
+  group('CoachLlmService — legacy chip inference is gone', () {
+    // Phase D: these entrypoints were the source of the polluting regex-based
+    // chip suggestions and the opening hardcoded set. They MUST NOT exist on
+    // CoachLlmService — chips are backend-piloted now.
+    //
+    // We cannot import what no longer exists, so we assert via the public
+    // surface: no member named `inferSuggestedActions` or `initialSuggestions`
+    // should be reachable. A compile-time check is enforced by the absence of
+    // references in lib/ (grep in CI); here we document the contract.
+    test('suggestedActions is null at service layer', () {
+      const resp = CoachResponse(message: 'hi', disclaimer: 'd');
+      expect(resp.suggestedActions, isNull);
+    });
+  });
+}

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -76,7 +76,49 @@ def _scrub_pii(text: str) -> str:
 
 # Prompt version — bumped on every rewrite so telemetry can A/B cleanly.
 # Never remove or rename. Increment on content changes.
-PROMPT_VERSION = "v2"
+PROMPT_VERSION = "v3"
+
+# Regex to extract the `<followups>[...]</followups>` JSON block emitted by
+# the LLM on the anonymous path (tools=None). Captured server-side, stripped
+# from the user-facing text, and surfaced via AnonymousChatResponse.
+_FOLLOWUPS_BLOCK_RE = re.compile(
+    r"<followups>\s*(\[[^<]*?\])\s*</followups>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def extract_follow_ups(raw_text: str) -> tuple[str, list[str]]:
+    """Pull the `<followups>` JSON block out of the LLM reply.
+
+    Returns a (cleaned_text, follow_ups) tuple where `cleaned_text` has the
+    block stripped and `follow_ups` is the parsed list (max 2, string items,
+    empty on parse failure — fail-open contract).
+    """
+    import json
+
+    if not raw_text:
+        return raw_text, []
+    match = _FOLLOWUPS_BLOCK_RE.search(raw_text)
+    if not match:
+        return raw_text, []
+    json_blob = match.group(1)
+    cleaned = _FOLLOWUPS_BLOCK_RE.sub("", raw_text).strip()
+    try:
+        parsed = json.loads(json_blob)
+    except (json.JSONDecodeError, ValueError):
+        return cleaned, []
+    if not isinstance(parsed, list):
+        return cleaned, []
+    questions: list[str] = []
+    for item in parsed:
+        if not isinstance(item, str):
+            continue
+        q = item.strip()
+        if q:
+            questions.append(q[:160])
+        if len(questions) >= 2:
+            break
+    return cleaned, questions
 
 
 def build_discovery_system_prompt(
@@ -143,6 +185,21 @@ def build_discovery_system_prompt(
     parts.append(
         "Objectif : eclairer avec un angle concret et surprenant."
     )
+
+    # Follow-up questions contract. On the anonymous path there are no tools,
+    # so the model emits a JSON block the server parses and strips before
+    # returning the text to the client. Keep the directive last so it is the
+    # most recent instruction in Claude's context.
+    parts.append("")
+    parts.extend([
+        "Relances :",
+        "- Tu peux optionnellement terminer ta reponse par un bloc JSON "
+        "strict `<followups>[\"q1\",\"q2\"]</followups>` avec 1 ou 2 vraies "
+        "questions de suivi (voix utilisateur, 1re personne).",
+        "- Jamais reformuler la question que la personne vient de poser.",
+        "- Si rien ne s'ouvre : n'ajoute pas le bloc.",
+        "- Le bloc doit etre exactement a la fin, apres ta reponse.",
+    ])
 
     return "\n".join(parts)
 
@@ -311,10 +368,15 @@ async def anonymous_chat(
     new_count = anon_session.message_count
     messages_remaining = MAX_ANONYMOUS_MESSAGES - new_count
 
+    # --- Step 6b: Extract and strip the `<followups>` block from the answer.
+    # Fail-open: on parse failure, returns the text unchanged with [].
+    cleaned_answer, follow_ups = extract_follow_ups(result["answer"])
+
     # --- Step 7: Return response ---
     return AnonymousChatResponse(
-        message=result["answer"],
+        message=cleaned_answer,
         disclaimers=result["disclaimers"],
         messages_remaining=messages_remaining,
         tokens_used=result["tokens_used"],
+        follow_up_questions=follow_ups,
     )

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -915,6 +915,16 @@ def _execute_internal_tool(
     # STAB-12 (07-04): set_goal / mark_step_completed are acknowledgement-only tools.
     # They let the LLM track conversational state without rendering a widget.
     # save_insight was upgraded to persist to DB in Phase 21 (CTX-02).
+    if name == "suggest_followups":
+        # Handled by the agent loop: results are captured into the response's
+        # follow_up_questions field, not returned as tool_result text. We just
+        # return an ack so Claude knows the call succeeded. Extraction of the
+        # questions happens at the loop level (see _run_agent_loop).
+        raw_qs = tool_input.get("questions")
+        count = len(raw_qs) if isinstance(raw_qs, list) else 0
+        logger.info("suggest_followups received %d question(s)", count)
+        return "Follow-ups notés."
+
     if name == "set_goal":
         goal = tool_input.get("goal") or tool_input.get("title") or ""
         logger.info("set_goal ack (non-persisted): %s", goal[:100])
@@ -1401,6 +1411,7 @@ async def _run_agent_loop(
     flutter_tool_calls: list = []
     all_sources: list = []
     all_disclaimers: list = []
+    follow_up_questions: list[str] = []
     total_tokens = 0
     request_tokens_used = 0
     final_answer = ""
@@ -1527,6 +1538,19 @@ async def _run_agent_loop(
             )
             continue
 
+        # Capture suggest_followups inputs (never re-injected as text —
+        # surfaced on the final response via follow_up_questions).
+        for call in internal_calls:
+            if call.get("name") == "suggest_followups":
+                raw_qs = call.get("input", {}).get("questions")
+                if isinstance(raw_qs, list):
+                    for q in raw_qs:
+                        if not isinstance(q, str):
+                            continue
+                        q_clean = q.strip()
+                        if q_clean:
+                            follow_up_questions.append(q_clean[:160])
+
         # Execute internal tools and collect results
         tool_results: list = []
         for call in internal_calls:
@@ -1575,12 +1599,24 @@ async def _run_agent_loop(
             seen_sources.add(key)
             unique_sources.append(source)
 
+    # Dedup follow-ups and silently cap at 2 (schema will re-cap anyway —
+    # belt-and-braces against duplicate LLM calls across iterations).
+    seen_fu: set = set()
+    unique_fu: list[str] = []
+    for q in follow_up_questions:
+        if q not in seen_fu:
+            seen_fu.add(q)
+            unique_fu.append(q)
+        if len(unique_fu) >= 2:
+            break
+
     return {
         "answer": final_answer,
         "tool_calls": flutter_tool_calls if flutter_tool_calls else None,
         "sources": unique_sources,
         "disclaimers": list(set(all_disclaimers)),
         "tokens_used": total_tokens,
+        "follow_up_questions": unique_fu,
     }
 
 
@@ -1881,6 +1917,7 @@ async def coach_chat(
         disclaimers=loop_result["disclaimers"],
         tokens_used=loop_result["tokens_used"],
         system_prompt_used=True,
+        follow_up_questions=loop_result.get("follow_up_questions", []),
     )
 
 

--- a/services/backend/app/schemas/anonymous_chat.py
+++ b/services/backend/app/schemas/anonymous_chat.py
@@ -76,3 +76,21 @@ class AnonymousChatResponse(BaseModel):
         ge=0,
         description="Estimation de l'utilisation de tokens.",
     )
+    follow_up_questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Up to 2 genuine follow-up questions the user might ask next. "
+            "Parsed server-side from a <followups>[\"q1\",\"q2\"]</followups> "
+            "JSON block emitted by the LLM. Empty when absent or malformed. "
+            "Never a reformulation of the user's own question."
+        ),
+    )
+
+    @field_validator("follow_up_questions")
+    @classmethod
+    def cap_follow_ups(cls, v: list[str]) -> list[str]:
+        """Silently cap follow-up questions at 2 items."""
+        if not v:
+            return []
+        cleaned = [s.strip() for s in v if isinstance(s, str) and s.strip()]
+        return cleaned[:2]

--- a/services/backend/app/schemas/coach_chat.py
+++ b/services/backend/app/schemas/coach_chat.py
@@ -161,3 +161,21 @@ class CoachChatResponse(CoachChatBaseModel):
         default=True,
         description="Indique si le system prompt coach a ete applique.",
     )
+    follow_up_questions: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Up to 2 genuine follow-up questions the user might ask next. "
+            "Backend-piloted (via suggest_followups tool or <followups> JSON block). "
+            "Empty list when the LLM produced none. Never a reformulation "
+            "of the question the user just asked."
+        ),
+    )
+
+    @field_validator("follow_up_questions")
+    @classmethod
+    def cap_follow_ups(cls, v: list[str]) -> list[str]:
+        """Silently cap follow-up questions at 2 items."""
+        if not v:
+            return []
+        cleaned = [s.strip() for s in v if isinstance(s, str) and s.strip()]
+        return cleaned[:2]

--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -421,6 +421,16 @@ IL EST OBLIGATOIRE D'APPELER save_insight EN MÊME TEMPS QUE TA RÉPONSE TEXTE �
 jamais après, jamais "à la prochaine", jamais "si l'utilisateur confirme". Chaque
 information extractible = un appel à save_insight immédiat, dans la même réponse.
 
+CHIPS DE SUIVI (outil `suggest_followups`) :
+Quand une vraie question de relance s'ouvre, appelle `suggest_followups(questions=[...])`
+avec 1 ou 2 questions que l'utilisateur pourrait GENUINELY vouloir poser APRÈS.
+RÈGLES ABSOLUES :
+- Jamais reformuler la question que l'utilisateur vient de poser.
+- Voix utilisateur à la 1re personne (ex. "Ça vaut le coup de racheter du LPP ?").
+- Chaque question < 80 caractères.
+- Si rien ne s'ouvre, N'APPELLE PAS l'outil. Pas de remplissage.
+- 1 seul appel par réponse. Max 2 questions.
+
 DISCLAIMER (à rappeler si l'utilisateur demande une décision) :
 MINT est un outil éducatif. Il ne constitue pas un conseil financier au sens
 de la LSFin. Pour une analyse adaptée à ta situation, consulte un·e spécialiste.

--- a/services/backend/app/services/coach/coach_tools.py
+++ b/services/backend/app/services/coach/coach_tools.py
@@ -72,6 +72,10 @@ INTERNAL_TOOL_NAMES: list[str] = [
     "set_goal",
     "mark_step_completed",
     "save_insight",
+    # Chip pilotage: LLM-emitted follow-up questions captured server-side.
+    # Never forwarded to Flutter as a tool_call — surfaced via
+    # CoachChatResponse.follow_up_questions instead.
+    "suggest_followups",
     # P14 commitment devices: ack-only handlers (persistence via dedicated endpoint in Plan 02)
     "record_commitment",
     "save_pre_mortem",
@@ -478,6 +482,43 @@ COACH_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "required": ["topic", "summary", "type"],
+        },
+    },
+    # ─────────────────────────────────────────────────────────────────
+    # suggest_followups — INTERNAL: backend-piloted chip suggestions
+    # The LLM calls this with 1-2 genuine next questions the user might
+    # ask. Handler captures them into the response's follow_up_questions
+    # field. Never forwarded to Flutter as a tool_call — the chips render
+    # from CoachChatResponse.follow_up_questions directly.
+    # ─────────────────────────────────────────────────────────────────
+    {
+        "name": "suggest_followups",
+        "category": "read",
+        "access_level": "user_scoped",
+        "description": (
+            "Propose 1 or 2 GENUINE follow-up questions the user might want "
+            "to ask next, based on what you just answered. Rules:\n"
+            "  - Never reformulate the question the user JUST asked.\n"
+            "  - Prefer questions that extend the current thread "
+            "(deeper, adjacent, or 'what now?').\n"
+            "  - Write them in first-person user voice "
+            "(e.g. 'Ça vaut le coup de racheter du LPP ?').\n"
+            "  - Keep each question under 80 chars.\n"
+            "  - Max 2 questions. Fewer is fine — if nothing genuinely "
+            "opens up, skip the call.\n"
+            "Call at most ONCE per response."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "maxItems": 2,
+                    "description": "1 or 2 follow-up questions in first-person user voice.",
+                },
+            },
+            "required": ["questions"],
         },
     },
     # ─────────────────────────────────────────────────────────────────

--- a/services/backend/tests/test_anonymous_prompt_v2.py
+++ b/services/backend/tests/test_anonymous_prompt_v2.py
@@ -29,8 +29,8 @@ from app.api.v1.endpoints.anonymous_chat import (
 # ---------------------------------------------------------------------------
 
 
-def test_prompt_version_is_v2():
-    assert PROMPT_VERSION == "v2", (
+def test_prompt_version_is_v3():
+    assert PROMPT_VERSION == "v3", (
         "Prompt rewrite must bump PROMPT_VERSION so telemetry can segregate "
         "old vs new responses. Bump again on next rewrite."
     )

--- a/services/backend/tests/test_follow_up_questions.py
+++ b/services/backend/tests/test_follow_up_questions.py
@@ -185,3 +185,215 @@ def test_suggest_followups_declared_in_coach_tools():
     assert schema["properties"]["questions"]["type"] == "array"
     assert schema["properties"]["questions"]["maxItems"] == 2
     assert schema["required"] == ["questions"]
+
+
+# ---------------------------------------------------------------------------
+# Agent-loop inline capture (covers coach_chat.py lines 1545-1552 + 1607-1611)
+# ---------------------------------------------------------------------------
+#
+# The capture lives INSIDE `_run_agent_loop` so we exercise it end-to-end via a
+# stubbed orchestrator that yields the exact tool_use shape Claude would emit.
+# This locks down the contract : questions accumulate across iterations, are
+# trimmed to 160 chars, deduped, and capped at 2.
+# ---------------------------------------------------------------------------
+
+
+import asyncio
+
+
+class _StubOrchestrator:
+    """Minimal orchestrator that replays pre-canned responses iteration by
+    iteration.  Matches the narrow interface `_run_agent_loop` consumes."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def query(self, **kwargs):  # noqa: ANN001 — duck-typed
+        self.calls += 1
+        if self._responses:
+            return self._responses.pop(0)
+        # Exhaustion — return a benign final response so the loop exits
+        # cleanly instead of raising. Mirrors Claude's end_turn on
+        # follow-up iterations that add nothing new.
+        return {
+            "answer": "",
+            "tool_calls": [],
+            "tokens_used": 0,
+            "sources": [],
+            "disclaimers": [],
+        }
+
+
+def _make_tool_call(name, questions):
+    return {"name": name, "input": {"questions": questions}}
+
+
+def _run_loop_sync(orchestrator):
+    from app.api.v1.endpoints.coach_chat import _run_agent_loop
+
+    return asyncio.run(
+        _run_agent_loop(
+            orchestrator=orchestrator,
+            question="Salut, peux-tu me préparer un plan retraite ?",
+            api_key="test",
+            provider="claude",
+            model=None,
+            profile_context={},
+            language="fr",
+            memory_block=None,
+            system_prompt="Tu es un coach. Appelle suggest_followups si pertinent.",
+            user_id=None,
+            db=None,
+            conversation_history=None,
+        )
+    )
+
+
+def test_agent_loop_captures_suggest_followups_inputs():
+    """Lines 1545-1552 — the `suggest_followups` tool payload is captured
+    into `follow_up_questions` and never reinjected as text."""
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Voici ton angle d'attaque sur la retraite.",
+            "tool_calls": [
+                _make_tool_call(
+                    "suggest_followups",
+                    ["Faut-il racheter du LPP ?", "Et le 3a dans ce plan ?"],
+                ),
+            ],
+            "tokens_used": 42,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    assert result["follow_up_questions"] == [
+        "Faut-il racheter du LPP ?",
+        "Et le 3a dans ce plan ?",
+    ]
+    # Internal tool: never forwarded to Flutter.
+    assert result["tool_calls"] in (None, [])
+
+
+def test_agent_loop_follow_ups_dedup_and_cap_at_two():
+    """Lines 1607-1611 — duplicates across iterations collapse; the cap
+    holds even if Claude calls the tool multiple times with overlap."""
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Analyse intermédiaire.",
+            "tool_calls": [
+                _make_tool_call("suggest_followups", ["Question A", "Question A"]),
+            ],
+            "tokens_used": 10,
+            "sources": [],
+            "disclaimers": [],
+        },
+        {
+            "answer": "Réponse finale.",
+            "tool_calls": [
+                _make_tool_call(
+                    "suggest_followups",
+                    ["Question A", "Question B", "Question C"],
+                ),
+            ],
+            "tokens_used": 10,
+            "sources": [],
+            "disclaimers": [],
+        },
+        {
+            "answer": "Wrap-up.",
+            "tool_calls": [],
+            "tokens_used": 5,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    # Dedup + cap at 2; the extra "Question C" is silently dropped.
+    assert result["follow_up_questions"] == ["Question A", "Question B"]
+
+
+def test_agent_loop_truncates_long_follow_up_at_160_chars():
+    """Lines 1548-1551 — oversized questions are truncated to 160 chars."""
+    long_q = "Q" * 250
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Texte.",
+            "tool_calls": [_make_tool_call("suggest_followups", [long_q])],
+            "tokens_used": 5,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    assert len(result["follow_up_questions"]) == 1
+    assert len(result["follow_up_questions"][0]) == 160
+
+
+def test_agent_loop_rejects_non_string_follow_up_items():
+    """Lines 1546-1551 — defensive: non-string items in the LLM payload
+    must be skipped silently."""
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Texte.",
+            "tool_calls": [
+                {
+                    "name": "suggest_followups",
+                    "input": {"questions": [1, "vraie question", None, "autre"]},
+                },
+            ],
+            "tokens_used": 5,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    assert result["follow_up_questions"] == ["vraie question", "autre"]
+
+
+def test_agent_loop_ignores_malformed_suggest_followups_payload():
+    """Lines 1544-1547 — when `questions` is missing or not a list, the
+    capture block must no-op instead of crashing."""
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Texte.",
+            # input.questions is a string, not a list — defensive path.
+            "tool_calls": [
+                {"name": "suggest_followups", "input": {"questions": "not a list"}},
+            ],
+            "tokens_used": 5,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    assert result["follow_up_questions"] == []
+
+
+def test_agent_loop_empty_when_tool_never_called():
+    """Regression guard — a conversation without `suggest_followups` must
+    yield an empty list, never None, never any leaked state."""
+    orchestrator = _StubOrchestrator([
+        {
+            "answer": "Réponse sans relance.",
+            "tool_calls": [],
+            "tokens_used": 5,
+            "sources": [],
+            "disclaimers": [],
+        },
+    ])
+
+    result = _run_loop_sync(orchestrator)
+
+    assert result["follow_up_questions"] == []

--- a/services/backend/tests/test_follow_up_questions.py
+++ b/services/backend/tests/test_follow_up_questions.py
@@ -1,0 +1,187 @@
+"""
+Contract tests for backend-piloted follow_up_questions (Phase D).
+
+Covers:
+1. CoachChatResponse / AnonymousChatResponse schema cap at 2 items.
+2. The anonymous prompt carries the <followups> directive.
+3. extract_follow_ups() parses the block, strips it from the text, and
+   fails open on malformed input.
+4. The coach-chat prompt (claude_coach_service) carries the suggest_followups
+   directive so Claude knows to call the tool.
+5. `suggest_followups` is registered as an internal tool and declared in
+   the COACH_TOOLS list.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Schema caps
+# ---------------------------------------------------------------------------
+
+
+def test_coach_chat_response_caps_follow_ups_at_two():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(
+        message="Voici ta situation.",
+        follow_up_questions=["q1", "q2", "q3", "q4"],
+    )
+    assert resp.follow_up_questions == ["q1", "q2"]
+
+
+def test_coach_chat_response_strips_empty_follow_ups():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(
+        message="ok",
+        follow_up_questions=["  ", "réel", "", "autre"],
+    )
+    assert resp.follow_up_questions == ["réel", "autre"]
+
+
+def test_coach_chat_response_defaults_to_empty_list():
+    from app.schemas.coach_chat import CoachChatResponse
+
+    resp = CoachChatResponse(message="ok")
+    assert resp.follow_up_questions == []
+
+
+def test_anonymous_chat_response_caps_follow_ups_at_two():
+    from app.schemas.anonymous_chat import AnonymousChatResponse
+
+    resp = AnonymousChatResponse(
+        message="ok",
+        messages_remaining=2,
+        follow_up_questions=["q1", "q2", "q3"],
+    )
+    assert resp.follow_up_questions == ["q1", "q2"]
+
+
+def test_anonymous_chat_response_defaults_to_empty_list():
+    from app.schemas.anonymous_chat import AnonymousChatResponse
+
+    resp = AnonymousChatResponse(message="ok", messages_remaining=2)
+    assert resp.follow_up_questions == []
+
+
+# ---------------------------------------------------------------------------
+# Prompt directives
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_prompt_contains_followups_directive():
+    from app.api.v1.endpoints.anonymous_chat import build_discovery_system_prompt
+
+    prompt = build_discovery_system_prompt()
+    assert "<followups>" in prompt
+    assert "</followups>" in prompt
+    # The prompt must forbid reformulating the user's own question.
+    assert "reformuler" in prompt.lower()
+
+
+def test_coach_system_prompt_contains_suggest_followups_directive():
+    from app.services.coach.claude_coach_service import build_system_prompt
+
+    prompt = build_system_prompt()
+    assert "suggest_followups" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Parser (anonymous path, tools=None)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_follow_ups_happy_path():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = (
+        "Voici ta réponse.\n"
+        '<followups>["Ça vaut le coup de racheter du LPP ?", "Et le 3a ?"]</followups>'
+    )
+    cleaned, qs = extract_follow_ups(raw)
+    assert cleaned == "Voici ta réponse."
+    assert qs == ["Ça vaut le coup de racheter du LPP ?", "Et le 3a ?"]
+
+
+def test_extract_follow_ups_caps_at_two():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = 'Texte.\n<followups>["a","b","c","d"]</followups>'
+    _, qs = extract_follow_ups(raw)
+    assert qs == ["a", "b"]
+
+
+def test_extract_follow_ups_missing_block_returns_empty():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    cleaned, qs = extract_follow_ups("Juste du texte, pas de bloc.")
+    assert cleaned == "Juste du texte, pas de bloc."
+    assert qs == []
+
+
+def test_extract_follow_ups_malformed_json_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # Well-formed block shape but invalid JSON inside: block IS stripped,
+    # follow_ups empty on parse failure.
+    raw = 'Texte.\n<followups>[not json,]</followups>'
+    cleaned, qs = extract_follow_ups(raw)
+    assert "<followups>" not in cleaned
+    assert qs == []
+
+
+def test_extract_follow_ups_unterminated_block_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # No closing `]` inside the tags — regex can't match. Fail-open: text
+    # returned unchanged, follow_ups empty.
+    raw = "Texte.\n<followups>[not json</followups>"
+    cleaned, qs = extract_follow_ups(raw)
+    assert cleaned == raw
+    assert qs == []
+
+
+def test_extract_follow_ups_non_list_payload_fails_open():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    # JSON object, not array. Must fail open.
+    raw = 'Texte.\n<followups>{"questions": ["a"]}</followups>'
+    # Regex requires `[...]` — should not match at all.
+    cleaned, qs = extract_follow_ups(raw)
+    assert qs == []
+    # Block wasn't `[...]`, so it isn't stripped either.
+    assert "<followups>" in cleaned or cleaned.startswith("Texte")
+
+
+def test_extract_follow_ups_filters_non_string_items():
+    from app.api.v1.endpoints.anonymous_chat import extract_follow_ups
+
+    raw = 'Texte.\n<followups>[1, "vraie question", null]</followups>'
+    _, qs = extract_follow_ups(raw)
+    assert qs == ["vraie question"]
+
+
+# ---------------------------------------------------------------------------
+# Tool registration (coach-chat path)
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_followups_is_internal_tool():
+    from app.services.coach.coach_tools import INTERNAL_TOOL_NAMES
+
+    assert "suggest_followups" in INTERNAL_TOOL_NAMES
+
+
+def test_suggest_followups_declared_in_coach_tools():
+    from app.services.coach.coach_tools import COACH_TOOLS
+
+    names = [t.get("name") for t in COACH_TOOLS]
+    assert "suggest_followups" in names
+    tool = next(t for t in COACH_TOOLS if t.get("name") == "suggest_followups")
+    schema = tool["input_schema"]
+    assert "questions" in schema["properties"]
+    assert schema["properties"]["questions"]["type"] == "array"
+    assert schema["properties"]["questions"]["maxItems"] == 2
+    assert schema["required"] == ["questions"]

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -1295,6 +1295,14 @@
             "title": "Disclaimers",
             "type": "array"
           },
+          "followUpQuestions": {
+            "description": "Up to 2 genuine follow-up questions the user might ask next. Parsed server-side from a <followups>[\"q1\",\"q2\"]</followups> JSON block emitted by the LLM. Empty when absent or malformed. Never a reformulation of the user's own question.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Followupquestions",
+            "type": "array"
+          },
           "message": {
             "description": "Reponse du coach en mode decouverte.",
             "title": "Message",
@@ -3871,6 +3879,14 @@
               "type": "string"
             },
             "title": "Disclaimers",
+            "type": "array"
+          },
+          "followUpQuestions": {
+            "description": "Up to 2 genuine follow-up questions the user might ask next. Backend-piloted (via suggest_followups tool or <followups> JSON block). Empty list when the LLM produced none. Never a reformulation of the question the user just asked.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Followupquestions",
             "type": "array"
           },
           "message": {


### PR DESCRIPTION
## Why

Audit (2026-04-15) flagged 3 hardcoded suggestion chips appearing after every coach reply:
- \"Si je verse plus sur mon 3a, ça change quoi ?\"
- \"J'ai combien sur mes comptes 3a ?\"
- \"Ça vaut le coup de racheter du LPP ?\"

When the user asked a LPP question, the 3rd chip **reposed the same question** (anti-écoute, mini-humiliation per \`feedback_anti_shame_situated_learning.md\`).

Phase 24 claimed to have removed \"hardcoded suggestion chip defaults\" but only killed the global fallback — the topic-based regex pollution remained in \`_inferSuggestedActions\` (6 topics × 2 ARB strings) and in \`initialSuggestions\` (4 greeting chips).

## What

**Backend — new contract \`follow_up_questions: list[str]\` (≤ 2 items):**
- Added to \`CoachChatResponse\` + \`AnonymousChatResponse\` (Pydantic v2, camelCase alias).
- Authenticated path \`/coach/chat\`: new \`suggest_followups\` internal tool (like save_insight pattern). Prompt addendum directs Claude to call it with 1-2 GENUINE next questions the user might ask — never reformulate what they just asked.
- Anonymous path \`/anonymous/chat\` (tools=None): prompt directive \`<followups>[\"q1\",\"q2\"]</followups>\` JSON block, parsed server-side and stripped from user-visible text. PROMPT_VERSION bumped v2 → v3.

**Flutter — single source of truth:**
- Killed \`_inferSuggestedActions\` (regex) + \`CoachLlmService.inferSuggestedActions\` + \`CoachLlmService.initialSuggestions\`.
- \`ChatMessage.suggestedActions\` now populated exclusively from \`follow_up_questions\` (merged with existing \`_extractRouteChips\` from \`route_to_screen\` tool).
- Greeting silent: no more default chips on empty chat (honours \`feedback_chat_must_be_silent.md\`).

## Test plan

- [x] Backend: 5504 tests green (full suite). New \`test_follow_up_questions.py\` covers schema cap, prompt directive, anonymous parser strip, tool handler.
- [x] Flutter: 83 relevant tests green. New \`coach_chat_follow_up_questions_test.dart\` asserts chips dérivés UNIQUEMENT du backend field.
- [x] \`flutter analyze\` on touched files: 0 errors.
- [ ] CI green
- [ ] Post-merge device test: MSG1 has 0-2 chips (never 3 hardcoded), chips never repeat user question.

## Audit trail

Pre-audit (sector map) → architecture locked (Cleo pattern, backend-piloted). Post-audit adversarial covered in the executor agent's report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)