### PR TITLE
fix(coach): truncate list-aware + suggest_followups obligatoire (Run-001)

### DIFF
--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -436,15 +436,34 @@ IL EST OBLIGATOIRE D'APPELER save_insight EN MÊME TEMPS QUE TA RÉPONSE TEXTE �
 jamais après, jamais "à la prochaine", jamais "si l'utilisateur confirme". Chaque
 information extractible = un appel à save_insight immédiat, dans la même réponse.
 
-CHIPS DE SUIVI (outil `suggest_followups`) :
-Quand une vraie question de relance s'ouvre, appelle `suggest_followups(questions=[...])`
-avec 1 ou 2 questions que l'utilisateur pourrait GENUINELY vouloir poser APRÈS.
+CHIPS DE SUIVI (outil `suggest_followups`) — APPEL OBLIGATOIRE par défaut :
+
+Sauf cas explicite ci-dessous, tu DOIS appeler `suggest_followups(questions=[...])`
+EN MÊME TEMPS que ta réponse texte, avec 1 ou 2 questions que l'utilisateur
+pourrait GENUINELY vouloir poser APRÈS. Ce n'est pas optionnel — c'est ce qui
+nourrit la boucle conversation→action de MINT.
+
 RÈGLES ABSOLUES :
-- INTERDICTION ABSOLUE de reformuler la question que l'utilisateur vient de poser — c'est de l'anti-écoute.
-- Voix utilisateur à la 1re personne, question ouverte < 15 mots qui ÉTEND la conversation (pas une paraphrase).
+- INTERDICTION ABSOLUE de reformuler la question que l'utilisateur vient de poser
+  — c'est de l'anti-écoute (le user voit ses propres mots renvoyés = il abandonne).
+- Voix utilisateur à la 1re personne, question ouverte < 15 mots qui ÉTEND la
+  conversation : approfondit, élargit, ou propose un calcul concret.
 - Chaque question < 80 caractères.
-- Si rien ne s'ouvre, N'APPELLE PAS l'outil. Pas de remplissage.
 - 1 seul appel par réponse. Max 2 questions.
+
+EXEMPLES (à NE PAS recopier — inspiration de FORMAT seulement) :
+- Après une réponse sur un rachat LPP : "Et si j'étalais le rachat sur 3 ans ?"
+- Après une réponse sur le 3a : "Mon employeur abonde-t-il mes versements ?"
+- Après une réponse fiscale : "Quel canton serait optimal pour mon profil ?"
+- Après un calcul de rente : "Comment évolue ce chiffre si je travaille 2 ans de plus ?"
+
+CAS où tu N'APPELLES PAS l'outil (et seulement ces cas) :
+- L'utilisateur dit explicitement au revoir / merci / clôt la conversation.
+- Ta réponse est une demande de clarification (tu poses TOI une question pour
+  comprendre la situation) — dans ce cas la relance EST ta question.
+- L'utilisateur a clairement épuisé le sujet et tu ne vois aucune extension réelle.
+
+Dans tous les autres cas (= 95% des tours), APPELLE `suggest_followups`.
 
 DISCLAIMER (à rappeler si l'utilisateur demande une décision) :
 MINT est un outil éducatif. Il ne constitue pas un conseil financier au sens

--- a/services/backend/app/services/rag/guardrails.py
+++ b/services/backend/app/services/rag/guardrails.py
@@ -484,17 +484,59 @@ class ComplianceGuardrails:
 
         Splits on `.!?…` followed by whitespace. Preserves the terminal
         punctuation. Returns (text, was_truncated). No-op on empty input.
+
+        Post-fix 2026-04-15 (bug Run-001 #1): list markers like "1.", "2.",
+        "3." are merged into the following sentence instead of being
+        counted as sentences themselves, and a kept truncation that ends
+        on a dangling list marker or conjunction is cleaned up so the
+        output never terminates mid-enumeration.
         """
         if not isinstance(text, str) or not text.strip():
             return text, False
-        parts = _SENTENCE_SPLIT_RE.split(text.strip())
+        raw_parts = _SENTENCE_SPLIT_RE.split(text.strip())
+
+        # Merge dangling list markers ("1.", "2.") into the following
+        # sentence so they don't consume a slot.
+        list_marker = re.compile(r"^\d+\.$")
+        parts: list[str] = []
+        pending: str | None = None
+        for p in raw_parts:
+            p = p.strip()
+            if not p:
+                continue
+            if list_marker.match(p):
+                pending = p
+                continue
+            if pending is not None:
+                parts.append(f"{pending} {p}")
+                pending = None
+            else:
+                parts.append(p)
+        if pending is not None:
+            # Trailing list marker with no following sentence — drop it.
+            pass
+
         if len(parts) <= max_sentences:
-            return text, False
-        truncated = " ".join(p.strip() for p in parts[:max_sentences]).strip()
+            return " ".join(parts), False
+
+        kept = parts[:max_sentences]
+        # Clean up trailing fragment that ends on a bullet/conjunction
+        # ("et", "mais", ",", "(" without close, etc.) — if the last kept
+        # sentence clearly ends mid-thought, drop it rather than ship a
+        # mutilated tail.
+        last = kept[-1]
+        ends_badly = (
+            last.endswith(",")
+            or re.search(r"\b(et|mais|ou|donc|car|puis|alors)\s*$", last, re.IGNORECASE)
+            or (last.count("(") > last.count(")"))
+        )
+        if ends_badly and len(kept) > 1:
+            kept = kept[:-1]
+        truncated = " ".join(kept).strip()
         logger.info(
             "compliance.length_truncated original=%d kept=%d",
             len(parts),
-            max_sentences,
+            len(kept),
         )
         return truncated, True
 

--- a/services/backend/app/services/rag/guardrails.py
+++ b/services/backend/app/services/rag/guardrails.py
@@ -527,7 +527,11 @@ class ComplianceGuardrails:
         last = kept[-1]
         ends_badly = (
             last.endswith(",")
-            or re.search(r"\b(et|mais|ou|donc|car|puis|alors)\s*$", last, re.IGNORECASE)
+            or re.search(
+                r"\b(et|mais|ou|donc|car|puis|alors)\b[\.\s]*$",
+                last,
+                re.IGNORECASE,
+            )
             or (last.count("(") > last.count(")"))
         )
         if ends_badly and len(kept) > 1:

--- a/services/backend/tests/test_truncate_to_sentences.py
+++ b/services/backend/tests/test_truncate_to_sentences.py
@@ -1,0 +1,155 @@
+"""Tests for ComplianceGuardrails.truncate_to_sentences edge cases.
+
+Covers the list-marker merge + ends-badly cleanup added in PR #332 to fix
+the Run-001 bug where a coach reply ended on a dangling '2.' because list
+markers were counted as sentences.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.rag.guardrails import ComplianceGuardrails as CG
+
+
+# ---------------------------------------------------------------------------
+# Baseline behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_no_truncation_when_under_limit():
+    text = "Phrase un. Phrase deux."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=3)
+    assert out == "Phrase un. Phrase deux."
+    assert trunc is False
+
+
+def test_basic_truncation_to_max():
+    text = "Une. Deux. Trois. Quatre. Cinq."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=2)
+    assert trunc is True
+    assert "Une." in out
+    assert "Deux." in out
+    assert "Trois" not in out
+
+
+def test_empty_text_is_noop():
+    out, trunc = CG.truncate_to_sentences("", max_sentences=3)
+    assert out == ""
+    assert trunc is False
+
+
+def test_non_string_is_noop():
+    out, trunc = CG.truncate_to_sentences(None, max_sentences=3)  # type: ignore[arg-type]
+    assert out is None
+    assert trunc is False
+
+
+# ---------------------------------------------------------------------------
+# List-marker merge (covers the new pre-merge loop)
+# ---------------------------------------------------------------------------
+
+
+def test_list_markers_merged_with_following_sentence():
+    text = "Trois alertes : 1. Première alerte longue. 2. Deuxième alerte. 3. Troisième."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=5)
+    # After merge: 4 sentences ("Trois alertes :", "1. Première...", "2. ...", "3. ...")
+    # ≤ 5 so no truncation.
+    assert trunc is False
+    assert "1." in out and "Première" in out
+    assert "2." in out and "Deuxième" in out
+
+
+def test_list_markers_dont_inflate_sentence_count():
+    text = "1. Un. 2. Deux. 3. Trois. 4. Quatre."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=4)
+    # 4 merged sentences ≤ 4 → no truncation
+    assert trunc is False
+    assert "Quatre" in out
+
+
+def test_trailing_list_marker_dropped():
+    text = "Phrase un. Phrase deux. 3."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=5)
+    # Dangling "3." with no following content → dropped
+    assert "3." not in out or out.rstrip().endswith("deux.")
+    assert "deux." in out
+
+
+# ---------------------------------------------------------------------------
+# Ends-badly cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_ends_on_comma_drops_last_kept():
+    text = "Phrase un. Phrase deux fragment, Phrase trois normale. Phrase quatre."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=2)
+    # First 2 = ["Phrase un.", "Phrase deux fragment, Phrase trois normale."]
+    # Second one ends on "normale." not a bad ending → kept
+    assert trunc is True
+
+
+def test_ends_on_conjunction_drops():
+    text = "Premiere phrase. Deuxieme phrase mais. Troisieme phrase normale. Quatrieme."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=2)
+    # First 2 kept = ["Premiere phrase.", "Deuxieme phrase mais."]
+    # Second ends with "mais." → trailing conjunction → drop
+    assert "mais" not in out
+    assert "Premiere" in out
+    assert trunc is True
+
+
+def test_ends_on_unbalanced_paren_drops():
+    text = "Premiere. Deuxieme phrase (avec paren ouverte. Troisieme. Quatrieme."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=2)
+    # The second kept sentence has "(" but no ")" → drop
+    assert "(avec" not in out
+    assert "Premiere" in out
+
+
+def test_min_one_sentence_kept_even_if_ends_badly():
+    """If only 1 sentence to keep and it ends badly, do NOT drop it."""
+    text = "Premiere phrase mais. Deuxieme."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=1)
+    # Only 1 kept → keep it even with bad ending (else returns nothing)
+    assert "Premiere" in out
+    assert trunc is True
+
+
+# ---------------------------------------------------------------------------
+# Real Run-001 regression
+# ---------------------------------------------------------------------------
+
+
+def test_run_001_julien_dangling_two_dot():
+    text = (
+        "**300k LPP + trou de 50k = tu peux racheter maintenant.** "
+        "Mais 3 alertes avant de signer : "
+        "1. **Blocage EPL** : si tu rachètes, interdiction immobilière 3 ans. "
+        "2. **Étalement** : tu peux étaler sur 3 ans. "
+        "3. **Conjoint** : impact si Lauren US."
+    )
+    out, _ = CG.truncate_to_sentences(text, max_sentences=5)
+    # Must NOT end on dangling "2." or "3."
+    assert not out.rstrip().endswith("2.")
+    assert not out.rstrip().endswith("3.")
+    # If list-merge worked, we keep all 4 effective sentences (intro + 3 bullets) ≤ 5
+    assert "Blocage EPL" in out
+
+
+# ---------------------------------------------------------------------------
+# Whitespace robustness
+# ---------------------------------------------------------------------------
+
+
+def test_extra_whitespace_handled():
+    text = "  Une.   Deux.   Trois.  "
+    out, _ = CG.truncate_to_sentences(text, max_sentences=2)
+    assert "Une." in out
+    assert "Deux." in out
+    assert "Trois" not in out
+
+
+def test_only_whitespace_returns_unchanged():
+    out, trunc = CG.truncate_to_sentences("   ", max_sentences=3)
+    assert out == "   "
+    assert trunc is False


### PR DESCRIPTION
Live test Run-001 found coach reply ending on a dangling '2.' because the sentence splitter counted list markers as sentences. Fixed: merge '1.','2.' into following sentence, drop last kept sentence if it ends on a comma/conjunction/unbalanced paren.

35 tests green (prompt hardening + integration suite).