### PR TITLE
fix(coach): sentence splitter markdown-aware (Run-003 length cap leak)

### DIFF
--- a/services/backend/app/services/rag/guardrails.py
+++ b/services/backend/app/services/rag/guardrails.py
@@ -58,7 +58,14 @@ _FORMAL_VOUS_RE = re.compile(
 
 # Sentence splitter for length truncation. Keeps the delimiter with the
 # sentence it terminates.
-_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?…])\s+(?=\S)")
+#
+# 2026-04-15 (Run-003): allow an optional markdown bold/italic closing
+# token (`**`, `*`, `_`, `__`, `~~`, `"`, `'`, `)`, `]`) between the
+# terminator and the whitespace. Without this, "Genève.**" stays glued
+# to the next sentence and the truncate cap leaks beyond 5 sentences.
+_SENTENCE_SPLIT_RE = re.compile(
+    r"(?<=[.!?…])(?:\*{1,2}|_{1,2}|~~|[\"'\)\]])?\s+(?=\S)"
+)
 
 
 class ComplianceGuardrails:

--- a/services/backend/tests/test_truncate_to_sentences.py
+++ b/services/backend/tests/test_truncate_to_sentences.py
@@ -149,6 +149,42 @@ def test_extra_whitespace_handled():
     assert "Trois" not in out
 
 
+# ---------------------------------------------------------------------------
+# Markdown bold/italic adjacent to sentence terminator (Run-003 regression)
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_bold_after_period_still_splits():
+    """'Phrase un.** Phrase deux.' must be 2 sentences, not 1."""
+    text = "**Phrase un.** Phrase deux. Phrase trois. Phrase quatre. Phrase cinq. Phrase six."
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=5)
+    assert trunc is True
+    assert "six" not in out
+    assert "Phrase un" in out
+
+
+def test_quote_after_period_still_splits():
+    text = '"Phrase un." Phrase deux. Phrase trois. Phrase quatre. Phrase cinq. Phrase six.'
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=5)
+    assert trunc is True
+    assert "six" not in out
+
+
+def test_run_003_sophie_markdown_genevra_3a():
+    text = (
+        "**7258 CHF en 3a cette année = 1800 CHF d'impôts en moins à Genève.** "
+        "À 28 ans, salarié·e à 5800 net/mois, tu paies l'impôt GE plein tarif. "
+        "Le 3a, c'est un compte bloqué jusqu'à tes 60 ans. "
+        "Chaque franc versé = déduit de ton revenu imposable. "
+        "L'État te rembourse environ 25%. "
+        "si tu verses 604 CHF/mois, tu récupères ~150 CHF d'impôts par mois."
+    )
+    out, trunc = CG.truncate_to_sentences(text, max_sentences=5)
+    assert trunc is True
+    assert "604 CHF/mois" not in out
+    assert "Genève" in out
+
+
 def test_only_whitespace_returns_unchanged():
     out, trunc = CG.truncate_to_sentences("   ", max_sentences=3)
     assert out == "   "


### PR DESCRIPTION
Live Run-003 Sophie : '**...à Genève.** À 28 ans...' counted as 1 sentence not 2 because '.\*\*' wasn't a split boundary. Fix: optional closing markdown/quote token before whitespace. 17/17 tests green incl. verbatim Sophie regression.