### PR TITLE
fix(coach): add income_gross_yearly to _PROFILE_SAFE_FIELDS whitelist (Run-005 #2 root)

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -560,8 +560,14 @@ def _load_persisted_profile_fields(
             archetype = "swiss_native"
     result["archetype"] = archetype
     # Numeric fields: safe to inject.
+    # Run-005: added income_gross_yearly + income_net_yearly so the coach
+    # can answer "quel est mon salaire brut/net annuel" once the salary
+    # certificate has been confirmed (was returning "je n'ai pas ton brut").
     _SAFE_NUMERIC_KEYS = {
         "incomeNetMonthly": "monthly_income",
+        "incomeGrossYearly": "income_gross_yearly",
+        "incomeNetYearly": "income_net_yearly",
+        "incomeGrossMonthly": "income_gross_monthly",
         "pillar3aAnnual": "annual_3a_contribution",
         "lppInsuredSalary": "lpp_insured_salary",
         "avoirLpp": "lpp_capital",
@@ -569,6 +575,8 @@ def _load_persisted_profile_fields(
         "rachatMaximum": "lpp_buyback_max",
         "lppBuybackMax": "lpp_buyback_max",
         "pillar3aBalance": "existing_3a_ytd",
+        "wealthEstimate": "wealth_estimate",
+        "fortuneImposable": "wealth_estimate",
     }
     for src, dst in _SAFE_NUMERIC_KEYS.items():
         v = d.get(src)
@@ -613,9 +621,21 @@ def _build_user_facts_block(merged_profile: dict) -> str:
     inc = merged_profile.get("monthly_income")
     if inc:
         lines.append(f"- Salaire net mensuel : {int(inc)} CHF")
+    inc_gross_yr = merged_profile.get("income_gross_yearly")
+    if inc_gross_yr:
+        lines.append(f"- Salaire brut annuel : {int(inc_gross_yr)} CHF")
+    inc_net_yr = merged_profile.get("income_net_yearly")
+    if inc_net_yr:
+        lines.append(f"- Salaire net annuel : {int(inc_net_yr)} CHF")
+    inc_gross_mo = merged_profile.get("income_gross_monthly")
+    if inc_gross_mo:
+        lines.append(f"- Salaire brut mensuel : {int(inc_gross_mo)} CHF")
     lpp_sal = merged_profile.get("lpp_insured_salary")
     if lpp_sal:
         lines.append(f"- Salaire assure LPP : {int(lpp_sal)} CHF")
+    wealth = merged_profile.get("wealth_estimate")
+    if wealth:
+        lines.append(f"- Fortune imposable : {int(wealth)} CHF")
     lpp_cap = merged_profile.get("lpp_capital")
     if lpp_cap:
         lines.append(f"- Avoir LPP total : {int(lpp_cap)} CHF")

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -436,6 +436,14 @@ _PROFILE_SAFE_FIELDS = {
     "planned_contributions",
     # BUG #2 FIX (2026-04-15): LPP salary + completion fields from persisted profile.
     "lpp_insured_salary",
+    # Run-005 FIX (2026-04-15): salary income + wealth fields from
+    # /documents/scan-confirmation merge — the whitelist gated them out
+    # so even when persisted, the coach never saw them.
+    "income_gross_yearly",
+    "income_net_yearly",
+    "income_gross_monthly",
+    "wealth_estimate",
+    "commune",
 }
 
 

--- a/services/backend/tests/test_user_facts_block.py
+++ b/services/backend/tests/test_user_facts_block.py
@@ -1,0 +1,95 @@
+"""Coverage tests for _build_user_facts_block branches added in PR #340.
+
+Targets coach_chat.py lines 626, 629, 632, 638 — the new salary income
+fields (gross yearly, net yearly, gross monthly, wealth_estimate)
+introduced after Run-005 found the coach couldn't cite incomeGrossYearly
+even after scan-confirmation persisted it.
+"""
+from __future__ import annotations
+
+from app.api.v1.endpoints.coach_chat import _build_user_facts_block
+
+
+def test_block_includes_income_gross_yearly():
+    block = _build_user_facts_block({
+        "age": 28,
+        "income_gross_yearly": 85000.0,
+    })
+    assert "<facts_user>" in block
+    assert "Salaire brut annuel" in block
+    assert "85000" in block
+
+
+def test_block_includes_income_net_yearly():
+    block = _build_user_facts_block({
+        "age": 49,
+        "income_net_yearly": 70000.0,
+    })
+    assert "Salaire net annuel" in block
+    assert "70000" in block
+
+
+def test_block_includes_income_gross_monthly():
+    block = _build_user_facts_block({
+        "age": 35,
+        "income_gross_monthly": 9500.0,
+    })
+    assert "Salaire brut mensuel" in block
+    assert "9500" in block
+
+
+def test_block_includes_wealth_estimate():
+    block = _build_user_facts_block({
+        "age": 56,
+        "wealth_estimate": 250000.0,
+    })
+    assert "Fortune imposable" in block
+    assert "250000" in block
+
+
+def test_block_combines_all_new_fields():
+    """All 4 new fields surface together when present, in stable order."""
+    block = _build_user_facts_block({
+        "age": 49,
+        "canton": "VS",
+        "monthly_income": 7600,
+        "income_gross_yearly": 122206,
+        "income_net_yearly": 91200,
+        "income_gross_monthly": 10183,
+        "lpp_insured_salary": 95941,
+        "wealth_estimate": 75000,
+    })
+    assert "Salaire net mensuel" in block
+    assert "Salaire brut annuel" in block
+    assert "Salaire net annuel" in block
+    assert "Salaire brut mensuel" in block
+    assert "Salaire assure LPP" in block
+    assert "Fortune imposable" in block
+
+
+def test_block_skips_zero_or_none_fields():
+    """Zero or None new fields must NOT emit empty lines."""
+    block = _build_user_facts_block({
+        "age": 28,
+        "monthly_income": 5800,
+        "income_gross_yearly": None,
+        "income_net_yearly": 0,
+        "income_gross_monthly": None,
+        "wealth_estimate": 0,
+    })
+    assert "Salaire net mensuel" in block
+    assert "Salaire brut annuel" not in block
+    assert "Salaire net annuel" not in block
+    assert "Fortune imposable" not in block
+
+
+def test_block_empty_when_only_none_fields():
+    """A profile with only the new keys all-None returns empty string
+    (no <facts_user> wrapper)."""
+    block = _build_user_facts_block({
+        "income_gross_yearly": None,
+        "income_net_yearly": None,
+        "income_gross_monthly": None,
+        "wealth_estimate": None,
+    })
+    assert block == ""


### PR DESCRIPTION
Run-005 traced the 'coach can't see incomeGrossYearly' bug to a 3rd gating layer: the _PROFILE_SAFE_FIELDS whitelist filtered the persisted fields out before they reached safe_profile. Added 5 keys to unblock.