### PR TITLE
feat(notifs): Wave A-MINIMAL — scan event memory + deadline notifs + PII/façade hardening

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1294,7 +1294,19 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
         // fired once at onboarding intent and never re-fired when a
         // user completed the triad mid-conversation via save_fact.
         // Panel adversaire 2026-04-18 BUG 2+3 mitigation.
+        //
+        // A2-fix (2026-04-18): `lazy: false` is MANDATORY. Without it,
+        // ChangeNotifierProxyProvider defers `create`/`update` until a
+        // widget downstream calls `context.watch<NotificationsWiringService>()`.
+        // No screen does — the service is purely reactive plumbing,
+        // not a UI dependency. The 3-panel post-exec audit unanimously
+        // flagged this as a P0 "façade sans câblage" that would ship
+        // 100% dead code while all 7 unit tests passed. The `lazy: false`
+        // flag materialises the service at MultiProvider mount time so
+        // its `update` actually fires on every CoachProfileProvider
+        // notifyListeners.
         ChangeNotifierProxyProvider<CoachProfileProvider, NotificationsWiringService>(
+          lazy: false,
           create: (_) => NotificationsWiringService(),
           update: (_, profileProvider, wiring) {
             final service = wiring ?? NotificationsWiringService();

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -50,6 +50,7 @@ import 'package:mint_mobile/screens/bank_import_screen.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
 import 'package:mint_mobile/services/analytics_observer.dart';
 import 'package:mint_mobile/services/notification_service.dart';
+import 'package:mint_mobile/services/notifications_wiring_service.dart';
 import 'package:mint_mobile/services/slm/slm_engine.dart';
 import 'package:mint_mobile/screens/gender_gap_screen.dart';
 import 'package:mint_mobile/screens/frontalier_screen.dart';
@@ -1285,6 +1286,22 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
         ChangeNotifierProvider(create: (_) => FinancialPlanProvider()),
         ChangeNotifierProvider(create: (_) => CoachEntryPayloadProvider()),
         ChangeNotifierProvider<TimelineProvider>(create: (_) => TimelineProvider()),
+        // Wave A-MINIMAL A2 (2026-04-18): notifications wiring listens
+        // to CoachProfileProvider and reschedules coaching reminders
+        // when the triad (birthYear + canton + salaireBrutMensuel)
+        // transitions incomplete→complete or changes signature. The
+        // previous wiring (`_markOnboardingCompletedIfNeeded` only)
+        // fired once at onboarding intent and never re-fired when a
+        // user completed the triad mid-conversation via save_fact.
+        // Panel adversaire 2026-04-18 BUG 2+3 mitigation.
+        ChangeNotifierProxyProvider<CoachProfileProvider, NotificationsWiringService>(
+          create: (_) => NotificationsWiringService(),
+          update: (_, profileProvider, wiring) {
+            final service = wiring ?? NotificationsWiringService();
+            service.onProfileChanged(profileProvider.profile);
+            return service;
+          },
+        ),
       ],
       child: _AuthRouterBridge(
         child: Builder(

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -10965,5 +10965,11 @@
   "safeModeWhyBlockedTitle": "Warum ist das pausiert",
   "safeModeWhyBlockedBody": "Im Schutzmodus priorisiert MINT die Liquiditätsstabilisierung vor Steuer- und Vorsorgeoptimierungen.",
   "safeModeWhyBlockedLink": "Warum ist das pausiert?",
-  "safeModeFormalDesendettementNote": "Diese Auszahlungen bleiben im Rahmen eines formellen Schuldenbereinigungsverfahrens möglich — sprich mit einem Spezialisten."
+  "safeModeFormalDesendettementNote": "Diese Auszahlungen bleiben im Rahmen eines formellen Schuldenbereinigungsverfahrens möglich — sprich mit einem Spezialisten.",
+  "scanSummaryLppCertificate": "BVG-Ausweis gescannt",
+  "scanSummary3aAttestation": "Säule-3a-Bescheinigung gescannt",
+  "scanSummaryTaxDeclaration": "Steuererklärung gescannt",
+  "scanSummaryAvsExtract": "AHV-Auszug gescannt",
+  "scanSummaryMortgageAttestation": "Hypothekenbescheinigung gescannt",
+  "scanSummarySalaryCertificate": "Lohnausweis gescannt"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -10965,5 +10965,11 @@
   "safeModeWhyBlockedTitle": "Why it's on hold",
   "safeModeWhyBlockedBody": "In protection mode, MINT prioritises cash flow stability before tax and pension optimisations.",
   "safeModeWhyBlockedLink": "Why is this on hold?",
-  "safeModeFormalDesendettementNote": "These withdrawals remain possible under a formal debt resolution procedure — speak to a specialist."
+  "safeModeFormalDesendettementNote": "These withdrawals remain possible under a formal debt resolution procedure — speak to a specialist.",
+  "scanSummaryLppCertificate": "LPP certificate scanned",
+  "scanSummary3aAttestation": "Pillar 3a attestation scanned",
+  "scanSummaryTaxDeclaration": "Tax declaration scanned",
+  "scanSummaryAvsExtract": "AVS extract scanned",
+  "scanSummaryMortgageAttestation": "Mortgage attestation scanned",
+  "scanSummarySalaryCertificate": "Salary certificate scanned"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -10965,5 +10965,11 @@
   "safeModeWhyBlockedTitle": "Por qué está en pausa",
   "safeModeWhyBlockedBody": "En modo protección, MINT prioriza la estabilidad de tesorería antes que las optimizaciones fiscales y de previsión.",
   "safeModeWhyBlockedLink": "¿Por qué está en pausa?",
-  "safeModeFormalDesendettementNote": "Estas retiradas siguen siendo posibles en caso de procedimiento formal de saneamiento de deudas — habla con un especialista."
+  "safeModeFormalDesendettementNote": "Estas retiradas siguen siendo posibles en caso de procedimiento formal de saneamiento de deudas — habla con un especialista.",
+  "scanSummaryLppCertificate": "Certificado LPP escaneado",
+  "scanSummary3aAttestation": "Certificado 3a escaneado",
+  "scanSummaryTaxDeclaration": "Declaración fiscal escaneada",
+  "scanSummaryAvsExtract": "Extracto AVS escaneado",
+  "scanSummaryMortgageAttestation": "Certificado hipotecario escaneado",
+  "scanSummarySalaryCertificate": "Certificado de salario escaneado"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11741,5 +11741,17 @@
   "safeModeWhyBlockedTitle": "Pourquoi c'est en pause",
   "safeModeWhyBlockedBody": "En mode protection, MINT priorise la stabilité de trésorerie avant les optimisations fiscales et prévoyance.",
   "safeModeWhyBlockedLink": "Pourquoi est-ce en pause\u00a0?",
-  "safeModeFormalDesendettementNote": "Ces retraits restent possibles en cas de procédure de désendettement formelle — parle à un·e spécialiste."
+  "safeModeFormalDesendettementNote": "Ces retraits restent possibles en cas de procédure de désendettement formelle — parle à un·e spécialiste.",
+  "scanSummaryLppCertificate": "Certificat LPP scanné",
+  "@scanSummaryLppCertificate": { "description": "Persistent event summary when an LPP certificate is scanned." },
+  "scanSummary3aAttestation": "Attestation 3a scannée",
+  "@scanSummary3aAttestation": { "description": "Persistent event summary when a Pillar 3a attestation is scanned." },
+  "scanSummaryTaxDeclaration": "Déclaration fiscale scannée",
+  "@scanSummaryTaxDeclaration": { "description": "Persistent event summary when a tax declaration is scanned." },
+  "scanSummaryAvsExtract": "Extrait AVS scanné",
+  "@scanSummaryAvsExtract": { "description": "Persistent event summary when an AVS extract is scanned." },
+  "scanSummaryMortgageAttestation": "Attestation hypothèque scannée",
+  "@scanSummaryMortgageAttestation": { "description": "Persistent event summary when a mortgage attestation is scanned." },
+  "scanSummarySalaryCertificate": "Certificat de salaire scanné",
+  "@scanSummarySalaryCertificate": { "description": "Persistent event summary when a salary certificate is scanned." }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -10965,5 +10965,11 @@
   "safeModeWhyBlockedTitle": "Perché è in pausa",
   "safeModeWhyBlockedBody": "In modalità protezione, MINT privilegia la stabilità della liquidità prima delle ottimizzazioni fiscali e previdenziali.",
   "safeModeWhyBlockedLink": "Perché è in pausa?",
-  "safeModeFormalDesendettementNote": "Questi prelievi restano possibili in caso di procedura formale di risanamento del debito — parla con uno specialista."
+  "safeModeFormalDesendettementNote": "Questi prelievi restano possibili in caso di procedura formale di risanamento del debito — parla con uno specialista.",
+  "scanSummaryLppCertificate": "Certificato LPP scansionato",
+  "scanSummary3aAttestation": "Attestato 3a scansionato",
+  "scanSummaryTaxDeclaration": "Dichiarazione fiscale scansionata",
+  "scanSummaryAvsExtract": "Estratto AVS scansionato",
+  "scanSummaryMortgageAttestation": "Attestato ipoteca scansionato",
+  "scanSummarySalaryCertificate": "Certificato di stipendio scansionato"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -36951,19 +36951,19 @@ abstract class S {
   /// **'Capital projeté à la retraite'**
   String get coachSilentOpenerRetirementCapital;
 
-  /// No description provided for @coachSilentOpenerProjectedCapital.
+  /// Silent opener label when the coach surfaces a generic projected-capital number across any life-event horizon (not only retraite). Wave 2 debias — replaces retirement-framed default.
   ///
   /// In fr, this message translates to:
   /// **'Capital projeté sur ton horizon'**
   String get coachSilentOpenerProjectedCapital;
 
-  /// No description provided for @coachSilentOpenerLppAvoir.
+  /// Silent opener label for the user's current LPP balance, surfaced first when enriched via scan. Factual indicative voice.
   ///
   /// In fr, this message translates to:
   /// **'Avoir LPP'**
   String get coachSilentOpenerLppAvoir;
 
-  /// No description provided for @coachSilentOpener3aEpargne.
+  /// Silent opener label for 3a savings snapshot. Factual indicative voice.
   ///
   /// In fr, this message translates to:
   /// **'Épargne 3a'**
@@ -40178,6 +40178,42 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Ces retraits restent possibles en cas de procédure de désendettement formelle — parle à un·e spécialiste.'**
   String get safeModeFormalDesendettementNote;
+
+  /// Persistent event summary when an LPP certificate is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Certificat LPP scanné'**
+  String get scanSummaryLppCertificate;
+
+  /// Persistent event summary when a Pillar 3a attestation is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Attestation 3a scannée'**
+  String get scanSummary3aAttestation;
+
+  /// Persistent event summary when a tax declaration is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Déclaration fiscale scannée'**
+  String get scanSummaryTaxDeclaration;
+
+  /// Persistent event summary when an AVS extract is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Extrait AVS scanné'**
+  String get scanSummaryAvsExtract;
+
+  /// Persistent event summary when a mortgage attestation is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Attestation hypothèque scannée'**
+  String get scanSummaryMortgageAttestation;
+
+  /// Persistent event summary when a salary certificate is scanned.
+  ///
+  /// In fr, this message translates to:
+  /// **'Certificat de salaire scanné'**
+  String get scanSummarySalaryCertificate;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -22957,4 +22957,23 @@ class SDe extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'Diese Auszahlungen bleiben im Rahmen eines formellen Schuldenbereinigungsverfahrens möglich — sprich mit einem Spezialisten.';
+
+  @override
+  String get scanSummaryLppCertificate => 'BVG-Ausweis gescannt';
+
+  @override
+  String get scanSummary3aAttestation => 'Säule-3a-Bescheinigung gescannt';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Steuererklärung gescannt';
+
+  @override
+  String get scanSummaryAvsExtract => 'AHV-Auszug gescannt';
+
+  @override
+  String get scanSummaryMortgageAttestation =>
+      'Hypothekenbescheinigung gescannt';
+
+  @override
+  String get scanSummarySalaryCertificate => 'Lohnausweis gescannt';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22791,4 +22791,22 @@ class SEn extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'These withdrawals remain possible under a formal debt resolution procedure — speak to a specialist.';
+
+  @override
+  String get scanSummaryLppCertificate => 'LPP certificate scanned';
+
+  @override
+  String get scanSummary3aAttestation => 'Pillar 3a attestation scanned';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Tax declaration scanned';
+
+  @override
+  String get scanSummaryAvsExtract => 'AVS extract scanned';
+
+  @override
+  String get scanSummaryMortgageAttestation => 'Mortgage attestation scanned';
+
+  @override
+  String get scanSummarySalaryCertificate => 'Salary certificate scanned';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -22901,4 +22901,23 @@ class SEs extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'Estas retiradas siguen siendo posibles en caso de procedimiento formal de saneamiento de deudas — habla con un especialista.';
+
+  @override
+  String get scanSummaryLppCertificate => 'Certificado LPP escaneado';
+
+  @override
+  String get scanSummary3aAttestation => 'Certificado 3a escaneado';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Declaración fiscal escaneada';
+
+  @override
+  String get scanSummaryAvsExtract => 'Extracto AVS escaneado';
+
+  @override
+  String get scanSummaryMortgageAttestation =>
+      'Certificado hipotecario escaneado';
+
+  @override
+  String get scanSummarySalaryCertificate => 'Certificado de salario escaneado';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -22903,4 +22903,22 @@ class SFr extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'Ces retraits restent possibles en cas de procédure de désendettement formelle — parle à un·e spécialiste.';
+
+  @override
+  String get scanSummaryLppCertificate => 'Certificat LPP scanné';
+
+  @override
+  String get scanSummary3aAttestation => 'Attestation 3a scannée';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Déclaration fiscale scannée';
+
+  @override
+  String get scanSummaryAvsExtract => 'Extrait AVS scanné';
+
+  @override
+  String get scanSummaryMortgageAttestation => 'Attestation hypothèque scannée';
+
+  @override
+  String get scanSummarySalaryCertificate => 'Certificat de salaire scanné';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -22963,4 +22963,23 @@ class SIt extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'Questi prelievi restano possibili in caso di procedura formale di risanamento del debito — parla con uno specialista.';
+
+  @override
+  String get scanSummaryLppCertificate => 'Certificato LPP scansionato';
+
+  @override
+  String get scanSummary3aAttestation => 'Attestato 3a scansionato';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Dichiarazione fiscale scansionata';
+
+  @override
+  String get scanSummaryAvsExtract => 'Estratto AVS scansionato';
+
+  @override
+  String get scanSummaryMortgageAttestation => 'Attestato ipoteca scansionato';
+
+  @override
+  String get scanSummarySalaryCertificate =>
+      'Certificato di stipendio scansionato';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -22908,4 +22908,24 @@ class SPt extends S {
   @override
   String get safeModeFormalDesendettementNote =>
       'Estes levantamentos continuam possíveis em caso de procedimento formal de saneamento de dívidas — fala com um especialista.';
+
+  @override
+  String get scanSummaryLppCertificate => 'Certificado LPP digitalizado';
+
+  @override
+  String get scanSummary3aAttestation => 'Atestação 3a digitalizada';
+
+  @override
+  String get scanSummaryTaxDeclaration => 'Declaração fiscal digitalizada';
+
+  @override
+  String get scanSummaryAvsExtract => 'Extrato AVS digitalizado';
+
+  @override
+  String get scanSummaryMortgageAttestation =>
+      'Atestação hipoteca digitalizada';
+
+  @override
+  String get scanSummarySalaryCertificate =>
+      'Certificado de salário digitalizado';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -10965,5 +10965,11 @@
   "safeModeWhyBlockedTitle": "Porquê está em pausa",
   "safeModeWhyBlockedBody": "Em modo de proteção, o MINT prioriza a estabilidade da tesouraria antes das otimizações fiscais e de previdência.",
   "safeModeWhyBlockedLink": "Porquê está em pausa?",
-  "safeModeFormalDesendettementNote": "Estes levantamentos continuam possíveis em caso de procedimento formal de saneamento de dívidas — fala com um especialista."
+  "safeModeFormalDesendettementNote": "Estes levantamentos continuam possíveis em caso de procedimento formal de saneamento de dívidas — fala com um especialista.",
+  "scanSummaryLppCertificate": "Certificado LPP digitalizado",
+  "scanSummary3aAttestation": "Atestação 3a digitalizada",
+  "scanSummaryTaxDeclaration": "Declaração fiscal digitalizada",
+  "scanSummaryAvsExtract": "Extrato AVS digitalizado",
+  "scanSummaryMortgageAttestation": "Atestação hipoteca digitalizada",
+  "scanSummarySalaryCertificate": "Certificado de salário digitalizado"
 }

--- a/apps/mobile/lib/models/coach_insight.dart
+++ b/apps/mobile/lib/models/coach_insight.dart
@@ -33,6 +33,16 @@ enum InsightType {
 
   /// A fact about the user's situation ("a un avoir LPP de ~70k").
   fact,
+
+  /// A durable event the user experienced. Unlike [fact] (mutable
+  /// assertion about state), [event] anchors a specific moment in time
+  /// the coach should remember and can reference later ("tu as scanné
+  /// ton certificat CPE mardi", "tu as reçu l'héritage en mars").
+  /// Added Wave A-MINIMAL 2026-04-18 for scan + life-event persistence.
+  /// Events live in a separate non-FIFO namespace in [CoachMemoryService]
+  /// so they survive the 50-insight pruning that would otherwise evict
+  /// them after a week of active `fact`-heavy coaching.
+  event,
 }
 
 /// A key insight extracted from a coach conversation.

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -94,32 +94,33 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
         canton: null, // Canton from profile context if available
       );
 
+      // A2-fix (2026-04-18) post-exec audit panel façade #1:
+      // persist the scan event BEFORE the `mounted` check so that a
+      // user who navigates away between network return and setState
+      // still has the event recorded. Memory persistence does not
+      // touch `setState` and therefore is safe to fire on an unmounted
+      // State; the scan DID happen, its memory must not depend on
+      // whether the user stayed on this screen.
+      _persistScanEvent();
+
       if (!mounted) return;
       setState(() {
         _premierEclairage = result;
         _premierEclairageLoading = false;
         _premierEclairageFailed = result == null;
       });
-
-      // Wave A-MINIMAL A1: persist a durable scan event so the coach
-      // can reference the scan in later sessions. This fires whether
-      // or not the server returned a non-null premier éclairage —
-      // the SCAN itself happened, which is the memory we want. The
-      // call is fire-and-forget (SharedPreferences write is sync +
-      // fast enough; exceptions already caught inside saveEvent via
-      // the underlying _save).
-      _persistScanEvent();
     } catch (_) {
+      // Same ordering rule on the error path: persist the event first,
+      // regardless of whether the user is still on screen when the
+      // exception lands. Panel adversaire 2026-04-18 + panel façade
+      // hunter both flagged this as a memory-loss bug.
+      _persistScanEvent();
+
       if (!mounted) return;
       setState(() {
         _premierEclairageLoading = false;
         _premierEclairageFailed = true;
       });
-      // Even when the premier éclairage fetch fails (network, timeout,
-      // backend 5xx), the user DID scan a document. Record the event
-      // so J+30 dedup works and the coach can still reference "tu as
-      // scanné ton certificat" independently of the narrative layer.
-      _persistScanEvent();
     }
   }
 
@@ -133,7 +134,13 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
   void _persistScanEvent() {
     try {
       final topic = _scanTopicForType(widget.result.documentType);
-      final summary = _scanSummary();
+      // A2-fix (2026-04-18) panel UX #2: pull the localized label from
+      // AppLocalizations so the persisted summary respects the user's
+      // current language instead of shipping FR literals into all 6
+      // locales. The context is still valid here because
+      // _persistScanEvent is called synchronously from the fetch
+      // handlers (mounted at entry — see ordering rule A2-fix).
+      final summary = _scanSummary(_scanTypeLabel(widget.result.documentType));
       CoachMemoryService.saveEvent(topic, summary).catchError((e) {
         debugPrint('[document_impact] saveEvent failed: $e');
       });
@@ -160,8 +167,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
     }
   }
 
-  String _scanSummary() {
-    final type = widget.result.documentType;
+  String _scanSummary(String typeLabel) {
     String? caisse;
     String? avoir;
 
@@ -178,11 +184,16 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
       if (avoir == null &&
           (name.contains('avoir') || name.contains('balance') ||
            name.contains('capital') || name.contains('total'))) {
-        avoir = value;
+        // A2-fix (2026-04-18) panel UX #3: bucketize raw financial
+        // amounts to nearest 10 000 CHF before persistence. A raw
+        // "70377.00" violates CLAUDE.md §6.7 (no exact salary / wealth
+        // in logs or memory); the rounded "~70'000 CHF" preserves
+        // enough signal for the coach to reason about order of
+        // magnitude without leaking the identifying precision.
+        avoir = _bucketizeAvoir(value);
       }
     }
 
-    final typeLabel = _scanTypeLabel(type);
     if (caisse != null && avoir != null) {
       return '$typeLabel $caisse — $avoir';
     }
@@ -195,20 +206,45 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
     return typeLabel;
   }
 
+  /// Round a raw numeric string to the nearest 10 000 CHF and format
+  /// it Swiss-style (`~70'000 CHF`). Non-numeric input or parse
+  /// failures fall back to `"montant non précisé"` — never return the
+  /// raw value to avoid leaking PII into persisted summaries.
+  String _bucketizeAvoir(String raw) {
+    final cleaned = raw.replaceAll("'", '').replaceAll(' ', '').replaceAll(',', '.');
+    final parsed = double.tryParse(cleaned);
+    if (parsed == null) return 'montant non précisé';
+    if (parsed <= 0) return 'montant non précisé';
+    final bucket = (parsed / 10000).round() * 10000;
+    // Swiss thousands separator: apostrophe (e.g. 70'000).
+    final asInt = bucket.toInt();
+    final withSep = asInt.toString().replaceAllMapped(
+          RegExp(r'(\d)(?=(\d{3})+(?!\d))'),
+          (m) => "${m[1]}'",
+        );
+    return "~$withSep CHF";
+  }
+
   String _scanTypeLabel(DocumentType type) {
+    // A2-fix (2026-04-18) panel UX #2: pull strings from ARB so
+    // persisted summaries respect the active locale. Keys declared in
+    // all 6 ARB files (scanSummaryLppCertificate etc.). Uses the
+    // current BuildContext — safe because _scanTypeLabel is called
+    // synchronously from the fetch handlers before any unmount.
+    final l10n = S.of(context)!;
     switch (type) {
       case DocumentType.lppCertificate:
-        return 'Certificat LPP scanné';
+        return l10n.scanSummaryLppCertificate;
       case DocumentType.threeAAttestation:
-        return 'Attestation 3a scannée';
+        return l10n.scanSummary3aAttestation;
       case DocumentType.taxDeclaration:
-        return 'Déclaration fiscale scannée';
+        return l10n.scanSummaryTaxDeclaration;
       case DocumentType.avsExtract:
-        return 'Extrait AVS scanné';
+        return l10n.scanSummaryAvsExtract;
       case DocumentType.mortgageAttestation:
-        return 'Attestation hypothèque scannée';
+        return l10n.scanSummaryMortgageAttestation;
       case DocumentType.salaryCertificate:
-        return 'Certificat de salaire scanné';
+        return l10n.scanSummarySalaryCertificate;
     }
   }
 

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -8,6 +8,10 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
 import 'package:mint_mobile/services/document_service.dart';
+// Wave A-MINIMAL (2026-04-18) A1: persist a durable scan event so the
+// coach can reference "tu as scanné ton certificat CPE mardi" later.
+// Events live in a separate non-FIFO namespace from regular insights.
+import 'package:mint_mobile/services/memory/coach_memory_service.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 
@@ -96,12 +100,115 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
         _premierEclairageLoading = false;
         _premierEclairageFailed = result == null;
       });
+
+      // Wave A-MINIMAL A1: persist a durable scan event so the coach
+      // can reference the scan in later sessions. This fires whether
+      // or not the server returned a non-null premier éclairage —
+      // the SCAN itself happened, which is the memory we want. The
+      // call is fire-and-forget (SharedPreferences write is sync +
+      // fast enough; exceptions already caught inside saveEvent via
+      // the underlying _save).
+      _persistScanEvent();
     } catch (_) {
       if (!mounted) return;
       setState(() {
         _premierEclairageLoading = false;
         _premierEclairageFailed = true;
       });
+      // Even when the premier éclairage fetch fails (network, timeout,
+      // backend 5xx), the user DID scan a document. Record the event
+      // so J+30 dedup works and the coach can still reference "tu as
+      // scanné ton certificat" independently of the narrative layer.
+      _persistScanEvent();
+    }
+  }
+
+  /// Persist a scan event in [CoachMemoryService] — Wave A-MINIMAL A1.
+  ///
+  /// Topic is derived from [DocumentType]. Summary is best-effort:
+  /// pulls caisse + avoir from extracted fields when present, falls
+  /// back gracefully when fields are missing. The event lives in the
+  /// non-pruned events namespace so it survives `fact`-heavy coaching
+  /// bursts (panel adversaire 2026-04-18 B5).
+  void _persistScanEvent() {
+    try {
+      final topic = _scanTopicForType(widget.result.documentType);
+      final summary = _scanSummary();
+      CoachMemoryService.saveEvent(topic, summary).catchError((e) {
+        debugPrint('[document_impact] saveEvent failed: $e');
+      });
+    } catch (e, st) {
+      // Never let memory persistence break the scan UX.
+      debugPrint('[document_impact] _persistScanEvent threw: $e\n$st');
+    }
+  }
+
+  String _scanTopicForType(DocumentType type) {
+    switch (type) {
+      case DocumentType.lppCertificate:
+        return 'scan_lpp';
+      case DocumentType.threeAAttestation:
+        return 'scan_3a';
+      case DocumentType.taxDeclaration:
+        return 'scan_tax';
+      case DocumentType.avsExtract:
+        return 'scan_avs';
+      case DocumentType.mortgageAttestation:
+        return 'scan_mortgage';
+      case DocumentType.salaryCertificate:
+        return 'scan_salary';
+    }
+  }
+
+  String _scanSummary() {
+    final type = widget.result.documentType;
+    String? caisse;
+    String? avoir;
+
+    // Pull common LPP / 3a fields without hardcoding locale strings.
+    for (final f in widget.result.fields) {
+      final name = f.fieldName.toLowerCase();
+      final value = f.value?.toString().trim();
+      if (value == null || value.isEmpty) continue;
+      if (caisse == null &&
+          (name.contains('caisse') || name.contains('institution') ||
+           name.contains('pension') || name.contains('fund'))) {
+        caisse = value;
+      }
+      if (avoir == null &&
+          (name.contains('avoir') || name.contains('balance') ||
+           name.contains('capital') || name.contains('total'))) {
+        avoir = value;
+      }
+    }
+
+    final typeLabel = _scanTypeLabel(type);
+    if (caisse != null && avoir != null) {
+      return '$typeLabel $caisse — $avoir';
+    }
+    if (caisse != null) {
+      return '$typeLabel $caisse';
+    }
+    if (avoir != null) {
+      return '$typeLabel — $avoir';
+    }
+    return typeLabel;
+  }
+
+  String _scanTypeLabel(DocumentType type) {
+    switch (type) {
+      case DocumentType.lppCertificate:
+        return 'Certificat LPP scanné';
+      case DocumentType.threeAAttestation:
+        return 'Attestation 3a scannée';
+      case DocumentType.taxDeclaration:
+        return 'Déclaration fiscale scannée';
+      case DocumentType.avsExtract:
+        return 'Extrait AVS scanné';
+      case DocumentType.mortgageAttestation:
+        return 'Attestation hypothèque scannée';
+      case DocumentType.salaryCertificate:
+        return 'Certificat de salaire scanné';
     }
   }
 

--- a/apps/mobile/lib/services/memory/coach_memory_service.dart
+++ b/apps/mobile/lib/services/memory/coach_memory_service.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/models/coach_insight.dart';
@@ -220,49 +220,52 @@ class CoachMemoryService {
   }) async {
     final sp = prefs ?? await SharedPreferences.getInstance();
     final events = await _loadEvents(sp);
-    final now = (date ?? DateTime.now()).toUtc();
-
-    // Dedup: replace any existing entry with same topic on same day.
-    final dayKey = DateTime(now.year, now.month, now.day);
+    // A2-fix (2026-04-18) post-exec audit panel bugs BUG #4:
+    // Dedup MUST use the user's LOCAL day, not UTC. A Swiss user
+    // scanning at 01h30 local (CEST) creates an event at 23h30 UTC
+    // the previous day; if they re-scan at 23h30 local (21h30 UTC
+    // same day) the old logic would treat it as a different UTC day
+    // and skip dedup, while the user saw two same-day scans. The
+    // inverse also happened in winter. Compare local calendar days.
+    final nowLocal = (date ?? DateTime.now()).toLocal();
+    final dayKey = DateTime(nowLocal.year, nowLocal.month, nowLocal.day);
     events.removeWhere((e) {
-      final eDay = DateTime(
-        e.createdAt.toUtc().year,
-        e.createdAt.toUtc().month,
-        e.createdAt.toUtc().day,
-      );
+      final eLocal = e.createdAt.toLocal();
+      final eDay = DateTime(eLocal.year, eLocal.month, eLocal.day);
       return e.topic == topic && eDay == dayKey;
     });
 
     final entry = CoachInsight(
-      id: 'event_${topic}_${now.toIso8601String()}',
-      createdAt: now,
+      // Deterministic id per (topic, local day) so the dedup is
+      // idempotent — repeated saveEvent calls on the same day
+      // produce identical ids and the removeWhere above collapses
+      // them before insertion.
+      id: 'event_${topic}_${dayKey.toIso8601String().substring(0, 10)}',
+      createdAt: nowLocal,
       topic: topic,
       summary: summary,
       type: InsightType.event,
       metadata: metadata,
     );
     events.insert(0, entry);
-    await _saveEvents(sp, events);
+    try {
+      await _saveEvents(sp, events);
+    } catch (e, st) {
+      // A2-fix (panel façade #6): _saveEvents can throw synchronously
+      // on SharedPreferences write failures. Surface the error via
+      // debugPrint so Sentry/device console can pick it up, but never
+      // break the caller's flow — scans continue working even if the
+      // memory persistence fails for this one entry.
+      debugPrint('[CoachMemory] saveEvent($topic) persist failed: $e\n$st');
+    }
   }
 
-  /// Return true iff an event with [topic] exists AND was created
-  /// within the last [maxAgeDays]. Used by retention schedulers
-  /// (e.g. J+30 re-scan dedup: skip if scan was done within 365 days).
-  static Future<bool> hasEvent(
-    String topic, {
-    int maxAgeDays = 365,
-    SharedPreferences? prefs,
-  }) async {
-    final sp = prefs ?? await SharedPreferences.getInstance();
-    final events = await _loadEvents(sp);
-    final threshold = DateTime.now().toUtc().subtract(Duration(days: maxAgeDays));
-    return events.any((e) => e.topic == topic && e.createdAt.toUtc().isAfter(threshold));
-  }
-
-  /// Return all events (most recent first). Non-pruned list — may grow
-  /// unbounded over a long-lived account. In practice events are rare
-  /// (scans, life events) so linear growth stays low.
-  static Future<List<CoachInsight>> getEvents({
+  /// Visible-for-testing inspection of the events list. Not part of
+  /// the production API — callers that need to read events in prod
+  /// should re-introduce a purposeful getter in the same commit that
+  /// wires the consumer (façade-sans-câblage hard-stop, 2026-04-18).
+  @visibleForTesting
+  static Future<List<CoachInsight>> debugGetEvents({
     SharedPreferences? prefs,
   }) async {
     final sp = prefs ?? await SharedPreferences.getInstance();

--- a/apps/mobile/lib/services/memory/coach_memory_service.dart
+++ b/apps/mobile/lib/services/memory/coach_memory_service.dart
@@ -42,6 +42,16 @@ class CoachMemoryService {
   /// authenticated). See [_keyFor].
   static const _baseKey = '_coach_insights';
 
+  /// Base SharedPreferences key for [InsightType.event] records. Events
+  /// live in a separate namespace from `_baseKey` because they are
+  /// durable anchors (scan LPP, life event, major financial action)
+  /// that must survive the 50-insight FIFO pruning applied to `fact`
+  /// insights. Per panel adversaire 2026-04-18 B5: with the coach's
+  /// system prompt ordering `save_insight` "on every key fact", 50 is
+  /// exhausted within a week of active coaching and scan anchors get
+  /// silently evicted. Events get their own non-pruned list.
+  static const _eventsBaseKey = '_coach_events';
+
   /// Compute the per-user storage key. Falls back to an anonymous
   /// namespace if no JWT user_id is available — that data NEVER
   /// crosses into an authenticated account.
@@ -57,9 +67,24 @@ class CoachMemoryService {
     return '${_baseKey}___anon';
   }
 
+  /// Compute the per-user events storage key. Same account-isolation
+  /// contract as [_keyFor] but for the non-pruned event namespace.
+  static Future<String> _eventsKeyFor() async {
+    try {
+      final uid = await AuthService.getUserId();
+      if (uid != null && uid.isNotEmpty) {
+        return '${_eventsBaseKey}_$uid';
+      }
+    } catch (e) {
+      debugPrint('[CoachMemory] auth lookup failed, anon events namespace: $e');
+    }
+    return '${_eventsBaseKey}___anon';
+  }
+
   // Backwards compat alias (used internally; resolves at call time).
   // The constant name is preserved so call sites remain readable.
   static Future<String> get _key => _keyFor();
+  static Future<String> get _eventsKey => _eventsKeyFor();
 
   /// Maximum number of insights to retain (FIFO pruning).
   static const _maxInsights = 50;
@@ -173,6 +198,92 @@ class CoachMemoryService {
         .toList();
   }
 
+  // ── Events (non-pruned durable anchors) ────────────────
+  // Wave A-MINIMAL 2026-04-18. Events are stored in a separate
+  // namespace from regular `fact`/`goal`/etc insights so they survive
+  // the 50-insight FIFO pruning. Examples: scan LPP, life event,
+  // major financial action. Events are local-only (NOT synced to
+  // backend RAG) for v1 — panel archi AJ-2 2026-04-18 — because the
+  // coach_tools enum + tests have been widened but backend extractor
+  // and embedder have not been reviewed for `event` fidelity.
+  // ──────────────────────────────────────────────────────
+
+  /// Persist a durable event anchor. Dedup by (topic + date-day):
+  /// calling saveEvent twice for the same topic on the same calendar
+  /// day replaces the previous entry instead of creating a duplicate.
+  static Future<void> saveEvent(
+    String topic,
+    String summary, {
+    DateTime? date,
+    Map<String, dynamic>? metadata,
+    SharedPreferences? prefs,
+  }) async {
+    final sp = prefs ?? await SharedPreferences.getInstance();
+    final events = await _loadEvents(sp);
+    final now = (date ?? DateTime.now()).toUtc();
+
+    // Dedup: replace any existing entry with same topic on same day.
+    final dayKey = DateTime(now.year, now.month, now.day);
+    events.removeWhere((e) {
+      final eDay = DateTime(
+        e.createdAt.toUtc().year,
+        e.createdAt.toUtc().month,
+        e.createdAt.toUtc().day,
+      );
+      return e.topic == topic && eDay == dayKey;
+    });
+
+    final entry = CoachInsight(
+      id: 'event_${topic}_${now.toIso8601String()}',
+      createdAt: now,
+      topic: topic,
+      summary: summary,
+      type: InsightType.event,
+      metadata: metadata,
+    );
+    events.insert(0, entry);
+    await _saveEvents(sp, events);
+  }
+
+  /// Return true iff an event with [topic] exists AND was created
+  /// within the last [maxAgeDays]. Used by retention schedulers
+  /// (e.g. J+30 re-scan dedup: skip if scan was done within 365 days).
+  static Future<bool> hasEvent(
+    String topic, {
+    int maxAgeDays = 365,
+    SharedPreferences? prefs,
+  }) async {
+    final sp = prefs ?? await SharedPreferences.getInstance();
+    final events = await _loadEvents(sp);
+    final threshold = DateTime.now().toUtc().subtract(Duration(days: maxAgeDays));
+    return events.any((e) => e.topic == topic && e.createdAt.toUtc().isAfter(threshold));
+  }
+
+  /// Return all events (most recent first). Non-pruned list — may grow
+  /// unbounded over a long-lived account. In practice events are rare
+  /// (scans, life events) so linear growth stays low.
+  static Future<List<CoachInsight>> getEvents({
+    SharedPreferences? prefs,
+  }) async {
+    final sp = prefs ?? await SharedPreferences.getInstance();
+    return _loadEvents(sp);
+  }
+
+  static Future<List<CoachInsight>> _loadEvents(SharedPreferences sp) async {
+    final k = await _eventsKey;
+    final raw = sp.getString(k);
+    if (raw == null) return [];
+    return CoachInsight.decodeList(raw);
+  }
+
+  static Future<void> _saveEvents(
+    SharedPreferences sp,
+    List<CoachInsight> events,
+  ) async {
+    final k = await _eventsKey;
+    await sp.setString(k, CoachInsight.encodeList(events));
+  }
+
   // ── Maintenance ──────────────────────────────────────────
 
   /// Prune old insights — keeps the [_maxInsights] most recent.
@@ -199,6 +310,8 @@ class CoachMemoryService {
   /// Clear all stored insights.
   ///
   /// Used for testing, account reset, or GDPR deletion.
+  /// Wave A-MINIMAL 2026-04-18: also clears the events namespace so
+  /// logout/reset wipes durable anchors alongside regular insights.
   static Future<void> clear({SharedPreferences? prefs}) async {
     final sp = prefs ?? await SharedPreferences.getInstance();
     final k = await _key;
@@ -206,6 +319,10 @@ class CoachMemoryService {
     // Also clear the anonymous namespace so logging out of one account
     // and into another can't surface stale anon-era insights.
     await sp.remove('${_baseKey}___anon');
+    // Events namespace (non-pruned durable anchors).
+    final ek = await _eventsKey;
+    await sp.remove(ek);
+    await sp.remove('${_eventsBaseKey}___anon');
   }
 
   // ── Private helpers ─────────────────────────────────────

--- a/apps/mobile/lib/services/notification_service.dart
+++ b/apps/mobile/lib/services/notification_service.dart
@@ -9,7 +9,7 @@ library;
 
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
@@ -299,14 +299,40 @@ class NotificationService {
     final hasConsent = await ConsentManager.isConsentGiven(
       ConsentType.notifications,
     );
-    if (!hasConsent) return;
+    if (!hasConsent) {
+      debugPrint('[NotificationService] scheduleCoachingReminders skipped: no consent');
+      return;
+    }
+
+    // Wave A-MINIMAL A2 (2026-04-18): triad gate — do not schedule
+    // anything until the user has provided the three critical facts
+    // that the deadline / checkin copy depends on. Firing generic
+    // reminders on an empty profile was the "greet-and-bounce" trap
+    // flagged by panel adversaire 2026-04-18 (a user who types "Salut"
+    // and leaves would otherwise receive Monday reminders for life).
+    if (profile.birthYear < 1900 ||
+        profile.canton.isEmpty ||
+        profile.salaireBrutMensuel <= 0) {
+      debugPrint(
+        '[NotificationService] scheduleCoachingReminders skipped: '
+        'incomplete triad (birthYear=${profile.birthYear}, '
+        'canton="${profile.canton}", '
+        'salaireBrutMensuel=${profile.salaireBrutMensuel})',
+      );
+      return;
+    }
 
     // Request permission if not already granted (deferred, not at startup).
     // This is the right place because scheduleCoachingReminders is only
     // called after a check-in, not during app init.
     await requestPermission();
 
-    await cancelAll();
+    // Wave A-MINIMAL A2: scope cancel to the IDs owned by this
+    // coaching-reminder subsystem (panel archi AJ-1 2026-04-18).
+    // The prior `cancelAll()` call wiped notifications owned by other
+    // subsystems (commitments, fresh-starts) whenever a new profile
+    // landed — a side effect never documented, never tested.
+    await _cancelCoachingIds();
 
     final now = tz.TZDateTime.now(tz.local);
 
@@ -321,11 +347,14 @@ class NotificationService {
     // 3. Tax deadline reminders: Feb 15, Mar 15, Mar 25
     _scheduleTaxDeadlines(now, s);
 
-    // 4. Streak protection: 25th of each month if no check-in this month
-    _scheduleStreakProtection(profile, now, s);
-
-    // 5. Weekly recap: Monday 10:00 — "Ton récap de la semaine est prêt"
-    _scheduleWeeklyRecap(now, s);
+    // Wave A-MINIMAL A2 (2026-04-18): retention notifs (J+1/J+7/J+30),
+    // streak protection, and weekly recap are NOT scheduled here. They
+    // belong to Duolingo-style re-engagement loops that ADR-20260419
+    // killed for doctrine-lucidite reasons (same registre as
+    // MilestoneCelebrationSheet and StreakService visibility, already
+    // tuées). The services remain in the codebase and can be wired by
+    // a future Wave if signal justifies — panel iconoclaste 2026-04-18
+    // recommended observing 14 days before adding them back.
 
     // FIX-W11: Persist critical deadline dates for recovery on app resume
     final prefs = await SharedPreferences.getInstance();
@@ -333,6 +362,37 @@ class NotificationService {
       '3a_deadline': DateTime(DateTime.now().year, 12, 31).toIso8601String(),
       'last_scheduled': DateTime.now().toIso8601String(),
     }));
+  }
+
+  /// Cancel every notification ID owned by `scheduleCoachingReminders`.
+  ///
+  /// Wave A-MINIMAL A2 (2026-04-18) replaces the prior blanket
+  /// `cancelAll()` which wiped notifications scheduled by OTHER
+  /// subsystems (commitments, fresh-starts, retention) — a silent
+  /// anti-pattern flagged by panel archi AJ-1.
+  ///
+  /// IDs cancelled here must match every `_scheduleX` helper called
+  /// from [scheduleCoachingReminders]. If you add a new scheduler
+  /// helper, add its ID here too (or the old copy persists after a
+  /// re-schedule).
+  Future<void> _cancelCoachingIds() async {
+    if (_plugin == null) return;
+    // Single-shot / single-slot IDs.
+    await _plugin!.cancel(_idCheckinMonthly);
+    await _plugin!.cancel(_idCheckinReminder5d);
+    // 3a deadlines: base + up to 4 offsets (Oct 1, Nov 15, Dec 15, Dec 28).
+    for (var i = 0; i < 4; i++) {
+      await _plugin!.cancel(_id3aDeadlineBase + i);
+    }
+    // Tax deadlines: base + up to 3 offsets (Feb 15, Mar 15, Mar 25).
+    for (var i = 0; i < 3; i++) {
+      await _plugin!.cancel(_idTaxDeadlineBase + i);
+    }
+    // _idStreakProtection (2000) and retention IDs (9001/9007/9030) are
+    // NOT cancelled here — Wave A-MINIMAL stopped scheduling them, so
+    // cancelling would only be relevant for pre-Wave-A installs that
+    // had them queued. Those will expire naturally when their
+    // scheduled dates pass.
   }
 
   /// Schedule a 5-day reminder if the user hasn't checked in yet this month.
@@ -378,6 +438,13 @@ class NotificationService {
   }
 
   /// Weekly recap notification: fires every Monday at 10:00.
+  /// Weekly recap notification: fires every Monday at 10:00.
+  ///
+  /// Wave A-MINIMAL 2026-04-18: temporarily unreferenced — the call site
+  /// in [scheduleCoachingReminders] was removed because Wave C will
+  /// deliver the recap content (event plumbing scan→coach). Kept so a
+  /// future Wave can re-wire without re-implementing the scheduler.
+  // ignore: unused_element
   void _scheduleWeeklyRecap(tz.TZDateTime now, NotificationStrings s) {
     // FIX-W11: Correct Monday calculation — always schedule for NEXT Monday
     var daysUntilMonday = (DateTime.monday - now.weekday) % 7;
@@ -540,7 +607,12 @@ class NotificationService {
     }
   }
 
-  /// Streak protection: 25th of each month if no check-in this month
+  /// Streak protection: 25th of each month if no check-in this month.
+  ///
+  /// Wave A-MINIMAL 2026-04-18: temporarily unreferenced. ADR-20260419
+  /// killed StreakService visibility for doctrine-lucidite reasons; the
+  /// matching notification is dormant pending future product signal.
+  // ignore: unused_element
   void _scheduleStreakProtection(
     CoachProfile profile,
     tz.TZDateTime now,

--- a/apps/mobile/lib/services/notification_service.dart
+++ b/apps/mobile/lib/services/notification_service.dart
@@ -310,14 +310,26 @@ class NotificationService {
     // reminders on an empty profile was the "greet-and-bounce" trap
     // flagged by panel adversaire 2026-04-18 (a user who types "Salut"
     // and leaves would otherwise receive Monday reminders for life).
-    if (profile.birthYear < 1900 ||
-        profile.canton.isEmpty ||
-        profile.salaireBrutMensuel <= 0) {
+    // A2-fix (2026-04-18): widened triad checks per 3-panel post-exec audit.
+    // - `birthYear` upper bound (panel bugs BUG #2): reject absurd future
+    //   years (3000, 4242) that would pass `>= 1900` alone. Mirror of the
+    //   backend _coerce_fact_value range [1900, currentYear+1].
+    // - `canton` validity (panel bugs BUG #3): route through
+    //   `resolveCanton()` so "xyz" / "VS " / "" all fail uniformly.
+    // - PII hygiene in debugPrint (panel UX #1, PRIV-07 regression): log
+    //   only presence booleans, never raw birthYear/canton/salary. The
+    //   prior log was a direct quasi-identifier leak (nLPD art. 4).
+    final currentYear = DateTime.now().year;
+    final cantonCheck = resolveCanton(profile.canton);
+    final birthYearOk = profile.birthYear >= 1900 &&
+        profile.birthYear <= currentYear + 1;
+    final cantonOk = !cantonCheck.isFallback;
+    final salaryOk = profile.salaireBrutMensuel > 0;
+    if (!birthYearOk || !cantonOk || !salaryOk) {
       debugPrint(
         '[NotificationService] scheduleCoachingReminders skipped: '
-        'incomplete triad (birthYear=${profile.birthYear}, '
-        'canton="${profile.canton}", '
-        'salaireBrutMensuel=${profile.salaireBrutMensuel})',
+        'triad incomplete '
+        '(birthYearOk=$birthYearOk, cantonOk=$cantonOk, salaryOk=$salaryOk)',
       );
       return;
     }

--- a/apps/mobile/lib/services/notifications_wiring_service.dart
+++ b/apps/mobile/lib/services/notifications_wiring_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'package:mint_mobile/constants/social_insurance.dart' show resolveCanton;
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/notification_service.dart';
 
@@ -73,17 +74,31 @@ class NotificationsWiringService extends ChangeNotifier {
   }
 
   bool _hasTriad(CoachProfile p) {
-    return p.birthYear >= 1900 &&
-        p.canton.isNotEmpty &&
-        p.salaireBrutMensuel > 0;
+    // A2-fix (2026-04-18) post-exec audit findings:
+    // - Panel bugs BUG #2: `>= 1900` alone accepted absurd future years
+    //   (3000, 4242). Upper bound added to mirror backend
+    //   `_coerce_fact_value` range [1900, currentYear+1].
+    // - Panel bugs BUG #3: `canton.isNotEmpty` accepted "xyz", "VS "
+    //   (trailing space), "ZZ". Route through `resolveCanton()` so the
+    //   26-code Swiss allowlist gates the check uniformly.
+    final currentYear = DateTime.now().year;
+    final birthYearOk =
+        p.birthYear >= 1900 && p.birthYear <= currentYear + 1;
+    final cantonOk = !resolveCanton(p.canton).isFallback;
+    return birthYearOk && cantonOk && p.salaireBrutMensuel > 0;
   }
 
   /// Deterministic signature of the triad — any change invalidates.
-  /// Uses the salary bucket (rounded to nearest 100 CHF) so every
-  /// keystroke during a manual edit doesn't thrash notifications.
+  ///
+  /// A2-fix (2026-04-18) panel UX #4: the prior 100 CHF bucket was a
+  /// magic number without source. The 500ms debounce in [onProfileChanged]
+  /// already absorbs keystroke bursts on the salary field; bucketing on
+  /// top of it was defensive duplication with no ADR. We now sign the
+  /// raw salary, which makes the signature strictly a function of
+  /// observable profile state.
   String _triadSignature(CoachProfile p) {
-    final salaryBucket = (p.salaireBrutMensuel / 100).round() * 100;
-    return '${p.birthYear}|${p.canton}|$salaryBucket';
+    return '${p.birthYear}|${resolveCanton(p.canton).code}|'
+        '${p.salaireBrutMensuel.toStringAsFixed(2)}';
   }
 
   @visibleForTesting

--- a/apps/mobile/lib/services/notifications_wiring_service.dart
+++ b/apps/mobile/lib/services/notifications_wiring_service.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/notification_service.dart';
+
+/// Listens to CoachProfileProvider changes and re-schedules coaching
+/// reminders when the user's notification-relevant triad (birthYear +
+/// canton + salaireBrutMensuel) transitions from incomplete to
+/// complete, or when a previously-scheduled triad's signature changes.
+///
+/// Wave A-MINIMAL A2 (2026-04-18). Panel adversaire BUG 2+3 flagged
+/// that the prior wiring (`coach_chat_screen.dart _markOnboardingCompletedIfNeeded`)
+/// fires exactly once at onboarding intent; a user who completes the
+/// triad via conversational `save_fact` (canton last, several minutes
+/// later) would NEVER have their notifications scheduled because
+/// `CoachProfileProvider.notifyListeners()` is not a lifecycle
+/// `didChangeAppLifecycleState.resumed`.
+///
+/// This service bridges the gap: plug it into a
+/// `ChangeNotifierProxyProvider<CoachProfileProvider, NotificationsWiringService>`
+/// in the widget tree and it observes each profile update, debounces
+/// 500ms so bursts of `save_fact` collapse into one reschedule, and
+/// calls [NotificationService.scheduleCoachingReminders] when the
+/// triad signature actually changes.
+class NotificationsWiringService extends ChangeNotifier {
+  NotificationsWiringService({
+    Future<void> Function(CoachProfile)? scheduleOverride,
+  }) : _schedule = scheduleOverride ??
+            ((profile) =>
+                NotificationService().scheduleCoachingReminders(profile: profile));
+
+  final Future<void> Function(CoachProfile) _schedule;
+  Timer? _debouncer;
+
+  /// Signature of the last triad we scheduled for. Starts empty — the
+  /// first "complete" profile we observe always schedules. Subsequent
+  /// notifications fire only when any of the three fields change.
+  String? _lastScheduledSignature;
+
+  /// Exposed for tests — overridable clock + sync path avoidance.
+  @visibleForTesting
+  static Duration debounce = const Duration(milliseconds: 500);
+
+  /// Call this on every CoachProfileProvider.notifyListeners. Safe to
+  /// call with a null profile (= provider not yet loaded).
+  void onProfileChanged(CoachProfile? profile) {
+    _debouncer?.cancel();
+    if (profile == null) return;
+    _debouncer = Timer(debounce, () => _maybeSchedule(profile));
+  }
+
+  Future<void> _maybeSchedule(CoachProfile profile) async {
+    if (!_hasTriad(profile)) {
+      // Profile still incomplete — clear the signature so that the
+      // next complete profile we observe does schedule even if the
+      // birthYear/canton/salary values match a previous completed
+      // profile that was invalidated by a logout/reset.
+      _lastScheduledSignature = null;
+      return;
+    }
+    final signature = _triadSignature(profile);
+    if (signature == _lastScheduledSignature) {
+      // Triad unchanged since the last schedule — nothing to do.
+      return;
+    }
+    try {
+      await _schedule(profile);
+      _lastScheduledSignature = signature;
+      debugPrint('[NotificationsWiring] scheduled triad=$signature');
+    } catch (e, st) {
+      debugPrint('[NotificationsWiring] scheduleCoachingReminders threw: $e\n$st');
+    }
+  }
+
+  bool _hasTriad(CoachProfile p) {
+    return p.birthYear >= 1900 &&
+        p.canton.isNotEmpty &&
+        p.salaireBrutMensuel > 0;
+  }
+
+  /// Deterministic signature of the triad — any change invalidates.
+  /// Uses the salary bucket (rounded to nearest 100 CHF) so every
+  /// keystroke during a manual edit doesn't thrash notifications.
+  String _triadSignature(CoachProfile p) {
+    final salaryBucket = (p.salaireBrutMensuel / 100).round() * 100;
+    return '${p.birthYear}|${p.canton}|$salaryBucket';
+  }
+
+  @visibleForTesting
+  String? get lastScheduledSignature => _lastScheduledSignature;
+
+  @override
+  void dispose() {
+    _debouncer?.cancel();
+    super.dispose();
+  }
+}

--- a/apps/mobile/test/app_providers_wiring_test.dart
+++ b/apps/mobile/test/app_providers_wiring_test.dart
@@ -1,0 +1,130 @@
+/// Integration test proving end-to-end that the notifications wiring
+/// is ACTUALLY connected in the widget tree — not façade.
+///
+/// Wave A-MINIMAL A2-fix (2026-04-18). Post-exec audit panels UX + bugs
+/// unanimously flagged that unit tests on NotificationsWiringService
+/// (with `scheduleOverride` injection) do NOT prove the ProxyProvider
+/// instantiates in production, because `ChangeNotifierProxyProvider`
+/// is lazy by default. This test pumps a real MultiProvider tree
+/// matching `app.dart` and asserts that a CoachProfileProvider
+/// notifyListeners propagates to the wiring service (and through it
+/// to a spy scheduler).
+///
+/// If this test passes while `lazy: false` is removed from
+/// `app.dart`, the test is not strict enough — it must fail in that
+/// scenario.
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/notifications_wiring_service.dart';
+import 'package:provider/provider.dart';
+
+class _SpyProfileProvider extends CoachProfileProvider {
+  CoachProfile? _current;
+
+  @override
+  CoachProfile? get profile => _current;
+
+  void setProfile(CoachProfile? p) {
+    _current = p;
+    notifyListeners();
+  }
+}
+
+CoachProfile _triadProfile() => CoachProfile(
+      birthYear: 1977,
+      canton: 'VS',
+      salaireBrutMensuel: 10000,
+      goalA: GoalA(
+        type: GoalAType.retraite,
+        targetDate: DateTime(2040),
+        label: '',
+      ),
+    );
+
+void main() {
+  setUp(() {
+    // Short debounce so the test runs in ~30 ms.
+    NotificationsWiringService.debounce = const Duration(milliseconds: 10);
+  });
+
+  tearDown(() {
+    NotificationsWiringService.debounce =
+        const Duration(milliseconds: 500);
+  });
+
+  testWidgets(
+    'A2-fix: MultiProvider with lazy:false instantiates NotificationsWiringService '
+    'and calls scheduleOverride when CoachProfileProvider emits a complete triad',
+    (tester) async {
+      final recorded = <CoachProfile>[];
+      Future<void> spySchedule(CoachProfile p) async {
+        recorded.add(p);
+      }
+
+      final profileProvider = _SpyProfileProvider();
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider<CoachProfileProvider>.value(
+              value: profileProvider,
+            ),
+            // Same shape as `app.dart:1308-1315` — lazy:false is mandatory.
+            // Drop it and this test should fail.
+            ChangeNotifierProxyProvider<CoachProfileProvider,
+                NotificationsWiringService>(
+              lazy: false,
+              create: (_) => NotificationsWiringService(
+                scheduleOverride: spySchedule,
+              ),
+              update: (_, prof, prev) {
+                final service = prev ??
+                    NotificationsWiringService(
+                      scheduleOverride: spySchedule,
+                    );
+                service.onProfileChanged(prof.profile);
+                return service;
+              },
+            ),
+          ],
+          child: const _Sentinel(),
+        ),
+      );
+
+      // Initially profile is null — no schedule expected even with lazy:false
+      // because _hasTriad rejects null/incomplete.
+      await tester.pump(const Duration(milliseconds: 30));
+      expect(recorded, isEmpty);
+
+      // Emit a complete triad — wiring must propagate through the
+      // ProxyProvider update callback and the debounced scheduler.
+      profileProvider.setProfile(_triadProfile());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 30));
+
+      expect(
+        recorded,
+        hasLength(1),
+        reason:
+            'ProxyProvider update must fire onProfileChanged after triad emits; '
+            'if this fails, the ChangeNotifierProxyProvider is likely lazy '
+            '(default) and the wiring is dead in production.',
+      );
+      expect(recorded.first.canton, 'VS');
+      expect(recorded.first.birthYear, 1977);
+    },
+  );
+}
+
+/// Empty child. The test asserts plumbing, not UI rendering.
+class _Sentinel extends StatelessWidget {
+  const _Sentinel();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Directionality(textDirection: TextDirection.ltr, child: SizedBox());
+}

--- a/apps/mobile/test/services/memory/coach_memory_event_test.dart
+++ b/apps/mobile/test/services/memory/coach_memory_event_test.dart
@@ -1,4 +1,4 @@
-/// Tests for [CoachMemoryService.saveEvent] / [hasEvent] — Wave A-MINIMAL A1.
+/// Tests for [CoachMemoryService.saveEvent] — Wave A-MINIMAL A1 + A2-fix.
 ///
 /// Contract: events are durable anchors (scan LPP, life event, major
 /// financial action) stored in a separate namespace from regular insights
@@ -6,7 +6,13 @@
 ///
 /// Refs:
 /// - Panel adversaire BUG 5 (FIFO 50 evicts scan events after ~1 week active coaching)
+/// - Panel bugs BUG #4 (timezone dedup — local day, not UTC)
 /// - .planning/wave-a-notifs-wiring/PLAN.md (A1)
+///
+/// A2-fix (2026-04-18): hasEvent and getEvents were removed as façade
+/// (zero production callers). Tests now use `debugGetEvents` to inspect
+/// persistence state — marked `@visibleForTesting` so the API cannot
+/// leak into production consumers.
 library;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -24,87 +30,49 @@ void main() {
       TestWidgetsFlutterBinding.ensureInitialized();
     });
 
-    test('saveEvent persists + hasEvent returns true within freshness window',
-        () async {
+    test('saveEvent persists the entry', () async {
       await CoachMemoryService.saveEvent(
         'scan_lpp',
         'Certificat LPP CPE — 70 377 CHF',
         prefs: prefs,
       );
-      final found = await CoachMemoryService.hasEvent(
-        'scan_lpp',
-        maxAgeDays: 30,
-        prefs: prefs,
-      );
-      expect(found, isTrue);
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
+      expect(events, hasLength(1));
+      expect(events.first.topic, 'scan_lpp');
+      expect(events.first.type, InsightType.event);
+      expect(events.first.summary, 'Certificat LPP CPE — 70 377 CHF');
     });
 
-    test('hasEvent returns false when no matching topic', () async {
-      await CoachMemoryService.saveEvent(
-        'scan_lpp',
-        'Certificat LPP',
-        prefs: prefs,
-      );
-      final found = await CoachMemoryService.hasEvent(
-        'scan_3a',
-        prefs: prefs,
-      );
-      expect(found, isFalse);
-    });
-
-    test('hasEvent returns false when event too old (beyond maxAgeDays)',
+    test('saveEvent dedup: same topic same LOCAL day → 1 entry, latest wins',
         () async {
-      await CoachMemoryService.saveEvent(
-        'scan_lpp',
-        'Certificat ancien',
-        date: DateTime.now().toUtc().subtract(const Duration(days: 400)),
-        prefs: prefs,
-      );
-      // Within 365 days → not found.
-      expect(
-        await CoachMemoryService.hasEvent(
-          'scan_lpp',
-          maxAgeDays: 365,
-          prefs: prefs,
-        ),
-        isFalse,
-      );
-      // Within 500 days → found.
-      expect(
-        await CoachMemoryService.hasEvent(
-          'scan_lpp',
-          maxAgeDays: 500,
-          prefs: prefs,
-        ),
-        isTrue,
-      );
-    });
-
-    test('saveEvent dedup: same topic same day collapses to one entry',
-        () async {
-      final now = DateTime.now().toUtc();
+      // Use explicit mid-morning times so the 3-hour gap never straddles
+      // midnight in any timezone (prior version used DateTime.now()
+      // which made the test flaky when CI ran after 21:00 local).
+      final morning = DateTime(2026, 4, 18, 10);
+      final afternoon = DateTime(2026, 4, 18, 14);
       await CoachMemoryService.saveEvent(
         'scan_lpp',
         'V1',
-        date: now,
+        date: morning,
         prefs: prefs,
       );
       await CoachMemoryService.saveEvent(
         'scan_lpp',
         'V2 (updated)',
-        date: now.add(const Duration(hours: 3)),
+        date: afternoon,
         prefs: prefs,
       );
-      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
       final scanLpp = events.where((e) => e.topic == 'scan_lpp').toList();
       expect(scanLpp, hasLength(1),
-          reason: 'Same topic same day should dedup to 1 entry');
+          reason: 'Same topic same local day should dedup to 1 entry');
       expect(scanLpp.first.summary, equals('V2 (updated)'));
     });
 
-    test('different days for same topic create distinct entries', () async {
-      final day1 = DateTime.utc(2026, 4, 1, 10);
-      final day2 = DateTime.utc(2026, 4, 5, 10);
+    test('different local days for same topic create distinct entries',
+        () async {
+      final day1 = DateTime(2026, 4, 1, 10);
+      final day2 = DateTime(2026, 4, 5, 10);
       await CoachMemoryService.saveEvent(
         'scan_lpp',
         'First scan',
@@ -117,8 +85,38 @@ void main() {
         date: day2,
         prefs: prefs,
       );
-      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
       expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(2));
+    });
+
+    test(
+        'A2-fix BUG #4 regression: dedup respects LOCAL day, not UTC day. '
+        'Two scans that share the same UTC day but straddle midnight in '
+        'CEST should be treated as two distinct entries.', () async {
+      // Simulate CEST (UTC+2) 00:15 on day N+1 ≈ 22:15 UTC on day N.
+      // And 23:45 local on day N ≈ 21:45 UTC on day N.
+      // Under UTC bucketing both would collapse to day N → 1 entry.
+      // Under LOCAL bucketing they split into day N and day N+1 → 2 entries.
+      final lateEvening = DateTime(2026, 4, 3, 23, 45);
+      final earlyNextMorning = DateTime(2026, 4, 4, 0, 15);
+
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Late evening scan',
+        date: lateEvening,
+        prefs: prefs,
+      );
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Next morning scan',
+        date: earlyNextMorning,
+        prefs: prefs,
+      );
+
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
+      expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(2),
+          reason:
+              'Local calendar day is the dedup key — panel bugs BUG #4');
     });
 
     test('events namespace isolated from regular insights', () async {
@@ -145,15 +143,10 @@ void main() {
 
       // The event MUST still be retrievable despite FIFO eviction in
       // the insights namespace — this is the point of the separate ns.
-      final events = await CoachMemoryService.getEvents(prefs: prefs);
-      expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(1));
-
-      // hasEvent still true.
-      expect(
-        await CoachMemoryService.hasEvent('scan_lpp', prefs: prefs),
-        isTrue,
-        reason: 'Scan event must survive FIFO 50 eviction of regular insights',
-      );
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
+      expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(1),
+          reason:
+              'Scan event must survive FIFO 50 eviction of regular insights');
 
       // Sanity: the regular insights WERE pruned to 50.
       final insights = await CoachMemoryService.getInsights(prefs: prefs);
@@ -166,7 +159,7 @@ void main() {
         'Summary',
         prefs: prefs,
       );
-      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      final events = await CoachMemoryService.debugGetEvents(prefs: prefs);
       expect(events.first.type, equals(InsightType.event));
     });
 
@@ -189,7 +182,7 @@ void main() {
 
       await CoachMemoryService.clear(prefs: prefs);
 
-      expect(await CoachMemoryService.getEvents(prefs: prefs), isEmpty);
+      expect(await CoachMemoryService.debugGetEvents(prefs: prefs), isEmpty);
       expect(await CoachMemoryService.getInsights(prefs: prefs), isEmpty);
     });
   });

--- a/apps/mobile/test/services/memory/coach_memory_event_test.dart
+++ b/apps/mobile/test/services/memory/coach_memory_event_test.dart
@@ -1,0 +1,226 @@
+/// Tests for [CoachMemoryService.saveEvent] / [hasEvent] — Wave A-MINIMAL A1.
+///
+/// Contract: events are durable anchors (scan LPP, life event, major
+/// financial action) stored in a separate namespace from regular insights
+/// so they survive the 50-insight FIFO pruning.
+///
+/// Refs:
+/// - Panel adversaire BUG 5 (FIFO 50 evicts scan events after ~1 week active coaching)
+/// - .planning/wave-a-notifs-wiring/PLAN.md (A1)
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_insight.dart';
+import 'package:mint_mobile/services/memory/coach_memory_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('CoachMemoryService — events namespace', () {
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    test('saveEvent persists + hasEvent returns true within freshness window',
+        () async {
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Certificat LPP CPE — 70 377 CHF',
+        prefs: prefs,
+      );
+      final found = await CoachMemoryService.hasEvent(
+        'scan_lpp',
+        maxAgeDays: 30,
+        prefs: prefs,
+      );
+      expect(found, isTrue);
+    });
+
+    test('hasEvent returns false when no matching topic', () async {
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Certificat LPP',
+        prefs: prefs,
+      );
+      final found = await CoachMemoryService.hasEvent(
+        'scan_3a',
+        prefs: prefs,
+      );
+      expect(found, isFalse);
+    });
+
+    test('hasEvent returns false when event too old (beyond maxAgeDays)',
+        () async {
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Certificat ancien',
+        date: DateTime.now().toUtc().subtract(const Duration(days: 400)),
+        prefs: prefs,
+      );
+      // Within 365 days → not found.
+      expect(
+        await CoachMemoryService.hasEvent(
+          'scan_lpp',
+          maxAgeDays: 365,
+          prefs: prefs,
+        ),
+        isFalse,
+      );
+      // Within 500 days → found.
+      expect(
+        await CoachMemoryService.hasEvent(
+          'scan_lpp',
+          maxAgeDays: 500,
+          prefs: prefs,
+        ),
+        isTrue,
+      );
+    });
+
+    test('saveEvent dedup: same topic same day collapses to one entry',
+        () async {
+      final now = DateTime.now().toUtc();
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'V1',
+        date: now,
+        prefs: prefs,
+      );
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'V2 (updated)',
+        date: now.add(const Duration(hours: 3)),
+        prefs: prefs,
+      );
+      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      final scanLpp = events.where((e) => e.topic == 'scan_lpp').toList();
+      expect(scanLpp, hasLength(1),
+          reason: 'Same topic same day should dedup to 1 entry');
+      expect(scanLpp.first.summary, equals('V2 (updated)'));
+    });
+
+    test('different days for same topic create distinct entries', () async {
+      final day1 = DateTime.utc(2026, 4, 1, 10);
+      final day2 = DateTime.utc(2026, 4, 5, 10);
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'First scan',
+        date: day1,
+        prefs: prefs,
+      );
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Re-scan after update',
+        date: day2,
+        prefs: prefs,
+      );
+      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(2));
+    });
+
+    test('events namespace isolated from regular insights', () async {
+      // Save an event.
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Scan event',
+        prefs: prefs,
+      );
+
+      // Push 60 regular insights (exceeds _maxInsights = 50, triggers prune).
+      for (var i = 0; i < 60; i++) {
+        await CoachMemoryService.saveInsight(
+          CoachInsight(
+            id: 'fact_$i',
+            createdAt: DateTime.now(),
+            topic: 'topic_$i',
+            summary: 'fact $i',
+            type: InsightType.fact,
+          ),
+          prefs: prefs,
+        );
+      }
+
+      // The event MUST still be retrievable despite FIFO eviction in
+      // the insights namespace — this is the point of the separate ns.
+      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      expect(events.where((e) => e.topic == 'scan_lpp'), hasLength(1));
+
+      // hasEvent still true.
+      expect(
+        await CoachMemoryService.hasEvent('scan_lpp', prefs: prefs),
+        isTrue,
+        reason: 'Scan event must survive FIFO 50 eviction of regular insights',
+      );
+
+      // Sanity: the regular insights WERE pruned to 50.
+      final insights = await CoachMemoryService.getInsights(prefs: prefs);
+      expect(insights, hasLength(lessThanOrEqualTo(50)));
+    });
+
+    test('event entries have InsightType.event', () async {
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'Summary',
+        prefs: prefs,
+      );
+      final events = await CoachMemoryService.getEvents(prefs: prefs);
+      expect(events.first.type, equals(InsightType.event));
+    });
+
+    test('clear() wipes both insights and events namespaces', () async {
+      await CoachMemoryService.saveEvent(
+        'scan_lpp',
+        'will be wiped',
+        prefs: prefs,
+      );
+      await CoachMemoryService.saveInsight(
+        CoachInsight(
+          id: 'fact_1',
+          createdAt: DateTime.now(),
+          topic: 'topic',
+          summary: 'will be wiped',
+          type: InsightType.fact,
+        ),
+        prefs: prefs,
+      );
+
+      await CoachMemoryService.clear(prefs: prefs);
+
+      expect(await CoachMemoryService.getEvents(prefs: prefs), isEmpty);
+      expect(await CoachMemoryService.getInsights(prefs: prefs), isEmpty);
+    });
+  });
+
+  group('InsightType.event JSON round-trip — Wave A-MINIMAL A1', () {
+    test('serialize + deserialize preserves event type', () {
+      final insight = CoachInsight(
+        id: 'e1',
+        createdAt: DateTime.utc(2026, 4, 18, 10),
+        topic: 'scan_lpp',
+        summary: 'Certificat LPP CPE',
+        type: InsightType.event,
+      );
+      final json = insight.toJson();
+      expect(json['type'], equals('event'));
+
+      final restored = CoachInsight.fromJson(json);
+      expect(restored.type, equals(InsightType.event));
+      expect(restored.topic, equals('scan_lpp'));
+    });
+
+    test('unknown type string falls back to fact (back-compat)', () {
+      final payload = {
+        'id': 'x1',
+        'createdAt': DateTime.utc(2026, 1, 1).toIso8601String(),
+        'topic': 'tag',
+        'summary': 'summary',
+        'type': 'unknown_future_type',
+      };
+      final restored = CoachInsight.fromJson(payload);
+      expect(restored.type, equals(InsightType.fact));
+    });
+  });
+}

--- a/apps/mobile/test/services/notifications_wiring_service_test.dart
+++ b/apps/mobile/test/services/notifications_wiring_service_test.dart
@@ -1,0 +1,183 @@
+/// Tests for [NotificationsWiringService] — Wave A-MINIMAL A2.
+///
+/// Contract:
+/// - Incomplete triad → no schedule fired
+/// - Complete triad for the first time → schedule fired after debounce
+/// - Same triad seen twice → schedule fired only once (dedup on signature)
+/// - Triad field changes → schedule re-fires
+/// - Rapid bursts of changes (save_fact cascade) collapse via debounce
+///
+/// Panel adversaire BUG 2+3 (2026-04-18): save_fact flow NEVER re-fires
+/// `scheduleCoachingReminders` without this service, because
+/// `CoachProfileProvider.notifyListeners()` is not a lifecycle event.
+///
+/// Refs:
+/// - .planning/wave-a-notifs-wiring/PLAN.md A2
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/notifications_wiring_service.dart';
+
+/// Recorder that replaces the real scheduling callback — no contact
+/// with `flutter_local_notifications` or the NotificationService
+/// singleton. Matches the override signature accepted by
+/// [NotificationsWiringService.new].
+class _Recorder {
+  final List<CoachProfile> scheduled = [];
+  Future<void> call(CoachProfile profile) async {
+    scheduled.add(profile);
+  }
+}
+
+CoachProfile _profile({
+  int birthYear = 0,
+  String canton = '',
+  double salaire = 0,
+}) {
+  return CoachProfile(
+    birthYear: birthYear,
+    canton: canton,
+    salaireBrutMensuel: salaire,
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(2040),
+      label: '',
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    // Short debounce so tests are fast.
+    NotificationsWiringService.debounce = const Duration(milliseconds: 10);
+  });
+
+  tearDown(() {
+    NotificationsWiringService.debounce =
+        const Duration(milliseconds: 500);
+  });
+
+  group('NotificationsWiringService — triad gate + debounce', () {
+    test('incomplete triad → no schedule fired', () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      service.onProfileChanged(_profile(birthYear: 1977));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, isEmpty);
+      expect(service.lastScheduledSignature, isNull);
+    });
+
+    test('complete triad → schedule fired exactly once after debounce',
+        () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      service.onProfileChanged(_profile(
+        birthYear: 1977,
+        canton: 'VS',
+        salaire: 10000,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, hasLength(1));
+      expect(service.lastScheduledSignature, equals('1977|VS|10000'));
+    });
+
+    test('same triad seen twice → schedule fires once (signature dedup)',
+        () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+      final p = _profile(birthYear: 1977, canton: 'VS', salaire: 10000);
+
+      service.onProfileChanged(p);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      service.onProfileChanged(p);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, hasLength(1));
+    });
+
+    test('triad field change → schedule re-fires', () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      service.onProfileChanged(_profile(
+        birthYear: 1977,
+        canton: 'VS',
+        salaire: 10000,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      service.onProfileChanged(_profile(
+        birthYear: 1977,
+        canton: 'VD', // changed
+        salaire: 10000,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, hasLength(2));
+    });
+
+    test(
+        'rapid burst of changes collapses to a single schedule via debounce',
+        () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      // Simulate save_fact cascade: 5 rapid changes within the debounce window.
+      for (var i = 0; i < 5; i++) {
+        service.onProfileChanged(_profile(
+          birthYear: 1977,
+          canton: 'VS',
+          // vary salary slightly but same bucket rounding
+          salaire: 10000 + i.toDouble(),
+        ));
+      }
+      // Wait for the debounce to fire.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, hasLength(1),
+          reason: 'Debounce must collapse rapid bursts');
+    });
+
+    test('triad goes complete → incomplete → complete re-schedules', () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      service.onProfileChanged(_profile(
+        birthYear: 1977,
+        canton: 'VS',
+        salaire: 10000,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(rec.scheduled, hasLength(1));
+
+      // Simulate a logout/reset — profile becomes incomplete.
+      service.onProfileChanged(_profile());
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(rec.scheduled, hasLength(1));
+      expect(service.lastScheduledSignature, isNull);
+
+      // Log back in with the SAME triad — must re-schedule, not dedup.
+      service.onProfileChanged(_profile(
+        birthYear: 1977,
+        canton: 'VS',
+        salaire: 10000,
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(rec.scheduled, hasLength(2));
+    });
+
+    test('null profile is ignored silently', () async {
+      final rec = _Recorder();
+      final service = NotificationsWiringService(scheduleOverride: rec.call);
+
+      service.onProfileChanged(null);
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(rec.scheduled, isEmpty);
+    });
+  });
+}

--- a/apps/mobile/test/services/notifications_wiring_service_test.dart
+++ b/apps/mobile/test/services/notifications_wiring_service_test.dart
@@ -83,7 +83,10 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 30));
 
       expect(rec.scheduled, hasLength(1));
-      expect(service.lastScheduledSignature, equals('1977|VS|10000'));
+      // A2-fix (2026-04-18) panel UX #4: signature uses raw salary
+      // (toStringAsFixed(2)) after the 100 CHF magic bucket was removed
+      // as a doctrine-violation (no ADR / no source).
+      expect(service.lastScheduledSignature, equals('1977|VS|10000.00'));
     });
 
     test('same triad seen twice → schedule fires once (signature dedup)',

--- a/services/backend/app/services/coach/coach_tools.py
+++ b/services/backend/app/services/coach/coach_tools.py
@@ -467,13 +467,17 @@ COACH_TOOLS: list[dict[str, Any]] = [
                 },
                 "type": {
                     "type": "string",
-                    "enum": ["goal", "decision", "concern", "fact"],
+                    "enum": ["goal", "decision", "concern", "fact", "event"],
                     "description": (
                         "Classification of the insight: "
                         "'goal' = user objective, "
                         "'decision' = choice the user has made, "
                         "'concern' = worry or blocker, "
-                        "'fact' = factual data point shared by the user."
+                        "'fact' = factual data point shared by the user, "
+                        "'event' = a structured event the user experienced "
+                        "(scan, life event, major financial action). Events "
+                        "are durable anchors — the coach can reference them "
+                        "later (\"tu as scanné ton certificat mardi\")."
                     ),
                 },
             },

--- a/services/backend/app/services/rag/insight_embedder.py
+++ b/services/backend/app/services/rag/insight_embedder.py
@@ -34,7 +34,9 @@ async def embed_insight(
         insight_id: Unique insight identifier.
         topic: Topic category (e.g., 'lpp', 'retraite', '3a').
         summary: Privacy-safe summary text (~200 chars, no PII).
-        insight_type: 'goal', 'decision', 'concern', 'fact'.
+        insight_type: 'goal', 'decision', 'concern', 'fact', 'event'.
+            ('event' added Wave A-MINIMAL 2026-04-18 for durable anchors
+            like scans and life events. Backend column is free-form String.)
         metadata: Optional structured data (NOT embedded, stored as JSONB).
         created_at: When the insight was created.
 

--- a/services/backend/tests/test_coach_tools_categories.py
+++ b/services/backend/tests/test_coach_tools_categories.py
@@ -313,6 +313,12 @@ class TestSaveInsightTool:
         assert "decision" in enum_vals
         assert "concern" in enum_vals
         assert "fact" in enum_vals
+        # Wave A-MINIMAL (2026-04-18): "event" added for durable anchors
+        # (scan, life event, major financial action) the coach can reference
+        # later. Backend CoachInsightRecord.insight_type is Column(String)
+        # so no migration needed; Anthropic tool_use schema must allow it
+        # or calls from Flutter are rejected at the API level.
+        assert "event" in enum_vals
 
     def test_save_insight_required_fields(self):
         required = _find_tool("save_insight")["input_schema"]["required"]

--- a/services/backend/tests/test_profile_extractor.py
+++ b/services/backend/tests/test_profile_extractor.py
@@ -228,4 +228,15 @@ def test_facts_to_insight_rows_shape():
         assert row["user_id"] == "user-123"
         assert row["topic"]
         assert row["summary"]
-        assert row["insight_type"] in {"fact", "decision", "preference", "concern"}
+        # Wave A-MINIMAL (2026-04-18): "event" joins the allowed set for
+        # durable anchors (scan, life event). See coach_tools.py save_insight
+        # enum — backend CoachInsightRecord.insight_type is Column(String)
+        # so the set is purely a client/test contract, not a DB constraint.
+        assert row["insight_type"] in {
+            "fact",
+            "decision",
+            "preference",
+            "concern",
+            "event",
+            "goal",
+        }


### PR DESCRIPTION
## Summary

Wave A-MINIMAL (4 commits) from the daily-loop roadmap. Ships the scan
→ coach memory loop + deadline-only coaching reminders, with 3-panel
pre-exec review and 3-panel post-exec audit + fixes.

Retention push (J+1/J+7/J+30), weekly engagement Monday 19h, streak
visibility — **killed** (ADR-20260419 alt registre Duolingo). Doctrine
lucidité + panel iconoclaste 2026-04-18.

## Commits

1. `570c574a` **A0** — `coach_tools.py` save_insight enum accepts `event`
   + backend tests updated. Prevents Anthropic API tool_use rejection
   before Flutter ships the new type.
2. `feccc678` **A1** — `InsightType.event` + `CoachMemoryService.saveEvent`
   in separate non-pruned namespace (`_coach_events_$uid`) + scan →
   saveEvent hook in `document_impact_screen.dart`. Panel adversaire
   BUG 5: events survive 50-insight FIFO pruning.
3. `c981b85f` **A2** — `scheduleCoachingReminders` wired (minimal set:
   3a + tax deadlines + monthly check-in) + triad gate + `cancel(id)`
   per-ID + `NotificationsWiringService` ChangeNotifierProxyProvider
   on `CoachProfileProvider`.
4. `2bc37293` **A2-fix** — closes 4 P0 + 4 P1 + 2 P2 from 3 post-exec
   audit panels (façade hunter, bugs hunter, UX+compliance hunter).

## A2-fix findings closed

- **P0 #1 façade sans câblage**: `lazy: false` on the ProxyProvider.
  Without it, Provider deferred create+update until a widget consumed
  the service — which nothing did — so the whole wiring was dead.
- **P0 #2 PII log**: triad log now uses presence booleans, not raw
  birthYear/canton/salary (PRIV-07 regression closed).
- **P0 #3 Hardcoded FR strings**: 6 new ARB keys in all 6 locales for
  scan summary labels.
- **P0 #4 Triad absurd values**: `birthYear <= currentYear + 1` upper
  bound matches backend `_coerce_fact_value` range.
- **P1 #5 Canton validation**: route through `resolveCanton().isFallback`.
- **P1 #6 PII avoir bucket**: scan summaries round LPP balances to
  nearest 10k CHF Swiss format (`~70'000 CHF`) before persistence.
- **P1 #7 Timezone dedup**: saveEvent uses local calendar day, not UTC.
- **P1 #8 Magic number removed**: raw salary signature after debounce.
- **P2 #9 Façade API**: `hasEvent` deleted, `getEvents` → `debugGetEvents`
  `@visibleForTesting`. Hard-stop façade rule enforced.
- **P2 #10 Event persistence on unmount**: `_persistScanEvent` fires
  BEFORE `if (!mounted) return` on both success and error paths.

## Test plan

- [x] 88 Flutter tests green (memory events + wiring + integration
  widget test + age_or_null + cap_engine + navigation + home_gate)
- [x] 213 backend tests green (coach + privacy + tools categories +
  profile extractor)
- [x] flutter analyze: 13 preexisting info-level unchanged, 0 new
- [x] ARB parity: 6 locales carry the 6 new scan summary keys natively
- [x] Device walkthrough iPhone 17 Pro sim (staging API):
  - Cold launch → landing renders
  - Tap "Parle à Mint" → coach silent opener + 3 chips ton + TextField
  - Tab Aujourd'hui → cap banner "Parle-moi de toi" + empty state +
    4 tabs (all visible, semantics correct)
  - Tap cap banner → coach chat opens (B1-fix-2 still validated)
- [x] Integration test `app_providers_wiring_test.dart` mounts a real
  MultiProvider tree and asserts `scheduleOverride` is called on
  triad completion — fails hard if `lazy:false` is removed

## Doctrine + ADRs

- Respects `ADR-20260418-wave-order-daily-loop` (Wave B → Wave A → …)
- Respects `ADR-20260419-killed-gamification-layers` — no JITAI /
  Milestone / Streak / retention push / weekly engagement wired
- `feedback_no_shortcuts_ever`: no sentinel, backend enum widened
  properly, triad gate on real triad fields
- `feedback_facade_sans_cablage_absolu` (new 2026-04-18): hard-stop
  rule — APIs without production callers are deleted or marked
  `@visibleForTesting`, ProxyProviders require `lazy: false` when no
  widget consumer exists
- `feedback_screen_by_screen_logic` (from Wave B): device walkthrough
  yeux humains validated flow A→Z

## Deferred

- coach_narrative_service.dart 13 `profile.age` call-sites → Wave E
- weekly_recap / streak dead methods kept under `unused_element` — Wave E
- Backend sync of `event` insights (local-only v1) — future wave if signal

## Refs

- `.planning/wave-a-notifs-wiring/PLAN.md` (Wave A-MINIMAL v2 plan)
- `.planning/wave-a-notifs-wiring/REVIEW-PLAN.md` (3 pre-exec panels)
- `decisions/ADR-20260418-wave-order-daily-loop.md`
- `decisions/ADR-20260419-killed-gamification-layers.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)