### PR TITLE
fix(gsd): restore v2.8 phase discovery (extractCurrentMilestone scope bug)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -87,7 +87,7 @@ Full phase detail for v2.5 (Phases 13-18), v2.6 (Phases 19-26), v2.7 (Phases 27-
 
 ---
 
-## v2.8 Phases
+### v2.8 Phases overview
 
 - [ ] **Phase 30.5: Context Sanity** — Fix MEMORY.md truncation + drift dashboard + CLAUDE.md restructure + UserPromptSubmit hook + spike validation go/no-go
 - [ ] **Phase 30.6: Tools Déterministes** — MCP tools on-demand (swiss_constants / banned_terms / arb_parity) — économise ~16k tokens/session
@@ -98,7 +98,7 @@ Full phase detail for v2.5 (Phases 13-18), v2.6 (Phases 19-26), v2.7 (Phases 27-
 - [ ] **Phase 35: Boucle Daily** — `mint-dogfood.sh` (simctl iPhone 17 Pro, 8-step scenario, ~10 min) + auto-PR threshold + pull Sentry events
 - [ ] **Phase 36: Finissage E2E** — 4 P0 fixes (UUID / anonymous / save_fact / Coach tab) + 388 catches → 0 + MintShell ARB parity audit + accents 100%
 
-## Phase Details
+### Phase Details
 
 ### Phase 30.5: Context Sanity
 **Goal**: Les agents Claude Code ne peuvent plus coder à l'aveugle — MEMORY.md est retrievable, le drift est mesuré, CLAUDE.md est restructuré contre lost-in-the-middle, un hook `UserPromptSubmit` injecte les rappels critiques contextuellement, et un spike agent valide go/no-go avant Phase 31.


### PR DESCRIPTION
## Summary

Bug bloquant : autres sessions Claude Code lançant \`/gsd-discuss-phase 30.5\` (ou autre phase v2.8) retournent \`phase_found: false\` → workflow GSD impossible.

## Root cause

\`gsd-tools.cjs init phase-op <num>\` appelle \`getRoadmapPhaseInternal\` qui appelle d'abord \`extractCurrentMilestone\` pour scoper la recherche au milestone courant.

\`extractCurrentMilestone\` lit \`STATE.md\` → milestone = v2.8, puis cherche dans ROADMAP.md la section commençant par \`## ... v2.8 ...\`. Trouve ligne 23 (\`## v2.8 L'Oracle & La Boucle — Overview\`). Cherche le PROCHAIN h2 avec \`v\d+\.\d+\` → trouve ligne 90 (\`## v2.8 Phases\`). **Cut la section là.**

Résultat : la section extraite ne contient PAS \`## Phase Details\` (ligne 101) ni les headers \`### Phase 30.5: Context Sanity\` (ligne 103+). Donc \`getRoadmapPhaseInternal\` ne trouve aucune phase v2.8.

## Fix

Demote 2 headers h2 → h3 pour qu'ils ne soient plus interprétés comme nouveaux milestones :

- \`## v2.8 Phases\` → \`### v2.8 Phases overview\`
- \`## Phase Details\` → \`### Phase Details\`

Les deux deviennent enfants h3 du parent \`## v2.8 L'Oracle & La Boucle — Overview\`. \`extractCurrentMilestone\` étend maintenant le scope jusqu'à \`## Progress\` (ligne 208), et \`getRoadmapPhaseInternal\` trouve les 8 phases v2.8 avec leur regex \`#{2,4}\\s*Phase\\s+30\\.5:\`.

## Verified mechanically

\`\`\`bash
for p in 30.5 30.6 31 32 33 34 35 36; do
  node gsd-tools.cjs init phase-op "\$p" | grep phase_found
done
# → all 8 return phase_found=true
\`\`\`

## Test plan

- [ ] CI green
- [ ] Vérifier qu'une session fresh \`/gsd-discuss-phase 30.5\` après merge trouve la phase
- [ ] Vérifier que les autres phases (30.6 → 36) sont aussi découvrables

## Note follow-up

Slug generator dans gsd-tools strippe les diacritiques françaises (\`Tools Déterministes\` → \`tools-d-terministes\`, \`Agent Guardrails mécaniques\` → \`agent-guardrails-m-caniques\`). Cosmétique, non-bloquant — fix séparé à capturer en backlog v2.8 (peut-être Phase 34 lints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)