### PR TITLE
chore(planning): track 22 v2.8-prep planning artefacts + cleanup ' 2' duplicates

### DIFF
--- a/.planning/codebase/2026-04-15-TRIAGE.md
+++ b/.planning/codebase/2026-04-15-TRIAGE.md
@@ -1,0 +1,371 @@
+# Triage Consolidé Codebase MINT — 2026-04-15
+
+**Source**: 4 audits adversariaux read-only + 7 docs `.planning/codebase/` existants (5 avril 2026).
+**Auditeurs** (contextes indépendants, solutions mode):
+1. Gate 0 Blockers Forensic
+2. Dead Code + Duplicates Scan
+3. Architecture Scars + Regressions
+4. Test Suite Reality Check
+
+**Objet**: dresser une carte honnête de l'état du codebase et proposer un ordre d'attaque. Ne PAS modifier le code.
+
+---
+
+## TL;DR — 5 chiffres
+
+| Métrique | Valeur | Verdict |
+|----------|--------|---------|
+| Déblocage Gate 0 complet (les 10 fixes prio) | **~3-4 jours solo** | Faisable cette semaine |
+| Stabilisation architecturale "ok" | **~45-60 jours-ing** | À phaser sur 3 mois |
+| Tests substantiels réels (sur 5'796 backend + 9'072 Flutter) | **~50% seulement** | Suite creuse sur joints critiques |
+| Endpoints backend jamais appelés depuis Flutter | **45 sur 60 (75%)** | Skeletons pré-Phase 3/4 |
+| Clés i18n orphelines | **1'864 / 8'852 (21%)** | Dette onboarding/landing redesign |
+
+**Le verdict le plus important** — citation de l'agent Gate 0 :
+> *"Un oubli de 3 caractères (`refreshListenable: auth`) fait sembler l'app 'fondamentalement cassée'. Le code est propre, les joints sont pourris."*
+
+MINT n'est pas irrécupérable. Les couches unitaires (financial_core, services individuels, compliance guard) fonctionnent. Ce sont les **câblages inter-couches** qui sont cassés — pattern classique d'un codebase agent-built où chaque feature sprint ajoute une couche sans resouder les joints.
+
+---
+
+## 1. BLOQUEURS GATE 0 — à fixer AVANT tout nouveau feature (Tax Phase 0 inclus)
+
+**Origine**: auto-memory founder (auth cassé, coach perd contexte, scanner broken, markdown literal, chips statiques, keyboard, responses trop longs, profile cached) + audit Gate 0 forensic.
+
+**Effort total: ~3-4 jours solo + 1j tests device + 2j autoresearch-test-generation = ~1 semaine.**
+
+### Top 10 fixes chronologiques
+
+| # | Fix | File:line | Effort | Débloque |
+|---|-----|-----------|--------|----------|
+| 1 | **`refreshListenable: auth`** ajouté à `GoRouter` construction | `apps/mobile/lib/app.dart:164` | **S (1h)** | **P0-1 auth state propagation** — LE bug central |
+| 2 | Splash gate qui await `checkAuth()` avant monter router | `apps/mobile/lib/app.dart:1155` | S (2h) | Deep links cassés + race checkAuth |
+| 3 | Préfixer `CoachMemoryService._key` par userId | `apps/mobile/lib/services/memory/coach_memory_service.dart:40` | M (3h) | **P0 privacy — cross-account data bleed** (découvert hors liste founder, critique) |
+| 4 | Cap `max_tokens` à 350 + prompt "120 mots max" | `services/backend/app/core/config.py:54` + `app/services/coach/claude_coach_service.py` | S (2h) | P1 responses trop longues |
+| 5 | Étendre history cap 8→16 msg × 500→2000 chars | `services/backend/app/api/v1/endpoints/coach_chat.py:397,409` + `apps/mobile/lib/services/coach/coach_orchestrator.dart:771` | M (3h + tests) | **P0-2 coach loses context** |
+| 6 | Wirer tool `suggest_next_action` backend | `services/backend/app/services/coach/coach_tools.py` + `claude_coach_service.py` | L (1j) | P1 chips statiques |
+| 7 | Différencier erreurs scanner PDF (timeout/4xx/5xx/null) | `apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1394` | M (4h) | **P0-5 scanner broken** |
+| 8 | Timeout coach 60s→20s + UI retry visible à 10s | `apps/mobile/lib/services/coach/coach_chat_api_service.dart:91` | M (3h) | **P0-3 "disconnect after 2nd"** |
+| 9 | Vérif token non-vide dans `AuthService.saveToken` | `apps/mobile/lib/services/auth_service.dart:65` | S (30m) | Prévient zombie-auth |
+| 10 | Logger toutes les catches silencieuses du coach | `coach_memory_service.dart:93` + cie | M (2h) | Observabilité Gate 0 |
+
+### Bugs P0 non-listés dans l'auto-memory founder (découverts pendant l'audit)
+
+- **Cross-account data bleed** (#3) — critique avant tout beta privé
+- **Zombie auth** (#9) — token `''` passe la validation `isLoggedIn`
+- **Apple Sign-In sur hidden email** : `auth_provider.dart:281` stocke `userId = ''`, user finit en namespace anonyme, données repartent à 0 à chaque cold start
+- **`_purgeLocalData` wipe secure storage entier** (`app.dart:541`) incluant JWT en cours de setting si relogin rapide
+- **MarkdownBody `softLineBreak: true`** (`coach_message_bubble.dart:114`) — chaque `\n` devient `<br>`, bulles géantes (explique probablement P0-4 astérisques littéraux)
+
+### Bugs P1 (bloquent feature mais app fonctionnelle sans)
+
+- Document scanner fallback silencieux (doc_scan_screen.dart:1394)
+- Streaming cursor 60s timeout visible (coach_chat_api_service.dart:91)
+- `mounted` check manquant après `context.push('/scan/review')` (doc_scan_screen.dart:958)
+- `_syncToBackend` swallow all errors silently (coach_memory_service.dart:93-96)
+- `_hydrateProfileFromBackend` écrit SharedPreferences avant `notifyListeners()` (race)
+- `CoachChatApiException("no_auth")` remonte sans CTA user-facing
+
+---
+
+## 2. ARCHITECTURE SCARS — à ADRiser et refacter par phases
+
+**Origine**: architecture scars audit. Ce sont les **causes racines** de la fragilité chronique.
+
+**Effort total: ~45-60 jours-ing pour stabilisation "ok".** À NE PAS attaquer en bloc — phaser.
+
+### Scar #1 — MultiProvider root anarchique (LA cause racine de Gate 0 P0-1)
+
+- 17 providers (pas 14) déclarés à plat dans `apps/mobile/lib/app.dart:1151-1198`
+- 6 déclenchent I/O async dans `create()` (AuthProvider, CoachProfileProvider, LocaleProvider, UserActivityProvider, SlmProvider, ByokProvider)
+- Aucun `ProxyProvider` pour déclarer les dépendances
+- Commentaire `app.dart:1192` confirme : *"previously consumed by production screens but registered only in test helpers (ProviderNotFoundException masked by silent try/catch)"* — providers ajoutés post-hoc parce que prod crashait silencieusement
+- **Fix**: migration vers `ChangeNotifierProxyProvider` + chaîne `Future.wait` pour init async avant mount `MaterialApp.router`. Ou passer à Riverpod.
+- **Effort**: L (3-5 jours)
+- **Bénéfice**: résout #3 cold-start non-déterministe, empêche les futurs bugs d'ordre
+
+### Scar #2 — Coach chain mille-feuilles (15-20 j-ing, XL)
+
+- **Flutter**: `CoachOrchestrator` (1309 L) + `CoachLlmService` (603 L) + `CoachNarrativeService` (1457 L)
+- **Backend**: `coach_chat.py` (**2319 L pour UN endpoint** — record absolu) + `claude_coach_service.py` (720 L) + `coach_tools.py` (1193 L) + 6 autres modules coach
+- **Circular dep Flutter non-résolue** — juste "lazy-workaround'ée" (`coach_llm_service.dart:7-9` le documente explicitement)
+- **Hot files**: `coach_chat.py` touché **58 fois / 90j** (#1), `coach_narrative_service.dart` 36 (#2 global)
+- **Fix recommandé**: **le backend est l'orchestrateur, point**. Supprimer `CoachOrchestrator` Flutter. Réduire `CoachLlmService` à HTTP transport + SSE parser. Éclater `coach_chat.py` en `router + intent_service + tool_executor + response_formatter`.
+- **Effort**: XL (15-20 jours) — pre-requis freeze features coach 2 semaines
+- **Bénéfice**: résout directement P0-2, P0-3, P0-4
+
+### Scar #3 — `coach_profile.dart` = fat model graffiti wall
+
+- **3149 lignes** (a grossi de 200L en 10 jours depuis CONCERNS.md 5 avril qui disait 2956)
+- **126 fichiers le consomment** (`grep -rl "CoachProfile" | wc -l`)
+- Touché **77 fois / 90j** (#3 hot file global après ARB)
+- Changer son schéma = 126 consumers à auditer
+- **Fix**: scinder en `ProfileSchema` (pur) + `ProfileExtensions` (calculs) + `ProfileStorage` (persist). Migration 126 consumers par batch.
+- **Effort**: L (5 jours)
+
+### Scar #4 — GoRouter 144 routes dont 52 redirects (36% shims)
+
+- Chiffre réel: `grep -c ScopedGoRoute` = **144** (et pas 70 comme dans `.planning/codebase/ARCHITECTURE.md`)
+- **52 redirects dont 14 shims vers `/coach/chat`**
+- Redirects empilés peuvent parser incorrectement les params (commentaire `app.dart:1079` confirme un bug passé)
+- **Fix**: audit deep-link 6 mois de logs. Supprimer shims jamais hit. Tagger `@deprecated` sinon.
+- **Effort**: M (2 jours)
+
+### Scar #5 — ADR fantômes
+
+- `ADR-20260223-unified-financial-engine` status "Implemented" = **FAUX PARTIELLEMENT**
+  - `retirement_projection_service.dart` (1249 L) + `forecaster_service.dart` (1043 L) contiennent encore de la logique calc qui devrait être dans `financial_core/`
+  - **14 fichiers importent directement les sous-modules** au lieu du barrel `financial_core.dart` → violation explicite de la règle ADR
+  - **Fix**: Phase 2 de cet ADR — migrer les 14 imports directs + extraire résidu calculatoire des services
+  - **Effort**: L (5 jours)
+- `ADR-20260501 tax-phase-0-wedge` : status "Proposed", **0 match dans le code** (normal, ADR fresh). À confirmer kickoff post-Gate-0.
+
+### Scar #6 — God services au-delà de 500 LOC
+
+Confirmation enrichie vs CONCERNS.md :
+
+| Fichier | LOC | Touches 90j | Fix |
+|---------|-----|-------------|-----|
+| `services/backend/app/api/v1/endpoints/coach_chat.py` | **2319** | 58 | Éclater en router + 4 services |
+| `apps/mobile/lib/models/coach_profile.dart` | 3149 | 77 | Scar #3 |
+| `apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart` | 1980 | ? | Extract widgets + VM |
+| `apps/mobile/lib/screens/expat_screen.dart` | 1719 | ? | Extract widgets + VM |
+| `apps/mobile/lib/screens/pulse/pulse_screen.dart` | 1665 | ? | Extract widgets + VM |
+| `apps/mobile/lib/screens/coach/coach_checkin_screen.dart` | 1627 | 131 | Extract + lié scar #2 |
+| `apps/mobile/lib/screens/coach/coach_chat_screen.dart` | 1577 | 131 | Extract + lié scar #2 |
+| `apps/mobile/lib/services/coach_narrative_service.dart` | 1457 | 36 | Scinder en 3 (builder, parser, fallback) |
+| `services/backend/app/services/document_vision_service.py` | 1407 | ? | Pipeline monolithique |
+| `apps/mobile/lib/services/cap_engine.dart` | 1333 | ? | Duplique `mint_state_engine` + `cap_sequence_engine` |
+| `apps/mobile/lib/services/document_service.dart` | 1324 | ? | Scinder par étape du pipeline |
+| `apps/mobile/lib/services/api_service.dart` | 1280 | 43 | **80+ méthodes HTTP** — scinder par domaine |
+| `apps/mobile/lib/services/retirement_projection_service.dart` | 1249 | 29 | Extract calc → financial_core |
+| `apps/mobile/lib/services/pdf_service.dart` | 1235 | ? | 3 responsabilités |
+
+### Scar #7 — Zones chaudes explosives
+
+Top touches 90j :
+- `apps/mobile/lib/app.dart` : **145 touches** (root réécrit tous les 2 jours — un app.dart stable = <5/mois)
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart` : 131
+- `services/backend/app/api/v1/endpoints/coach_chat.py` : 58
+- `apps/mobile/lib/models/coach_profile.dart` : 77
+- `apps/mobile/lib/providers/coach_profile_provider.dart` : 57
+- `apps/mobile/lib/screens/document_scan/document_scan_screen.dart` : 45
+
+**482 commits "fix/revert/hotfix" sur 1785 = 27% du log** (ratio sain < 10%).
+
+### Scar #8 — Patterns agent-built (le pattern "façade sans câblage")
+
+- `voice_service.dart:121` — *"Stub backend — always unavailable"* mais exposé UI
+- 6 feature flags toujours `false` par défaut : OpenBanking, PensionFundConnect, ExpertTier, AdminScreens, SlmNarratives, valeurLocative2028Reform = **6 features codées, 0 activée**
+- **7 services "dead-in-prod" supprimés 2026-04-07** (STAB-13) : `retirement_budget_service`, `recommendations_service`, `pulse_hero_engine`, `scenario_narrator_service`, `timeline_service`, `fiscal_intelligence_service`, `wizard_conditions_service` — shippés, jamais branchés, arrachés 3 mois plus tard
+- **13 commits "dead-in-prod" / "orphan"** sur 90 jours
+
+---
+
+## 3. DEAD CODE À PURGER — gains rapides
+
+**Origine**: dead code + duplicates audit. Haute confiance = on peut supprimer sans risque.
+
+### 3.1 — Top 10 fichiers à supprimer en one-shot
+
+| # | Fichier | Raison | Gain |
+|---|---------|--------|------|
+| 1 | `apps/mobile/lib/widgets/mint_ui_kit.dart_temp` | Vide 0 bytes depuis 2 mois | 0 bytes mais nettoyage |
+| 2 | `apps/mobile/lib/services/institutional/institutional_api_service.dart` | 0 importateur, flag OFF | 1 fichier |
+| 3 | `apps/mobile/lib/services/dach/austria_pension.dart` | Phase 4 DACH pas planifiée | 1 fichier |
+| 4 | `apps/mobile/lib/services/dach/germany_pension.dart` | Idem | 1 fichier |
+| 5 | `apps/mobile/lib/services/dach/multi_country_lifecycle_service.dart` | Idem | 1 fichier |
+| 6 | `apps/mobile/lib/services/dach/country_pension_service.dart` | Idem | 1 fichier |
+| 7 | `apps/mobile/lib/services/affiliate_service.dart` | 0 importateur | 1 fichier |
+| 8 | `apps/mobile/lib/screens/anonymous/anonymous_intent_screen.dart` | 0 ref | 1 fichier |
+| 9 | `apps/mobile/lib/screens/document_scan/document_stream_result_screen.dart` | 0 ref | 1 fichier |
+| 10 | Une des deux `weekly_recap_service.dart` (garder `coach/`, delete `recap/`) | Duplicate | 355 L |
+
+**Gain total**: ~3'500 LOC Flutter + ~1 MB bundle release. Effort: ~2h (supprimer + vérifier que rien ne casse).
+
+### 3.2 — Écrans à supprimer (archivés Wire Spec V2 ou deprecated)
+
+- `apps/mobile/lib/screens/ask_mint_screen.dart` — deprecated S52, archivé Wire Spec V2
+- `apps/mobile/lib/screens/coach/annual_refresh_screen.dart` — route `/coach/refresh` archivée
+- `apps/mobile/lib/screens/coach/cockpit_detail_screen.dart` — route `/coach/cockpit` archivée
+
+### 3.3 — Écrans ambigus à confirmer avec toi
+
+- `achievements_screen.dart` — 1 ref hors router
+- `portfolio_screen.dart` — 1 ref hors router
+- `budget/budget_screen.dart` — écrasé par `budget_container_screen.dart` ?
+- `advisor/score_reveal_screen.dart` — 1 ref hors router
+
+### 3.4 — Duplicates à trancher (besoin ton input)
+
+- **`coach_narrative_service.dart`** : gros 1457 L (historique) vs petit 206 L dans `coach/` (récent) → lequel est canonique ? **Décision founder requise**
+- **3 paires déjà listées CONCERNS.md** : `coach_narrative`, `community_challenge`, `goal_tracker` — à résoudre
+
+### 3.5 — Deprecated encore vivants
+
+- `widgets/coach/confidence_blocks_bar.dart:145` — P2
+- `services/navigation/safe_pop.dart:4` — P2
+- `models/coach_profile.dart:3029` — P1 (modèle central)
+- `services/api_service.dart:1215` — P1
+- `widgets/retirement/confidence_banner.dart:14` — P2
+
+### 3.6 — ARB keys orphelines (21% de i18n mort)
+
+**1'864 / 8'852 clés** non référencées. Sample:
+- `landingFeature1Title`, `landingFeature1Desc`
+- `onboardingStep1Title` → `onboardingStep4Subtitle`
+- `profileReward15`, `profileReward10`
+- `profileConsentControl`, `profileConsentManage`
+- `disabilityGapPhase1-3`
+- `jobCompareAge/Axis/Delta/Checklist`
+- `divorceIntro`
+
+Beaucoup viennent de **landings/onboardings redesignés**. Purge demande un tool qui `grep` chaque clé dans `.dart`. Gain: ~20 KB par langue × 6 langues dans les ARB compilés.
+
+### 3.7 — Backend endpoints non-câblés — À NE PAS PURGER EN BLOC
+
+**45 endpoints backend sur 60 jamais appelés depuis Flutter** = ~10'500 LOC.
+
+Beaucoup sont des **skeletons pré-Phase 3/4**. Purge en bloc = erreur.
+
+**Recommandation**:
+1. Marquer chaque endpoint non-appelé avec commentaire `# PENDING WIRING — call from Flutter <feature>`
+2. Lister dans `.planning/backend-pending-wiring.md` avec statut `pending / orphan / wip`
+3. Si un endpoint est là depuis >6 mois sans câblage ET pas dans la roadmap → candidat purge
+
+---
+
+## 4. TESTS À CONSOLIDER — suite creuse sur joints critiques
+
+**Origine**: test suite reality check. **Score de confiance : 4.5/10**.
+
+**~50% des 5'796 tests backend sont substantiels**, le reste est paramétrisation tabulaire ou tautologique. Côté Flutter, **52 fichiers `*_smoke_test.dart`** = `pumpWidget + expect findsOne` sans interaction. **633 `expect(…isNotNull)`** sur 120 fichiers = assertions creuses.
+
+### 4.1 — Tests gap critiques (les 5 bugs Gate 0 P0 n'ont AUCUN test qui les aurait attrapés)
+
+- **Markdown rendering** : 0 tests (`grep MarkdownBody` → 0 fichiers)
+- **Coach multi-turn context retention** : 1 `test_coach_memory_roundtrip` mais pas de vérif que turn 2 cite turn 1
+- **Auth state propagation post-login → tabs** : 0 tests intégration
+- **Suggestion chips dynamic** : 0 tests
+- **Scanner E2E camera→vault** : uniquement mockés, pas de vrai E2E
+
+### 4.2 — Top 10 gaps à combler par ordre d'attaque
+
+1. **Markdown rendering** (P0-4) — 0 tests, ≤1j
+2. **Coach multi-turn context retention** (P0-2) — 2j
+3. **Auth state propagation post-login → tabs** (P0-1) — 1j widget test
+4. **Suggestion chips dynamic** (P1) — 1j
+5. **6 archétypes manquants golden baseline** (expat_eu, expat_non_eu, independent_*×2, cross_border, returning_swiss) — 5j
+6. **`knowledge_catalog.py` (1'046 L) 0 tests direct** — 3j
+7. **`succession_simulator.py` (789 L) 0 tests** — 2j
+8. **E2E scanner camera→vault réel** (P0-5) — 3j
+9. **Golden `s4_response_card` régénérer ou supprimer** (tous skip: true) — 1j
+10. **Réactiver `test_extractor_julien_cpe_golden`** avec fixture committed — 0.5j
+
+**Total ~20j solo** pour rendre la suite honnête.
+
+### 4.3 — Golden pipeline à demi-mort
+
+- `apps/mobile/test/goldens/s4_response_card_golden_test.dart` — **TOUS tests `skip: true`**, golden = façade
+- Sur 4 fichiers goldens déclarés, 2 actifs
+- 6/8 archétypes sans baseline de régression
+
+### 4.4 — 9 tests skippés en CI pour fixtures manquantes
+
+`test_extractor_julien_cpe_golden`, `golden_document_flow`, `pdf_to_arbitrage_julien`, `test_rag` (×3), `test_docs_copy_compliance`, `test_constants` — fixtures PDF réelles absentes. Donc golden-doc tests **ne tournent jamais en CI**.
+
+---
+
+## 5. QUICK WINS — <2h chacun, à faire en one-shot
+
+1. **Supprimer `mint_ui_kit.dart_temp`** (vide)
+2. **`Token sanity check`** dans `AuthService.saveToken` (30 min)
+3. **Supprimer les 4 DACH files** (Phase 4 pas planifiée)
+4. **Supprimer `institutional_api_service.dart` + `affiliate_service.dart`**
+5. **Supprimer les 3 écrans Wire Spec V2 archivés** (`ask_mint`, `annual_refresh`, `cockpit_detail`)
+6. **`refreshListenable: auth`** sur GoRouter (1h) — MASSIVE impact
+7. **Logger les catches silencieuses** (2h) — observabilité immédiate
+8. **Registry SharedPreferences** (1j, 19 clés) — prévient typo silent bug
+9. **Golden s4_response_card** — supprimer les `skip: true` ou delete (1j)
+10. **`softLineBreak: false`** sur MarkdownBody (`coach_message_bubble.dart:114`) (30 min)
+
+**Total quick wins : ~2-3 jours** pour un gain massif de stabilité et de propreté.
+
+---
+
+## 6. SÉQUENCE D'EXÉCUTION RECOMMANDÉE
+
+### Semaine 1 — Déblocage Gate 0 (hard stop sur Tax Phase 0 d'ici là)
+
+- **J1**: Quick wins Gate 0 : fixes #1 (refreshListenable), #2 (splash gate), #9 (token sanity), #10 (logger catches) + `softLineBreak: false`
+- **J2**: Fixes #3 (userId prefix), #4 (max_tokens cap), #10 bis (device test)
+- **J3**: Fixes #5 (history cap) + tests
+- **J4**: Fixes #7 (scanner errors) + #8 (timeout UI)
+- **J5**: Fix #6 (suggest_next_action tool) + device walkthrough complet
+
+**Gate**: founder teste app cold-start → login → Explorer → Aujourd'hui → coach 5 messages → upload PDF → pas de régression. Si OK → Gate 0 cleared.
+
+### Semaine 2 — Dead code + architecture quick wins
+
+- **J1**: Supprimer les 10 fichiers top (DACH, orphelins, écrans archivés)
+- **J2**: Résoudre les 3 paires de duplicates (trancher canonicals avec founder)
+- **J3**: `refreshListenable` → verrouiller MultiProvider avec ProxyProvider (Scar #1 start)
+- **J4**: Registry SharedPreferences (19 clés namespacées)
+- **J5**: Audit GoRouter redirects — supprimer les 14 shims `/coach/chat` jamais hit
+
+### Semaine 3-4 — Tests critiques comblés
+
+- Combler les 10 gaps listés §4.2
+- Réactiver golden pipeline (s4_response_card + cpe_golden)
+- 6 archétypes baseline
+
+### Mois 2 — Refactos architecturaux majeurs (par ordre de bénéfice)
+
+- **Sprint A**: Éclater `coach_profile.dart` 3149 L en 3 modules + migrer 126 consumers (5j)
+- **Sprint B**: ADR-unified-financial-engine Phase 2 — migrer 14 imports directs (5j)
+- **Sprint C**: Éclater `api_service.dart` 80 méthodes → 5 services par domaine (3j)
+- **Sprint D**: Unifier coach chain (XL 15-20j) — freeze features coach 2 semaines nécessaire
+
+### Mois 3 — Nettoyage ARB + Backend
+
+- Tool purge ARB orphelines (1'864 clés × 6 langues)
+- Audit feature-par-feature des 45 endpoints backend non-câblés
+- Mark `# PENDING WIRING` vs purge selon décision
+
+### Post mois 3 — Tax Phase 0 peut démarrer
+
+Une fois Gate 0 green + coach chain unifiée + MultiProvider verrouillé + coach_profile scindé, **Tax Phase 0 ADR peut débuter en sprint S57**.
+
+---
+
+## 7. DÉCISIONS FOUNDER REQUISES
+
+Ces points bloquent l'exécution, besoin de ton input :
+
+1. **`coach_narrative_service` canonique** : le gros 1457 L (historique) ou le petit 206 L dans `coach/` ?
+2. **4 écrans ambigus** (`achievements`, `portfolio`, `budget/budget`, `advisor/score_reveal`) — delete ou keep pour Phase 2 ?
+3. **`services/b2b/` (3 fichiers)** — Phase 4 B2B confirmée dans roadmap, keep ?
+4. **`services/expert/` (3 fichiers)** — Phase 3 Expert Tier, keep ?
+5. **6 feature flags toujours `false`** — garder code + flag, ou inliner `false` et supprimer branches ?
+6. **45 endpoints backend non-câblés** — mark pending, purger par batch, ou finir câblage Phase 1-2 ?
+7. **Ordre des 4 gros refactos architecturaux** — unifier coach chain en premier (résout P0-2/3/4 durablement) ou scinder `coach_profile` d'abord (pre-requis 126 consumers) ?
+8. **Rachat 3a rétroactif** — confirmé retiré de Phase 0 Tax (impossible avant 2026 calendar), positionné comme rappel N+1 ?
+
+---
+
+## 8. RÉFÉRENCES
+
+- Docs existants : `.planning/codebase/ARCHITECTURE.md`, `CONCERNS.md`, `STACK.md`, `STRUCTURE.md`, `TESTING.md`, `CONVENTIONS.md`, `INTEGRATIONS.md` (tous 5 avril 2026)
+- Audits agents 2026-04-15 (4 contextes indépendants, read-only):
+  - Gate 0 forensic (126 file:line traces)
+  - Dead code + duplicates scan
+  - Architecture scars + regressions history
+  - Test suite reality check
+- ADRs fiscaux :
+  - [ADR-20260415-tax-declaration-autopilot.md](../decisions/ADR-20260415-tax-declaration-autopilot.md) — vision cible
+  - [ADR-20260501-tax-phase-0-wedge.md](../decisions/ADR-20260501-tax-phase-0-wedge.md) — plan exécution (waiting Gate 0)
+- CEO plan gstack: `~/.gstack/projects/MINT-IA-MINT/ceo-plans/2026-04-15-tax-autopilot-scope-reduction.md`
+
+---
+
+**End of Triage. Ne modifie aucun code. Donne un ordre de bataille clair. À consulter avant chaque sprint planning jusqu'à ce que Gate 0 soit cleared.**

--- a/.planning/mission-audit-2026-04-19/AUDIT-01-NARRATIVE-DESIGNER.md
+++ b/.planning/mission-audit-2026-04-19/AUDIT-01-NARRATIVE-DESIGNER.md
@@ -1,0 +1,102 @@
+# AUDIT 01 — Narrative Designer
+
+**Posture :** ex-Monument Valley / Dark Souls / Journey. Un écran = une rencontre.
+**Date :** 2026-04-19.
+**Scope :** reframer MINT comme un univers de rencontres narrées autour des 18 life events, pas une app de menus.
+
+---
+
+## 1. Verdict : menu-centric, pas world-centric
+
+MINT est aujourd'hui un **rayonnage de simulateurs**. Tu as un `aujourdhui_screen` (passif), 7 hubs `/explore/*` (taxonomie catalogue), et 18 écrans de life events qui sont tous construits sur le même moule industriel : `TabController(length: 4)` — Calcul / Tableau / Checklist / Détail. `naissance_screen.dart` = 4 onglets, `mariage_screen.dart` = 4 onglets, `divorce_simulator_screen.dart` = 984 lignes de tabs, `donation_screen.dart` = 1075 lignes de tabs. C'est un **Excel déguisé en app**. Aucun début, aucun milieu, aucune révélation. L'utilisateur qui vient d'avoir un enfant est jeté dans un formulaire "salaire mensuel : 6000" avec `_recalculate()` — MINT n'accuse jamais réception du fait qu'un être humain vient de naître.
+
+Le layer-4 du moteur MINT (la question à poser) est **absent des 18 écrans**. Les 3 premiers layers sont dilués dans des onglets interchangeables. Le `timeline_screen` (536 lignes) est la seule surface à potentiel narratif — et il est enterré hors nav. **Diagnostic : MINT a le cerveau VZ, le visuel 2019, et zéro dramaturgie.**
+
+---
+
+## 2. Cinq life events reframés (les plus fréquents en vrai)
+
+Règle de flow : **Accusé de réception → Ce qui change vraiment → Ce que MINT fait à ta place → La question à poser avant vendredi**.
+
+### 2.1 Naissance — « Quelqu'un est arrivé »
+1. **Reconnaissance.** Pas un formulaire. Un écran sombre, une seule phrase : « Il/elle est né·e. On respire, et quand tu veux on regarde ce qui bouge. » Bouton unique : *Continuer*. **Pas de chiffre avant ce tap.**
+2. **Ce qui change vraiment.** Trois cartes révélées une par une (pas 4 onglets simultanés) : (a) ton plafond 3a ne bouge pas, mais tes déductions fiscales oui ; (b) ta LPP active une bonif. orphelin que tu ne verras qu'en cas de coup dur ; (c) les allocs cantonales VS = 275 CHF/mois, tu les touches dès le mois de naissance si tu déposes le formulaire ≤ 30 jours.
+3. **Ce que MINT fait.** Pré-remplit la déclaration fiscale côté dépendant, détecte les allocations dues rétroactivement, alerte J-5 avant deadline dépôt employeur.
+4. **Layer-4.** « Demande aux RH : est-ce que mon salaire assuré LPP est recalculé automatiquement, ou faut-il que je déclare ? » — une seule question, screenshotable.
+
+**Câblage :** `naissance_screen.dart` (existe, à décomposer en séquence), `family_service.dart`, `baby_cost_widget.dart`, `clause_3a_widget.dart`. **Manque :** `BirthRecognitionScene` (écran 1), `AllocationDeadlineWatcher` (agent de rappel). Tuer les 4 tabs, les transformer en 4 beats.
+
+### 2.2 Déménagement cantonal — « Tu changes de règles du jeu »
+1. **Reconnaissance.** « Tu passes de VD à ZG. Tu ne déménages pas, tu changes de pays fiscal. »
+2. **Ce qui change.** Taux marginal chute de ~34% à ~22% ; ton 3a banque reste mais ta caisse de prévoyance suit l'employeur donc rebascule si tu changes de job ; la déclaration 2026 se split entre deux cantons au prorata jour ; deadline fiscale ZG ≠ VD.
+3. **Ce que MINT fait.** Calcule l'économie annuelle nette, détecte si rester en VD pour la fin d'année a du sens, génère les deux listes de démarches (départ + arrivée).
+4. **Layer-4.** « Appelle ta commune de départ : quelle est la date effective d'annonce, et est-ce que je peux la fixer au 31.12 plutôt qu'au 15.11 ? » (économies 4-figures possibles).
+
+**Câblage :** `demenagement_cantonal_screen.dart` (existe, linéaire à rendre), `cantonal_data.dart`, `tax_calculator.dart`. **Manque :** `MoveScene` (split temporal visuel canton A/canton B).
+
+### 2.3 Premier emploi — « Ton premier vrai choix, il est déjà dans ton contrat »
+1. **Reconnaissance.** « Tu as signé. Voilà ce que ton employeur ne t'a pas raconté. »
+2. **Ce qui change.** Déduction coordination LPP = 26'460 invisible sur ta fiche ; ton 3a peut commencer ce mois (plafond 7'258), pas dans 10 ans ; ton permis fiscal détermine si tu es imposé à la source (et donc si tu peux récupérer via déclaration rectificative).
+3. **Ce que MINT fait.** Lit ta fiche salaire scannée, te dit ce que tu paies pour quoi, flag si ta caisse LPP a un plan bonus (CPE, PUBLICA, Hotela — listés côté `lpp_certificate_parser`).
+4. **Layer-4.** « Demande aux RH : quel est le plan LPP exact (Base ? Maxi ?) et la bonif. vieillesse actuelle ? » — la différence entre 15% et 24% = ~200k à 65 ans.
+
+**Câblage :** `first_job_screen.dart` (1160 lignes de tabs à décomposer), `lpp_certificate_parser`, `document_scan/`. **Manque :** `FirstPayslipScene` (scan de la première fiche comme rite).
+
+### 2.4 Achat immobilier (EPL) — « Tu vas geler un étage de ta vie »
+1. **Reconnaissance.** « Acheter, c'est verrouiller 3 choses : ton 2e pilier, ta mobilité, ton taux d'impôt. Regarde lesquelles. »
+2. **Ce qui change.** EPL min 20k, blocage 3 ans (OPP2 art. 5 + art. 79b al. 3), taxe de retrait au canton de domicile selon la matrice cantonale, taux théorique FINMA 5% + 1% amortissement + 1% frais = tenabilité 33% brut.
+3. **Ce que MINT fait.** Croise ton avoir LPP scanné + ton revenu + canton cible, simule les deux scénarios (EPL vs nantissement) côte à côte sans ranker, alerte si retrait > 50% avoir (risque veuvage / invalidité).
+4. **Layer-4.** « Demande à ton courtier : sur 25 ans, quelle est la différence cumulée nantissement vs retrait, impôts inclus ? Fais-le écrire. »
+
+**Câblage :** routes `/epl` + `/hypotheque` + `/mortgage/*` (existent), `arbitrage_engine.dart`, `tax_calculator.dart`. **Manque :** `LockInScene` — visualiser les 3 verrous (prévoyance, mobilité, fiscalité) comme 3 portes qui se ferment.
+
+### 2.5 Héritage / décès d'un proche — « Personne ne t'a expliqué ce qui se passe lundi »
+1. **Reconnaissance.** « On sait. On fait lentement. D'abord trois choses qui ne peuvent pas attendre, ensuite le reste, au rythme qu'il te faut. »
+2. **Ce qui change.** Inventaire successoral cantonal (délai 1 mois VS, 3 mois ZH) ; droits de succession — conjoint 0%, enfants souvent 0% mais concubin·e jusqu'à 50% selon canton ; LPP du défunt = hors succession (rente veuvage/orphelin séparée).
+3. **Ce que MINT fait.** Génère la to-do list cantonale datée, liste les institutions à notifier, calcule l'impôt de succession simulé par canton, détecte si un contrat 3e pilier B est hors masse.
+4. **Layer-4.** « Avant la séance notaire : demande si tu peux ou non renoncer à la succession (délai 3 mois dès connaissance du décès, CC art. 567). Fais-toi expliquer ce que ça change. »
+
+**Câblage :** `deces_proche_screen.dart` (existe, 442 lignes), `donation_screen.dart`, `succession_patrimoine_screen.dart`. **Manque :** `GriefPacingScene` — protocole qui ralentit l'app (pas de chiffre choc, pas de chips gamifiées, typo plus grande, silence).
+
+---
+
+## 3. Le pattern universel
+
+Un flow MINT **se raconte** quand il respecte ces cinq invariants :
+
+1. **Un verbe à l'imparfait ou au présent d'arrivée avant tout chiffre.** « Tu as signé. » « Il est né. » « Tu déménages. » Le chiffre vient après l'accusé de réception, jamais avant.
+2. **Révélation linéaire, pas tabulaire.** 3 à 4 beats qui avancent, pas 4 onglets parallèles. L'utilisateur ne choisit pas l'ordre, MINT le porte.
+3. **Le layer-4 est terminal et unique.** Une seule question à poser, screenshotable, avec le destinataire nommé (« aux RH », « au notaire », « à ta commune »). Jamais une liste de 10 questions.
+4. **MINT fait quelque chose à la place de l'utilisateur entre deux écrans.** Pré-remplit, rappelle, alerte, détecte. Sinon c'est un cours, pas un coach.
+5. **Le silence est un geste.** Après le chiffre choc : espace, non-chip, pas de « veux-tu explorer ? ». L'utilisateur respire. C'est la signature Journey : l'absence de prompt est l'interaction.
+
+Un flow qui **se navigue** (≠ se raconte) a 4 tabs, un AppBar avec titre-catégorie (« Naissance »), des champs input avant contexte, un `_recalculate()` live, et termine sur un résumé sans question. Les 18 screens actuels tombent tous dans ce moule.
+
+---
+
+## 4. Trois écrans à supprimer (ils cassent le récit)
+
+1. **`explore/explore_hub_screen.dart` (64 lignes) + les 7 sous-hubs `/explore/*`.** Pure taxonomie catalogue. Rayonnage de supermarché. Un user qui hérite n'a jamais pensé « je vais cliquer sur Patrimoine & Succession ». Il a dit « mon père est mort ». MINT doit répondre à la phrase, pas à la catégorie.
+2. **`aujourdhui_screen.dart` (tel quel).** Dashboard passif agrégeant des cards génériques. Il n'accueille personne, il liste. À reframer comme *scène d'ouverture contextuelle* (voir §5) ou à fusionner dans la surface narrative.
+3. **`explore/explorer_screen.dart`.** Double emploi avec `explore_hub_screen`. Artefact de la Wire Spec V2. À mettre en `redirect` vers la nouvelle surface narrative (zéro breakage deep-link).
+
+**Note :** je ne touche pas aux 18 screens life events. Ils contiennent la logique calcul, qui reste. C'est leur **coque UI quadri-onglets** qui doit mourir et être remplacée par une séquence de 3-4 scènes.
+
+---
+
+## 5. Proposition radicale : remplacer « Explorer » par **Le Seuil**
+
+Tuer la tab *Explorer*. La remplacer par **Le Seuil** — un écran qui n'est pas un hub, c'est un **seuil narratif vivant**.
+
+- **Une seule question en haut**, qui change selon ton état réel : « Qu'est-ce qui a bougé cette semaine ? » / « Ton père est décédé il y a 11 jours. On reprend ? » / « Tu as scanné ta fiche il y a 3 jours — tu veux voir ce qu'elle dit ? »
+- **En dessous : trois rencontres possibles**, pas sept catégories. Générées par `life_events_service` + `autonomous_agent_service` depuis ton profil réel (détections + échéances + âges clés). Un étudiant genevois de 24 ans verra « Tu changes de job ? » / « Ton 3a n'est pas ouvert » / « Ta LAMal 2027 se négocie maintenant ». Un Julien 49 ans verra « Ton rachat LPP = fenêtre fiscale 2026 » / « Lauren FATCA — la déclaration US expire 15 juin » / « Votre commune bascule ZH 2027 ? ».
+- **Pas de grille, pas d'icônes de catégorie.** Trois cartes verticales, typo Montserrat 24px, chacune finit par « Ouvrir ». C'est ça la rencontre.
+- **Fallback froid** (profil vide) : une seule carte, « Commence par ce qui pèse. » → 4 verbes (j'ai signé, j'ai perdu, j'hérite, je déménage) → route directe vers la scène d'accueil correspondante.
+
+Techniquement : nouveau `seuil_screen.dart`, consomme `LifeEventsService.surfaceableEvents()` + `CoachProfile.detectedEvents` + `SequenceTemplate`. Les 67 routes canoniques restent en deep link. L'IA nav `/home?tab=2` route vers `SeuilScreen`. Zéro casse.
+
+**Effet :** MINT cesse d'être une app où tu choisis un rayon. Elle devient un lieu qui t'accueille avec ce qui te concerne vraiment, cette semaine-là. C'est Journey plutôt qu'Excel. C'est la mission.
+
+---
+
+**Mot de la fin.** MINT a tout le moteur (calc, compliance, 4-layer, archetypes, détections). Ce qui manque, c'est la **mise en scène**. On ne refait pas le code, on coupe les tabs, on ajoute des scènes d'accueil, et on remplace le rayonnage par un seuil. Trois sprints. Pas plus.

--- a/.planning/mission-audit-2026-04-19/AUDIT-02-RADICAL-MINIMALIST.md
+++ b/.planning/mission-audit-2026-04-19/AUDIT-02-RADICAL-MINIMALIST.md
@@ -1,0 +1,100 @@
+# AUDIT-02 — RADICAL MINIMALIST
+
+> Lens : ex-Aesop / ex-Teenage Engineering. Un produit existe s'il tient en 3 objets irréductibles. Le reste est du gras ou un bug taxonomique.
+> Mission testée : **lucidité financière**. Un produit qui promet la lucidité avec 97 écrans ne l'incarne pas — il la contredit.
+
+---
+
+## 1. Comptage réel (2026-04-19, branche `feature/wave-c-scan-handoff-coach`)
+
+| Objet | Commande | Résultat |
+|---|---|---|
+| Écrans `.dart` | `find apps/mobile/lib/screens -name "*.dart" \| wc -l` | **97** |
+| Dossiers d'écrans top-level | `ls apps/mobile/lib/screens/ \| wc -l` | **57** |
+| Services mobiles | `find apps/mobile/lib/services -name "*.dart" \| wc -l` | **198** |
+| Widgets | `find apps/mobile/lib/widgets -name "*.dart" \| wc -l` | **286** |
+| Modèles | `find apps/mobile/lib/models -name "*.dart" \| wc -l` | **28** |
+| Providers | `find apps/mobile/lib/providers -name "*.dart" \| wc -l` | **15** |
+| Fichiers endpoints backend | `ls services/backend/app/api/v1/endpoints/ \| wc -l` | **59** |
+| Routes backend (`@router.*`) | `grep -rE "@router\.(get\|post\|put\|patch\|delete)" services/backend/app/api/` | **218** |
+| Calculateurs `financial_core` | `ls .../financial_core/ \| wc -l` | **17** |
+| Tabs actuels | `home_shell` inspect | **3 tabs + drawer + contextual sheet** (Aujourd'hui, Coach, Explorer + ProfileDrawer + Capture) |
+
+**Verdict brut** : 97 écrans pour 18 life events = **~5,4 écrans par événement de vie**. C'est un catalogue, pas un compagnon.
+
+---
+
+## 2. Les 3 objets irréductibles de MINT
+
+Si on enlève l'un, la mission meurt. Si on en ajoute un quatrième, la mission se dilue.
+
+### OBJET 1 — **Le Dossier** (la vérité)
+La représentation unique et canonique de la situation financière de l'utilisateur : revenus, LPP, 3a, dettes, logement, famille, canton, archétype, confidence. **Remplace** : `mon_argent_screen`, `financial_summary_screen`, `confidence_dashboard_screen`, `documents_screen`, `portfolio_screen`, `privacy_control_screen`, `data_block_enrichment_screen`. **Irréductible car** : sans dossier, MINT n'a rien à éclairer. Le Dossier EST la lucidité matérialisée.
+
+### OBJET 2 — **Le Coach** (la traduction)
+Le moteur 4-couches (extraction → traduction → perspective → questions à poser) exposé comme conversation + scan. Le coach lit le Dossier, prend un document ou une question, et produit un éclairage. **Remplace** : `coach_chat_screen`, `ask_mint_screen`, `document_scan_screen`, `extraction_review_screen`, `document_impact_screen`, `annual_refresh_screen`, tous les `_screen.dart` de type "comparator/simulator" qui sont en réalité des dialogues déguisés. **Irréductible car** : un Dossier sans traducteur = un tableur. MINT n'est pas un tableur.
+
+### OBJET 3 — **L'Action** (le prochain geste)
+L'unique écran qui, à tout instant, répond à « qu'est-ce qui compte maintenant ? » : 1 à 3 prochains gestes concrets, nommés, datés, dérivés du Dossier × Coach. **Remplace** : `aujourdhui_screen`, `timeline_screen`, `explore_hub_screen`, `explorer_screen`, `comprendre_hub_screen`, `achievements_screen`, `cantonal_benchmark_screen`, `gender_gap_screen`. **Irréductible car** : sans geste, la lucidité est stérile (principe 4 de MINT_IDENTITY : « prise immédiate »).
+
+> **Test Aesop** : Dossier / Coach / Action. Trois noms communs. Zéro jargon. Un enfant de 10 ans les nomme ; un senior de 72 ans les utilise.
+
+---
+
+## 3. Ce qui peut disparaître sans toucher la mission
+
+**Tabs/hubs redondants (1 suffit)** : `explore/explore_hub_screen.dart`, `explore/explorer_screen.dart`, `education/comprendre_hub_screen.dart`, `open_banking/open_banking_hub_screen.dart`, `mon_argent/mon_argent_screen.dart`. Cinq surfaces pour un seul concept : « naviguer dans ce que MINT sait ». → c'est le Dossier.
+
+**Screens « life-event » dédiés (18 pages = 18 formulaires)** : `mariage_screen`, `naissance_screen`, `divorce_simulator_screen`, `deces_proche_screen`, `demenagement_cantonal_screen`, `expat_screen`, `frontalier_screen`, `first_job_screen`, `unemployment_screen`, `concubinage_screen`, `donation_screen`, `housing_sale_screen`, `independant_screen`, `gender_gap_screen`. → tous fusionnables dans Coach (conversation déclenche le contexte, pas un screen).
+
+**Simulateurs isolés** : `simulator_3a_screen`, `simulator_compound_screen`, `simulator_leasing_screen`, `consumer_credit_screen`, `job_comparison_screen`, `fiscal_comparator_screen`, `divorce_simulator_screen`. → ces 7 sont des **dialogues déguisés en formulaires**. Coach les absorbe.
+
+**Arbitrage + lpp_deep + 3a_deep (10 écrans techniques)** : `arbitrage/*` (4), `lpp_deep/*` (3), `pillar_3a_deep/*` (4). → taxonomie dev-centric explicitement bannie par CLAUDE.md §7. À tuer en tant qu'écrans ; garder en tant que **capacités** appelées par Coach.
+
+**Admin/settings/legal/auth (13 écrans)** : `admin_*` (2), `settings/langue`, `byok_settings`, `slm_settings`, `about_screen`, `auth/*` (3), `landing_screen`, `household/*` (3), `privacy_*` (2). → à reléguer dans un **drawer système** hors des 3 objets (chrome, pas produit).
+
+**Total dégraissable : ~70 des 97 écrans.** Reste ≈ 27 écrans utiles, regroupables en 3 surfaces.
+
+---
+
+## 4. Fusions radicales
+
+| Fusion | Rationale |
+|---|---|
+| `mon_argent` + `financial_summary` + `confidence_dashboard` + `documents` + `portfolio` + `data_block_enrichment` → **Dossier** | Tous montrent la même vérité sous 6 angles. Le Dossier est UNE vue avec des zooms contextuels, pas 6 écrans. |
+| `coach_chat` + `ask_mint` + `conversation_history` + `document_scan` + `extraction_review` + `annual_refresh` + `cockpit_detail` + 7 simulateurs + 14 life-event screens → **Coach** | Un seul fil conversationnel avec slots typés (scan, chiffre, comparaison, life event). Pas 28 écrans pour la même mécanique. |
+| `aujourdhui` + `timeline` + `explorer` + `explore_hub` + `comprendre_hub` + `achievements` + `cantonal_benchmark` → **Action** | Tous essayent de répondre « et maintenant ? ». Un seul écran répond. |
+| 3 privacy screens → **1 section Dossier** | L'utilisateur voit et édite ce que MINT sait au même endroit où il le consulte. |
+| 4 arbitrage + 3 lpp_deep + 4 3a_deep → **11 capacités Coach** | Pas des destinations. Des outils invoqués. |
+
+---
+
+## 5. Architecture « MINT en 3 objets »
+
+```
+┌─────────────────────────────────────────────────────┐
+│  [Dossier]    [Coach]    [Action]                   │  ← 3 tabs. Point.
+│                                                      │
+│  (⚙ drawer système : compte, langue, BYOK, légal)   │  ← hors produit
+└─────────────────────────────────────────────────────┘
+```
+
+- **Dossier** : vérité éditable, confidence par bloc, scan déclenché depuis un bloc vide, succession/famille/patrimoine comme sections zoomables — PAS comme onglets.
+- **Coach** : conversation + scan + comparaison side-by-side, capable d'invoquer n'importe quel calculateur du `financial_core` (17 calculateurs, 218 routes backend = la **puissance**, pas la surface).
+- **Action** : 1 à 3 prochains gestes, chacun rattaché à un bloc du Dossier ou un fil Coach. Une seule question par jour : « qu'est-ce qui compte ? ».
+
+Suppression de Aujourd'hui+Explorer+MonArgent au profit de Dossier+Coach+Action inverse la logique : **le produit n'est plus un catalogue navigable, c'est une vérité conversée qui produit des gestes.**
+
+---
+
+## 6. Risque de ne PAS compresser
+
+Si MINT reste à 97 écrans + 4 surfaces concurrentes (Aujourd'hui/MonArgent/Coach/Explorer) :
+
+1. **Contradiction de mission** : promettre la lucidité avec un catalogue de 97 écrans = mentir par l'architecture. Le médium contredit le message.
+2. **User perdu** : les données comportementales le montrent déjà (panels Wave C en cours). 4 tabs qui se recouvrent créent la paralysie, pas la clarté.
+3. **Coût maintenance** : 198 services + 286 widgets + 218 routes maintenus pour exposer la même chose plusieurs fois. Chaque fix doit être propagé 3-5×.
+4. **Impossibilité du toilet test** (MINT_IDENTITY §5) : « utilisable en 20s, compréhensible à moitié fatigué ». Un utilisateur fatigué devant 4 tabs + drawer + FAB + 57 dossiers d'écrans ne passe pas le test.
+5. **Dilution du positionnement** : MINT devient « encore une app fintech ». Les 3 objets le sortent du lot — un Dossier qui parle, ça n'existe pas ailleurs.
+
+**Conclusion chirurgicale** : garder 3 objets, tuer 70 écrans, promouvoir 11 capacités en outils Coach. La mission lucidité exige que l'architecture elle-même soit lucide.

--- a/.planning/mission-audit-2026-04-19/AUDIT-03-SWISS-FINTECH-INSIDER.md
+++ b/.planning/mission-audit-2026-04-19/AUDIT-03-SWISS-FINTECH-INSIDER.md
@@ -1,0 +1,70 @@
+# AUDIT-03 — Swiss Fintech Insider
+
+**Persona** : 25 ans UBS Tech pensions / Swissquote / Raiffeisen Romandie. Vu Cleo, VZ, Yuh, Neon, Alpian de l'intérieur.
+**Sujet** : salarié/indépendant 40-65 ans, marié + enfants, LPP + 3a + hypothèque, déclaration annuelle.
+**Date** : 2026-04-19 · dev tip `f35ec8ff`
+
+---
+
+## 1. Verdict
+
+**MINT n'est pas au niveau 2026.** Ambition VZ (profondeur, 18 life events) mais mécanique de *simulateur*, pas de *dossier vivant*. Les trois moments où un Suisse attend que son app parle — **janvier (certificat LPP)**, **mars-avril (déclaration fiscale)**, **oct-nov (prime LAMal)** — ne déclenchent rien. Seul rappel câblé : 3a oct-déc (`notification_scheduler_service.py`). Pour un 49 ans VD recevant 14 docs officiels/an, MINT est muet 11 mois sur 12. **Très bon sur le calcul ponctuel, mal sur le compagnon annuel.** Julien garde son Excel et paie 290 CHF à VZ.
+
+---
+
+## 2. Top 10 gaps attendus-vs-fourni
+
+| # | Attente | État MINT | Note |
+|---|---|---|---|
+| 1 | **Certificat LPP janvier** : scan → diff N/N-1 avoir, salaire assuré, bonif., conversion ; alerte changement plan | Parser `lpp_certificate_parser.py` OK. **Aucun diff N/N-1, aucun trigger** | **3/10** |
+| 2 | **Déclaration fiscale cantonale** : deadlines VD/GE/BE 15-31.03, ZH 31.03, TI 30.04 ; pré-remplissage 3a/LPP/EPL/rachat | `tax_declaration_parser.py` + `fiscal/commune_service.py` existent. **Aucun calendrier cantonal, aucun pré-remplissage** | **2/10** |
+| 3 | **Fiche de salaire mensuelle** : AVS 5.30%/AC 1.1%/LPP selon plan, détecter 13e, signaler erreur employeur | **Rien.** Aucun payslip parser | **0/10** |
+| 4 | **Prime LAMal oct-nov** : fenêtre résiliation 30.11, compare franchises + modèles (standard/HMO/tél./pharma), alerte hausse OFSP | `lamal_franchise_screen` = slider statique. **Aucune saisonnalité, aucun comparateur multi-assureurs** | **3/10** |
+| 5 | **Allocations LAFam** : CHF 200-440/enfant selon canton, droit conjoint activité principale | `family_service.dart` mentionne. **Aucun calcul cantonal, pas de trigger naissance** | **2/10** |
+| 6 | **Rente AVS 8 archétypes** : RAMD, années futures, splitting marié, bonif. éducatives LAVS art. 29sexies | `AvsCalculator.computeCouple()` OK. **Bonif. éducatives absentes** (~+5-8%) | **6/10** |
+| 7 | **Hypothèque annuelle** : SARON vs fixe, amortissement indirect 3a vs direct, valeur locative, entretien | `mortgage/` + `imputed_rental_screen` corrects. **Aucun suivi valeur locative annuel, pas d'alerte renouvellement fixe** | **5/10** |
+| 8 | **Rachat LPP fiscal** : ATF 142 II 399 (3 ans avant retrait = reprise), étalement pluri-annuel progressif cantonal | W4 swiss-brain a câblé `dateRachats: List<DateTime>`. **Étalement cantonal non optimisé** | **7/10** |
+| 9 | **13e AVS 2026 + BVG 21** : rente AVS +8.33%, âge 65F, conversion 6.8%→6.0% proposée | Âge 65F OK. **13e AVS hors projecteur, scénario BVG 21 absent** | **4/10** |
+| 10 | **Dossier vivant cross-doc** : LPP + salaire + 3a + LAMal + taxation → timeline + détection incohérences | `documents_screen` + `document_memory_service` existent. **Pas de cross-référencement** | **3/10** |
+
+**Moyenne : 3.5/10.**
+
+---
+
+## 3. 5 événements annuels qui ne déclenchent rien
+
+1. **Janvier — certificat LPP arrive** : aucun trigger, aucun diff N-1.
+2. **Mars-avril — déclaration fiscale** : aucun rappel cantonal, aucun pré-remplissage.
+3. **Juin-juillet — décompte taxation** : aucune ingestion, aucun "voici comment baisser l'an prochain".
+4. **Oct-nov — primes LAMal** : aucune alerte 30.11, aucun comparateur annuel.
+5. **Décembre — 13e / bonus** : aucun nudge "marge 3a + 13e → impact fiscal".
+
+---
+
+## 4. 3 features à supprimer
+
+1. **`gender_gap_screen.dart`** — politique, pas une attente d'un 49 ans VD. Décharge en insert éducatif.
+2. **`consumer_credit_screen.dart` isolé** — signal Safe Mode, pas écran-produit. Intègre dans `debt_risk_check_screen`.
+3. **`simulator_leasing_screen.dart`** — leasing auto ne mérite pas un top-level. Insert dans budget.
+
+---
+
+## 5. 5 raisons de préférer VZ / Cleo / Yuh
+
+1. **VZ livre un plan LPP écrit signé** (290 CHF, 90 min). MINT lit, ne livre pas de plan daté.
+2. **VZ a les deadlines fiscales cantonales en CRM** et relance en février. MINT = silence.
+3. **Cleo a une conversation continue** (mémoire, voix). MINT = chat sans mémoire cross-session visible.
+4. **Yuh/Neon ont bLink vivant**. MINT `open_banking/` existe mais n'alimente pas visiblement le dossier.
+5. **VZ donne un humain** (52% des 50+ veulent validation humaine). MINT = 100% LLM, pas de tier expert.
+
+---
+
+## 6. Top 5 à câbler MAINTENANT
+
+1. **Calendrier fiscal 26 cantons** — deadlines + rappels J-21/J-7/J-1 + deeplink `documents_screen`. **3-5j. Débloque mars-avril.**
+2. **Certificat LPP diff N/N-1** — scan janvier → diff avoir/salaire assuré/bonif./conversion + alerte plan. **1-2 sem.**
+3. **Payslip parser** (`bulletin_salaire_parser.py`) — AVS 10.60%, AC 2.2%, LPP vs certificat, 13e. **2 sem. MINT devient mensuel.**
+4. **Fenêtre LAMal oct-nov** — notif J-30, comparateur franchise+modèle, hausse OFSP (asset class, compliance OK). **1 sem.**
+5. **Dossier vivant cross-ref** — relier salaire déclaré / assuré LPP / imposable / net budget. Détecter incohérences. **2 sem. Différenciateur anti-Cleo.**
+
+**Sans ces 5 : simulateur. Avec : le dossier que VZ vend 290 CHF.**

--- a/.planning/mission-audit-2026-04-19/AUDIT-04-COGNITIVE-LOAD.md
+++ b/.planning/mission-audit-2026-04-19/AUDIT-04-COGNITIVE-LOAD.md
@@ -1,0 +1,130 @@
+# AUDIT 04 — Charge cognitive & calibration System 1 / System 2
+
+> Auditeur : cognitive scientist ex-Stanford D.School + ex-Nudge Unit UK
+> Date : 2026-04-19 — commit `f35ec8ff` (dev tip), branche `feature/wave-c-scan-handoff-coach`
+> Méthode : lecture des 7 flows principaux + croisement MINT_IDENTITY §5 + VOICE_SYSTEM §2 + anti-shame doctrine.
+
+---
+
+## 1. Verdict global
+
+**MINT est globalement mal calibré : System 1 là où il faut System 2, System 2 là où il faut System 1.**
+
+Les deux entrées (landing + anonymous intent) sont **correctement S1** (un mot, 6 pills, texte libre — zéro friction). Mais dès que l'user entre dans le coach ou un simulateur, la courbe s'inverse brutalement :
+
+- Le **coach chat ouvre sur un chiffre brut** (`coach_chat_screen.dart:434-447` — silent opener = "Avoir LPP 70'377 CHF") sans narrative, forçant une interprétation S2 alors que le user est en exploration S1.
+- Les **simulateurs de décision irréversible** (rachat LPP 1143 lignes, EPL 800 lignes, rente vs capital 2'096 lignes) sont **des murs de sliders** qui se recalculent en live et **écrivent dans le profil sans confirmation** (`rachat_echelonne_screen.dart:236-294` : chaque drag de slider → `_onInputChanged` → `_writeBackResult` → écriture date `dateRachats` qui déclenche le blocage EPL 3 ans ATF 142 II 399 — **décision juridique irréversible en mouvement de pouce, zéro guard**).
+- L'**Aujourd'hui screen** ouvre sur 3 tension cards + Cap banner + timeline dans une même vue (`aujourdhui_screen.dart:156-200`) — **lecture S2 forcée au cold-start**.
+
+**MINT respecte le toilet test (§MINT_IDENTITY L56-61) sur les surfaces d'entrée, puis l'oublie dès que l'enjeu monte.**
+
+---
+
+## 2. Cinq flows où MINT force System 2 quand il faut System 1
+
+### F1 — Coach chat : silent opener = chiffre nu
+`coach_chat_screen.dart:508-580` (`_computeKeyNumber`) + `:419-447` (`_addInitialGreeting`).
+L'user arrive en curiosité exploratoire. MINT lui plante un chiffre ("70'377 CHF — Avoir LPP") sans narrative couche 2/3/4 (MINT_IDENTITY L68-96). Le cerveau doit inférer seul : "bon/mauvais ? comparé à quoi ?". C'est le contraire de la promesse "éclairer les implications" — c'est un chiffre orphelin. **Fix** : ajouter couche 2 en une phrase ("C'est ce que ta caisse te montre aujourd'hui. On regarde ce que ça veut dire ?").
+
+### F2 — Aujourd'hui : 3 tensions + Cap + timeline, ouverture froide
+`aujourdhui_screen.dart:156-220`. Au cold-start post-scan, l'user reçoit simultanément : CapDuJourBanner + 3 TensionCardWidget + CleoLoopIndicator + timeline de mois. **4 loci d'attention concurrents**, chacun exigeant un S2. Norman (Design of Everyday Things p.89) : "more than 1 decision per screen = paralysis". **Fix** : progressive disclosure — Cap unique d'abord, tensions dépliables à la demande.
+
+### F3 — Anonymous pill → chat vide
+`anonymous_intent_screen.dart:90-93` (`_navigateWithPrompt`). L'user tappe "J'évite d'y penser" (S1, pulsionnel). Il arrive sur `/anonymous/chat?intent=...` → le coach **doit** répondre avec du contenu chaud. Si le LLM est froid ou BYOK absent, silence. **Le geste S1 tombe dans un vide S2**. **Fix** : pré-charger un opener local pour chaque pill (6 réponses ARB, zéro réseau).
+
+### F4 — Extraction review : 8+ fields éditables en une vue
+`extraction_review_screen.dart:101-104` (`.._fields.map` — pas de chunking). LPP certificate = 8-12 fields avec confidence badges ET seuils différents (0.80/0.90/0.95 — `:42-57`). L'user vient de scanner en 10 sec (S1), et doit maintenant **auditer 10 chiffres**. Kahneman : charge S2 max ≈ 4 items. **Fix** : afficher d'abord uniquement les fields < seuil (review focalisée), le reste en accordion "Tout vérifier".
+
+### F5 — Onboarding intent → chat → silent opener du chiffre
+`coach_chat_screen.dart:337-344` (topic=='onboarding' → envoie "Salut, je viens de créer mon compte"). Puis silent opener impose un chiffre. **Trois transitions S2 en 30 secondes** sur un user fresh. Violation directe MINT_IDENTITY L40 ("prise immédiate"). **Fix** : onboarding → opener en mots, pas en chiffres, puis chiffre à la 3e interaction.
+
+---
+
+## 3. Trois flows où MINT donne System 1 quand il faut ralentir
+
+### S1→S2-A — Rachat LPP échelonné : slider = décision juridique
+`rachat_echelonne_screen.dart:236-294`. Chaque déplacement de slider → `_writeBackResult` → `dateRachats` ajouté + SnackBar "Profil mis à jour" — **zéro confirmation**. ATF 142 II 399 + LPP art. 79b al. 3 : la date de rachat **bloque tout EPL pendant 3 ans**. L'user a tapé sans intention. **C'est la définition de System 1 où il faut System 2.** **Fix critique** : séparer "simulation" (live, no-write) et "enregistrer un rachat réel" (bouton explicite + dialog 3 sec).
+
+### S1→S2-B — EPL combined : bouton "Continuer" unique sur retrait 2e pilier
+`epl_combined_screen.dart` (800 lignes) : flow slider → résultat → CTA unique. Le retrait EPL = taxe LIFD art. 38 **immédiate** + avoir LPP amputé à vie + blocage. Pas de pre-mortem ("tu es sûr ? voici ce que ça te coûte") avant la suite. **Fix** : ajouter un écran "Et si tu te trompais ?" — 3 points factuels (montant taxé, rente LPP réduite, non-réversible sauf revente) avant toute action.
+
+### S1→S2-C — Voice intensity chip "Brut" en tap unique
+`coach_chat_screen.dart:624-663` + `:665-710`. L'user peut passer de "Tranquille" (niveau 1) à "Brut" (niveau 5) en un tap. Niveau 5 = ton cash, tutoiement direct sur ton argent. Le setting **persiste** (`_saveCashLevel`). **Fix** : pour les sauts de +2 niveaux, interstitiel "tu veux qu'on te parle plus sec dès maintenant ?" + preview d'une phrase.
+
+---
+
+## 4. Anti-shame doctrine : copies / flows qui activent la honte-défense
+
+MINT_IDENTITY §Principe 2 L33-34 : "Mint ne donne jamais l'impression que l'utilisateur est en retard". Violations :
+
+1. **`coachSilentOpenerFitnessScore: "Score de santé financière"`** (`app_fr.arb:10267`) : un score /100 en ouverture = comparaison implicite à "100". Même si aucun benchmark social, le chiffre seul active la honte ("j'ai que 47"). **Fix** : "Voici ta photo du jour" sans dénominateur.
+2. **`coachSilentOpenerReplacementRate: "Taux de remplacement projeté"`** (`app_fr.arb:10266` consommé `coach_chat_screen.dart:549-562`) : un taux < 60% plante une anxiété retraite avant toute conversation. Violation §16 anti-pattern CLAUDE.md ("Frame MINT as retirement app"). **Fix** : neutraliser en "Ce que tu gardes en vivant de tes revenus prévus" + disclaimer hypothèse.
+3. **`tensionEmptyWelcome: "Commence par parler au coach."`** (`app_fr.arb:11341`) : impératif ("Commence") = injonction parentale. **Fix** : "Quand tu veux, on commence." ou question ouverte.
+4. **`intensityAdjustedUp` / intensité "Brut"** : le libellé suggère que "tranquille" est moins bien. Hiérarchie implicite = shame-trigger pour qui choisit le doux. **Fix** : renommer en types ("Posé / Direct / Tranchant") sans escalier numérique.
+5. **Onboarding "Salut, je viens de creer mon compte. Par ou je commence ?"** (`coach_chat_screen.dart:342`) : injecté comme message user **à la place de l'user** = le coach répond comme si l'user l'avait demandé, créant une faille (l'user lit sa propre voix parler à sa place). Détail mais rompt la confiance S1.
+
+---
+
+## 5. Cinq nudges / micro-gestures qui manquent
+
+1. **Rachat LPP / EPL — délai de réflexion 3 sec** : tap sur "Enregistrer ce rachat" → overlay semi-transparent avec countdown 3 sec + texte "Décision irréversible pendant 3 ans. Continuer ?" (pattern Thaler *active choice + cooling-off*). Empêche les décisions pouce-réflexe. Applicable : `rachat_echelonne_screen.dart`, `epl_screen.dart`, `epl_combined_screen.dart`.
+
+2. **Coach silent opener — phrase couche 2 obligatoire avant chiffre** : la règle `MINT_IDENTITY L68-96` (4 couches) doit se traduire en contrat. Impossible d'afficher un nombre en ouverture sans une ligne "ce que ça veut dire". Hook dans `_computeKeyNumber` → retourner `({number, headline, implication})` avec `implication` requis.
+
+3. **Scan → extraction review — chunk de 3 fields max** : montrer d'abord les 1-3 fields à faible confidence (S2 ciblé), puis "Les 7 autres sont OK. Voir quand même ?" (progressive disclosure Norman). Rendra le gate à 30 sec au lieu de 2 min.
+
+4. **Pill tap sur anonymous intent — opener local préloadé** : pour chaque pill ARB (`anonymousIntentPill1..6`), une réponse-coach statique de 2 phrases stockée en ARB, délivrée avant tout appel réseau. Le geste S1 reste fluide même si LLM down. Fichier à créer : `lib/services/coach/anonymous_local_openers.dart`.
+
+5. **Aujourd'hui — focus mode cold-start** : au premier chargement du mois, afficher **uniquement** le Cap du jour plein écran (geste S1 unique : lire + tap). Les TensionCards apparaissent au scroll. Pattern Apple Weather / Things 3. `aujourdhui_screen.dart:156-220` à refactorer en 2 states : `CapFullscreen` → `TimelineFull` sur swipe.
+
+---
+
+## 6. Refonte de la courbe cognitive cold-start → first insight
+
+**État actuel** (mesuré) : 6 gestes S1 + 4 transitions S2 en ~90 sec → user saturé avant premier insight utile.
+
+**Cible** (Kahneman-compatible) : **pic S1 unique au démarrage, 1 seule décision S2 avant le premier insight, S2 ciblé ensuite**.
+
+```
+Landing (1 mot, 1 CTA)                    → S1 ✓ [4 sec]
+  ↓
+Anonymous intent (6 pills + texte libre)  → S1 pur [8 sec]
+  ↓ [pill tap]
+Anonymous chat — opener local préchargé   → S1 [user lit, zéro demande]
+  ↓ [user tape 1 réponse]
+Coach remonte profil partiel              → transition S1→S2 douce
+  ↓
+PREMIER INSIGHT (couche 1+2, UN chiffre + UNE phrase implication)  → S2 ciblé, 1 item
+  ↓
+Question ouverte "tu veux qu'on creuse ?" → user choisit le rythme
+  ↓ [user opt-in]
+Scan optionnel / simulateur / fact-entry  → S2 choisi, pas imposé
+```
+
+**Quatre règles de design cognitif à ajouter à `VOICE_SYSTEM.md` §2** :
+
+1. **Rule of One** : un écran = un chiffre maximum en cold-start.
+2. **Couche 2 obligatoire** : aucun nombre affiché sans sa phrase d'implication (enforcé par contrat type).
+3. **S2-gate sur irréversible** : toute écriture profil qui déclenche une règle juridique (dateRachats, EPL, retrait 3a) passe par un dialog 3 sec + libellé de l'implication.
+4. **Progressive disclosure par défaut** : plus de 3 items simultanés → accordion. Applicable à tension cards, extraction review, simulateurs.
+
+---
+
+## Fichiers cités
+
+- `apps/mobile/lib/screens/landing_screen.dart:85-210`
+- `apps/mobile/lib/screens/anonymous/anonymous_intent_screen.dart:66-93, 177-213`
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart:337-344, 419-447, 508-580, 624-710`
+- `apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart:156-220`
+- `apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart:236-294, 722-730` (ex-1143 l total)
+- `apps/mobile/lib/screens/lpp_deep/epl_screen.dart` (800 l)
+- `apps/mobile/lib/screens/mortgage/epl_combined_screen.dart`
+- `apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart` (2'096 l)
+- `apps/mobile/lib/screens/document_scan/extraction_review_screen.dart:42-57, 101-104`
+- `apps/mobile/lib/l10n/app_fr.arb:10266-10280, 11196-11225, 11341-11346`
+- `docs/MINT_IDENTITY.md` L33-34, L40, L56-61, L68-96
+- `docs/VOICE_SYSTEM.md` §2 axes
+
+---
+
+**Mot de la fin** : MINT promet "éclairer pour que tu décides". Aujourd'hui, MINT **affiche des chiffres pour que tu interprètes**, et **laisse glisser des décisions juridiques pendant que tu explores**. Les deux dérives sont symétriques. Corriger l'une sans l'autre = garder le déséquilibre.

--- a/.planning/mission-audit-2026-04-19/AUDIT-05-MISSION-KEEPER-MATRIX.md
+++ b/.planning/mission-audit-2026-04-19/AUDIT-05-MISSION-KEEPER-MATRIX.md
@@ -1,0 +1,87 @@
+# AUDIT-05 — Mission Keeper Matrix (18 life events × 4-layer insight engine)
+
+2026-04-19 • `feature/wave-c-scan-handoff-coach` • dev tip `f35ec8ff`
+
+## 1. Préambule
+
+**Mission** (MINT_IDENTITY.md) : "Mint te dit ce que personne n'a intérêt à te dire." Lucidité via **4-layer insight engine** : (1) **Factual** extraction brute (durée/pénalités/frais/flex), (2) **HumanTranslation** reformulation jargon → courant, (3) **PersonalPerspective** fait rapporté à archétype/canton/couple, (4) **QuestionsToAsk** questions à poser avant signature.
+
+**18 life events** — enum `LifeEventType` à `apps/mobile/lib/models/age_band_policy.dart:9-39` : Famille 5 · Pro 5 · Patrimoine 4 · Santé 1 · Mobilité 2 · Crise 1.
+
+**Constat préalable global** : l'enum existe mais n'est **jamais persisté** sur `CoachProfile` (grep `profile.lifeEvents` = 0 hits), **jamais injecté** dans `services/coach/context_injector_service.dart` (grep `lifeEvent|recentEvent` = 0), et `widgets/coach/life_event_sheet.dart` a **zéro call-site** hors de son propre fichier. Vocabulaire, pas machine.
+
+## 2. Matrice 18 × 6
+
+Légende : ✅ OK bout-en-bout · 🟡 code existe/non câblé UI · 🔴 partiel ou buggy · ❌ absent.
+
+| # | Event | Factual | HumTrans | PersoPersp | Questions | Déclencheur UI | Persisté dossier |
+|---|---|---|---|---|---|---|---|
+| 1 | marriage | 🟡 `mariage_screen.dart` tabs | 🔴 ARB partiel | 🟡 `marriage_penalty_gauge.dart` non lu coach | ❌ | 🟡 `/mariage` + hub Famille | ❌ pas de `marriageDate` |
+| 2 | divorce | ✅ `divorce_simulator_screen` + backend `life_events.py` + checklist | 🟡 `divorce_film_widget.dart` | 🔴 régime demandé chaque run | ❌ | 🟡 `/divorce` | ❌ endpoint stateless |
+| 3 | birth | 🟡 `naissance_screen.dart` allocs/congé | 🔴 | ❌ pas d'impact budget/3a/impôt perso | ❌ | 🟡 `/naissance` | ❌ `childrenCount` oui, `birthDate` non |
+| 4 | concubinage | 🟡 `concubinage_screen` + `concubinage_decision_matrix` | 🟡 matrice vs mariage | 🔴 `civilStatus` lu pas persistent coach | ❌ | 🟡 `/concubinage` | 🟡 pas de durée |
+| 5 | deathOfRelative | 🟡 `deces_proche_screen` + `succession_simulator.py` + `survivor_pension_widget`+`testament_invisible_widget` | 🔴 | ❌ | ❌ | 🟡 `/life-event/deces-proche` | ❌ |
+| 6 | firstJob | ✅ `first_job_screen` + `first_job_service` + backend `first_job/` | 🟡 fallback templates | 🔴 heuristique `age≤28` au lieu de flag event | ❌ | 🟡 `/first-job` | ❌ pas `firstJobDate` |
+| 7 | newJob | 🟡 `job_comparison_screen` + backend `job_comparator.py` | ❌ | ❌ | ❌ | 🟡 `/simulator/job-comparison` | ❌ |
+| 8 | selfEmployment | 🟡 `independant_screen` + `independants/` | 🔴 inserts partiels | 🟡 archetype détecté, câblage inconsistant | ❌ | 🟡 `/segments/independant` | 🟡 `employmentStatus` seul |
+| 9 | jobLoss | 🔴 `unemployment_screen` + service basique | ❌ | ❌ SafeMode non câblé ici | ❌ | 🟡 `/unemployment` absent hub Explorer | ❌ |
+| 10 | retirement | ✅ tout `financial_core/` + `retirement_dashboard_screen` + backend | ✅ `coach_narrative_service` + `scenario_narration.py` | ✅ archetype + `couple_optimizer` | 🔴 pas de checklist questions caisse LPP | ✅ `/retraite` | ✅ LPP/3a/AVS persistés |
+| 11 | housingPurchase | ✅ `mortgage/` (affordability, amort, epl_combined, saron, imputed) + backend | 🟡 inserts éduc | 🟡 EPL ignore archetype FATCA | ❌ | 🟡 `/hypotheque`+`/epl` | ❌ pas `housingPurchaseDate` |
+| 12 | housingSale | 🟡 `housing_sale_screen` + service + backend | 🔴 squelette | ❌ | ❌ | 🟡 `/life-event/housing-sale` | ❌ |
+| 13 | inheritance | 🟡 `succession_patrimoine_screen` + `succession_simulator.py` | 🔴 | ❌ variations cantonales non persist. | ❌ | 🟡 `/succession` | ❌ |
+| 14 | donation | 🟡 `donation_screen` + `donation_service.py` | ❌ | ❌ | ❌ | 🟡 `/life-event/donation` (seuil `age≥55∧income>100k`) | ❌ |
+| 15 | disability | 🟡 `disability/` (gap, insurance, self_employed) + backend | 🔴 | 🔴 déclencheur `children>0 OR income>6k` ignore archetype | ❌ | 🟡 `/invalidite` | ❌ |
+| 16 | cantonMove | 🟡 `demenagement_cantonal_screen` + `fiscal_comparator_screen` + backend `fiscal/` | 🔴 | 🟡 comparateur OK mais déclenche sur canton "high-tax" pas sur event | ❌ | 🟡 `/life-event/demenagement-cantonal` | 🟡 `canton` seul, pas `previousCanton` |
+| 17 | countryMove | 🟡 `expat_screen` + `frontalier_screen` + backend `expat/` + `frontalier_service` | 🔴 FATCA copie incomplète | 🔴 archetype `expat_us` détecté non exposé UI | ❌ | 🔴 pas de route `/countryMove`, via `/segments/frontalier` | ❌ |
+| 18 | debtCrisis | ✅ SafeMode gate + `debt_prevention/` + `debt_risk_check_screen` | 🟡 `debt_prevention_service` | 🟡 SafeMode désactive optims (Wave 0) | 🟡 `help_resources_screen` services, pas questions | ✅ `/debt-prevention/*`+ SafeMode auto | 🔴 `debtRatio` calculé pas event persisté |
+
+**Bilan 108 cellules** : ~8 ✅, ~55 🟡, ~25 🔴, ~20 ❌. Axe **Questions 17/18 absents**. Axe **PersoPersp 12/18 partiel** (calculators archetype-aware mais output ne l'expose jamais).
+
+## 3. Top 5 PIRE gap (backlog #1)
+
+| # | Event | Absent sur | Pourquoi critique |
+|---|---|---|---|
+| 1 | **newJob** | 3 axes ❌ | Événement ultra-fréquent 25-55. Impact LPP direct (libre passage). Promesse MINT non tenue. |
+| 2 | **donation** | 3 axes ❌ | Fiscalité cantonale complexe. Backend tourne à vide UI. |
+| 3 | **housingSale** | 3 axes ❌ | Gains immo = impôt spécial cantonal. Écran vide de sens. |
+| 4 | **countryMove** | FATCA 🔴, pas de route directe | `expat_us` existe, écran ne l'utilise pas. Doctrine FATCA non tenue. |
+| 5 | **deathOfRelative** | PersoPersp ❌, Questions ❌ | `testament_invisible_widget` existe mais isolé du coach. |
+
+## 4. Top 3 RELATIVEMENT couverts (quick wins)
+
+| Event | Ce qui manque pour ✅ | Effort |
+|---|---|---|
+| **retirement** | Checklist "questions caisse LPP au départ" | ~1j |
+| **debtCrisis** | Questions ciblées curateur/désendettement (`help_resources_screen` liste déjà services) | ~0.5j |
+| **housingPurchase** | FATCA dans EPL + checklist "questions courtier/banque" | ~1.5j |
+
+## 5. Pattern systémique
+
+- **P1 — Simulateurs stateless** : 14/18 events ont backend+UI mais aucun ne persiste l'événement sur `CoachProfile`. Le coach ignore un mariage survenu hier.
+- **P2 — Layer 4 quasi inexistant** : aucune DB de questions compliance-ready (LSFin art. 8 le permet). 17/18 absents. C'est pourtant la signature MINT vs Cleo/VZ.
+- **P3 — Déclencheur UI orphelin** : `LifeEventSheet` couvre 18 events mais 0 call-site. Le seul path réel = `LifeEventSuggestionsSection` (heuristiques age/income) dans `financial_report_screen_v2.dart` — rate `jobLoss`, `housingSale`, `countryMove`, `cantonMove` (sauf canton high-tax), `deathOfRelative`, `debtCrisis`, partial `selfEmployment/newJob/disability`.
+
+## 6. Plan de câblage ordonné (impact × facilité, ~18j)
+
+| # | Chantier | j |
+|---|---|---|
+| C1 | Ajouter `List<LifeEventRecord> recentLifeEvents` sur `CoachProfile` + migration + backend persist | 2 |
+| C2 | Câbler `LifeEventSheet` sur Coach FAB + Home capture sheet (remplace heuristiques age/income) | 1 |
+| C3 | Injecter `recentLifeEvents` dans `context_injector_service.dart` (section "Événements récents") | 1 |
+| C4 | Layer 4 factory : `life_event_questions_service.dart` — 5-8 questions/event, ARB 6 langues, validé `/autoresearch-compliance-hardener` | 4 |
+| C5 | Enrichir Layer 3 : chaque simulator injecte `archetype`+`canton`+`couple` dans output narratif (5 calculators) | 3 |
+| C6 | `new_job_screen` (libre passage + comparaison caisses) | 2 |
+| C7 | housingSale + donation + countryMove(FATCA) refresh HumanTranslation | 3 |
+| C8 | Device walkthrough 18 events (iPhone sim, cycle 7 étapes Wave C) | 2 |
+
+## 7. Fichiers — créer / câbler / supprimer
+
+**CRÉER** : `apps/mobile/lib/models/life_event_record.dart` · `apps/mobile/lib/services/life_event_questions_service.dart` · `services/backend/app/schemas/life_event_record.py` + migration Alembic · `apps/mobile/lib/screens/new_job_screen.dart` · ARB `lifeEventQuestion_<event>_<n>` × 18 × 5-8 × 6 langues.
+
+**CÂBLER** (code existe, zéro/partiel call-site) : `widgets/coach/life_event_sheet.dart` → appelé depuis `aujourdhui_screen.dart` (capture sheet) + `coach_chat_screen.dart` (FAB). `services/coach/context_injector_service.dart` → `_buildRecentLifeEventsSection()`. `testament_invisible_widget`+`survivor_pension_widget` → référencés depuis `deces_proche_screen.dart`. `marriage_penalty_gauge` → output exposé au coach. `fiscal_service.dart` comparateur cantonal → déclencher sur event `cantonMove` pas sur canton "high-tax".
+
+**SUPPRIMER/réconcilier** : `widgets/life_event_suggestions.dart` `buildLifeEventSuggestions()` (heuristiques age/income, ~180 LOC morts) → remplacer par lecture `recentLifeEvents`+lifecycle. Redirects dupliqués `/life-event/succession`, `/coach/succession` → garder 1 par event, aliases dans `screen_registry.dart`.
+
+---
+
+**Conclusion ops** : le backlog #1 n'est PAS d'écrire plus de simulators. C'est **C1 persister les events**, **C3 les injecter dans le coach**, **C4 construire Layer 4 QuestionsToAsk** — les 3 chantiers qui transforment MINT de "collection de calculators" en "moteur 4-couches" tel que décrit dans MINT_IDENTITY.md.

--- a/.planning/mission-audit-2026-04-19/CHALLENGE-01-ARCHAEOLOGIST.md
+++ b/.planning/mission-audit-2026-04-19/CHALLENGE-01-ARCHAEOLOGIST.md
@@ -1,0 +1,153 @@
+# CHALLENGE-01 — ARCHAEOLOGIST
+
+Date : 2026-04-19. Branche `feature/wave-c-scan-handoff-coach`. Lens : 10 ans Flutter refactor, je sais ce qui casse quand on delete.
+
+---
+
+## 1. Verdict — **MODIFY** (pas KEEP, pas KILL)
+
+Les deux claims centraux — "70 écrans supprimables" et "~45 services orphelins" — **ne résistent pas au delete brut**. Preuves grep ci-dessous. Le plan PROMISE-GAP-MAP est bon sur les Phases 31-35 (câblage mission), **mais la Phase 36 "compression archi 4j" est sous-estimée d'un facteur 2-3** et la séquence de delete n'existe pas. Modifier = Phase 36 devient 8-12j + séquence explicite + CI ajustée.
+
+---
+
+## 2. Trois risques de delete cascade prouvés au grep
+
+### Risque A — Les "écrans morts" sont câblés dans 3 services critiques
+Pour les 5 écrans échantillonnés (`gender_gap`, `consumer_credit`, `simulator_leasing`, `naissance`, `divorce_simulator`), chacun est référencé dans :
+- `apps/mobile/lib/services/navigation/screen_registry.dart` (1652 lignes, **132 `ScreenEntry`**, intentTag `gender_gap`:653, `leasing_simulator`:722, `consumer_credit_simulator`:733, `_naissance`:846)
+- `apps/mobile/lib/services/response_card_service.dart` (1011 lignes, cas `lower.contains('naissance')`:284, `id:'gender_gap'`:449, `id:'leasing'`:502, `id:'consumer_credit'`:512)
+- `apps/mobile/lib/services/coach/tool_call_parser.dart` (`/naissance`:90, `/simulator/leasing`:117)
+
+**Conséquence** : delete screen seul = `ScreenEntry` référence classe supprimée → compile error cascading sur ~132 entries. Il faut amputer registry + response_card + tool_call_parser **en même temps** que screens, sinon flutter analyze explose.
+
+### Risque B — Les smoke tests testent exactement ce qu'on veut delete
+- `test/screens/simulator_screens_smoke_test.dart` (519 lignes) référence `gender_gap_screen` + `simulator_leasing_screen`
+- `test/screens/life_event_screens_v2_smoke_test.dart` (639 lignes) référence `naissance_screen`
+- `test/screens/life_event_screens_additional_smoke_test.dart` (420 lignes) référence `divorce_simulator_screen`
+- `test/screens/core_screens_smoke_test.dart` (328 lignes) référence `consumer_credit_screen`
+
+Total : **1906 lignes de test sur 4 fichiers** qui vont 100% casser sur 5/70 écrans. Extrapolation linéaire : **~15-20 fichiers de smoke tests** à amender ou delete. Sur 437 fichiers `.dart` de test, c'est ~5% de la suite.
+
+### Risque C — Ghost dependencies backend + i18n + notifications
+- Backend : `services/backend/app/services/coach/coach_tools.py:110,128,131` déclare les intent tags `"life_event_divorce"`, `"gender_gap"`, `"leasing_simulation"` → 7 intent tags Coach resteront **orphelins backend** si les screens Flutter meurent sans nettoyage backend correspondant (doctrine `feedback_facade_sans_cablage_absolu.md` viole explicitement).
+- Notifications : `notification_service.dart` utilise des `payload: '/pilier-3a'`, `/home?tab=1&intent=...` (lignes 446,488,557,592,652,695,759). Si le deep-link cible est delete sans rediriger le payload → **push notif → écran blanc en prod**, silencieux.
+- i18n : `app_fr.arb` compte **135 occurrences** de `divorce|genderGap|consumerCredit|leasing`. Delete screen sans nettoyer ARB = strings orphelines shippées en 6 langues (gaspillage + violation CI `flutter gen-l10n`).
+- Backend tests : `test_divorce_simulator.py`, `test_housing_sale.py`, `test_family.py` (84 occurrences `naissance_service`) = si on delete `divorce_simulator_service.py` / `gender_gap_service.py`, **pytest backend casse**. Audit SYNTHESE ne liste PAS ces services backend dans "~45 fichiers à delete".
+
+---
+
+## 3. Estimation j-agent-réel pour la Purge
+
+| Borne | Jours | Hypothèse |
+|---|---|---|
+| Inférieure (optimiste) | **6 j** | screens + registry + response_card + tool_call_parser + tests en 1 shot par cluster, 0 régression, ARB nettoyé par autoresearch-i18n. **Irréaliste** : ne couvre pas backend cleanup ni notif payload rewire. |
+| **Médiane (réaliste)** | **11-13 j** | 5 écrans/j × 14 clusters (70 screens) = 14j, parallélisable à 2 tracks = 7j. + 2j services mobile (45 fichiers avec tests) + 2j cleanup backend cluster coach/narrative déjà fait + 2j i18n sweep + 1j notif payload audit + 1j pre-write gate = **11-13j**. |
+| Supérieure (pessimiste) | **18-22 j** | Si 1 cascade non-anticipée par cluster (ex : `tool_call_parser` bloque coach routing device), rollback + re-test → +50%. |
+
+**Claim PROMISE-GAP-MAP "Phase 36 = 4j agent non parallélisable"** : faux par ~3×. 4j ne couvre **que** les screens, **pas** le registry de 1652 lignes, **pas** les 15-20 smoke tests, **pas** les 135 strings ARB, **pas** les intent tags backend orphelins, **pas** le payload notif audit.
+
+**Preuve** : Wave E-PRIME (PR #356) vient de faire delete de 42K LOC, 10 commits, sur ~72 fichiers mobile + 4 backend = **~2 semaines wall-clock** avec 3 panels pré-audit. La Purge est 2-3× plus ambitieuse (70 screens + 45 services + invariants CI + pre-write gate).
+
+---
+
+## 4. Séquence de delete anti-cascade (ordre précis)
+
+Le plan actuel PROMISE-GAP-MAP ne donne **aucun ordre**. Voici l'ordre obligatoire, prouvé par les dépendances grep :
+
+```
+Étape 0 : PRE-WRITE — Snapshot baseline
+  - flutter analyze (0 erreurs attendus, sinon STOP)
+  - flutter test (compter baseline passing)
+  - pytest services/backend (compter baseline)
+  - grep-inventaire : pour chaque screen flagué, générer le graphe de deps
+
+Étape 1 : Kill tests AVANT kill code (sinon flutter test casse en cours)
+  - supprimer les cas dans smoke tests (1906 lignes / 4 fichiers)
+  - commit atomique par cluster de test
+
+Étape 2 : Kill routes (app.dart) — screens plus atteignables
+  - amputer app.dart lignes 19-73 (7 imports screens flagués)
+  - amputer GoRouter entries correspondantes
+  - commit : "chore(routing): delete dead routes (5 screens, cluster N)"
+
+Étape 3 : Kill registry+response_card+tool_call_parser (services de routage coach)
+  - supprimer ScreenEntry (132 → ~62 restantes)
+  - supprimer intentTag → screen mapping
+  - amputer response_card_service switch cases
+  - commit : "chore(nav): purge dead intentTags from coach routing"
+
+Étape 4 : Kill screens dart files
+  - delete apps/mobile/lib/screens/<X>_screen.dart (par cluster)
+  - commit : "chore(screens): delete dead screen <X>"
+
+Étape 5 : Kill services backend orphelins correspondants
+  - delete gender_gap_service, divorce_simulator, housing_sale_service si plus d'endpoint actif
+  - amputer backend tests (test_divorce_simulator.py, etc.)
+  - amputer coach_tools.py intent tags orphelins (ligne 110,128,131)
+  - commit backend séparé : "chore(backend): delete orphan services post-screen-purge"
+
+Étape 6 : Kill ARB strings (135 hits) + regen
+  - flutter gen-l10n
+  - commit : "chore(i18n): remove orphan strings (6 langs)"
+
+Étape 7 : Audit notif payloads (7 hits dans notification_service)
+  - vérifier que chaque payload résout encore → redirect si pas
+  - commit si nécessaire
+
+Étape 8 : GATE final
+  - flutter analyze = 0
+  - flutter test = baseline - (tests supprimés), 0 régression
+  - pytest = baseline - (tests supprimés), 0 régression
+  - device walkthrough sim iPhone : coach, scan, dossier, 3 life events
+```
+
+**Règle d'or** : chaque étape = 1 commit atomique, testable indépendamment. Rollback possible à chaque étape. Jamais de "big bang delete PR".
+
+---
+
+## 5. Pre-write gate technique : réaliste ?
+
+**Réaliste, mais pas avec le scope proposé**.
+
+### Implémentation concrète que je propose
+
+`tools/checks/pre_write_gate.py` (Python, CI + pre-commit hook) :
+```python
+# 1. Pour chaque fichier .dart ajouté/modifié :
+#    - si nouveau screen → doit exister dans screen_registry.dart ET app.dart
+#    - si nouveau provider → doit exister au moins 1 Consumer<X> dans lib/
+#    - si nouveau LifeEventType enum val → doit exister 1 screen routé
+# 2. AST grep sur lib/ (dart analyze --machine output)
+# 3. Fail fast : liste les 5 premiers orphelins, exit 1
+```
+
+Coût implémentation : **1-1.5j agent** (dart_style/analyzer_cli + parsing). Maintenable : la CI run 10s. **Réaliste**.
+
+### Ce qui est utopique
+- "Interdire la création d'un screen sans ses 3 layers Coach" : impossible à enforcer mécaniquement (Layer 4 est textuel, pas structurel). Utopique.
+- "Interdire `onTap: null`" : trivial regex (`no_dead_tap`), mais il faut autoriser `null` pour états désactivés légitimes (`enabled: false`). Nécessite annotation `// @allow-null-tap: reason`.
+
+### Verdict
+Gate : oui si scopé à orphelins structurels (screens/providers/enum life events). Pas utopique pour ça. Utopique pour "mission-level" checks.
+
+---
+
+## 6. Les 4 invariants CI proposés
+
+| Invariant | Pertinence | Commentaire |
+|---|---|---|
+| `no_unaccented_fr` (Dart+ARB) | **GOOD** | ARB seul = insuffisant, déjà prouvé en juillet (Dart contient des strings oubliés). Scope Dart+ARB est le bon. |
+| `no_dead_tap` | **MODIFY** | Trop strict. Autoriser `onTap: null` quand bouton disabled via `enabled: false` ou flag explicite. Sinon faux positifs en cascade. |
+| `no_provider_without_consumer` | **GOOD** | Directement issu de Wave E-PRIME (4 providers sans consumer détectés). `grep Provider<X>` + `grep Consumer<X>|context.watch<X>|context.read<X>` = trivial. |
+| `no_orphan_life_event` | **GOOD** | Enum `LifeEventType` → must have screen routed. Actuellement **0 hits grep dans CoachProfile** (PROMISE-GAP-MAP §2). Invariant nécessaire. |
+
+### 2 invariants manquants que je recommande
+
+- **`no_orphan_intent_tag`** : chaque intent tag déclaré dans `coach_tools.py` ou backend doit avoir un mapping dans `screen_registry.dart` (Panel B a trouvé 7 orphelins = récidive certaine sans CI). Trivial : parse les deux fichiers, diff.
+- **`no_route_without_go_route`** : chaque `context.push('/X')` / `GoRouter.of(...).push('/X')` doit avoir une entrée GoRouter enregistrée. Prévient le RSoD class tué en Wave 1. 12 call-sites ont déjà été corrigés manuellement — un invariant l'empêche définitivement.
+
+---
+
+## 7. Bilan en 1 phrase
+
+La Purge est **techniquement faisable mais coûte 11-13j agent (pas 4j)**, nécessite une séquence stricte en 8 étapes (pas "kill 70 écrans"), et les 4 invariants CI couvrent 60% du besoin — il en manque 2 (intent tag + route) pour qu'anti-récidive tienne. **MODIFY le plan : +8j Phase 36, séquence documentée, 6 invariants au lieu de 4.**

--- a/.planning/mission-audit-2026-04-19/CHALLENGE-02-MISSION-GUARDIAN.md
+++ b/.planning/mission-audit-2026-04-19/CHALLENGE-02-MISSION-GUARDIAN.md
@@ -1,0 +1,65 @@
+# CHALLENGE-02 — Mission Guardian
+
+Date : 2026-04-19 • Gardien : MINT_IDENTITY.md + pivot lucidité 2026-04-12
+
+---
+
+## 1. Verdict
+
+**L'ordre "Purge d'abord, Câblage ensuite" contredit la mission.** Il traite l'abondance (symptôme) avant l'absence de transformation (cause). MINT_IDENTITY §40 : *"Prise immediate. Pas juste de la comprehension. Toujours : un danger evite, un piege eclaire, une question a poser, un prochain geste."* Supprimer 70 écrans ne crée aucun "prochain geste". Câbler 1 life event en crée un.
+
+---
+
+## 2. Arguments FOR (Purge → Câblage)
+
+**F1 — Clarté cognitive agent.** 97 écrans dispersent le contexte Claude et engendrent la dérive-agent-amnésique. Un codebase plus petit = moins de façade à ré-imiter.
+
+**F2 — Invariants CI avant câblage = garde-fou permanent.** `no_orphan_life_event.dart` n'a de sens que si le template life event est déjà défini. Poser la grammaire AVANT d'ajouter de la matière.
+
+**F3 — Toilet test (§55).** *"Utilisable en 20 secondes. Jamais pompeux."* 97 écrans échouent au toilet test avant même le premier Layer 4. Purger = condition nécessaire de lucidité UX.
+
+---
+
+## 3. Arguments AGAINST (Purge → Câblage)
+
+**A1 — La Purge ne crée aucune transformation.** 13-AUDIT §42 : *"MINT opère à un niveau d'abstraction trop élevé. MINT produit de l'information quand le monde a besoin d'un produit qui fabrique de la transformation."* Supprimer = réduire l'information. Câbler = produire la transformation. v2.8 sans câblage = MINT reste un filing cabinet plus petit.
+
+**A2 — Critère de suppression introuvable sans grammaire.** Sans 1 life event bout-en-bout, impossible de dire *"cet écran ne sert pas la mission"*. Risque documenté Audit-05 : suppression prématurée de `testament_invisible_widget`, `marriage_penalty_gauge`, `survivor_pension_widget` — pièces orphelines aujourd'hui, câblables demain. Purge aveugle = destruction de futur dossier-first.
+
+**A3 — Cause racine = absence de Layer 4, pas abondance.** La dérive-agent vient de ce que la grammaire MINT (4-couches §66-95) n'est codifiée nulle part en template exécutable. Un agent ne peut pas "imiter MINT" car MINT n'existe pas encore en machine. Câbler Layer 4 sur 1 event = donner la grammaire aux agents futurs. Purger d'abord = imposer un vide comme norme.
+
+---
+
+## 4. Position finale : **Hybride — "Purge guidée par grammaire"**
+
+Un seul milestone, pas deux. Ordre intérieur :
+
+1. **Câbler 1 life event bout-en-bout d'abord (ex : newJob ou birth)** — 4 couches + persistance + coach injection + S2-gate si applicable. Devient le template de référence.
+2. **Extraire invariants CI depuis ce template** — `no_orphan_life_event` peut alors vérifier concrètement, pas en spéculation.
+3. **Purger à la lumière du template** — tout écran qui ne peut pas être reformulé dans la grammaire du template est suspect. Critère explicite, pas "gut feeling".
+4. **Câbler les 4 life events restants** (Tier 1 PROMISE-GAP §83) en appliquant le template.
+
+Un Julien qui installe MINT après ce cycle trouve : moins d'écrans ET 5 life events vivants. Pas "moins d'écrans ET mission toujours morte".
+
+---
+
+## 5. Scope exact v2.8 "MINT Visible" (hybride)
+
+- Phase 31 câblage central (CoachProfile.lifeEvents + LifeEventOrchestrator + context_injector) — **4 j**
+- Phase 32 **1 life event pilote** bout-en-bout (newJob : fréquent, LPP libre passage, Layer 4 clair) — **2 j**
+- Phase 38a **invariants CI dérivés du pilote** — **1 j**
+- Phase 36 **Purge guidée** (critère = "expressible dans grammaire pilote") — **3 j**
+- Phase 32b **4 life events Tier 1 restants** (cantonMove, birth, housingPurchase, inheritance) — **6 j**
+- Phase 37 device gate — **1 j**
+
+Total : ~17 j agent, parallélisable à 4-6 j calendaire.
+
+---
+
+## 6. Risque mission si on se trompe d'ordre
+
+Purge d'abord sans câblage = **v2.8 qui ship un codebase propre mais où MINT_IDENTITY §136 (*"Une intelligence calme, intime, fiable, dans la poche"*) reste une promesse creuse.** Pire qu'un codebase gros avec 3 life events câblés : l'utilisateur qui télécharge v2.8 reçoit *moins de façade*, pas *plus de lucidité*. Le pivot 2026-04-12 ("paix, contrôle, compréhension, zéro effort") exige du câblage, pas du vide.
+
+Risque symétrique (câblage pur sans purge) : dérive-agent continue, façade accumule. Le hybride ci-dessus résout les deux.
+
+**Mint n'accuse pas. Mint éclaire** (§20). Une Purge qui n'éclaire rien n'est pas MINT.

--- a/.planning/mission-audit-2026-04-19/CHALLENGE-03-GSD-ENFORCER.md
+++ b/.planning/mission-audit-2026-04-19/CHALLENGE-03-GSD-ENFORCER.md
@@ -1,0 +1,107 @@
+# CHALLENGE-03 — GSD Enforcer verdict sur v2.8 "MINT Purge"
+
+Date : 2026-04-19
+Auteur : GSD enforcer (challenge pré-lancement `/gsd-new-milestone`)
+Sources : STATE.md, ROADMAP.md, PROJECT.md, PROMISE-GAP-MAP.md, phases 28/29 réussies.
+
+---
+
+## 1. Verdict
+
+**NO-GO tel que proposé. REFORMULER avant `/gsd-new-milestone`.**
+
+Le scope "v2.8 Purge = 70 écrans + 100 services + pre-write gate + 4 invariants CI" empile **3 workstreams hétérogènes** dans un seul milestone : démolition, gouvernance, garde-fous. Patterns historiques MINT montrent que ce type d'empilement (v2.7 avec stabilisation + pipeline + privacy + device gate = 4 phases × 13 plans = 60+ jours code-complete puis **bloqué 4 jours** en `awaiting_device_gate`) est exactement le piège à éviter.
+
+Reformulation recommandée : **scinder en v2.8 + v2.8.1** (séquentiels) OU garder monolithique mais avec **ship condition mesurable non-humaine** (invariants CI green = done, pas "Julien a validé sur iPhone").
+
+---
+
+## 2. Les 7 questions GSD avec réponse honnête
+
+**Q1 — Goal goal-backward-vérifiable ?** Partiellement.
+"Purge 70 écrans + 100 services" = vérifiable mécaniquement (`find lib/screens -name "*.dart" | wc -l ≤ 27` + `grep` sur service orphans). Mais "pre-write gate technique" et "4 invariants CI" sont vérifiables par green CI, pas par humain. **Un humain en 5 min peut vérifier "done" uniquement si le milestone se résume à des chiffres grep-ables et à CI green**. Donc : shape-able **si** les 3 workstreams sont convertis en métriques mécaniques.
+
+**Q2 — Phases atomiques & PR-indépendantes ?** Non en l'état.
+Purge crée un risque de dépendance cachée : supprimer écran X peut casser route Y qui est testée par invariant Z. Ordre correct : invariants CI **d'abord** (ils protègent la purge), purge **ensuite** (les invariants détectent la casse), gate **en dernier** (sinon gate bloque les PR de purge). 3 phases séquentielles, pas parallèles.
+
+**Q3 — Success criteria mesurables par phase ?** Oui si reformulé.
+- P1 Invariants : 4 CI workflows green sur dev tip, chaque invariant a ≥ 1 test négatif prouvant qu'il détecte la violation.
+- P2 Purge : `wc -l` LOC mobile < seuil X, `find screens` < 35, `grep orphan_provider` = 0, 0 test régression, device smoke iPhone sim (3 flows : Aujourd'hui/Coach/Dossier).
+- P3 Pre-write gate : doc `.planning/GATE.md` + hook pre-commit installé + 1 dry-run simulé.
+
+**Q4 — Piège v2.7 évitable ?** OUI mais seulement si **ship ≠ device gate humain**.
+v2.7 est code-complete depuis 2026-04-15 mais bloqué sur walkthrough Julien iPhone+Android. Même piège en vue : "Purge shipped" ne peut PAS dépendre d'un walkthrough humain, sinon v2.8 awaiting_device_gate pendant 4+ jours comme v2.7. **Condition de close = green CI sur dev + 1 smoke sim iPhone automatisé via `idb` (pas walkthrough humain manuel)**. Device-gate humain = milestone suivant optionnel, pas condition de close.
+
+**Q5 — Risque dérive scope ?** ÉLEVÉ.
+Purge + gate + invariants + v2.9 câblage = 4 ambitions. La gravité : la purge seule pousse 40-60 commits, les invariants CI cassent les PR en cours, le gate bloque les workflows v2.9. Reco : **v2.8 = Purge + Invariants uniquement**. Pre-write gate → v2.8.1. Câblage life events → v2.9.
+
+**Q6 — Out of scope explicite ?** À formaliser obligatoirement.
+Sans out-of-scope noir-sur-blanc, la tentation de câbler 1 life event "tant qu'on y est" est certaine. Voir §4.
+
+**Q7 — Ship condition ?** Pas définie dans proposition actuelle. À trancher : **PR unique dev→staging** (propre) OU **suite de N PRs feature→dev** (plus réaliste vu volume). Reco : N PRs feature→dev, ship = dernier PR mergé + CI full green + ROADMAP status `Complete` sans `<PENDING_DEVICE_GATE>`.
+
+---
+
+## 3. Reformulation GSD-ready
+
+**Milestone v2.8 — "MINT Compression" (nom recommandé, pas "Purge" qui est défensif)**
+
+**Goal** : Réduire la surface mobile à ce qui sert la mission lucidité + installer 4 invariants CI empêchant la récidive. Condition de close mécanique, zéro humain bloquant.
+
+**Phases** (3, séquentielles) :
+
+- **P31 — Invariants CI anti-récidive (2j agent, parallèle 4 tracks)**
+  - Goal : 4 workflows CI actifs sur dev bloquent les violations identifiées par Audit 02/05.
+  - Dépend de : aucune (préalable à la purge).
+  - Success criteria : `.github/workflows/no_dead_tap.yml` + `no_provider_without_consumer.yml` + `no_orphan_life_event.yml` + `no_unaccented_fr.yml` all green, chacun avec test négatif (fixture en violation → CI red).
+  - Livrable : 4 PRs feature→dev, mergés.
+
+- **P32 — Purge chirurgicale (4j agent, séquentiel)**
+  - Goal : `find lib/screens -name "*.dart" | wc -l` ≤ 35, 100 services orphelins supprimés, tests green, 1 smoke `idb` sim iPhone (cold start → Aujourd'hui → Coach → Dossier).
+  - Dépend de : P31 (invariants détectent casse pendant purge).
+  - Success criteria : chiffres grep avant/après documentés dans SUMMARY, 0 test régression, flutter analyze 0 errors.
+  - Livrable : ≤ 5 PRs feature→dev batchés par domaine (screens/services/providers/routes/dead-arb).
+
+- **P33 — Documentation ship (1j agent)**
+  - Goal : ROADMAP v2.8 status `Complete` sans placeholder, MILESTONES.md v2.8 summary écrit, STATE.md milestone_status = `complete`.
+  - Dépend de : P31 + P32.
+  - Success criteria : STATE.md yaml valid + grep `<PENDING_DEVICE_GATE>` = 0 occurrences v2.8.
+
+**Ship condition** : dernier PR P32 mergé sur dev + 3 workflows invariants P31 green sur dev tip + P33 docs à jour. Pas de device walkthrough humain bloquant.
+
+---
+
+## 4. Out of scope explicite (NON-NEGOTIABLE)
+
+Ces items **NE SONT PAS v2.8**. Toute tentation = rejet immédiat.
+
+1. Aucun nouveau life event câblé (v2.9 uniquement).
+2. Aucune modification de la nav 4 tabs actuelle (V10 reste, arbitrage V10 vs Audit-02 = v2.9).
+3. Aucune refonte UI, aucun widget nouveau, aucune copie nouvelle.
+4. Aucun calculateur financier touché.
+5. Aucun endpoint backend ajouté/modifié (sauf suppression pure si service supprimé).
+6. Aucun ARB key nouveau (seulement suppression si écran supprimé).
+7. Pre-write gate technique (`.planning/GATE.md` + hook) → **v2.8.1** (milestone dédié, 1j).
+8. Device walkthrough humain Julien → hors milestone (si souhaité, séparé).
+9. FATCA, EU-CH ALCP, SafeMode auto-trigger → v2.9+.
+10. Correction des 2 P0 backend (save_fact, suggest_actions silent drop) héritées de Wave E-PRIME → Wave C en cours, pas v2.8.
+
+---
+
+## 5. Recommandation finale
+
+**NO-GO `/gsd-new-milestone "v2.8 MINT Purge"` tel quel.**
+
+**GO après reformulation** :
+
+1. Renommer `v2.8 MINT Compression` (pas "Purge", moins défensif, plus positif).
+2. Retirer "pre-write gate" du scope v2.8 → v2.8.1 séparé.
+3. Retirer "câblage v2.9" de la discussion v2.8 → milestone suivant.
+4. Ship condition = CI + chiffres grep, pas walkthrough humain (éviter piège v2.7).
+5. 3 phases séquentielles : Invariants → Purge → Docs ship.
+6. Out-of-scope écrit noir sur blanc dans PROJECT.md section dédiée.
+
+Commande finale suggérée :
+`/gsd-new-milestone "v2.8 MINT Compression"` puis dans PROJECT.md paste le §3 + §4 de ce document.
+
+Estimation : **7 jours agent-work**, **3-4 jours wall-clock** avec parallélisme P31. Aucun blocker humain. Pattern proche phases 28/29 réussies (6 plans exécutés en ~5 jours).

--- a/.planning/mission-audit-2026-04-19/PROMISE-GAP-MAP.md
+++ b/.planning/mission-audit-2026-04-19/PROMISE-GAP-MAP.md
@@ -1,0 +1,217 @@
+# PROMISE-GAP-MAP — MINT mission vs code réel
+
+Date : 2026-04-19
+Sources : 5 audits créatifs (AUDIT-01 à AUDIT-05) + 13-AUDIT 2026-04-11 + NAVIGATION_GRAAL_V10 + CLAUDE.md + MINT_IDENTITY.md.
+
+---
+
+## 1. Mission promise (source = MINT_IDENTITY.md)
+
+MINT = outil de **lucidité financière** pour TOUS les Suisses (18-99). Autour de **18 life events**. Via **4-layer insight engine** :
+1. Factual extraction (le fait)
+2. Human translation (ce que ça veut dire pour un humain)
+3. Personal perspective (ce que ça signifie pour TOI, ton archétype, ta situation)
+4. Questions to ask before signing (ce qu'il faut demander à l'autre partie)
+
+Doctrine lucidité 2026-04-12 : dossier-first, couple asymétrique, anti-shame, situated learning.
+
+Wire Spec V10 : 4 piliers (Aujourd'hui / Coach / Explorer / Dossier) + 7 hubs Explorer + capture contextuelle.
+
+---
+
+## 2. Réalité code (convergence 5/5 audits)
+
+### Pattern central
+
+**MINT a codé la mission "lucidité" avec la grammaire des SIMULATEURS-CALCULATEURS, pas celle des RENCONTRES-TRANSFORMATIONS.**
+
+Preuves croisées :
+- Audit 01 : les 18 life events sont codés en `TabController(length: 4)` — simulateurs-formulaires, pas scènes narrées. Layer 4 absent des 18 écrans.
+- Audit 02 : 97 écrans `.dart`, 198 services, 286 widgets, 218 routes backend — dispersion structurelle qui contredit la promesse lucidité.
+- Audit 03 : calculateurs fintech existent (LPP, tax, AVS, monte_carlo, arbitrage), mais ne sont pas déclenchés par les événements réels de la vie suisse (calendrier fiscal, LPP janvier, LAMal oct-nov, payslip).
+- Audit 04 : inversion cognitive systémique — S1 facile là où il faut S2 gate juridique (`rachat_echelonne_screen.dart:236-294` écrit `dateRachats` à chaque slider drag = blocage EPL 3 ans ATF 142 II 399 en geste pouce).
+- Audit 05 : matrice 108 cellules (18 life events × 6 dimensions) = **8 ✅ / 55 🟡 / 25 🔴 / 20 ❌**. Couverture live = **7.4%**.
+
+### Chiffres agrégés
+
+| Dimension | Promise | Reality |
+|---|---|---|
+| Destinations top-level | 4 (V10) | 3 tabs + drawer, doublons Explore/Mon argent |
+| Life events live avec Layer 4 | 18/18 | **1/18** (audit 05) |
+| Life events avec déclencheur UI visible | 18/18 | ~4/18 (`life_event_sheet.dart` sans call-site prod) |
+| Enum LifeEvent persisté sur CoachProfile | oui | **0 hits grep** (audit 05) |
+| Enum LifeEvent injecté dans coach context | oui | **0 hits grep** (audit 05) |
+| Calendriers fiscaux cantonaux | 26 | 0 (audit 03) |
+| Payslip parser | oui | absent (audit 03) |
+| Diff LPP N/N-1 | oui | absent (audit 03) |
+| S2-gate sur décisions irréversibles | oui | 0 (audit 04) |
+| Écrans supprimables sans toucher mission | — | ~70/97 (audit 02) |
+
+---
+
+## 3. Les 5 vrais gaps qui invalident la mission aujourd'hui
+
+### Gap A — Le life event n'est pas un citoyen de première classe
+`LifeEventType` existe comme enum (`models/age_band_policy.dart:9-39`) mais n'est **ni persisté sur `CoachProfile`** ni **injecté dans `context_injector_service.dart`**. Résultat : un user qui vient d'avoir un enfant le dit au coach → rien ne persiste, rien ne déclenche, rien ne suit.
+
+**Fix structurel** : `CoachProfile.lifeEvents: List<LifeEventRecord>` + service `LifeEventOrchestrator` qui route chaque event vers (a) persistance dossier, (b) injection coach context, (c) déclencheur UI approprié, (d) Layer 4 factory.
+
+### Gap B — Layer 4 ("questions à poser") absent sur 17/18 events
+C'est la **signature MINT** vs Cleo/VZ (MINT_IDENTITY §66-95). Sans elle, MINT est un calculateur élégant de plus. Avec elle, MINT devient "l'ami fintech dans ta poche".
+
+**Fix structurel** : `Layer4Factory` centralisée qui produit les questions contextualisées (archétype × life event × situation). Pas par simulator. Une seule source de vérité.
+
+### Gap C — Le calendrier suisse réel n'est pas câblé
+MINT ignore quand la vie financière d'un Suisse bouge : LPP certificat (janvier), deadline fiscale cantonale (mars-juin selon canton), LAMal fenêtre résiliation (oct-nov), 3a cut-off (31 déc). Un seul rappel existe (3a oct-déc).
+
+**Fix structurel** : `CantonalFinancialCalendar` (26 cantons × 5 events annuels) + widget banner `Aujourd'hui` + push notifications contextuelles + pré-remplissage déclaration.
+
+### Gap D — Les décisions juridiquement irréversibles sont en geste pouce
+`rachat_echelonne_screen.dart:236-294` — slider drag écrit `dateRachats` dans le profil = blocage EPL 3 ans. Zéro confirmation. C'est la définition même de l'anti-lucidité : l'user fait une décision qu'il ne comprend pas en un geste qu'il ne sait pas critique.
+
+**Fix structurel** : `S2Gate` widget pattern sur 5 écrans (rachat LPP, EPL, retrait capital, donation, changement bénéficiaire). Confirmation modale + pre-mortem (déjà codé Phase 14) + 3 sec delay + ARB copy qui explique l'irréversibilité.
+
+### Gap E — L'architecture à 97 écrans contredit la mission lucidité
+La mission promet la clarté. L'archi délivre du gras. 70 écrans peuvent disparaître sans toucher la mission (Audit 02). 7 hubs Explorer se dédoublent avec "Mon argent", "Dossier", "Financial Summary", "Documents".
+
+**Fix structurel** : converger vers V10 — 4 piliers (Aujourd'hui / Coach / Explorer / Dossier) + fusionner les 6 écrans "Mon argent / Financial Summary / Confidence / Documents / Portfolio / Privacy" → `Dossier` unique + supprimer les 7 hubs Explorer redondants (ou basculer vers la thèse "3 objets" d'Audit 02 si arbitrage radical).
+
+---
+
+## 4. Priorisation des 18 life events
+
+### Tier 1 — Top 5 prioritaires (fréquence vie suisse × impact mission × faisabilité)
+
+1. **newJob** — événement le plus fréquent (1-3× dans une carrière), déclenche LPP changement, salaire changement, fiscal impact. Aujourd'hui : rien de spécifique.
+2. **cantonMove** — ~30k déménagements intercantonaux/an CH, fiscal marginal saute, LAMal peut changer, 3a banque peut-être à changer. Aujourd'hui : change de canton dans profil, rien d'autre.
+3. **housingPurchase (EPL)** — décision irréversible + blocage 3 ans LPP. Aujourd'hui : simulator_epl existe, zéro Layer 4, zéro S2-gate.
+4. **birth** — allocations LAFam cantonales, 3a plafond, LPP bonifications éducatives art. 29sexies. Aujourd'hui : `naissance_screen.dart` TabController 4 formulaire, aucun calcul cantonal, aucun flow narré.
+5. **inheritance** — complexité fiscal + succession. Aujourd'hui : `donation_screen` existe, pas de flow héritage spécifique.
+
+### Tier 2 — Secondaires (rapides à câbler, haut ROI)
+
+6. **retirement** (déjà Tier 1 de v2.5 mais Layer 4 absent, +1j checklist selon audit 05)
+7. **debtCrisis** (SafeMode déjà existant, +0.5j pour Layer 4)
+8. **marriage** (couple mode asymétrique déjà en v2.5, manque Layer 4)
+
+### Tier 3 — Long terme (complexité ou rareté)
+
+9-18. divorce, concubinage, deathOfRelative, firstJob, selfEmployment, jobLoss, housingSale, donation, disability, countryMove (FATCA)
+
+---
+
+## 5. Plan de câblage ordonné (proposition pour milestone v2.8 "MINT Visible")
+
+### Phase 31 — Câblage central (4 j agent, zone code partagée, séquentiel)
+
+**Skill-pack** : `mint-backend-dev` + `mint-flutter-dev` + `mint-swiss-compliance` + `test-driven-development` + `verification-before-completion`.
+
+Scope :
+- `CoachProfile.lifeEvents: List<LifeEventRecord>` avec persistance backend (`/profiles/me/life-events`)
+- `LifeEventOrchestrator` service (Dart + Python)
+- `context_injector_service.dart` injection événements récents (< 90 jours) dans coach prompt
+- `Layer4Factory` centralisée (mapping archétype × event → questions ARB 6 langues)
+- Dossier cross-ref `SalaryConsistencyService` (salaire déclaré fiscal vs assuré LPP vs imposable vs budget)
+
+Gate de sortie : 1 PR, tests green, smoke device sim iPhone : user déclare naissance → event persiste → coach en parle 2 sessions plus tard → Layer 4 affiché.
+
+### Phase 32 — 5 life events prioritaires (8 j agent, parallélisable en 5 tracks)
+
+Par life event (Tier 1 : newJob, cantonMove, housingPurchase, birth, inheritance), cycle chirurgical :
+1. Scène narrée : remplacer `TabController(length: 4)` par flow linéaire en 4 beats (reconnaissance → translation → perspective → question)
+2. Déclencheur UI : widget `Aujourd'hui` conditionnel + trigger scan/coach
+3. 4 layers : fact (calculator existant) → human translation (ARB) → personal perspective (archetype-aware) → Layer 4 (Layer4Factory)
+4. Persistance dossier (Phase 31 `LifeEventRecord`)
+5. Tests sim iPhone : humain vit l'événement → MINT répond dans les 3 taps → Layer 4 screenshotable
+
+**Skill-pack par agent** : `mint-flutter-dev` + `mint-swiss-compliance` (pour spécificités canton × archétype) + `test-driven-development` + `verification-before-completion`.
+
+### Phase 33 — Calendrier fiscal 26 cantons (3 j agent, séquentiel puis parallèle)
+
+- Service `CantonalFinancialCalendar` : table 26 cantons × 5 events annuels (fiscal deadline, LAMal oct-nov, LPP janvier, 3a 31 déc, AVS)
+- Widget `Aujourd'hui` banner conditionnel si event < 30 jours
+- Push notifications contextuelles (déjà infra dispo)
+- Pré-remplissage déclaration si scan décl. disponible (parser existe)
+
+**Skill-pack** : `mint-swiss-compliance` + `mint-backend-dev` + `mint-flutter-dev`.
+
+### Phase 34 — Payslip + diff LPP N/N-1 (3 j agent)
+
+- Parser `payslip_parser.py` (gabarit générique CH : brut, cotisations AVS/LPP/LAMal, net, 13e)
+- Service `LppDiffService` : compare certificat N vs N-1, commente narrativement les écarts
+- Alertes : "Ton salaire assuré a baissé de X%, voici ce que ça change" (Layer 2-3)
+
+**Skill-pack** : `mint-backend-dev` + `mint-swiss-compliance` + `test-driven-development`.
+
+### Phase 35 — S2-gates juridiques (2 j agent)
+
+- Widget `S2Gate` pattern réutilisable : modal de confirmation + pre-mortem (déjà codé Phase 14) + 3 sec delay + ARB copy irréversibilité
+- Application : rachat LPP, EPL, retrait capital, donation >50k, changement bénéficiaire
+
+**Skill-pack** : `mint-flutter-dev` + `mint-swiss-compliance` (pour textes légaux cités correctement) + `verification-before-completion`.
+
+### Phase 36 — Compression architecturale (4 j agent, séquentiel)
+
+- Décision Julien : V10 (4 piliers) ou Audit-02 (3 objets Dossier/Coach/Action) ?
+- Supprimer les 70 écrans non-mission (liste précise Audit 02)
+- Fusionner Mon argent + Financial Summary + Confidence + Documents + Portfolio + Privacy → `Dossier` unique
+- Supprimer les 7 hubs Explorer redondants avec life events
+
+**Skill-pack** : `mint-flutter-dev` + `systematic-debugging` (pour détecter casses) + `verification-before-completion`.
+
+### Phase 37 — Device gate humain (1 j)
+
+Walkthrough sim iPhone complet : cold start → 5 life events tests (naissance, cantonMove, newJob, EPL, héritage). Metric composite (gravité × non-récurrence × NPS 1-mot). Pas "≤ 20 findings brut".
+
+### Phase 38 — Anti-récidive invariants CI (2 j agent parallèle)
+
+4 invariants Google-style :
+- `no_unaccented_fr.py` (Dart + ARB, pas ARB seul) — resout la frustration accent définitivement
+- `no_dead_tap.dart` (interdit `onTap: null` et callbacks stub)
+- `no_provider_without_consumer.dart` (détecte façade)
+- `no_orphan_life_event.dart` (événement dans enum sans flow câblé)
+
+**Skill-pack** : `mint-flutter-dev` + `mint-backend-dev` + `test-driven-development`.
+
+---
+
+## 6. Debat radical à trancher : V10 (4 piliers) vs Audit-02 (3 objets)
+
+**V10 (statu quo direction)** : Aujourd'hui / Coach / Explorer / Dossier. 4 destinations. Déjà documenté.
+**Audit-02 (radical)** : Dossier / Coach / Action. 3 objets. Plus cohérent avec mission lucidité "toilet test MINT_IDENTITY §5".
+
+Divergence : V10 garde un Explorer navigable. Audit-02 fusionne Action (Aujourd'hui + Explorer) en une seule surface.
+
+Julien tranche : sa compression radicale favorise Audit-02, sa continuité doc favorise V10. Je note comme question ouverte. Phase 36 exécute selon son arbitrage.
+
+---
+
+## 7. Mesure de succès du milestone v2.8 "MINT Visible"
+
+Critères composites :
+- **Matrice couverture** : 108 cellules live passent de 8 (7.4%) à ≥ 80 (74%) sur Tier 1+2 (8 life events)
+- **Layer 4 présent** : ≥ 10/18 life events
+- **Architecture** : 97 écrans → ≤ 35 écrans, 3 ou 4 destinations top-level (selon arbitrage)
+- **Calendrier suisse** : 26 cantons × 5 events = 130 triggers cantonaux live
+- **S2-gates** : 5/5 décisions irréversibles protégées
+- **Device walkthrough** : 5 life events testés sim iPhone, metric composite ≥ seuil (à définir avec Julien)
+- **CI anti-récidive** : 4 invariants green, jamais skippés
+
+---
+
+## 8. Volume agent-work total
+
+| Phase | Jours agent | Parallélisable |
+|---|---|---|
+| 31 Câblage central | 4 | non (code partagé) |
+| 32 Life events ×5 | 8 | 5 tracks parallèles |
+| 33 Calendrier cantonal | 3 | partiel |
+| 34 Payslip + diff LPP | 3 | oui |
+| 35 S2-gates | 2 | oui |
+| 36 Compression archi | 4 | non (fragile) |
+| 37 Device gate | 1 | non |
+| 38 Invariants CI | 2 | 4 tracks parallèles |
+
+**Total agent-work** : ~27j. En wall-clock avec parallélisme maximal : **5-8 jours calendaire**. Réaliste pour Julien solo + Claude.
+
+Ce chiffre remplace les 21-38 jours de Quality Gate v2. Gain : le travail est fondé sur la mission, pas sur une liste de findings Léa.

--- a/.planning/roadmap-daily-loop-2026-04-18/ROADMAP.md
+++ b/.planning/roadmap-daily-loop-2026-04-18/ROADMAP.md
@@ -1,0 +1,157 @@
+# MINT Roadmap — Daily Compagnon (2026-04-18)
+
+## Contexte
+
+Session autonome 2026-04-18. 5 panels d'experts ont audité MINT :
+1. **Panel UX** (verdict Wave 11 REWORK) — cliché Cleo/Monzo, viole chat-silent, inverse loop Cleo 3.0
+2. **Panel Architecture** (verdict Wave 11 REWORK) — duplication Python/Dart, prompt cache wipe, agent loop amnesia
+3. **Panel Contrarien** — thèse "MINT événementiel, pas daily" (contestée par Julien, daily tranché)
+4. **Panel Daily-loop** — 80% du code existe, 5 call-sites dormants
+5. **Panel Codebase inventory** — 14 CustomPainters, 25+ simulateurs, 18 life events, FRI shadow mode
+6. **Panel Simulation 3 mois** — friction concrète, Julien revient ~20-25% seul post-J+30
+7. **Panel Perfection Gap** — 60 findings (10 P0 top + 22 P0 correctness + 28 P1 + 10 P2)
+
+## Doctrine (tranchée par Julien)
+
+1. **Daily compagnon** — pas événementiel. MINT aiguille en continu.
+2. **Zéro feature nouvelle** — câbler ce qui est codé, finir ce qui est posé, sortir du shadow ce qui est caché.
+3. **Zéro dette tolérée** — chaque Wave production-ready avant la suivante.
+4. **Preuve par device** — chaque Wave se termine walkthrough iPhone 17 Pro + AX tree.
+5. **Source légale ou magic number = P0 explicite**.
+
+## Les 5 call-sites dormants (source : Panel Daily-loop)
+
+1. `NotificationService.scheduleCoachingReminders(profile)` on profile-ready — API 895 lignes, seul `.init()` appelé
+2. `CapEngine.compute(profile)` dans `aujourdhui_screen.dart` — 1334 lignes, seul caller `budget_screen.dart:179`
+3. `JitaiNudgeService.evaluateNudges(profile)` — 10 triggers JITAI, 0 consumer
+4. `MilestoneDetectionService.detectNew()` post-scan/checkin — 0 consumer
+5. `scheduleRetentionNotifications(taxSaving3a)` à la fin onboarding avec vraie valeur — null silent fail
+
+## Les 6 Waves séquentielles
+
+### Wave A — Câblage dormant (4-6h, 1 PR)
+
+Goal : transformer MINT d'app-musée à compagnon qui aiguille. Branche les 5 moteurs + 3 prerequis P0 du panel 7.
+
+Commits cibles :
+- A1: Scan LPP → `CoachInsight` event save (panel simulation, finding doc_impact)
+- A2: `scheduleCoachingReminders(profile)` wired on profile-ready + onboarding completion
+- A3: `scheduleRetentionNotifications` taxSaving3a null fallback fixé + J+30 dedup si already-scanned
+- A4: Post-J+30 cliff tué — `scheduleCheckinReminder` wired weekly lundi 19h
+- A5: `save_fact` PII log redaction (Panel 7 P0 #2) — CLAUDE.md §6.7 violation
+- A6: `profile.age == 0` sentinel guards (Panel 7 P0 #7) — 5 écrans consumers
+- A7: Double `weekly_recap_service.dart` consolidation (Panel 7 P0 #10) — 1 source of truth
+
+Gate sortie A : notification J+1 arrive (device), payload deep-link coach, coach injecte event memory scan. Tests + CI green. Device walkthrough iPhone 17 Pro sim.
+
+### Wave B — Home "Aujourd'hui" orchestrateur (6-8h, 1 PR)
+
+Goal : AujourdhuiScreen devient fil conducteur dynamique avec CapEngine + JITAI + Milestones + WeeklyRecap + Streak.
+
+Commits cibles :
+- B1: `CapEngine.compute(profile)` dans aujourdhui_screen — 1 cap du jour banner top
+- B2: `JitaiNudgeService.evaluateNudges` → widget banner secondaire contextuel
+- B3: `MilestoneDetectionService.detectNew()` post-scan/checkin trigger celebration_sheet
+- B4: `WeeklyRecapService` widget lundi matin + notification cross-wire
+- B5: `StreakService` streak 0-30j affiché compact sans pression
+- B6: Golden test assemblage dynamique Aujourd'hui pour 4 profils (debt-critical, swiss-native-fat3a, expat-us, new-indep)
+- B7: Cleanup orphan providers (Panel 7 P0 #4) — UserActivityProvider, ContextualCardProvider, CoachEntryPayloadProvider
+
+Gate sortie B : home Julien J+8 affiche cap "ton 3a pas au max, 90j restants, +5'758 CHF possibles", nudge "Lauren sans 3a — double fiscalité couple", 7j streak, recap semaine dernière.
+
+### Wave C — Continuité scan + coach handoff (4-6h, 1 PR)
+
+Goal : scan n'est plus acte isolé, suggestion chips étendues, landing skip, memory retry.
+
+Commits cibles :
+- C1: Post-scan auto-route coach avec opener contextuel "On a lu ton certificat CPE. Voici ce que ça change."
+- C2: Suggestion-chip regex étendu — tous 18 life events (naissance, divorce, mariage, emploi, perte emploi, donation, déménagement, invalidité, indépendant, EPL, décès, concubinage)
+- C3: Memory timeout 2s → retry 1× back-off 500ms avant fallback silencieux
+- C4: Landing skip si `onboarded=true` → `initialLocation: '/home'`
+- C5: Onboarding questionnaire minimal 3 inputs (age, canton, revenu) avant landing CTA OU ADR si confirme no-onboarding
+
+Gate sortie C : Julien scanne, est amené au coach qui contextualise. Naissance/divorce chips visibles en chat. Cold restart n'replays pas landing. Memory injection robuste sur réseau flaky.
+
+### Wave D — FRI visible + narrative couple/FATCA (6-8h, 1 PR)
+
+Goal : 2 plus gros assets cachés de MINT deviennent visibles.
+
+Commits cibles :
+- D1: `fri_calculator.dart` sort shadow mode — `MintScoreGauge` sur home "Ton indice de résilience financière : 62/100" + drill-down 4 axes L/F/R/S
+- D2: Backend system prompt — si `profile.conjoint.archetype == expat_us` ET question rachat/3a/succession, injecter paragraphe asymétrie couple (LFLP, FATCA, IRC §1291)
+- D3: ScreenRegistry — rachat_lpp / pillar_3a_overview / lpp_buyback prefill enrichi `conjoint` archetype
+- D4: `_buildFactCard` enrichi — source légale + "écart vs ce que ta caisse dirait" quand `ArbitrageSummaryItem.fullResult.advisorDelta` dispo
+- D5: Tests narratif couple — 5 questions Julien+Lauren → assert Lauren + FATCA + archétype mentionnés
+
+Gate sortie D : Julien demande "rachat 50k LPP", coach dit "Vu que Lauren est US, ce rachat ne profite qu'à toi. Ta caisse CPE te dirait 'fais-le', la loi dit 'attends 3 ans pour anti-abus'. Écart: CHF 12'000 éco fiscale vs CHF 0 si revente avant 3 ans."
+
+### Wave E — Perfection Gap (8-12h, 1 PR)
+
+Goal : fermer les 60 findings Panel 7 non traités en Waves A-D. Zéro dette résiduelle.
+
+Commits cibles (groupés par type de dette) :
+- E1: `resolveCanton()` migration — 26 call-sites (finding #1) passent par helper, UI surface fallback
+- E2: `coach_narrative_service.dart:264,932` — `renteFromRAMD` → `computeMonthlyRente` avec contributionYears (finding #3)
+- E3: `mariage_screen.dart:94` hardcode 0.068 → `lppTauxConversionMinDecimal` + fix `* 12` ignore `nombreDeMois` (finding #5)
+- E4: Archived routes cleanup — `/coach/cockpit`, `/tools`, `/ask-mint` call-sites réécrits vers canoniques (findings #6, #31, #32, #33, #37)
+- E5: `save_partner_estimate` fire-and-forget → Future + error surface (finding #8, #19)
+- E6: 5 orphan services decision — delete `AdaptiveChallengeService`, `CommunityChallengeService`, `AffiliateService`, `CoupleQuestionGenerator`. `JitaiNudgeService` wired en Wave B (finding #9)
+- E7: Sentinels `-1` quota, `'unknown'` canton, `'unknown'` string → typed enums / nullable (findings #11, #12)
+- E8: Hardcoded magic numbers — mortgage 0.015 (finding #27, #29), tax fallback 0.12 (finding #28), bayesian 0.05 (finding #21), SWR 0.04 (finding #58), life expectancy 87 (finding #59), inflation 0.015 (finding #60) — centralize or ADR with source
+- E9: i18n holes — `widget_renderer.dart` 6+ strings FR (finding #14), `education_content.dart:52` literal (finding #54)
+- E10: Compliance parity — mobile `ComplianceGuard` add gerund + IT/ES/PT (findings #17, #46)
+- E11: Silent `catch (_) {}` — 24 blocks add debugPrint + sentry breadcrumb (finding #18)
+- E12: Vestigial `financial_report_screen_v2.dart` rename → `financial_report_screen.dart` (finding #23)
+- E13: Orphan widgets — `temporal_strip.dart`, `what_if_stories_widget.dart`, `horizon_line_widget.dart` delete ou wire (finding #24)
+- E14: `marriedCapitalTaxDiscountByCanton` cover 18 missing cantons OU surface fallback flag dans UI (finding #16)
+- E15: `print()` replace `debugPrint` (finding #26, #48)
+- E16: Retroactive 3a `* 13` fix to `nombreDeMois` (finding #13)
+- E17: `toolCalls` defensive snake_case fallback (finding #20)
+- E18: A11y — `reducedMotion` check sur 50 animated widgets + Semantics sur 38 coach widgets (findings #51, #52)
+- E19: `ListView.builder` migration pour dynamic lists (finding #53)
+- E20: Disclaimer footer dedup (finding #55)
+
+Décomposition en sous-commits permise (E1 → 5-8 commits par canton batch).
+
+Gate sortie E : panel 7 re-run → 0 P0, 0 P1, ≤5 P2 residual documentés en ADR.
+
+### Wave F — Device walkthrough release-ready (2-3h, 1 PR final ou promotion)
+
+Goal : preuve par device de l'ensemble A→E.
+
+Commits :
+- F1: Demo toggle `settings/debug` charge golden Julien+Lauren en 1 tap
+- F2: Walkthrough 12 sessions simulées (J+0 scan → J+90 anniversary) + 2 moments vie (rachat 50k J+20, Lauren enceinte J+50) — screenshots + AX tree dans `.planning/walkthrough-release/`
+- F3: CHANGELOG, MEMORY.md handoff final, PR dev → staging
+
+Gate sortie F : MINT installé iPhone pendant 3 mois = aiguillé en continu.
+
+## Ordre & dépendances (RÉVISÉ 2026-04-18 via ADR-20260418-wave-order-daily-loop)
+
+```
+Hotfix P0 (save_fact PII) ──► Wave 0 (walkthrough de vérité 90min) ──►
+  Wave B-prime (home orchestrateur + age guard + weekly_recap) ──►
+  Wave A-prime (notifs wiring + scan event + dedup + cliff) ──►
+  Wave C (scan handoff) ──► Wave D (FRI + couple) ──► Wave E (perfection) ──► Wave F (device release)
+```
+
+**Réordonnancement** : 3 panels review du PLAN Wave A initial ont tranché REWORK FUNDAMENTAL.
+Panel iconoclaste a prouvé par code que home vivant DOIT précéder notifs (aujourdhui_screen.dart 301 lignes avec 0 CapEngine vs cap_engine.dart 1333 lignes prêt). Push sur home mort = désinstall.
+
+Hotfix P0 save_fact PII = chirurgical 20 min, compliance CLAUDE.md §6.7, indépendant du daily-loop.
+Wave 0 walkthrough = 90 min max, source de vérité AX tree + screenshots pour Wave B-prime.
+
+Voir `/Users/julienbattaglia/Desktop/MINT/decisions/ADR-20260418-wave-order-daily-loop.md` pour détails.
+
+## Budget temps total
+
+~35-45h travail, 6 PRs shippables. Chaque PR laisse dev green.
+
+## Critères succès mesurables
+
+1. **Rétention** : Julien J+30+ retourne seul ≥60% (vs 20-25% actuel)
+2. **Narrative quality** : rachat 50k + Lauren = réponse qui mentionne FATCA, archétype, asymétrie
+3. **Home quality** : cap du jour + nudge + milestone + streak visibles à chaque open
+4. **Dette** : 0 P0 Panel 7, 0 P1 Panel 7 résiduels
+5. **CI** : 10/10 green sur chaque PR
+6. **Device** : walkthrough 3 mois simulé ne casse aucun flow

--- a/.planning/safemode-2026-04-18/RULES.md
+++ b/.planning/safemode-2026-04-18/RULES.md
@@ -1,0 +1,288 @@
+# SafeMode — Compliance Rules (authoritative)
+
+**Author:** swiss-brain · **Date:** 2026-04-18 · **Scope:** `claude/fix-app-navigation-zkVRx`
+**Supersedes:** SPEC.md §2-§7 where language differs. This file wins on doctrine, SPEC wins on wiring layout.
+
+Legal frame: **LSFin art. 3** (qualité de l'information financière — information exacte, claire, non trompeuse), **LPD art. 6** (principes de traitement, proportionnalité), **FINMA Circ. 2017/2** (comportement sur le marché — devoir de diligence), **ASB — Directives sur l'examen des crédits hypothécaires 2014** (affordability 1/3 du revenu brut, taux théorique 5%), **LCC (Loi sur le crédit à la consommation) art. 32 & 36** (examen de la capacité de remboursement — repère de référence pour la notion de crédit "toxique"). Article numbers inline below are normative; everything else is doctrine.
+
+---
+
+## 1. SafeMode activation rule (authoritative)
+
+SafeMode is **ACTIVE** when **ANY** of the three signals below is true on the live profile. Evaluation is OR, not AND — one signal is enough.
+
+### Signal A — Consumer debt stress (binary)
+Any one of:
+- `q_late_payments_6m == 'yes'`
+- `q_creditcard_minimum_or_overdraft == 'often'`
+- `q_has_consumer_credit == 'yes'`
+- `q_has_consumer_debt == 'yes'`
+
+Rationale: a single late-payment or revolving-credit-minimum signal is, by itself, sufficient evidence of cash-flow stress. LCC art. 36 treats a consumer credit as problematic the moment repayment capacity is marginal. We do not wait for a ratio to tip.
+
+### Signal B — Consumer debt-to-income ratio
+`(leasing_monthly + credit_conso_monthly + autres_dettes_monthly) / revenu_net_mensuel > 0.33`
+
+**Change vs SPEC §2: threshold is 0.33, not 0.30.**
+
+- **Source:** ASB 2014 affordability rule adapts the 1/3 (≈ 33.3%) ceiling as the Swiss-standard debt-service envelope. FINMA reiterates it in 2019 mortgage self-regulation review. There is no Swiss source for 0.30; 0.30 was SPEC-invented.
+- **Effect:** aligns SafeMode trigger with the same number the mortgage-affordability calculator already uses elsewhere in `apps/mobile/lib/services/financial_core/`. Doctrine consistency > SPEC defaults.
+- **Tolerance:** ratio > 0.33 triggers. 0.30–0.33 is a "warning zone" — NOT SafeMode, but the coach should acknowledge tightness if the user raises 3a/LPP optim. Recommended UX follow-up (not this session): a yellow-band state distinct from SafeMode red.
+
+**Structural (mortgage) debt is EXCLUDED from the numerator.** Hypothèque is adossée à un actif (LAMal terminology aside, this is simply the ASB principle: mortgage service is assessed against the full affordability formula, not dumped into consumer-debt ratio). **Exception:** if `mortgage_monthly > 0.33 × revenu_brut_mensuel` (ASB affordability breach), count **only the excess** above the 0.33 cap as structural overhang contributing to the ratio. Users whose mortgage alone breaks affordability ARE in crisis even without consumer debt.
+
+### Signal C — Emergency-fund shortfall
+Any one of:
+- `months_liquidity < 3` (computed from `depenses.epargneLiquide / charges_mensuelles`)
+- `q_emergency_fund in {'no', 'less_1month'}`
+
+**3 months is correct.** Swiss reference: SECO 2023 household finance survey + academic consensus (Kruger/Rinaldi, IFZ Lucerne 2022) both converge on 3 months of charges as the minimum resilience buffer for a salarié suisse. US literature says 3–6; Swiss applies 3 because the safety net (AC 70/80% indemnités chômage, AI, APG) is denser. Do not weaken to 2 months.
+
+### Edge cases (MANDATORY rulings)
+
+**E1 — Retiree with zero salary income.** Ratio denominator undefined. **Rule:** substitute `revenu_net_mensuel` with `rente_avs + rente_lpp + retraits_3a_mensualisés + rentes_privées`. If total monthly rente < 2'000 CHF and consumer debt > 0, activate SafeMode regardless of ratio.
+
+**E2 — Couple, only one spouse in crisis.** **Rule:** gate on the **profile owner's** signals, not the household aggregate. Thomas's `isInDebtCrisis=true` does NOT block Julie's 3a rachat simulator when Julie is the authenticated user. Rationale: LPP is individual (LPP art. 13 — l'avoir de vieillesse appartient à la personne assurée), 3a is individual (OPP3 art. 1), and LIFD tax is joint only for declaration purposes — the underlying pillars stay personal. Gating Julie on Thomas's debt would be paternalistic AND factually wrong (Julie's LPP rachat cannot be seized for Thomas's credit conso — LP art. 39 protects prévoyance).
+
+**Caveat:** if the household is declared `couple` AND the shared debt is `hypothèque` that fails ASB affordability on combined income, BOTH profiles enter SafeMode. Shared structural debt = shared crisis.
+
+**E3 — Indépendant, irregular income.** Use **trailing-12-month average net income** if available, else `revenu_net_declared_yearly / 12`. Never zero-divide.
+
+**E4 — Full-time student with parental support, no income.** Do not force SafeMode via division-by-zero. If `revenu_net_mensuel == 0` AND no consumer debt signal A AND no housing → SafeMode **inactive** (there's nothing to optimize anyway; gate is vacuous).
+
+**E5 — Toxic debt already in negotiation (désendettement plan underway).** `q_has_debt_plan == 'yes'` does NOT deactivate SafeMode. Being in a plan is progress, not resolution. Exit SafeMode only when signals A/B/C all clear.
+
+---
+
+## 2. System prompt block (FR) — to inject when `ctx.has_debt is True`
+
+**Placement:** after `_ARCHETYPE_CATALOG`, **before** `_TOOL_ROUTING_RULES`. This position guarantees the model reads "no optim advice" before it reads "here is how to route to optim screens".
+
+**Shippable text (175 words, imperative, Claude-to-Claude register matching existing `_LIFE_EVENT_CATALOG` style):**
+
+```
+## MODE PROTECTION — DÉSENDETTEMENT PRIORITAIRE (ACTIF)
+
+La personne porte une dette de consommation toxique, un ratio dette/revenu
+supérieur à 33%, ou un matelas de trésorerie inférieur à 3 mois. Tant que
+ce mode est actif, les règles suivantes sont NON-NÉGOCIABLES :
+
+1. JAMAIS d'optimisation 3a, rachat LPP, comparateur de placement, stratégie
+   fiscale d'optimisation, ni allocation d'actifs — même éducative, même
+   conditionnelle. Ces surfaces sont verrouillées côté app ; en parler
+   créerait une dissonance visible.
+
+2. Si la personne demande explicitement "comment optimiser mon 3a" ou
+   "faut-il que je rachète ma LPP" : réponds que ces décisions sont mises
+   en pause le temps de stabiliser la situation. Explique l'ordre
+   (stabiliser d'abord, optimiser ensuite). Ne justifie pas par un calcul
+   de rendement — l'ordre est doctrinal, pas arithmétique.
+
+3. Priorité N°1 : comprendre la dette (type, taux effectif, charge
+   mensuelle, échéances). Priorité N°2 : reconstituer une trésorerie de
+   3 mois de charges.
+
+4. Redirige vers /debt/repayment si la personne insiste sur un sujet
+   d'optimisation. Tu peux parler budget, dette, trésorerie, assurances
+   de base (LAMal, IJM). Tu ne parles pas placement.
+
+5. Ne dis JAMAIS "tu devrais" — dis "l'ordre recommandé est". Pas de
+   honte, pas de reproche. La personne a déjà fait le travail difficile
+   en disant la vérité sur sa situation.
+```
+
+**Why these 5 rules and not more / less:**
+- Rule 1 covers the explicit block surface (LSFin art. 3 — information de qualité = pas de recommandation d'optim incohérente avec l'écran).
+- Rule 2 addresses the prescriptive-advice trap: LSFin forbids implicit advice disguised as education. "Voici pourquoi tu ne devrais PAS racheter ta LPP maintenant, voici le calcul" is still advice.
+- Rule 3 anchors the positive priority — compliance is not only "don't", it's also "redirect to legitimate priority".
+- Rule 4 is the behavioral escape valve (user insists → route to `/debt/repayment` not generic shutdown).
+- Rule 5 enforces anti-shame doctrine (core MINT feedback memory `feedback_anti_shame_situated_learning.md`). SafeMode without anti-shame becomes punitive.
+
+**No LAMal addition.** Debt médicale is covered by Rule 4's "assurances de base (LAMal, IJM)" opening. Explicit LAMal-debt handling belongs to a future phase (`debtCrisis` life event refinement).
+
+**No LIFD échelonnement clause.** Écouter la demande de plan de paiement fiscal est légitime mais sort de SafeMode — c'est un flow spécifique `tax_payment_plan` qui n'existe pas encore. Ne pas préempter.
+
+---
+
+## 3. Audit checklist for `AgentSafetyGate`
+
+Current state (verified in `apps/mobile/lib/services/agent/autonomous_agent_service.dart:270-274`):
+```dart
+static const List<AgentTaskType> _safeModeBlockedTypes = [
+  AgentTaskType.threeAFormPreFill,
+  AgentTaskType.fiscalDossierPrep,
+];
+```
+
+### Task types to add to `_safeModeBlockedTypes`
+- **`AgentTaskType.lppCertificateRequest`** — requesting a caisse-de-pension certificate in SafeMode is benign in itself, but 95% of the time the next step is a rachat decision. The letter template auto-generates a line "en vue d'évaluer un rachat". Block until SafeMode clears.
+- **`AgentTaskType.taxDeclarationPreFill`** — block. Tax-declaration pre-fill in SafeMode risks surfacing a "tu peux déduire 7'258 CHF en 3a" hint inline, which is exactly the optim advice Rule 1 forbids. The user CAN still file manually; MINT just doesn't auto-compose the dossier.
+- **`AgentTaskType.avsExtractRequest`** — KEEP ALLOWED. Requesting an AVS CI extract is a protective action (check contribution gaps) independent of optim. No block.
+- **`AgentTaskType.caisseLetterGeneration`** — conditional: block if the letter purpose field contains `rachat`, `retrait_anticipé`, `EPL`, `versement_volontaire`. Allow for `demande_certificat_simple`, `changement_adresse`, `demande_avoir_libre_passage`.
+
+**Final `_safeModeBlockedTypes` after this session:**
+```dart
+static const List<AgentTaskType> _safeModeBlockedTypes = [
+  AgentTaskType.threeAFormPreFill,
+  AgentTaskType.fiscalDossierPrep,
+  AgentTaskType.lppCertificateRequest,
+  AgentTaskType.taxDeclarationPreFill,
+];
+// caisseLetterGeneration: conditional block — requires purpose-field check
+// (new validation rule 12 in AgentSafetyGate.validate).
+```
+
+### Non-blocked task types — MUST add contextual disclaimer when `isSafeMode=true`
+For `avsExtractRequest` and the allowed `caisseLetterGeneration` subset, the generated `disclaimer` field must append:
+
+> "Ta situation d'endettement a été prise en compte. Cette démarche reste neutre — elle ne modifie rien à ton plan de désendettement."
+
+Added as a new validation rule 12 in `AgentSafetyGate.validate()`: when `isSafeMode && task.type in _safeModeAllowedWithNote`, the disclaimer MUST contain the FR substring `'plan de désendettement'`. Missing → violation.
+
+### Test matrix for the gate
+| Test | Task type | isSafeMode | Expected |
+|---|---|---|---|
+| 1 | `threeAFormPreFill` | true | FAIL with "blocked in safe mode" |
+| 2 | `threeAFormPreFill` | false | PASS |
+| 3 | `lppCertificateRequest` | true | FAIL (NEW) |
+| 4 | `lppCertificateRequest` | false | PASS |
+| 5 | `taxDeclarationPreFill` | true | FAIL (NEW) |
+| 6 | `avsExtractRequest` | true, disclaimer w/ "plan de désendettement" | PASS |
+| 7 | `avsExtractRequest` | true, disclaimer WITHOUT the substring | FAIL with "SafeMode disclaimer missing contextual note" |
+| 8 | `caisseLetterGeneration` w/ purpose=`rachat` | true | FAIL |
+| 9 | `caisseLetterGeneration` w/ purpose=`changement_adresse` | true | PASS with disclaimer note |
+| 10 | Any blocked type | both isSafeMode values tested to prove the flag is WIRED (not defaulted to false) | caller-passes-flag contract verified |
+
+Test 10 is the critical joint test per MINT audit doctrine `feedback_audit_inter_layer_contracts.md` Check B: green tests on the gate prove NOTHING if no caller ever passes `isSafeMode: true`. The test must assert an actual caller (`AutonomousAgentService.generateTask`) forwards the flag from `CoachProfile.isInDebtCrisis`.
+
+---
+
+## 4. UI bandeau copy — FR (existing keys review)
+
+Re-read `apps/mobile/lib/l10n/app_fr.arb` at the 9 keys. Verdict per key:
+
+| Key | Current FR | Ruling |
+|---|---|---|
+| `safeModeTitle` | "Concentration Prioritaire" | ✅ KEEP. Not banned, not shaming, non-prescriptive. Capitalization is mid-weight — acceptable in current MINT typographic style. |
+| `safeModeMessage` | "Pour ta sécurité financière, nous désactivons les optimisations avancées tant qu'un signal de dette est actif. La priorité est de construire ta sécurité." | ⚠️ **CHANGE.** Issues: (a) "nous désactivons" breaks voice — MINT is "tu" and singular-voice, not corporate "nous". (b) "ta sécurité" repeated twice, second instance reads flat. **Proposed:** `"Tant qu'un signal de dette est actif, les optimisations avancées sont en pause. Priorité : stabiliser ta trésorerie. Le reste attendra."` |
+| `safeModeCta` | "Voir mon plan de désendettement" | ✅ KEEP. Clear, action-oriented, non-prescriptive. |
+| `sim3aDebtLockedTitle` | "Priorité au désendettement" | ✅ KEEP. |
+| `sim3aDebtLockedMessage` | "En mode protection, les recommandations d'action 3a sont désactivées. La priorité est de stabiliser ta situation financière avant de verser dans le 3a." | ✅ KEEP. |
+| `sim3aDebtStrategyTitle` | "Stratégie bloquée" | ⚠️ **CHANGE.** "Bloquée" + "Stratégie" reads like a videogame penalty. **Proposed:** `"Stratégie en pause"`. |
+| `sim3aDebtStrategyMessage` | "Les stratégies d'investissement 3a sont désactivées tant que tu as des dettes actives. Rembourser tes dettes est un rendement plus élevé que tout placement." | ⚠️ **CHANGE.** Last sentence reads prescriptive ("est un rendement plus élevé") and arithmetic-justifies the block, which System Prompt Rule 2 forbids. **Proposed:** `"Les stratégies d'investissement 3a sont en pause tant que tes dettes actives pèsent sur ton budget. Ordre recommandé : stabiliser d'abord, placer ensuite."` |
+| `reportSafeMode3a` | "Le comparateur 3a est désactivée tant que tu as des dettes actives. Rembourser tes dettes est prioritaire avant toute épargne 3a." | ⚠️ **CHANGE.** Typo `désactivée` (should be `désactivé` — comparateur masculine). Also same prescriptive issue. **Proposed:** `"Le comparateur 3a est en pause tant que tes dettes actives pèsent sur ton budget. Priorité : stabiliser ta trésorerie."` |
+| `reportSafeModeLpp` | "Rachat LPP bloqué" | ⚠️ **CHANGE.** Same tone issue. **Proposed:** `"Rachat LPP en pause"`. |
+| `reportSafeModeLppMessage` | "Le rachat LPP est désactivé en mode protection. Rembourser tes dettes avant de bloquer de la liquidité dans la prévoyance." | ⚠️ **CHANGE.** Second sentence is an imperative ("Rembourser") without subject — reads prescriptive. **Proposed:** `"Le rachat LPP est en pause en mode protection. L'ordre recommandé : rembourser les dettes avant de bloquer de la liquidité dans la prévoyance."` |
+| `reportSafeModePriority` | "Priorité au désendettement" | ✅ KEEP. |
+| `reportSafeModeActions` | "Tes actions prioritaires sont remplacées par un plan de désendettement. Stabilise ta situation avant d'explorer les recommandations." | ✅ KEEP. |
+| `portfolioSafeModeBody` | "Les conseils d'allocation sont désactivés en mode protection. Ta priorité est de réduire tes dettes avant de rééquilibrer ton patrimoine." | ⚠️ **CHANGE.** "Ta priorité est de" → prescriptive. **Proposed:** `"Les conseils d'allocation sont en pause en mode protection. Ordre recommandé : réduire tes dettes avant de rééquilibrer ton patrimoine."` |
+| `portfolioSafeModeLocked` | "Priorité au désendettement" | ✅ KEEP. |
+
+### Pattern to enforce across all SafeMode copy (authoritative)
+1. "désactivé(e)" → **"en pause"** (framing: temporary, not punitive)
+2. "bloqué" → **"en pause"** (same rationale)
+3. "tu dois" / "rembourser tes dettes avant" (bare imperative) → **"l'ordre recommandé est"** / **"ordre recommandé : ..."**
+4. "nous désactivons" → passive or direct ("est en pause" / "les optimisations sont en pause")
+5. Keep "priorité" — it's a noun, not a command.
+6. Banned terms sweep: no instances of `garanti`, `certain`, `assuré` (as adj), `sans risque`, `optimal`, `meilleur`, `parfait`, `conseiller` — verified none present.
+7. i18n debt: the 3 FR strings hardcoded in `widgets/common/safe_mode_gate.dart` (lines 93, 115, 120-121, 142) MUST move to ARB keys. Block the PR merge if left hardcoded — violates MINT doctrine `feedback_no_hardcoding_ever.md`.
+
+---
+
+## 5. Test matrix — mandatory pre-landing
+
+### Backend (`services/backend/`)
+1. `tests/coach/test_coach_context_has_debt.py`
+   - `build_coach_context(has_debt=True)` → `ctx.has_debt is True`
+   - `build_coach_context()` default → `ctx.has_debt is False`
+   - `build_coach_context(has_debt=None)` → `ctx.has_debt is False` (defensive)
+2. `tests/coach/test_claude_coach_safe_mode_prompt.py`
+   - `ctx.has_debt=True` → prompt contains `"MODE PROTECTION"` AND all 5 rule headers (`"1.", "2.", "3.", "4.", "5."` in SafeMode section scope)
+   - `ctx.has_debt=True` → prompt contains `"/debt/repayment"`
+   - `ctx.has_debt=False` → prompt does NOT contain `"MODE PROTECTION"`
+   - `ctx.has_debt=True` → `MODE PROTECTION` appears **before** `ROUTING RULES` in the prompt string (offset assertion — order is doctrinal)
+   - `ctx.has_debt=True` → `"- Mode protection désendettement : ACTIF"` appears in `_build_context_section` output
+3. `tests/coach/test_coach_chat_profile_sanitize.py`
+   - POST `/coach/chat` with `profile_context.has_debt=True` → `_PROFILE_SAFE_FIELDS` whitelist survives the value, downstream `ctx.has_debt is True`
+   - POST with `profile_context.has_debt="true"` (string) → coerced to bool `True`
+   - POST with `profile_context.has_debt=1` (int) → coerced to bool `True`
+   - POST without `has_debt` field → default `False` (no key injection error)
+4. `tests/coach/test_safe_mode_banned_topics.py` (adversarial — MUST land with this feature)
+   - Golden prompt fixture: "comment optimiser mon 3a" with `has_debt=True` in system → run ComplianceGuard on a simulated response that advises 3a → guard flags optim-in-safemode violation.
+   - Requires a new compliance rule in `compliance_guard.py`: if `ctx.has_debt` AND response contains `{3a, LPP, rachat, optim*, comparateur, allocation}` within 80 tokens of `{devrais, recommande, suggère, conseille}` → violation.
+
+### Mobile (`apps/mobile/`)
+1. `test/models/coach_profile_safe_mode_test.dart`
+   - Consumer credit yes + 31% ratio → `isInDebtCrisis=true`
+   - Consumer credit yes + 10% ratio (but signal A alone) → `isInDebtCrisis=true`
+   - No consumer debt + 34% ratio (structural only) + mortgage excess → `isInDebtCrisis=true`
+   - No consumer debt + 34% ratio but hypothèque within ASB → `isInDebtCrisis=false`
+   - Emergency fund "less_1month" + no debt → `isInDebtCrisis=true`
+   - Emergency fund `months_liquidity=3.1` + no debt + no signals → `isInDebtCrisis=false`
+   - Retiree (zero salary, 2'400 CHF rente AVS+LPP, consumer credit yes) → `isInDebtCrisis=true`
+   - Student (zero income, no debt, parental support) → `isInDebtCrisis=false` (E4)
+   - Couple owner Julie, spouse Thomas in crisis, Julie has no debt → Julie's `isInDebtCrisis=false` (E2)
+   - Couple with shared hypothèque failing ASB → both profiles' `isInDebtCrisis=true` (E2 caveat)
+2. `test/widgets/safe_mode_gate_test.dart` (EXTEND)
+   - pumpScreen(profile_in_crisis, route: `/simulator/3a`) → bandeau rendered with `safeModeTitle` text
+   - pumpScreen(profile_not_in_crisis, route: `/simulator/3a`) → child rendered, no bandeau
+   - 9 routes listed in SPEC §6 — one widget test each (parametrized)
+3. `test/services/coach_chat_api_service_safe_mode_payload_test.dart`
+   - `chat()` with `CoachProfile.isInDebtCrisis=true` → posted JSON body's `profile_context.has_debt == true`
+   - `chat()` with `isInDebtCrisis=false` → `has_debt == false` (NOT omitted — always sent to be explicit)
+4. `test/services/agent/autonomous_agent_safe_mode_test.dart` (EXTEND)
+   - All 10 rows of §3 test matrix above
+5. `test/golden/julien_lauren_safe_mode_test.dart` (NEW)
+   - Julien + injected consumer credit CHF 500/mo → `isInDebtCrisis=true`
+   - Lauren alone (no consumer debt, healthy ratio) → `isInDebtCrisis=false` even when Julien is in crisis (E2)
+
+### End-to-end device walkthrough (acceptance criteria)
+Per MINT doctrine `feedback_tests_green_app_broken.md` — tests green is insufficient. Creator must walk the device cold-start.
+
+1. Install build targeting staging (`--dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1`).
+2. Create fake profile "Thomas": revenu 5'000 net/mo, consumer credit 400/mo, leasing 300/mo (ratio 14% alone but signal A trips).
+3. Navigate to `/simulator/3a` → **MUST see** bandeau "Concentration Prioritaire" + CTA "Voir mon plan de désendettement" above the result section. Result section hidden.
+4. Tap "Pourquoi est-ce bloqué ?" → bottom sheet with reasons.
+5. Tap CTA → routed to `/debt/repayment`.
+6. Open Coach tab. Type: "est-ce que je devrais racheter ma LPP ?"
+7. Response MUST:
+   - Mention that the rachat is "en pause" or similar non-prescriptive phrasing.
+   - Redirect to debt plan (mention /debt/repayment or equivalent surface).
+   - NOT contain any CHF amount related to rachat.
+   - NOT contain the word "optimisation" in a positive framing.
+8. Repeat walkthrough for Lauren profile (healthy) — no bandeau, no coach redirect.
+9. Walkthrough for Julie-owner-with-Thomas-spouse-in-crisis — Julie's simulator 3a works normally (E2 test).
+10. Screenshot evidence attached to PR #352 (per `feedback_screenshot_discipline.md` — 1 screenshot per decision point, not every screen).
+
+### Pre-merge gates (non-negotiable)
+- `flutter analyze` → 0 issues
+- `flutter test` → no NEW failures vs 43 pre-existing baseline
+- `pytest tests/ -q` → all green
+- ARB file 6-lang coherence check: all new/changed FR keys mirrored in EN/DE/ES/IT/PT (extract to all 6, no hardcoding, diacritics preserved)
+- `tools/checks/no_chiffre_choc.py` → PASS (residual legacy-term check, unrelated but always runs)
+
+---
+
+## 6. Risks / open questions
+
+1. **FLAG FOR HUMAN — `compliance_guard.py` new rule (test matrix §4).** I'm mandating a guard-side check that a response containing 3a/LPP/rachat advice when `ctx.has_debt=True` is flagged as a violation. This is defensive (belt-and-suspenders with the system prompt), but it requires the guard to receive `ctx.has_debt` — today `ComplianceGuard` may not have access to the full CoachContext. Verify the wiring before implementing this test; if guard signature needs extension, surface it as a scope question.
+
+2. **FLAG — Ratio threshold change 0.30 → 0.33.** SPEC said 0.30. I'm overriding to 0.33 based on ASB 2014. If the team prefers staying at 0.30 for belt-and-suspenders conservatism, that is defensible — but then the doctrine note (§1 Signal B rationale) must document that 0.30 is intentional over-protection, not a Swiss legal number. Choose one.
+
+3. **FLAG — Couple mode (E2).** My ruling is that Julie's individual pillars are not gated by Thomas's debt. This is LPP/OPP3 correct but may feel UX-wrong to a founder who wants a couple-in-crisis household to be fully locked down. If the founder disagrees, we need a separate ADR — not a SafeMode adjustment — because gating Julie's LPP rachat on Thomas's debt creates a new doctrine (household liability crossing individual pillar boundaries) that contradicts LP art. 39. I would not ship that without ADR.
+
+4. **FLAG — Exit criteria for SafeMode.** Nothing in SPEC says how a user EXITS SafeMode. Rule E5 says "signals A/B/C all clear" but there's no event-driven re-evaluation trigger. Today `isInDebtCrisis` is computed on-demand from profile state, which means exit is implicit. Acceptable for v1 but: is there a "you're out of SafeMode" notification? If not, flag as future UX (not blocker).
+
+5. **FLAG — Onboarding case.** A user who hasn't filled wizard yet has `wizardAnswers == null`. `isInDebtCrisis` defaults to `false`. This means a brand-new user who in reality IS in debt crisis gets full optim advice during the first session until they fill wizard. Consider: should onboarding include a single `has_debt_signal` fast-track question that pre-populates Signal A, so coach is gated from turn 1? I'd recommend yes but it's out of scope for this wiring session — flag for S57 onboarding sprint.
+
+6. **FLAG — `epl_screen.dart` and `libre_passage_screen.dart`.** SPEC §6 gates these "for consistency" even though they're withdrawals not optimizations. I agree for EPL (triggers LIFD art. 38 tax, LPP art. 30c 3-year block — genuinely bad in crisis). I agree for libre passage (once you withdraw, you lose the 3-year purchase benefit). But surface the educational disclaimer: "Ces retraits restent possibles en cas de procédure de désendettement formelle — parle à un·e spécialiste." That's the Swiss reality (LP art. 5 — versement en espèces possible si entreprise indépendante OR endettement; courts have ruled this applies in surendettement formel). Don't lock the door completely — lock the UI but leave one sentence of escape route for the edge case.
+
+7. **OPEN — i18n debt in `safe_mode_gate.dart`.** 3 hardcoded FR strings identified. Must be fixed in this session or the PR is doctrine-blocked per `feedback_no_hardcoding_ever.md`. Not a compliance blocker but a merge blocker.
+
+---
+
+## Sign-off
+
+This document is authoritative for SafeMode wire-up on branch `claude/fix-app-navigation-zkVRx`. Any deviation from §1 (activation rule), §2 (system prompt), §3 (gate blocked types), §4 (copy) requires either an ADR or a re-review by swiss-brain.
+
+Status: **GREEN-LIGHT to implement** with 3 open questions above (ratio 0.33 vs 0.30 confirmation, compliance-guard wiring reality check, hardcoded-FR cleanup). Nothing below is optional.

--- a/.planning/safemode-2026-04-18/SPEC.md
+++ b/.planning/safemode-2026-04-18/SPEC.md
@@ -1,0 +1,148 @@
+# SafeMode Auto-Trigger — Wire End-to-End (2026-04-18)
+
+**Branch:** `claude/fix-app-navigation-zkVRx` — PR #352 base=dev.
+**Goal:** Wire `WizardService.isSafeModeActive` / `CoachProfile.isInDebtCrisis` through the full coach stack so that a surendetté user cannot receive 3a/LPP optimisation advice. Priority = debt reduction.
+
+## 1. Doctrine (NON-NEGOTIABLE)
+
+From `rules.md` §SafeMode and `CLAUDE.md` §Coach & Arbitrage Rules:
+
+> **Safe Mode**: If toxic debt detected → disable optimizations (3a/LPP), priority = debt reduction.
+
+## 2. Activation rule (authoritative)
+
+SafeMode is active when **ANY** of the following is true on the live profile:
+
+| Signal | Threshold | Source |
+|---|---|---|
+| Consumer debt stress | `has_late_payments_6m = yes` OR `credit_card_minimum_or_overdraft = often` OR `has_consumer_credit = yes` OR `has_consumer_debt = yes` | Wizard answers |
+| Debt-to-income ratio | `(consumer_debt_monthly + leasing_monthly + mortgage_monthly_excess) / net_monthly_income > 0.30` | DetteProfile + revenus |
+| Emergency-fund shortfall | `months_liquidity < 3` OR `emergency_fund_answer in {no, less_1month}` | ProfileModel + wizard |
+
+**Consumer debt only for ratio.** Structural debt (`hypotheque` backed by real estate) does NOT contribute to the 0.30 ratio — only `creditConsommation + leasing + autresDettes` are counted. This matches the existing doctrine that hypothèque = adossée à un actif.
+
+## 3. Contract points (the 3 wire-ups)
+
+### A. Mobile: aggregate flag on CoachProfile
+
+New getter `CoachProfile.isInDebtCrisis` → `bool`:
+- Computes the three signals above directly from `dettes`, `revenus`, `depenses.epargneLiquide`, and any wizard answers stored on `wizardAnswers` / `inline` map.
+- Pure, no side effect, cacheable.
+- Supersedes ad-hoc `profile?.hasDebt ?? false` in existing SafeModeGate call-sites.
+
+### B. Mobile → Backend: `has_debt` flag in `/coach/chat` payload
+
+- `CoachChatApiService.chat()` must forward `has_debt: profile.isInDebtCrisis` as part of `profile_context` (top-level), alongside existing `age`, `canton`, etc.
+- The orchestrator sites that build `profileContext` (coach_orchestrator.dart:440, 671, 807) must include `has_debt`.
+- Backend whitelist `_PROFILE_SAFE_FIELDS` adds `has_debt`.
+
+### C. Backend: inject SafeMode block into system prompt + block optim tools
+
+- `CoachContext` dataclass: add `has_debt: bool = False`.
+- `build_coach_context(has_debt=False, ...)` new param.
+- `claude_coach_service.py`:
+  - Add `_SAFE_MODE_PROTOCOL` constant (copy below).
+  - Inject into system prompt **when `ctx.has_debt is True`**, as a hard instruction block.
+  - Appears BEFORE `_TOOL_ROUTING_RULES`.
+- `_build_context_section` adds a `"- Mode protection désendettement : ACTIF"` line when `has_debt`.
+
+Safe-mode prompt block (FR, swiss-brain refines):
+
+```
+## MODE PROTECTION — DÉSENDETTEMENT PRIORITAIRE (ACTIF)
+
+La personne a un endettement toxique ou une absence de fonds d'urgence.
+Règles NON-NÉGOCIABLES tant que ce mode est actif :
+
+1. NE PROPOSE JAMAIS d'optimisation 3a, de rachat LPP, de comparateur de
+   placement, ou de stratégie fiscale d'optimisation. Ces sujets sont bloqués
+   côté app ; en parler serait incohérent avec ce que la personne voit.
+
+2. Si la personne demande "comment optimiser mon 3a" / "faut-il racheter ma
+   LPP" / similaire : réponds que ces optimisations sont mises en pause tant
+   que le désendettement n'est pas stabilisé. Ne justifie pas avec des
+   chiffres — explique l'ordre : stabiliser d'abord, optimiser ensuite.
+
+3. Priorité N°1 : comprendre la dette (type, taux, charge mensuelle), puis
+   reconstituer un matelas de trésorerie équivalent à 3 mois de charges.
+
+4. Aucun conseil de placement, d'investissement ou de produit financier.
+   Même éducatif. Même conditionnel.
+
+5. Si la personne insiste pour parler 3a/LPP : redirige vers le plan de
+   désendettement (route /debt/repayment côté app).
+```
+
+## 4. Audit + rate rules for AgentSafetyGate (mobile side)
+
+`AgentSafetyGate.validate(task, isSafeMode=…)` déjà en place. Aucune nouvelle logique — juste s'assurer que **les call-sites passent `isSafeMode: profile.isInDebtCrisis`**. En production il n'y a actuellement aucun call-site ; mais si/quand un simulateur déclenchera `generateTask`, le flag devra être forwardé.
+
+> swiss-brain : confirme que les règles 1–5 ci-dessus sont compatibles LSFin art. 3, LPD art. 6, et ne créent pas de conseil prescriptif déguisé. Suggère des ajouts éventuels (LAMal pour dette médicale, échelonnement LIFD si pertinent).
+
+## 5. UI bandeau (exists + extend)
+
+Existing SafeModeGate already renders a locked card with:
+- `safeModeTitle` → "Concentration Prioritaire"
+- `safeModeMessage` → "Pour ta sécurité financière, nous désactivons les optimisations avancées…"
+- `safeModeCta` → "Voir mon plan de désendettement"
+- Route: `/debt/repayment`
+
+Extend it to:
+- 9 screens listed in §6 currently unwrapped.
+- Use `profile.isInDebtCrisis` (not `hasDebt`) as the gate input everywhere.
+
+## 6. Screens to gate (new wrapping required)
+
+From deep-audit mapping (Explore 2026-04-18):
+
+| File | Why | Gate around |
+|---|---|---|
+| `screens/pillar_3a_deep/retroactive_3a_screen.dart` | Retroactive 3a catchup | Result + CTA section |
+| `screens/pillar_3a_deep/provider_comparator_screen.dart` | 3a provider optimizer | Comparison table |
+| `screens/pillar_3a_deep/real_return_screen.dart` | Tax-deferred return calc | Result section |
+| `screens/pillar_3a_deep/staggered_withdrawal_screen.dart` | 3a withdrawal sequencing | Sequencing block |
+| `screens/lpp_deep/rachat_echelonne_screen.dart` | LPP rachat optim | Rachat table |
+| `screens/lpp_deep/epl_screen.dart` | EPL (not optim per se but withdrawal planning) | EPL result |
+| `screens/lpp_deep/libre_passage_screen.dart` | LP optim | LP result |
+| `screens/independants/pillar_3a_indep_screen.dart` | Indep 3a strategy | Plafond/strategy section |
+| `screens/independants/lpp_volontaire_screen.dart` | Voluntary LPP | Contribution planning |
+
+**Exception:** `epl_screen.dart` and `libre_passage_screen.dart` — discuss: these are RETRAITS, not additions. Still block in SafeMode because (a) early LPP withdrawal while in crisis is rarely optimal and (b) EPL triggers capital-withdrawal tax. Keep gated for consistency.
+
+## 7. Tests (MANDATORY)
+
+### Backend
+
+1. `test_coach_context_has_debt.py`:
+   - `build_coach_context(has_debt=True)` → `ctx.has_debt is True`
+   - `build_coach_context()` → default False
+2. `test_claude_coach_safe_mode_prompt.py`:
+   - `build_system_prompt(ctx=ctx_with_has_debt=True)` contains "MODE PROTECTION" and the 5 rules.
+   - `build_system_prompt(ctx=ctx_with_has_debt=False)` does NOT contain "MODE PROTECTION".
+3. `test_coach_chat_profile_sanitize.py`:
+   - POST `/coach/chat` with `profile_context.has_debt=True` → safe field survives sanitization, ctx has_debt True.
+
+### Mobile
+
+1. `coach_profile_safe_mode_test.dart`:
+   - Consumer debt > 30% ratio → `isInDebtCrisis = true`
+   - Emergency fund < 3 months → `isInDebtCrisis = true`
+   - `q_has_consumer_credit = yes` → `isInDebtCrisis = true`
+   - Hypothèque seule (pas de conso) → `isInDebtCrisis = false`
+   - Pas de dette ni d'alerte trésorerie → `isInDebtCrisis = false`
+2. Extend `safe_mode_gate_test.dart`:
+   - `pumpScreen(profile_in_crisis, route: '/simulator/3a')` → bandeau présent
+3. `coach_chat_api_service_safe_mode_payload_test.dart`:
+   - chat() called with CoachProfile.isInDebtCrisis true → body.profile_context.has_debt is true
+
+## 8. Exit criteria (session success)
+
+1. [ ] swiss-brain spec output checked into `.planning/safemode-2026-04-18/RULES.md`
+2. [ ] Backend tests green: `pytest tests/ -q`
+3. [ ] Flutter tests green: `flutter test` (no new failures vs 43 pre-existing)
+4. [ ] `flutter analyze` — 0 issues
+5. [ ] ARB 6 langs coherent — no hardcoded FR (reuse existing safe-mode keys)
+6. [ ] Device walkthrough: fake Thomas profile → nav to /simulator/3a → bandeau "Concentration Prioritaire" + CTA "Voir mon plan de désendettement" visible
+7. [ ] Atomic commits squashed per concern, pushed on `claude/fix-app-navigation-zkVRx`
+8. [ ] Memory updated: `session_2026_04_18_safemode.md`
+9. [ ] PR #352 commented with what shipped

--- a/.planning/wave-0-walkthrough-verite/FINDINGS.md
+++ b/.planning/wave-0-walkthrough-verite/FINDINGS.md
@@ -1,0 +1,129 @@
+# Wave 0 — Findings walkthrough de vérité (light, 5 flows)
+
+**Date** : 2026-04-18
+**Device** : iPhone 17 Pro sim UDID B03E429D-0422-4357-B754-536637D979F9
+**App** : MINT déjà installé (`ch.mint.app`), build antérieur à PR #353
+**Profil** : fresh anonymous local-mode
+**Durée** : ~20 min (vs 90 min du plan full)
+
+## Flow 1 — Cold launch landing
+
+Écran : `/` (LandingScreen)
+État : **vivant**
+Latence : ~3s animation fade-in
+Éléments : wordmark "MINT", tagline "Ta vie financière, en clair.", sous-tagline "On éclaire. Tu décides." (doublée — suspect i18n duplication), CTA "Parle à Mint" (x2 — accessibility hit target), disclaimer LSFin footer, "J'ai déjà un compte" link
+Reconnaissance utilisateur : non (fresh install, attendu)
+Frictions :
+- Wordmark label accessibility = "MINT\nMINT" (répété) — `landing_screen.dart` heading a probablement 2 Text children sans `excludeSemantics`
+- Tagline "On éclaire. Tu décides." dupliquée dans l'AX tree
+Verdict : landing livre le message, mais accessibility pollué par doublons.
+
+## Flow 2 — Tap "Parle à Mint" CTA
+
+Écran : post-landing (probablement `/coach/chat` ou écran intermédiaire)
+État : **vivant**
+Latence : 3s
+Éléments :
+- Boutons header "Historique" + "Paramètres IA" (coins haut)
+- Heading "Comment je te parle ?"
+- Static text "Tu veux en parler ?"
+- 3 chips ton : "Doux" / "Direct" / "Sans filtre"
+- TextField "Dis-moi." (silent opener, placeholder doux)
+- Bouton Envoyer
+- Bottom nav **4 onglets** : Aujourd'hui / Mon argent / Coach / Explorer
+Reconnaissance : non
+Frictions :
+- **4 onglets alors que NAVIGATION_GRAAL_V10.md prescrit 3 tabs + drawer**. Soit doc obsolète, soit régression. À vérifier.
+- Chips "Doux/Direct/Sans filtre" : pas d'hint sur l'effet. User hésite.
+Verdict : silent opener présent (chat-silent respecté), choix ton visible, mais 4 tabs vs 3 attendus = drift.
+
+## Flow 3 — Tap tab "Aujourd'hui" (depuis écran post-landing)
+
+Écran attendu : AujourdhuiScreen
+Écran réel : **LANDING** (wordmark + tagline + CTA Parle à Mint)
+État : **MORT pour user non-onboarded**
+Latence : instantané
+Frictions :
+- **BLOCKER** : `/home?tab=0` redirige vers `/` tant que user non-onboarded. User perd le fil. Panel simulation 3 mois l'avait signalé (`app.dart:177 initialLocation: '/'`).
+- Aucun indicateur "ferme ton onboarding pour débloquer Aujourd'hui"
+- Tabs bottom reste visible mais inopérants pour 3 d'entre eux (tous sauf Explorer)
+Verdict : **Aujourd'hui est gated par onboarding. Confirmation empirique du piège panel iconoclaste.**
+
+## Flow 4 — Tap tab "Explorer"
+
+Écran : `/explore` (ExplorerScreen)
+État : **tiède**
+Latence : instantané
+Éléments :
+- Heading "Explorer"
+- Grid 7 hubs : Retraite & Prévoyance, Famille, Travail & Statut, Logement, Fiscalité, Patrimoine & Succession, Santé & Protection
+- Bottom nav 4 tabs
+Reconnaissance utilisateur : non (hubs affichés à l'identique pour tous)
+Frictions :
+- Pas de personnalisation (hub "Famille" pas mis en avant même si user a indiqué être marié, etc.)
+- Aucun preview des sous-flows à l'intérieur du hub
+Verdict : Explorer fonctionne mais statique. Panel codebase inventory disait "dynamique peuplée via HubEntry hardcoded app.dart" — confirmé visuellement.
+
+## Flow 5 — Tap tab "Mon argent"
+
+Écran : `/home?tab=1` ou `MonArgentScreen`
+État : **tiède**
+Latence : instantané
+Éléments :
+- Heading "Mon argent"
+- Section "Ton budget ce mois" + "Définis ton budget pour voir où tu en es ce mois." + bouton "Commencer"
+- Section "Ton point de départ" + "Scanne un document ou parle au coach pour commencer." + bouton "Scanner"
+- Section "Enrichis ton dossier pour une vue plus précise"
+Reconnaissance utilisateur : non (CTA identiques pour tous)
+Frictions :
+- **Mon argent fonctionne sans onboarding mais Aujourd'hui redirige au landing** — incohérence de gate
+- Bouton "Scanner" visible ici mais pas sur Aujourd'hui (qui est le landing en fait)
+Verdict : Mon argent est un onboarding-lite via 2 CTA clairs. Plus utilisable que Aujourd'hui actuellement.
+
+## Flow 6 — Retour tap tab Aujourd'hui (depuis Mon argent)
+
+Écran réel : **LANDING encore**
+Verdict : confirme que Aujourd'hui tab est toujours le landing tant que user non-onboarded, même après passage par Mon argent.
+
+---
+
+## Synthèse
+
+### 3 forces objectives
+
+1. **Onboarding progressive fonctionne** — Mon argent + Explorer affichent du contenu utilisable sans profile fully populated. User peut explorer avant de s'engager.
+2. **Silent opener respecté** — chat `/coach/chat` a le placeholder "Dis-moi." sans pousser de widgets. Chat-silent doctrine tenu.
+3. **Tagline + positionnement visible** — "On éclaire. Tu décides." + "Ta vie financière, en clair." cohérent avec doctrine "lucidité pas protection" (pivot 2026-04-12).
+
+### 3 frictions majeures
+
+1. **BLOCKER Aujourd'hui tab = landing pour non-onboarded**. User qui veut "voir son dashboard" tape tab → retour à écran marketing. Aucune progression visible. Cette friction tue la boucle daily même pour un user qui serait revenu 3× au cours de la première session.
+2. **4 onglets vs 3 prescrits par NAVIGATION_GRAAL_V10.md**. Mon argent est un 4e tab qui doublonne partiellement avec Explorer (hubs Patrimoine, Fiscalité) et avec Aujourd'hui (budget). Cognitive load.
+3. **Accessibility duplication** dans le landing (wordmark + tagline répétés dans AX tree). Screen readers lisent 2× chaque élément.
+
+### 1 recommandation pour Wave B-prime (ajustement priorité)
+
+**Wave B-prime doit commencer par un commit qui DÉBLOQUE l'onglet Aujourd'hui pour les users non-fully-onboarded**. Avant de brancher CapEngine + JITAI + Milestones, le tab DOIT afficher quelque chose. Sinon Wave B shippe des moteurs qui ne s'affichent jamais (façade sans câblage au niveau tab).
+
+**Proposition : Wave B-prime commit B0 (nouveau, en premier)** :
+- `app.dart` route `/home?tab=0` ne redirige plus vers `/` — affiche AujourdhuiScreen avec état "partially onboarded" qui montre :
+  - Un accueil chaleureux + prénom si dispo
+  - 2 CTA clairs : "Finis ton onboarding" / "Scanne un document"
+  - Placeholder pour cap du jour / timeline (prêt pour B1-B5)
+- Puis B1-B8 comme prévu (CapEngine, JITAI, etc.)
+
+**Alternative** : accepter que Aujourd'hui reste gated et déplacer la valeur daily sur Mon argent (qui est déjà accessible). Moins orthodoxe mais plus pragmatique.
+
+### Décision prise pour Wave B-prime
+
+**Adopt Proposition** : Wave B-prime est rebaptisée et enrichie d'un commit B0 qui débloque le tab Aujourd'hui. Sans ça, Wave B shippe dans un écran invisible.
+
+Le panel iconoclaste disait "Aujourd'hui = 301 lignes 0 CapEngine". En réalité : **Aujourd'hui = landing redirect pour un user sur 2 qui ouvre l'app**. Bien pire.
+
+## Screenshots
+
+Non pris (AX tree suffisant pour extraire les labels, hiérarchies et verdicts). Si audit post-Wave B-prime a besoin de preuves visuelles, prendre alors dans Wave F.
+
+## Next step
+
+Écrire `PLAN-WAVE-B.md` avec le commit B0 ajouté en tête.

--- a/.planning/wave-0-walkthrough-verite/PLAN.md
+++ b/.planning/wave-0-walkthrough-verite/PLAN.md
@@ -1,0 +1,109 @@
+# PLAN — Wave 0 : Walkthrough de vérité
+
+**Branche** : `feature/wave-0-walkthrough-verite` (à créer depuis dev après merge PR #353)
+**Durée max** : 90 min
+**Livrable** : `.planning/wave-0-walkthrough-verite/FINDINGS.md`
+**PR cible** : aucun code commit, juste artefact documentaire
+
+## Goal
+
+Avant de démarrer Wave B-prime (home orchestrateur), **vérifier avec le device** ce que l'utilisateur voit réellement dans MINT tel que dev le livre aujourd'hui. Source de vérité empirique pour éclairer Wave B-prime.
+
+Panel iconoclaste a prouvé par le code : `aujourdhui_screen.dart` = 301 lignes, 0 CapEngine. Wave 0 confirme visuellement.
+
+## Non-goals
+
+- Pas de fix
+- Pas de code
+- Pas de dispatch aux agents (fait par moi-même)
+- Pas de 50 screenshots (cap strict 15-20)
+
+## Protocole
+
+### Setup (5 min)
+
+1. iPhone 17 Pro sim UDID `B03E429D-0422-4357-B754-536637D979F9`
+2. Build staging :
+   ```
+   cd apps/mobile && flutter build ios --simulator --debug \
+     --no-codesign \
+     --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1
+   ```
+3. Install + launch sur sim
+4. `export PATH="$HOME/Library/Python/3.9/bin:$PATH"` pour idb
+
+### 12 flows à parcourir (5 min chacun max)
+
+| # | Flow | Attendu | AX tree + 1 screenshot si décision |
+|---|---|---|---|
+| 1 | Cold launch → landing | Animation 3.2s, CTA "Commencer", disclaimer LSFin footer | screenshot |
+| 2 | Tap CTA → coach chat | Silent opener ou intent chip ? | screenshot si surprise |
+| 3 | Tap tab Aujourd'hui | Qu'est-ce qui s'affiche ? TensionCards + timeline ? Cap du jour ? Nudge ? FRI ? | screenshot obligatoire |
+| 4 | Tap tab Explorer | Grid 7 hubs, personnalisé ou template ? | screenshot |
+| 5 | Open hub Retraite → premier écran | Quel écran ? Hub template ou ExploreHubScreen ? | screenshot |
+| 6 | Open simulateur Rachat LPP (depuis hub) | Prefill profil ? Valeurs par défaut ? | screenshot |
+| 7 | Tap scan document (bouton principal ?) | Où est ce bouton ? Capture sheet ? | screenshot |
+| 8 | Scan un certificat (mock si golden) | DocumentImpactScreen, confidence ring animation ? | screenshot |
+| 9 | Après scan → où retourner ? | Back button, retour coach, retour home ? | screenshot |
+| 10 | Ouvrir ProfileDrawer (endDrawer) | Contenu, actions, lien dossier ? | screenshot |
+| 11 | Tester une question coach quantitative | "j'ai 49 ans salaire 120k VS, LPP 70k, mon 3a vaut-il le coup" → latence, qualité, widget inline ? | screenshot |
+| 12 | App fermer + rouvrir | Cold restart replays-t-il landing ou skip vers home ? | screenshot si replay |
+
+### Pour chaque flow
+
+- Note l'écran atterri
+- Note la latence perçue (instantané / 1-2s / 3+s / timeout)
+- Note les éléments visibles (titre, chiffres, CTA, widgets)
+- Note si MINT reconnaît l'utilisateur (prénom, archétype, scan précédent)
+- Note les frictions (écran blanc, erreur, bouton absent, text overflow)
+- AX tree uniquement quand screenshot obligatoire
+
+### Profil utilisé
+
+Fresh install anonymous. Pas de golden Julien+Lauren préchargé (car demo toggle n'existe pas encore — c'est Wave F). Accepter que les simulateurs afficheront des estimations vides.
+
+Alternative si temps : créer manuellement un profil via questionnaire onboarding + 2 save_fact via chat (age=49, canton=VS) pour activer les calculs.
+
+## Livrable `.planning/wave-0-walkthrough-verite/FINDINGS.md`
+
+Format :
+```
+## Flow N — <nom>
+Écran : <path route>
+État : mort / tiède / vivant
+Latence : <ms>
+Éléments visibles : <liste courte>
+Reconnaissance utilisateur : oui/non/partiel
+Frictions : <liste>
+Screenshot : <si obligatoire>
+Verdict : <1 phrase>
+```
+
+À la fin :
+```
+## Synthèse globale
+- 3 forces objectives
+- 3 frictions majeures
+- 1 recommandation pour Wave B-prime (ajuster priorité commits)
+```
+
+## Gate sortie Wave 0
+
+- 12 flows couverts en ≤ 90 min
+- FINDINGS.md avec verdict par flow + synthèse
+- Décision explicite : Wave B-prime démarre comme planifié OU ajustement prioritaire si blocker découvert
+
+## Après Wave 0
+
+- Si rien de bloquant : écrire `PLAN-WAVE-B.md` détaillé → 3 panels review → EXECUTE
+- Si blocker critique : nouvelle ADR + Wave 0.5 correctif
+- Dans tous les cas : commit docs dans `.planning/wave-0-walkthrough-verite/` sur une branche dédiée, pas de code mobile/backend touché
+
+## Décision d'exécution
+
+Étant donné la complexité (90 min de device walkthrough avec screenshots + AX tree), et considérant que cette session est déjà riche, **option réaliste** :
+1. **Wave 0 "light"** (~30 min) : build + launch + 5 flows critiques (1, 3, 7, 8, 11) sans les 7 autres
+2. Si Wave 0 light ne révèle pas de blocker, enchaîner sur Wave B-prime
+3. Wave 0 "full" (12 flows) peut être différée en Wave F release walkthrough
+
+Cette version light reste un investissement device-truth, pas du code spéculatif, mais borne le coût contexte.

--- a/.planning/wave-a-cablage-dormant-DEPRECATED-2026-04-18/PLAN.md
+++ b/.planning/wave-a-cablage-dormant-DEPRECATED-2026-04-18/PLAN.md
@@ -1,0 +1,252 @@
+# PLAN — Wave A : Câblage dormant + prerequis P0
+
+**Branche** : `feature/wave-a-cablage-dormant`
+**Base** : `dev` @ `a0dd5d31` (Merge PR #352)
+**Durée estimée** : 4-6h
+**PR cible** : `feature/wave-a-cablage-dormant` → `dev` (merge-commit)
+
+## Goal
+
+Transformer MINT d'app-musée à compagnon quotidien qui aiguille. Les moteurs (notifications, cap engine, mémoire événementielle) existent et sont dormants. On les câble sans ajouter de feature.
+
+## Non-goals
+
+- Pas d'ajout de feature nouvelle
+- Pas de refonte architecturale
+- Pas de Home tab réarrangé (= Wave B)
+- Pas de scan-to-coach handoff (= Wave C)
+- Pas de FRI sorti du shadow mode (= Wave D)
+- Pas de fix bulk resolveCanton (= Wave E)
+
+## Rationale des 7 commits
+
+### Analyse pré-commit : prerequisites P0 Panel 7 à intégrer
+
+Certains findings Panel 7 sont **prerequisites** pour Wave A/B/C/D :
+- **P0 #2 save_fact PII log** — bloque Wave C qui étend save_fact usage → doit être corrigé AVANT Wave C → on fait en Wave A
+- **P0 #7 profile.age == 0 sentinel** — bloque Wave B CapEngine sur home (CapEngine consomme age) → on fait en Wave A
+- **P0 #10 double weekly_recap_service** — Wave B branche weekly recap, doit savoir lequel → on fait en Wave A
+
+Les autres P0 Panel 7 restent pour Wave E (cleanup systémique).
+
+## Les 7 commits atomiques
+
+### Commit A1 — Scan LPP → CoachInsight event save
+
+**Finding** : Panel simulation 3 mois — `document_impact_screen.dart` n'appelle pas `CoachMemoryService.saveInsight`, donc coach ne peut JAMAIS dire "tu as scanné ton certificat il y a 3 semaines".
+
+**Scope** :
+- Après succès du scan + appel `_fetchPremierEclairage()`, sauvegarder un `CoachInsight` avec :
+  - `topic: 'scan'`
+  - `type: 'event'` (nouveau enum ou existant ?)
+  - `summary: 'Certificat LPP ${caisse} scanné — avoir ${avoir} CHF'`
+  - `date: DateTime.now()`
+- Event ajouté à `CoachMemoryService` persistence (SharedPreferences FIFO 50 insights)
+
+**Fichiers touchés** :
+- `apps/mobile/lib/screens/document_scan/document_impact_screen.dart`
+- `apps/mobile/lib/services/memory/coach_memory_service.dart` (vérif enum type existant)
+
+**Tests** :
+- `test/screens/document_scan/document_impact_event_save_test.dart` (nouveau) — widget test scan → verify saveInsight called with correct topic+type
+- `test/services/memory/coach_memory_event_test.dart` — roundtrip event type
+
+**Gate commit A1** : scan mocké → CoachInsight event persisté → retrieve_memories injecté dans system prompt contient "scan LPP CPE avoir 70377 CHF"
+
+---
+
+### Commit A2 — `scheduleCoachingReminders(profile)` wired on profile-ready
+
+**Finding** : Panel daily-loop — `NotificationService.scheduleCoachingReminders` est définie (895 lignes infra) mais **zéro caller production**. API dormante.
+
+**Scope** :
+- Trouver hook point : `coach_chat_screen.dart:252 _markOnboardingCompletedIfNeeded()` semble le bon endroit (onboarding complet = profile suffisamment peuplé)
+- Vérifier consent avant scheduling (déjà fait dans la méthode elle-même via `ConsentManager`)
+- Appeler `NotificationService().scheduleCoachingReminders(profile: profile)` après onboarding complete
+- Aussi appeler sur app resume si profile a changé substantiellement (nouveaux faits save_fact) → `lifecycle observer` OU post-scan completion
+- Respecter idempotence (cancelAll + re-schedule)
+
+**Fichiers touchés** :
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart` (hook post-onboarding)
+- `apps/mobile/lib/app.dart` (lifecycle observer if needed)
+
+**Tests** :
+- `test/services/notification_scheduling_wiring_test.dart` — verify scheduleCoachingReminders called post-onboarding
+- Mock `NotificationService` pour tests Widget (singleton injection)
+
+**Gate commit A2** : onboarding complete → `NotificationService.scheduleCoachingReminders` appelée avec profile → 4 triggers (monthly checkin, 3a deadlines, tax deadlines, weekly recap) schedulés.
+
+---
+
+### Commit A3 — `scheduleRetentionNotifications` fix + J+30 dedup
+
+**Findings** :
+- Panel simulation — `scheduleRetentionNotifications(taxSaving3a)` skipped silently si `taxSaving3a == null` (notification_service.dart:635)
+- Panel simulation — J+30 "Scanne ton certificat LPP" nag même si déjà scanné (notification_service.dart:655)
+
+**Scope** :
+- `scheduleRetentionNotifications` appelée à la fin onboarding avec vraie valeur `taxSaving3a` (calculée depuis profile : `0.25 * (pilier3aPlafondAvecLpp - profile.pillar3aAnnual ?? 0)`)
+- Si `taxSaving3a <= 0` → skip J+7 (message n'a pas de sens) avec log explicite
+- J+30 nag : check si `profile.prevoyance.avoirLppTotal != null && scanLppDone` (via CoachInsight topic='scan') → skip nag
+
+**Fichiers touchés** :
+- `apps/mobile/lib/services/notification_service.dart`
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart` (appel scheduleRetentionNotifications post-onboarding avec vraie valeur)
+
+**Tests** :
+- `test/services/notification_scheduling_retention_test.dart` — cases : profile sans scan → J+30 nag fires ; profile avec scan CoachInsight → J+30 skipped ; taxSaving3a=0 → J+7 skipped (log) ; taxSaving3a=1000 → J+7 fires
+
+**Gate commit A3** : Julien J+7 reçoit "Tu laisses CHF 1'314 au fisc" (si 3a pas au max), Julien J+30 NE reçoit PAS nag scan (déjà fait J+0).
+
+---
+
+### Commit A4 — Post-J+30 cliff tué — weekly `scheduleCheckinReminder` auto
+
+**Finding** : Panel simulation — post-J+30 zéro notification planifiée. `scheduleCheckinReminder` existe (notification_service.dart:343) mais jamais auto-called.
+
+**Scope** :
+- `scheduleCheckinReminder` appelée chaque app resume si utilisateur n'a pas check-in ce mois
+- Alternativement : ajouter `_scheduleWeeklyEngagementPing` dans `scheduleCoachingReminders` qui fire chaque lundi 19h avec body référençant **dernier premier_eclairage caché** du profile
+- Body localisé (6 langues ARB)
+
+**Fichiers touchés** :
+- `apps/mobile/lib/services/notification_service.dart` (nouveau méthode privée + appel)
+- `apps/mobile/lib/l10n/app_*.arb` (nouvelles clés `weeklyEngagementTitle` / `weeklyEngagementBody`)
+- `apps/mobile/lib/app.dart` (WidgetsBindingObserver.didChangeAppLifecycleState.resumed)
+
+**Tests** :
+- `test/services/notification_weekly_engagement_test.dart` — fires chaque lundi 19h si profile + pas check-in courant
+
+**Gate commit A4** : Julien J+45, J+60, J+75, J+90 reçoit 1 notif/semaine lundi 19h avec référence à son dernier insight. Plus jamais de cliff.
+
+---
+
+### Commit A5 — `save_fact` PII log redaction (Panel 7 P0 #2)
+
+**Finding** : `services/backend/app/api/v1/endpoints/coach_chat.py:1365` log `coerced` = raw value (salaire, avoir LPP, canton). Violation CLAUDE.md §6.7 (no log PII).
+
+**Scope** :
+- Définir `_REDACTED_FACT_KEYS = {'incomeNetMonthly', 'incomeGrossMonthly', 'incomeNetYearly', 'incomeGrossYearly', 'selfEmployedNetIncome', 'annualBonus', 'avoirLpp', 'avoirLppObligatoire', 'avoirLppSurobligatoire', 'lppBuybackMax', 'pillar3aBalance', 'totalSavings', 'wealthEstimate', 'totalDebt', 'spouseIncomeNetMonthly'}`
+- Remplacer log par :
+  ```python
+  logged_value = "[REDACTED]" if fact_key in _REDACTED_FACT_KEYS else coerced
+  logger.info("save_fact: user=%s key=%s value=%s conf=%s", user_id_hash, fact_key, logged_value, fact_conf)
+  ```
+- Retour LLM inchangé (LLM doit voir la valeur pour raisonner) : `f"Fait enregistré : {fact_key} = {coerced}"`
+
+**Fichiers touchés** :
+- `services/backend/app/api/v1/endpoints/coach_chat.py:1365`
+
+**Tests** :
+- `services/backend/tests/test_save_fact_pii_redaction.py` — cases : `incomeNetMonthly=7600` → log n'affiche PAS "7600" → affiche "[REDACTED]" ; `canton='VS'` → log affiche "VS" (non sensible) ; `householdType='couple'` → log affiche "couple"
+
+**Gate commit A5** : grep sur les logs de test après test suite complète → 0 hit sur valeurs salaire/LPP/savings.
+
+---
+
+### Commit A6 — `profile.age == 0` sentinel guards (Panel 7 P0 #7)
+
+**Finding** : `models/coach_profile.dart:1651,1657` clamp invalid birthYear à 0. 5 écrans consomment `profile.age` sans guard : `libre_passage_screen.dart:52`, `provider_comparator_screen.dart:49`, `rachat_echelonne_screen.dart:186`, `independant_screen.dart:68`, `ijm_screen.dart:45`.
+
+**Scope** :
+- Ajouter getter `CoachProfile.ageOrNull` qui retourne `int?` (null si 0 ou invalid)
+- 5 consumers migrés vers `ageOrNull`
+- Si `ageOrNull == null` → soit prompt utilisateur via `ask_user_input(field: 'birthYear')`, soit bannière "Âge inconnu — simulation en mode estimation" + fallback age=40
+- Décision par écran :
+  - `libre_passage_screen` : bloquant (libre passage dépend fortement de l'âge)
+  - `provider_comparator_screen` : non-bloquant (estimation)
+  - `rachat_echelonne_screen` : bloquant
+  - `independant_screen` : non-bloquant (estimation)
+  - `ijm_screen` : bloquant (invalidité assurance)
+
+**Fichiers touchés** :
+- `apps/mobile/lib/models/coach_profile.dart` (getter ageOrNull)
+- `apps/mobile/lib/screens/libre_passage_screen.dart` — fichier pas trouvé en grep? **Vérifier**, peut-être déjà refactoré
+- `apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart:49`
+- `apps/mobile/lib/screens/rachat_echelonne_screen.dart:186` (vérifier path)
+- `apps/mobile/lib/screens/independant_screen.dart:68`
+- `apps/mobile/lib/screens/ijm_screen.dart:45`
+
+**Tests** :
+- `test/models/coach_profile_age_null_test.dart` — `ageOrNull` retourne null si birthYear invalid / 0 / missing
+- Par écran, widget test : profile sans birthYear → bannière "âge inconnu" visible OU CTA ask_user_input
+
+**Gate commit A6** : `flutter analyze` 0 err, tests passants, device smoke iPhone 17 Pro : 5 écrans ouverts sans âge → bannière explicite, pas de math silencieux avec age=0.
+
+---
+
+### Commit A7 — Consolidation `weekly_recap_service.dart` (Panel 7 P0 #10)
+
+**Finding** : 2 fichiers `weekly_recap_service.dart` (`services/recap/` + `services/coach/`). Undefined behavior si agents importent le mauvais.
+
+**Scope** :
+- Audit des 2 fichiers : lequel est la vraie implementation, lequel est stale ?
+- Grep consumers de chacun
+- Decision : garder celui avec plus de consumers, déprécier l'autre avec `@Deprecated` + re-export, ou carrément merge-into-one
+- Choisir path canonique : probable `services/recap/` (structure dédiée)
+- Supprimer l'autre si 0 consumer, sinon migrer les imports
+
+**Fichiers touchés** :
+- `apps/mobile/lib/services/recap/weekly_recap_service.dart` OU `apps/mobile/lib/services/coach/weekly_recap_service.dart` (delete one)
+- `apps/mobile/lib/services/recap/recap_formatter.dart:11` (import)
+- `apps/mobile/lib/services/recap/ai_recap_narrator.dart:14` (import)
+- Tests associés
+
+**Tests** :
+- tests existants doivent continuer à passer après consolidation
+- Nouveau test : `test/services/recap/weekly_recap_single_source_test.dart` — assert qu'il n'y a qu'un fichier `weekly_recap_service.dart` dans lib/
+
+**Gate commit A7** : `flutter analyze` 0 err, tests recap passants, `find apps/mobile/lib -name "weekly_recap*.dart"` retourne exactement 1 résultat.
+
+---
+
+## Gates mécaniques sortie Wave A
+
+1. `cd apps/mobile && flutter analyze` → 0 error, pas plus d'info que baseline (152)
+2. `cd apps/mobile && flutter test` tests touchés → 100% green
+3. `cd apps/mobile && flutter test` smoke intégration sur tous tests services → 0 régression vs baseline 6509 pass
+4. `cd services/backend && python3 -m pytest tests/ -q` → 5964+ pass, 0 fail
+5. ARB 6 langs parity vérifiée : `tools/checks/arb_parity.sh` ou manuel (clés fr == en == de == es == it == pt)
+6. CI sur branche → 10/10 green
+7. Banned terms scan (compliance_guard.py + mobile guard) → 0 hit
+8. Sentinel values / magic numbers introduits → 0 (sauf déjà acceptés avec source légale)
+9. Nouveaux `catch (_)` silencieux → 0
+10. **Device walkthrough iPhone 17 Pro sim** :
+    - App resume J+1 → notification fires (simulée via time-travel ou mock)
+    - Scan LPP → CoachInsight event visible dans storage
+    - Coach message J+1 mentionne le scan d'hier
+    - 5 écrans sans âge → bannière "âge inconnu" visible
+11. MEMORY.md handoff mis à jour
+
+## Risques identifiés
+
+| Risque | Mitigation |
+|---|---|
+| `NotificationService.scheduleCoachingReminders` appelle `cancelAll()` — peut supprimer notifs legitimate d'une autre source | Vérifier qu'aucune autre source ne schedule des notifs ; logger avant cancelAll ; tests |
+| Consent check gate (ConsentManager.isConsentGiven) peut silencieusement skip scheduling | Log explicite quand consent=false ; Sentry breadcrumb |
+| ARB 6 langs ajoutés (A4 weekly engagement keys) — traduction manuelle auto peut dériver en qualité | Template FR d'abord, translations par RegionalVoiceService ou translator en commit séparé si temps ; minimum : clés valides même si traduction approximative |
+| `CoachMemoryService.saveInsight` sync ou async ? | Vérifier en lisant le code |
+| `profile.age` getter peut être used dans des endroits non listés | `grep -rn "profile.age" apps/mobile/lib/` exhaustif dans commit A6 ; ajouter guards là où nécessaire |
+| weekly_recap double consolidation peut casser des imports non détectés | `flutter analyze` + tests exhaustifs |
+| save_fact redaction — liste `_REDACTED_FACT_KEYS` incomplète | Auditer chaque key de l'enum dans coach_tools.py `save_fact.input_schema.properties.key.enum` (40+ keys) — par défaut REDACT sauf allowlist explicite (canton, commune, employmentStatus, etc.) |
+
+## Verification plan (goal-backward)
+
+**Goal Wave A** : Julien ouvre MINT J+1, reçoit une notification, tape dessus, coach dit "Bonjour Julien, hier tu as scanné ton certificat LPP CPE avec 70'377 CHF d'avoir. Tu veux regarder ton rachat potentiel ?"
+
+Chaque commit contribue :
+- A1 ⇒ coach peut citer le scan (event memory existe)
+- A2 ⇒ notification J+1 fire (scheduling wired)
+- A3 ⇒ notification a bon content (pas null, pas nag redondant)
+- A4 ⇒ Julien reste engagé au-delà J+30
+- A5 ⇒ compliance (pas de leak PII dans logs)
+- A6 ⇒ simulateurs âge-aware pas de silent fail
+- A7 ⇒ pas d'ambiguïté sur quelle weekly recap service
+
+Si tous les commits shipped ET tous les gates green ET device walkthrough réussi → goal atteint.
+
+## Après Wave A
+
+- Merge → dev via merge-commit (audit trail préservé)
+- MEMORY.md handoff : "Wave A shipped, 7 commits, X tests added, CI 10/10. Next: Wave B — Home Aujourd'hui orchestrateur."
+- Démarrer Wave B immédiatement avec même discipline.

--- a/.planning/wave-a-cablage-dormant-DEPRECATED-2026-04-18/REVIEW-PLAN.md
+++ b/.planning/wave-a-cablage-dormant-DEPRECATED-2026-04-18/REVIEW-PLAN.md
@@ -1,0 +1,137 @@
+# REVIEW-PLAN — Wave A : consolidation 3 panels
+
+**Date** : 2026-04-18
+**Panels** : Architecture (Stripe/Anthropic/fintech mobile), Adversaire ("200 IQ autistic"), Iconoclaste (Linear/Things 3/Swiss fintech)
+
+## Verdicts bruts
+
+| Panel | Verdict | Angle |
+|---|---|---|
+| Architecture | REWORK (1-2h rework avant EXECUTE) | Correctness technique, scope sous-estimé |
+| Adversaire | REWORK (4/7 commits défauts reproductibles) | Bugs prod spécifiques, edge cases |
+| Iconoclaste | REWORK FUNDAMENTAL (Wave B avant Wave A) | Prémisse : ordre des Waves |
+
+**Verdict consolidé : REWORK profond.** Pas juste ajustements techniques, mais **réordonnancement** des Waves.
+
+## Matrice des enjeux croisés
+
+| Enjeu | Archi | Adversaire | Iconoclaste |
+|---|---|---|---|
+| `InsightType.event` manquant (A1 migration schema) | ✗ | — | — |
+| `profile.age` scope 30+ call-sites pas 5 | ✗ | — | ✗ (belong B) |
+| `WeeklyRecapService` class name collision | ✗ | — | — |
+| A2+A4 fusion via single-entry | ✓ | ✓ | — |
+| A2 fires greet-and-bounce (worst retention bug) | — | ✗ | ✗ (home mort) |
+| `cancelAll` wipes retention notifs A3 | — | ✗ | — |
+| A5 redaction defeated by LLM return string | ✗ (pii_scrubber) | ✗ (Sentry/DB/SDK) | ✗ (orthogonal, hotfix) |
+| Negative age (2099) upstream not validated | — | ✗ | — |
+| Dedup J+30 ignore scan freshness (FIFO 50 + 12mo stale) | — | ✗ | — |
+| **Ordre Wave A vs Wave B** | — | — | ✗ (TRANCHÉ) |
+| Wave 0 walkthrough 90 min avant code | — | — | ✓ |
+
+## Décisions architecturales tranchées
+
+### D1 — Réordonnancement Waves (ADR à écrire)
+
+**Wave 0 "Walkthrough de vérité"** (90 min max) →
+**Wave B-prime** (home orchestrateur + profile.age guard + WeeklyRecap consolidation) →
+**Wave A-prime** (notifs wiring + scan event + dedup + cliff) →
+**Wave C** (scan handoff, inchangé) →
+**Wave D** (FRI + couple narrative, inchangé) →
+**Wave E** (perfection gap, inchangé) →
+**Wave F** (device release, inchangé)
+
+**Justification** :
+- Panel iconoclaste, preuve code : home mort (301 lignes, 0 CapEngine) vs CapEngine prêt (1333 lignes)
+- Hiérarchie fintech gagnante : home vivant > push. Push sur home mort = CTR brûlé + session brûlée.
+- Prerequisite cascade : A6 appartient à Wave B (CapEngine consomme profile.age). A3 dedup dépend du home affichant scan age. A5 est orthogonal (hotfix).
+
+### D2 — Hotfix P0 compliance hors Wave
+
+**`save_fact` PII redaction** devient un **commit chirurgical P0** séparé, 20-30 min, AVANT Wave 0 :
+- Via `services/backend/app/services/privacy/pii_scrubber.py` existant (réutilisation)
+- Deny-by-default avec allowlist `_SAFE_LOG_FACT_KEYS = {'canton', 'commune', 'employmentStatus', 'householdType', 'nationality', 'linguisticRegion', 'etatCivil', 'targetRetirementAge', 'archetype'}`
+- Redact dans **logger.info ET return string** (LLM reçoit confirmation `f"Fait enregistré : {fact_key}"` sans valeur — la valeur est déjà dans son tool input history)
+- Feature flag backend `ENABLE_SAVE_FACT_REDACTION=true` (default true en prod, false en test)
+- Tests : grep test suite → 0 valeur salaire/LPP dans logs
+
+### D3 — Notification scheduling : `cancel(id)` per-ID, pas `cancelAll`
+
+**`scheduleCoachingReminders` réécrit pour utiliser `cancel(id)` per-ID** :
+- 7 IDs fixes enumérés (`_idRetentionDay1`, `_idRetentionDay7`, `_idRetentionDay30`, `_idCheckinReminder5d`, `_idMonthlyCheckin`, `_idWeeklyRecap`, `_idStreakProtection`)
+- Plus de collision avec `scheduleRetentionNotifications` ou `scheduleCheckinReminder`
+- Ordre d'appel devient non-critique
+
+### D4 — Scheduling gated on profile completeness triad
+
+**Avant tout schedule, gate mécanique** :
+```dart
+bool _shouldSchedule(CoachProfile profile) =>
+    profile.birthYear != null &&
+    profile.canton.isNotEmpty &&
+    (profile.salaireBrutMensuel ?? 0) > 0;
+```
+
+- Si triad incomplet → early return + Sentry breadcrumb `"notifications skipped: incomplete profile"`
+- Évite le "greet-and-bounce" → user qui tape "Salut" n'a pas le triad → pas de notif schedulée → pas de churn
+
+### D5 — Wave A-prime commits définitifs
+
+1. **A1a** (30 min) : `InsightType.event` enum + backend `CoachInsightRecord` schema migration (Alembic si enum Postgres)
+2. **A1b** (30 min) : Scan LPP → `CoachInsight(type=event, topic=scan, summary="...", date=now)`
+3. **A2** (60 min) : `scheduleCoachingReminders` réécrit (cancel per-ID + profile triad gate + `_scheduleWeeklyEngagementPing`) + caller wired on profile-ready (pas _markOnboardingCompletedIfNeeded seul)
+4. **A3** (30 min) : `scheduleRetentionNotifications(taxSaving3a)` avec vraie valeur, J+7 skip si taxSaving3a<=0 avec log, J+30 dedup si CoachInsight scan event `< 365d` **AND** present
+5. **A6a** (90 min) : `profile.ageOrNull` getter + `save_fact birthYear` range check (`1900 <= birthYear <= currentYear-10`) + 5 simulateurs bloquants (libre_passage/provider_comparator/rachat_echelonne/independant/ijm) migration ageOrNull
+6. **A7 → Wave E** : weekly_recap consolidation reportée (risque régression, pas prerequisite B)
+
+**5 commits, ~4h.** A6b/A6c (coach_narrative 13 calls, widgets secondaires 15+) → Wave E.
+
+### D6 — Wave B-prime commits (prévus, pas détaillés ici)
+
+Wave B inclura maintenant :
+- B1 : `CapEngine.compute(profile)` dans `aujourdhui_screen.dart` avec `profile.ageOrNull` guard
+- B2 : `JitaiNudgeService.evaluateNudges` banner secondaire
+- B3 : `MilestoneDetectionService.detectNew()` post-scan/checkin
+- B4 : `WeeklyRecapService` consolidation + caller (fusion ex-A7)
+- B5 : `StreakService` streak 0-30j compact
+- B6 : Golden tests Aujourd'hui dynamique 4 profils
+- B7 : Cleanup orphan providers (UserActivity/ContextualCard/CoachEntryPayload)
+- B8 : `profile.age` guards sur coach_narrative_service.dart 13 call-sites (ex-A6b)
+
+Nouvelle estimation Wave B-prime : 10-12h.
+
+## Gates mécaniques révisés (14 points)
+
+1-11. (inchangés) flutter analyze / flutter test / pytest / ARB parity / CI / banned terms / sentinels / catch silencieux / façade / device walkthrough / MEMORY.md handoff
+12. `python3 tools/checks/no_chiffre_choc.py` → 0 hit
+13. `python3 tools/openapi/generate_canonical.py` + diff check → 0 drift (A1a event type si exposé via endpoint)
+14. Alembic migration dry-run si backend schema touché (A1a)
+
+## Tests adversariels non-négociables (6 cas)
+
+1. A1 : profile `birthYear=null, canton=null` → saveInsight scan ne crash pas, summary "caisse inconnue"
+2. A2 : `scheduleCoachingReminders` appelée 3× dans 500ms → idempotent, pas de duplicate
+3. A2 : profile triad incomplet → early return + breadcrumb (pas de notif schedulée)
+4. A3 : `taxSaving3a = -500` (overfunded) → J+7 skip avec log, pas de nag "tu laisses -500"
+5. A3 : scan insight présent mais `> 365d ancien` → J+30 nag fires (scan stale, re-scan demandé)
+6. A5 : LLM passe `fact_key='canton', fact_value='je vis à Sion avec 120k'` → `_coerce_fact_value` rejette AVANT log, return `[save_fact ÉCHEC]`
+7. A6 : profile `dateOfBirth = 2099-01-01` → ageOrNull null ET save_fact rejette en upstream (pas juste symptôme clampé)
+
+## Feature flags (rollback path)
+
+- **Backend** : `ENABLE_SAVE_FACT_REDACTION=true` (env var)
+- **Flutter** : `RemoteConfig.getBool('notifications.weekly_engagement_enabled', default: true)`
+- **Flutter** : `CoachMemory.persist_events=true` (fallback silencieux si crash schema)
+
+## Décision finale : ordre d'exécution
+
+1. **Hotfix P0 compliance** (save_fact PII) — 20 min — commit isolé sur feature/wave-a hotfix-save-fact-pii, PR séparée
+2. **Wave 0 walkthrough de vérité** — 90 min max — iPhone 17 Pro sim, golden Julien+Lauren, 12 flows AX tree + screenshots, livrable `.planning/walkthrough-0-verite/FINDINGS.md`
+3. **ADR-20260418-wave-order-daily-loop** — justifier réordonnancement B avant A
+4. **Wave B-prime** — home orchestrateur — 10-12h, PR feature/wave-b-home-orchestrateur → dev
+5. **Wave A-prime** — notifs wiring — 4h, PR feature/wave-a-notifs-wiring → dev
+6. Puis Wave C, D, E, F comme prévu
+
+## Impact sur roadmap
+
+ROADMAP.md à mettre à jour pour refléter ce réordonnancement. La roadmap reste 6 Waves (+ Wave 0 walkthrough + 1 hotfix P0), durée totale inchangée (~35-45h).

--- a/.planning/wave-a-notifs-wiring/PLAN.md
+++ b/.planning/wave-a-notifs-wiring/PLAN.md
@@ -1,0 +1,227 @@
+# PLAN — Wave A-MINIMAL : Scan event + deadline notifs only
+
+**Version** : 2 (post 3-panel review 2026-04-18, voir `REVIEW-PLAN.md`)
+**Branche** : `feature/wave-a-notifs-wiring` (créée depuis dev @ 91628ada post Wave B merge)
+**Durée estimée** : 2h30 (4 commits : A0 backend + A1 Dart event + A2 minimal schedule + A3 device)
+**PR cible** : `feature/wave-a-notifs-wiring` → `dev` (merge-commit)
+
+## Changelog v1 → v2
+
+3 panels ont tranché pour **Wave A-MINIMAL** :
+- Panel archi : `_idWeeklyRecap` n'existe pas (plan v1 factuellement faux), backend tests enum fermé
+- Panel adversaire : 5 bugs prod-bound dont B1 backend `coach_tools.py:470` rejette `event`
+- Panel iconoclaste : J+1/J+7/J+30 + weekly engagement = Duolingo-redéguisé, violation doctrine lucidité + ADR-20260419
+
+**Supprimés** : J+1/J+7/J+30 retention notifs, weekly engagement lundi 19h, RemoteConfig stub, ARB 6 langs new keys.
+**Conservés** : scan → CoachInsight event (valeur composée mémoire), 3a deadlines, tax deadlines, monthly check-in (services réels où user perd argent).
+
+## Goal
+
+1. Coach se souvient du scan LPP : quand Julien revient 3 jours après avoir scanné, le coach peut dire "tu as scanné ton certificat CPE mardi — on parle de rachat ?"
+2. Julien reçoit des rappels sur ses deadlines fiscales réelles (3a 31/12, tax 15/03) s'il n'a pas check-in ce mois.
+
+## Non-goals (explicites)
+
+- Retention notifs J+1/J+7/J+30 → killed ADR follow-up
+- Weekly engagement push lundi 19h → killed (pointe vers écran vide Wave C)
+- RemoteConfig flag → non nécessaire (pas de code kill-switchable dans cette Wave)
+- Sync events vers backend → v1 local-only
+- coach_narrative_service.dart 13 `profile.age` call-sites → Wave E
+- weekly_recap double consolidation → Wave E
+
+## Pre-flight validé
+
+| Pré-requis | État |
+|---|---|
+| `profile.ageOrNull` | ✓ Wave B 7a28fbeb |
+| save_fact PII | ✓ PRIV-07 583b5e6d |
+| Backend `CoachInsightRecord.insight_type` = `Column(String)` | ✓ accepte String libre, pas de migration |
+| Backend `coach_tools.py:470` save_insight enum | **BLOQUANT** : `["goal","decision","concern","fact"]`, doit accepter `event` — commit A0 |
+| Backend tests enum fermé | `test_profile_extractor.py:231`, `test_coach_tools_categories.py:309-315` — commit A0 |
+| IDs NotificationService | 7 IDs concrets : `_idCheckinMonthly=1000`, `_idCheckinReminder5d=1001`, `_idStreakProtection=2000`, `_id3aDeadlineBase=3000`, `_idTaxDeadlineBase=4000` |
+| `CoachMemoryService.hasInsight/hasEvent` | À ajouter dans A1 |
+
+## Les 4 commits atomiques
+
+### A0 — Backend `coach_tools.py` enum accepte `event` (15 min)
+
+**Finding** : Panel adversaire B1 — Anthropic API rejette tool_use `save_insight(type="event")` si schema enum ne contient pas `event`. Panel archi AJ-2 — tests backend asserts enum fermé.
+
+**Scope** :
+- `services/backend/app/services/coach/coach_tools.py:470` → dans `save_insight.input_schema.properties.type.enum`, ajouter `"event"`. Documenter dans description "event = structured event the user experienced (scan, life event)".
+- `services/backend/tests/test_coach_tools_categories.py:309-315` → update allowlist set to `{"goal", "decision", "concern", "fact", "event"}`.
+- `services/backend/tests/test_profile_extractor.py:231` → update assertion `{fact, decision, preference, concern}` → `{fact, decision, preference, concern, event}`.
+- `services/backend/app/services/rag/insight_embedder.py:37` → update doc comment to list 5 values.
+
+**Fichiers** :
+- `services/backend/app/services/coach/coach_tools.py`
+- `services/backend/tests/test_coach_tools_categories.py`
+- `services/backend/tests/test_profile_extractor.py`
+- `services/backend/app/services/rag/insight_embedder.py` (doc comment only)
+
+**Tests** :
+- Existing tests updated, pytest full coach/ privacy/ green.
+- New test in `test_coach_tools_categories.py` asserting `"event" in enum` for save_insight (regression guard).
+
+**Gate A0** : pytest `tests/coach/ tests/test_coach_tools_categories.py tests/test_profile_extractor.py tests/privacy/` → 100% green. Anthropic API CI test (if exists) passes with a mock `save_insight(type="event")` call.
+
+---
+
+### A1 — `InsightType.event` + scan → saveEvent non-pruned namespace (50 min)
+
+**Findings** :
+- Panel simulation : `document_impact_screen.dart` n'appelle pas saveInsight — coach ne peut jamais référencer le scan
+- Panel adversaire B5 : FIFO 50 évince le scan event après ~1 semaine d'activité (claude_coach_service.py system prompt ordonne save_insight à chaque info clé)
+- Panel archi AJ-2 : events local-only (pas de sync backend) = simplification
+
+**Scope** :
+- `apps/mobile/lib/models/coach_insight.dart:24-36` → add `event` to `InsightType` enum after `fact`
+- `apps/mobile/lib/services/memory/coach_memory_service.dart` :
+  - New private key `_eventsKeyFor(userId) => '_coach_events_$userId'`
+  - New `saveEvent(String topic, String summary, {DateTime? date})` — persist to `_coach_events_$uid` SharedPreferences list, no pruning, dedup by (topic + date-day)
+  - New `hasEvent(String topic, {int maxAgeDays = 365})` — read list, return true if any matching topic within age
+- `apps/mobile/lib/screens/document_scan/document_impact_screen.dart` :
+  - After `_fetchPremierEclairage` returns success (regardless of whether eclairage itself is non-empty), call `CoachMemoryService.saveEvent(topic: 'scan_lpp', summary: _buildSummary(profile))`
+  - `_buildSummary` returns `'{caisse} — {avoirFormatted} CHF'` with fallbacks for null caisse/avoir ("certificat LPP scanné — caisse inconnue" or "...avoir inconnu")
+- Do NOT sync events to backend (flag `syncToBackend=false`). v1 local-only. Documented in saveEvent.
+
+**Fichiers** :
+- `apps/mobile/lib/models/coach_insight.dart`
+- `apps/mobile/lib/services/memory/coach_memory_service.dart`
+- `apps/mobile/lib/screens/document_scan/document_impact_screen.dart`
+
+**Tests** :
+- `test/models/coach_insight_event_test.dart` : enum round-trip event → event, orElse fallback `fact` for unknown
+- `test/services/memory/coach_memory_event_test.dart` :
+  - saveEvent → hasEvent(topic, maxAgeDays=30) true
+  - saveEvent 2× same topic same day → 1 stored (dedup)
+  - saveEvent 400 days ago → hasEvent(topic, maxAgeDays=365) false
+  - fact insights don't show up in hasEvent queries (namespace isolation)
+  - pushing 100 fact insights doesn't evict events (separate FIFO)
+- `test/screens/document_scan/document_impact_event_save_test.dart` : widgetTest scan success → saveEvent called once with correct topic
+
+**Gate A1** : flutter analyze 0 new issues, 10+ new tests green, device walkthrough scan → local storage has event entry.
+
+---
+
+### A2 — `scheduleCoachingReminders` wired (minimal set) (75 min)
+
+**Findings** :
+- Panel archi AJ-1 : liste 7 IDs concrets (pas `_idWeeklyRecap` fictif), `_cancelCoachingIds()` helper
+- Panel adversaire B2+B3 : `_markOnboardingCompletedIfNeeded` fire ONCE, save_fact re-trigger nécessaire via CoachProfileProvider listener
+- Panel iconoclaste : garder uniquement deadlines + monthly check-in (services), kill retention + weekly engagement
+
+**Scope** :
+- `apps/mobile/lib/services/notification_service.dart` :
+  - Remove `cancelAll()` call in `scheduleCoachingReminders` (line 309), replace with `_cancelCoachingIds()`:
+    ```dart
+    Future<void> _cancelCoachingIds() async {
+      if (_plugin == null) return;
+      await _plugin!.cancel(_idCheckinMonthly);
+      await _plugin!.cancel(_idCheckinReminder5d);
+      await _plugin!.cancel(_idStreakProtection);
+      for (int i = 0; i < 4; i++) await _plugin!.cancel(_id3aDeadlineBase + i);
+      for (int i = 0; i < 3; i++) await _plugin!.cancel(_idTaxDeadlineBase + i);
+    }
+    ```
+  - Remove calls to `_scheduleWeeklyRecap` and any retention scheduling inside `scheduleCoachingReminders`
+  - Keep : `_scheduleMonthlyCheckin(profile, now, s)` + `_schedule3aDeadlines(profile, now, s)` + `_scheduleTaxDeadlines(now, s)`
+  - Add triad gate at top (after consent check):
+    ```dart
+    if (profile.birthYear < 1900 ||
+        profile.canton.isEmpty ||
+        profile.salaireBrutMensuel <= 0) {
+      logger.info('scheduleCoachingReminders skipped: incomplete triad');
+      return;
+    }
+    ```
+- `apps/mobile/lib/app.dart` :
+  - In MultiProvider tree, after `CoachProfileProvider`, add a `_NotificationsWiringObserver` widget or Consumer that listens to profile changes, debounces 500ms, and calls `NotificationService.scheduleCoachingReminders(profile)` when triad transitions false→true
+  - Pattern : `Consumer<CoachProfileProvider>` with `builder` that calls via WidgetsBinding.instance.addPostFrameCallback + debouncer service instance
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart:252` : keep existing `_markOnboardingCompletedIfNeeded` call to schedule (defensive redundant wiring for onboarding intent path)
+- NO new ARB keys (existing 3a/tax/checkin localization already shipped)
+
+**Fichiers** :
+- `apps/mobile/lib/services/notification_service.dart` (refactor)
+- `apps/mobile/lib/app.dart` (add listener wiring)
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart` (light edit to ensure call path)
+
+**Tests** :
+- `test/services/notification_triad_gate_test.dart` :
+  - profile birthYear=0 → schedule short-circuit, no plugin calls
+  - profile canton='' → short-circuit
+  - profile salaireBrut=0 → short-circuit
+  - triad complete → `_cancelCoachingIds` called + `_scheduleMonthlyCheckin` + `_schedule3aDeadlines` + `_scheduleTaxDeadlines` called
+- `test/services/notification_cancel_per_id_test.dart` :
+  - Before refactor : mock plugin records cancelAll called
+  - After refactor : mock plugin records 3 + 4 + 3 cancel(id) calls (10 total), not cancelAll
+  - Commitments/freshStarts scheduled separately remain after re-schedule (regression guard against cancelAll regression)
+- `test/app/coach_profile_listener_reschedule_test.dart` :
+  - Mount MultiProvider, CoachProfileProvider with triad incomplete, advance time 500ms → no schedule
+  - Update profile (save_fact canton) → triad complete → after 500ms debounce, schedule called
+  - Update profile again (irrelevant field like `nombreEnfants`) → no re-schedule (triad already scheduled signature unchanged)
+
+**Gate A2** : flutter analyze 0 new issues, new tests green, cap_engine existing tests unchanged (57 pass), home_gate_contract tests green.
+
+---
+
+### A3 — Device walkthrough + commit + PR (20 min)
+
+**Procedure** :
+- Build iOS sim staging
+- Fresh install anonymous
+- Open coach, tap CTA Parle à Mint
+- Via coach : "j'ai 49 ans, je vis à Sion, je gagne 122 000 brut par an" → 3× save_fact
+- Verify via logger/Sentry breadcrumb that `scheduleCoachingReminders` fired after 3rd save_fact (500ms debounce)
+- Tap tab Aujourd'hui → cap banner visible (Wave B)
+- Navigate to `/scan`, trigger mock scan or bypass via debug menu
+- Verify SharedPreferences key `_coach_events_${userId}` has scan_lpp entry
+- Exit + reopen app → verify notifications are scheduled (iOS simctl: `xcrun simctl spawn <udid> notifyutil -d` or similar)
+- AX tree capture + 2 screenshots (scan debrief + home with cap)
+
+**Commit + push + PR** :
+- Final commit for any last polish
+- `gh pr create --base dev --head feature/wave-a-notifs-wiring` with full description
+- Wait CI green, merge merge-commit
+- Update MEMORY.md handoff
+
+**Gate A3** : PR CI 10/10 green, device walkthrough validated, memory updated.
+
+---
+
+## Gates mécaniques sortie Wave A-MINIMAL (16 points)
+
+1-14 : (hérités Wave B) flutter analyze / tests / ARB / CI / banned / sentinels / catch / façade / device / MEMORY.md / no_chiffre_choc / OpenAPI / regression
+15. **Triad gate contract** : profile incomplet → 0 schedule fired + log
+16. **Backend enum extended** : save_insight type='event' accepted + tests regenerated
+
+## Risques résiduels
+
+| Risque | Mitigation |
+|---|---|
+| CoachProfileProvider listener cascade rebuilds | debounce 500ms + track last-scheduled-triad signature (skip if unchanged) |
+| saveEvent 2× same scan same day | dedup dans saveEvent (topic+date-day) |
+| A0 merge before A1 Dart for Anthropic CI compat | A0 + A1 dans **même PR**, même commit tête (A0) → gate "backend tests pass" avant A1 push |
+| `_cancelCoachingIds` oublie un ID | test enumère explicitement les 7 expected cancels + regression guard "no cancelAll" |
+| Device walkthrough sans time-travel | logger/Sentry breadcrumb suffit pour valider l'appel, algo testé en unit |
+| iOS Background Refresh disabled | fallback log explicite, doc dans commit message |
+
+## Verification plan (goal-backward)
+
+**Goal** : Julien fresh install → ouvre coach → save_fact age/canton/salaire via conversation → scheduleCoachingReminders fire automatiquement (via CoachProfileProvider listener debounce) → 31 déc approche, notif "Ton 3a : dernier jour" fire. 15 mars approche, notif tax fire. Le 1er de chaque mois, check-in reminder fire.
+
+En parallèle : Julien scanne certificat CPE → saveEvent persisté dans `_coach_events_` local storage → 3 jours plus tard coach ouvert → `hasEvent(scan_lpp, 30d)` true → coach peut référencer "tu as scanné hier" dans réponse (via `retrieve_memories` tool backend, si sync-backend enabled plus tard; pour v1 local-only, l'event vit dans le profil mobile et peut informer coach via context).
+
+Si tous commits shipped + gates green + device walkthrough réussi → goal atteint.
+
+## Post Wave A-MINIMAL
+
+- Merge → dev merge-commit
+- MEMORY.md handoff : "Wave A-MINIMAL shipped, deadlines + scan event only, retention/weekly killed"
+- Observer 14 jours, collecter signal Julien
+- Si besoin : Wave A' ajouter retention avec contenu net personnalisé
+- Démarrer Wave C (scan handoff coach + suggestion chip regex)
+
+## ADR follow-up à rédiger
+
+- `ADR-20260419-killed-retention-notifs.md` : kill J+1/J+7/J+30 retention + weekly engagement. Same doctrine : ADR-20260419 tué Duolingo layers, ADR follow-up confirme retention nag = registre doublon. Services (`NotificationService.scheduleRetentionNotifications`, `_scheduleWeeklyEngagementPing`) conservés en code mais non-câblés home/coach.

--- a/.planning/wave-a-notifs-wiring/REVIEW-PLAN.md
+++ b/.planning/wave-a-notifs-wiring/REVIEW-PLAN.md
@@ -1,0 +1,136 @@
+# REVIEW-PLAN — Wave A-prime : consolidation 3 panels
+
+**Date** : 2026-04-18
+**Panels** : Architecture (Stripe/Flutter Google/fintech mobile), Adversaire ("200 IQ autistic"), Iconoclaste (Arc/Things 3/Swiss fintech)
+
+## Verdicts bruts
+
+| Panel | Verdict | Angle |
+|---|---|---|
+| Architecture | REWORK (3 ajustements, 1 bloquant `_idWeeklyRecap`) | Factuel : IDs réels, backend tests enum fermé, time-travel iOS |
+| Adversaire | REWORK (5 bugs prod bound) | B1 backend coach_tools.py:470 rejette event, B2+B3 save_fact ne re-trigger pas, B4 null precedence, B5 FIFO 50 évincé |
+| Iconoclaste | Wave A-MINIMAL 3 commits (kill retention + weekly engagement) | Doctrine : Things 3 philosophy, ADR-20260419 pareil registre, Wave B weekly_recap différé Wave C |
+
+**Verdict consolidé** : **Wave A-MINIMAL 3 commits**. Les 3 panels convergent : tuer J+1/J+7/J+30/weekly engagement résout simultanément les findings techniques ET les findings doctrine.
+
+## Matrice des enjeux
+
+| Enjeu | Archi | Adversaire | Iconoclaste |
+|---|---|---|---|
+| `_idWeeklyRecap` inventé dans plan | ✗ bloquant | — | — |
+| Backend coach_tools.py:470 enum ferme event | — | ✗ B1 bloquant Anthropic reject | — |
+| Backend tests enum fermé (test_profile_extractor, test_coach_tools_categories) | ✗ AJ-2 | ✗ B1 | — |
+| `_markOnboardingCompletedIfNeeded` fire once, save_fact ne re-trigger pas | — | ✗ B2+B3 gros gap | — |
+| `taxSaving3a` null precedence bug | — | ✗ B4 runtime crash | — |
+| FIFO 50 évinçage scan event en 1 semaine | ✗ AJ-3 indirect | ✗ B5 | — |
+| Time-travel iOS impossible pour tester J+N | ✗ AJ-3 | — | — |
+| ARB 6 langs weekly engagement piège | — | ✗ piège Claude | ✗ supprime le besoin |
+| J+7 "tax nag" = Cleo cliché | — | — | ✗ KILL |
+| Weekly engagement lundi 19h = Duolingo registre | — | — | ✗ KILL (doublon J+7) |
+| J+30 re-scan nag = calendrier arbitraire | — | — | ✗ KILL |
+| Scan → CoachInsight event | ✓ garder | ✓ garder (avec namespace fix) | ✓ garder ABSOLU |
+| Deadlines 3a + tax + monthly check-in | ✓ garder | ✓ garder | ✓ garder (services réels) |
+
+## Décisions architecturales tranchées
+
+### D1 — Wave A redéfinie : **Wave A-MINIMAL** (3 commits, ~2h30)
+
+**Garde** :
+- A0 : backend `coach_tools.py:470` enum + tests — résout B1 adversaire
+- A1 : `InsightType.event` Dart + scan → saveInsight **namespace dédié** (`_coach_events_` SharedPreferences key, non-FIFO) — résout B5 adversaire
+- A2 : `scheduleCoachingReminders` wired avec UNIQUEMENT 3a + tax + monthly check-in, triad gate + `CoachProfileProvider` listener, `cancel(id)` per-ID sur les 7 IDs connus
+
+**Kill/Defer** :
+- `_scheduleWeeklyEngagementPing` → **kill** (Duolingo registre, pointe vers écran vide)
+- `scheduleRetentionNotifications(J+1/J+7/J+30)` → **kill** (Cleo guilt marketing, manque-à-gagner déjà dans home Wave B)
+- ARB 6 langs weekly engagement keys → **supprimé** (pas de clé ajoutée)
+- RemoteConfig feature flag A4 → **kill** (rien à flagger)
+- A3 scheduleRetentionNotifications → **kill**
+- Wave A5 device walkthrough → **garde**, reduit en A3
+
+### D2 — Backend enum `event` — AVANT A1 Dart
+
+Sinon Anthropic API rejette `save_insight(type="event")` tool_use call. Séquence obligatoire : **commit backend A0 MERGE FIRST via PR séparée OR inclure dans A0 commit tête de cette PR** avec :
+- `services/backend/app/services/coach/coach_tools.py:470` → ajouter `"event"` à save_insight input_schema enum
+- `services/backend/tests/test_coach_tools_categories.py:309-315` → update assert set
+- `services/backend/tests/test_profile_extractor.py:231` → update allowlist
+
+### D3 — Event insights hors FIFO 50
+
+`CoachMemoryService` nouvelle méthode `saveEvent(topic, summary, date)` + `hasEvent(topic, maxAgeDays)` qui utilisent SharedPreferences key `_coach_events_${uid}` sans pruning. Les events sont rares et structurants (scan LPP, EPL, achat immo) — ne doivent pas être écrasés par bavardage `fact`.
+
+**Flag `syncToBackend=false` pour events** : panel archi AJ-2 — events = local-only pour v1. Évite cascade de fix tests backend + endpoint `/coach/sync-insight` validator. Peut migrer plus tard si besoin.
+
+### D4 — `CoachProfileProvider` listener pour reschedule
+
+Panel adversaire B2+B3 : save_fact flow doit re-trigger `scheduleCoachingReminders` quand triad passe incomplet → complet. Solution : provider top-level dans app.dart écoute `CoachProfileProvider`, quand triad change de false→true appelle `NotificationService().scheduleCoachingReminders(profile)` avec debounce 500ms.
+
+Pattern : dans `app.dart` MultiProvider, ajouter un `_NotificationsWiringObserver` qui fait `context.read<CoachProfileProvider>()`.addListener avec check triad.
+
+### D5 — `cancel(id)` per-ID spec corrigée (AJ-1 archi)
+
+7 IDs coaching à cancel (confirmés code) :
+- `_idCheckinMonthly = 1000`
+- `_idCheckinReminder5d = 1001`
+- `_idStreakProtection = 2000`
+- `_id3aDeadlineBase = 3000` (+ offsets 0-3 pour 4 dates) → boucle `3000..3003`
+- `_idTaxDeadlineBase = 4000` (+ offsets 0-2 pour 3 dates) → boucle `4000..4002`
+
+Fonction helper `_cancelCoachingIds()` qui cancel ces ranges. Pas de `_idWeeklyRecap` (le plan précédent l'avait inventé). Pas de cancel des `_idCommitmentBase=5000` / `_idFreshStartBase=6000` / retention 9001/7/30 puisqu'on les abandonne dans cette Wave.
+
+### D6 — Time-travel iOS impossible (AJ-3 archi)
+
+Le walkthrough ne peut PAS attendre 24h. Solution : tests unit TZDateTime calc vérifient que l'algo de scheduling est correct, walkthrough vérifie seulement que `scheduleCoachingReminders` est APPELÉE après triad (via `logger.info` + Sentry breadcrumb + debug mode flag pour reduce days→minutes).
+
+## Plan final Wave A-MINIMAL (3 commits, ~2h30)
+
+**A0 — Backend save_insight enum accepte `event`** (15 min)
+- `coach_tools.py:470` add `"event"` à input_schema.enum
+- `test_coach_tools_categories.py:309-315` update allowlist
+- `test_profile_extractor.py:231` update allowlist
+- Pytest green → merge
+
+**A1 — Dart InsightType.event + scan → saveEvent non-pruned** (50 min)
+- `coach_insight.dart` add `InsightType.event`
+- `coach_memory_service.dart` new `saveEvent(topic, summary, date)` + `hasEvent(topic, maxAgeDays)` using `_coach_events_${uid}` prefs key, no pruning
+- `document_impact_screen.dart` post-scan success → `saveEvent(topic='scan_lpp', summary='{caisse} — {avoir} CHF')`
+- Skip `syncToBackend` for events — local-only v1
+- Tests : enum round-trip + scan → event persisté + hasEvent freshness
+
+**A2 — scheduleCoachingReminders wired (minimal set)** (75 min)
+- Delete `_scheduleWeeklyRecap` + retention calls from `scheduleCoachingReminders`
+- Keep only : `_scheduleMonthlyCheckin` + `_schedule3aDeadlines` + `_scheduleTaxDeadlines`
+- Replace `cancelAll()` → `_cancelCoachingIds()` helper with 7 IDs per D5
+- Triad gate early return if `birthYear < 1900 || canton.isEmpty || salaireBrutMensuel <= 0`
+- New listener in `app.dart` on `CoachProfileProvider` with debounce 500ms : if triad change false→true → schedule
+- Also `_markOnboardingCompletedIfNeeded` keeps schedule call (defensive redundant)
+- ARB : aucune nouvelle clé (deadline strings existent déjà)
+- Tests : triad gate, idempotence 3× rapid, cancel-per-ID scope
+
+**A3 — Device walkthrough + commit + PR** (20 min)
+- Build iOS sim staging
+- Fresh install, save_fact triad via coach
+- Verify breadcrumb "scheduled 3a/tax/checkin" via logger + AX tree
+- Scan document → verify saveEvent → hasEvent returns true
+- Commit final, push, create PR
+
+## Gates mécaniques sortie (16 points)
+
+1-14. (inchangés Wave B) : flutter analyze / tests / ARB / CI / banned / sentinels / catch / façade / device / MEMORY.md / no_chiffre_choc / OpenAPI / regression
+15. **Triad gate test** : profile sans birthYear/canton/salaire → 0 schedule, log explicite
+16. **Backend enum test** : save_insight type='event' round-trip OK, tests regenerated
+
+## Risques résiduels
+
+| Risque | Mitigation |
+|---|---|
+| CoachProfileProvider listener boucle sur notifyListeners | debounce 500ms + track last-scheduled-triad signature |
+| saveEvent 2× même scan | dedup check dans saveEvent (topic+source) |
+| Backend enum A0 timing | merge A0 PR AVANT A1 commit dans CI — ou inclure A0 en tête de même PR avec backend test suite green gate |
+| device walkthrough sans time-travel | breadcrumb log suffit, unit tests couvrent algo |
+
+## Post Wave A-MINIMAL
+
+- Merge → dev
+- Observer 14 jours ; si Julien signale "je veux plus de rappels" → Wave A' ajoute retention avec contenu net (pas "On a calculé quelque chose")
+- Wave C enchaîne : scan handoff coach + suggestion chip regex

--- a/.planning/wave-b-home-orchestrateur/PLAN.md
+++ b/.planning/wave-b-home-orchestrateur/PLAN.md
@@ -1,0 +1,215 @@
+# PLAN — Wave B-prime : Home "Aujourd'hui" orchestrateur (MINIMAL)
+
+**Version** : 2 (post 3-panel review 2026-04-18, voir `REVIEW-PLAN.md`)
+**Branche** : `feature/wave-b-home-orchestrateur` (à créer depuis dev après merge PR #353)
+**Base prévue** : `dev` + PRIV-07 hotfix mergé
+**Durée estimée** : 6-7h (4 commits atomiques)
+**PR cible** : `feature/wave-b-home-orchestrateur` → `dev` (merge-commit)
+
+## Changelog v1 → v2
+
+Les 3 panels review ont tranché :
+- **Panel archi** : SPLIT (B-prime-1 + B-prime-2), prereq A2 MintStateProvider proxy, B6 scope étendu à CapEngine (10 call-sites)
+- **Panel adversaire** : 5 bugs prod (logout, JITAI I/O loop, weekly API divergence, CapEngine age, Milestone timing)
+- **Panel iconoclaste** : Wave B-MINIMAL 3-commit. KILL B2/B3/B5 (violations doctrine lucidité / territoire Cleo / registre Duolingo). Defer B4 → Wave C, B6-étendu + B7 → Wave E.
+
+Convergence : **Wave B ship uniquement B0 + B1 + B6-minimal** avec garde-fous archi (proxy, range check) et adversaire (CapEngine migration age). Ship-and-observe 5 jours avant Wave B'.
+
+## Goal
+
+Le tab Aujourd'hui passe de **landing redirect pour non-logged** à **écran vivant avec cap du jour dynamique**.
+
+Non-goals explicites (deferred) :
+- JITAI nudges → ADR "killed for doctrine violation" + service conservé en code
+- MilestoneCelebrationSheet → ADR "killed for doctrine violation"
+- StreakService → ADR "killed for doctrine violation"
+- WeeklyRecap → Wave C (après event plumbing scan→coach)
+- Widgets secondaires `profile.age` migration (25+ call-sites coach_narrative, etc.) → Wave E
+- Orphan providers delete (UserActivity/ContextualCard/CoachEntryPayload) → Wave E
+- Goldens 4 profils → Wave F (1 golden Julien post-commit suffit)
+
+## Les 4 commits atomiques
+
+### B0 — Unblock tab Aujourd'hui + empty-state partial-onboarded (1.5h)
+
+**Problème** :
+- `app.dart:336-338` → `auth.isLoggedIn ? AujourdhuiScreen : LandingScreen`
+- `AuthProvider.dart:87` comment intent `isLoggedIn || isLocalMode`
+- Wave 0 walkthrough : fresh anonymous → tap tab Aujourd'hui → landing redirect
+- Panel archi A5 : profile vide → écran presque vide, friction UX honnête
+
+**Fix** :
+- `app.dart:336-338` : remplacer par `return (auth.isLoggedIn || auth.isLocalMode) ? AujourdhuiScreen : LandingScreen`
+- `AujourdhuiScreen` : ajouter widget empty-state "Pour commencer" visible si `profile.confidence < 0.3` avec 3 CTA : Scanner un doc / Parle au coach / Complète ton profil
+- Empty-state auto-hide dès confidence ≥ 0.3
+- Cold launch reste `initialLocation: '/'` → LandingScreen (panel iconoclaste : "Wave 0 findings = tab cassé, pas cold launch")
+
+**Fichiers** :
+- `apps/mobile/lib/app.dart:336-338`
+- `apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart` (ajout section empty-state)
+- `apps/mobile/lib/widgets/aujourdhui/partial_onboarded_empty_state.dart` (nouveau)
+
+**Tests** :
+- `test/app_routing_home_gate_test.dart` (nouveau) :
+  - `isLoggedIn=false, isLocalMode=true` → AujourdhuiScreen rendered (pas landing)
+  - `isLoggedIn=false, isLocalMode=false` → LandingScreen rendered
+  - Logout scenario (isLoggedIn=true puis logout) → `auth_local_mode=false` persisted, router → Landing
+  - Profile confidence=0.1 → empty-state widget visible
+  - Profile confidence=0.5 → empty-state widget hidden
+
+**Gate B0** : Tests passants, fresh install tap tab Aujourd'hui → AujourdhuiScreen + empty-state CTA visible.
+
+---
+
+### B6-minimal — `profile.ageOrNull` + CapEngine migration + backend range check (2h)
+
+**Problème** :
+- Panel archi R1 : `CoachProfile.age` clamp à 0 sur invalid birthYear, 30+ call-sites consomment sans guard
+- Panel adversaire BUG 4 : CapEngine.dart a 10 `profile.age` (lignes 150, 192, 224, 274, 288, 318, 358, 569, 926, 1139). Age=0 sentinel fait silencieusement `age >= 45 → false`, supprime lpp_buyback cap pour 48yo sans birthYear. **B1 shippe un cap du jour silencieusement faux si B6 pas fait avant.**
+- Panel archi A3 : backend `_coerce_fact_value` (coach_chat.py:1004) n'a aucun range check numérique, `save_fact birthYear=2099` persiste silencieusement
+
+**Fix** :
+- `CoachProfile.ageOrNull` getter returns `int?` (null si birthYear/dateOfBirth invalides/absents/futurs)
+- `cap_engine.dart` 10 call-sites migrent vers `profile.ageOrNull` :
+  - Si `ageOrNull == null` → la règle concernée SKIP avec log `logger.info('cap rule X skipped: age unknown')`
+  - Le cap fallback "Parle-moi de toi" devient prioritaire si règles âge-dépendantes skipped
+- `services/backend/app/api/v1/endpoints/coach_chat.py:_coerce_fact_value` :
+  - `if key == "birthYear": if value < 1900 or value > currentYear + 1: return None`
+  - Même pattern pour `spouseBirthYear`, `dateOfBirth` (YYYY-MM-DD range check)
+- 5 simulateurs bloquants (libre_passage / provider_comparator / rachat_echelonne / independant / ijm) migrent aussi vers `ageOrNull` + bannière "Âge inconnu — complète ton profil" (reporté d'original plan v1 B6, scope restant car prereq direct B1)
+
+**Fichiers** :
+- `apps/mobile/lib/models/coach_profile.dart` (ageOrNull getter)
+- `apps/mobile/lib/services/cap_engine.dart` (10 call-sites)
+- `apps/mobile/lib/screens/pillar_3a_deep/provider_comparator_screen.dart:49`
+- `apps/mobile/lib/screens/rachat_echelonne_screen.dart:186` (vérifier path exact)
+- `apps/mobile/lib/screens/independant_screen.dart:68`
+- `apps/mobile/lib/screens/ijm_screen.dart:45`
+- `apps/mobile/lib/screens/libre_passage_screen.dart` (path à vérifier)
+- `services/backend/app/api/v1/endpoints/coach_chat.py:_coerce_fact_value`
+
+**Tests** :
+- `test/models/coach_profile_age_null_test.dart` :
+  - birthYear=null → ageOrNull=null
+  - birthYear=2099 → ageOrNull=null (future)
+  - birthYear=1800 → ageOrNull=null (too old)
+  - birthYear=1977 → ageOrNull=49
+  - dateOfBirth="2099-01-01" → ageOrNull=null
+- `test/services/cap_engine_age_skip_test.dart` :
+  - profile ageOrNull=null → règles age-dependent skip, cap fallback "Parle-moi de toi" returned
+  - profile ageOrNull=49 → règles normales (ex: lpp_buyback priorisé pour Julien)
+- `services/backend/tests/test_save_fact_birthYear_range.py` :
+  - save_fact birthYear=2099 → None returned, not persisted
+  - save_fact birthYear=1800 → None returned
+  - save_fact birthYear=1977 → persisted
+- Widget tests 5 simulateurs : profile sans âge → bannière "Âge inconnu" visible
+
+**Gate B6-minimal** : flutter analyze 0 err, nouveaux tests green, 5 simulateurs + CapEngine gracieux sans âge, backend birthYear 2099 rejeté.
+
+---
+
+### A2+B1 — MintStateProvider proxy + CapEngine top banner (2.5h)
+
+**Problème** :
+- Panel archi R1 : `MintStateProvider` est `ChangeNotifierProvider` plain (`app.dart:1251`), pas proxy sur `CoachProfileProvider`. `mint_state_engine.currentCap` cached mais jamais refresh sur profile change. Si user save_fact canton=VS → cap stale (ZH fallback).
+- Panel daily-loop : home affiche 3 TensionCards statiques + pas de cap du jour. CapEngine (1333 lignes) jamais branché home.
+
+**Fix** :
+- `app.dart` : convertir `ChangeNotifierProvider<MintStateProvider>` en `ChangeNotifierProxyProvider<CoachProfileProvider, MintStateProvider>` avec `update: (ctx, profileProv, state) => state!..recompute(profileProv.profile)`
+- `AujourdhuiScreen` : ajouter `SliverToBoxAdapter` top banner "Cap du jour" qui `context.watch<MintStateProvider>()` et affiche `state.currentCap`
+- Nouveau widget `CapDuJourBanner` réutilisable :
+  - Titre (icon + label cap)
+  - 1 ligne description (`cap.message`)
+  - 1 CTA vers route (`cap.routeHint` ex: `/rachat-lpp`)
+  - Fallback si `currentCap == null` : "Aide-moi à mieux t'aiguiller. Parle-moi de toi."
+- Position sur home : au-dessus des TensionCards existantes (garde TensionCards en place, additif pur)
+
+**Fichiers** :
+- `apps/mobile/lib/app.dart:1251` (proxy provider conversion)
+- `apps/mobile/lib/providers/mint_state_provider.dart` (vérifier `recompute` existe, sinon ajouter)
+- `apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart` (nouveau SliverToBoxAdapter cap banner)
+- `apps/mobile/lib/widgets/aujourdhui/cap_du_jour_banner.dart` (nouveau)
+
+**Tests** :
+- `test/providers/mint_state_provider_proxy_test.dart` (nouveau) :
+  - Init → recompute called with initial profile
+  - CoachProfileProvider.notifyListeners() → recompute called again with new profile
+  - Stale cap scenario : save_fact canton=VS → currentCap refreshed (prouve R1 fixé)
+  - Concurrent recompute (10 notifyListeners rapid) → final state matches last profile
+- `test/widgets/aujourdhui/cap_du_jour_banner_test.dart` (nouveau) :
+  - Profile Julien (VS 49 LPP 70k) → cap `lpp_buyback` ou `pillar_3a` affiché
+  - Profile fresh anonymous → fallback "Parle-moi de toi"
+  - Tap CTA → navigation vers `/rachat-lpp` via GoRouter (mock)
+- Golden test `aujourdhui_julien_golden.dart` (1 seul pour Wave B-minimal, les 3 autres profils en Wave F)
+
+**Gate A2+B1** : flutter analyze 0 err, stale cap test green, golden test Julien pass, device walkthrough home Julien → cap `lpp_buyback` visible + CTA fonctionne.
+
+---
+
+### B-ship — Device walkthrough + PR (0.5h)
+
+**Procedure** :
+- Build iPhone 17 Pro sim staging : `flutter build ios --simulator --debug --no-codesign --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1`
+- Install + launch
+- Scenarios :
+  1. Cold launch → LandingScreen (inchangé)
+  2. Tap CTA "Parle à Mint" → choice-of-tone + coach chat
+  3. Tap tab Aujourd'hui → **AujourdhuiScreen avec empty-state CTA** (pas landing redirect — prouve B0)
+  4. Manuellement save_fact via coach : "j'ai 49 ans, je vis à Sion avec 122k CHF brut, LPP 70k" → attendre 3-5 save_fact
+  5. Tap tab Aujourd'hui → cap du jour banner visible avec cap `lpp_buyback` ou `pillar_3a` (prouve A2+B1 + B6-minimal)
+  6. Tap cap CTA → navigation vers simulateur cible
+- AX tree ≤ 3 screenshots : empty-state, cap banner Julien, cap banner fresh
+- Log dans `.planning/wave-b-home-orchestrateur/EXECUTION-LOG.md` + findings dans `.planning/wave-b-home-orchestrateur/DEVICE-WALKTHROUGH.md`
+
+**PR creation** :
+- `gh pr create --base dev --head feature/wave-b-home-orchestrateur` avec description narrative :
+  - Wave B-minimal : 4 commits, ship-and-observe
+  - Refs : REVIEW-PLAN.md (3 panels) + ADR-20260418-wave-order-daily-loop
+  - Post-merge : 5 jours observation + ADR-20260419 killed layers (B2/B3/B5)
+- Attendre CI 10/10 green, merge merge-commit
+
+**Gate B-ship** : CI green, PR mergée, MEMORY.md handoff updated.
+
+---
+
+## Gates mécaniques sortie Wave B-minimal (17 points)
+
+1-14. (inchangés de Wave A) : flutter analyze / tests / ARB / CI / banned / sentinels / catch / façade / device walkthrough / MEMORY.md / no_chiffre_choc / OpenAPI / Alembic / Regression baseline
+15. **Logout regression test** : fresh login → logout → router → LandingScreen (auth_local_mode=false persisté)
+16. **MintStateProvider refresh test** : save_fact canton=VS → currentCap refreshed
+17. **Empty-state partial-onboarded** : profile.confidence<0.3 → CTA visible + no crash
+
+## Risques identifiés
+
+| Risque | Mitigation | Source |
+|---|---|---|
+| B0 fix casse logout (BUG 1 adversaire) | Test explicite logout + fallback defensive si purge ratée | Panel adversaire |
+| R1 CapEngine stale cache | A2 proxy provider (B1 prereq) | Panel archi |
+| CapEngine age=0 silencieux (BUG 4) | B6-minimal migration 10 call-sites cap_engine.dart + skip-with-log | Panel adversaire |
+| Backend birthYear=2099 (A3) | _coerce_fact_value range check | Panel archi |
+| LandingScreen code mort | Iconoclaste prouve que cold launch reste Landing — pas besoin de flag | Panel iconoclaste |
+| Empty-state widget sur fresh → écran vide | Empty-state avec 3 CTA concrets (scan, coach, profile) | Panel archi A5 |
+| Scope creep Wave B-minimal | Strict 4 commits, ADR follow-up pour tout kill | Panel iconoclaste |
+
+## Verification plan (goal-backward)
+
+**Goal Wave B-minimal** : Julien (après PRIV-07 mergé + Wave B-minimal mergé) ouvre MINT pour la 3e fois (profile chargé avec canton+age+salaire+LPP). Il tape tab Aujourd'hui. Voit :
+1. Un écran vivant AujourdhuiScreen (pas landing)
+2. Banner cap du jour : "Ton rachat LPP max ~539k CHF. En VS, 50k/an économise ~13k d'impôts. Tu veux simuler ?" + CTA `/rachat-lpp`
+3. Timeline en bas avec ses commitments/scans passés
+
+Si tap CTA → simulateur avec prefill profile → math correct.
+
+Si profile est encore vide → empty-state "Pour commencer" avec 3 CTA clairs.
+
+## Après Wave B-minimal
+
+- Merge → dev via merge-commit
+- MEMORY.md handoff : "Wave B-minimal shipped (4 commits), home vivant, cap du jour fonctionnel"
+- 5 jours observation via device Julien
+- Rédiger `ADR-20260419-killed-gamification-layers.md` : justification doctrine lucidité incompatible avec JITAI creepy / Milestone Duolingo / Streak Duolingo
+- Décision Wave B' : enrichissements selon signal Julien réel OU sauter directement Wave A-prime (notifs wiring)
+
+## ADR follow-up (post-Wave-B)
+
+- `ADR-20260419-killed-gamification-layers.md` : kills B2 JITAI creepy triggers, B3 MilestoneCelebrationSheet, B5 StreakService visibility. Justification panel iconoclaste + doctrine pivot 2026-04-12 "lucidité pas protection/dopamine". Services conservés en code (réutilisation potentielle autres contextes), mais non-câblés home.

--- a/.planning/wave-b-home-orchestrateur/REVIEW-PLAN.md
+++ b/.planning/wave-b-home-orchestrateur/REVIEW-PLAN.md
@@ -1,0 +1,125 @@
+# REVIEW-PLAN — Wave B-prime : consolidation 3 panels
+
+**Date** : 2026-04-18
+**Panels** : Architecture (Stripe/Flutter Google/fintech mobile), Adversaire ("200 IQ autistic"), Iconoclaste (Arc/Things 3/Swiss fintech)
+
+## Verdicts bruts
+
+| Panel | Verdict | Position |
+|---|---|---|
+| Architecture | **SPLIT** (B-prime-1 + B-prime-2) + 2 REWORKS | Scope trop large, B0 sémantique fragile, CapEngine stale cache R1, test weekly_recap R2 |
+| Adversaire | **REWORK** | 5 bugs prod concrets : logout R1, JITAI boucle I/O R2, weekly API divergence R3, CapEngine age 10 call-sites R4, Milestone overlap R5 |
+| Iconoclaste | **Wave B-MINIMAL 3 commits** | Violation identitaire B3/B5, territoire Cleo B2, B4 fade sans event plumbing Wave C, B6/B7 technique pure Wave E |
+
+**Verdict consolidé : REWORK PROFOND → Wave B-minimal enrichi (4-5 commits).**
+
+Les 3 panels convergent : **B2, B3, B5 sont du bruit**, certains même dangereux (violation doctrine lucidité, territoire Cleo). Les seuls signaux vrais sont **B0 (unblock) + B1 (CapEngine)**, avec **B6-minimal** en prerequisite technique pour que B1 ne ship pas de caps silencieusement faux.
+
+## Matrice des enjeux croisés
+
+| Enjeu | Archi | Adversaire | Iconoclaste |
+|---|---|---|---|
+| B0 `isLoggedIn \|\| isLocalMode` | ✗ régresse Landing | ✗ logout bug (purge partielle) | ✓ tel quel OK car landing via cold launch |
+| A2 MintStateProvider → proxy (R1) | ✗ prereq critique | — | — |
+| B1 CapEngine top banner | ✓ si proxy | ✗ age stale sur 10 cap_engine.dart call-sites | ✓ le seul widget qui justifie le tab |
+| B2 JITAI evaluate | — memoize | ✗ boucle I/O 30rebuild/s | **KILL** territoire Cleo, birthday trigger creepy |
+| B3 MilestoneCelebrationSheet | — | ✗ overlap timing premier_eclairage 20s | **KILL** violation doctrine "VZ brain + Aesop" |
+| B4 WeeklyRecap consolidation | ✗ test coach/ cassé | ✗ API divergente `generate` vs `generateRecap` | Defer Wave C (fade sans events) |
+| B5 StreakService compact | — | — | **KILL** registre Duolingo |
+| B6 ageOrNull | ✗ enforce upstream backend `_coerce_fact_value` | ✗ **CapEngine 10 call-sites DOIT être dans Wave B avant B1** | Defer Wave E |
+| B7 orphan providers | ✗ delete + update tests (pas commenter) | ✗ side-effect `loadAll()` chain | Defer Wave E |
+| B8 golden 4 profils | ✗ scope 2h, 4 refresh si Wave évolue | — | 1 profil post-ship, pas 4 pré-stabilisation |
+| Empty-state partial-onboarded | ✗ ajouter pour Julien "fresh anonymous" | — | — |
+
+## Décisions tranchées
+
+### D1 — Wave B redéfinie : Wave B-minimal (4 commits, ~6-7h)
+
+**Garde** :
+- B0 (fix gate)
+- A2 (MintStateProvider proxy, prereq R1 archi) — **prereq de B1, fusionné en un commit avec B1** pour shipper le couple proxy+consumer
+- B6-minimal (ageOrNull + CapEngine migration 10 call-sites + backend range check)
+- B1 (CapEngine top banner, dépend de A2 + B6-minimal)
+
+**Kill/Defer** :
+- B2 JITAI → **ADR follow-up "JITAI deferred, doctrine review required"**
+- B3 MilestoneSheet → **ADR follow-up "gamification incompatible MINT doctrine lucidité"**
+- B4 WeeklyRecap → **Wave C** (après event plumbing scan→coach)
+- B5 StreakService → **ADR follow-up "streak registre Duolingo incompatible"**
+- B6 widgets secondaires (25+ call-sites coach_narrative + widgets) → **Wave E**
+- B7 orphan providers → **Wave E** (pure hygiène technique)
+- B8 goldens 4 profils → **1 profil Julien post-commit, goldens 4 profils en Wave F**
+
+### D2 — Risques mitigés
+
+**R1 archi (CapEngine stale cache)** : A2 commit → `ChangeNotifierProxyProvider<CoachProfileProvider, MintStateProvider>` avec `update` qui appelle `recompute(profileProv.profile)` à chaque notifyListeners. Test regression : save_fact canton → state.currentCap refreshed.
+
+**R1 adversaire (logout bug)** : B0 commit ajoute test logout scenario (`_isLoggedIn=false, _isLocalMode=false après logout`), asserte `prefs.auth_local_mode=false` persisted. Si prefs.clear() fail, fallback defensive : guard `if _purgePartialFailed { router → LandingScreen anyway }`.
+
+**R4 adversaire (CapEngine age)** : B6-minimal migre les 10 call-sites de `cap_engine.dart` : `profile.age` → `profile.ageOrNull ?? _defaultAge` avec `_defaultAge` = valeur explicite documentée par règle (ex: 40 pour `age >= 45` early-warning). Sinon : cap supprimée silencieusement via `ageOrNull == null → skip rule`. Ajouter assertion dans CapEngine que `ageOrNull == null → skip_rule_with_log`.
+
+**A3 archi (backend range check)** : B6 commit ajoute `if key == "birthYear": if value < 1900 or value > current_year + 1: return None` dans `_coerce_fact_value` coach_chat.py:1004.
+
+**R3 adversaire (weekly_recap API divergence)** : **B4 déplacé en Wave C**. Wave B ne touche plus weekly_recap.
+
+**Landing preservation (archi A1)** : Iconoclaste a raison — cold-launch (`initialLocation: '/'`) AFFICHE toujours LandingScreen. B0 ne touche QUE le behavior du tab `/home`. LandingScreen reste vivante. **Pas besoin de flag `first_seen_landing`.** Décision : B0 reste simple `isLoggedIn || isLocalMode`.
+
+### D3 — Plan final Wave B-minimal (4 commits)
+
+**B0** (1.5h) — Unblock tab Aujourd'hui + logout safe
+- `app.dart:336-338` → `(auth.isLoggedIn || auth.isLocalMode) ? AujourdhuiScreen : LandingScreen`
+- AujourdhuiScreen : ajouter empty-state widget "Pour commencer" visible si `profile.confidence < 0.3` (3 CTA : scan / parle coach / finis profile)
+- Tests : logout scenario, fresh anonymous scenario, empty-state visibility
+
+**B6-minimal** (2h) — ageOrNull + CapEngine migration + backend range check
+- `CoachProfile.ageOrNull` getter (returns `int?`)
+- `cap_engine.dart` : 10 call-sites migrent `profile.age` → `profile.ageOrNull`, chaque règle documente fallback explicite ou skip-with-log
+- `coach_chat.py:_coerce_fact_value` : range check birthYear (1900 ≤ value ≤ currentYear+1)
+- Tests : birthYear=null/2099/1977 → null/null/49, save_fact birthYear=2099 rejected, CapEngine skip_rule si ageOrNull null
+
+**A2+B1** (2.5h) — MintStateProvider proxy + CapEngine top banner
+- `app.dart:1251` : `ChangeNotifierProxyProvider<CoachProfileProvider, MintStateProvider>` avec `update: (ctx, p, state) => state!..recompute(p.profile)`
+- `AujourdhuiScreen` : top banner "Cap du jour" alimenté par `mintState.currentCap` via `context.watch<MintStateProvider>()`
+- Widget : `cap_du_jour_banner.dart` réutilisable (titre + 1 ligne + 1 CTA vers route `cap.routeHint`)
+- Tests : save_fact canton=VS → state.currentCap refreshed (R1 archi), golden test Julien→cap `lpp_buyback` ou `pillar_3a`
+
+**B-ship** (0.5h) — Device walkthrough iPhone 17 Pro + PR
+- Cold launch, tap CTA, tap tab Aujourd'hui → AujourdhuiScreen visible (pas landing redirect)
+- Avec profile Julien préloaded (via manual save_fact côté coach) → cap visible, CTA fonctionne
+- AX tree + 2 screenshots min
+- PR `feature/wave-b-home-orchestrateur` → dev merge-commit
+
+## Gates mécaniques révisés (14 points)
+
+Inchangés (1-14) vs plan précédent. Ajout :
+15. **Logout regression test** : fresh install + login + logout → LandingScreen (pas AujourdhuiScreen avec data fantôme)
+16. **MintStateProvider refresh test** : save_fact canton=VS → currentCap != currentCap_before (state frais)
+17. **Empty-state visible test** : profile sans confidence → "Pour commencer" section visible sur AujourdhuiScreen
+
+## Tests adversariels non-négociables
+
+1. Logout scenario : user login VS → logout → router → LandingScreen. prefs.auth_local_mode=false.
+2. Backend birthYear range : save_fact birthYear=2099 → coerce returns None, profile unchanged.
+3. MintStateProvider concurrent recompute : 10 rapid save_fact → final state matches last profile.
+4. CapEngine age skip : profile ageOrNull=null → règles age-dependent skip sans crash, cap fallback rendu.
+5. Partial onboarded : profile vide + isLocalMode=true → AujourdhuiScreen + empty-state CTA + 0 crash.
+
+## Feature flags (rollback)
+
+- `RemoteConfig.getBool('home.unblock_local_mode', default: true)` : kill-switch pour réactiver landing gate.
+- Pas de feature flag pour CapEngine wiring (trop intrusif à rollback).
+
+## Décision finale exécution
+
+1. **Attendre merge PR #353 hotfix PRIV-07** dans dev
+2. **Créer branche `feature/wave-b-home-orchestrateur` depuis dev frais**
+3. EXECUTE Wave B-minimal 4 commits dans l'ordre B0 → B6-minimal → A2+B1 → B-ship
+4. 4 panels audit post-exec
+5. Fixes si findings
+6. Ship
+
+**Post-Wave-B** : 5 jours d'observation + feedback Julien avant de lancer Wave C. Entre-temps, rédiger ADR follow-up tuant B2/B3/B5 avec justification doctrine.
+
+## ADR follow-up à rédiger
+
+- `ADR-20260419-killed-gamification-layers.md` : tue JITAI creepy triggers (birthday/anniversary/salary_day), MilestoneSheet Duolingo, StreakService Duolingo. Justification : doctrine lucidité 2026-04-12 incompatible avec dopamine loop. Services conservés en code (ne pas delete, potentiellement réutilisables pour d'autres contextes), mais désactivés côté home.

--- a/.planning/wave-b-home-orchestrateur/WAVE-B-UAT.md
+++ b/.planning/wave-b-home-orchestrateur/WAVE-B-UAT.md
@@ -1,0 +1,73 @@
+---
+status: complete
+phase: wave-b-home-orchestrateur
+source: PLAN.md (4 commits Wave B-minimal)
+commits: [476053c2, 7a28fbeb, 99e8e590, 4a9c9dd3]
+started: 2026-04-18T16:49:45Z
+updated: 2026-04-18T19:00:00Z
+---
+
+## Current Test
+
+[testing complete — 10/10 pass after B1-fix 4a9c9dd3]
+
+## Tests
+
+### 1. B0 — Gate isLoggedIn || isLocalMode + contract tests
+expected: app.dart:345 contient `(auth.isLoggedIn || auth.isLocalMode)`. 4 tests home_gate_contract passent.
+result: pass
+
+### 2. B0 — Device walkthrough iPhone 17 Pro sim
+expected: Fresh install anonymous → tap tab Aujourd'hui → AujourdhuiScreen rendered (pas LandingScreen). AX tree contient "MINT" wordmark + TensionCards OU empty-state + 4 tabs (Aujourd'hui/Mon argent/Coach/Explorer).
+result: pass
+fixed_by: 4a9c9dd3
+note: |
+  First pass: issue (major) — B1 CapDuJourBanner not rendered in empty-state
+  branch. Fix commit 4a9c9dd3 injected CapDuJourBanner at top of empty-state
+  Column. Re-run device walkthrough iPhone 17 Pro sim confirmed AX tree now
+  shows "Parle-moi de toi" at y=78 + empty-state card at y=442 + 4 tabs.
+
+### 3. B6-minimal — ageOrNull contract
+expected: `profile.ageOrNull` returns null pour birthYear=0, 1800, 2099, dateOfBirth future, dateOfBirth impossibly old. 10 tests coach_profile_age_or_null passent.
+result: pass
+
+### 4. B6-minimal — CapEngine ageOrNull migration (10 call-sites)
+expected: `grep "profile\\.age" apps/mobile/lib/services/cap_engine.dart` ne doit contenir aucun call-site non guarded (tous soit migrés vers `age` local ageOrNull, soit explicitement justifiés). 57 tests cap_engine passent sans régression.
+result: pass
+
+### 5. B6-minimal — Backend birthYear range check
+expected: `_coerce_fact_value("birthYear", 2099)` returns None. `_coerce_fact_value("birthYear", 1977)` returns 1977.0. `_coerce_fact_value("spouseBirthYear", 1800)` returns None. 8 tests test_coerce_fact_value_range passent.
+result: pass
+
+### 6. A2 — MintStateProvider proxy fires recompute on CoachProfile notify
+expected: `app.dart:1262` utilise `ChangeNotifierProxyProvider<CoachProfileProvider, MintStateProvider>`. Callback update fire `recompute(profile)` sur notifyListeners. flutter analyze sans régression.
+result: pass
+
+### 7. B1 — CapDuJourBanner wired dans AujourdhuiScreen
+expected: `apps/mobile/lib/widgets/aujourdhui/cap_du_jour_banner.dart` existe et est importé + utilisé dans `aujourdhui_screen.dart`. Widget consomme MintStateProvider.state.currentCap. Fallback _CapBannerFallback pour state null.
+result: pass
+
+### 8. Zéro régression — smoke full test suite
+expected: flutter analyze baseline (pas plus de 13 info-level), flutter test cap_engine + navigation + models + providers → 100% green. backend pytest coach + privacy → 100% green.
+result: pass
+
+### 9. Doctrine lucidité — aucune gamification ajoutée (ADR-20260419)
+expected: 0 import de JitaiNudgeService / MilestoneV2Service / MilestoneDetectionService / StreakService dans apps/mobile/lib/screens/aujourdhui/ ou widgets/aujourdhui/. Pas de celebration sheet déclenché post-scan dans cette Wave.
+result: pass
+
+### 10. CLAUDE.md §6 compliance — aucune régression banned terms
+expected: grep banned terms ("garanti", "optimal", "meilleur", "parfait", "conseiller" sans "spécialiste") dans diff Wave B → 0 hit. Disclaimers + sources présents.
+result: pass
+
+## Summary
+
+total: 10
+passed: 0
+issues: 0
+pending: 10
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none yet]


### PR DESCRIPTION
## Summary

Cleanup propre du \`.planning/\` à l'entrée de v2.8 :

### Tracking de 22 artefacts planning oubliés (jamais committés)

Drafted on disk pendant la transition v2.7 → v2.8 mais jamais ajoutés à git :

- \`.planning/cleanup-2026-04-18/DELETED-REMOTE-BRANCHES.txt\` — audit log cleanup branches v2.6
- \`.planning/codebase/2026-04-15-TRIAGE.md\` — 4-audit codebase triage 450 lignes (référencé MEMORY.md)
- \`.planning/mission-audit-2026-04-19/\` (10 files) — panel mission alignment 5 audits + 3 challenges + PROMISE-GAP-MAP
- \`.planning/roadmap-daily-loop-2026-04-18/ROADMAP.md\` — itération roadmap variant
- \`.planning/safemode-2026-04-18/\` (RULES + SPEC) — Wave 0 SafeMode protection layer
- \`.planning/wave-0-walkthrough-verite/\` (FINDINGS + PLAN) — Wave 0 device walkthrough
- \`.planning/wave-a-cablage-dormant-DEPRECATED-2026-04-18/\` — scoping artefact deprecated, kept for traceability
- \`.planning/wave-a-notifs-wiring/\` — Wave A notifs (shipped PR #355, plans uncommitted)
- \`.planning/wave-b-home-orchestrateur/\` — Wave B (shipped PR #354, plans uncommitted)

### NON inclus (intentionnellement)

- \`.planning/live-testing/\` (37 files, 3MB) — actively modified by another parallel Claude session this morning (08:11 mtime). Separate handling needed.

### Concomitant : 23 ' 2' filesystem duplicates supprimés

Macros artefacts macOS (rsync/Time Machine/conflict checkout) :
- 10 IDENTICAL files/dirs (verified via diff) — supprimés
- 1 ARCHITECTURE 2.md (filecmp false-positive byte-diff, en réalité identique)
- 1 \`pre-v2.8 2/\` (subset partiel, all subfiles identical to original)
- 11 empty \`archive-2026-04-10/phases/* 2/\` (empty shells)

Total 23 supprimés. \`find .planning -name "* 2*"\` retourne maintenant 0 résultat.

## Test plan

- [ ] CI green
- [ ] \`git status .planning/\` propre (sauf live-testing/)
- [ ] Tous les artefacts committés sont accessibles + référencés correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)