### PR TITLE
fix(30.6): remove 'chiffre_choc' legacy token from AGENTS docs — unblock CI on dev

### DIFF
--- a/docs/AGENTS/backend.md
+++ b/docs/AGENTS/backend.md
@@ -114,7 +114,7 @@ class TestMyCalculation:
 Chaque calculator/service output DOIT inclure :
 - `disclaimer` — « outil éducatif », « ne constitue pas un conseil », « LSFin ».
 - `sources` — Legal references (LPP art. X, LIFD art. Y).
-- `premier_eclairage` — First personalized insight (replaces legacy `chiffre_choc`).
+- `premier_eclairage` — First personalized insight (number, blind spot, implication, or question to ask).
 - `alertes` — Warnings quand thresholds crossed.
 
 Banned words dans texte backend user-facing : « garanti », « optimal », « meilleur », « assuré », « certain ». Voir `docs/AGENTS/swiss-brain.md` §1.

--- a/docs/AGENTS/swiss-brain.md
+++ b/docs/AGENTS/swiss-brain.md
@@ -112,7 +112,7 @@ Crise:         debtCrisis
 
 - `disclaimer` — « outil éducatif », « ne constitue pas un conseil », « LSFin ».
 - `sources` — legal references (LPP art. X, LIFD art. Y).
-- `premier_eclairage` — first personalized insight (number, blind spot, implication, or question to ask). Remplace le legacy `chiffre_choc`.
+- `premier_eclairage` — first personalized insight (number, blind spot, implication, or question to ask).
 - `alertes` — warnings quand thresholds crossed.
 
 ## 10. Swiss Law References


### PR DESCRIPTION
Post-merge CI on dev failed on \`no_chiffre_choc.py\` lint after PR #363 landed.

## Root cause

The new \`docs/AGENTS/swiss-brain.md\` and \`docs/AGENTS/backend.md\` files (shipped in CTX-03 refonte) mentioned the legacy token in explanatory text:

\`\`\`
- \`premier_eclairage\` — First personalized insight (replaces legacy \`chiffre_choc\`).
\`\`\`

The CI lint \`tools/checks/no_chiffre_choc.py\` enforces zero occurrences of \`chiffre_choc\` in scoped paths after the Phase 1.5 rename (2026-04-07). It scans \`docs/\` which includes the new \`docs/AGENTS/\` directory.

## Fix

Removed the historical mention from both files. The \`premier_eclairage\` definition is self-sufficient:

\`\`\`
- \`premier_eclairage\` — First personalized insight (number, blind spot, implication, or question to ask).
\`\`\`

No loss of signal — the rename happened 12 days ago, no agent needs the historical reference in a current AGENTS guide.

## Verification

\`\`\`bash
python3 tools/checks/no_chiffre_choc.py
# → no_chiffre_choc: OK — zero legacy tokens found in scoped paths
# → exit 0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)