### PR TITLE
fix(31): SentryNavigatorObserver setRouteNameAsTransaction=true — J0 Task 2 hotfix

### DIFF
--- a/.planning/phases/32-cartographier/32-VALIDATION.md
+++ b/.planning/phases/32-cartographier/32-VALIDATION.md
@@ -185,16 +185,23 @@ Per M-4 strict 3-branch hierarchy: `nyquist_compliant` STAYS **false** because T
 
 ## Risks (P0 pending operator acknowledgment)
 
-### RISK 1 — J0 Task 2 BLOCKED (SentryNavigatorObserver contract unverified) [requires Julien acknowledgment]
+### RISK 1 — J0 Task 2 → Option A (hotfix) executed 2026-04-20, empirical re-verification pending next TestFlight
 
-- **Operator:** autonomous agent session (Claude, feature/v2.8-phase-32-cartographier). **Date:** 2026-04-20.
-- **Reason:** macOS Keychain access denied to non-interactive subprocess (`SecKeychainSearchCop...`); `SENTRY_DSN_MOBILE_STAGING` env var unset in session.
-- **Impact:** D-07 contract (SentryNavigatorObserver auto-sets `transaction.name` per Phase 31 `app.dart:184`) not empirically validated end-to-end. If D-07 is broken, `./tools/mint-routes health` CLI lookups return 0 events for every route → Phase 35 dogfood hollow, Phase 36 FIX prioritization misleading.
-- **Mitigation already in CLI:** sentry_client.py falls back to sequential 1 req/sec on 414; exits 78 (`EX_CONFIG`) on 401/403/scope-missing — the CLI will not ship misleading data, it will exit loud.
-- **Fallback available:** `./tools/mint-routes health --owner=X` sequential mode does NOT rely on auto-named transactions (queries per-path individually). Phase 35 dogfood can fall back to this mode on first error, at a 3-min/scan cost instead of 15-sec/scan.
-- **Julien must choose ONE:**
-  - **A)** Arrange staging credentials on local dev machine (unlock Keychain + export `SENTRY_DSN_MOBILE_STAGING`); re-run walker smoke + Sentry Issues API queries; flip `nyquist_compliant: true` if `transaction.name` matches path on 3 probes. [preferred]
-  - **B)** Accept `nyquist_compliant: false` for Phase 32 ship; defer the empirical gate to Phase 35 dogfood startup where the first `health` call will prove/disprove the contract and trigger Phase 31 retroactive `scope.setTag('route', ...)` patch (2–4 h) if needed.
+- **Status:** ✅ **Code fix shipped via PR #369** (`hotfix/v2.8-phase-31-sentry-transaction-name`, commit `5859894b`). Empirical re-verification pending staging TestFlight send.
+- **Original BLOCKER:** macOS Keychain denial in non-interactive subprocess prevented running the gate during the autonomous session.
+- **Julien re-ran locally (2026-04-20)** with token in Keychain + corrected `SENTRY_ORG=moneyint` env:
+  - `./tools/mint-routes --verify-token` → `[OK] token scopes are within allowed set: []` (the empty `[]` was a cosmetic parsing glitch; actual scopes confirmed `project:read + event:read + org:read` via direct `curl /api/0/`)
+  - `./tools/mint-routes health --json` → 147 routes queried, valid JSON output, PII redaction applied, **but all 147 routes reported `sentry_count_24h: 0`**
+- **Root cause confirmed empirically:** `mint-mobile` Sentry project had 2 issues in 90 days — neither had a route-path transaction. Recorded transactions: `delegate.dart in GoRouterDelegate.pop` + null. `SentryNavigatorObserver()` default constructor has `setRouteNameAsTransaction: false` (`sentry_flutter 9.14.0 sentry_navigator_observer.dart:82`), so `scope.transaction` is NEVER bound to the GoRouter route path. D-07 contract was silently broken in Phase 31-01.
+- **Fix (PR #369):** `apps/mobile/lib/app.dart:190` now passes `setRouteNameAsTransaction: true`. Test added (`test/app_router_observers_test.dart`) as regression guard via source grep. 37/37 local tests pass, 0 regressions.
+- **What Julien still needs to do** (after PR #369 merges to dev):
+  1. Send next staging TestFlight build to iPhone 17 Pro
+  2. Trigger intentional errors on ≥3 different routes (e.g., `/budget`, `/coach/chat`, `/retraite`)
+  3. Wait ≥30 s for Sentry ingest
+  4. Query Sentry Issues API: `transaction:/budget`, `transaction:/coach/chat`, `transaction:/retraite`
+  5. Verify each returns ≥1 event with matching transaction
+  6. Flip `32-VALIDATION.md` frontmatter: `j0_verdict: GREEN`, `j0_blocked_count: 0`, `j0_pass_count: 6`, `nyquist_compliant: true`
+  7. Commit + push
 
 ### RISK 2 — J0 Task 3 BLOCKED (batch OR-query live limit not empirically validated) [requires Julien acknowledgment]
 

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -185,9 +185,22 @@ final _authNotifier = ChangeNotifier();
 // can assert the list contents via `testOnlyRootRouterObservers`
 // without relying on @visibleForTesting getters on go_router
 // internals.
+//
+// Phase 32 J0 Task 2 retroactive hotfix (2026-04-20):
+// `setRouteNameAsTransaction: true` binds `scope.transaction` = current
+// route path on every didPush/didPop/didReplace. Without this flag the
+// SDK default is false (sentry_flutter 9.14.0
+// sentry_navigator_observer.dart:82) and Sentry issues report
+// `transaction = <file.dart in FunctionName>` instead of the route
+// path. This broke Phase 32 CLI `./tools/mint-routes health` which
+// queries `transaction:<path>` (D-07 contract) — empirically verified:
+// mint-mobile project had 2 issues in 90d, neither with route-path
+// transaction. Flipping the flag lets GoRouter's RouteSettings.name
+// flow into scope.transaction via _setCurrentRouteNameAsTransaction.
+// See .planning/phases/32-cartographier/32-VALIDATION.md §Risks Risk 1.
 final List<NavigatorObserver> _routerObservers = [
   AnalyticsRouteObserver(),
-  SentryNavigatorObserver(),
+  SentryNavigatorObserver(setRouteNameAsTransaction: true),
 ];
 
 final _router = GoRouter(

--- a/apps/mobile/test/app_router_observers_test.dart
+++ b/apps/mobile/test/app_router_observers_test.dart
@@ -1,6 +1,12 @@
 // Phase 31 OBS-05 (a) — SentryNavigatorObserver in GoRouter observers live test.
 //
 // Wave 1 Plan 31-01: flipped from skipped stub to live assertion.
+// Phase 32 J0 Task 2 hotfix (2026-04-20): added source assertion that
+// `setRouteNameAsTransaction: true` is passed to the observer. Without
+// this flag, Sentry issues report transaction = <file:function> instead
+// of the route path, breaking D-07 contract and Phase 32 CLI
+// `./tools/mint-routes health` queries. See .planning/phases/
+// 32-cartographier/32-VALIDATION.md §Risks Risk 1.
 //
 // Patches apps/mobile/lib/app.dart observers list to add
 // SentryNavigatorObserver alongside the existing AnalyticsRouteObserver.
@@ -11,6 +17,8 @@
 // GoRouter push/pop/replace events, giving every Sentry event a
 // replay-independent route trail. Crucial when sessionSampleRate is
 // 0.0 in prod (D-01 Option C).
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/app.dart';
 import 'package:mint_mobile/services/analytics_observer.dart';
@@ -55,6 +63,29 @@ void main() {
           analyticsIdx < sentryIdx,
           isTrue,
           reason: 'AnalyticsRouteObserver must come before SentryNavigatorObserver',
+        );
+      },
+    );
+
+    test(
+      'SentryNavigatorObserver configured with setRouteNameAsTransaction: true '
+      '(Phase 32 J0 Task 2 hotfix — D-07 contract)',
+      () {
+        // The SDK flag is private (sentry_flutter 9.14.0
+        // sentry_navigator_observer.dart:82/120). Asserting via source
+        // grep — cheap regression guard. Empirical verification happens
+        // on staging TestFlight by querying Sentry Issues API with
+        // `transaction:<expected-route-path>` (D-11 §J0 Task 2).
+        final source = File('lib/app.dart').readAsStringSync();
+        expect(
+          source.contains('SentryNavigatorObserver(setRouteNameAsTransaction: true)'),
+          isTrue,
+          reason: 'SentryNavigatorObserver MUST pass '
+              'setRouteNameAsTransaction: true to bind scope.transaction '
+              'to the current GoRouter path. Without this flag, Sentry '
+              'issues report transaction = <file:function> instead of '
+              'the route path, breaking `./tools/mint-routes health` '
+              'queries (Phase 32 CLI D-07 contract).',
         );
       },
     );


### PR DESCRIPTION
## Summary

Phase 32 J0 Task 2 retroactive hotfix per ADR-20260419 kill-policy option A + CONTEXT v4 D-11 §Task 2 fail-action. 2-4h scope, 1 production line changed + 1 test added.

## Root cause

`SentryNavigatorObserver()` default constructor (`sentry_flutter 9.14.0 sentry_navigator_observer.dart:82`) has `setRouteNameAsTransaction: false`. Result: `scope.transaction` is **never** bound to the current GoRouter route path. Every Sentry issue reports `transaction = <file.dart in FunctionName>` instead of `/budget`, `/coach/chat`, etc.

**Empirically verified** 2026-04-20 via staging Sentry (`org=moneyint, project=mint-mobile`):
- 2 issues total in last 90 days
- Transactions recorded: `delegate.dart in GoRouterDelegate.pop` + null
- **Zero** issues with a route-path transaction → D-07 contract broken

## Impact on downstream phases

- **Phase 32 CLI** `./tools/mint-routes health` queries `transaction:<path>` → returns 0 for all 147 routes (not a CLI bug, upstream instrumentation gap)
- **Phase 35 Boucle Daily dogfood** consumes CLI health JSON → would ship a dogfood producing zero-signal per-route data

## Fix

One-line change in `apps/mobile/lib/app.dart:190`:

```diff
-  SentryNavigatorObserver(),
+  SentryNavigatorObserver(setRouteNameAsTransaction: true),
```

Triggers SDK code path `_setCurrentRouteNameAsTransaction` (lines 272-282) which calls `scope.configureScope((s) => s.transaction = name)` on every `didPush` / `didPop` / `didReplace`. For GoRouter, `RouteSettings.name` defaults to `matchedLocation` (URL path), so `scope.transaction = /path` on every navigation.

## Verification

- **Unit test added** (`test/app_router_observers_test.dart`): source grep assertion that `setRouteNameAsTransaction: true` is present. Cheap regression guard (the SDK flag is private, not exposed via public API).
- **37/37 tests pass** (observer + Sentry breadcrumbs + Phase 32 admin UI + routes suites). Zero regressions.
- **Empirical re-verification** of J0 Task 2 requires next staging TestFlight send → trigger errors on ≥3 different routes → query Sentry `transaction:/path` returns events. Documented in follow-up commit updating `32-VALIDATION.md §Risks Risk 1`.

## Test plan

- [x] `cd apps/mobile && flutter analyze lib/app.dart test/app_router_observers_test.dart` → 0 issues
- [x] `cd apps/mobile && flutter test test/app_router_observers_test.dart` → 2 green
- [x] `cd apps/mobile && flutter test test/routes/ test/screens/admin/ test/services/sentry_breadcrumbs*` → 35 green
- [ ] Post-merge: send staging TestFlight build, trigger errors on 3 routes, query Sentry `transaction:/<path>` returns ≥1 event each → flip `32-VALIDATION.md nyquist_compliant: true`

## Context

- CONTEXT v4 D-11 §Task 2 fail-action: option A (patch Phase 31 retroactive)
- ADR-20260419 kill-policy: non-empruntable Phase 36 budget preserved, this hotfix is in-scope Phase 31-01 not a descope
- `feedback_no_shortcuts_ever`: no "accept AMBER forever" shortcut — code the fix, ship, verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)