### PR TITLE
fix(walker): bundle ID + --no-codesign for macOS Tahoe sim install

### DIFF
--- a/tools/simulator/walker.sh
+++ b/tools/simulator/walker.sh
@@ -34,7 +34,10 @@
 set -euo pipefail
 
 DEVICE="${MINT_WALKER_DEVICE:-iPhone 17 Pro}"
-BUNDLE="com.mint.mintMobile"
+# Bundle ID matches Xcode project CFBundleIdentifier (ch.mint.app).
+# Previously hardcoded "com.mint.mintMobile" which did not match — simctl
+# launch failed with FBSOpenApplicationServiceErrorDomain code=4.
+BUNDLE="${MINT_WALKER_BUNDLE:-ch.mint.app}"
 MODE="${1:---quick-screenshot}"
 DRY_RUN="${MINT_WALKER_DRY_RUN:-0}"
 
@@ -113,8 +116,8 @@ else
   # -------------------------------------------------------------------------
   : "${SENTRY_DSN_STAGING:?SENTRY_DSN_STAGING required for simulator build}"
 
-  log "build: flutter build ios --simulator (staging dart-defines)"
-  (cd apps/mobile && flutter build ios --simulator \
+  log "build: flutter build ios --simulator --no-codesign (staging dart-defines, macOS Tahoe)"
+  (cd apps/mobile && flutter build ios --simulator --no-codesign \
     --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
     --dart-define=SENTRY_DSN="${SENTRY_DSN_STAGING}") 2>&1 | tee -a "$LOG"
 
@@ -176,8 +179,8 @@ case "$MODE" in
       mkdir -p "$ADMIN_OUT"
       log "admin-routes: output dir ${ADMIN_OUT}"
 
-      log "admin-routes: flutter build ios --simulator with ENABLE_ADMIN=1"
-      (cd apps/mobile && flutter build ios --simulator \
+      log "admin-routes: flutter build ios --simulator --no-codesign with ENABLE_ADMIN=1 (macOS Tahoe)"
+      (cd apps/mobile && flutter build ios --simulator --no-codesign \
         --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
         --dart-define=SENTRY_DSN="${SENTRY_DSN_STAGING}" \
         --dart-define=ENABLE_ADMIN=1) 2>&1 | tee -a "$LOG"


### PR DESCRIPTION
## Summary

2 latent walker.sh bugs discovered while executing J0 Task 6 (Phase 32 `walker.sh --scenario=admin-routes` smoke) on macOS Tahoe after Phase 32 merge.

## Bugs fixed

1. **Bundle ID mismatch** (`line 37`): hardcoded `com.mint.mintMobile` ≠ actual Xcode `CFBundleIdentifier: ch.mint.app`. Result: `simctl launch` failed with `FBSOpenApplicationServiceErrorDomain code=4`.  
   Fix: `BUNDLE="${MINT_WALKER_BUNDLE:-ch.mint.app}"` + override-via-env pattern.

2. **CodeSign on Tahoe simulator** (`line 117` + `line 180`): `flutter build ios --simulator` without `--no-codesign` hits `Command CodeSign failed with a nonzero exit code` on Tahoe (same provenance xattr issue that breaks device builds per `feedback_ios_build_macos_tahoe.md`).  
   Fix: add `--no-codesign` to both the staging build AND the admin-routes rebuild.

## Verification

Executed successfully 2026-04-20:
- `bash tools/simulator/walker.sh --scenario=admin-routes` → build 8s (cache warm) / 45s (cold), install OK, launch OK
- Mint Lucidité landing renders, tap navigation to Coach screen works (verified via 4 screenshots)

## Follow-up out of scope

- `simctl shutdown all + erase + boot` at line ~96 is destructive by design (wipes user data). Should be gated behind `--force-erase` opt-in flag. Filed as separate concern, not in this PR.
- Tahoe sim icon-promise install flake (`Failed to set icon resources promise`) works on retry — not walker's scope.

## Test plan

- [x] `bash tools/simulator/walker.sh --scenario=admin-routes` succeeds (build → install → launch)
- [x] Mint app launches and renders landing page
- [x] `ch.mint.app` bundle ID resolves correctly on `simctl launch booted`
- [ ] CI: walker.sh is not exercised by CI (simulator-only); PR relies on local verification