### PR TITLE
hotfix(backend): pin jinja2 — Railway prod boot loop post-#374

### DIFF
--- a/services/backend/pyproject.toml
+++ b/services/backend/pyproject.toml
@@ -29,6 +29,14 @@ dependencies = [
     # tools/simulator/trace_round_trip_test.sh against staging to confirm
     # cross-project link behaviour with sentry-flutter 9.14.0.
     "sentry-sdk[fastapi]==2.53.0",
+    # Required transitively: sentry-sdk 2.53.0 StarletteIntegration
+    # auto-patches Jinja2Templates on setup_once(), which forces
+    # `from starlette.templating import Jinja2Templates`. Without jinja2
+    # in the image, every gunicorn worker crashes on boot with
+    # ModuleNotFoundError. starlette declares jinja2 as an EXTRA
+    # (starlette[full]), not a core dep, so we pin it here.
+    # Incident: Railway deploy loop 2026-04-21 post-#374.
+    "jinja2>=3.1,<4.0",
     "defusedxml>=0.7.0,<1.0.0",
     "redis>=5.0,<6.0",
     "pymupdf>=1.24,<2.0",


### PR DESCRIPTION
## 🚨 Prod is down — hotfix to main

Railway prod + staging workers are in a crash-loop since #374 merged.

## Root cause

sentry-sdk 2.53.0 StarletteIntegration's \`setup_once()\` calls \`patch_templates()\`, which unconditionally imports \`starlette.templating\` → \`Jinja2Templates\` → \`jinja2\`.

starlette only declares jinja2 as an extra (\`starlette[full]\`), not a core dep. Our minimal FastAPI install never pulled it in, and the previous sentry-sdk version didn't hit this path at init time.

When #374 landed the Phase 31 OBS-03 tracing rework (which added \`sentry_sdk.init()\` at import time in [app/main.py:25](services/backend/app/main.py#L25)), every gunicorn worker now dies on boot:

\`\`\`
ModuleNotFoundError: No module named 'jinja2'
  File "/app/app/main.py", line 25, in <module>
    sentry_sdk.init(...)
  File ".../sentry_sdk/integrations/starlette.py", line 137, in setup_once
    patch_templates()
ImportError: jinja2 must be installed to use Jinja2Templates
\`\`\`

## Fix

Pin \`jinja2>=3.1,<4.0\` as a direct backend dependency in \`services/backend/pyproject.toml\`. Small (~300 KB), no security surface, unblocks prod.

## Why main and not dev→staging→main

Prod is down. Beta testers blocked. One-person team ship discipline per \`feedback_ship_discipline_one_person_team.md\`. Will cascade to staging and dev via Sync-branches after merge.

## Test plan
- [x] Inspected Railway log tail — confirmed ModuleNotFoundError is the crash point
- [x] Local \`python -c "from app.main import app"\` — no regression (note: local env already has jinja2 transitively; this fixes the Docker image)
- [ ] Auto-deploy to Railway staging + prod after merge
- [ ] Verify \`/api/v1/health\` returns 200 within 15s on both
- [ ] Verify sentry cross-project trace still works (mobile ↔ backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)