### PR TITLE
hotfix(backend): gate create_all() on non-prod — 2nd Railway healthcheck blocker

### DIFF
--- a/services/backend/alembic/versions/29_05_magic_link_tokens.py
+++ b/services/backend/alembic/versions/29_05_magic_link_tokens.py
@@ -1,0 +1,82 @@
+"""Create magic_link_tokens table for passwordless login.
+
+Backfills a table that has lived in the ORM since 2025 but never had its
+own alembic revision. Previous boots relied on
+``Base.metadata.create_all()`` at lifespan startup to create it in dev;
+production got the table the same way on first deploy and has carried
+it since — undocumented in alembic's head.
+
+The latent debt surfaced 2026-04-21 when
+``Base.metadata.create_all()`` raised
+``psycopg2.errors.UniqueViolation`` on ``pg_type_typname_nsp_index``
+for ``magic_link_tokens`` (orphan row-type surviving schema churn),
+keeping Railway healthcheck from ever passing. The lifespan boot
+now gates ``create_all()`` to non-production environments — so prod
+must rely on alembic alone, which means this migration MUST own the
+table shape going forward.
+
+Idempotent: checks ``inspector.has_table`` before emitting CREATE,
+so running it on prod DBs that already carry the table is a no-op.
+New prod DBs (and dev DBs once we delete ``create_all()``) get it
+natively from this revision.
+
+Revision ID: 29_05_magic_link_tokens
+Revises:    29_04_drop_auto_confirmed
+"""
+from __future__ import annotations
+
+revision = "29_05_magic_link_tokens"
+down_revision = "29_04_drop_auto_confirmed"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+_TABLE = "magic_link_tokens"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in inspector.get_table_names():
+        # Already present (most prod + dev DBs today). Skip quietly.
+        return
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("used", sa.Boolean(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_email"),
+        _TABLE,
+        ["email"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_magic_link_tokens_token_hash"),
+        _TABLE,
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return
+    op.drop_index(
+        op.f("ix_magic_link_tokens_token_hash"),
+        table_name=_TABLE,
+    )
+    op.drop_index(
+        op.f("ix_magic_link_tokens_email"),
+        table_name=_TABLE,
+    )
+    op.drop_table(_TABLE)

--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -63,7 +63,17 @@ async def lifespan(app: FastAPI):
     """Create database tables and auto-ingest RAG knowledge base on startup."""
     # Import models to ensure they're registered with Base
     from app import models as _models  # noqa: F401
-    Base.metadata.create_all(bind=engine)
+
+    # Alembic is the source of truth in production — running create_all()
+    # after migrate conflicts with existing tables whose implicit row-type
+    # already exists in pg_type (UniqueViolation on pg_type_typname_nsp_index,
+    # observed 2026-04-21 for magic_link_tokens which has no alembic migration
+    # yet). Keep create_all() in dev/test where the DB can start empty and
+    # there is no alembic at boot time. Any production-only table missing a
+    # migration must be backfilled via a dedicated alembic revision, not by
+    # this bypass. Incident: Railway prod healthcheck loop post-#376.
+    if settings.ENVIRONMENT != "production":
+        Base.metadata.create_all(bind=engine)
 
     # FIX-106: Validate DB connectivity at startup — fail fast if misconfigured.
     try:


### PR DESCRIPTION
## 🚨 Production still down — 2nd hotfix after #376

The jinja2 fix in #376 resolved the first crash, but the deploy still fails the healthcheck. Workers now get past gunicorn boot but crash inside \`lifespan()\` in [app/main.py:66](services/backend/app/main.py#L66):

\`\`\`
psycopg2.errors.UniqueViolation:
  duplicate key value violates unique constraint "pg_type_typname_nsp_index"
DETAIL: Key (typname, typnamespace)=(magic_link_tokens, 2200) already exists.
\`\`\`

Confirmed from Railway deploy logs for PR #376's image (pasted above).

## Root cause

\`Base.metadata.create_all(bind=engine)\` runs at app startup, AFTER alembic has already migrated. In production alembic is the source of truth; the \`magic_link_tokens\` table already exists (and crucially, the implicit postgres row-type with it). SQLAlchemy re-issues \`CREATE TABLE\` which collides in \`pg_type\` on the type, even though \`checkfirst=True\` would have skipped the table check itself.

\`magic_link_tokens\` has no alembic revision — it was originally created by a past \`create_all()\` boot. That's the latent debt that surfaced now.

## Fix

Gate \`create_all()\` on \`settings.ENVIRONMENT != "production"\`, matching the pattern already in use 15 lines below for \`AUTH_AUTO_PURGE_ON_STARTUP\`.

- Dev + test: boot empty DB via ORM as before
- Prod: alembic alone. The table is already populated in prod so no runtime loss.

## Follow-up (separate PR, not blocking)

Write an alembic migration that OWNS \`magic_link_tokens\` so future prod DBs can be bootstrapped cleanly without \`create_all()\`. Not required for this fix — current prod DB already has the table.

## Why main directly

Prod rollback-looping since #374 (3 hours ago). All subsequent deploys failed healthcheck, bound to the 3-week-old "Budget Vivant" container. Beta testers blocked. One-person-team ship discipline override.

## Test plan
- [x] Log confirms crash at main.py:66 lifespan
- [x] \`settings\` already imported in main.py
- [ ] Railway auto-deploy on merge
- [ ] Verify actual NEW-container \`/api/v1/health\` answers (active deployment marker updates, not just arbitrary 200 from rollback container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)