### PR TITLE
fix(coach): opener promise offensive + chips grammaticalement correctes

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -9886,7 +9886,7 @@
   "@coachOpenerIdentity": {
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data."
   },
-  "coachOpenerPromise": "Ich verkaufe nichts, ich bewerte nichts, ich vergleiche dich mit niemandem. Ich helfe dir nur, klar zu sehen bei dem, was dir niemand erklären will.",
+  "coachOpenerPromise": "Ich kenne dich. Ich sehe, was kommt. Ich begleite dich.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible."
   },

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -9886,7 +9886,7 @@
   "@coachOpenerIdentity": {
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data."
   },
-  "coachOpenerPromise": "I sell nothing, I rate nothing, I compare you to no one. I just help you see clearly into what no one has any interest in explaining to you.",
+  "coachOpenerPromise": "I know you. I see what is coming. I guide you.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible."
   },

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -9886,7 +9886,7 @@
   "@coachOpenerIdentity": {
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data."
   },
-  "coachOpenerPromise": "No vendo nada, no califico nada, no te comparo con nadie. Solo te ayudo a ver claro en lo que nadie tiene interés en explicarte.",
+  "coachOpenerPromise": "Te conozco. Veo lo que viene. Te guío.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible."
   },

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10351,7 +10351,7 @@
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data.",
     "x-mint-meta": { "level": "N3" }
   },
-  "coachOpenerPromise": "Je ne vends rien, je ne note rien, je ne te compare à personne. Je t'aide juste à voir clair dans ce que personne n'a intérêt à t'expliquer.",
+  "coachOpenerPromise": "Je te connais. Je vois ce qui vient. Je te guide.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible.",
     "x-mint-meta": { "level": "N3" }
@@ -10361,7 +10361,7 @@
     "description": "First-contact opener closing question.",
     "x-mint-meta": { "level": "N3" }
   },
-  "coachStarterPaper": "Un papier que je comprends pas",
+  "coachStarterPaper": "Un papier que je ne comprends pas",
   "@coachStarterPaper": {
     "description": "Conversation starter chip — routes to scanner.",
     "x-mint-meta": { "level": "N3" }
@@ -10371,7 +10371,7 @@
     "description": "Conversation starter chip — life events opener.",
     "x-mint-meta": { "level": "N3" }
   },
-  "coachStarterCost": "Un truc qui me coûte, je sais pas quoi",
+  "coachStarterCost": "Un truc qui me coûte, je ne sais pas quoi",
   "@coachStarterCost": {
     "description": "Conversation starter chip — budget/fiscal opener.",
     "x-mint-meta": { "level": "N3" }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -9886,7 +9886,7 @@
   "@coachOpenerIdentity": {
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data."
   },
-  "coachOpenerPromise": "Non vendo nulla, non valuto nulla, non ti paragono a nessuno. Ti aiuto solo a vedere chiaro in ciò che nessuno ha interesse a spiegarti.",
+  "coachOpenerPromise": "Ti conosco. Vedo cosa arriva. Ti guido.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible."
   },

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -37038,7 +37038,7 @@ abstract class S {
   /// First-contact opener line 2 — trust promise. LSFin-compatible.
   ///
   /// In fr, this message translates to:
-  /// **'Je ne vends rien, je ne note rien, je ne te compare à personne. Je t\'aide juste à voir clair dans ce que personne n\'a intérêt à t\'expliquer.'**
+  /// **'Je te connais. Je vois ce qui vient. Je te guide.'**
   String get coachOpenerPromise;
 
   /// First-contact opener closing question.
@@ -37050,7 +37050,7 @@ abstract class S {
   /// Conversation starter chip — routes to scanner.
   ///
   /// In fr, this message translates to:
-  /// **'Un papier que je comprends pas'**
+  /// **'Un papier que je ne comprends pas'**
   String get coachStarterPaper;
 
   /// Conversation starter chip — life events opener.
@@ -37062,7 +37062,7 @@ abstract class S {
   /// Conversation starter chip — budget/fiscal opener.
   ///
   /// In fr, this message translates to:
-  /// **'Un truc qui me coûte, je sais pas quoi'**
+  /// **'Un truc qui me coûte, je ne sais pas quoi'**
   String get coachStarterCost;
 
   /// Conversation starter chip — dismisses opener without forcing engagement.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -21106,7 +21106,7 @@ class SDe extends S {
 
   @override
   String get coachOpenerPromise =>
-      'Ich verkaufe nichts, ich bewerte nichts, ich vergleiche dich mit niemandem. Ich helfe dir nur, klar zu sehen bei dem, was dir niemand erklären will.';
+      'Ich kenne dich. Ich sehe, was kommt. Ich begleite dich.';
 
   @override
   String get coachOpenerQuestion => 'Womit fangen wir an?';

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -20950,7 +20950,7 @@ class SEn extends S {
 
   @override
   String get coachOpenerPromise =>
-      'I sell nothing, I rate nothing, I compare you to no one. I just help you see clearly into what no one has any interest in explaining to you.';
+      'I know you. I see what is coming. I guide you.';
 
   @override
   String get coachOpenerQuestion => 'Where do we start?';

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -21059,8 +21059,7 @@ class SEs extends S {
   String get coachOpenerIdentity => 'Hola. Soy Mint.';
 
   @override
-  String get coachOpenerPromise =>
-      'No vendo nada, no califico nada, no te comparo con nadie. Solo te ayudo a ver claro en lo que nadie tiene interés en explicarte.';
+  String get coachOpenerPromise => 'Te conozco. Veo lo que viene. Te guío.';
 
   @override
   String get coachOpenerQuestion => '¿Por dónde empezamos?';

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -21056,19 +21056,19 @@ class SFr extends S {
 
   @override
   String get coachOpenerPromise =>
-      'Je ne vends rien, je ne note rien, je ne te compare à personne. Je t\'aide juste à voir clair dans ce que personne n\'a intérêt à t\'expliquer.';
+      'Je te connais. Je vois ce qui vient. Je te guide.';
 
   @override
   String get coachOpenerQuestion => 'Par quoi on commence ?';
 
   @override
-  String get coachStarterPaper => 'Un papier que je comprends pas';
+  String get coachStarterPaper => 'Un papier que je ne comprends pas';
 
   @override
   String get coachStarterChoice => 'Un choix que je dois faire';
 
   @override
-  String get coachStarterCost => 'Un truc qui me coûte, je sais pas quoi';
+  String get coachStarterCost => 'Un truc qui me coûte, je ne sais pas quoi';
 
   @override
   String get coachStarterLurk => 'Je regarde, je me présente après';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -21116,8 +21116,7 @@ class SIt extends S {
   String get coachOpenerIdentity => 'Ciao. Sono Mint.';
 
   @override
-  String get coachOpenerPromise =>
-      'Non vendo nulla, non valuto nulla, non ti paragono a nessuno. Ti aiuto solo a vedere chiaro in ciò che nessuno ha interesse a spiegarti.';
+  String get coachOpenerPromise => 'Ti conosco. Vedo cosa arriva. Ti guido.';
 
   @override
   String get coachOpenerQuestion => 'Da dove cominciamo?';

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -21062,8 +21062,7 @@ class SPt extends S {
   String get coachOpenerIdentity => 'Olá. Eu sou o Mint.';
 
   @override
-  String get coachOpenerPromise =>
-      'Não vendo nada, não classifico nada, não te comparo com ninguém. Só te ajudo a ver claro naquilo que ninguém tem interesse em te explicar.';
+  String get coachOpenerPromise => 'Conheço-te. Vejo o que vem. Guio-te.';
 
   @override
   String get coachOpenerQuestion => 'Por onde começamos?';

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -9886,7 +9886,7 @@
   "@coachOpenerIdentity": {
     "description": "First-contact opener line 1 — identity. Shown once on first Parle a Mint tap for a user with no profile data."
   },
-  "coachOpenerPromise": "Não vendo nada, não classifico nada, não te comparo com ninguém. Só te ajudo a ver claro naquilo que ninguém tem interesse em te explicar.",
+  "coachOpenerPromise": "Conheço-te. Vejo o que vem. Guio-te.",
   "@coachOpenerPromise": {
     "description": "First-contact opener line 2 — trust promise. LSFin-compatible."
   },


### PR DESCRIPTION
## Feedback direct Julien 2026-04-22

Deux corrections de copy. Aucun code logique touché, seulement 6 ARB + fichiers générés l10n.

### 1. Nouvelle promise du coach opener

**Avant** :
> « Je ne vends rien, je ne note rien, je ne te compare à personne. Je t'aide juste à voir clair dans ce que personne n'a intérêt à t'expliquer. »

**Problèmes (feedback Julien)** :
- « je ne note rien » — contredit le produit. MINT retient tout : c'est le **cœur du dossier-miroir** et du Graduation Protocol. Sans mémoire complète, pas de guidance proactive, pas de « bam tu veux acheter → plan », pas de « bam tu dévies → je te remets sur la trajectoire ».
- « je ne te compare à personne » — défensive sans valeur. Julien : « franchement je m'en fous ».
- « personne n'a intérêt à t'expliquer » — complotiste, déjà aboli lors d'une review précédente, revenu par régression.

**Après** :
> **« Je te connais. Je vois ce qui vient. Je te guide. »**

3 verbes offensifs : mémoire · anticipation · action. Zéro défensive dans le premier contact. Les engagements LSFin/nLPD (consentement granulaire, but de collecte, droit d'effacer) iront dans le legal footer + consent screen, pas dans la promise.

### 2. Chips grammaticalement correctes

Deux chips parlaient en slang (chute du « ne »), incompatible avec le registre MINT (doctrine Chloé/Aesop/Wise — direct mais pas familier, pas Cleo) :

| Avant | Après |
|---|---|
| « Un papier que je comprends pas » | « Un papier que je ne comprends pas » |
| « Un truc qui me coûte, je sais pas quoi » | « Un truc qui me coûte, je ne sais pas quoi » |

### Impact

- 6 locales synchronisées (FR / EN / DE / ES / IT / PT)
- `flutter gen-l10n` régénéré
- Aucune logique touchée, strictement copy
- Feedback doctrinal scellé dans [feedback_mint_retains_everything.md](../../../.claude/projects/-Users-julienbattaglia-Desktop-MINT/memory/topics/feedback_mint_retains_everything.md) pour ne plus régresser

### Test plan
- [x] ARB parity : les 6 locales portent la même clé avec traduction équivalente
- [x] accent_lint_fr : pas de régression (exit 0 hors warnings pré-existants)
- [ ] Ship + build sim : vérifier l'écran coach opener affiche les 3 phrases nouvelles