### PR TITLE
fix(fix-02): /start redirect default → /anonymous/chat (Phase 36 P0)

### DIFF
--- a/.planning/phases/30.9-fix-02-anonymous-cta/30.9-00-READ.md
+++ b/.planning/phases/30.9-fix-02-anonymous-cta/30.9-00-READ.md
@@ -1,0 +1,38 @@
+# 30.9-00 — FIX-02 landing default → /anonymous/chat
+
+## Context
+FIX-02 per REQUIREMENTS.md (Phase 36):
+> P0 Anonymous flow one-line fix — `landing_screen.dart` CTA cible
+> `/anonymous/chat` (pas `/coach/chat` auth-gated), regression test Flutter.
+
+PR #384 shipped `/start` redirect with `/coach/chat` as default (flag OFF).
+That preserved historic behavior but `/coach/chat` is auth-gated —
+anonymous users landing there get bounced to `/auth/login` silently.
+FIX-02 flips the default to the true anonymous entry point.
+
+## Files read
+- `.planning/REQUIREMENTS.md` FIX-02 line — canonical spec.
+- `apps/mobile/lib/app.dart:308-315` — /start redirect, default branch.
+- `apps/mobile/lib/app.dart:354` — `/anonymous/chat` route exists
+  (`AnonymousChatScreen`). Public scope, no auth.
+- `apps/mobile/lib/services/coach/coach_chat_api_service.dart:160` —
+  backend endpoint `/anonymous/chat` shipped, 3 free messages.
+- `apps/mobile/test/screens/landing_screen_test.dart` — CTA routing
+  assertion uses `_buildRouter()` mirror.
+- `apps/mobile/lib/routes/route_metadata.dart:172` — `/anonymous/chat`
+  already in registry (RouteCategory, owner, requiresAuth=false).
+
+## Change
+- `app.dart` line 314: `'/coach/chat'` → `'/anonymous/chat'` in redirect.
+- `landing_screen_test.dart`: stub route `/coach/chat` → `/anonymous/chat`,
+  assertion text `COACH_CHAT_STUB` → `ANONYMOUS_CHAT_STUB`, test title
+  `(KILL-05)` → `(FIX-02)`, header comment updated.
+
+## Verification
+- `flutter test test/screens/landing_screen_test.dart` → 4/4 green.
+
+## Notes
+- MVP wedge flag branch (`'/onb'`) unchanged.
+- Phase 33 kill flag `enableAnonymousFlow` not yet shipped — this fix
+  lands without kill-switch. When Phase 33 ships, wrap the redirect
+  with a fallback if `enableAnonymousFlow == false`.

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -307,11 +307,14 @@ final _router = GoRouter(
     ),
     // Landing CTA target — flag-gated redirect. Keeps `LandingScreen`
     // pure (LAND-01: no `services/` imports in the widget itself).
+    // Default branch = /anonymous/chat (FIX-02: anonymous flow is the
+    // default entry, NOT the auth-gated /coach/chat). MVP wedge flag
+    // overrides to /onb when enabled for the guided intent storyboard.
     ScopedGoRoute(
       path: '/start',
       scope: RouteScope.public,
       redirect: (_, __) =>
-          FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/coach/chat',
+          FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/chat',
     ),
     // MVP Wedge onboarding — storyboard v2 (2026-04-22). 9-step flow
     // with 4 intents + dossier densification + 3 N2 scenes + magic link.

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -4,7 +4,7 @@
 //   • The 4 text surfaces render (wordmark, paragraphe-mère, CTA, legal).
 //   • Privacy micro-phrase is present.
 //   • No banned term (retirement framing, aggressive CTAs) is rendered.
-//   • CTA navigates to /coach/chat (KILL-05: no mandatory account creation).
+//   • CTA navigates to /anonymous/chat (FIX-02 default + KILL-05 no-account).
 //   • Reduced-motion fallback renders content on first pump (no wait).
 //
 // CONTEXT.md §2 D-01..D-13 | LAND-01, LAND-02, LAND-04, LAND-05, LAND-06.
@@ -30,12 +30,12 @@ GoRouter _buildRouter() {
       GoRoute(
         path: '/start',
         redirect: (_, __) =>
-            FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/coach/chat',
+            FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/chat',
       ),
       GoRoute(
-        path: '/coach/chat',
+        path: '/anonymous/chat',
         builder: (_, __) => const Scaffold(
-          body: Center(child: Text('COACH_CHAT_STUB')),
+          body: Center(child: Text('ANONYMOUS_CHAT_STUB')),
         ),
       ),
       GoRoute(
@@ -123,14 +123,14 @@ void main() {
       }
     });
 
-    testWidgets('CTA routes to /coach/chat (KILL-05)', (tester) async {
+    testWidgets('CTA routes to /anonymous/chat (FIX-02)', (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
-      expect(find.text('COACH_CHAT_STUB'), findsOneWidget);
+      expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
     });
 
     testWidgets('reduced-motion: content visible on first pump', (tester) async {


### PR DESCRIPTION
## Summary
Phase 36 FIX-02. PR #384 (just merged) introduced the `/start` redirect with `/coach/chat` as default (flag OFF) to preserve historic behavior. Per `.planning/REQUIREMENTS.md`, FIX-02 requires the default to be `/anonymous/chat` — the true anonymous entry point (3 free messages, public scope, no auth). Sending users to `/coach/chat` silently bounces anonymous users to `/auth/login`, defeating the anonymous-first promise.

## Changes
- [app.dart:314](apps/mobile/lib/app.dart#L314) — redirect default `'/coach/chat'` → `'/anonymous/chat'`
- [landing_screen_test.dart](apps/mobile/test/screens/landing_screen_test.dart) — test router stub + assertion updated to `ANONYMOUS_CHAT_STUB`, test title `(FIX-02)`
- MVP wedge branch (`'/onb'` when `enableMvpWedgeOnboarding` ON) — unchanged

## Test plan
- [x] `flutter test test/screens/landing_screen_test.dart` → 4/4 green (local)
- [ ] Flutter screens shard green on CI
- [ ] Mobile smoke: tap landing CTA → lands on `/anonymous/chat` (AnonymousChatScreen), not `/auth/login`

## Note
Kill flag `enableAnonymousFlow` (per kill-policy ADR) will be wired in Phase 33. For now this is a direct fix without the flag envelope. If Phase 33 lands first, wrap the redirect in a flag check.

Refs: `.planning/REQUIREMENTS.md` FIX-02, `.planning/phases/30.9-fix-02-anonymous-cta/30.9-00-READ.md`.