### PR TITLE
fix(guard-04): exclude tests + lint-scripts from accent_lint_fr scan

### DIFF
--- a/.planning/phases/30.12-accent-lint-exclusions/30.12-00-READ.md
+++ b/.planning/phases/30.12-accent-lint-exclusions/30.12-00-READ.md
@@ -1,0 +1,42 @@
+# 30.12-00 — accent_lint_fr exclusions for test/meta paths
+
+## Context
+Phase 34 GUARD-04 (`accent_lint_fr.py` via lefthook) flagged test files
+with intentional ASCII content when run `--all-files` in CI :
+- HTTP URL paths like `/premier-eclairage` (MUST stay ASCII for REST)
+- Test fixtures (`tools/agent-drift/tests/test_drift_rate.py` feeds
+  the lint its own expected inputs)
+- Backend test category/enum keys (`prevoyance`, kept ASCII for DB)
+- Lint scripts themselves that contain ASCII anti-patterns by design
+
+Without this fix, Phase 34's `lefthook-ci.yml` would fail on main for
+pre-existing test content, blocking Phase 34 re-ship → blocking FIX-05
+and FIX-07 enforcement in Phase 36.
+
+## Files read
+- `tools/checks/accent_lint_fr.py` (136 lines) — lint script with
+  `PATTERNS` + `EXCLUDE_SUBSTRINGS` + `_collect_paths` + `main()`.
+- `.github/workflows/lefthook-ci.yml` (PR #383 earlier) — re-run
+  lefthook on PR range with `--all-files --force`.
+- Phase 34-01 `066fb178` commit message — "reconcile PATTERNS with
+  CLAUDE.md §2" (patterns list already matches CLAUDE.md rules).
+- Backend service hits : found 234 REAL user-facing violations in
+  `services/backend/app/services/` after exclusions applied
+  (specialiste→spécialiste, securite→sécurité, etc.) → FIX-07 scope.
+
+## Changes
+- `tools/checks/accent_lint_fr.py` `EXCLUDE_SUBSTRINGS` :
+  - `/tests/` and `/test/` — skip test code (developer-facing only)
+  - `/tools/checks/` — skip self-scanning (lint scripts have ASCII anti-patterns by design)
+- `main()` `--file` branch now respects `EXCLUDE_SUBSTRINGS` so
+  lefthook staged-file invocations match `--all-files` mode behavior.
+
+## Verification
+- `python3 tools/checks/accent_lint_fr.py --file services/backend/tests/test_onboarding_contract.py` → rc=0 (excluded)
+- `python3 tools/checks/accent_lint_fr.py` → 234 remaining violations in `services/backend/app/services/` (real user-facing drift, scoped to FIX-07 follow-up)
+
+## Impact
+- Phase 34 re-ship path unblocked for lefthook-ci.yml green-on-main.
+- FIX-07 (accents 100%) now has a clear target : 234 backend service strings.
+- Wave 3+ of FIX-05 (bare catches) can proceed once Phase 34 GUARD-02
+  scope-to-PR + this lint fix are both in dev.

--- a/tools/checks/accent_lint_fr.py
+++ b/tools/checks/accent_lint_fr.py
@@ -51,6 +51,17 @@ EXCLUDE_SUBSTRINGS = (
     "/__pycache__/",
     "/docs/archive/",
     "/.planning/archives/",
+    # Test code is developer-facing, not user-facing. Excluded to avoid false
+    # positives on: (a) HTTP URL paths that MUST stay ASCII for REST compatibility,
+    # (b) intentional fixtures (test harnesses that feed the lint its own
+    # expected inputs), and (c) backend category / enum keys kept ASCII for
+    # DB and JSON serialization stability. User-facing accent correctness is
+    # enforced on lib/ + app/services/* sources.
+    "/tests/",
+    "/test/",
+    # Lint scripts themselves contain ASCII-flattened patterns by design
+    # (anti-patterns to detect). Skip self-scanning to avoid meta-loops.
+    "/tools/checks/",
 )
 
 
@@ -115,6 +126,12 @@ def main() -> int:
         if not target.exists():
             print(f"accent_lint_fr: file not found: {target}", file=sys.stderr)
             return 1
+        # Respect EXCLUDE_SUBSTRINGS for per-file mode too so lefthook
+        # staged-file invocations don't re-introduce the false positives
+        # that --all-files mode already filters out (tests, build artefacts).
+        rel = "/" + target.as_posix() + "/"
+        if any(ex in rel for ex in EXCLUDE_SUBSTRINGS):
+            return 0
         paths = [target]
     else:
         paths = _collect_paths(args.scope)


### PR DESCRIPTION
## Summary
Unblocks Phase 34 GUARD-04 re-ship path. When Phase 34 `lefthook-ci.yml` runs `--all-files`, `accent_lint_fr.py` was failing on pre-existing test content that must stay ASCII for legitimate reasons.

## Root cause
3 legit ASCII zones were scanned incorrectly:
1. **Test URL paths** (`/premier-eclairage` etc.) — REST routing MUST be ASCII.
2. **Test fixtures** (`tools/agent-drift/tests/test_drift_rate.py`) — feed the lint its own expected inputs.
3. **Backend test category keys** (`prevoyance`, `eclairage` in tests) — DB / JSON serialization stability.
4. **Lint scripts themselves** (`tools/checks/*.py`) — contain ASCII anti-patterns by design (detection targets).

## Changes
- `tools/checks/accent_lint_fr.py` `EXCLUDE_SUBSTRINGS` += `/tests/`, `/test/`, `/tools/checks/`
- `main()` `--file` branch now respects `EXCLUDE_SUBSTRINGS` (lefthook staged-file mode aligned with `--all-files`)

Zero change to user-facing source scan. Phase 34-01 PATTERNS list untouched.

## Verification
- `python3 tools/checks/accent_lint_fr.py --file services/backend/tests/test_onboarding_contract.py` → rc=0 (was rc=1)
- `python3 tools/checks/accent_lint_fr.py` → 234 violations remaining, ALL in `services/backend/app/services/` = real user-facing French drift, scoped to **FIX-07 follow-up**.

## Phase 36 impact
- Phase 34 re-ship unblocked (lefthook-ci.yml can now be green-on-main).
- FIX-07 (accents 100%) now has a concrete target: 234 backend service strings.
- Wave 3+ of FIX-05 bare-catch migration dependency chain clears.

Refs: `.planning/phases/30.12-accent-lint-exclusions/30.12-00-READ.md`, Phase 36 §FIX-07.