### PR TITLE
docs(fix-06): MintShell ARB parity audit — PASS

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -99,7 +99,7 @@ Chaque FIX provisionné avec kill-switch flag AVANT Phase 36 (per kill-policy AD
 - [ ] **FIX-03** (kill: `enableSaveFactSync`): P0 save_fact sync backend→mobile — `responseMeta.profileInvalidated` field dans canonical OpenAPI, `CoachProfile` reactive invalidation, regression test Flutter
 - [ ] **FIX-04** (kill: `enableCoachTab`): P0 Coach tab routing stable — navigation state fix, regression test Flutter
 - [ ] **FIX-05**: 388 bare catches → 0 — classification-first (P0 : core flows / P1 : UX best-effort / P2 : test mocks exemptés), backend 56 d'abord (pattern simple), mobile 332 batched 20/PR, `tools/checks/no_bare_catch.py` (GUARD-02) empêche régression pendant migration
-- [ ] **FIX-06**: MintShell ARB parity 6 langs audit — labels `l.tabAujourdhui / l.tabMonArgent / l.tabCoach / l.tabExplorer` DÉJÀ i18n-wired ([apps/mobile/lib/widgets/mint_shell.dart:50-65](apps/mobile/lib/widgets/mint_shell.dart)), audit seulement : clés présentes dans fr/en/de/es/it/pt, pas de ASCII-only residue (pas rewrite, MEMORY.md était stale)
+- [x] **FIX-06**: MintShell ARB parity 6 langs audit — **PASS 2026-04-24** ([AUDIT.md](phases/30.13-fix-06-mintshell-arb-audit/AUDIT.md)). All 4 labels (`tabAujourdhui/tabMonArgent/tabCoach/tabExplorer`) present in fr/en/de/es/it/pt, wired at [mint_shell.dart:50-65](apps/mobile/lib/widgets/mint_shell.dart), zero ASCII residue. No rewrite needed.
 - [ ] **FIX-07**: Accents 100% — `tools/checks/accent_lint_fr.py` (GUARD-04) gate green sur `.dart` + `.py` + `.arb`
 - [ ] **FIX-08**: **43 redirects legacy** (reconciled 2026-04-20, ROADMAP estimate was 23) — analytics instrumentés (MAP-05, Phase 32), sunset DEFER v2.9+ (PAS suppression v2.8, zero-traffic validation d'abord)
 - [ ] **FIX-09**: Regression test par P0 fix — chaque FIX-01 à FIX-05 ship avec test qui aurait failé pre-fix (empêche régression future, enforcé par code review)
@@ -210,7 +210,7 @@ Every v2.8 REQ is mapped to exactly one phase. Status is `Pending, Phase X assig
 | FIX-03 | 36 | `enableSaveFactSync` | Pending, Phase 36 assigned |
 | FIX-04 | 36 | `enableCoachTab` | Pending, Phase 36 assigned |
 | FIX-05 | 36 | cross-cutting (guarded by GUARD-02) | Pending, Phase 36 assigned |
-| FIX-06 | 36 | — | Pending, Phase 36 assigned |
+| FIX-06 | 36 | — | **Done 2026-04-24** (audit-only pass) |
 | FIX-07 | 36 | enforced by GUARD-04 | Pending, Phase 36 assigned |
 | FIX-08 | 36 | defer v2.9+ | Pending, Phase 36 assigned |
 | FIX-09 | 36 | — | Pending, Phase 36 assigned |

--- a/.planning/phases/30.13-fix-06-mintshell-arb-audit/AUDIT.md
+++ b/.planning/phases/30.13-fix-06-mintshell-arb-audit/AUDIT.md
@@ -1,0 +1,60 @@
+# FIX-06 — MintShell ARB parity audit
+
+**Status :** ✅ **PASS** (audit only, zero code change needed)
+
+**Generated :** 2026-04-24
+
+## Scope
+Per `REQUIREMENTS.md` FIX-06 :
+> Labels `l.tabAujourdhui / l.tabMonArgent / l.tabCoach / l.tabExplorer`
+> DÉJÀ i18n-wired ([mint_shell.dart:50-65]), **audit seulement** : clés
+> présentes dans fr/en/de/es/it/pt, pas de ASCII-only residue
+> (pas rewrite, MEMORY.md était stale).
+
+## Verification
+
+### 1. Widget wiring confirmed
+`apps/mobile/lib/widgets/mint_shell.dart` :
+```dart
+50:                label: l.tabAujourdhui,
+55:                label: l.tabMonArgent,
+60:                label: l.tabCoach,
+65:                label: l.tabExplorer,
+```
+All 4 tab labels consume `AppLocalizations` lookups — no hardcoded strings.
+
+### 2. ARB parity (6 languages)
+
+| Lang | tabAujourdhui | tabMonArgent | tabCoach | tabExplorer |
+|------|---------------|--------------|----------|-------------|
+| fr | Aujourd'hui | Mon argent | Coach | Explorer |
+| en | Today | My money | Coach | Explore |
+| de | Heute | Mein Geld | Coach | Entdecken |
+| es | Hoy | Mi dinero | Coach | Explorar |
+| it | Oggi | I miei soldi | Coach | Esplora |
+| pt | Hoje | Meu dinheiro | Coach | Explorar |
+
+All 24 key/value pairs present.  Zero missing keys.  No duplicate definitions.
+
+### 3. ASCII-residue check
+- `fr` has `Aujourd'hui` (apostrophe correctly typed).
+- All other labels either natively unaccented in target language, or proper loanwords ("Coach").
+- No ASCII-flattened French in any ARB ("aujourdhui" without apostrophe, "creer" instead of "créer", etc. — none found).
+
+### 4. MEMORY.md stale reference
+`REQUIREMENTS.md` noted MEMORY.md had stale information claiming labels
+needed re-wiring. Confirmed : labels are live + wired + i18n-complete
+since Phase 7 (Landing v2) + Phase 26 (MintShell). FIX-06 was already
+delivered by historical work; the audit formalises that fact.
+
+## Result
+**FIX-06 passes without any code change required.**
+
+Phase 36 Success Criteria §4 satisfied :
+> Les labels MintShell (`l.tabAujourdhui / l.tabMonArgent / l.tabCoach /
+> l.tabExplorer`) sont présents dans les 6 ARB (fr/en/de/es/it/pt), sans
+> ASCII-only residue — audit passé.
+
+## Mark REQUIREMENTS.md
+Update FIX-06 status `[ ]` → `[x]` at `.planning/REQUIREMENTS.md` line 117
+with note "Audit passed 2026-04-24, no rewrite needed, see FIX-06 AUDIT.md".


### PR DESCRIPTION
## Summary
Phase 36 FIX-06 audit-only requirement. Zero code change, docs only.

## Verified
| Lang | tabAujourdhui | tabMonArgent | tabCoach | tabExplorer |
|------|---------------|--------------|----------|-------------|
| fr | Aujourd'hui | Mon argent | Coach | Explorer |
| en | Today | My money | Coach | Explore |
| de | Heute | Mein Geld | Coach | Entdecken |
| es | Hoy | Mi dinero | Coach | Explorar |
| it | Oggi | I miei soldi | Coach | Esplora |
| pt | Hoje | Meu dinheiro | Coach | Explorar |

All 24 key/value pairs present, wired at [mint_shell.dart:50-65](apps/mobile/lib/widgets/mint_shell.dart#L50-L65), zero ASCII-flattened French.

## Changes
- `.planning/REQUIREMENTS.md` — FIX-06 `[ ]` → `[x]`, status table updated
- `.planning/phases/30.13-fix-06-mintshell-arb-audit/AUDIT.md` — full audit report

## Phase 36 progress
This is the 5th Phase 36 deliverable this morning (after LAND-01 purity, FIX-02 anonymous CTA, bare-catch inventory, Wave 1 comments, accent_lint exclusions).

Refs: `.planning/REQUIREMENTS.md` FIX-06, AUDIT.md.