### PR TITLE
fix(walk-p0-1): wire /anonymous/intent route (was orphan, landing → empty chat)

### DIFF
--- a/.planning/phases/30.14-wire-anonymous-intent/30.14-00-READ.md
+++ b/.planning/phases/30.14-wire-anonymous-intent/30.14-00-READ.md
@@ -1,0 +1,40 @@
+# 30.14-00 — Wire /anonymous/intent route (walk 2026-04-24 P0-1)
+
+## Context
+Walk 2026-04-24 surfaced P0-1 : tap landing CTA → `/anonymous/chat`
+empty screen, no greeting, no pill, placeholder "Ou dis-le comme tu
+veux" teases alternatives that never existed. User dead-end.
+
+Root cause : `AnonymousIntentScreen` (felt-state pills + free-text)
+exists as orphan Dart code, never registered in the router. v2.9 audit
+P0-5 called this out ("Anonymous flow DEAD — /anonymous/chat orphaned").
+
+## Files read / modified
+- `.planning/walker/2026-04-24-walk/WALK-REPORT.md` — walk findings P0-1.
+- `apps/mobile/lib/screens/anonymous/anonymous_intent_screen.dart` (head) — confirmed it exists, navigates to `/anonymous/chat?intent=X` on pill/text submit.
+- `apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart:42-63` — confirmed empty `_messages[]` when `widget.intent` null (no greeting injection).
+- `apps/mobile/lib/app.dart:353-363` — existing `/anonymous/chat` route, no `/anonymous/intent` registered.
+- `apps/mobile/lib/routes/route_metadata.dart:171-178` — `/anonymous/chat` entry only.
+
+## Changes
+- `app.dart` — import `anonymous_intent_screen.dart`, register `/anonymous/intent` route, change `/start` redirect to `/anonymous/intent`. Drop duplicate `feature_flags.dart` import.
+- `route_metadata.dart` — add `/anonymous/intent` RouteMeta (flow, anonymous owner, killFlag enableAnonymousFlow).
+- Tests bumped 150 → 151 routes (test_mint_routes.py, routes_registry_screen_test.dart).
+- `landing_screen_test.dart` — stub routes to `/anonymous/intent` (`ANONYMOUS_INTENT_STUB`), test title updated.
+
+## Verification
+- `flutter analyze` → No issues found
+- `flutter test test/screens/landing_screen_test.dart` → 4/4 green
+- `flutter test test/screens/admin/routes_registry_screen_test.dart` → 3/3 green
+- `python3 tools/checks/route_registry_parity.py` → 144 routes parity OK
+
+## Flow after fix
+1. Landing → tap "Parle à Mint" → `/start`
+2. `/start` redirects → `/anonymous/intent` (unless `enableMvpWedgeOnboarding`)
+3. User sees 6 felt-state pills + free-text field
+4. Pill pick / text submit → `/anonymous/chat?intent=X` with auto-send
+
+## Remaining Phase 36 walk findings (not in this PR)
+- P0-2 : backend error → generic fallback (needs error mapping)
+- P0-3 : dev onboarding doc gap (needs backend README + SLM fallback)
+- P0-4 : MVP wedge retraite-first + "email demain" copy (needs product design)

--- a/.planning/phases/30.14-wire-anonymous-intent/WALK-REPORT-2026-04-24.md
+++ b/.planning/phases/30.14-wire-anonymous-intent/WALK-REPORT-2026-04-24.md
@@ -1,0 +1,96 @@
+# Walk Report — 2026-04-24 18:42-18:50
+
+**Device:** iPhone 17 Pro simulator (B03E429D)
+**Build:** `feature/S30.13-fix-06-mintshell-arb-audit` (post-merge of 6 morning PRs)
+**Walker:** Claude autonomous, driven by cliclick + AppleScript + xcrun simctl
+
+## What worked
+- ✅ Build iOS sim (after `ditto --noextattr` + manual codesign workaround for macOS Tahoe `com.apple.provenance` blocker)
+- ✅ Install + launch via `xcrun simctl`
+- ✅ Landing screen renders cleanly (LAND-01 landing purity confirmed)
+- ✅ CTA tap routes via `/start` (FIX-02 redirect fires)
+
+## Walls hit (P0 → P2)
+
+### P0-1 : `/anonymous/chat` arrive sur ÉCRAN VIDE
+
+**Symptom:** Tap "Parle à Mint" → screen with back arrow, empty body, input "Ou dis-le comme tu veux…", send arrow grey.
+
+**Root cause:** `AnonymousChatScreen` constructor takes optional `intent` param. When null, no auto-send → `_messages[]` stays empty → zero greeting, zero chips. The placeholder "**Ou** dis-le comme tu veux…" grammatically implies alternatives above that don't exist.
+
+**Architectural bug:** `AnonymousIntentScreen` EXISTS as a Dart file with 6 felt-state pills + free-text (meant as the REAL first screen), but **it's not registered in the router anywhere**. Orphan code. The v2.9 audit P0-5 noted this exactly: "Anonymous flow DEAD — /anonymous/chat orphaned."
+
+**Fix:** Register `/anonymous/intent` route + change `/start` redirect target from `/anonymous/chat` to `/anonymous/intent`. When user picks a pill, intent screen nav to `/anonymous/chat?intent=X` (auto-send).
+
+Screenshot: [02-post-cta.png](02-post-cta.png)
+
+---
+
+### P0-2 : Silent backend error → generic fallback
+
+**Symptom:** Type message, send via Return key, coach responds "Je rencontre un problème technique. Réessaie dans un instant." No distinction between network down, missing auth, rate limit, malformed input, server 5xx.
+
+**Root cause matrix (investigated manually):**
+- `http://localhost:8888` (debug default) → no backend running → catch-all fallback
+- With backend running + invalid session header → 400 "Format de session invalide. UUID requis."
+- With valid UUID session + no `ANTHROPIC_API_KEY` → 503 "Service temporairement indisponible."
+
+**User impact:** Indistinguishable from genuine backend being down. No retry button. No "Vérifier ta connexion" hint. No escalation path.
+
+**Fix:** Map 503 → "On répare côté serveur, reviens dans 2 minutes." Map network error → "Pas de réseau, vérifie ton wifi." Map 429 → "Tu as fait ta quota gratuite, crée un compte." Surface `X-Trace-Id` header as discreet `ref #abc123` for support.
+
+Screenshots: [05-after-send.png](05-after-send.png), [07-response.png](07-response.png)
+
+---
+
+### P0-3 : Dev onboarding is blocked without docs
+
+**Symptom:** Fresh dev clones, runs `flutter run`. App builds (after xattr workaround — which is documented). App launches. First action = CTA tap = backend 503. Zero indication of HOW to get past this.
+
+**Root cause:** Debug build hardcoded to `localhost:8888`. No `.env.example → .env` bootstrap. No README mention that `ANTHROPIC_API_KEY` is required for coach to respond. No SLM on-device fallback.
+
+**Fix:**
+1. Add `services/backend/README.md` first-run section with required env vars
+2. Wire mobile `SlmAutoPromptService` as fallback when backend returns 503
+3. Show a "dev mode banner" when `!kReleaseMode && backend_unreachable`
+
+---
+
+### P0-4 (from Julien's screenshots earlier) : MVP wedge retraite-first framing
+
+**Not in this walk** (MVP wedge flag OFF default post-FIX-02), but Julien captured:
+- 34yo shown "CHF 4'653 – 6'210 / mois dès 65 ans" as FIRST hero number
+- "Laisse-moi un email. Je te retrouve demain." = stupid user-eject pattern
+- "Intention : Ma retraite" dossier re-anchors to retirement mindset
+
+**Fix:** Refonte scene "Ta retraite projetée" → show LEVIER présent. Kill "mail demain" copy — replace with inline retention ("Tu veux qu'on continue ? Donne-moi une minute de plus."). Broaden dossier intention.
+
+See Julien's message 2026-04-24 ~18:30.
+
+---
+
+### P1-1 : macOS Tahoe `com.apple.provenance` blocks `flutter build ios --simulator`
+
+**Symptom:** `codesign` fails with "resource fork, Finder information, or similar detritus not allowed" on `App.framework/App` even after `Strip xattrs before codesign` build phase runs.
+
+**Root cause:** macOS Tahoe SIP-level xattr that standard `xattr -c` / `xattr -d` can't remove as normal user. Xcode's codesign re-reads the xattr post-strip.
+
+**Workaround found:** `ditto --noextattr` to a clean copy + `codesign --force --deep --sign -` on the copy. Install the clean copy.
+
+**Fix for dev ergonomics:** Add this workaround to the xcode Strip phase (it currently uses `xattr -cr` which doesn't work). Or script `tools/simulator/rebuild-sim.sh`.
+
+---
+
+## Next fix order (my recommendation)
+
+1. **Wire `/anonymous/intent` route** — fix the broken walk path (highest user impact, smallest PR)
+2. **Map backend errors to user-friendly copy** (P0-2 error mapping)
+3. **Kill "email demain" wedge copy** — separate PR
+4. **Dev ergonomics doc** — backend README first-run
+5. **Retraite-first reframing** — biggest scope, needs product design
+
+## Data
+
+- Screenshots: 01-landing.png, 02-post-cta.png, 03-typing.png, 03a-focus.png, 04-typed.png, 05-after-send.png, 06-return-key.png, 07-response.png
+- Time-to-first-wall: ~30s after app launch (tap CTA → empty screen)
+- Time-to-second-wall: ~1min (type + send → silent error)

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -11,6 +11,7 @@ import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/screens/landing_screen.dart';
 import 'package:mint_mobile/screens/anonymous/anonymous_chat_screen.dart';
+import 'package:mint_mobile/screens/anonymous/anonymous_intent_screen.dart';
 import 'package:mint_mobile/screens/auth/login_screen.dart';
 import 'package:mint_mobile/screens/auth/register_screen.dart';
 import 'package:mint_mobile/screens/auth/forgot_password_screen.dart';
@@ -125,7 +126,6 @@ import 'package:mint_mobile/screens/document_scan/document_scan_screen.dart';
 import 'package:mint_mobile/screens/document_scan/avs_guide_screen.dart';
 import 'package:mint_mobile/screens/document_scan/extraction_review_screen.dart';
 import 'package:mint_mobile/screens/document_scan/document_impact_screen.dart';
-import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/providers/household_provider.dart';
 import 'package:mint_mobile/providers/biography_provider.dart';
 import 'package:mint_mobile/providers/timeline_provider.dart';
@@ -314,7 +314,7 @@ final _router = GoRouter(
       path: '/start',
       scope: RouteScope.public,
       redirect: (_, __) =>
-          FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/chat',
+          FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/intent',
     ),
     // MVP Wedge onboarding — storyboard v2 (2026-04-22). 9-step flow
     // with 4 intents + dossier densification + 3 N2 scenes + magic link.
@@ -352,6 +352,17 @@ final _router = GoRouter(
       ),
     ),
 
+    // ── Anonymous intent (public — felt-state pills + free-text) ──
+    // First screen for unauth users after landing CTA. Pill pick routes
+    // to /anonymous/chat?intent=X with auto-send. Without this, the chat
+    // screen renders empty (no greeting, no chips, placeholder "Ou dis-le
+    // comme tu veux" teases alternatives that never appeared) — walk report
+    // 2026-04-24 P0-1.
+    ScopedGoRoute(
+      path: '/anonymous/intent',
+      scope: RouteScope.public,
+      builder: (context, state) => const AnonymousIntentScreen(),
+    ),
     // ── Anonymous chat (public — outside shell, no tabs/drawer) ──
     ScopedGoRoute(
       path: '/anonymous/chat',

--- a/apps/mobile/lib/routes/route_metadata.dart
+++ b/apps/mobile/lib/routes/route_metadata.dart
@@ -168,7 +168,15 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     description: 'Magic-link verification landing',
   ),
 
-  // ── Anonymous chat (public, outside shell) ─────────────────────
+  // ── Anonymous flow (public, outside shell) ─────────────────────
+  '/anonymous/intent': RouteMeta(
+    path: '/anonymous/intent',
+    category: RouteCategory.flow,
+    owner: RouteOwner.anonymous,
+    requiresAuth: false,
+    killFlag: 'enableAnonymousFlow',
+    description: 'Anonymous intent picker — felt-state pills + free-text entry point',
+  ),
   '/anonymous/chat': RouteMeta(
     path: '/anonymous/chat',
     category: RouteCategory.destination,

--- a/apps/mobile/test/screens/admin/routes_registry_screen_test.dart
+++ b/apps/mobile/test/screens/admin/routes_registry_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
       expect(RouteOwner.values.length, 15);
     });
 
-    testWidgets('sum of route rows across all buckets == 150', (tester) async {
+    testWidgets('sum of route rows across all buckets == 151', (tester) async {
       // Force a large viewport so every ExpansionTile is laid out simultaneously
       // (default test surface is 800x600 which clips tiles below fold, preventing
       // taps from reaching them reliably after each expansion relayout).
@@ -68,8 +68,8 @@ void main() {
       );
       expect(
         rows,
-        findsNWidgets(150),
-        reason: 'registry has 150 entries; UI must render all',
+        findsNWidgets(151),
+        reason: 'registry has 151 entries; UI must render all',
       );
     });
 

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -4,7 +4,7 @@
 //   • The 4 text surfaces render (wordmark, paragraphe-mère, CTA, legal).
 //   • Privacy micro-phrase is present.
 //   • No banned term (retirement framing, aggressive CTAs) is rendered.
-//   • CTA navigates to /anonymous/chat (FIX-02 default + KILL-05 no-account).
+//   • CTA navigates to /anonymous/intent (walk 2026-04-24 P0-1: pill picker first).
 //   • Reduced-motion fallback renders content on first pump (no wait).
 //
 // CONTEXT.md §2 D-01..D-13 | LAND-01, LAND-02, LAND-04, LAND-05, LAND-06.
@@ -30,12 +30,12 @@ GoRouter _buildRouter() {
       GoRoute(
         path: '/start',
         redirect: (_, __) =>
-            FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/chat',
+            FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/intent',
       ),
       GoRoute(
-        path: '/anonymous/chat',
+        path: '/anonymous/intent',
         builder: (_, __) => const Scaffold(
-          body: Center(child: Text('ANONYMOUS_CHAT_STUB')),
+          body: Center(child: Text('ANONYMOUS_INTENT_STUB')),
         ),
       ),
       GoRoute(
@@ -123,14 +123,15 @@ void main() {
       }
     });
 
-    testWidgets('CTA routes to /anonymous/chat (FIX-02)', (tester) async {
+    testWidgets('CTA routes to /anonymous/intent (FIX-02 + walk 2026-04-24)',
+        (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
-      expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+      expect(find.text('ANONYMOUS_INTENT_STUB'), findsOneWidget);
     });
 
     testWidgets('reduced-motion: content visible on first pump', (tester) async {

--- a/tests/tools/test_mint_routes.py
+++ b/tests/tools/test_mint_routes.py
@@ -94,11 +94,11 @@ def test_missing_token_returns_71(monkeypatch):
 # ---------- DRY_RUN health output ----------
 
 
-def test_health_dry_run_produces_150_json_lines():
+def test_health_dry_run_produces_151_json_lines():
     r = _run(["health", "--json"], env_extra={"MINT_ROUTES_DRY_RUN": "1"})
     assert r.returncode == 0, r.stderr.decode()[:400]
     lines = [ln for ln in r.stdout.decode().splitlines() if ln.strip()]
-    assert len(lines) == 150, "expected 150 JSON lines, got {}".format(
+    assert len(lines) == 151, "expected 151 JSON lines, got {}".format(
         len(lines)
     )
 
@@ -110,7 +110,7 @@ def test_health_dry_run_owner_filter():
     )
     assert r.returncode == 0
     lines = [ln for ln in r.stdout.decode().splitlines() if ln.strip()]
-    assert 0 < len(lines) < 150
+    assert 0 < len(lines) < 151
 
 
 def test_no_color_env_var_suppresses_ansi():


### PR DESCRIPTION
## Summary
Device walk 2026-04-24 surfaced **P0-1** : tap landing CTA → `/anonymous/chat` lands on EMPTY screen (no greeting, no chips, placeholder "Ou dis-le comme tu veux…" teases alternatives that never existed). Dead-end UX.

**Root cause** : `AnonymousIntentScreen` (6 felt-state pills + free-text) exists as orphan Dart code but **is not registered in the router**. v2.9 audit P0-5 had flagged this already.

## Fix
- Register `/anonymous/intent` route → `AnonymousIntentScreen`
- Change `/start` redirect target `/anonymous/chat` → `/anonymous/intent` (MVP wedge flag branch `/onb` unchanged)
- Intent screen navigates to `/anonymous/chat?intent=X` with auto-send (existing behavior in `anonymous_intent_screen.dart:93`)
- Add `/anonymous/intent` to `kRouteRegistry` (MAP-04 parity)
- Drop duplicate `feature_flags.dart` import in app.dart
- Bump hardcoded test route counts 150 → 151 (mint-routes + admin UI)
- Update `landing_screen_test` stub to `ANONYMOUS_INTENT_STUB`

## Test plan
- [x] `flutter analyze` → No issues found
- [x] `flutter test test/screens/landing_screen_test.dart` → 4/4 green
- [x] `flutter test test/screens/admin/routes_registry_screen_test.dart` → 3/3 green
- [x] `python3 tools/checks/route_registry_parity.py` → 144 parity OK
- [ ] Device walk : tap landing CTA → see 6 pills, not empty screen
- [ ] Device walk : tap pill → chat with auto-sent intent

## Walk report shipped
`.planning/phases/30.14-wire-anonymous-intent/WALK-REPORT-2026-04-24.md` captures all 4 P0s found on iPhone 17 Pro simulator :
- **P0-1** — empty anonymous chat (THIS PR)
- **P0-2** — backend error → generic fallback (follow-up)
- **P0-3** — dev onboarding doc gap (follow-up)
- **P0-4** — MVP wedge retraite-first + email copy (follow-up, needs product design)

## Remaining Phase 36 scope
After this PR + follow-ups on P0-2/3/4, the anonymous flow is walkable. FIX-01 UUID + FIX-03 save_fact + FIX-04 Coach tab remain.

Refs : `.planning/phases/30.14-wire-anonymous-intent/30.14-00-READ.md`, walk report, v2.9 audit P0-5.