### PR TITLE
feat(doc-ext): tax LIFD false-positive fix + AVS IK table heuristic

### DIFF
--- a/.planning/phases/30.19-tax-avs-extraction-uplift/30.19-00-READ.md
+++ b/.planning/phases/30.19-tax-avs-extraction-uplift/30.19-00-READ.md
@@ -1,0 +1,74 @@
+# 30.19-00 — Tax + AVS extractor uplift
+
+## Context
+Continuation of Julien's mandate: "que toutes les valeurs qui sont dans
+ces certificats soient bien reconnues par l'application." After PR #394
+brought LPP to 15/18, this round patches Tax + AVS parsers found broken
+on `tests/fixtures/documents/`.
+
+## Files read / modified
+- `tests/fixtures/documents/tax_declaration_vs_julien.pdf`
+- `tests/fixtures/documents/avs_ik_extract.pdf`
+- `services/backend/app/services/document_parser/tax_declaration_parser.py`
+  (TAX_FIELD_PATTERNS dict)
+- `services/backend/app/services/document_parser/avs_extract_parser.py`
+  (parse_avs_extract function + new helpers)
+- `services/backend/tests/test_tax_avs_parsers.py`
+
+## Bugs found & fixed
+
+### Tax — `LIFD art. 33` law citation matched as impot_federal
+`(LIFD art. 33): 7'258 CHF` line was the 3a deduction context. The
+`r"ifd"` pattern matched "LIFD" inside the law citation and stole the
+7'258 amount as `impot_federal`. **Wrong**.
+
+Fix: tighten the pattern with negative lookbehind
+`(?<![A-Za-z])ifd\b(?!\s*art)`. Same for German `dbst`.
+
+### AVS — IK extract table format was unsupported
+The official Caisse de Compensation IK extract is printed as
+
+    Annee | Employeur | Revenu cotisant (CHF)
+    2016  | Employer 1| 95000
+    ...
+
+with NO `années de cotisation` / `RAMD` literal label. The parser
+returned 0 fields.
+
+Fix: add `_parse_ik_year_table` heuristic invoked as a fallback when
+explicit-label patterns yield nothing. Heuristic:
+- Match lines starting with a 4-digit year (1960..2039).
+- Pick the LARGEST 4+ digit number on the row as the income.
+- Floor at 5'000 CHF (rules out employer-index digits like
+  "Employeur 5", apprenticeship part-years).
+- Require ≥3 rows.
+- annees_cotisation = unique year count.
+- ramd = mean income (proxy for true LAVS art. 29sexies RAMD,
+  needs_review=True flag set).
+
+## Verification
+
+| Document | Before | After |
+|----------|-------:|------:|
+| `tax_declaration_vs_julien.pdf` | 3 fields (1 wrong : false impot_federal) | 2 fields (both correct) |
+| `avs_ik_extract.pdf` | 0/4 fields, conf 0.00 | 2/4 fields, conf 0.73 |
+
+7 new regression tests added in `test_tax_avs_parsers.py`:
+- `test_lifd_article_citation_does_not_match_impot_federal`
+- `test_explicit_impot_federal_still_matches`
+- `test_dbst_law_citation_does_not_match_german`
+- `test_table_with_10_years_extracts_annees_and_ramd`
+- `test_table_with_only_2_rows_does_not_trigger`
+- `test_employer_index_digits_ignored_for_income`
+- `test_explicit_label_takes_precedence_over_table`
+
+Total tests : 183 → 190, 7 new green.
+
+## Limitations (out of scope)
+- `tax_declaration_vs_julien.pdf` is a synthetic fixture without actual
+  tax amounts (only deductions and bases). Real cantonal/federal tax
+  figures will be tested when a real `avis de taxation` fixture is
+  added.
+- `taux_marginal_effectif` not extracted because the fixture doesn't
+  include it (real avis de taxation typically print it as % chiffre
+  near the impot_federal block).

--- a/services/backend/app/services/document_parser/avs_extract_parser.py
+++ b/services/backend/app/services/document_parser/avs_extract_parser.py
@@ -206,6 +206,75 @@ _SOURCES = [
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+# ── Table-style IK extract heuristic ────────────────────────────────
+# Official AVS account extracts (CI/IK) print one row per contribution
+# year, typically `YEAR | EMPLOYER | INCOME (CHF)`. We accept any
+# 4-digit year between 1960 and the current year + 1 followed by an
+# income amount on the same line. Min 3 rows to qualify.
+#
+# Income matching: pick the LARGEST number on the year-row that is
+# > 5'000 (typical AVS-cotisable income floor — sub-floor entries are
+# either employer-test indices or apprenticeship part-years).
+
+_IK_YEAR_LINE_RE = re.compile(
+    r"^\s*(?P<year>(?:19[6-9]\d|20[0-3]\d))\b(?P<rest>[^\n]*)$",
+    re.MULTILINE,
+)
+_IK_AMOUNT_TOKEN_RE = re.compile(
+    r"\d{1,3}(?:['’\s]\d{3})+(?:[.,]\d{1,2})?|\d{4,}(?:[.,]\d{1,2})?"
+)
+
+
+def _parse_ik_year_table(text: str) -> Optional[tuple[int, float, str]]:
+    """Detect a YEAR/EMPLOYER/INCOME row table in AVS IK extracts.
+
+    Returns ``(years_count, mean_revenue, raw_window)`` if at least 3
+    rows match. Returns None otherwise. The mean revenue is a *proxy*
+    for RAMD (true RAMD applies LAVS art. 29sexies indexation) and is
+    flagged needs_review by the caller.
+
+    Income heuristic: the income is the LARGEST 4+ digit token (or
+    Swiss-formatted thousands token) on the year-row. Single digits
+    embedded in employer names (`Employeur Test 5`) are ignored.
+    """
+    rows: list[tuple[int, float]] = []
+    raw_lines: list[str] = []
+    for m in _IK_YEAR_LINE_RE.finditer(text):
+        try:
+            year = int(m.group("year"))
+        except ValueError:
+            continue
+        rest = m.group("rest")
+        candidates: list[float] = []
+        for tok in _IK_AMOUNT_TOKEN_RE.findall(rest):
+            cleaned = (
+                tok.replace("'", "").replace("’", "")
+                .replace(" ", "").replace(",", ".")
+            )
+            try:
+                val = float(cleaned)
+            except ValueError:
+                continue
+            # Income floor: AVS-cotisable income above 5'000 CHF.
+            # Years like "2016" are ruled out by the line-anchor design,
+            # but enforce a positive floor here too.
+            if val < 5000.0 or val > 5_000_000.0:
+                continue
+            candidates.append(val)
+        if not candidates:
+            continue
+        amount = max(candidates)
+        rows.append((year, amount))
+        raw_lines.append(f"{year}{rest}".strip())
+    if len(rows) < 3:
+        return None
+    # Years count = unique year count.
+    years_count = len({y for y, _ in rows})
+    mean_revenue = sum(a for _, a in rows) / len(rows)
+    raw_window = "\n".join(raw_lines[:5])
+    return years_count, mean_revenue, raw_window
+
+
 def parse_avs_extract(text: str) -> ExtractionResult:
     """Extrait les champs structures d'un texte OCR d'extrait de compte AVS.
 
@@ -276,6 +345,38 @@ def parse_avs_extract(text: str) -> ExtractionResult:
 
         if best_match is not None:
             extracted_fields.append(best_match)
+
+    # Table-style IK extract fallback: official AVS account extracts (CI/IK)
+    # are usually printed as a YEAR | EMPLOYER | INCOME table without the
+    # explicit "années de cotisation" / "RAMD" labels the patterns above
+    # expect. Detect such tables and derive both fields from the rows.
+    # 2026-04-25: ground-truth `tests/fixtures/documents/avs_ik_extract.pdf`.
+    extracted_field_names = {f.field_name for f in extracted_fields}
+    if "annees_cotisation" not in extracted_field_names or "ramd" not in extracted_field_names:
+        table = _parse_ik_year_table(text)
+        if table is not None:
+            years_count, mean_revenue, raw_window = table
+            if "annees_cotisation" not in extracted_field_names:
+                extracted_fields.append(
+                    ExtractedField(
+                        field_name="annees_cotisation",
+                        value=float(years_count),
+                        confidence=0.85,
+                        source_text=raw_window,
+                        needs_review=False,
+                    )
+                )
+            if "ramd" not in extracted_field_names and mean_revenue >= AVS_RAMD_MIN:
+                extracted_fields.append(
+                    ExtractedField(
+                        field_name="ramd",
+                        value=float(round(mean_revenue, 2)),
+                        confidence=0.75,
+                        source_text=raw_window,
+                        needs_review=True,  # mean of the window, not an
+                                            # official RAMD figure
+                    )
+                )
 
     result.fields = extracted_fields
 

--- a/services/backend/app/services/document_parser/tax_declaration_parser.py
+++ b/services/backend/app/services/document_parser/tax_declaration_parser.py
@@ -99,10 +99,15 @@ TAX_FIELD_PATTERNS: dict[str, dict] = {
         "patterns": [
             r"imp[oô]t\s+f[ée]d[ée]ral\s+direct",
             r"imp[oô]t\s+f[ée]d[ée]ral",
-            r"ifd",
+            # `ifd` standalone matched the law name "LIFD" (Loi sur l'IFD)
+            # in citations like "(LIFD art. 33)" and stole the amount on
+            # that line (typically a 3a deduction). Require word boundary
+            # AND no preceding letter (rules out 'L' in 'LIFD'). 2026-04-25.
+            r"(?<![A-Za-z])ifd\b(?!\s*art)",
             r"direkte?\s+bundessteuer",
             r"bundessteuer",
-            r"dbst",
+            # Same fix for German DBST law reference.
+            r"(?<![A-Za-z])dbst\b(?!\s*art)",
         ],
     },
     "taux_marginal_effectif": {

--- a/services/backend/tests/test_tax_avs_parsers.py
+++ b/services/backend/tests/test_tax_avs_parsers.py
@@ -736,3 +736,154 @@ class TestFieldPatterns:
         """AVS_HIGH_IMPACT_FIELDS est un sous-ensemble de AVS_FIELD_PATTERNS."""
         for field in AVS_HIGH_IMPACT_FIELDS:
             assert field in AVS_FIELD_PATTERNS, f"{field} absent de AVS_FIELD_PATTERNS"
+
+
+# ── Regression tests added 2026-04-25 (extraction uplift) ───────────
+
+
+class TestTaxLifdLawCitationDoesNotPickAmount:
+    """Regression: `(LIFD art. 33): 7'258 CHF` line was matching the
+    `ifd` pattern of impot_federal and stealing the 3a deduction
+    amount as if it was a federal tax. Fixed by negative lookbehind
+    on `[A-Za-z]ifd` and negative lookahead on `ifd\\s*art`."""
+
+    def test_lifd_article_citation_does_not_match_impot_federal(self):
+        """3a deduction line MUST NOT be matched as impot_federal."""
+        text = (
+            "Revenu brut: 122'207 CHF\n"
+            "Deductions:\n"
+            "3e pilier A (LIFD art. 33): 7'258 CHF\n"
+            "Revenu imposable: 112'400 CHF\n"
+        )
+        result = parse_tax_declaration(text)
+        federal = next(
+            (f for f in result.fields if f.field_name == "impot_federal"),
+            None,
+        )
+        assert federal is None, (
+            "Regression: LIFD law citation matched as impot_federal "
+            f"(value: {federal.value if federal else None})"
+        )
+
+    def test_explicit_impot_federal_still_matches(self):
+        """Real impot_federal label MUST still extract the amount."""
+        text = (
+            "Recapitulatif:\n"
+            "Impot federal direct: 8'200 CHF\n"
+            "Impot cantonal: 12'500 CHF\n"
+        )
+        result = parse_tax_declaration(text)
+        federal = next(
+            (f for f in result.fields if f.field_name == "impot_federal"),
+            None,
+        )
+        assert federal is not None
+        assert federal.value == 8200.0
+
+    def test_dbst_law_citation_does_not_match_german(self):
+        """Same fix for German DBST law citation."""
+        text = (
+            "Saulen 3a (DBSt art. 81): 7'056 CHF\n"
+            "Steuerbares Einkommen: 95'000 CHF\n"
+        )
+        result = parse_tax_declaration(text)
+        federal = next(
+            (f for f in result.fields if f.field_name == "impot_federal"),
+            None,
+        )
+        assert federal is None
+
+
+class TestAvsIkTableHeuristic:
+    """Regression: AVS IK extracts printed as YEAR/EMPLOYER/INCOME tables
+    were extracting 0 fields because no `années de cotisation` /
+    `RAMD` literal label was present. Fallback heuristic now derives
+    both from row count + mean income."""
+
+    def test_table_with_10_years_extracts_annees_and_ramd(self):
+        text = (
+            "Extrait du compte individuel AVS\n"
+            "Annee | Employeur | Revenu cotisant (CHF)\n"
+            "2016 | Employeur Test 1 | 95000\n"
+            "2017 | Employeur Test 2 | 97500\n"
+            "2018 | Employeur Test 3 | 100000\n"
+            "2019 | Employeur Test 4 | 103500\n"
+            "2020 | Employeur Test 5 | 108000\n"
+            "2021 | Employeur Test 6 | 111000\n"
+            "2022 | Employeur Test 7 | 114500\n"
+            "2023 | Employeur Test 8 | 117000\n"
+            "2024 | Employeur Test 9 | 119500\n"
+            "2025 | Employeur Test 10 | 122207\n"
+        )
+        result = parse_avs_extract(text)
+        annees = next(
+            (f for f in result.fields if f.field_name == "annees_cotisation"),
+            None,
+        )
+        ramd = next(
+            (f for f in result.fields if f.field_name == "ramd"), None
+        )
+        assert annees is not None and annees.value == 10.0, (
+            f"annees_cotisation mismatch: {annees.value if annees else None}"
+        )
+        assert ramd is not None
+        # Mean of (95000 + 97500 + 100000 + 103500 + 108000 + 111000 +
+        #          114500 + 117000 + 119500 + 122207) / 10 = 108_820.70
+        assert abs(ramd.value - 108_820.70) < 1.0
+        assert ramd.needs_review is True  # Heuristic, not official
+
+    def test_table_with_only_2_rows_does_not_trigger(self):
+        """Below the 3-row floor: no table extraction."""
+        text = (
+            "Annee | Employeur | Revenu\n"
+            "2024 | Test | 100000\n"
+            "2025 | Test | 105000\n"
+        )
+        result = parse_avs_extract(text)
+        # Neither annees nor ramd should be set from the table.
+        annees = next(
+            (f for f in result.fields if f.field_name == "annees_cotisation"),
+            None,
+        )
+        ramd = next(
+            (f for f in result.fields if f.field_name == "ramd"), None
+        )
+        assert annees is None and ramd is None
+
+    def test_employer_index_digits_ignored_for_income(self):
+        """`Employeur 5` digit 5 must NOT be picked as income."""
+        text = (
+            "Annee | Employeur | Revenu\n"
+            "2023 | Employeur 5 | 117000\n"
+            "2024 | Employeur 9 | 119500\n"
+            "2025 | Employeur 10 | 122000\n"
+        )
+        result = parse_avs_extract(text)
+        ramd = next(
+            (f for f in result.fields if f.field_name == "ramd"), None
+        )
+        assert ramd is not None
+        assert ramd.value > 100_000
+
+    def test_explicit_label_takes_precedence_over_table(self):
+        """If both an explicit RAMD label AND a table are present, the
+        explicit label must win (already in extracted_fields before
+        the table fallback runs)."""
+        text = (
+            "Annees de cotisation: 25\n"
+            "Revenu annuel moyen determinant (RAMD): 95'000 CHF\n"
+            "Annee | Employeur | Revenu\n"
+            "2023 | A | 80000\n"
+            "2024 | B | 82000\n"
+            "2025 | C | 84000\n"
+        )
+        result = parse_avs_extract(text)
+        annees = next(
+            (f for f in result.fields if f.field_name == "annees_cotisation"),
+            None,
+        )
+        ramd = next(
+            (f for f in result.fields if f.field_name == "ramd"), None
+        )
+        assert annees is not None and annees.value == 25.0
+        assert ramd is not None and ramd.value == 95000.0


### PR DESCRIPTION
## Summary
Continuation of #394 LPP uplift. Found 2 bugs running the tax + AVS parsers on `tests/fixtures/documents/`.

## Bug 1 — Tax: LIFD law citation matched as impot_federal

**Symptom:** line `(LIFD art. 33): 7'258 CHF` (a 3a deduction context) was extracted as `impot_federal=7258`. The lax `r"ifd"` regex matched "LIFD" inside the law citation.

**Fix:** tighten with negative lookbehind on letters + negative lookahead on `art`:
```python
r"(?<![A-Za-z])ifd\b(?!\s*art)"
```
Same for German `dbst`.

## Bug 2 — AVS IK table format unsupported (0 fields)

Official Caisse de Compensation IK extracts print

```
Annee | Employeur | Revenu cotisant (CHF)
2016  | Employer 1| 95000
...
```

with **no** `années de cotisation` / `RAMD` literal labels. Pattern-only parser returned 0 fields.

**Fix:** added `_parse_ik_year_table` fallback that fires only when explicit labels yielded nothing:
- Match lines starting with a 4-digit year (1960..2039).
- Pick LARGEST 4+ digit number on row as income (floor 5'000 CHF — rules out employer-index digits like "Employeur 5", apprenticeship quarters).
- Require ≥3 rows.
- `annees_cotisation` = unique year count.
- `ramd` = mean income, flagged `needs_review=True` (proxy for true LAVS art. 29sexies RAMD).
- **Explicit labels still take precedence**.

## Coverage uplift

| Document | Before | After |
|----------|-------:|------:|
| `tax_declaration_vs_julien.pdf` | 3 fields (1 wrong : impot_federal=7258) | 2 fields (both correct) |
| `avs_ik_extract.pdf` | 0/4 fields, conf 0.00 | 2/4 fields, conf 0.73 |

## Tests
- 7 new regression assertions in `tests/test_tax_avs_parsers.py`:
  - `test_lifd_article_citation_does_not_match_impot_federal`
  - `test_explicit_impot_federal_still_matches`
  - `test_dbst_law_citation_does_not_match_german`
  - `test_table_with_10_years_extracts_annees_and_ramd`
  - `test_table_with_only_2_rows_does_not_trigger`
  - `test_employer_index_digits_ignored_for_income`
  - `test_explicit_label_takes_precedence_over_table`
- 183 → **190 tests green**, zero regressions

## Limitations
- `tax_declaration_vs_julien.pdf` is a synthetic fixture without real tax figures (only declared bases + deductions). Cantonal/communal/marginal will be tested with a real `avis de taxation` fixture when added.

Refs: `.planning/phases/30.19-tax-avs-extraction-uplift/`.