### PR TITLE
fix(login): bump magic link button 48→56 (text crop fix)

### DIFF
--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -239,7 +239,15 @@ class _LoginScreenState extends State<LoginScreen> {
                             label: l10n.authSendLink,
                             button: true,
                             child: SizedBox(
-                              height: 48,
+                              // Material 3 spec primary CTA = 56 (matches
+                              // landing_screen.dart « Parle à Mint » CTA which
+                              // uses minimumSize: Size.fromHeight(56)).
+                              // 48px caused vertical clip on
+                              // « Recevoir un lien magique » (23 chars under
+                              // the project's font-scale exceeded the 48px
+                              // content area — visible bug confirmed via
+                              // live sim screenshot 2026-05-02).
+                              height: 56,
                               child: FilledButton(
                                 onPressed: authProvider.isLoading
                                     ? null


### PR DESCRIPTION
## Summary
- Bump `SizedBox(height: 48)` → `height: 56` on the « Recevoir un lien magique » button in `login_screen.dart`
- Fixes a visible vertical text-clip bug observed live on iPhone 17 Pro sim 2026-05-02
- Aligns with Material 3 primary CTA spec + with `landing_screen.dart` « Parle à Mint » CTA which already uses `minimumSize: Size.fromHeight(56)`

## Why now
This was caught during an autonomous Product Leader walkthrough of the sim by Claude on 2026-05-02 (see `/tmp/mint-bug-report/index.html` Bug #5). The crop was visible at first glance and Julien confirmed it visually. Inter-screen height inconsistency (landing 56 px, login 48 px) was likely an oversight from the auth screen polish phase.

## Test plan
- [ ] `flutter analyze lib/screens/auth/login_screen.dart` → 0 issues (verified locally)
- [ ] On the iPhone 17 Pro sim: launch app → tap « J'ai déjà un compte » → Connexion screen renders → « Recevoir un lien magique » button is 56 px tall, text fully visible (no top/bottom clip)
- [ ] Visual diff vs main: button is taller, no other layout shifts (Spacing.md gap above/below preserved)

## Out of scope
- The deeper Bug #1 from the same audit (anonymous chat shows no chat-vivant scenes by design — `anonymous_chat.py` has `tools=None`) requires a product call (Phase 51.5 « anonymous scene teaser » or v2.11) and is NOT addressed here.
- Other bugs in the audit (chip 8s reveal animation, no chat back nav, walker text-input untestable) are filed for follow-up but unrelated to this fix.

🤖 Generated by Claude as autonomous Product Leader audit + ship.