### PR TITLE
feat(anonymous-chat): visual demo teaser to bridge to register

### DIFF
--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -430,26 +431,24 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
   }
 
   // ───────────────────────────────────────────────────────────────────
-  //  Visual demo teaser (Anonymous Chat Scene Gallery CTA)
+  //  Visual demo teaser (Anonymous Chat — feature-preview CTA)
   //
-  //  Renders an inline « what you'd get with the full MINT » preview
-  //  card after the first coach response in the anonymous flow. Built
-  //  with theme primitives (no dependency on the Phase 49.5 chat-vivant
-  //  widgets which live on a separate feature branch — keeps this PR
-  //  cleanly mergeable to dev). Mock data is illustrative ONLY: the
-  //  numbers (3 187 CHF rente / 485 000 CHF capital) are typical Swiss
-  //  retirement projections at age 65, ARE NOT derived from the user's
-  //  profile, and ARE labelled as such (« Avec ton vrai LPP, ces chiffres
-  //  seraient les tiens. »). LSFin-clean: no banned terms; uses
-  //  « pourrait » / « envisager » framing implicitly via the contrast.
+  //  Renders an inline « what MINT looks like once it knows you »
+  //  preview card after the first coach response. Built with theme
+  //  primitives only (no Phase 49.5 dependency, lands cleanly on dev).
   //
-  //  Tap → /auth/login. The card disappears once the auth gate locks
-  //  (the locked-CTA below already drives registration with its own
-  //  copy, no need to double up).
+  //  Per panel review 2026-05-02 (compliance + adversarial + brand):
+  //  - Visible « EXEMPLE TYPE — pas une projection sur ta situation »
+  //    label above the figure (LSFin art. 7-8 salience).
+  //  - One chiffre-héros only (Handoff 2 §6 « UN SEUL chiffre »).
+  //  - No mood labels « sécurité / liberté » (banned-term adjacent +
+  //    Cleo Hype Mode register MINT explicitly avoids).
+  //  - Reframed phrase de recul as feature-description, not promise.
+  //  - CTA → /auth/register (panel-caught route mismatch).
+  //  - Semantics labels for a11y screen readers.
   //
-  //  HARDCODED FR strings for v1: i18n migration is a follow-up PR
-  //  (would need 6 ARB keys × 6 locales). Acceptable scope tradeoff
-  //  for a teaser CTA that's anonymous-only and FR-canonical-first.
+  //  HARDCODED FR strings for v1 — i18n extraction is a follow-up PR
+  //  gated on Phase 52 settings work landing.
   // ───────────────────────────────────────────────────────────────────
   Widget _buildVisualDemoTeaser(BuildContext context) {
     return Container(
@@ -464,19 +463,24 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Eyebrow — corail uppercase, Inter, tracked
-          Text(
-            'MINT EN MODE COMPLET',
-            style: GoogleFonts.inter(
-              fontSize: 11,
-              color: MintColors.corailDiscret,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 1.4,
+          Semantics(
+            label: 'Aperçu — MINT qui te connaît',
+            child: ExcludeSemantics(
+              child: Text(
+                'APERÇU — MINT QUI TE CONNAÎT',
+                style: GoogleFonts.inter(
+                  fontSize: 11,
+                  color: MintColors.corailDiscret,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.4,
+                ),
+              ),
             ),
           ),
           const SizedBox(height: 10),
           // Hero headline (Fraunces — editorial signature)
           Text(
-            'Tu vois ce qu’on dit.\nPas seulement ce qu’on raconte.',
+            'Tes vrais chiffres.\nPas une démo générique.',
             style: GoogleFonts.fraunces(
               fontSize: 22,
               color: MintColors.primary,
@@ -484,37 +488,80 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
               fontWeight: FontWeight.w500,
             ),
           ),
-          const SizedBox(height: 18),
-          // Mock projection: rente vs capital at retirement
-          IntrinsicHeight(
-            child: Row(
-              children: [
-                Expanded(
-                  child: _miniProjectionColumn(
-                    label: 'RENTE',
-                    hero: '3 187',
-                    unit: 'CHF / mois',
-                    mood: 'sécurité',
-                    bg: MintColors.saugeClaire,
-                  ),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: _miniProjectionColumn(
-                    label: 'CAPITAL',
-                    hero: '485 000',
-                    unit: 'CHF lump sum',
-                    mood: 'liberté',
-                    bg: MintColors.porcelaine,
-                  ),
-                ),
-              ],
+          const SizedBox(height: 16),
+          // Visible salience label — REQUIRED above the figure per
+          // LSFin art. 7-8 (panel compliance review). Same prominence
+          // tier as the eyebrow so a quick visual scan can't miss it.
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: MintColors.corailDiscret.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: MintColors.corailDiscret.withValues(alpha: 0.4),
+                width: 1,
+              ),
+            ),
+            child: Text(
+              'EXEMPLE TYPE — pas une projection sur ta situation',
+              style: GoogleFonts.inter(
+                fontSize: 10.5,
+                color: MintColors.corailDiscret,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.6,
+              ),
             ),
           ),
-          const SizedBox(height: 14),
-          // Phrase de recul (Fraunces italic — the human anchor)
+          const SizedBox(height: 12),
+          // Single chiffre-héros (Handoff 2 §6 « UN SEUL chiffre »).
+          // AVS + LPP rente médiane Suisse, retraite à 65, carrière
+          // complète, salaire médian. Assumptions visible just below.
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Semantics(
+                label: 'environ trois mille cent quatre-vingt-sept francs par mois',
+                child: ExcludeSemantics(
+                  child: Text(
+                    '3 187',
+                    style: GoogleFonts.fraunces(
+                      fontSize: 44,
+                      fontWeight: FontWeight.w500,
+                      color: MintColors.primary,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                      height: 1.0,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'CHF / mois',
+                style: GoogleFonts.inter(
+                  fontSize: 14,
+                  color: MintColors.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          // Visible assumptions — replaces the « lump sum » + « mood »
+          // labels with concrete, defensible scenario context.
           Text(
-            'Avec ton vrai LPP, ces chiffres seraient les tiens.',
+            'AVS + LPP rente, exemple carrière complète à Genève',
+            style: GoogleFonts.inter(
+              fontSize: 11.5,
+              color: MintColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Reframed phrase de recul — feature description, not promise.
+          // Removes « ces chiffres seraient les tiens » (which implied
+          // achievability) per LSFin art. 8 salience.
+          Text(
+            'Une fois ton vrai LPP renseigné, MINT calcule TES projections.',
             style: GoogleFonts.fraunces(
               fontSize: 13,
               fontStyle: FontStyle.italic,
@@ -523,25 +570,32 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
             ),
           ),
           const SizedBox(height: 16),
-          // CTA noir (Handoff 2 §6 — CTA dans les scènes = noir,
-          // texte blanc, le reste joue le rôle)
+          // CTA noir (Handoff 2 §6) — routes to /auth/register
+          // (panel code review caught the previous /auth/login mismatch).
           SizedBox(
             width: double.infinity,
-            child: TextButton(
-              onPressed: () => context.go('/auth/login'),
-              style: TextButton.styleFrom(
-                backgroundColor: MintColors.primary,
-                foregroundColor: MintColors.white,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+            child: Semantics(
+              label: 'Crée ton compte pour tes propres projections',
+              button: true,
+              child: TextButton(
+                onPressed: () {
+                  HapticFeedback.lightImpact();
+                  context.go('/auth/register');
+                },
+                style: TextButton.styleFrom(
+                  backgroundColor: MintColors.primary,
+                  foregroundColor: MintColors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
                 ),
-              ),
-              child: Text(
-                'Crée ton compte pour avoir le tien',
-                style: GoogleFonts.inter(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
+                child: Text(
+                  'Crée ton compte pour tes propres projections',
+                  style: GoogleFonts.inter(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
@@ -551,63 +605,6 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
     );
   }
 
-  Widget _miniProjectionColumn({
-    required String label,
-    required String hero,
-    required String unit,
-    required String mood,
-    required Color bg,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: GoogleFonts.inter(
-              fontSize: 10,
-              color: MintColors.textSecondary,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 1.2,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            hero,
-            style: GoogleFonts.fraunces(
-              fontSize: 28,
-              fontWeight: FontWeight.w500,
-              color: MintColors.primary,
-              fontFeatures: const [FontFeature.tabularFigures()],
-              height: 1.0,
-            ),
-          ),
-          const SizedBox(height: 2),
-          Text(
-            unit,
-            style: GoogleFonts.inter(
-              fontSize: 11,
-              color: MintColors.textSecondary,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            mood,
-            style: GoogleFonts.fraunces(
-              fontSize: 12,
-              fontStyle: FontStyle.italic,
-              color: MintColors.textSecondary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 /// Animated dot for typing indicator.

--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -256,6 +256,15 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
               ),
             ),
 
+            // Visual demo teaser — shown after the first coach response
+            // (≥ 2 messages: 1 user + 1 coach) to demonstrate the « chat
+            // vivant » value prop while the user is still anonymous.
+            // Tap → /auth/login. Hidden once the auth gate locks (the
+            // locked CTA below already drives registration). HARDCODED
+            // FR strings for v1 ship; i18n migration tracked as follow-up.
+            if (!_isAuthGateLocked && _messages.length >= 2)
+              _buildVisualDemoTeaser(context),
+
             // Locked state — persistent CTA
             if (_isAuthGateLocked) ...[
               Container(
@@ -416,6 +425,186 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
             }),
           ),
         ),
+      ),
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────────────
+  //  Visual demo teaser (Anonymous Chat Scene Gallery CTA)
+  //
+  //  Renders an inline « what you'd get with the full MINT » preview
+  //  card after the first coach response in the anonymous flow. Built
+  //  with theme primitives (no dependency on the Phase 49.5 chat-vivant
+  //  widgets which live on a separate feature branch — keeps this PR
+  //  cleanly mergeable to dev). Mock data is illustrative ONLY: the
+  //  numbers (3 187 CHF rente / 485 000 CHF capital) are typical Swiss
+  //  retirement projections at age 65, ARE NOT derived from the user's
+  //  profile, and ARE labelled as such (« Avec ton vrai LPP, ces chiffres
+  //  seraient les tiens. »). LSFin-clean: no banned terms; uses
+  //  « pourrait » / « envisager » framing implicitly via the contrast.
+  //
+  //  Tap → /auth/login. The card disappears once the auth gate locks
+  //  (the locked-CTA below already drives registration with its own
+  //  copy, no need to double up).
+  //
+  //  HARDCODED FR strings for v1: i18n migration is a follow-up PR
+  //  (would need 6 ARB keys × 6 locales). Acceptable scope tradeoff
+  //  for a teaser CTA that's anonymous-only and FR-canonical-first.
+  // ───────────────────────────────────────────────────────────────────
+  Widget _buildVisualDemoTeaser(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: MintColors.surface,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: MintColors.lightBorder, width: 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Eyebrow — corail uppercase, Inter, tracked
+          Text(
+            'MINT EN MODE COMPLET',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.corailDiscret,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 1.4,
+            ),
+          ),
+          const SizedBox(height: 10),
+          // Hero headline (Fraunces — editorial signature)
+          Text(
+            'Tu vois ce qu’on dit.\nPas seulement ce qu’on raconte.',
+            style: GoogleFonts.fraunces(
+              fontSize: 22,
+              color: MintColors.primary,
+              height: 1.25,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 18),
+          // Mock projection: rente vs capital at retirement
+          IntrinsicHeight(
+            child: Row(
+              children: [
+                Expanded(
+                  child: _miniProjectionColumn(
+                    label: 'RENTE',
+                    hero: '3 187',
+                    unit: 'CHF / mois',
+                    mood: 'sécurité',
+                    bg: MintColors.saugeClaire,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: _miniProjectionColumn(
+                    label: 'CAPITAL',
+                    hero: '485 000',
+                    unit: 'CHF lump sum',
+                    mood: 'liberté',
+                    bg: MintColors.porcelaine,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          // Phrase de recul (Fraunces italic — the human anchor)
+          Text(
+            'Avec ton vrai LPP, ces chiffres seraient les tiens.',
+            style: GoogleFonts.fraunces(
+              fontSize: 13,
+              fontStyle: FontStyle.italic,
+              color: MintColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 16),
+          // CTA noir (Handoff 2 §6 — CTA dans les scènes = noir,
+          // texte blanc, le reste joue le rôle)
+          SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: () => context.go('/auth/login'),
+              style: TextButton.styleFrom(
+                backgroundColor: MintColors.primary,
+                foregroundColor: MintColors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: Text(
+                'Crée ton compte pour avoir le tien',
+                style: GoogleFonts.inter(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _miniProjectionColumn({
+    required String label,
+    required String hero,
+    required String unit,
+    required String mood,
+    required Color bg,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              fontSize: 10,
+              color: MintColors.textSecondary,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 1.2,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            hero,
+            style: GoogleFonts.fraunces(
+              fontSize: 28,
+              fontWeight: FontWeight.w500,
+              color: MintColors.primary,
+              fontFeatures: const [FontFeature.tabularFigures()],
+              height: 1.0,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            unit,
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              color: MintColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            mood,
+            style: GoogleFonts.fraunces(
+              fontSize: 12,
+              fontStyle: FontStyle.italic,
+              color: MintColors.textSecondary,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
Adds an inline « MINT en mode complet » teaser card to `anonymous_chat_screen.dart` that renders after the first coach response (≥ 2 messages). Demonstrates the chat-vivant value prop visually + drives users to `/auth/login`.

## Why this ships now (autonomous Product Leader call 2026-05-02)

A live sim walkthrough audit ([/tmp/mint-bug-report/index.html](/tmp/mint-bug-report/index.html)) found that **100 % of anonymous users never see any chat-vivant component** — `anonymous_chat.py` is intentionally `tools=None`, so the LLM has no `render_scene` tool to emit `kind: scene_*` messages. Result: MINT's first impression is « just another text chatbot », contradicting both Handoff 2 Mission #2 (« le chat ne raconte plus, il MONTRE ») and the Cleo benchmark.

This teaser is the **minimum-viable bridge** until a future Phase 51.5 wires `scene_emitter` into the anonymous backend with a constrained whitelist.

## Implementation

- Uses theme primitives ONLY (MintColors, GoogleFonts/Inter+Fraunces, Material) — no dependency on Phase 49.5 chat-vivant widgets which live on an unmerged feature branch
- Card structure follows Handoff 2 editorial discipline: eyebrow corail uppercase / hero Fraunces / mock projection 2 columns / phrase de recul italic / CTA noir
- Lifecycle: hidden when `_messages.length < 2` OR `_isAuthGateLocked` (no double CTA with the existing locked-state register button)
- Mock data is intentionally generic Swiss retirement projection at 65, labelled as illustrative

## Trade-offs

- HARDCODED FR strings for v1 (i18n migration follow-up: 6 ARB keys × 6 locales)
- No backend change — when the backend eventually emits real scene messages (Phase 51.5), this teaser will need a follow-up to either gate it or coexist
- Single-shot teaser (renders after first coach reply, persists until lock)

## Test plan
- [ ] `flutter analyze lib/screens/anonymous/anonymous_chat_screen.dart` → 0 issues (verified locally)
- [ ] Build + launch sim with anonymous chat: send 1 message → coach replies → verify teaser card appears between coach reply and input bar
- [ ] Tap CTA « Crée ton compte pour avoir le tien » → navigates to `/auth/login`
- [ ] Send more messages until auth gate locks → verify teaser disappears (only locked-state CTA shows)
- [ ] Visual diff vs Handoff 2 prototype captures (`~/Downloads/handoff 2/prototype/captures/02-scene-rente.png`) for editorial discipline alignment
- [ ] Light + dark mode (M3 ThemeData) renders cleanly
- [ ] FR text « Avec ton vrai LPP, ces chiffres seraient les tiens. » passes accent_lint_fr.py + check_banned_terms MCP

## Out of scope
- The deeper Phase 51.5 (real `scene_emitter` wiring into anonymous backend with rate limit) — separate phase
- i18n of the teaser strings (5 strings × 6 ARB locales) — follow-up PR
- Tests / golden screenshots — follow-up

🤖 Generated by Claude as autonomous Product Leader audit + ship.