### PR TITLE
Phase 52 (planning) — auth local-first toggle (CONTEXT + PLAN)

### DIFF
--- a/.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md
+++ b/.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md
@@ -1,0 +1,108 @@
+# Phase 52 — Auth Local-First Toggle (CONTEXT)
+
+**Status:** Open (planning)
+**Origin:** Companion phase to PR #422 (register subtitle l10n) + PR #423 (data residency decision doc). Without Phase 52 landing, PR #422's promise « Sync controls coming to Settings soon » remains a forward-looking statement without code behind it.
+**Decided by:** Julien signoff pending (data residency decision doc Status = Proposed).
+
+## Goal (one sentence)
+
+Refactor `auth_provider.dart` so account creation does NOT implicitly enable cloud sync, and add a Settings › Confidentialité toggle that lets the user explicitly opt IN to multi-device cloud sync. After Phase 52 lands, the « tes données restent sur ton appareil » strings across the app become universally accurate again.
+
+## Why now
+
+1. PR #422 shipped a forward-looking promise (« Sync controls coming to Settings soon ») in 6 locales. Phase 52 is what makes that promise true.
+2. The data residency decision doc (Path A v2.x → Q3 Swiss-region → v3.0 E2EE) explicitly identifies Phase 52 as the v2.x deliverable.
+3. Brand positioning « Ta lucidité. Ton appareil. Ton choix de synchroniser. » requires the toggle to exist.
+4. nFADP art. 19 (information at collection) + LSFin art. 8 (no overstatement of feature availability) — without Phase 52, the gap between « what we say » and « what the code does » remains material.
+
+## Locked decisions
+
+### D-01 — Default local-mode after register/login
+After this phase, `auth_provider.dart` keeps `_isLocalMode = true` after register/login. Account creation is identity-only (auth + JWT, profile metadata server-side for password reset). User data (chat history, profile fields, documents, insights) STAYS on device unless user explicitly enables cloud sync.
+
+### D-02 — Settings location: Settings › Confidentialité
+A new `confidentialite_settings_screen.dart` lives next to the existing `langue_settings_screen.dart` in `apps/mobile/lib/screens/settings/`. The route is `/settings/confidentialite`. The route is reachable from the Profile screen (Phase 50.x nav) under a « Confidentialité » row.
+
+### D-03 — Toggle UX
+A single explicit toggle: « Synchronisation cloud (multi-appareils) » with subtitle « Sauvegarde + sync chiffrée sur nos serveurs européens. Activable / désactivable à tout moment. » Default OFF. When toggled ON, the next sync push goes through; when OFF, no further data leaves the device. Existing cloud-side data is NOT auto-deleted on toggle-off (user can issue a separate « Supprimer mes données cloud » action — out of scope for Phase 52, deferred to v2.11).
+
+### D-04 — Backwards compatibility for existing accounts
+Existing users (registered before Phase 52) currently have `_isLocalMode = false` (silently set at register). On first launch post-update, we preserve their current behavior (cloud sync stays ON for them) but show a one-time « Nouvelle option : tu peux maintenant désactiver la synchronisation cloud depuis Réglages › Confidentialité » toast/sheet. Migration is opt-out for existing users (don't surprise-disable their sync), opt-IN for new users (default OFF).
+
+### D-05 — Transparent state surfacing
+The Profile screen displays a compact « Synchronisation : activée / désactivée » status row. The « Coach personnalisé » feature still works in both states — uses local SQLite for opted-out users, server-side coaching context for opted-in.
+
+### D-06 — No backend changes in this phase
+The backend `_isLocalMode` flag is mobile-only state. The backend already accepts both authenticated AND anonymous calls. Mobile gates whether to push profile updates / chat history / documents to the backend based on the local flag. Zero backend code change in Phase 52 (server-side opt-out implementation = v2.11 if needed).
+
+### D-07 — String key naming convention
+New ARB keys prefixed `settingsPrivacy*`:
+- `settingsPrivacyTitle` → « Confidentialité »
+- `settingsPrivacyCloudSyncTitle` → « Synchronisation cloud (multi-appareils) »
+- `settingsPrivacyCloudSyncSubtitle` → « Sauvegarde + sync chiffrée sur nos serveurs européens. Activable / désactivable à tout moment. »
+- `settingsPrivacyCloudSyncOn` → « Activée »
+- `settingsPrivacyCloudSyncOff` → « Désactivée »
+- `settingsPrivacyMigrationToast` → « Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité »
+- `settingsPrivacyDataLocation` → « Tes données restent chiffrées sur ton appareil. Avec la sync cloud, elles sont aussi chiffrées sur nos serveurs européens (sauvegarde + multi-appareils). »
+
+All 6 locales (FR canonical / EN / DE / ES / IT / PT). FR uses tutoiement.
+
+### D-08 — Update register screen subtitle (post-Phase 52)
+After Phase 52 ships, update `authRegisterSubtitle` in 6 locales again — this time to the « really true » copy from the decision doc:
+- FR: « Crée un compte chiffré. La synchronisation entre tes appareils est désactivable depuis Réglages › Confidentialité (par défaut activée). »
+- (Or default-OFF + explicit opt-in framing depending on D-04 final wording — to confirm at PR time.)
+
+### D-09 — Test coverage
+- Widget test for the toggle Settings screen
+- Provider test for `AuthProvider.toggleCloudSync(bool)` API
+- Integration test: register new account → verify `_isLocalMode == true` post-register
+- Integration test: existing account migration → verify `_isLocalMode` preserved
+- Golden test for the Settings › Confidentialité screen (light + dark mode)
+
+### D-10 — HTML report integration (per Julien instruction 2026-05-02)
+Phase 52 produces `.planning/phases/52-auth-local-first-toggle/52-VERIFICATION-REPORT.html` alongside the standard text VERIFICATION.md. The HTML includes: live sim screenshots of the toggle in both states, before/after register-screen subtitle, network-inspector evidence that no PII transits while local mode is ON, panel review verdicts.
+
+## Out of scope
+
+- Server-side cloud-data deletion when user opts out (deferred v2.11)
+- Per-data-class opt-in (e.g., sync chat but not profile) — deferred v2.11
+- E2EE — deferred v3.0 (separate epic)
+- Swiss-region hosting migration — deferred Q3 2026 (separate phase)
+- Bulk sanitization of the « tes données restent sur ton appareil » strings across the app — they remain accurate post-Phase 52 (the toggle being default-OFF for new users + opt-out for existing makes the original claim true again)
+
+## Risk register
+
+| ID | Risk | Mitigation |
+|----|------|------------|
+| R-01 | Existing users surprised by toggle change → support tickets | Migration toast + status visible in Profile (D-04, D-05) |
+| R-02 | Sync state desync between mobile and backend (mobile thinks OFF, backend has stale data) | Mobile is the writer; backend is read-only follower of mobile state. Never the other way. |
+| R-03 | Coach quality drops for opted-out users (no server-side context) | Local SQLite holds last 50 chat turns + profile snapshot; coaching prompt assembled client-side from local data; LLM call is single-shot stateless server-side. |
+| R-04 | Toggle confusion: users don't know what « cloud sync » means in Swiss-financial context | Settings row subtitle explicit; status row in Profile; first-time toast (D-04) |
+| R-05 | i18n drift across 7 new ARB keys × 6 locales | accent_lint_fr + arb_parity (existing checks) + native review for DE/IT/PT |
+
+## Verification plan (high level)
+
+1. Unit + widget tests pass (D-09)
+2. Live sim walkthrough: register → verify default-OFF → toggle ON in Settings → verify sync starts → toggle OFF → verify no further outbound calls (network inspector evidence in the HTML report per D-10)
+3. Migration test: launch with pre-Phase-52 account state → verify sync-ON preserved + migration toast shown once
+4. ARB parity check passes
+5. accent_lint_fr passes on FR strings
+6. Panel review on the PR before merge (per `feedback_expert_panel_pattern.md` sub-pattern)
+
+## Estimated effort
+
+- Implementation (auth_provider refactor + Settings screen + Profile status row + ARB × 6 + migration logic): 1-1.5 days
+- Tests: 0.5 day
+- Live sim verification + HTML report: 0.5 day
+- Panel review + revisions: 0.5 day
+- **Total: 2.5-3 days**
+
+## References
+
+- `.planning/decisions/2026-05-02-data-residency.md` (Path A locked decision)
+- `.planning/reviews/2026-05-02-pr-batch-1.md` (panel review batch 1, identifies Phase 52 as required follow-up to PR #422)
+- `~/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/feedback_app_targets_staging_always.md`
+- `~/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/feedback_public_repo_discipline.md`
+- PR #420, #421, #422, #423, #424, #425 (related ships in the 2026-05-02 session)
+- `apps/mobile/lib/providers/auth_provider.dart:135` (the `_isLocalMode = false` flip site to refactor)
+- `apps/mobile/lib/screens/settings/langue_settings_screen.dart` (sibling settings screen — pattern to follow)

--- a/.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md
+++ b/.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md
@@ -1,19 +1,17 @@
 # Phase 52 — Auth Local-First Toggle (CONTEXT)
 
-**Status:** Open (planning)
-**Origin:** Companion phase to PR #422 (register subtitle l10n) + PR #423 (data residency decision doc). Without Phase 52 landing, PR #422's promise « Sync controls coming to Settings soon » remains a forward-looking statement without code behind it.
-**Decided by:** Julien signoff pending (data residency decision doc Status = Proposed).
+**Status:** Drafting
+**Origin:** Companion phase to PR #422 (register subtitle l10n) and the data-residency decision doc. PR #422's subtitle says « Sync controls coming to Settings soon »; Phase 52 is the code behind that line.
 
 ## Goal (one sentence)
 
-Refactor `auth_provider.dart` so account creation does NOT implicitly enable cloud sync, and add a Settings › Confidentialité toggle that lets the user explicitly opt IN to multi-device cloud sync. After Phase 52 lands, the « tes données restent sur ton appareil » strings across the app become universally accurate again.
+Refactor `auth_provider.dart` so account creation does not enable cloud sync as a side effect, and add a Settings › Confidentialité toggle that lets the user opt in or out of multi-device cloud sync. After Phase 52 lands, the « tes données restent sur ton appareil » strings across the app match the runtime behavior.
 
 ## Why now
 
-1. PR #422 shipped a forward-looking promise (« Sync controls coming to Settings soon ») in 6 locales. Phase 52 is what makes that promise true.
-2. The data residency decision doc (Path A v2.x → Q3 Swiss-region → v3.0 E2EE) explicitly identifies Phase 52 as the v2.x deliverable.
-3. Brand positioning « Ta lucidité. Ton appareil. Ton choix de synchroniser. » requires the toggle to exist.
-4. nFADP art. 19 (information at collection) + LSFin art. 8 (no overstatement of feature availability) — without Phase 52, the gap between « what we say » and « what the code does » remains material.
+1. PR #422 references Settings controls that do not yet exist; Phase 52 makes that copy match the code.
+2. The data-residency decision doc (Path A v2.x → Q3 Swiss-region → v3.0 E2EE) names Phase 52 as the v2.x deliverable.
+3. nFADP art. 19 (information at collection) and LSFin art. 8 (accurate description of feature availability) frame the alignment between in-app copy and runtime behavior.
 
 ## Locked decisions
 
@@ -27,13 +25,15 @@ A new `confidentialite_settings_screen.dart` lives next to the existing `langue_
 A single explicit toggle: « Synchronisation cloud (multi-appareils) » with subtitle « Sauvegarde + sync chiffrée sur nos serveurs européens. Activable / désactivable à tout moment. » Default OFF. When toggled ON, the next sync push goes through; when OFF, no further data leaves the device. Existing cloud-side data is NOT auto-deleted on toggle-off (user can issue a separate « Supprimer mes données cloud » action — out of scope for Phase 52, deferred to v2.11).
 
 ### D-04 — Backwards compatibility for existing accounts
-Existing users (registered before Phase 52) currently have `_isLocalMode = false` (silently set at register). On first launch post-update, we preserve their current behavior (cloud sync stays ON for them) but show a one-time « Nouvelle option : tu peux maintenant désactiver la synchronisation cloud depuis Réglages › Confidentialité » toast/sheet. Migration is opt-out for existing users (don't surprise-disable their sync), opt-IN for new users (default OFF).
+Existing users (registered before Phase 52) currently have `_isLocalMode = false` as part of the existing register flow. On first launch post-update, we preserve their current sync state and show a one-time « Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité » toast or sheet. New accounts default OFF; existing accounts retain whatever state they had. The migration toast surfaces the new control so existing users can adopt the new default if they wish — without changing their sync state without consent.
 
 ### D-05 — Transparent state surfacing
-The Profile screen displays a compact « Synchronisation : activée / désactivée » status row. The « Coach personnalisé » feature still works in both states — uses local SQLite for opted-out users, server-side coaching context for opted-in.
+The Profile screen displays a compact « Synchronisation : activée / désactivée » status row. The « Coach personnalisé » feature works in both states — local SQLite for opted-out users, server-side coaching context for opted-in.
 
-### D-06 — No backend changes in this phase
-The backend `_isLocalMode` flag is mobile-only state. The backend already accepts both authenticated AND anonymous calls. Mobile gates whether to push profile updates / chat history / documents to the backend based on the local flag. Zero backend code change in Phase 52 (server-side opt-out implementation = v2.11 if needed).
+### D-06 — Mobile state only in this phase; cloud-side deletion in v2.11
+The local-mode flag is mobile-only state. Mobile gates whether to push profile updates, chat history, and documents to the backend based on this flag. Phase 52 does not change backend code.
+
+The cloud-side data already pushed before a user toggles OFF stays on the backend until the v2.11 « Supprimer mes données cloud » action lands. The toggle subtitle and Settings page must say so explicitly, so a user toggling OFF understands that "no further data leaves the device" and "delete what is already on the server" are separate actions. nFADP art. 32 (right to deletion / Recht auf Löschung) is the handle for the v2.11 follow-up, not Phase 52.
 
 ### D-07 — String key naming convention
 New ARB keys prefixed `settingsPrivacy*`:
@@ -48,9 +48,9 @@ New ARB keys prefixed `settingsPrivacy*`:
 All 6 locales (FR canonical / EN / DE / ES / IT / PT). FR uses tutoiement.
 
 ### D-08 — Update register screen subtitle (post-Phase 52)
-After Phase 52 ships, update `authRegisterSubtitle` in 6 locales again — this time to the « really true » copy from the decision doc:
-- FR: « Crée un compte chiffré. La synchronisation entre tes appareils est désactivable depuis Réglages › Confidentialité (par défaut activée). »
-- (Or default-OFF + explicit opt-in framing depending on D-04 final wording — to confirm at PR time.)
+After Phase 52 ships, update `authRegisterSubtitle` in 6 locales to match D-01 (default OFF for new accounts):
+- FR: « Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l'activer depuis Réglages › Confidentialité. »
+- EN / DE / ES / IT / PT: equivalent default-OFF framing.
 
 ### D-09 — Test coverage
 - Widget test for the toggle Settings screen
@@ -64,11 +64,11 @@ Phase 52 produces `.planning/phases/52-auth-local-first-toggle/52-VERIFICATION-R
 
 ## Out of scope
 
-- Server-side cloud-data deletion when user opts out (deferred v2.11)
+- Server-side deletion of data already pushed before opt-out (deferred v2.11; nFADP art. 32 follow-up — see D-06)
 - Per-data-class opt-in (e.g., sync chat but not profile) — deferred v2.11
 - E2EE — deferred v3.0 (separate epic)
 - Swiss-region hosting migration — deferred Q3 2026 (separate phase)
-- Bulk sanitization of the « tes données restent sur ton appareil » strings across the app — they remain accurate post-Phase 52 (the toggle being default-OFF for new users + opt-out for existing makes the original claim true again)
+- Bulk rewrite of the « tes données restent sur ton appareil » strings across the app — they describe the new default once Phase 52 ships
 
 ## Risk register
 
@@ -99,10 +99,8 @@ Phase 52 produces `.planning/phases/52-auth-local-first-toggle/52-VERIFICATION-R
 
 ## References
 
-- `.planning/decisions/2026-05-02-data-residency.md` (Path A locked decision)
+- `.planning/decisions/2026-05-02-data-residency.md` (Path A — Proposed)
 - `.planning/reviews/2026-05-02-pr-batch-1.md` (panel review batch 1, identifies Phase 52 as required follow-up to PR #422)
-- `~/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/feedback_app_targets_staging_always.md`
-- `~/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/feedback_public_repo_discipline.md`
 - PR #420, #421, #422, #423, #424, #425 (related ships in the 2026-05-02 session)
-- `apps/mobile/lib/providers/auth_provider.dart:135` (the `_isLocalMode = false` flip site to refactor)
+- `apps/mobile/lib/providers/auth_provider.dart` (`_isLocalMode = false` flip site to refactor)
 - `apps/mobile/lib/screens/settings/langue_settings_screen.dart` (sibling settings screen — pattern to follow)

--- a/.planning/phases/52-auth-local-first-toggle/52-PLAN.md
+++ b/.planning/phases/52-auth-local-first-toggle/52-PLAN.md
@@ -1,6 +1,6 @@
 # Phase 52 — Auth Local-First Toggle (PLAN)
 
-**Status:** Open (awaiting Julien signoff on data residency Path A decision)
+**Status:** Drafting
 **Companion CONTEXT:** `52-CONTEXT.md`
 **Estimated effort:** 2.5-3 days
 **Branch:** `feature/phase-52-auth-local-first-toggle` (from dev)
@@ -17,11 +17,11 @@ Make MINT's local-first promise structurally true: refactor `auth_provider.dart`
 - `apps/mobile/test/providers/auth_provider_test.dart`
 
 **Behavior:**
-- `_isLocalMode` defaults to `true` on fresh install (already does — line 138 « Local-mode default: true on fresh install »)
-- Register / login does NOT auto-flip `_isLocalMode = false` (REMOVE the silent flip at line 135)
-- New API: `Future<void> AuthProvider.toggleCloudSync(bool enabled)` — sets `_isLocalMode = !enabled`, persists to SharedPreferences, notifies listeners
-- New getter: `bool get isCloudSyncEnabled => !_isLocalMode`
-- Migration: existing accounts (registered pre-Phase 52 with `_isLocalMode = false`) keep their current state (don't surprise-disable). Detect by absence of a new key `auth_phase52_migrated` — set it true on first launch post-update.
+- `_isLocalMode` defaults to `true` on fresh install (already does — see the « Local-mode default: true on fresh install » comment).
+- Remove the assignment that flips `_isLocalMode = false` inside the existing register flow so register / login no longer changes the default.
+- New API: `Future<void> AuthProvider.toggleCloudSync(bool enabled)` — sets `_isLocalMode = !enabled`, persists to SharedPreferences, notifies listeners.
+- New getter: `bool get isCloudSyncEnabled => !_isLocalMode`.
+- Migration: existing accounts (registered pre-Phase 52 with `_isLocalMode = false`) keep their current state. Detect by absence of a new SharedPreferences key `auth_phase52_migrated` — set it true on first launch post-update.
 
 **Test:** widget tests for the API + integration test for register flow asserting `_isLocalMode == true` post-register.
 
@@ -79,15 +79,14 @@ Make MINT's local-first promise structurally true: refactor `auth_provider.dart`
 
 **Verify:** `flutter gen-l10n` regenerates dart files. `python3 tools/checks/accent_lint_fr.py --file app_fr.arb` clean. `arb_parity` check (existing) passes.
 
-### T-52-06 — Update `authRegisterSubtitle` to reflect post-Phase 52 reality
+### T-52-06 — Update `authRegisterSubtitle` to match Phase 52 default
 **Files:** 6 ARB locales
 
 **Behavior:**
-- After T-52-01 lands, the « bientôt / coming soon » caveat in PR #422's subtitle becomes obsolete. Update to:
-  - FR: « Compte chiffré. Synchronisation cloud désactivable depuis Réglages › Confidentialité. »
-  - EN: « Encrypted account. Cloud sync can be turned off in Settings › Privacy. »
-  - (DE / ES / IT / PT equivalents)
-- Drop the « bientôt / coming soon » framing entirely.
+- After T-52-01 lands, replace the placeholder copy from PR #422 with text that matches D-01 (default OFF for new accounts):
+  - FR: « Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l'activer depuis Réglages › Confidentialité. »
+  - EN: « Create an encrypted account. Cloud sync is off by default; you can turn it on in Settings › Privacy. »
+  - DE / ES / IT / PT: equivalent default-OFF framing.
 
 ### T-52-07 — Live sim verification + HTML evidence report
 **Files:**
@@ -143,6 +142,5 @@ Make MINT's local-first promise structurally true: refactor `auth_provider.dart`
 
 ## Notes
 
-- This phase is gated on Julien's signoff of the data residency Path A decision (`.planning/decisions/2026-05-02-data-residency.md` Status = Proposed). Do NOT start implementation until signoff is confirmed.
-- The phase produces both standard GSD text artifacts (CONTEXT.md, PLAN.md, SUMMARY.md, VERIFICATION.md) AND an HTML report (per Julien instruction 2026-05-02 « En y intégrant ton fichier HTML, évidemment »).
-- `feedback_public_repo_discipline.md` applies — no forensic legal language in any commit / doc / PR description.
+- This phase tracks the data-residency decision doc (`.planning/decisions/2026-05-02-data-residency.md`, Status = Proposed). If Path A is replaced, revisit D-01 and D-04 before starting implementation.
+- The phase produces standard GSD text artifacts (CONTEXT.md, PLAN.md, SUMMARY.md, VERIFICATION.md) plus an HTML evidence report alongside.

--- a/.planning/phases/52-auth-local-first-toggle/52-PLAN.md
+++ b/.planning/phases/52-auth-local-first-toggle/52-PLAN.md
@@ -1,0 +1,148 @@
+# Phase 52 — Auth Local-First Toggle (PLAN)
+
+**Status:** Open (awaiting Julien signoff on data residency Path A decision)
+**Companion CONTEXT:** `52-CONTEXT.md`
+**Estimated effort:** 2.5-3 days
+**Branch:** `feature/phase-52-auth-local-first-toggle` (from dev)
+
+## Goal (one sentence)
+
+Make MINT's local-first promise structurally true: refactor `auth_provider.dart` so account creation does NOT implicitly enable cloud sync, and add a Settings › Confidentialité toggle for explicit user opt-in.
+
+## Tasks (sequential)
+
+### T-52-01 — Refactor `auth_provider.dart` for local-mode default
+**Files:**
+- `apps/mobile/lib/providers/auth_provider.dart`
+- `apps/mobile/test/providers/auth_provider_test.dart`
+
+**Behavior:**
+- `_isLocalMode` defaults to `true` on fresh install (already does — line 138 « Local-mode default: true on fresh install »)
+- Register / login does NOT auto-flip `_isLocalMode = false` (REMOVE the silent flip at line 135)
+- New API: `Future<void> AuthProvider.toggleCloudSync(bool enabled)` — sets `_isLocalMode = !enabled`, persists to SharedPreferences, notifies listeners
+- New getter: `bool get isCloudSyncEnabled => !_isLocalMode`
+- Migration: existing accounts (registered pre-Phase 52 with `_isLocalMode = false`) keep their current state (don't surprise-disable). Detect by absence of a new key `auth_phase52_migrated` — set it true on first launch post-update.
+
+**Test:** widget tests for the API + integration test for register flow asserting `_isLocalMode == true` post-register.
+
+### T-52-02 — New Settings › Confidentialité screen
+**Files:**
+- `apps/mobile/lib/screens/settings/confidentialite_settings_screen.dart` (new)
+- `apps/mobile/lib/app.dart` (route registration `/settings/confidentialite`)
+
+**UX:**
+- AppBar title `settingsPrivacyTitle` (« Confidentialité »)
+- One row: « Synchronisation cloud (multi-appareils) » with subtitle, ListTile + trailing Switch
+- Subtitle: « Sauvegarde + sync chiffrée sur nos serveurs européens. Activable / désactivable à tout moment. »
+- Below: « Tes données restent chiffrées sur ton appareil. Avec la sync cloud, elles sont aussi chiffrées sur nos serveurs européens (sauvegarde + multi-appareils). » (italic textMuted)
+- Pattern: mirror `langue_settings_screen.dart` styling for consistency
+- Tap toggle → calls `AuthProvider.toggleCloudSync(value)` → HapticFeedback.selectionClick
+
+**Test:** widget test asserting the toggle state mirrors `AuthProvider.isCloudSyncEnabled`.
+
+### T-52-03 — Profile screen « Synchronisation » status row + entry to Settings › Confidentialité
+**Files:**
+- `apps/mobile/lib/screens/profile/financial_summary_screen.dart` (or wherever the Profile tabs live — to confirm during impl)
+
+**UX:**
+- New compact row in the Profile screen: « Synchronisation » + status badge (« Activée » sauge / « Désactivée » muted) + chevron → tap navigates to `/settings/confidentialite`
+- The « Confidentialité » row also accessible from a Settings menu if such menu exists (need to check current Profile layout — currently the Profile mostly shows financial summary, may need to add a « Réglages » section)
+
+**Test:** widget test asserting the status row reflects the provider state.
+
+### T-52-04 — Migration toast for existing users
+**Files:**
+- `apps/mobile/lib/services/migration_phase52_service.dart` (new)
+- `apps/mobile/lib/main.dart` (call into migration check on startup)
+
+**Behavior:**
+- On startup, after AuthProvider hydrates: if user is logged in AND `auth_phase52_migrated` key absent in SharedPreferences:
+  - Set `auth_phase52_migrated = true`
+  - Schedule a one-shot SnackBar / bottom sheet for the user's next chat surface visit:  
+    « Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité » + CTA « Voir » → `/settings/confidentialite`
+- New users (registered post-Phase 52) skip the toast entirely (their default is OFF)
+
+**Test:** unit test for the migration service.
+
+### T-52-05 — ARB strings ×6 locales
+**Files:**
+- `apps/mobile/lib/l10n/app_fr.arb` (canonical) + `app_en.arb` + `app_de.arb` + `app_es.arb` + `app_it.arb` + `app_pt.arb`
+
+**New keys (per CONTEXT D-07):**
+- `settingsPrivacyTitle`
+- `settingsPrivacyCloudSyncTitle`
+- `settingsPrivacyCloudSyncSubtitle`
+- `settingsPrivacyCloudSyncOn`
+- `settingsPrivacyCloudSyncOff`
+- `settingsPrivacyMigrationToast`
+- `settingsPrivacyDataLocation`
+
+**Verify:** `flutter gen-l10n` regenerates dart files. `python3 tools/checks/accent_lint_fr.py --file app_fr.arb` clean. `arb_parity` check (existing) passes.
+
+### T-52-06 — Update `authRegisterSubtitle` to reflect post-Phase 52 reality
+**Files:** 6 ARB locales
+
+**Behavior:**
+- After T-52-01 lands, the « bientôt / coming soon » caveat in PR #422's subtitle becomes obsolete. Update to:
+  - FR: « Compte chiffré. Synchronisation cloud désactivable depuis Réglages › Confidentialité. »
+  - EN: « Encrypted account. Cloud sync can be turned off in Settings › Privacy. »
+  - (DE / ES / IT / PT equivalents)
+- Drop the « bientôt / coming soon » framing entirely.
+
+### T-52-07 — Live sim verification + HTML evidence report
+**Files:**
+- `.planning/phases/52-auth-local-first-toggle/52-VERIFICATION-REPORT.html` (new — per CONTEXT D-10 HTML report integration)
+- `.planning/phases/52-auth-local-first-toggle/52-VERIFICATION.md` (new — standard GSD text dossier)
+- Screenshot artifacts under `.planning/phases/52-auth-local-first-toggle/screenshots/`
+
+**Steps:**
+- Build sim with the new code
+- Live walkthrough:
+  1. Fresh install → register new account → verify Settings › Confidentialité shows « Désactivée » by default
+  2. Open Profile → verify « Synchronisation : Désactivée » status row
+  3. Tap into Settings › Confidentialité → toggle ON → verify HapticFeedback + Switch animation
+  4. Send a chat message → verify backend receives it (network inspector OR backend log)
+  5. Toggle OFF → verify next chat message NOT pushed to backend (local only)
+  6. Migration test: install pre-Phase-52 build → register → install Phase 52 build over it → verify migration toast appears once + sync stays ON
+- Capture screenshots for each step
+- Compile HTML report with:
+  - Screenshots
+  - Pre/post code diff highlights
+  - Network-inspector evidence
+  - Test counts + analyze output
+  - Panel review verdicts (run a 3-reviewer panel on the implementation)
+
+### T-52-08 — Panel review (per « Panel Reviews of MY OWN PRs » sub-pattern)
+**Reviewers:** code (Flutter/M3/a11y), compliance (nFADP/LSFin), brand voice.
+
+**Synthesize, fix critical findings, push, then merge.**
+
+## Dependencies
+
+- T-52-01 → T-52-02 (toggle screen needs the API)
+- T-52-02 → T-52-03 (Profile status row needs the route to navigate to)
+- T-52-04 (migration) can land in parallel with T-52-02/03
+- T-52-05 (ARB) feeds T-52-02/03/04
+- T-52-06 (register subtitle update) blocked on T-52-01 landing in dev
+- T-52-07 + T-52-08 are post-impl
+
+## Acceptance criteria (« must-haves »)
+
+1. `AuthProvider._isLocalMode` defaults true on fresh install + STAYS true after register/login
+2. Settings › Confidentialité screen exists at `/settings/confidentialite`
+3. Toggle Switch is wired to `AuthProvider.toggleCloudSync(bool)`
+4. Profile screen displays the sync status + tap entry into Settings
+5. Migration toast appears exactly once for pre-Phase-52 users
+6. ARB parity check passes (7 new keys × 6 locales)
+7. `flutter analyze` exits 0 on changed files
+8. `flutter test` exits 0 (new widget + provider + integration tests included)
+9. `accent_lint_fr.py` clean on FR strings
+10. Live sim walkthrough captured (≥6 screenshots) in 52-VERIFICATION-REPORT.html
+11. Panel review (3 reviewers) verdict: APPROVE on critical, follow-ups logged
+12. PR description references CONTEXT.md + decision doc + companion PRs (#422 to be updated post-merge per T-52-06)
+
+## Notes
+
+- This phase is gated on Julien's signoff of the data residency Path A decision (`.planning/decisions/2026-05-02-data-residency.md` Status = Proposed). Do NOT start implementation until signoff is confirmed.
+- The phase produces both standard GSD text artifacts (CONTEXT.md, PLAN.md, SUMMARY.md, VERIFICATION.md) AND an HTML report (per Julien instruction 2026-05-02 « En y intégrant ton fichier HTML, évidemment »).
+- `feedback_public_repo_discipline.md` applies — no forensic legal language in any commit / doc / PR description.


### PR DESCRIPTION
## Summary
Planning artifacts only — no implementation in this PR.

Opens Phase 52: refactor `auth_provider.dart` so account creation does not enable cloud sync as a side effect, and add a Settings › Confidentialité toggle for explicit user opt-in.

## What's in this PR
- `.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md` — D-01..D-10 (default-OFF for new accounts, Settings location, toggle UX, backwards compatibility, ARB key naming, deletion follow-up handed to v2.11, HTML evidence report)
- `.planning/phases/52-auth-local-first-toggle/52-PLAN.md` — 8 sequential tasks (T-52-01..08), files / behaviors / acceptance, ~2.5–3 days

## Why
PR #422 shipped « Sync controls coming to Settings soon » in 6 locales. Phase 52 makes that copy match the code. Decision doc `.planning/decisions/2026-05-02-data-residency.md` (Path A — Proposed) names Phase 52 as the v2.x deliverable.

## Status
Drafting. Implementation tracks the data-residency decision; if Path A is replaced, revisit D-01 and D-04 before starting.

## Out of scope
- Server-side deletion of data already pushed before opt-out (deferred v2.11; nFADP art. 32 follow-up — see D-06)
- Per-data-class opt-in — deferred v2.11
- E2EE — deferred v3.0
- Swiss-region hosting migration — deferred Q3 2026

## Companion ships (2026-05-02 session)
- PR #420, #421, #422, #423, #424, #425, #427

Co-Authored-By: Claude <noreply@anthropic.com>