### PR TITLE
fix(coach,l10n): drop banned LSFin term « Parfait » from chat copy

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -9913,6 +9913,7 @@
   "coachProactiveOptIn": "Übrigens — soll ich dir wichtige Dinge anzeigen, wenn du die App öffnest? Oder möchtest du lieber nur reden, wenn du Lust hast?",
   "coachOptInAccept": "Ja, zeig mir an",
   "coachOptInDecline": "Nein, ich komme wenn ich will",
+  "coachOptInAcknowledged": "Verstanden, ich melde dir, was wichtig ist.",
   "coachSilentOpenerReplacementRate": "Projizierte Ersatzrate",
   "coachSilentOpenerFitnessScore": "Finanzieller Fitness-Score",
   "coachSilentOpenerRetirementCapital": "Projiziertes Pensionierungskapital",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -9913,6 +9913,7 @@
   "coachProactiveOptIn": "By the way — would you like me to flag important things when you open the app? Or do you prefer we only talk when you feel like it?",
   "coachOptInAccept": "Yes, flag for me",
   "coachOptInDecline": "No, I'll come when I want",
+  "coachOptInAcknowledged": "Got it — I'll flag what matters.",
   "coachSilentOpenerReplacementRate": "Projected replacement rate",
   "coachSilentOpenerFitnessScore": "Financial fitness score",
   "coachSilentOpenerRetirementCapital": "Projected retirement capital",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -9913,6 +9913,7 @@
   "coachProactiveOptIn": "Por cierto — ¿quieres que te señale las cosas importantes al abrir la app? ¿O prefieres que hablemos solo cuando te apetezca?",
   "coachOptInAccept": "Sí, señálame",
   "coachOptInDecline": "No, vengo cuando quiera",
+  "coachOptInAcknowledged": "Entendido, te avisaré de lo importante.",
   "coachSilentOpenerReplacementRate": "Tasa de reemplazo proyectada",
   "coachSilentOpenerFitnessScore": "Puntuación de salud financiera",
   "coachSilentOpenerRetirementCapital": "Capital proyectado a la jubilación",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10398,6 +10398,7 @@
   "coachProactiveOptIn": "Au fait — tu veux que je te signale les choses importantes quand tu ouvres l'app ? Ou tu préfères qu'on se parle seulement quand tu en as envie ?",
   "coachOptInAccept": "Oui, signale-moi",
   "coachOptInDecline": "Non, je viens quand je veux",
+  "coachOptInAcknowledged": "Bien noté, je te signalerai ce qui compte.",
   "coachSilentOpenerReplacementRate": "Taux de remplacement projeté",
   "coachSilentOpenerFitnessScore": "Score de santé financière",
   "coachSilentOpenerRetirementCapital": "Capital projeté à la retraite",
@@ -10820,7 +10821,7 @@
       }
     }
   },
-  "checkInCoachSummary": "Parfait, {summary}. C'est noté !",
+  "checkInCoachSummary": "Bien noté, {summary}.",
   "@checkInCoachSummary": {
     "placeholders": {
       "summary": {

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -9913,6 +9913,7 @@
   "coachProactiveOptIn": "A proposito — vuoi che ti segnali le cose importanti quando apri l'app? O preferisci che parliamo solo quando ne hai voglia?",
   "coachOptInAccept": "Sì, segnalami",
   "coachOptInDecline": "No, vengo quando voglio",
+  "coachOptInAcknowledged": "Capito, ti segnalerò ciò che conta.",
   "coachSilentOpenerReplacementRate": "Tasso di sostituzione proiettato",
   "coachSilentOpenerFitnessScore": "Punteggio di salute finanziaria",
   "coachSilentOpenerRetirementCapital": "Capitale proiettato alla pensione",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -37089,6 +37089,12 @@ abstract class S {
   /// **'Non, je viens quand je veux'**
   String get coachOptInDecline;
 
+  /// No description provided for @coachOptInAcknowledged.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bien noté, je te signalerai ce qui compte.'**
+  String get coachOptInAcknowledged;
+
   /// No description provided for @coachSilentOpenerReplacementRate.
   ///
   /// In fr, this message translates to:
@@ -38088,7 +38094,7 @@ abstract class S {
   /// No description provided for @checkInCoachSummary.
   ///
   /// In fr, this message translates to:
-  /// **'Parfait, {summary}. C\'est noté !'**
+  /// **'Bien noté, {summary}.'**
   String checkInCoachSummary(String summary);
 
   /// No description provided for @checkInErrorNoPlan.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -21134,6 +21134,10 @@ class SDe extends S {
   String get coachOptInDecline => 'Nein, ich komme wenn ich will';
 
   @override
+  String get coachOptInAcknowledged =>
+      'Verstanden, ich melde dir, was wichtig ist.';
+
+  @override
   String get coachSilentOpenerReplacementRate => 'Projizierte Ersatzrate';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -20978,6 +20978,9 @@ class SEn extends S {
   String get coachOptInDecline => 'No, I\'ll come when I want';
 
   @override
+  String get coachOptInAcknowledged => 'Got it — I\'ll flag what matters.';
+
+  @override
   String get coachSilentOpenerReplacementRate => 'Projected replacement rate';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -21087,6 +21087,10 @@ class SEs extends S {
   String get coachOptInDecline => 'No, vengo cuando quiera';
 
   @override
+  String get coachOptInAcknowledged =>
+      'Entendido, te avisaré de lo importante.';
+
+  @override
   String get coachSilentOpenerReplacementRate => 'Tasa de reemplazo proyectada';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -21084,6 +21084,10 @@ class SFr extends S {
   String get coachOptInDecline => 'Non, je viens quand je veux';
 
   @override
+  String get coachOptInAcknowledged =>
+      'Bien noté, je te signalerai ce qui compte.';
+
+  @override
   String get coachSilentOpenerReplacementRate => 'Taux de remplacement projeté';
 
   @override
@@ -21691,7 +21695,7 @@ class SFr extends S {
 
   @override
   String checkInCoachSummary(String summary) {
-    return 'Parfait, $summary. C\'est noté !';
+    return 'Bien noté, $summary.';
   }
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -21144,6 +21144,9 @@ class SIt extends S {
   String get coachOptInDecline => 'No, vengo quando voglio';
 
   @override
+  String get coachOptInAcknowledged => 'Capito, ti segnalerò ciò che conta.';
+
+  @override
   String get coachSilentOpenerReplacementRate =>
       'Tasso di sostituzione proiettato';
 

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -21090,6 +21090,10 @@ class SPt extends S {
   String get coachOptInDecline => 'Não, venho quando quiser';
 
   @override
+  String get coachOptInAcknowledged =>
+      'Entendido, vou sinalizar o que é importante.';
+
+  @override
   String get coachSilentOpenerReplacementRate =>
       'Taxa de substituição projetada';
 

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -9913,6 +9913,7 @@
   "coachProactiveOptIn": "A propósito — queres que te sinalize as coisas importantes quando abres a app? Ou preferes que falemos só quando te apetecer?",
   "coachOptInAccept": "Sim, sinaliza-me",
   "coachOptInDecline": "Não, venho quando quiser",
+  "coachOptInAcknowledged": "Entendido, vou sinalizar o que é importante.",
   "coachSilentOpenerReplacementRate": "Taxa de substituição projetada",
   "coachSilentOpenerFitnessScore": "Pontuação de saúde financeira",
   "coachSilentOpenerRetirementCapital": "Capital projetado na reforma",

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -1627,7 +1627,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         ));
         _messages.add(ChatMessage(
           role: 'assistant',
-          content: 'Parfait, je te signalerai ce qui compte.',
+          content: s.coachOptInAcknowledged,
           timestamp: DateTime.now(),
           tier: ChatTier.none,
         ));


### PR DESCRIPTION
## Summary
Two user-visible chatbot copies used « Parfait » (banned LSFin term per CLAUDE.md TOP rule #1). This PR routes both through ARB and replaces the FR value.

| Site | Before | After |
|---|---|---|
| `coach_chat_screen.dart:1630` (hardcoded) | « Parfait, je te signalerai ce qui compte. » | `s.coachOptInAcknowledged` (« Bien noté, je te signalerai ce qui compte. ») |
| `checkInCoachSummary` FR ARB value | « Parfait, {summary}. C'est noté ! » | « Bien noté, {summary}. » |

The other 5 locales (EN/DE/ES/IT/PT) already used non-banned equivalents (Great / Super / Perfecto / Perfetto / Perfeito); only FR needed the value rewrite.

## New ARB key
`coachOptInAcknowledged` added in 6 locales:
- FR « Bien noté, je te signalerai ce qui compte. »
- EN « Got it — I'll flag what matters. »
- DE « Verstanden, ich melde dir, was wichtig ist. »
- ES « Entendido, te avisaré de lo importante. »
- IT « Capito, ti segnalerò ciò che conta. »
- PT « Entendido, vou sinalizar o que é importante. »

## Verification
- `check_banned_terms()` clean on all 7 new copies (verified via `tools/mcp/mint-tools/tools/banned_terms.py`)
- `flutter gen-l10n` regenerated all 6 locale getters (`coachOptInAcknowledged` + updated `checkInCoachSummary`)
- `flutter analyze lib/screens/coach/coach_chat_screen.dart` shows only pre-existing warnings; no new issues from this change
- Pre-existing accent issues in this file (« creer », « deja » on lines 343/1263/1266/1610/1614) deliberately not touched here — those chip labels need ARB-key migration first; tracked as a follow-up

## Out of scope
- Pan-locale superlative discipline beyond the FR LSFin list (separate decision)
- Migrating the « Creer mon compte » / « J'ai deja un compte » chip strings to ARB (follow-up)

Co-Authored-By: Claude <noreply@anthropic.com>