### PR TITLE
fix(profile,privacy): i18n + hardcoded color + tap target

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11138,5 +11138,6 @@
   "wedgeSalaryInputActionSemantics": "Meine Schätzung berechnen",
   "wedgeSalaryStaysOnDevice": "Dein Lohn bleibt auf deinem Gerät. MINT sendet ihn nirgendwohin.",
   "wedgeSalaryErrorInvalid": "Gib einen Betrag in Ziffern ein, zum Beispiel 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Zwischen 10 000 und 1 000 000 CHF pro Jahr."
+  "wedgeSalaryErrorOutOfRange": "Zwischen 10 000 und 1 000 000 CHF pro Jahr.",
+  "cantonLabel": "Kanton"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11138,5 +11138,6 @@
   "wedgeSalaryInputActionSemantics": "Calculate my estimate",
   "wedgeSalaryStaysOnDevice": "Your salary stays on your device. MINT never sends it anywhere.",
   "wedgeSalaryErrorInvalid": "Enter an amount in digits, for example 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Between 10 000 and 1 000 000 CHF per year."
+  "wedgeSalaryErrorOutOfRange": "Between 10 000 and 1 000 000 CHF per year.",
+  "cantonLabel": "Canton"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11138,5 +11138,6 @@
   "wedgeSalaryInputActionSemantics": "Calcular mi estimación",
   "wedgeSalaryStaysOnDevice": "Tu salario se queda en tu dispositivo. MINT no lo envía a ninguna parte.",
   "wedgeSalaryErrorInvalid": "Introduce un importe en cifras, por ejemplo 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Entre 10 000 y 1 000 000 CHF al año."
+  "wedgeSalaryErrorOutOfRange": "Entre 10 000 y 1 000 000 CHF al año.",
+  "cantonLabel": "Cantón"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12028,5 +12028,6 @@
   "wedgeSalaryInputActionSemantics": "Calculer mon estimation",
   "wedgeSalaryStaysOnDevice": "Ton salaire reste sur ton appareil. MINT ne l'envoie nulle part.",
   "wedgeSalaryErrorInvalid": "Entre un montant en chiffres, par exemple 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Entre 10 000 et 1 000 000 CHF par an."
+  "wedgeSalaryErrorOutOfRange": "Entre 10 000 et 1 000 000 CHF par an.",
+  "cantonLabel": "Canton"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11138,5 +11138,6 @@
   "wedgeSalaryInputActionSemantics": "Calcola la mia stima",
   "wedgeSalaryStaysOnDevice": "Il tuo stipendio resta sul tuo dispositivo. MINT non lo invia da nessuna parte.",
   "wedgeSalaryErrorInvalid": "Inserisci un importo in cifre, ad esempio 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Tra 10 000 e 1 000 000 CHF all'anno."
+  "wedgeSalaryErrorOutOfRange": "Tra 10 000 e 1 000 000 CHF all'anno.",
+  "cantonLabel": "Cantone"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40514,6 +40514,12 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Entre 10 000 et 1 000 000 CHF par an.'**
   String get wedgeSalaryErrorOutOfRange;
+
+  /// No description provided for @cantonLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Canton'**
+  String get cantonLabel;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23151,4 +23151,7 @@ class SDe extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Zwischen 10 000 und 1 000 000 CHF pro Jahr.';
+
+  @override
+  String get cantonLabel => 'Kanton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22982,4 +22982,7 @@ class SEn extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Between 10 000 and 1 000 000 CHF per year.';
+
+  @override
+  String get cantonLabel => 'Canton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23094,4 +23094,7 @@ class SEs extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Entre 10 000 y 1 000 000 CHF al año.';
+
+  @override
+  String get cantonLabel => 'Cantón';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23096,4 +23096,7 @@ class SFr extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Entre 10 000 et 1 000 000 CHF par an.';
+
+  @override
+  String get cantonLabel => 'Canton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23155,4 +23155,7 @@ class SIt extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Tra 10 000 e 1 000 000 CHF all\'anno.';
+
+  @override
+  String get cantonLabel => 'Cantone';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23102,4 +23102,7 @@ class SPt extends S {
   @override
   String get wedgeSalaryErrorOutOfRange =>
       'Entre 10 000 e 1 000 000 CHF por ano.';
+
+  @override
+  String get cantonLabel => 'Cantão';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11138,5 +11138,6 @@
   "wedgeSalaryInputActionSemantics": "Calcular a minha estimativa",
   "wedgeSalaryStaysOnDevice": "O teu salário fica no teu dispositivo. MINT não o envia para nenhum lado.",
   "wedgeSalaryErrorInvalid": "Insere um montante em algarismos, por exemplo 95 000.",
-  "wedgeSalaryErrorOutOfRange": "Entre 10 000 e 1 000 000 CHF por ano."
+  "wedgeSalaryErrorOutOfRange": "Entre 10 000 e 1 000 000 CHF por ano.",
+  "cantonLabel": "Cantão"
 }

--- a/apps/mobile/lib/screens/profile/privacy_center_screen.dart
+++ b/apps/mobile/lib/screens/profile/privacy_center_screen.dart
@@ -81,9 +81,9 @@ class _PrivacyCenterScreenState extends State<PrivacyCenterScreen> {
   Widget build(BuildContext context) {
     final l = S.of(context)!;
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: MintColors.white,
       appBar: AppBar(
-        backgroundColor: Colors.white,
+        backgroundColor: MintColors.white,
         elevation: 0,
         title: Text(
           l.privacyCenterTitle,
@@ -214,6 +214,10 @@ class _ConsentRow extends StatelessWidget {
           if (onRevoke != null)
             TextButton(
               onPressed: onRevoke,
+              style: TextButton.styleFrom(
+                minimumSize: const Size(0, 48),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+              ),
               child: Text(l.consentRevoke),
             ),
         ],

--- a/apps/mobile/lib/screens/profile/privacy_control_screen.dart
+++ b/apps/mobile/lib/screens/profile/privacy_control_screen.dart
@@ -319,7 +319,7 @@ class _PrivacyControlScreenState extends State<PrivacyControlScreen> {
     if (provided.contains('canton')) {
       items.add(_ProfileDataItem(
         icon: Icons.location_on_outlined,
-        label: 'Canton',
+        label: l.cantonLabel,
         value: profile.canton,
       ));
     }


### PR DESCRIPTION
## Summary
Three small Profile-surface fixes from the post-merge audit.

| Issue | File | Doctrine | Fix |
|---|---|---|---|
| Hardcoded label « Canton » | `privacy_control_screen.dart:322` | NEVER #1 (i18n) | New ARB key `cantonLabel` × 6 locales, route via `l.cantonLabel` |
| `Colors.white` ×2 | `privacy_center_screen.dart:84, 86` | NEVER #2 (theme tokens) | `MintColors.white` |
| TextButton « Révoquer » <48dp | `privacy_center_screen.dart:215` | WCAG 2.5.5 / M3 | `minimumSize: Size(0, 48)` |

## i18n — new key
- FR / EN: « Canton »
- DE: « Kanton »
- ES: « Cantón »
- IT: « Cantone »
- PT: « Cantão »

## Verification
- `flutter analyze` clean on the two touched screens
- `flutter gen-l10n` regenerated `cantonLabel` in all 6 locale files

## Out of scope
- Drawer / authenticated coach chat surface — separate audit / PR

Co-Authored-By: Claude <noreply@anthropic.com>