### PR TITLE
fix+feat(coach): ARB-route hardcoded copy + wire ProactiveTrigger opener

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11139,5 +11139,9 @@
   "wedgeSalaryStaysOnDevice": "Dein Lohn bleibt auf deinem Gerät. MINT sendet ihn nirgendwohin.",
   "wedgeSalaryErrorInvalid": "Gib einen Betrag in Ziffern ein, zum Beispiel 95 000.",
   "wedgeSalaryErrorOutOfRange": "Zwischen 10 000 und 1 000 000 CHF pro Jahr.",
+  "coachOnboardingFirstUserMessage": "Hi, ich habe gerade ein Konto erstellt. Wo fange ich an?",
+  "coachAnonymousAuthGateMessage": "Wir haben schon ein paar Spuren zusammen erkundet. Erstelle dein Konto, damit ich mich an alles erinnere.",
+  "coachAuthGateChipRegister": "Konto erstellen",
+  "coachAuthGateChipLogin": "Ich habe schon ein Konto",
   "cantonLabel": "Kanton"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11139,5 +11139,9 @@
   "wedgeSalaryStaysOnDevice": "Your salary stays on your device. MINT never sends it anywhere.",
   "wedgeSalaryErrorInvalid": "Enter an amount in digits, for example 95 000.",
   "wedgeSalaryErrorOutOfRange": "Between 10 000 and 1 000 000 CHF per year.",
+  "coachOnboardingFirstUserMessage": "Hi, I just created my account. Where do I start?",
+  "coachAnonymousAuthGateMessage": "We already explored a few leads together. Create your account so I remember it all.",
+  "coachAuthGateChipRegister": "Create my account",
+  "coachAuthGateChipLogin": "I already have an account",
   "cantonLabel": "Canton"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11139,5 +11139,9 @@
   "wedgeSalaryStaysOnDevice": "Tu salario se queda en tu dispositivo. MINT no lo envía a ninguna parte.",
   "wedgeSalaryErrorInvalid": "Introduce un importe en cifras, por ejemplo 95 000.",
   "wedgeSalaryErrorOutOfRange": "Entre 10 000 y 1 000 000 CHF al año.",
+  "coachOnboardingFirstUserMessage": "Hola, acabo de crear mi cuenta. ¿Por dónde empiezo?",
+  "coachAnonymousAuthGateMessage": "Ya hemos explorado algunas pistas juntos. Crea tu cuenta para que recuerde todo.",
+  "coachAuthGateChipRegister": "Crear mi cuenta",
+  "coachAuthGateChipLogin": "Ya tengo una cuenta",
   "cantonLabel": "Cantón"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12029,5 +12029,9 @@
   "wedgeSalaryStaysOnDevice": "Ton salaire reste sur ton appareil. MINT ne l'envoie nulle part.",
   "wedgeSalaryErrorInvalid": "Entre un montant en chiffres, par exemple 95 000.",
   "wedgeSalaryErrorOutOfRange": "Entre 10 000 et 1 000 000 CHF par an.",
+  "coachOnboardingFirstUserMessage": "Salut, je viens de créer mon compte. Par où je commence ?",
+  "coachAnonymousAuthGateMessage": "On a déjà découvert quelques pistes ensemble. Crée ton compte pour que je me souvienne de tout.",
+  "coachAuthGateChipRegister": "Créer mon compte",
+  "coachAuthGateChipLogin": "J'ai déjà un compte",
   "cantonLabel": "Canton"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11139,5 +11139,9 @@
   "wedgeSalaryStaysOnDevice": "Il tuo stipendio resta sul tuo dispositivo. MINT non lo invia da nessuna parte.",
   "wedgeSalaryErrorInvalid": "Inserisci un importo in cifre, ad esempio 95 000.",
   "wedgeSalaryErrorOutOfRange": "Tra 10 000 e 1 000 000 CHF all'anno.",
+  "coachOnboardingFirstUserMessage": "Ciao, ho appena creato il mio account. Da dove comincio?",
+  "coachAnonymousAuthGateMessage": "Abbiamo già esplorato alcune piste insieme. Crea il tuo account così ricordo tutto.",
+  "coachAuthGateChipRegister": "Crea il mio account",
+  "coachAuthGateChipLogin": "Ho già un account",
   "cantonLabel": "Cantone"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40515,6 +40515,30 @@ abstract class S {
   /// **'Entre 10 000 et 1 000 000 CHF par an.'**
   String get wedgeSalaryErrorOutOfRange;
 
+  /// No description provided for @coachOnboardingFirstUserMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'Salut, je viens de créer mon compte. Par où je commence ?'**
+  String get coachOnboardingFirstUserMessage;
+
+  /// No description provided for @coachAnonymousAuthGateMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'On a déjà découvert quelques pistes ensemble. Crée ton compte pour que je me souvienne de tout.'**
+  String get coachAnonymousAuthGateMessage;
+
+  /// No description provided for @coachAuthGateChipRegister.
+  ///
+  /// In fr, this message translates to:
+  /// **'Créer mon compte'**
+  String get coachAuthGateChipRegister;
+
+  /// No description provided for @coachAuthGateChipLogin.
+  ///
+  /// In fr, this message translates to:
+  /// **'J\'ai déjà un compte'**
+  String get coachAuthGateChipLogin;
+
   /// No description provided for @cantonLabel.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23153,5 +23153,19 @@ class SDe extends S {
       'Zwischen 10 000 und 1 000 000 CHF pro Jahr.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Hi, ich habe gerade ein Konto erstellt. Wo fange ich an?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'Wir haben schon ein paar Spuren zusammen erkundet. Erstelle dein Konto, damit ich mich an alles erinnere.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Konto erstellen';
+
+  @override
+  String get coachAuthGateChipLogin => 'Ich habe schon ein Konto';
+
+  @override
   String get cantonLabel => 'Kanton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22984,5 +22984,19 @@ class SEn extends S {
       'Between 10 000 and 1 000 000 CHF per year.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Hi, I just created my account. Where do I start?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'We already explored a few leads together. Create your account so I remember it all.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Create my account';
+
+  @override
+  String get coachAuthGateChipLogin => 'I already have an account';
+
+  @override
   String get cantonLabel => 'Canton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23096,5 +23096,19 @@ class SEs extends S {
       'Entre 10 000 y 1 000 000 CHF al año.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Hola, acabo de crear mi cuenta. ¿Por dónde empiezo?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'Ya hemos explorado algunas pistas juntos. Crea tu cuenta para que recuerde todo.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Crear mi cuenta';
+
+  @override
+  String get coachAuthGateChipLogin => 'Ya tengo una cuenta';
+
+  @override
   String get cantonLabel => 'Cantón';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23098,5 +23098,19 @@ class SFr extends S {
       'Entre 10 000 et 1 000 000 CHF par an.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Salut, je viens de créer mon compte. Par où je commence ?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'On a déjà découvert quelques pistes ensemble. Crée ton compte pour que je me souvienne de tout.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Créer mon compte';
+
+  @override
+  String get coachAuthGateChipLogin => 'J\'ai déjà un compte';
+
+  @override
   String get cantonLabel => 'Canton';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23157,5 +23157,19 @@ class SIt extends S {
       'Tra 10 000 e 1 000 000 CHF all\'anno.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Ciao, ho appena creato il mio account. Da dove comincio?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'Abbiamo già esplorato alcune piste insieme. Crea il tuo account così ricordo tutto.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Crea il mio account';
+
+  @override
+  String get coachAuthGateChipLogin => 'Ho già un account';
+
+  @override
   String get cantonLabel => 'Cantone';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23104,5 +23104,19 @@ class SPt extends S {
       'Entre 10 000 e 1 000 000 CHF por ano.';
 
   @override
+  String get coachOnboardingFirstUserMessage =>
+      'Olá, acabei de criar a minha conta. Por onde começo?';
+
+  @override
+  String get coachAnonymousAuthGateMessage =>
+      'Já explorámos algumas pistas juntos. Cria a tua conta para eu me lembrar de tudo.';
+
+  @override
+  String get coachAuthGateChipRegister => 'Criar a minha conta';
+
+  @override
+  String get coachAuthGateChipLogin => 'Já tenho uma conta';
+
+  @override
   String get cantonLabel => 'Cantão';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11139,5 +11139,9 @@
   "wedgeSalaryStaysOnDevice": "O teu salário fica no teu dispositivo. MINT não o envia para nenhum lado.",
   "wedgeSalaryErrorInvalid": "Insere um montante em algarismos, por exemplo 95 000.",
   "wedgeSalaryErrorOutOfRange": "Entre 10 000 e 1 000 000 CHF por ano.",
+  "coachOnboardingFirstUserMessage": "Olá, acabei de criar a minha conta. Por onde começo?",
+  "coachAnonymousAuthGateMessage": "Já explorámos algumas pistas juntos. Cria a tua conta para eu me lembrar de tudo.",
+  "coachAuthGateChipRegister": "Criar a minha conta",
+  "coachAuthGateChipLogin": "Já tenho uma conta",
   "cantonLabel": "Cantão"
 }

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -28,7 +28,10 @@ import 'package:mint_mobile/services/financial_fitness_service.dart';
 import 'package:mint_mobile/services/forecaster_service.dart';
 import 'package:mint_mobile/services/pdf_service.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/mint_state_provider.dart';
 import 'package:mint_mobile/services/coach/coach_chat_api_service.dart';
+import 'package:mint_mobile/services/coach/proactive_trigger_service.dart'
+    show ProactiveTrigger, ProactiveTriggerType;
 import 'package:mint_mobile/services/rag_service.dart';
 import 'package:mint_mobile/widgets/coach/lightning_menu.dart';
 import 'package:mint_mobile/services/coach/conversation_store.dart';
@@ -160,6 +163,12 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
 
   /// Whether the proactive opt-in question has been shown this session.
   bool _optInShownThisSession = false;
+
+  /// Whether a `ProactiveTrigger` has been surfaced as an opener this
+  /// session. Per-day deduplication is upstream in
+  /// [ProactiveTriggerService.evaluate] (cooldown on evaluation date);
+  /// this flag prevents re-showing within a single screen lifetime.
+  bool _proactiveTriggerShownThisSession = false;
 
   /// Whether the user has already chosen an intensity (hides picker chips).
   bool _intensityChosen = false;
@@ -361,6 +370,15 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
             // not as a user message.
             _entryPayloadContext = payload.toContextInjection();
           }
+        } else if (!_isResumingConversation) {
+          // No entryPayload + authenticated + fresh conversation:
+          // surface a `MintStateProvider.pendingTrigger` if one was
+          // evaluated this calendar day. Single consumer of the
+          // proactive-trigger pipeline that was previously evaluated
+          // upstream but never displayed.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _maybeShowProactiveTrigger();
+          });
         }
       } else {
         // CHAT-01: Anonymous user (no profile) — show silent opener
@@ -490,6 +508,54 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       ));
     });
     _scrollToBottom();
+  }
+
+  /// Resolve a [ProactiveTrigger] to its localized opener string.
+  ///
+  /// `messageKey` on the trigger refers to a generated `AppLocalizations`
+  /// getter or method; the switch routes through the strongly-typed
+  /// API so missing params surface at compile time instead of runtime.
+  String _resolveProactiveOpener(S l, ProactiveTrigger t) {
+    switch (t.type) {
+      case ProactiveTriggerType.lifecyclePhaseChange:
+        return l.proactiveLifecycleChange;
+      case ProactiveTriggerType.weeklyRecapAvailable:
+        return l.proactiveWeeklyRecap;
+      case ProactiveTriggerType.goalMilestone:
+        return l.proactiveGoalMilestone(t.params?['progress'] ?? '');
+      case ProactiveTriggerType.seasonalReminder:
+        return l.proactiveSeasonalReminder(t.params?['event'] ?? '');
+      case ProactiveTriggerType.inactivityReturn:
+        return l.proactiveInactivityReturn(t.params?['days'] ?? '');
+      case ProactiveTriggerType.confidenceImproved:
+        return l.proactiveConfidenceUp(t.params?['delta'] ?? '');
+      case ProactiveTriggerType.newCapAvailable:
+        return l.proactiveNewCap;
+      case ProactiveTriggerType.contractDeadlineApproaching:
+        return l.proactiveContractDeadline(
+          t.params?['days'] ?? '',
+          t.params?['label'] ?? '',
+        );
+    }
+  }
+
+  /// If [MintStateProvider] holds a `pendingTrigger`, surface it as the
+  /// opening coach message. Per-day deduplication is enforced upstream
+  /// in [ProactiveTriggerService.evaluate]; this method also guards
+  /// re-show within a single screen lifetime via
+  /// [_proactiveTriggerShownThisSession].
+  void _maybeShowProactiveTrigger() {
+    if (_proactiveTriggerShownThisSession) return;
+    final stateProvider = context.read<MintStateProvider>();
+    final trigger = stateProvider.state?.pendingTrigger;
+    if (trigger == null) return;
+    _proactiveTriggerShownThisSession = true;
+    final opener = _resolveProactiveOpener(S.of(context)!, trigger);
+    _addCoachOpenerMessage(opener);
+    AnalyticsService().trackEvent('coach_proactive_trigger_shown', data: {
+      'type': trigger.type.name,
+      'has_intent_tag': trigger.intentTag != null,
+    });
   }
 
   /// Increment the conversation count in SharedPreferences.

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -339,9 +339,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
             // Onboarding topic — send a real intake question instead of
             // injecting raw context. This replaces the old ?prompt=onboarding.
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              _sendMessage(
-                'Salut, je viens de creer mon compte. Par ou je commence\u00a0?',
-              );
+              _sendMessage(S.of(context)!.coachOnboardingFirstUserMessage);
             });
           } else if (_isNotificationTopic(payload.topic)) {
             // Notification topics (monthlyCheckIn, commitmentReminder,
@@ -1256,14 +1254,16 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
   /// with tappable chips for register / login.
   void _showAnonymousAuthGate() {
     if (!mounted) return;
+    final s = S.of(context)!;
     setState(() {
       _messages.add(ChatMessage(
         role: 'assistant',
-        content:
-            'On a deja decouvert quelques pistes ensemble. '
-            'Cree ton compte pour que je me souvienne de tout.',
+        content: s.coachAnonymousAuthGateMessage,
         timestamp: DateTime.now(),
-        suggestedActions: ['Creer mon compte', 'J\'ai deja un compte'],
+        suggestedActions: [
+          s.coachAuthGateChipRegister,
+          s.coachAuthGateChipLogin,
+        ],
         tier: ChatTier.none,
       ));
     });
@@ -1607,11 +1607,11 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     final s = S.of(context)!;
 
     // Handle anonymous auth gate chips.
-    if (action == 'Creer mon compte') {
+    if (action == s.coachAuthGateChipRegister) {
       context.push('/auth/register');
       return;
     }
-    if (action == 'J\'ai deja un compte') {
+    if (action == s.coachAuthGateChipLogin) {
       context.push('/auth/login');
       return;
     }


### PR DESCRIPTION
## Summary
Two cohesive coach-chat changes bundled in one PR (same file, related audit findings).

## Part 1 — ARB-route hardcoded copy + restore FR accents (NEVER #1 + #2)
Three coach-chat surfaces hardcoded FR strings with broken accents. All three now go through `AppLocalizations` via 4 new ARB keys × 6 locales.

| Surface | Before | After |
|---|---|---|
| Onboarding intake (line 343) | « Salut, je viens de creer mon compte. Par ou je commence ? » | `s.coachOnboardingFirstUserMessage` |
| Anonymous auth gate message (lines 1261-1262) | « On a deja decouvert quelques pistes ensemble. Cree ton compte... » | `s.coachAnonymousAuthGateMessage` |
| Auth gate chip labels + handlers (1264, 1610, 1614) | string literals | `s.coachAuthGateChipRegister` / `coachAuthGateChipLogin` |

Restored accents (FR canonical): `creer`→`créer` ×2, `deja`→`déjà` ×3, `decouvrir`→`découvrir`, `ou`→`où`.

## Part 2 — Wire `ProactiveTriggerService` output to chat opener (P0 dead-feature)
`MintStateEngine.compute()` populated `MintUserState.pendingTrigger` via `ProactiveTriggerService.evaluate`, but no screen displayed it. The marketed silent-opener WOW moment never fired on app open.

Wire-through:
- When the coach chat opens with no `entryPayload`, no resumed conversation, and an authenticated profile, read `MintStateProvider.state.pendingTrigger`.
- If non-null, resolve `messageKey` → localized opener via the 8 existing ARB keys (`proactiveLifecycleChange`, `proactiveWeeklyRecap`, `proactiveGoalMilestone`, `proactiveSeasonalReminder`, `proactiveInactivityReturn`, `proactiveConfidenceUp`, `proactiveNewCap`, `proactiveContractDeadline`).
- Inject via `_addCoachOpenerMessage`.
- Emit `coach_proactive_trigger_shown` analytics event.

Per-day dedup is upstream (`ProactiveTriggerService` cooldown). Session flag prevents re-show within a single screen lifetime. Resolver routes through the strongly-typed `AppLocalizations` API via `switch (ProactiveTriggerType)`, so any missing param surfaces at compile time.

## Verification
- `check_banned_terms()` clean on all 4 new FR strings
- `accent_lint_fr.py` reports no `coach_chat_screen.dart` hits (228 remaining repo-wide, all pre-existing)
- `flutter gen-l10n` regenerated 4 keys × 6 locales
- `flutter analyze lib/screens/coach/coach_chat_screen.dart` shows only pre-existing warnings, no new issues from either change

## Out of scope (separate follow-ups)
- **P1 — silent-opener cards**: `ResponseCardService.generateForChat` only fires after a user message. Need to handle null-message + integrate into silent opener for the visual scene-card WOW.
- **P2 — conversation count never resets on logout**: `_conversationCountKey` and `_proactiveOptInAskedKey` persist across logout, blocking re-prompts.
- **Accent fix on `_notificationOpener` (lines 465-473)**: 5 hardcoded strings still have « tenir a », « par quoi », « commence ? » without proper FR typography.
- **Trigger consumption clear**: currently relies on per-day cooldown upstream; could clear `MintUserState.pendingTrigger` in provider on display for stricter once-only semantics.

Co-Authored-By: Claude <noreply@anthropic.com>