### PR TITLE
feat(coach): render scene card alongside silent opener key number

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -39,6 +39,8 @@ import 'package:mint_mobile/widgets/coach/coach_app_bar.dart';
 import 'package:mint_mobile/widgets/coach/coach_input_bar.dart';
 import 'package:mint_mobile/widgets/coach/coach_loading_indicator.dart';
 import 'package:mint_mobile/widgets/coach/coach_message_bubble.dart';
+import 'package:mint_mobile/widgets/coach/response_card_widget.dart'
+    show ResponseCardStrip;
 import 'package:mint_mobile/models/coach_insight.dart';
 import 'package:mint_mobile/services/memory/coach_memory_service.dart';
 import 'package:mint_mobile/models/coach_entry_payload.dart';
@@ -1889,6 +1891,11 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       return const SizedBox.shrink();
     }
 
+    final silentOpenerCards = ResponseCardService.generateForSilentOpener(
+      _profile!,
+      l: s,
+    );
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 24),
@@ -1919,6 +1926,15 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
               ),
               textAlign: TextAlign.center,
             ),
+            // Handoff 2 « scènes inline » applied to the silent opener:
+            // a single contextual scene card surfaces alongside the key
+            // number so the screen feels like a coach who already opened
+            // the right tab, not a static stat. Cards are picked from
+            // profile shape only — no user message required.
+            if (silentOpenerCards.isNotEmpty) ...[
+              const SizedBox(height: 28),
+              ResponseCardStrip(cards: silentOpenerCards),
+            ],
           ],
         ),
       ),

--- a/apps/mobile/lib/services/response_card_service.dart
+++ b/apps/mobile/lib/services/response_card_service.dart
@@ -587,6 +587,44 @@ class ResponseCardService {
     return prompts.take(3).toList();
   }
 
+  /// Returns up to [limit] cards relevant to the user's profile, picked
+  /// without any user message. Used by the coach silent opener to surface
+  /// a contextual scene card alongside the key number — closes the gap
+  /// between the marketed Handoff 2 « scènes inline » and the actual
+  /// silent-opener UI which previously displayed only text.
+  ///
+  /// Priority mirrors `coach_chat_screen._computeKeyNumber`:
+  /// 1. LPP avoir present → buyback card
+  /// 2. 3a épargne present → pilier 3a card
+  /// 3. replacement-rate / projected-capital available → replacement
+  ///    rate card
+  /// Falls back to AVS gap card when none of the above resolve.
+  static List<ResponseCard> generateForSilentOpener(
+    CoachProfile profile, {
+    required S l,
+    int limit = 2,
+  }) {
+    final cards = <ResponseCard>[];
+    final avoirLpp = profile.prevoyance.avoirLppTotal;
+    if (avoirLpp != null && avoirLpp > 0) {
+      final c = _tryLppBuyback(profile, l);
+      if (c != null) cards.add(c);
+    }
+    if (profile.prevoyance.totalEpargne3a > 0) {
+      final c = _tryPillar3a(profile, l);
+      if (c != null) cards.add(c);
+    }
+    if (cards.isEmpty) {
+      final c = _tryReplacementRate(profile, l);
+      if (c != null) cards.add(c);
+    }
+    if (cards.isEmpty) {
+      final c = _tryAvsGap(profile, l);
+      if (c != null) cards.add(c);
+    }
+    return cards.take(limit).toList();
+  }
+
   // ════════════════════════════════════════════════════════════
   //  CARD GENERATORS
   // ════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Activates the Handoff 2 « scènes inline » WOW on the coach chat silent opener. Previously the screen rendered the key number + headline only — `ResponseCardService.generateForChat` is keyword-driven on the user message, so cards never rendered before the user typed.

## Change
- **New service entry point** — `ResponseCardService.generateForSilentOpener(profile, l)`. Profile-shape-driven card picker that mirrors `coach_chat_screen._computeKeyNumber`'s priority:
  1. `avoirLpp` present → `LppBuyback` card
  2. `epargne3a` present → `Pillar3a` card
  3. forecaster yields a positive replacement rate → `ReplacementRate` card
  4. fallback → `AvsGap` card
- **UI** — `_buildSilentOpener` now appends `ResponseCardStrip(cards: silentOpenerCards)` below the headline. Empty list collapses gracefully (`SizedBox.shrink`) so users without enough profile data still see the clean opener.

## Why
Closes the audit P1 from coach-chat surface review: the silent opener was the single biggest "marketed but absent" Handoff 2 element — the user landed on the coach with a number but no scene to act on it. The infrastructure (`ResponseCardService`, `ResponseCardStrip`, all `_try*` helpers, all ARB rcXxx keys) was already shipped; only the entry point was missing.

## Verification
- `flutter analyze lib/screens/coach/coach_chat_screen.dart lib/services/response_card_service.dart` — same 5 pre-existing warnings, no new issues
- `_tryLppBuyback`, `_tryPillar3a`, `_tryReplacementRate`, `_tryAvsGap` already return `ResponseCard?` and are safe to call without a user message
- Empty-result branch shrinks (no layout regression for users with empty profile)

## Out of scope
- Multiple-card variant on silent opener (currently capped to 2 via `limit: 2`; could later be sized to screen width)
- Silent-opener-specific A11y label on the strip
- Sentry breadcrumb on card tap from silent opener context

Co-Authored-By: Claude <noreply@anthropic.com>