### PR TITLE
fix(coach): route _notificationOpener through ARB + restore one accent

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11143,5 +11143,9 @@
   "coachAnonymousAuthGateMessage": "Wir haben schon ein paar Spuren zusammen erkundet. Erstelle dein Konto, damit ich mich an alles erinnere.",
   "coachAuthGateChipRegister": "Konto erstellen",
   "coachAuthGateChipLogin": "Ich habe schon ein Konto",
-  "cantonLabel": "Kanton"
+  "cantonLabel": "Kanton",
+  "coachNotificationOpenerMonthlyCheckIn": "Zeit für den Monatsrückblick. Wie war's?",
+  "coachNotificationOpenerCommitmentWithLabel": "Du hast mir gesagt, du würdest {commitment}. Erledigt?",
+  "coachNotificationOpenerCommitmentGeneric": "Du hattest eine Verpflichtung. Erledigt?",
+  "coachNotificationOpenerFreshStart": "Neuer Monat. Wo fangen wir an?"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11143,5 +11143,9 @@
   "coachAnonymousAuthGateMessage": "We already explored a few leads together. Create your account so I remember it all.",
   "coachAuthGateChipRegister": "Create my account",
   "coachAuthGateChipLogin": "I already have an account",
-  "cantonLabel": "Canton"
+  "cantonLabel": "Canton",
+  "coachNotificationOpenerMonthlyCheckIn": "Time for the monthly check-in. How was it?",
+  "coachNotificationOpenerCommitmentWithLabel": "You told me you were going to {commitment}. Done?",
+  "coachNotificationOpenerCommitmentGeneric": "You had a commitment to keep. Done?",
+  "coachNotificationOpenerFreshStart": "New month. Where do we start?"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11143,5 +11143,9 @@
   "coachAnonymousAuthGateMessage": "Ya hemos explorado algunas pistas juntos. Crea tu cuenta para que recuerde todo.",
   "coachAuthGateChipRegister": "Crear mi cuenta",
   "coachAuthGateChipLogin": "Ya tengo una cuenta",
-  "cantonLabel": "Cantón"
+  "cantonLabel": "Cantón",
+  "coachNotificationOpenerMonthlyCheckIn": "Hora del balance mensual. ¿Qué tal?",
+  "coachNotificationOpenerCommitmentWithLabel": "Me dijiste que ibas a {commitment}. ¿Hecho?",
+  "coachNotificationOpenerCommitmentGeneric": "Tenías un compromiso. ¿Hecho?",
+  "coachNotificationOpenerFreshStart": "Nuevo mes. ¿Por dónde empezamos?"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12033,5 +12033,16 @@
   "coachAnonymousAuthGateMessage": "On a déjà découvert quelques pistes ensemble. Crée ton compte pour que je me souvienne de tout.",
   "coachAuthGateChipRegister": "Créer mon compte",
   "coachAuthGateChipLogin": "J'ai déjà un compte",
-  "cantonLabel": "Canton"
+  "cantonLabel": "Canton",
+  "coachNotificationOpenerMonthlyCheckIn": "On fait le point sur le mois ?",
+  "coachNotificationOpenerCommitmentWithLabel": "Tu m'avais dit que tu allais {commitment}. C'est fait ?",
+  "@coachNotificationOpenerCommitmentWithLabel": {
+    "placeholders": {
+      "commitment": {
+        "type": "String"
+      }
+    }
+  },
+  "coachNotificationOpenerCommitmentGeneric": "Tu avais un engagement à tenir. C'est fait ?",
+  "coachNotificationOpenerFreshStart": "Nouveau mois. On commence par quoi ?"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11143,5 +11143,9 @@
   "coachAnonymousAuthGateMessage": "Abbiamo già esplorato alcune piste insieme. Crea il tuo account così ricordo tutto.",
   "coachAuthGateChipRegister": "Crea il mio account",
   "coachAuthGateChipLogin": "Ho già un account",
-  "cantonLabel": "Cantone"
+  "cantonLabel": "Cantone",
+  "coachNotificationOpenerMonthlyCheckIn": "È ora del punto mensile. Com'è andata?",
+  "coachNotificationOpenerCommitmentWithLabel": "Mi avevi detto che avresti {commitment}. Fatto?",
+  "coachNotificationOpenerCommitmentGeneric": "Avevi un impegno da mantenere. Fatto?",
+  "coachNotificationOpenerFreshStart": "Nuovo mese. Da dove cominciamo?"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40544,6 +40544,30 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Canton'**
   String get cantonLabel;
+
+  /// No description provided for @coachNotificationOpenerMonthlyCheckIn.
+  ///
+  /// In fr, this message translates to:
+  /// **'On fait le point sur le mois ?'**
+  String get coachNotificationOpenerMonthlyCheckIn;
+
+  /// No description provided for @coachNotificationOpenerCommitmentWithLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tu m\'avais dit que tu allais {commitment}. C\'est fait ?'**
+  String coachNotificationOpenerCommitmentWithLabel(String commitment);
+
+  /// No description provided for @coachNotificationOpenerCommitmentGeneric.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tu avais un engagement à tenir. C\'est fait ?'**
+  String get coachNotificationOpenerCommitmentGeneric;
+
+  /// No description provided for @coachNotificationOpenerFreshStart.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nouveau mois. On commence par quoi ?'**
+  String get coachNotificationOpenerFreshStart;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23168,4 +23168,21 @@ class SDe extends S {
 
   @override
   String get cantonLabel => 'Kanton';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'Zeit für den Monatsrückblick. Wie war\'s?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'Du hast mir gesagt, du würdest $commitment. Erledigt?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'Du hattest eine Verpflichtung. Erledigt?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'Neuer Monat. Wo fangen wir an?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22999,4 +22999,21 @@ class SEn extends S {
 
   @override
   String get cantonLabel => 'Canton';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'Time for the monthly check-in. How was it?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'You told me you were going to $commitment. Done?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'You had a commitment to keep. Done?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'New month. Where do we start?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23111,4 +23111,21 @@ class SEs extends S {
 
   @override
   String get cantonLabel => 'Cantón';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'Hora del balance mensual. ¿Qué tal?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'Me dijiste que ibas a $commitment. ¿Hecho?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'Tenías un compromiso. ¿Hecho?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'Nuevo mes. ¿Por dónde empezamos?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23113,4 +23113,21 @@ class SFr extends S {
 
   @override
   String get cantonLabel => 'Canton';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'On fait le point sur le mois ?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'Tu m\'avais dit que tu allais $commitment. C\'est fait ?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'Tu avais un engagement à tenir. C\'est fait ?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'Nouveau mois. On commence par quoi ?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23172,4 +23172,21 @@ class SIt extends S {
 
   @override
   String get cantonLabel => 'Cantone';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'È ora del punto mensile. Com\'è andata?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'Mi avevi detto che avresti $commitment. Fatto?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'Avevi un impegno da mantenere. Fatto?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'Nuovo mese. Da dove cominciamo?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23119,4 +23119,21 @@ class SPt extends S {
 
   @override
   String get cantonLabel => 'Cantão';
+
+  @override
+  String get coachNotificationOpenerMonthlyCheckIn =>
+      'Hora do ponto do mês. Como foi?';
+
+  @override
+  String coachNotificationOpenerCommitmentWithLabel(String commitment) {
+    return 'Tinhas-me dito que ias $commitment. Feito?';
+  }
+
+  @override
+  String get coachNotificationOpenerCommitmentGeneric =>
+      'Tinhas um compromisso. Feito?';
+
+  @override
+  String get coachNotificationOpenerFreshStart =>
+      'Novo mês. Por onde começamos?';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11143,5 +11143,9 @@
   "coachAnonymousAuthGateMessage": "Já explorámos algumas pistas juntos. Cria a tua conta para eu me lembrar de tudo.",
   "coachAuthGateChipRegister": "Criar a minha conta",
   "coachAuthGateChipLogin": "Já tenho uma conta",
-  "cantonLabel": "Cantão"
+  "cantonLabel": "Cantão",
+  "coachNotificationOpenerMonthlyCheckIn": "Hora do ponto do mês. Como foi?",
+  "coachNotificationOpenerCommitmentWithLabel": "Tinhas-me dito que ias {commitment}. Feito?",
+  "coachNotificationOpenerCommitmentGeneric": "Tinhas um compromisso. Feito?",
+  "coachNotificationOpenerFreshStart": "Novo mês. Por onde começamos?"
 }

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -480,17 +480,18 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
   /// [data] may carry notification-specific fields. For commitmentReminder,
   /// `data['commitment']` (String) is interpolated into the message.
   String? _notificationOpener(String topic, Map<String, dynamic>? data) {
+    final l = S.of(context)!;
     switch (topic) {
       case 'monthlyCheckIn':
-        return 'On fait le point sur le mois\u00a0?';
+        return l.coachNotificationOpenerMonthlyCheckIn;
       case 'commitmentReminder':
         final commitment = data?['commitment']?.toString();
         if (commitment != null && commitment.trim().isNotEmpty) {
-          return 'Tu m\u2019avais dit que tu allais $commitment. C\u2019est fait\u00a0?';
+          return l.coachNotificationOpenerCommitmentWithLabel(commitment);
         }
-        return 'Tu avais un engagement a tenir. C\u2019est fait\u00a0?';
+        return l.coachNotificationOpenerCommitmentGeneric;
       case 'freshStart':
-        return 'Nouveau mois. On commence par quoi\u00a0?';
+        return l.coachNotificationOpenerFreshStart;
       default:
         return null;
     }


### PR DESCRIPTION
## Summary
The notification-driven opener (`monthlyCheckIn`, `commitmentReminder`, `freshStart`) hardcoded 4 user-facing strings. NEVER #1 violation (i18n) and one string (« engagement a tenir » → « à ») was also a NEVER #2 violation (accent).

## Change
4 new ARB keys × 6 locales:
- `coachNotificationOpenerMonthlyCheckIn`
- `coachNotificationOpenerCommitmentWithLabel({commitment})` (parameterised)
- `coachNotificationOpenerCommitmentGeneric`
- `coachNotificationOpenerFreshStart`

`_notificationOpener` now resolves via `S.of(context)!`. State's `context` is always available; no signature change needed at the callsite.

## Verification
- `check_banned_terms()` clean on all 4 new FR strings
- `flutter gen-l10n` regenerated all 4 keys × 6 locales
- `flutter analyze` on the touched file shows only the same 5 pre-existing warnings, no new issues
- `accent_lint_fr.py` reports 228 repo-wide violations, identical count before / after this PR (confirms no regressions and no `coach_chat_screen.dart` hits)

## Out of scope
- Pan-locale superlative discipline beyond FR
- The remaining 228 accent violations are spread across `services/backend/` and unrelated screens — separate sweep PR

Co-Authored-By: Claude <noreply@anthropic.com>