### PR TITLE
ci(arb): annotate 9 coach* keys with x-mint-meta level N3

### DIFF
--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10399,6 +10399,11 @@
   "coachOptInAccept": "Oui, signale-moi",
   "coachOptInDecline": "Non, je viens quand je veux",
   "coachOptInAcknowledged": "Bien noté, je te signalerai ce qui compte.",
+  "@coachOptInAcknowledged": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "coachSilentOpenerReplacementRate": "Taux de remplacement projeté",
   "coachSilentOpenerFitnessScore": "Score de santé financière",
   "coachSilentOpenerRetirementCapital": "Capital projeté à la retraite",
@@ -12030,19 +12035,57 @@
   "wedgeSalaryErrorInvalid": "Entre un montant en chiffres, par exemple 95 000.",
   "wedgeSalaryErrorOutOfRange": "Entre 10 000 et 1 000 000 CHF par an.",
   "coachOnboardingFirstUserMessage": "Salut, je viens de créer mon compte. Par où je commence ?",
+  "@coachOnboardingFirstUserMessage": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "coachAnonymousAuthGateMessage": "On a déjà découvert quelques pistes ensemble. Crée ton compte pour que je me souvienne de tout.",
+  "@coachAnonymousAuthGateMessage": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "coachAuthGateChipRegister": "Créer mon compte",
+  "@coachAuthGateChipRegister": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "coachAuthGateChipLogin": "J'ai déjà un compte",
+  "@coachAuthGateChipLogin": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "cantonLabel": "Canton",
   "coachNotificationOpenerMonthlyCheckIn": "On fait le point sur le mois ?",
+  "@coachNotificationOpenerMonthlyCheckIn": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
   "coachNotificationOpenerCommitmentWithLabel": "Tu m'avais dit que tu allais {commitment}. C'est fait ?",
   "@coachNotificationOpenerCommitmentWithLabel": {
     "placeholders": {
       "commitment": {
         "type": "String"
       }
+    },
+    "x-mint-meta": {
+      "level": "N3"
     }
   },
   "coachNotificationOpenerCommitmentGeneric": "Tu avais un engagement à tenir. C'est fait ?",
-  "coachNotificationOpenerFreshStart": "Nouveau mois. On commence par quoi ?"
+  "@coachNotificationOpenerCommitmentGeneric": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  },
+  "coachNotificationOpenerFreshStart": "Nouveau mois. On commence par quoi ?",
+  "@coachNotificationOpenerFreshStart": {
+    "x-mint-meta": {
+      "level": "N3"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Fixes the dev-branch CI failure on **Backend tests > ARB sentence-subject lint (TRUST-02 + ALERT-02)** introduced when 9 coach-namespaced ARB keys were added in PRs #428, #431, #433 without their VOICE-14 mandatory `@key.x-mint-meta.level` annotation.

## Why CI was red
The Phase 11 / Plan 11-05 lint (`tools/checks/sentence_subject_arb_lint.py`) requires every new ARB key whose name matches `^(coach|chat|messageCoach|intentChip|mintHome|alert)` to declare a voice-cursor level (`N1`=murmure → `N5`=tonnerre). Missing the annotation is a hard fail.

## Annotation — N3 (« voix posée », default conversational)
| Key | From PR |
|---|---|
| coachOptInAcknowledged | #428 |
| coachOnboardingFirstUserMessage | #431 |
| coachAnonymousAuthGateMessage | #431 |
| coachAuthGateChipRegister | #431 |
| coachAuthGateChipLogin | #431 |
| coachNotificationOpenerMonthlyCheckIn | #433 |
| coachNotificationOpenerCommitmentWithLabel | #433 |
| coachNotificationOpenerCommitmentGeneric | #433 |
| coachNotificationOpenerFreshStart | #433 |

N3 is the default conversational tone — appropriate for chatbot acknowledgements, onboarding intake, auth-gate copy, and notification openers (none of these are whispers or alerts).

The parameterised `coachNotificationOpenerCommitmentWithLabel` key keeps its existing `placeholders` block; the new `x-mint-meta` is added alongside.

## Verification
- `python3 tools/checks/sentence_subject_arb_lint.py` → OK
- ARB parses as valid JSON (verified by gen-l10n round-trip locally)

## Out of scope
- Bulk audit of every ARB key in scope (they are either annotated or grandfathered via `tools/checks/arb_meta_level_grandfathered.txt`)
- Adding @meta to keys not in the LEVEL_SCOPE namespace (settingsPrivacy*, wedge*, etc.)

Co-Authored-By: Claude <noreply@anthropic.com>