### PR TITLE
feat(phase-52): cloud-sync opt-in toggle (T-52-01/02/05/06)

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -43,6 +43,7 @@ import 'package:mint_mobile/screens/job_comparison_screen.dart';
 import 'package:mint_mobile/screens/divorce_simulator_screen.dart';
 import 'package:mint_mobile/screens/byok_settings_screen.dart';
 import 'package:mint_mobile/screens/slm_settings_screen.dart';
+import 'package:mint_mobile/screens/settings/confidentialite_settings_screen.dart';
 import 'package:mint_mobile/screens/settings/langue_settings_screen.dart';
 import 'package:mint_mobile/screens/about_screen.dart';
 // ask_mint_screen.dart DELETED (deep-audit 2026-04-17) — route /ask-mint redirects to /coach/chat
@@ -1184,6 +1185,11 @@ final _router = GoRouter(
       path: '/settings/langue',
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const LangueSettingsScreen(),
+    ),
+    ScopedGoRoute(
+      path: '/settings/confidentialite',
+      parentNavigatorKey: _rootNavigatorKey,
+      builder: (context, state) => const ConfidentialiteSettingsScreen(),
     ),
 
     // ── ABOUT (public) ─────────────────────────────────────────

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -3507,7 +3507,7 @@
   "authGateCreateAccount": "Mein Konto erstellen",
   "authGateLogin": "Ich habe bereits ein Konto",
   "authGatePrivacyNote": "Deine Daten bleiben auf deinem Gerät und sind verschlüsselt.",
-  "authRegisterSubtitle": "Verschlüsseltes Konto, geräteübergreifend synchronisiert. Synchronisationssteuerung folgt bald in den Einstellungen.",
+  "authRegisterSubtitle": "Erstelle ein verschlüsseltes Konto. Cloud-Synchronisation ist standardmässig aus; du kannst sie in Einstellungen › Datenschutz aktivieren.",
   "authWhyCreateAccount": "Warum ein Konto erstellen?",
   "authBenefitProjections": "AHV/BVG-Projektionen auf deine Situation abgestimmt",
   "authBenefitCoach": "Persönlicher Coach mit deinem Vornamen",
@@ -11147,5 +11147,13 @@
   "coachNotificationOpenerMonthlyCheckIn": "Zeit für den Monatsrückblick. Wie war's?",
   "coachNotificationOpenerCommitmentWithLabel": "Du hast mir gesagt, du würdest {commitment}. Erledigt?",
   "coachNotificationOpenerCommitmentGeneric": "Du hattest eine Verpflichtung. Erledigt?",
-  "coachNotificationOpenerFreshStart": "Neuer Monat. Wo fangen wir an?"
+  "coachNotificationOpenerFreshStart": "Neuer Monat. Wo fangen wir an?",
+  "settingsPrivacyTitle": "Datenschutz",
+  "settingsPrivacyCloudSyncTitle": "Cloud-Synchronisation (mehrere Geräte)",
+  "settingsPrivacyCloudSyncSubtitle": "Backup und Zugriff von einem anderen Gerät. Du kannst sie jederzeit deaktivieren.",
+  "settingsPrivacyCloudSyncOn": "Aktiviert",
+  "settingsPrivacyCloudSyncOff": "Deaktiviert",
+  "settingsPrivacyMigrationToast": "Neue Option: Du kannst die Cloud-Synchronisation in Einstellungen › Datenschutz deaktivieren.",
+  "settingsPrivacyDataLocation": "Deine Daten bleiben verschlüsselt auf deinem Gerät gespeichert. Mit aktivierter Synchronisation sind sie auch verschlüsselt auf unseren europäischen Servern (Schweiz/EU) gespeichert — Ende-zu-Ende-Verschlüsselung geplant für v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -3507,7 +3507,7 @@
   "authGateCreateAccount": "Create my account",
   "authGateLogin": "I already have an account",
   "authGatePrivacyNote": "Your data stays on your device and is encrypted.",
-  "authRegisterSubtitle": "Encrypted account, synced across your devices. Sync controls are coming to Settings soon.",
+  "authRegisterSubtitle": "Create an encrypted account. Cloud sync is off by default; you can turn it on in Settings › Privacy.",
   "authWhyCreateAccount": "Why create an account?",
   "authBenefitProjections": "AVS/LPP projections aligned to your situation",
   "authBenefitCoach": "Personalised coach with your first name",
@@ -11147,5 +11147,13 @@
   "coachNotificationOpenerMonthlyCheckIn": "Time for the monthly check-in. How was it?",
   "coachNotificationOpenerCommitmentWithLabel": "You told me you were going to {commitment}. Done?",
   "coachNotificationOpenerCommitmentGeneric": "You had a commitment to keep. Done?",
-  "coachNotificationOpenerFreshStart": "New month. Where do we start?"
+  "coachNotificationOpenerFreshStart": "New month. Where do we start?",
+  "settingsPrivacyTitle": "Privacy",
+  "settingsPrivacyCloudSyncTitle": "Cloud sync (multi-device)",
+  "settingsPrivacyCloudSyncSubtitle": "Backup and access from another device. You can turn it off anytime.",
+  "settingsPrivacyCloudSyncOn": "On",
+  "settingsPrivacyCloudSyncOff": "Off",
+  "settingsPrivacyMigrationToast": "New option: you can turn off cloud sync from Settings › Privacy.",
+  "settingsPrivacyDataLocation": "Your data stays encrypted at rest on your device. With sync on, it's also encrypted at rest on our European servers (Switzerland/EU) — end-to-end encryption planned for v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Turning sync off doesn't delete data already saved to our servers. To remove it, go to Account › Delete my account."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -3507,7 +3507,7 @@
   "authGateCreateAccount": "Crear mi cuenta",
   "authGateLogin": "Ya tengo una cuenta",
   "authGatePrivacyNote": "Tus datos permanecen en tu dispositivo y están cifrados.",
-  "authRegisterSubtitle": "Cuenta cifrada, sincronizada entre tus dispositivos. Los controles de sincronización llegarán pronto a Ajustes.",
+  "authRegisterSubtitle": "Crea una cuenta cifrada. La sincronización en la nube está desactivada por defecto; puedes activarla en Ajustes › Privacidad.",
   "authWhyCreateAccount": "¿Por qué crear una cuenta?",
   "authBenefitProjections": "Proyecciones AVS/LPP adaptadas a tu situación",
   "authBenefitCoach": "Coach personalizado con tu nombre",
@@ -11147,5 +11147,13 @@
   "coachNotificationOpenerMonthlyCheckIn": "Hora del balance mensual. ¿Qué tal?",
   "coachNotificationOpenerCommitmentWithLabel": "Me dijiste que ibas a {commitment}. ¿Hecho?",
   "coachNotificationOpenerCommitmentGeneric": "Tenías un compromiso. ¿Hecho?",
-  "coachNotificationOpenerFreshStart": "Nuevo mes. ¿Por dónde empezamos?"
+  "coachNotificationOpenerFreshStart": "Nuevo mes. ¿Por dónde empezamos?",
+  "settingsPrivacyTitle": "Privacidad",
+  "settingsPrivacyCloudSyncTitle": "Sincronización en la nube (multidispositivo)",
+  "settingsPrivacyCloudSyncSubtitle": "Copia de seguridad y acceso desde otro dispositivo. Puedes desactivarla cuando quieras.",
+  "settingsPrivacyCloudSyncOn": "Activada",
+  "settingsPrivacyCloudSyncOff": "Desactivada",
+  "settingsPrivacyMigrationToast": "Nueva opción: puedes desactivar la sincronización en la nube desde Ajustes › Privacidad.",
+  "settingsPrivacyDataLocation": "Tus datos quedan cifrados en tu dispositivo. Con la sincronización activada, también están cifrados en nuestros servidores europeos (Suiza/UE) — cifrado de extremo a extremo previsto en la v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -3880,7 +3880,7 @@
   "disabilityAppBarTitle": "Si je ne peux plus travailler",
   "disabilityStatLine1": "1 personne sur 5",
   "disabilityStatLine2": "sera touchée avant 65 ans",
-  "authRegisterSubtitle": "Compte chiffré, synchronisé entre tes appareils. Tu pourras gérer la synchronisation depuis tes réglages bientôt.",
+  "authRegisterSubtitle": "Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l'activer depuis Réglages › Confidentialité.",
   "authWhyCreateAccount": "Pourquoi créer un compte ?",
   "authBenefitProjections": "Projections AVS/LPP alignées à ta situation",
   "authBenefitCoach": "Coach personnalisé avec ton prénom",
@@ -12087,5 +12087,13 @@
     "x-mint-meta": {
       "level": "N3"
     }
-  }
+  },
+  "settingsPrivacyTitle": "Confidentialité",
+  "settingsPrivacyCloudSyncTitle": "Synchronisation cloud (multi-appareils)",
+  "settingsPrivacyCloudSyncSubtitle": "Sauvegarde et accès depuis un autre appareil. Tu peux la désactiver à tout moment.",
+  "settingsPrivacyCloudSyncOn": "Activée",
+  "settingsPrivacyCloudSyncOff": "Désactivée",
+  "settingsPrivacyMigrationToast": "Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité.",
+  "settingsPrivacyDataLocation": "Tes données restent stockées chiffrées sur ton appareil. Avec la sync activée, elles sont aussi stockées chiffrées sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Désactiver la sync n'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -3507,7 +3507,7 @@
   "authGateCreateAccount": "Crea il mio account",
   "authGateLogin": "Ho già un account",
   "authGatePrivacyNote": "I tuoi dati restano sul tuo dispositivo e sono crittografati.",
-  "authRegisterSubtitle": "Account cifrato, sincronizzato tra i tuoi dispositivi. I controlli di sincronizzazione arriveranno presto in Impostazioni.",
+  "authRegisterSubtitle": "Crea un account cifrato. La sincronizzazione cloud è disattivata di default; puoi attivarla da Impostazioni › Privacy.",
   "authWhyCreateAccount": "Perché creare un account?",
   "authBenefitProjections": "Proiezioni AVS/LPP adattate alla tua situazione",
   "authBenefitCoach": "Coach personalizzato con il tuo nome",
@@ -11147,5 +11147,13 @@
   "coachNotificationOpenerMonthlyCheckIn": "È ora del punto mensile. Com'è andata?",
   "coachNotificationOpenerCommitmentWithLabel": "Mi avevi detto che avresti {commitment}. Fatto?",
   "coachNotificationOpenerCommitmentGeneric": "Avevi un impegno da mantenere. Fatto?",
-  "coachNotificationOpenerFreshStart": "Nuovo mese. Da dove cominciamo?"
+  "coachNotificationOpenerFreshStart": "Nuovo mese. Da dove cominciamo?",
+  "settingsPrivacyTitle": "Privacy",
+  "settingsPrivacyCloudSyncTitle": "Sincronizzazione cloud (multidispositivo)",
+  "settingsPrivacyCloudSyncSubtitle": "Backup e accesso da un altro dispositivo. Puoi disattivarla in qualsiasi momento.",
+  "settingsPrivacyCloudSyncOn": "Attiva",
+  "settingsPrivacyCloudSyncOff": "Disattivata",
+  "settingsPrivacyMigrationToast": "Nuova opzione: puoi disattivare la sincronizzazione cloud da Impostazioni › Privacy.",
+  "settingsPrivacyDataLocation": "I tuoi dati restano cifrati sul tuo dispositivo. Con la sincronizzazione attiva, sono anche cifrati sui nostri server europei (Svizzera/UE) — cifratura end-to-end prevista nella v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -13767,7 +13767,7 @@ abstract class S {
   /// No description provided for @authRegisterSubtitle.
   ///
   /// In fr, this message translates to:
-  /// **'Compte chiffré, synchronisé entre tes appareils. Tu pourras gérer la synchronisation depuis tes réglages bientôt.'**
+  /// **'Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l\'activer depuis Réglages › Confidentialité.'**
   String get authRegisterSubtitle;
 
   /// No description provided for @authWhyCreateAccount.
@@ -40568,6 +40568,54 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Nouveau mois. On commence par quoi ?'**
   String get coachNotificationOpenerFreshStart;
+
+  /// No description provided for @settingsPrivacyTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Confidentialité'**
+  String get settingsPrivacyTitle;
+
+  /// No description provided for @settingsPrivacyCloudSyncTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Synchronisation cloud (multi-appareils)'**
+  String get settingsPrivacyCloudSyncTitle;
+
+  /// No description provided for @settingsPrivacyCloudSyncSubtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Sauvegarde et accès depuis un autre appareil. Tu peux la désactiver à tout moment.'**
+  String get settingsPrivacyCloudSyncSubtitle;
+
+  /// No description provided for @settingsPrivacyCloudSyncOn.
+  ///
+  /// In fr, this message translates to:
+  /// **'Activée'**
+  String get settingsPrivacyCloudSyncOn;
+
+  /// No description provided for @settingsPrivacyCloudSyncOff.
+  ///
+  /// In fr, this message translates to:
+  /// **'Désactivée'**
+  String get settingsPrivacyCloudSyncOff;
+
+  /// No description provided for @settingsPrivacyMigrationToast.
+  ///
+  /// In fr, this message translates to:
+  /// **'Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité.'**
+  String get settingsPrivacyMigrationToast;
+
+  /// No description provided for @settingsPrivacyDataLocation.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes données restent stockées chiffrées sur ton appareil. Avec la sync activée, elles sont aussi stockées chiffrées sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0.'**
+  String get settingsPrivacyDataLocation;
+
+  /// No description provided for @settingsPrivacyCloudSyncOffServerCaveat.
+  ///
+  /// In fr, this message translates to:
+  /// **'Désactiver la sync n\'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.'**
+  String get settingsPrivacyCloudSyncOffServerCaveat;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -7765,7 +7765,7 @@ class SDe extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Verschlüsseltes Konto, geräteübergreifend synchronisiert. Synchronisationssteuerung folgt bald in den Einstellungen.';
+      'Erstelle ein verschlüsseltes Konto. Cloud-Synchronisation ist standardmässig aus; du kannst sie in Einstellungen › Datenschutz aktivieren.';
 
   @override
   String get authWhyCreateAccount => 'Warum ein Konto erstellen?';
@@ -23185,4 +23185,33 @@ class SDe extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'Neuer Monat. Wo fangen wir an?';
+
+  @override
+  String get settingsPrivacyTitle => 'Datenschutz';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle =>
+      'Cloud-Synchronisation (mehrere Geräte)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Backup und Zugriff von einem anderen Gerät. Du kannst sie jederzeit deaktivieren.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'Aktiviert';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Deaktiviert';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'Neue Option: Du kannst die Cloud-Synchronisation in Einstellungen › Datenschutz deaktivieren.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'Deine Daten bleiben verschlüsselt auf deinem Gerät gespeichert. Mit aktivierter Synchronisation sind sie auch verschlüsselt auf unseren europäischen Servern (Schweiz/EU) gespeichert — Ende-zu-Ende-Verschlüsselung geplant für v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -7701,7 +7701,7 @@ class SEn extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Encrypted account, synced across your devices. Sync controls are coming to Settings soon.';
+      'Create an encrypted account. Cloud sync is off by default; you can turn it on in Settings › Privacy.';
 
   @override
   String get authWhyCreateAccount => 'Why create an account?';
@@ -23016,4 +23016,32 @@ class SEn extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'New month. Where do we start?';
+
+  @override
+  String get settingsPrivacyTitle => 'Privacy';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle => 'Cloud sync (multi-device)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Backup and access from another device. You can turn it off anytime.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'On';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Off';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'New option: you can turn off cloud sync from Settings › Privacy.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'Your data stays encrypted at rest on your device. With sync on, it\'s also encrypted at rest on our European servers (Switzerland/EU) — end-to-end encryption planned for v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Turning sync off doesn\'t delete data already saved to our servers. To remove it, go to Account › Delete my account.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -7749,7 +7749,7 @@ class SEs extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Cuenta cifrada, sincronizada entre tus dispositivos. Los controles de sincronización llegarán pronto a Ajustes.';
+      'Crea una cuenta cifrada. La sincronización en la nube está desactivada por defecto; puedes activarla en Ajustes › Privacidad.';
 
   @override
   String get authWhyCreateAccount => '¿Por qué crear una cuenta?';
@@ -23128,4 +23128,33 @@ class SEs extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'Nuevo mes. ¿Por dónde empezamos?';
+
+  @override
+  String get settingsPrivacyTitle => 'Privacidad';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle =>
+      'Sincronización en la nube (multidispositivo)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Copia de seguridad y acceso desde otro dispositivo. Puedes desactivarla cuando quieras.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'Activada';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Desactivada';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'Nueva opción: puedes desactivar la sincronización en la nube desde Ajustes › Privacidad.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'Tus datos quedan cifrados en tu dispositivo. Con la sincronización activada, también están cifrados en nuestros servidores europeos (Suiza/UE) — cifrado de extremo a extremo previsto en la v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -7750,7 +7750,7 @@ class SFr extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Compte chiffré, synchronisé entre tes appareils. Tu pourras gérer la synchronisation depuis tes réglages bientôt.';
+      'Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l\'activer depuis Réglages › Confidentialité.';
 
   @override
   String get authWhyCreateAccount => 'Pourquoi créer un compte ?';
@@ -23130,4 +23130,33 @@ class SFr extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'Nouveau mois. On commence par quoi ?';
+
+  @override
+  String get settingsPrivacyTitle => 'Confidentialité';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle =>
+      'Synchronisation cloud (multi-appareils)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Sauvegarde et accès depuis un autre appareil. Tu peux la désactiver à tout moment.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'Activée';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Désactivée';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'Tes données restent stockées chiffrées sur ton appareil. Avec la sync activée, elles sont aussi stockées chiffrées sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Désactiver la sync n\'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -7761,7 +7761,7 @@ class SIt extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Account cifrato, sincronizzato tra i tuoi dispositivi. I controlli di sincronizzazione arriveranno presto in Impostazioni.';
+      'Crea un account cifrato. La sincronizzazione cloud è disattivata di default; puoi attivarla da Impostazioni › Privacy.';
 
   @override
   String get authWhyCreateAccount => 'Perché creare un account?';
@@ -23189,4 +23189,33 @@ class SIt extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'Nuovo mese. Da dove cominciamo?';
+
+  @override
+  String get settingsPrivacyTitle => 'Privacy';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle =>
+      'Sincronizzazione cloud (multidispositivo)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Backup e accesso da un altro dispositivo. Puoi disattivarla in qualsiasi momento.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'Attiva';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Disattivata';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'Nuova opzione: puoi disattivare la sincronizzazione cloud da Impostazioni › Privacy.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'I tuoi dati restano cifrati sul tuo dispositivo. Con la sincronizzazione attiva, sono anche cifrati sui nostri server europei (Svizzera/UE) — cifratura end-to-end prevista nella v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -7743,7 +7743,7 @@ class SPt extends S {
 
   @override
   String get authRegisterSubtitle =>
-      'Conta cifrada, sincronizada entre os teus dispositivos. Os controlos de sincronização chegarão em breve às Definições.';
+      'Cria uma conta cifrada. A sincronização cloud está desativada por defeito; podes ativá-la em Definições › Privacidade.';
 
   @override
   String get authWhyCreateAccount => 'Porquê criar uma conta?';
@@ -23136,4 +23136,33 @@ class SPt extends S {
   @override
   String get coachNotificationOpenerFreshStart =>
       'Novo mês. Por onde começamos?';
+
+  @override
+  String get settingsPrivacyTitle => 'Privacidade';
+
+  @override
+  String get settingsPrivacyCloudSyncTitle =>
+      'Sincronização cloud (multidispositivo)';
+
+  @override
+  String get settingsPrivacyCloudSyncSubtitle =>
+      'Backup e acesso a partir de outro dispositivo. Podes desativá-la a qualquer momento.';
+
+  @override
+  String get settingsPrivacyCloudSyncOn => 'Ativada';
+
+  @override
+  String get settingsPrivacyCloudSyncOff => 'Desativada';
+
+  @override
+  String get settingsPrivacyMigrationToast =>
+      'Nova opção: podes desativar a sincronização cloud em Definições › Privacidade.';
+
+  @override
+  String get settingsPrivacyDataLocation =>
+      'Os teus dados ficam cifrados no teu dispositivo. Com a sincronização ativa, ficam também cifrados nos nossos servidores europeus (Suíça/UE) — cifragem ponto a ponto prevista na v3.0.';
+
+  @override
+  String get settingsPrivacyCloudSyncOffServerCaveat =>
+      'Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -3507,7 +3507,7 @@
   "authGateCreateAccount": "Criar a minha conta",
   "authGateLogin": "Já tenho uma conta",
   "authGatePrivacyNote": "Os teus dados ficam no teu dispositivo e estão encriptados.",
-  "authRegisterSubtitle": "Conta cifrada, sincronizada entre os teus dispositivos. Os controlos de sincronização chegarão em breve às Definições.",
+  "authRegisterSubtitle": "Cria uma conta cifrada. A sincronização cloud está desativada por defeito; podes ativá-la em Definições › Privacidade.",
   "authWhyCreateAccount": "Porquê criar uma conta?",
   "authBenefitProjections": "Projeções AVS/LPP adaptadas à tua situação",
   "authBenefitCoach": "Coach personalizado com o teu nome",
@@ -11147,5 +11147,13 @@
   "coachNotificationOpenerMonthlyCheckIn": "Hora do ponto do mês. Como foi?",
   "coachNotificationOpenerCommitmentWithLabel": "Tinhas-me dito que ias {commitment}. Feito?",
   "coachNotificationOpenerCommitmentGeneric": "Tinhas um compromisso. Feito?",
-  "coachNotificationOpenerFreshStart": "Novo mês. Por onde começamos?"
+  "coachNotificationOpenerFreshStart": "Novo mês. Por onde começamos?",
+  "settingsPrivacyTitle": "Privacidade",
+  "settingsPrivacyCloudSyncTitle": "Sincronização cloud (multidispositivo)",
+  "settingsPrivacyCloudSyncSubtitle": "Backup e acesso a partir de outro dispositivo. Podes desativá-la a qualquer momento.",
+  "settingsPrivacyCloudSyncOn": "Ativada",
+  "settingsPrivacyCloudSyncOff": "Desativada",
+  "settingsPrivacyMigrationToast": "Nova opção: podes desativar a sincronização cloud em Definições › Privacidade.",
+  "settingsPrivacyDataLocation": "Os teus dados ficam cifrados no teu dispositivo. Com a sincronização ativa, ficam também cifrados nos nossos servidores europeus (Suíça/UE) — cifragem ponto a ponto prevista na v3.0.",
+  "settingsPrivacyCloudSyncOffServerCaveat": "Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta."
 }

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -98,6 +98,12 @@ class AuthProvider extends ChangeNotifier {
   bool get requiresEmailVerification => _requiresEmailVerification;
   bool get isLocalMode => _isLocalMode;
 
+  /// Phase 52: cloud-sync state from the user's perspective.
+  /// `true` ⇔ user has explicitly opted into multi-device sync; data
+  /// is mirrored to the backend on each save. `false` (default after
+  /// register) ⇔ data stays on device.
+  bool get isCloudSyncEnabled => !_isLocalMode;
+
   /// Check stored auth on app startup
   Future<void> checkAuth() async {
     _isLoading = true;
@@ -127,9 +133,12 @@ class AuthProvider extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       _requiresEmailVerification =
           prefs.getBool('requires_email_verification') ?? false;
-      // Local-mode default: true on fresh install (local-first per UX copy
-      // "Compte optionnel : tes données restent locales par défaut").
-      // Explicit register/login flips it to false.
+      // Local-mode default: true on fresh install. Phase 52 (D-01):
+      // register / login no longer auto-flip this to false; cloud sync
+      // is opt-in via Settings › Confidentialité (`toggleCloudSync`).
+      // Existing users registered pre-Phase-52 retain whatever value
+      // was persisted — their `auth_local_mode = false` stays, no
+      // surprise switch in their sync state.
       if (!prefs.containsKey('auth_local_mode')) {
         await prefs.setBool('auth_local_mode', true);
       }
@@ -176,9 +185,8 @@ class AuthProvider extends ChangeNotifier {
           refreshToken: response['refresh_token'] as String?,
         );
         _isLoggedIn = true;
-        _isLocalMode = false;
-        await (await SharedPreferences.getInstance())
-            .setBool('auth_local_mode', false);
+        // Phase 52 (D-01): no longer auto-disable local mode on register.
+        // Cloud sync is opt-in via Settings › Confidentialité.
         // FIX-W11-7: Set user prefix for conversation isolation.
         ConversationStore.setCurrentUserId(userId);
       } else {
@@ -244,9 +252,8 @@ class AuthProvider extends ChangeNotifier {
       _email = userEmail;
       _displayName = response['display_name'] as String?;
       _isLoggedIn = true;
-      _isLocalMode = false;
-      await (await SharedPreferences.getInstance())
-          .setBool('auth_local_mode', false);
+      // Phase 52 (D-01): no longer auto-disable local mode on login.
+      // Cloud sync is opt-in via Settings › Confidentialité.
       // FIX-W11-7: Set user prefix for conversation isolation.
       ConversationStore.setCurrentUserId(userId);
       _requiresEmailVerification = false;
@@ -325,9 +332,8 @@ class AuthProvider extends ChangeNotifier {
       _email = userEmail;
       _displayName = displayName;
       _isLoggedIn = true;
-      _isLocalMode = false;
-      await (await SharedPreferences.getInstance())
-          .setBool('auth_local_mode', false);
+      // Phase 52 (D-01): no longer auto-disable local mode on Apple SSO.
+      // Cloud sync is opt-in via Settings › Confidentialité.
       _requiresEmailVerification = false;
       _error = null;
       // FIX-W11-7: Set user prefix for conversation isolation.
@@ -411,9 +417,8 @@ class AuthProvider extends ChangeNotifier {
       }
 
       _isLoggedIn = true;
-      _isLocalMode = false;
-      await (await SharedPreferences.getInstance())
-          .setBool('auth_local_mode', false);
+      // Phase 52 (D-01): no longer auto-disable local mode on magic link.
+      // Cloud sync is opt-in via Settings › Confidentialité.
       _requiresEmailVerification = false;
       _error = null;
       _isLoading = false;
@@ -750,6 +755,17 @@ class AuthProvider extends ChangeNotifier {
     _isLocalMode = true;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('auth_local_mode', true);
+    notifyListeners();
+  }
+
+  /// Phase 52 (D-01, D-03): user-controlled cloud-sync toggle from
+  /// Settings › Confidentialité. `true` enables multi-device sync
+  /// (next save pushes to the backend), `false` keeps data on device.
+  /// Persisted across launches via `auth_local_mode`.
+  Future<void> toggleCloudSync(bool enabled) async {
+    _isLocalMode = !enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('auth_local_mode', _isLocalMode);
     notifyListeners();
   }
 

--- a/apps/mobile/lib/routes/route_metadata.dart
+++ b/apps/mobile/lib/routes/route_metadata.dart
@@ -1007,6 +1007,12 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     owner: RouteOwner.system,
     requiresAuth: true,
   ),
+  '/settings/confidentialite': RouteMeta(
+    path: '/settings/confidentialite',
+    category: RouteCategory.destination,
+    owner: RouteOwner.system,
+    requiresAuth: true,
+  ),
 
   // ── About (public) ─────────────────────────────────────────────
   '/about': RouteMeta(

--- a/apps/mobile/lib/screens/settings/confidentialite_settings_screen.dart
+++ b/apps/mobile/lib/screens/settings/confidentialite_settings_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:provider/provider.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/theme/mint_spacing.dart';
+import 'package:mint_mobile/theme/mint_text_styles.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
+
+/// Settings › Confidentialité — Phase 52 cloud-sync opt-in toggle.
+///
+/// Single explicit Switch wired to [AuthProvider.toggleCloudSync]. Reads
+/// state from [AuthProvider.isCloudSyncEnabled]. The whole row is tappable
+/// (mirrors LangueSettingsScreen). Below the row, two static disclosure
+/// paragraphs explain (a) where data lives in each state and (b) — only
+/// when sync is OFF and the user is logged in — that previously-pushed
+/// server data is not auto-deleted (D-06 from Phase 52 CONTEXT).
+///
+/// Route: `/settings/confidentialite`.
+class ConfidentialiteSettingsScreen extends StatelessWidget {
+  const ConfidentialiteSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    final auth = context.watch<AuthProvider>();
+    final cloudSyncOn = auth.isCloudSyncEnabled;
+    final showServerCaveat = !cloudSyncOn && auth.isLoggedIn;
+
+    void toggle() {
+      HapticFeedback.selectionClick();
+      context.read<AuthProvider>().toggleCloudSync(!cloudSyncOn);
+    }
+
+    return Scaffold(
+      backgroundColor: MintColors.porcelaine,
+      appBar: AppBar(
+        backgroundColor: MintColors.white,
+        surfaceTintColor: MintColors.white,
+        elevation: 0,
+        title: Text(
+          l.settingsPrivacyTitle,
+          style: MintTextStyles.headlineMedium(),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(MintSpacing.lg),
+        children: [
+          MintSurface(
+            tone: MintSurfaceTone.blanc,
+            padding: const EdgeInsets.symmetric(
+              horizontal: MintSpacing.md,
+              vertical: MintSpacing.md,
+            ),
+            child: InkWell(
+              onTap: toggle,
+              borderRadius: BorderRadius.circular(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l.settingsPrivacyCloudSyncTitle,
+                          style: MintTextStyles.titleMedium(
+                            color: MintColors.textPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: MintSpacing.xs),
+                        Text(
+                          l.settingsPrivacyCloudSyncSubtitle,
+                          style: MintTextStyles.bodySmall(
+                            color: MintColors.textSecondary,
+                          ),
+                        ),
+                        const SizedBox(height: MintSpacing.sm),
+                        // State label is announced by the Switch itself —
+                        // exclude from a11y to avoid double-read.
+                        ExcludeSemantics(
+                          child: Text(
+                            cloudSyncOn
+                                ? l.settingsPrivacyCloudSyncOn
+                                : l.settingsPrivacyCloudSyncOff,
+                            style: MintTextStyles.labelMedium(
+                              color: cloudSyncOn
+                                  ? MintColors.success
+                                  : MintColors.textMuted,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: MintSpacing.md),
+                  Semantics(
+                    container: true,
+                    label: l.settingsPrivacyCloudSyncTitle,
+                    hint: l.settingsPrivacyCloudSyncSubtitle,
+                    child: Switch(
+                      value: cloudSyncOn,
+                      activeThumbColor: MintColors.primary,
+                      onChanged: (value) {
+                        HapticFeedback.selectionClick();
+                        context.read<AuthProvider>().toggleCloudSync(value);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: MintSpacing.lg),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: MintSpacing.sm),
+            child: Text(
+              l.settingsPrivacyDataLocation,
+              style: MintTextStyles.bodySmall(
+                color: MintColors.textSecondary,
+              ),
+            ),
+          ),
+          if (showServerCaveat) ...[
+            const SizedBox(height: MintSpacing.md),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: MintSpacing.sm),
+              child: Text(
+                l.settingsPrivacyCloudSyncOffServerCaveat,
+                style: MintTextStyles.bodySmall(
+                  color: MintColors.textSecondary,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/screens/admin/routes_registry_screen_test.dart
+++ b/apps/mobile/test/screens/admin/routes_registry_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
       expect(RouteOwner.values.length, 15);
     });
 
-    testWidgets('sum of route rows across all buckets == 151', (tester) async {
+    testWidgets('sum of route rows across all buckets == 152', (tester) async {
       // Force a large viewport so every ExpansionTile is laid out simultaneously
       // (default test surface is 800x600 which clips tiles below fold, preventing
       // taps from reaching them reliably after each expansion relayout).
@@ -68,8 +68,8 @@ void main() {
       );
       expect(
         rows,
-        findsNWidgets(151),
-        reason: 'registry has 151 entries; UI must render all',
+        findsNWidgets(152),
+        reason: 'registry has 152 entries; UI must render all',
       );
     });
 

--- a/apps/mobile/test/screens/auth_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/auth_screens_smoke_test.dart
@@ -249,7 +249,7 @@ void main() {
       await tester.pump();
 
       expect(
-        find.textContaining('Compte chiffré'),
+        find.textContaining('compte chiffré'),
         findsOneWidget,
       );
     });

--- a/tests/tools/test_mint_routes.py
+++ b/tests/tools/test_mint_routes.py
@@ -94,11 +94,11 @@ def test_missing_token_returns_71(monkeypatch):
 # ---------- DRY_RUN health output ----------
 
 
-def test_health_dry_run_produces_151_json_lines():
+def test_health_dry_run_produces_152_json_lines():
     r = _run(["health", "--json"], env_extra={"MINT_ROUTES_DRY_RUN": "1"})
     assert r.returncode == 0, r.stderr.decode()[:400]
     lines = [ln for ln in r.stdout.decode().splitlines() if ln.strip()]
-    assert len(lines) == 151, "expected 151 JSON lines, got {}".format(
+    assert len(lines) == 152, "expected 152 JSON lines, got {}".format(
         len(lines)
     )
 
@@ -110,7 +110,7 @@ def test_health_dry_run_owner_filter():
     )
     assert r.returncode == 0
     lines = [ln for ln in r.stdout.decode().splitlines() if ln.strip()]
-    assert 0 < len(lines) < 151
+    assert 0 < len(lines) < 152
 
 
 def test_no_color_env_var_suppresses_ansi():


### PR DESCRIPTION
## Summary
Wires Phase 52 « auth local-first toggle » per PR #426 planning. Bundles 4 sub-tasks into one shippable unit because they're cohesive (provider + screen + ARB + register subtitle).

| Task | Scope |
|---|---|
| **T-52-01** | `auth_provider.dart` — remove the 4 register/login/Apple-SSO/magic-link `_isLocalMode = false` flips; add `toggleCloudSync(bool)` and `isCloudSyncEnabled` getter |
| **T-52-02** | New `confidentialite_settings_screen.dart` at `/settings/confidentialite` — single Switch wired to the new API, whole-row tappable, conditional D-06 caveat |
| **T-52-05** | 8 new `settingsPrivacy*` ARB keys × 6 locales (title, toggle title/subtitle/states, data-location body, server-caveat, migration-toast) |
| **T-52-06** | `authRegisterSubtitle` rewritten in 6 locales: « Cloud sync is off by default; you can turn it on in Settings › Privacy. » |

## Behavior change (D-01)
- **New accounts**: register / login no longer flip `_isLocalMode` to false. Default `true` from initState is preserved → cloud sync **OFF** by default. User opts in via Settings › Confidentialité.
- **Existing accounts** (registered pre-Phase-52): their persisted `auth_local_mode = false` stays. No surprise switch in their sync state. Migration toast (T-52-04) will surface the new control on first post-Phase-52 launch (separate PR — the ARB key is added here).

## Design panel applied BEFORE push (per the new design-panel-first rule)
Verdict was REQUEST_CHANGES with 3 critical fixes. All applied in the same commit:

1. **D-06 caveat surfaced.** New `settingsPrivacyCloudSyncOffServerCaveat` ARB key, rendered conditionally when `!cloudSyncOn && auth.isLoggedIn`. Closes the FDPIC LPD art. 6 transparency gap (« toggle OFF doesn't delete server data »).
2. **E2EE-honesty rewrite.** Previous copy claimed « chiffrée sur nos serveurs européens » — quotable as misleading because the backend uses envelope encryption at rest with operator-held keys, not E2EE. Reworded to « stockée chiffrée sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0 » in all 6 locales.
3. **Switch a11y double-semantics fix.** Previous draft wrapped the Switch in `Semantics(toggled:)` and also exposed the visual « Activée/Désactivée » Text — VoiceOver read the state twice. Fix: row wrapped in `InkWell(onTap: toggle)` so users hit any part of the row; visible state Text wrapped in `ExcludeSemantics`; Switch gets a `Semantics(hint: subtitle)` so VO users hear the explanation.

Plus the panel's nice-to-have:
- « Activée » uses `MintColors.success` for positive affordance, « Désactivée » uses `textMuted`. Both `labelMedium` (12pt) instead of `labelSmall` (11pt).

## Verification
- `flutter analyze` clean on all 3 touched files
- `flutter gen-l10n` regenerated 8 settingsPrivacy* keys + updated subtitle in all 6 locales
- `python3 tools/checks/sentence_subject_arb_lint.py` clean (settingsPrivacy*, authRegister, cantonLabel are out of LEVEL_SCOPE; no @meta annotation needed)
- `check_banned_terms()` clean on all new FR strings (no « garanti », « optimal », etc.)
- ARB FR parses as valid JSON

## Out of scope (next PRs)
- **T-52-03** — Profile screen status row + entry into Settings › Confidentialité
- **T-52-04** — Migration toast trigger on first post-Phase-52 launch for legacy users (the ARB is added here; the wire-through ships separately)
- **T-52-07** — Live sim verification + HTML evidence report
- **T-52-08** — Post-merge panel review

## References
- `.planning/phases/52-auth-local-first-toggle/52-CONTEXT.md` (D-01..D-10)
- `.planning/phases/52-auth-local-first-toggle/52-PLAN.md` (T-52-01..08)
- `.planning/decisions/2026-05-02-data-residency.md` (Path A — Proposed)

Co-Authored-By: Claude <noreply@anthropic.com>