### PR TITLE
feat(phase-52): Profile sync status row (T-52-03)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11155,5 +11155,6 @@
   "settingsPrivacyCloudSyncOff": "Deaktiviert",
   "settingsPrivacyMigrationToast": "Neue Option: Du kannst die Cloud-Synchronisation in Einstellungen › Datenschutz deaktivieren.",
   "settingsPrivacyDataLocation": "Deine Daten bleiben verschlüsselt auf deinem Gerät gespeichert. Mit aktivierter Synchronisation sind sie auch verschlüsselt auf unseren europäischen Servern (Schweiz/EU) gespeichert — Ende-zu-Ende-Verschlüsselung geplant für v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen.",
+  "profileSyncRowHint": "Verwalten in Einstellungen › Datenschutz"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11155,5 +11155,6 @@
   "settingsPrivacyCloudSyncOff": "Off",
   "settingsPrivacyMigrationToast": "New option: you can turn off cloud sync from Settings › Privacy.",
   "settingsPrivacyDataLocation": "Your data stays encrypted at rest on your device. With sync on, it's also encrypted at rest on our European servers (Switzerland/EU) — end-to-end encryption planned for v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Turning sync off doesn't delete data already saved to our servers. To remove it, go to Account › Delete my account."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Turning sync off doesn't delete data already saved to our servers. To remove it, go to Account › Delete my account.",
+  "profileSyncRowHint": "Manage in Settings › Privacy"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11155,5 +11155,6 @@
   "settingsPrivacyCloudSyncOff": "Desactivada",
   "settingsPrivacyMigrationToast": "Nueva opción: puedes desactivar la sincronización en la nube desde Ajustes › Privacidad.",
   "settingsPrivacyDataLocation": "Tus datos quedan cifrados en tu dispositivo. Con la sincronización activada, también están cifrados en nuestros servidores europeos (Suiza/UE) — cifrado de extremo a extremo previsto en la v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta.",
+  "profileSyncRowHint": "Gestionar en Ajustes › Privacidad"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12095,5 +12095,6 @@
   "settingsPrivacyCloudSyncOff": "Désactivée",
   "settingsPrivacyMigrationToast": "Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité.",
   "settingsPrivacyDataLocation": "Tes données restent stockées chiffrées sur ton appareil. Avec la sync activée, elles sont aussi stockées chiffrées sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Désactiver la sync n'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Désactiver la sync n'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.",
+  "profileSyncRowHint": "Gérer dans Réglages › Confidentialité"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11155,5 +11155,6 @@
   "settingsPrivacyCloudSyncOff": "Disattivata",
   "settingsPrivacyMigrationToast": "Nuova opzione: puoi disattivare la sincronizzazione cloud da Impostazioni › Privacy.",
   "settingsPrivacyDataLocation": "I tuoi dati restano cifrati sul tuo dispositivo. Con la sincronizzazione attiva, sono anche cifrati sui nostri server europei (Svizzera/UE) — cifratura end-to-end prevista nella v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account.",
+  "profileSyncRowHint": "Gestisci in Impostazioni › Privacy"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40616,6 +40616,12 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Désactiver la sync n\'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.'**
   String get settingsPrivacyCloudSyncOffServerCaveat;
+
+  /// No description provided for @profileSyncRowHint.
+  ///
+  /// In fr, this message translates to:
+  /// **'Gérer dans Réglages › Confidentialité'**
+  String get profileSyncRowHint;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23214,4 +23214,7 @@ class SDe extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen.';
+
+  @override
+  String get profileSyncRowHint => 'Verwalten in Einstellungen › Datenschutz';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23044,4 +23044,7 @@ class SEn extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Turning sync off doesn\'t delete data already saved to our servers. To remove it, go to Account › Delete my account.';
+
+  @override
+  String get profileSyncRowHint => 'Manage in Settings › Privacy';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23157,4 +23157,7 @@ class SEs extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta.';
+
+  @override
+  String get profileSyncRowHint => 'Gestionar en Ajustes › Privacidad';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23159,4 +23159,7 @@ class SFr extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Désactiver la sync n\'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.';
+
+  @override
+  String get profileSyncRowHint => 'Gérer dans Réglages › Confidentialité';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23218,4 +23218,7 @@ class SIt extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account.';
+
+  @override
+  String get profileSyncRowHint => 'Gestisci in Impostazioni › Privacy';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23165,4 +23165,7 @@ class SPt extends S {
   @override
   String get settingsPrivacyCloudSyncOffServerCaveat =>
       'Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta.';
+
+  @override
+  String get profileSyncRowHint => 'Gerir em Definições › Privacidade';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11155,5 +11155,6 @@
   "settingsPrivacyCloudSyncOff": "Desativada",
   "settingsPrivacyMigrationToast": "Nova opção: podes desativar a sincronização cloud em Definições › Privacidade.",
   "settingsPrivacyDataLocation": "Os teus dados ficam cifrados no teu dispositivo. Com a sincronização ativa, ficam também cifrados nos nossos servidores europeus (Suíça/UE) — cifragem ponto a ponto prevista na v3.0.",
-  "settingsPrivacyCloudSyncOffServerCaveat": "Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta."
+  "settingsPrivacyCloudSyncOffServerCaveat": "Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta.",
+  "profileSyncRowHint": "Gerir em Definições › Privacidade"
 }

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
+import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:provider/provider.dart';
@@ -315,6 +318,13 @@ class FinancialSummaryScreen extends StatelessWidget {
             MintEntrance(delay: const Duration(milliseconds: 400), child: _buildDisclaimer(context)),
             const SizedBox(height: 24),
 
+            // ── PHASE 52 SYNC STATUS ROW ──
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg),
+              child: _buildSyncStatusRow(context),
+            ),
+            const SizedBox(height: 24),
+
             // ── RESTART DIAGNOSTIC ──
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg),
@@ -366,6 +376,108 @@ class FinancialSummaryScreen extends StatelessWidget {
       child: Text(
         S.of(context)!.financialSummaryDisclaimer,
         style: MintTextStyles.labelSmall(),
+      ),
+    );
+  }
+
+  // ══════════════════════════════════════════════════════════════
+  //  SYNC STATUS ROW (Phase 52 T-52-03)
+  // ══════════════════════════════════════════════════════════════
+  //
+  // Compact navigation affordance. Shows the current cloud-sync state
+  // and routes to /settings/confidentialite for management. Always
+  // visible (local-mode users see « Désactivée », which is correct).
+  //
+  // Design panel decisions (2026-05-03):
+  //  - reuse settingsPrivacyCloudSyncTitle/On/Off ARB keys
+  //  - new key: profileSyncRowHint (« Gérer dans Réglages › Confidentialité »)
+  //  - context.push (not go) — preserves back stack to Profile
+  //  - cloud_done_outlined when ON, cloud_outlined when OFF
+  //  - state color matches Settings screen (success / textMuted)
+  //  - ExcludeSemantics on chevron + state Text; Semantics(button:)
+  //    wraps the whole InkWell
+  Widget _buildSyncStatusRow(BuildContext context) {
+    final s = S.of(context)!;
+    final cloudSyncOn = context.watch<AuthProvider>().isCloudSyncEnabled;
+    final stateLabel = cloudSyncOn
+        ? s.settingsPrivacyCloudSyncOn
+        : s.settingsPrivacyCloudSyncOff;
+    return MintSurface(
+      tone: MintSurfaceTone.blanc,
+      padding: EdgeInsets.zero,
+      child: Semantics(
+        button: true,
+        container: true,
+        label: '${s.settingsPrivacyCloudSyncTitle}, $stateLabel',
+        hint: s.profileSyncRowHint,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(20),
+          onTap: () {
+            HapticFeedback.selectionClick();
+            context.push('/settings/confidentialite');
+          },
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 56),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MintSpacing.md,
+                vertical: MintSpacing.md,
+              ),
+              child: Row(
+                children: [
+                  ExcludeSemantics(
+                    child: Icon(
+                      cloudSyncOn
+                          ? Icons.cloud_done_outlined
+                          : Icons.cloud_outlined,
+                      size: 24,
+                      color: MintColors.textSecondary,
+                    ),
+                  ),
+                  const SizedBox(width: MintSpacing.md),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          s.settingsPrivacyCloudSyncTitle,
+                          style: MintTextStyles.titleMedium(
+                            color: MintColors.textPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        ExcludeSemantics(
+                          child: AnimatedDefaultTextStyle(
+                            duration: const Duration(milliseconds: 200),
+                            style: MintTextStyles.labelMedium(
+                              color: cloudSyncOn
+                                  ? MintColors.success
+                                  : MintColors.textMuted,
+                            ),
+                            child: Text(stateLabel),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          s.profileSyncRowHint,
+                          style: MintTextStyles.bodySmall(
+                            color: MintColors.textSecondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const ExcludeSemantics(
+                    child: Icon(
+                      Icons.chevron_right,
+                      color: MintColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Implements **T-52-03** from the Phase 52 plan — a compact « Synchronisation cloud » status row on the user's Profile screen that shows the current state and routes to `/settings/confidentialite` (the toggle screen shipped in PR #435).

## Design panel applied BEFORE writing code
Per the design-panel-first discipline (memory: `feedback_design_panel_before_push.md`). The panel returned a complete spec; this PR implements it as-written.

| Decision | Choice |
|---|---|
| Location | Between disclaimer + restart-diagnostic blocks (settings/account zone tail) |
| ARB reuse | `settingsPrivacyCloudSyncTitle` + `On`/`Off` — no new copy for title or state |
| New ARB | One key: `profileSyncRowHint` × 6 locales (« Gérer dans Réglages › Confidentialité ») |
| Structure | `MintSurface(blanc)` + `InkWell` + custom `Row` (rejected `ListTile` to keep Profile rhythm) |
| Navigation | `context.push` (back stack to Profile preserved) |
| Tap target | `ConstrainedBox(minHeight: 56)` — whole row tappable |
| a11y | `Semantics(button:, label: title+state, hint: manage-in-settings)`; `ExcludeSemantics` on chevron + visual state Text |
| State color | `MintColors.success` (ON) / `textMuted` (OFF) — matches Settings screen |
| Icon variant | `cloud_done_outlined` (ON) / `cloud_outlined` (OFF) |
| Animation | `AnimatedDefaultTextStyle` 200ms on the state color flip |
| Auth gate | None — local-mode users correctly see « Désactivée » |

## Files changed
- `apps/mobile/lib/screens/profile/financial_summary_screen.dart` — new `_buildSyncStatusRow` helper + insertion point + 2 imports (`AuthProvider`, `HapticFeedback`, `MintSurface`)
- `apps/mobile/lib/l10n/app_*.arb` (6 locales) — `profileSyncRowHint`
- `apps/mobile/lib/l10n/app_localizations*.dart` — regenerated

## Verification
- `flutter analyze lib/screens/profile/financial_summary_screen.dart` clean
- `python3 tools/checks/sentence_subject_arb_lint.py` OK (`profileSyncRowHint` not in LEVEL_SCOPE)
- `python3 tools/checks/route_registry_parity.py` OK (no new route)
- ARB FR parses as valid JSON; gen-l10n round-trip clean

## Out of scope
- **T-52-04** — first-launch migration toast for legacy users (separate PR)
- **T-52-07/08** — live sim verification + post-merge panel review
- Profile screen restructure beyond this row insertion

Co-Authored-By: Claude <noreply@anthropic.com>