### PR TITLE
feat(phase-52): one-time migration toast for legacy users (T-52-04)

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/widgets/auth/migration_notice_listener.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -151,6 +152,7 @@ import 'package:mint_mobile/screens/admin/routes_registry_screen.dart';
 import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
+final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 final _shellNavigatorKeyHome = GlobalKey<NavigatorState>(debugLabel: 'shellHome');
 final _shellNavigatorKeyMonArgent = GlobalKey<NavigatorState>(debugLabel: 'shellMonArgent');
 final _shellNavigatorKeyCoach = GlobalKey<NavigatorState>(debugLabel: 'shellCoach');
@@ -1550,20 +1552,26 @@ class _MintAppState extends State<MintApp> with WidgetsBindingObserver {
         ),
       ],
       child: _AuthRouterBridge(
-        child: Builder(
-          builder: (context) {
-            final localeProvider = context.watch<LocaleProvider>();
-            return MaterialApp.router(
-              title: 'Mint',
-              debugShowCheckedModeBanner: false,
-              theme: _buildPremiumTheme(),
-              themeMode: ThemeMode.light,
-              routerConfig: _router,
-              localizationsDelegates: S.localizationsDelegates,
-              supportedLocales: S.supportedLocales,
-              locale: localeProvider.locale,
-            );
-          },
+        child: MigrationNoticeListener(
+          getMessenger: () => _scaffoldMessengerKey.currentState,
+          getNavContext: () => _rootNavigatorKey.currentContext,
+          onCtaTap: () => _router.go('/settings/confidentialite'),
+          child: Builder(
+            builder: (context) {
+              final localeProvider = context.watch<LocaleProvider>();
+              return MaterialApp.router(
+                title: 'Mint',
+                debugShowCheckedModeBanner: false,
+                theme: _buildPremiumTheme(),
+                themeMode: ThemeMode.light,
+                routerConfig: _router,
+                scaffoldMessengerKey: _scaffoldMessengerKey,
+                localizationsDelegates: S.localizationsDelegates,
+                supportedLocales: S.supportedLocales,
+                locale: localeProvider.locale,
+              );
+            },
+          ),
         ),
       ),
     );
@@ -1893,3 +1901,7 @@ class _AuthRouterBridgeState extends State<_AuthRouterBridge> {
   @override
   Widget build(BuildContext context) => widget.child;
 }
+
+// _MigrationNoticeListener (Phase 52 T-52-04) — extracted to
+// `apps/mobile/lib/widgets/auth/migration_notice_listener.dart`
+// for testability. The wrapper used at line ~1554 imports it.

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11156,5 +11156,6 @@
   "settingsPrivacyMigrationToast": "Neue Option: Du kannst die Cloud-Synchronisation in Einstellungen › Datenschutz deaktivieren.",
   "settingsPrivacyDataLocation": "Deine Daten bleiben verschlüsselt auf deinem Gerät gespeichert. Mit aktivierter Synchronisation sind sie auch verschlüsselt auf unseren europäischen Servern (Schweiz/EU) gespeichert — Ende-zu-Ende-Verschlüsselung geplant für v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen.",
-  "profileSyncRowHint": "Verwalten in Einstellungen › Datenschutz"
+  "profileSyncRowHint": "Verwalten in Einstellungen › Datenschutz",
+  "settingsPrivacyMigrationToastCta": "Ansehen"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11156,5 +11156,6 @@
   "settingsPrivacyMigrationToast": "New option: you can turn off cloud sync from Settings › Privacy.",
   "settingsPrivacyDataLocation": "Your data stays encrypted at rest on your device. With sync on, it's also encrypted at rest on our European servers (Switzerland/EU) — end-to-end encryption planned for v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Turning sync off doesn't delete data already saved to our servers. To remove it, go to Account › Delete my account.",
-  "profileSyncRowHint": "Manage in Settings › Privacy"
+  "profileSyncRowHint": "Manage in Settings › Privacy",
+  "settingsPrivacyMigrationToastCta": "View"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11156,5 +11156,6 @@
   "settingsPrivacyMigrationToast": "Nueva opción: puedes desactivar la sincronización en la nube desde Ajustes › Privacidad.",
   "settingsPrivacyDataLocation": "Tus datos quedan cifrados en tu dispositivo. Con la sincronización activada, también están cifrados en nuestros servidores europeos (Suiza/UE) — cifrado de extremo a extremo previsto en la v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta.",
-  "profileSyncRowHint": "Gestionar en Ajustes › Privacidad"
+  "profileSyncRowHint": "Gestionar en Ajustes › Privacidad",
+  "settingsPrivacyMigrationToastCta": "Ver"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12096,5 +12096,6 @@
   "settingsPrivacyMigrationToast": "Nouvelle option : tu peux désactiver la synchronisation cloud depuis Réglages › Confidentialité.",
   "settingsPrivacyDataLocation": "Tes données restent stockées chiffrées sur ton appareil. Avec la sync activée, elles sont aussi stockées chiffrées sur nos serveurs européens (Suisse/UE) — chiffrement de bout en bout prévu en v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Désactiver la sync n'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.",
-  "profileSyncRowHint": "Gérer dans Réglages › Confidentialité"
+  "profileSyncRowHint": "Gérer dans Réglages › Confidentialité",
+  "settingsPrivacyMigrationToastCta": "Voir"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11156,5 +11156,6 @@
   "settingsPrivacyMigrationToast": "Nuova opzione: puoi disattivare la sincronizzazione cloud da Impostazioni › Privacy.",
   "settingsPrivacyDataLocation": "I tuoi dati restano cifrati sul tuo dispositivo. Con la sincronizzazione attiva, sono anche cifrati sui nostri server europei (Svizzera/UE) — cifratura end-to-end prevista nella v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account.",
-  "profileSyncRowHint": "Gestisci in Impostazioni › Privacy"
+  "profileSyncRowHint": "Gestisci in Impostazioni › Privacy",
+  "settingsPrivacyMigrationToastCta": "Vedi"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40622,6 +40622,12 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Gérer dans Réglages › Confidentialité'**
   String get profileSyncRowHint;
+
+  /// No description provided for @settingsPrivacyMigrationToastCta.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voir'**
+  String get settingsPrivacyMigrationToastCta;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23217,4 +23217,7 @@ class SDe extends S {
 
   @override
   String get profileSyncRowHint => 'Verwalten in Einstellungen › Datenschutz';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'Ansehen';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23047,4 +23047,7 @@ class SEn extends S {
 
   @override
   String get profileSyncRowHint => 'Manage in Settings › Privacy';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'View';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23160,4 +23160,7 @@ class SEs extends S {
 
   @override
   String get profileSyncRowHint => 'Gestionar en Ajustes › Privacidad';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'Ver';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23162,4 +23162,7 @@ class SFr extends S {
 
   @override
   String get profileSyncRowHint => 'Gérer dans Réglages › Confidentialité';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'Voir';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23221,4 +23221,7 @@ class SIt extends S {
 
   @override
   String get profileSyncRowHint => 'Gestisci in Impostazioni › Privacy';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'Vedi';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23168,4 +23168,7 @@ class SPt extends S {
 
   @override
   String get profileSyncRowHint => 'Gerir em Definições › Privacidade';
+
+  @override
+  String get settingsPrivacyMigrationToastCta => 'Ver';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11156,5 +11156,6 @@
   "settingsPrivacyMigrationToast": "Nova opção: podes desativar a sincronização cloud em Definições › Privacidade.",
   "settingsPrivacyDataLocation": "Os teus dados ficam cifrados no teu dispositivo. Com a sincronização ativa, ficam também cifrados nos nossos servidores europeus (Suíça/UE) — cifragem ponto a ponto prevista na v3.0.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta.",
-  "profileSyncRowHint": "Gerir em Definições › Privacidade"
+  "profileSyncRowHint": "Gerir em Definições › Privacidade",
+  "settingsPrivacyMigrationToastCta": "Ver"
 }

--- a/apps/mobile/lib/widgets/auth/migration_notice_listener.dart
+++ b/apps/mobile/lib/widgets/auth/migration_notice_listener.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+
+/// Phase 52 T-52-04 — One-time migration notification.
+///
+/// Detects users who registered BEFORE Phase 52 (i.e. have
+/// `auth_local_mode = false` persisted) and surfaces a one-shot
+/// `SnackBar` informing them about the new cloud-sync toggle in
+/// Settings › Confidentialité.
+///
+/// Detection rule (panel spec):
+///   isLoggedIn && !isLoading
+///     && prefs.containsKey('auth_local_mode')
+///     && prefs.getBool('auth_local_mode') == false
+///     && prefs.getBool('auth_phase52_migration_shown') != true
+///
+/// Per D-01 the register flow no longer creates `auth_local_mode`
+/// for new users (default true from initState), so the
+/// `containsKey` clause naturally filters them out.
+///
+/// Idempotency:
+///   * `auth_phase52_migration_shown` is written BEFORE showing
+///     the SnackBar so a crash mid-show doesn't trigger re-show.
+///   * A process-level static flag guards rebuild storms.
+///
+/// Test seams: [getMessenger] and [getNavContext] return the
+/// `ScaffoldMessengerState` and `BuildContext` to render against;
+/// production wires them to global keys, tests wire them to local
+/// keys. [onCtaTap] is the navigation callback used by the action
+/// chip; production calls `GoRouter.go('/settings/confidentialite')`,
+/// tests assert it was called.
+class MigrationNoticeListener extends StatefulWidget {
+  const MigrationNoticeListener({
+    super.key,
+    required this.child,
+    required this.getMessenger,
+    required this.getNavContext,
+    required this.onCtaTap,
+  });
+
+  final Widget child;
+  final ScaffoldMessengerState? Function() getMessenger;
+  final BuildContext? Function() getNavContext;
+  final VoidCallback onCtaTap;
+
+  /// SharedPreferences key — written before the SnackBar shows so the
+  /// notice is never repeated on a clean cold start.
+  static const String prefsKeyShown = 'auth_phase52_migration_shown';
+
+  /// Process-level dedup. Exposed for tests so each test starts clean.
+  @visibleForTesting
+  static void resetForTesting() {
+    _MigrationNoticeListenerState._shownThisProcess = false;
+  }
+
+  @override
+  State<MigrationNoticeListener> createState() =>
+      _MigrationNoticeListenerState();
+}
+
+class _MigrationNoticeListenerState extends State<MigrationNoticeListener> {
+  static bool _shownThisProcess = false;
+
+  AuthProvider? _bound;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final auth = context.read<AuthProvider>();
+    if (!identical(_bound, auth)) {
+      _bound?.removeListener(_check);
+      auth.addListener(_check);
+      _bound = auth;
+      _check();
+    }
+  }
+
+  @override
+  void dispose() {
+    _bound?.removeListener(_check);
+    super.dispose();
+  }
+
+  Future<void> _check() async {
+    if (_shownThisProcess) return;
+    final auth = _bound;
+    if (auth == null || auth.isLoading || !auth.isLoggedIn) return;
+    final prefs = await SharedPreferences.getInstance();
+    if (!prefs.containsKey('auth_local_mode')) return;
+    if (prefs.getBool('auth_local_mode') != false) return;
+    if (prefs.getBool(MigrationNoticeListener.prefsKeyShown) == true) return;
+    _shownThisProcess = true;
+    await prefs.setBool(MigrationNoticeListener.prefsKeyShown, true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final messenger = widget.getMessenger();
+      final navContext = widget.getNavContext();
+      if (messenger == null || navContext == null) return;
+      final l = S.of(navContext);
+      if (l == null) return;
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l.settingsPrivacyMigrationToast),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 6),
+          action: SnackBarAction(
+            label: l.settingsPrivacyMigrationToastCta,
+            onPressed: widget.onCtaTap,
+          ),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/apps/mobile/test/widgets/migration_notice_listener_test.dart
+++ b/apps/mobile/test/widgets/migration_notice_listener_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/widgets/auth/migration_notice_listener.dart';
+
+// Phase 52 T-52-04 — widget test for the one-time migration notification.
+//
+// Three cases per the design panel spec:
+//  1. legacy user (auth_local_mode = false, no migration_shown key)
+//     → SnackBar shows + prefs key set
+//  2. re-mount with migration_shown = true → no SnackBar
+//  3. new user (no auth_local_mode key) → no SnackBar
+
+class _MockAuthProvider extends ChangeNotifier implements AuthProvider {
+  @override
+  bool isLoggedIn = true;
+  @override
+  bool isLoading = false;
+
+  // Unused getters / methods — return defaults / throw on call so the
+  // test surfaces accidental coupling.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _buildHarness({
+  required AuthProvider auth,
+  required GlobalKey<ScaffoldMessengerState> messengerKey,
+  VoidCallback? onCtaTap,
+}) {
+  return MaterialApp(
+    scaffoldMessengerKey: messengerKey,
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [Locale('fr')],
+    home: ChangeNotifierProvider<AuthProvider>.value(
+      value: auth,
+      child: Builder(
+        builder: (ctx) => MigrationNoticeListener(
+          getMessenger: () => messengerKey.currentState,
+          getNavContext: () => ctx,
+          onCtaTap: onCtaTap ?? () {},
+          child: const Scaffold(body: Text('home')),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    MigrationNoticeListener.resetForTesting();
+  });
+
+  testWidgets('legacy user → SnackBar shows + migration_shown set', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({'auth_local_mode': false});
+    MigrationNoticeListener.resetForTesting();
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+    final auth = _MockAuthProvider();
+
+    await tester.pumpWidget(
+      _buildHarness(auth: auth, messengerKey: messengerKey),
+    );
+    await tester.pump();
+    // Allow the async _check() + post-frame callback to fire.
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Confidentialité'),
+      findsOneWidget,
+      reason: 'SnackBar with migration toast should be visible',
+    );
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getBool(MigrationNoticeListener.prefsKeyShown),
+      true,
+      reason: 'shown flag must be persisted',
+    );
+  });
+
+  testWidgets('migration_shown already true → no SnackBar', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'auth_local_mode': false,
+      MigrationNoticeListener.prefsKeyShown: true,
+    });
+    MigrationNoticeListener.resetForTesting();
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+    final auth = _MockAuthProvider();
+
+    await tester.pumpWidget(
+      _buildHarness(auth: auth, messengerKey: messengerKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Confidentialité'),
+      findsNothing,
+      reason: 'no SnackBar should fire when migration was already shown',
+    );
+  });
+
+  testWidgets('new user (no auth_local_mode key) → no SnackBar', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    MigrationNoticeListener.resetForTesting();
+    final messengerKey = GlobalKey<ScaffoldMessengerState>();
+    final auth = _MockAuthProvider();
+
+    await tester.pumpWidget(
+      _buildHarness(auth: auth, messengerKey: messengerKey),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Confidentialité'),
+      findsNothing,
+      reason: 'new users (no auth_local_mode persisted) must not see toast',
+    );
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.containsKey(MigrationNoticeListener.prefsKeyShown),
+      false,
+      reason: 'shown flag must not be set when toast did not fire',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Closes Phase 52. Pre-Phase-52 users (registered with the old register flow that flipped `auth_local_mode = false`) now see a single floating SnackBar on first post-update launch surfacing the new cloud-sync toggle in Settings › Confidentialité — without changing their sync state.

## Design panel applied BEFORE coding (design-panel-first discipline)

Critical decisions made by the 3-reviewer panel (UX + engineering + adversarial), all implemented as specified:

| Decision | Choice |
|---|---|
| Surface | Floating `SnackBar`, 6s, swipe-dismiss. Top-banner / bottom-sheet rejected as too heavy for a no-behavior-change nuance. |
| CTA | « Voir » action chip → `/settings/confidentialite`. New ARB key `settingsPrivacyMigrationToastCta` × 6 locales. |
| Detection | `isLoggedIn && !isLoading && containsKey('auth_local_mode') && getBool('auth_local_mode') == false && getBool('auth_phase52_migration_shown') != true`. Per D-01 the register flow no longer creates the key for new accounts → `containsKey` filters them out cleanly. |
| Idempotency | Write « shown » prefs key BEFORE showing the SnackBar (so a crash mid-show doesn't trigger re-show); also `static bool _shownThisProcess` guard for rebuild storms. |
| Hook point | `_AuthRouterBridge` wraps `MigrationNoticeListener` wraps `Builder` → `MaterialApp.router`. New global `_scaffoldMessengerKey` lets the listener push the SnackBar from outside the MaterialApp's context. |
| Copy | Reuses the existing `settingsPrivacyMigrationToast` ARB (already shipped in PR #435 × 6 locales) — no rewrite. New CTA key adds « Voir » / « View » / « Ansehen » / « Ver » / « Vedi » / « Ver ». |

## Files
- `apps/mobile/lib/widgets/auth/migration_notice_listener.dart` (new) — extracted with constructor-injected test seams (messenger getter, nav-context getter, CTA callback) so the widget tests run in isolation
- `apps/mobile/lib/app.dart` — wraps `Builder` with `MigrationNoticeListener`; adds global `_scaffoldMessengerKey` + wires it onto `MaterialApp.router`
- `apps/mobile/lib/l10n/app_*.arb` (6 locales) — `settingsPrivacyMigrationToastCta`
- `apps/mobile/test/widgets/migration_notice_listener_test.dart` (new) — 3 cases per panel spec

## Verification
- `flutter analyze` clean on `app.dart`, the new widget, and the new test (3 items)
- `flutter test test/widgets/migration_notice_listener_test.dart` → **3/3 pass**:
  1. Legacy user (`auth_local_mode = false`, no `migration_shown`) → SnackBar shows + key persisted
  2. `migration_shown = true` already → no SnackBar (re-show prevented)
  3. New user (no `auth_local_mode` key) → no SnackBar + no key persisted

## Phase 52 status — COMPLETE
| Task | PR | Status |
|---|---|---|
| T-52-01 auth_provider refactor + toggleCloudSync | #435 | merged |
| T-52-02 Settings › Confidentialité screen | #435 | merged |
| T-52-03 Profile sync status row | #436 | merged |
| **T-52-04 Migration toast for legacy users** | **this** | **in CI** |
| T-52-05 ARB × 6 locales | #435 | merged |
| T-52-06 authRegisterSubtitle default-OFF | #435 | merged |
| T-52-07 Live sim verification | TBD | manual / device-walkthrough |
| T-52-08 Post-merge panel review | TBD | spawn after this PR lands |

Co-Authored-By: Claude <noreply@anthropic.com>