### PR TITLE
feat(phase-52.1): re-time migration toast (N-3) + audit logout CTA (N-4)

### DIFF
--- a/apps/mobile/lib/widgets/auth/migration_notice_listener.dart
+++ b/apps/mobile/lib/widgets/auth/migration_notice_listener.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -51,6 +53,13 @@ class MigrationNoticeListener extends StatefulWidget {
   /// notice is never repeated on a clean cold start.
   static const String prefsKeyShown = 'auth_phase52_migration_shown';
 
+  /// Phase 52.1 N-3: how long `isLoading` must be stable false before
+  /// the SnackBar is allowed to fire. Prevents the toast from showing
+  /// during the splash → login transition or during a profile refetch.
+  /// Tests can override to `Duration.zero` for instant assertions.
+  @visibleForTesting
+  static Duration stabilityDelay = const Duration(seconds: 3);
+
   /// Process-level dedup. Exposed for tests so each test starts clean.
   @visibleForTesting
   static void resetForTesting() {
@@ -67,28 +76,58 @@ class _MigrationNoticeListenerState extends State<MigrationNoticeListener> {
 
   AuthProvider? _bound;
 
+  /// Phase 52.1 N-3: pending fire timer. Started when `isLoading=false`
+  /// and conditions look promising; cancelled if `isLoading` flips back
+  /// to true (e.g. profile refetch in flight). Only fires the SnackBar
+  /// after the configured `stabilityDelay`.
+  Timer? _stabilityTimer;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final auth = context.read<AuthProvider>();
     if (!identical(_bound, auth)) {
-      _bound?.removeListener(_check);
-      auth.addListener(_check);
+      _bound?.removeListener(_onAuthTick);
+      auth.addListener(_onAuthTick);
       _bound = auth;
-      _check();
+      _onAuthTick();
     }
   }
 
   @override
   void dispose() {
-    _bound?.removeListener(_check);
+    _stabilityTimer?.cancel();
+    _bound?.removeListener(_onAuthTick);
     super.dispose();
   }
 
-  Future<void> _check() async {
+  /// Reactive entry point. Called on every AuthProvider tick.
+  /// Phase 52.1 N-3: defers the actual show by [stabilityDelay] so a
+  /// transient `isLoading=true` (profile refetch, etc.) doesn't fire
+  /// the SnackBar mid-transition. Cancels any pending timer if loading
+  /// flips back true.
+  void _onAuthTick() {
     if (_shownThisProcess) return;
     final auth = _bound;
-    if (auth == null || auth.isLoading || !auth.isLoggedIn) return;
+    if (auth == null) return;
+    if (auth.isLoading || !auth.isLoggedIn) {
+      _stabilityTimer?.cancel();
+      _stabilityTimer = null;
+      return;
+    }
+    if (_stabilityTimer != null && _stabilityTimer!.isActive) return;
+    _stabilityTimer = Timer(MigrationNoticeListener.stabilityDelay, () {
+      if (!mounted) return;
+      // Re-verify state at fire time — auth may have flipped during
+      // the delay window.
+      final a = _bound;
+      if (a == null || a.isLoading || !a.isLoggedIn) return;
+      _attemptShow();
+    });
+  }
+
+  Future<void> _attemptShow() async {
+    if (_shownThisProcess) return;
     final prefs = await SharedPreferences.getInstance();
     if (!prefs.containsKey('auth_local_mode')) return;
     if (prefs.getBool('auth_local_mode') != false) return;
@@ -96,6 +135,7 @@ class _MigrationNoticeListenerState extends State<MigrationNoticeListener> {
     _shownThisProcess = true;
     await prefs.setBool(MigrationNoticeListener.prefsKeyShown, true);
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       final messenger = widget.getMessenger();
       final navContext = widget.getNavContext();
       if (messenger == null || navContext == null) return;

--- a/apps/mobile/test/widgets/migration_notice_listener_test.dart
+++ b/apps/mobile/test/widgets/migration_notice_listener_test.dart
@@ -60,6 +60,15 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     MigrationNoticeListener.resetForTesting();
+    // Phase 52.1 N-3: 3s prod stability delay would slow tests; use
+    // Duration.zero for non-timing-specific cases.
+    MigrationNoticeListener.stabilityDelay = Duration.zero;
+  });
+
+  tearDown(() {
+    // Restore production default so accidental cross-test bleed doesn't
+    // hide a real timing regression.
+    MigrationNoticeListener.stabilityDelay = const Duration(seconds: 3);
   });
 
   testWidgets('legacy user → SnackBar shows + migration_shown set', (
@@ -73,9 +82,11 @@ void main() {
     await tester.pumpWidget(
       _buildHarness(auth: auth, messengerKey: messengerKey),
     );
-    await tester.pump();
-    // Allow the async _check() + post-frame callback to fire.
-    await tester.pumpAndSettle();
+    // Phase 52.1 N-3 timing: stabilityDelay is Duration.zero in tests
+    // (set in setUp), but the Timer still posts on the next event-loop
+    // iteration. Use pumpAndSettle with a small Duration to drain the
+    // Timer + the async _attemptShow + post-frame callback.
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
 
     expect(
       find.textContaining('Confidentialité'),
@@ -136,4 +147,53 @@ void main() {
       reason: 'shown flag must not be set when toast did not fire',
     );
   });
+
+  // Phase 52.1 N-3 — assert the re-timing: if isLoading flips back true
+  // during the stability window, the pending Timer is cancelled and the
+  // SnackBar does NOT fire. This is the specific regression class
+  // « toast appears mid-splash / mid-refetch » we're guarding against.
+  testWidgets(
+    'isLoading flips back true during stability window → no SnackBar',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({'auth_local_mode': false});
+      MigrationNoticeListener.resetForTesting();
+      MigrationNoticeListener.stabilityDelay =
+          const Duration(milliseconds: 500);
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+      final auth = _MockAuthProvider()
+        ..isLoggedIn = true
+        ..isLoading = false;
+
+      await tester.pumpWidget(
+        _buildHarness(auth: auth, messengerKey: messengerKey),
+      );
+      await tester.pump();
+      // Mid-window: loading flips back true (e.g. profile refetch).
+      await tester.pump(const Duration(milliseconds: 200));
+      auth.isLoading = true;
+      auth.notifyListeners();
+      // Wait past what would have been the original fire time.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(
+        find.textContaining('Confidentialité'),
+        findsNothing,
+        reason:
+            'cancelling Timer mid-window must prevent the toast — '
+            'this is the actual N-3 contract.',
+      );
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getBool(MigrationNoticeListener.prefsKeyShown),
+        isNot(true),
+        reason: 'shown flag must NOT be set when the gate cancelled the show',
+      );
+
+      // Cleanup pending timer to avoid post-test « pending timer » error.
+      auth.isLoading = false;
+      auth.notifyListeners();
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Phase 52.1 PR 3 — closes the two « needs-followup » items from the post-merge audit. After this lands, T-52-08 panel re-runs to verify Phase 52.1 close-out posture.

## N-3 — migration toast re-timing

The original `MigrationNoticeListener` fired the SnackBar the moment `!isLoading && isLoggedIn` first became true → on cold start, that's during the splash → home transition with no contextual anchor; on profile refetch, a transient `isLoading=true` could also re-trigger the show race.

**Refactor**:
- `_onAuthTick()` reactive entry: starts a `Timer` (default 3 s) when conditions look promising; cancels it if `isLoading` flips back true.
- Show logic moved to `_attemptShow()`, only runs after the timer fires AND state is still valid (re-checks `auth.isLoggedIn`/`isLoading` at fire time too).
- `dispose()` cancels any pending timer.
- `MigrationNoticeListener.stabilityDelay` is `@visibleForTesting` so tests can override.

## N-4 — logout local-mode CTA audit

Pure audit, no code change. Verified by grep that `enableLocalMode()` is wired at:
- `apps/mobile/lib/screens/auth/login_screen.dart:514`
- `apps/mobile/lib/screens/auth/register_screen.dart:613`

`authContinueLocal` ARB key exists in all 6 locales. Post-logout the user can still re-enable local mode via the existing CTAs. No regression.

## Tests — 4/4 pass

| # | Case |
|---|---|
| 1 | legacy user → SnackBar shows + migration_shown set |
| 2 | migration_shown already true → no SnackBar |
| 3 | new user (no auth_local_mode key) → no SnackBar |
| 4 | **isLoading flips back true during stability window → no SnackBar (NEW)** — proves the Timer cancellation is the actual N-3 contract |

## Pre-push checklist applied (per `feedback_pre_push_checklist.md` memory rule)

| # | Check | Result |
|---|---|---|
| 1 | Sweep callers (`grep -rn 'MigrationNoticeListener\|stabilityDelay'`) | only one production caller (`app.dart:1555`); no kwarg drift |
| 2 | Regen artefacts (OpenAPI / `flutter gen-l10n`) | N/A — no schema, no new ARB key |
| 3 | Full test suite (`flutter test test/widgets/`) | **961/961 pass** |

This is the discipline I committed to after PR #439's 4-cycle CI debacle. No claim of « clean » before all 3 pass.

## Phase 52.1 status after this PR lands

| Task | Status |
|---|---|
| B-1 / B-2 / B-4 / N-1 (mobile gates + copy) | ✅ #438 |
| B-3 (chat persistence_consent + backend gating) | ✅ #439 |
| **N-3 (toast re-timing) + N-4 (logout CTA audit)** | **this** |
| T-52-08 close-out panel re-run | next — verifies « sync OFF actually stops every PII write » |

Co-Authored-By: Claude <noreply@anthropic.com>