### PR TITLE
fix(phase-52.2): close T-52-08 audit BLOCK — add 3 missed write-tier handlers to persistence gate

### DIFF
--- a/.planning/phases/52.1-cloud-sync-actual-gating/52.1-VERIFICATION-REPORT.html
+++ b/.planning/phases/52.1-cloud-sync-actual-gating/52.1-VERIFICATION-REPORT.html
@@ -136,7 +136,39 @@ CI on PR #438: in flight</pre>
   <li>Anonymous → register « one-tap sync everything » UX pattern (Phase 53+)</li>
 </ul>
 
-<p style="font-size: 12px; color: #95989d; margin-top: 32px;">Generated 2026-05-03 ~09:20. Updated on every PR landing in Phase 52.1.</p>
+<h2>Update — Phase 52.2 audit close-out (2026-05-04)</h2>
+
+<p><strong>T-52-08 close-out audit verdict:</strong> BLOCK on the Phase 52.1 PR 2 whitelist. The audit (re-verified by hand at <code>coach_chat.py:1496-1558</code>) found 3 handlers that issue real DB writes but were missing from <code>_WRITE_TIER_TOOLS</code>:</p>
+
+<ul>
+  <li><code>save_provenance</code> → <code>db.add(ProvenanceRecord(...))</code> @ <code>coach_chat.py:1510</code></li>
+  <li><code>save_earmark</code>    → <code>db.add(EarmarkTag(...))</code>     @ <code>coach_chat.py:1531</code></li>
+  <li><code>remove_earmark</code>  → <code>db.delete(tag)</code>              @ <code>coach_chat.py:1550</code></li>
+</ul>
+
+<p>Cloud-sync OFF was therefore still allowing those PII writes through. <strong>Root cause:</strong> the « # P14 commitment devices — ack-only handlers » comment at <code>coach_chat.py:1482</code> was misread as covering the 5 handlers below it; it actually only applied to the two immediately below (<code>record_commitment</code> + <code>save_pre_mortem</code>). Comment-block scope is not transitive.</p>
+
+<p><strong>Fix landed in PR #441 (<code>fix/phase-52.2-write-tier-whitelist-completion</code>):</strong></p>
+<ul>
+  <li>Extended <code>_WRITE_TIER_TOOLS</code> to all 5 verified writers</li>
+  <li>Updated <code>test_coach_chat_persistence_gate.py</code>: parametrized 3 new tools in <code>WRITE_TIER_FIXTURES</code>; updated <code>test_write_tier_set_is_complete</code> expected set; removed <code>save_provenance</code>/<code>save_earmark</code> from the read-tier « not in WRITE_TIER » list</li>
+  <li>Pre-push sweep (lesson from PR #439's 4 CI cycles): updated 12 <code>_execute_internal_tool</code> callsites in <code>test_coach_intelligence.py</code> to pass <code>persistence_consent=True</code> on the write path</li>
+  <li>Appended backend-side WRITE-tier section to <code>BACKEND-WRITE-SURFACE.md</code> documenting the audit-corrected whitelist + the lesson + a proposed AST-walk safety-net for v2.next</li>
+</ul>
+
+<pre>pytest tests/test_coach_chat_persistence_gate.py tests/test_coach_intelligence.py -v
+→ 57 passed
+
+pytest tests/  (full backend suite)
+→ 6032 passed, 6 skipped, 0 failed in 104.89s</pre>
+
+<p><strong>Acceptance criteria status update:</strong></p>
+<ul>
+  <li>(c) Chat behavior matches Option C — LLM call yes, structured fact writes refused server-side: ✅ PR #439 + PR #441 (5 of 5 verified writers gated)</li>
+  <li>Post-Phase-52.1 audit « does sync OFF actually stop backend writes? »: ✅ demonstrably yes, in code, after PR #441 merges (re-run T-52-08 to confirm CLOSE)</li>
+</ul>
+
+<p style="font-size: 12px; color: #95989d; margin-top: 32px;">Generated 2026-05-03 ~09:20. Updated 2026-05-04 with Phase 52.2 audit close-out (PR #441).</p>
 
 </body>
 </html>

--- a/.planning/phases/52.1-cloud-sync-actual-gating/BACKEND-WRITE-SURFACE.md
+++ b/.planning/phases/52.1-cloud-sync-actual-gating/BACKEND-WRITE-SURFACE.md
@@ -72,3 +72,43 @@
 - It does NOT prove the **backend itself** doesn't persist anything beyond what the mobile sends. The chat panel's claim « no verbatim conversation log » was based on its own grep of the backend; this inventory only certifies the mobile-side surface.
 - It does NOT cover any **future** endpoints. Whoever adds a new `http.post` after this date must re-run the sweep and update this table.
 - It does NOT verify the body-content classifications by inspecting actual production payloads — only by reading the source. If the backend silently logs more fields than the body sends (request headers, IP, etc.), that's a separate concern (server-side logging policy).
+
+---
+
+## Backend-side WRITE-tier whitelist (Phase 52.1 PR 2 + 52.2 audit-corrected)
+
+**Date:** 2026-05-04
+**Method:** read every `name == "<tool>"` branch in `_execute_internal_tool` (`services/backend/app/api/v1/endpoints/coach_chat.py:1197-1900`); for each, classify whether the handler issues `db.add` / `db.commit` / `db.delete` against a PII-bearing model. Re-verified after the **T-52-08 close-out audit (2026-05-03)** caught 3 false negatives in the first pass.
+
+### `_WRITE_TIER_TOOLS` final whitelist (all gated when `persistence_consent=False`)
+
+| Tool name | DB write site | Model | Source line |
+|---|---|---|---|
+| `save_fact` | `db.add(profile)` (mutates `ProfileModel.data`) | ProfileModel | dispatcher branch + `_apply_save_fact_handler` |
+| `save_insight` | `db.add(CoachInsightRecord(...))` | CoachInsightRecord | `coach_chat.py` save_insight branch |
+| `save_provenance` | `db.add(ProvenanceRecord(...))` | ProvenanceRecord | `coach_chat.py:1510` |
+| `save_earmark` | `db.add(EarmarkTag(...))` | EarmarkTag | `coach_chat.py:1531` |
+| `remove_earmark` | `db.delete(tag)` | EarmarkTag | `coach_chat.py:1550` |
+
+### NOT gated — verified non-writers (must NOT be added to the whitelist)
+
+| Tool name | Reason | Verified at |
+|---|---|---|
+| `set_goal` | ack-only string return (no DB call in dispatcher branch) | dispatcher |
+| `mark_step_completed` | ack-only string return | dispatcher |
+| `record_commitment` | « P14 commitment devices — ack-only handlers » comment | `coach_chat.py:1482` |
+| `save_pre_mortem` | same ack-only block | `coach_chat.py:1483-1495` |
+| `save_partner_estimate` | Flutter-bound; never reaches backend dispatcher | mobile gates in PR #438 |
+| `update_partner_estimate` | same | mobile gates in PR #438 |
+| `record_check_in` | same | mobile gates in PR #438 |
+| `get_*` (every reader) | read-only; LSP only fetches | dispatcher branches |
+
+### Audit lesson encoded in test_coach_chat_persistence_gate.py
+
+The first pass (Phase 52.1 PR 2) lumped `save_provenance` / `save_earmark` / `remove_earmark` with the ack-only block based on a comment header that **only applied to the two handlers immediately below it** (`record_commitment` + `save_pre_mortem`). The 3 handlers below those DO write to DB. Lesson: comment-block scope is not transitive — re-verify each branch by reading the body, not the section header.
+
+`test_write_tier_set_is_complete` now hard-asserts the full 5-tool set; adding a new write-tier handler requires extending BOTH `_WRITE_TIER_TOOLS` AND that assertion. This is the safety net against the « shipped a new write-tier handler but forgot to gate it » regression class.
+
+### Process improvement (deferred — opt-in for next phase)
+
+Panel suggested an AST-walk dispatcher test that flags any branch containing `db.add` / `db.commit` / `db.delete` whose tool name is NOT in `_WRITE_TIER_TOOLS`. That would have caught this audit gap automatically. Tracked for v2.next; current safety net is the hard-coded expected set + manual audit on each new tool.

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -1147,29 +1147,31 @@ _REPROMPT_EMPTY_END_TURN = (
 )
 
 
-# Phase 52.1 PR 2 — WRITE-tier tool whitelist (verified by direct
-# inspection of each handler in this file, NOT taken on the design
-# panel's word).
+# Phase 52.1 / 52.2 — WRITE-tier tool whitelist. Re-verified by direct
+# inspection of each handler in this file after the T-52-08 close-out
+# audit (2026-05-03) caught 3 false negatives in the first version.
 #
-# Only TWO tools in this dispatcher actually write user-identifying
-# data to the backend DB:
-#   - save_fact     → ProfileModel.data (line ~1342)
-#   - save_insight  → CoachInsightRecord (line ~1246)
+# Tools in this dispatcher that ACTUALLY write user-identifying data
+# to the backend DB:
+#   - save_fact         → ProfileModel.data (line ~1390+)
+#   - save_insight      → CoachInsightRecord (line ~1294+)
+#   - save_provenance   → ProvenanceRecord (line ~1510, db.add+commit)
+#   - save_earmark      → EarmarkTag (line ~1531, db.add+commit)
+#   - remove_earmark    → EarmarkTag (line ~1550, db.delete+commit)
 #
-# The remaining « save_* » handlers in this dispatcher (save_pre_mortem,
-# save_provenance, save_earmark) are ack-only — they only `logger.info`
-# and return a confirmation string. No DB write happens via the chat
-# dispatcher for them.
+# Genuinely ack-only handlers (NOT in the whitelist; they only
+# logger.info and return a confirmation string):
+#   - record_commitment (line ~1480)
+#   - save_pre_mortem   (line ~1488)
 #
-# `save_partner_estimate`, `update_partner_estimate`, and
-# `record_check_in` are NOT handled in this dispatcher at all — they
-# are Flutter-bound tools intercepted by widget_renderer on device
-# (see comment block at line 1546). The mobile gates shipped in PR #438
-# (`coach_profile_provider._syncToBackend`, `claimLocalData`) cover the
-# device-side persistence for those.
+# Flutter-bound tools intercepted by widget_renderer on device — never
+# reach this dispatcher; mobile gates in PR #438 cover device-side
+# persistence:
+#   - save_partner_estimate / update_partner_estimate
+#   - record_check_in
 #
 # When the request carries `persistence_consent=False` (cloud-sync OFF
-# on the mobile toggle), each WRITE-tier call is refused server-side
+# on the mobile toggle), every WRITE-tier call is refused server-side
 # and the LLM receives a stable rejection string so it can phrase its
 # reply appropriately. LLM call itself proceeds — there is no
 # on-device LLM. See
@@ -1179,6 +1181,9 @@ _REPROMPT_EMPTY_END_TURN = (
 _WRITE_TIER_TOOLS: frozenset[str] = frozenset({
     "save_fact",
     "save_insight",
+    "save_provenance",
+    "save_earmark",
+    "remove_earmark",
 })
 
 _PERSISTENCE_OFF_MARKER = (

--- a/services/backend/tests/test_coach_chat_persistence_gate.py
+++ b/services/backend/tests/test_coach_chat_persistence_gate.py
@@ -25,16 +25,21 @@ from app.api.v1.endpoints.coach_chat import (
 
 
 # Verified WRITE-tier handlers in coach_chat.py — those that ACTUALLY
-# write to DB through the chat dispatcher. The panel's first-pass list
-# included ack-only handlers (save_pre_mortem, save_provenance,
-# save_earmark) and Flutter-bound tools (save_partner_estimate,
-# update_partner_estimate, record_check_in) — re-verified by reading
-# each handler. Only save_fact and save_insight perform a real DB
-# write in this dispatcher; the rest are either logger.info-only or
-# never reach the backend.
+# write to DB through the chat dispatcher. Re-verified after the
+# T-52-08 close-out audit (2026-05-03) caught 3 false negatives in
+# the first version: save_provenance / save_earmark / remove_earmark
+# DO write to DB (db.add(ProvenanceRecord), db.add(EarmarkTag),
+# db.delete(tag)) at coach_chat.py:1510-1558 — they're not ack-only
+# despite the « # P14 commitment devices — ack-only handlers » comment
+# (which only applied to record_commitment + save_pre_mortem).
 WRITE_TIER_FIXTURES = [
     ("save_fact", {"key": "age", "value": 40}),
     ("save_insight", {"summary": "user lives in GE", "topic": "canton"}),
+    ("save_provenance",
+     {"product_type": "3a", "recommended_by": "mon banquier", "institution": "UBS"}),
+    ("save_earmark",
+     {"label": "argent de mamie", "source_description": "héritage", "amount_hint": "~50k"}),
+    ("remove_earmark", {"label": "argent de mamie"}),
 ]
 
 
@@ -84,8 +89,11 @@ def test_write_tier_set_is_complete():
     assertion — the safety net against the « shipped a new write-tier
     handler but forgot to gate it » regression class."""
     expected = {
-        "save_fact",   # writes ProfileModel.data
-        "save_insight",  # writes CoachInsightRecord
+        "save_fact",        # writes ProfileModel.data
+        "save_insight",     # writes CoachInsightRecord
+        "save_provenance",  # writes ProvenanceRecord (db.add @ coach_chat.py:1510)
+        "save_earmark",     # writes EarmarkTag (db.add @ coach_chat.py:1531)
+        "remove_earmark",   # deletes EarmarkTag (db.delete @ coach_chat.py:1550)
     }
     assert _WRITE_TIER_TOOLS == frozenset(expected), (
         f"WRITE-tier whitelist drift detected. Expected: {expected!r} "
@@ -103,12 +111,14 @@ def test_write_tier_set_is_complete():
         # Acknowledgement-only tools — return a confirmation string but
         # never write to DB. Must NOT be in the WRITE-tier whitelist
         # (gating these would block the LLM's ability to acknowledge
-        # the user's intent within the conversation).
+        # the user's intent within the conversation). Verified at
+        # coach_chat.py:1482-1495 (« # P14 commitment devices — ack-only
+        # handlers » applies ONLY to record_commitment + save_pre_mortem;
+        # save_provenance / save_earmark / remove_earmark below them DO
+        # write to DB and are gated — see test_write_tier_set_is_complete).
         "set_goal",
         "mark_step_completed",
         "save_pre_mortem",
-        "save_provenance",
-        "save_earmark",
         "record_commitment",
         # Flutter-bound tools — never reach the backend dispatcher.
         # Mobile-side gates in PR #438 cover the device-side persistence.

--- a/services/backend/tests/test_coach_intelligence.py
+++ b/services/backend/tests/test_coach_intelligence.py
@@ -236,6 +236,7 @@ class TestIntelligenceToolHandlers:
                 },
             },
             memory_block=None,
+            persistence_consent=True,
         )
         assert "Provenance notée" in result
         assert "3a" in result
@@ -255,6 +256,7 @@ class TestIntelligenceToolHandlers:
                 },
             },
             memory_block=None,
+            persistence_consent=True,
         )
         assert "Marquage enregistré" in result
         assert "l'argent de mamie" in result
@@ -271,6 +273,7 @@ class TestIntelligenceToolHandlers:
                 },
             },
             memory_block=None,
+            persistence_consent=True,
         )
         assert "Aucun marquage" in result
 
@@ -474,6 +477,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         assert "Provenance notée" in result
 
@@ -503,6 +507,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         assert "Marquage enregistré" in result
 
@@ -530,6 +535,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
 
         block = _build_intelligence_memory_block("test-user-intg", integration_db)
@@ -552,6 +558,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         # Verify it exists
         block_before = _build_intelligence_memory_block("test-user-intg", integration_db)
@@ -566,6 +573,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         assert "supprimé" in result
 
@@ -592,6 +600,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         _execute_internal_tool(
             tool_call={
@@ -605,6 +614,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
 
         block = _build_intelligence_memory_block("test-user-intg", integration_db)
@@ -630,6 +640,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
         _execute_internal_tool(
             tool_call={
@@ -642,6 +653,7 @@ class TestProvenanceRoundtrip:
             memory_block=None,
             user_id="test-user-intg",
             db=integration_db,
+            persistence_consent=True,
         )
 
         block = _build_intelligence_memory_block("test-user-intg", integration_db)


### PR DESCRIPTION
## Context

The Phase 52.1 PR 2 (#439) added a backend `_WRITE_TIER_TOOLS` whitelist that gates chat tools when `persistence_consent=False`. The **T-52-08 close-out audit (2026-05-03)** flagged a BLOCK: 3 handlers (`save_provenance`, `save_earmark`, `remove_earmark`) issue real DB writes but were missing from the whitelist, so cloud-sync OFF was still allowing those PII writes through.

I re-verified the audit by reading `coach_chat.py:1496-1558` directly — confirmed:
- `save_provenance` → `db.add(ProvenanceRecord(...))` at `coach_chat.py:1510`
- `save_earmark`    → `db.add(EarmarkTag(...))`     at `coach_chat.py:1531`
- `remove_earmark`  → `db.delete(tag)`              at `coach_chat.py:1550`

The first pass misread the « # P14 commitment devices — ack-only handlers » comment header at `coach_chat.py:1482` as covering the 5 handlers below it. It actually only applied to the two immediately below: `record_commitment` + `save_pre_mortem`. **Comment-block scope is not transitive.**

## Summary

- Extend `_WRITE_TIER_TOOLS` to `{save_fact, save_insight, save_provenance, save_earmark, remove_earmark}`
- Update `test_coach_chat_persistence_gate.py`:
  - Parametrize the 3 newly-gated tools in `WRITE_TIER_FIXTURES`
  - Update `test_write_tier_set_is_complete` expected set
  - Remove `save_provenance` / `save_earmark` from the read-tier « not in WRITE_TIER » parametrize list
- Update `test_coach_intelligence.py`: add `persistence_consent=True` to the 12 `_execute_internal_tool` callsites that exercise the write path of these now-gated tools (sweep done **before** push — explicit lesson from PR #439's 4 CI cycles)
- Append backend-side WRITE-tier section to `BACKEND-WRITE-SURFACE.md` documenting the audit-corrected whitelist + the comment-block scope lesson + a proposed AST-walk safety-net for v2.next

## Test plan

- [x] `pytest tests/test_coach_chat_persistence_gate.py tests/test_coach_intelligence.py -v` → 57 passed
- [x] `pytest tests/` (full backend suite) → 6032 passed, 6 skipped, 0 failed
- [x] Sweep complete: every caller of `_execute_internal_tool` for the 5 whitelisted tools either passes `persistence_consent=True` or is intentionally testing the rejection path
- [ ] CI green on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)