### PR TITLE
fix(phase-52.3): truth-in-crypto sweep — false E2EE claim at doc-scan auth gate (6 locales)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 tools/checks/landing_no_financial_core.py
 
-      # ─── Phase 52.3 / TRUTH-CRYPTO: no false E2EE / zero-knowledge claim ──
-      - name: Truth-in-crypto sweep — no E2EE over-claim (Phase 52.3)
-        working-directory: ${{ github.workspace }}
-        run: python3 tools/checks/no_e2ee_overclaim.py
-
       - name: Run tests
         env:
           TESTING: "1"
@@ -457,6 +452,29 @@ jobs:
           python-version: "3.11"
       - name: Run parity lint
         run: python3 tools/checks/route_registry_parity.py
+
+  # ─── Phase 52.3 / TRUTH-CRYPTO: no false E2EE / zero-knowledge claim ──
+  # Multilingual lint that scans user-facing strings (ARBs, screens,
+  # widgets) and docs for E2EE / « bout en bout » / « Ende-zu-Ende » /
+  # « extremo a extremo » / « end-to-end » / « ponto a ponto » / E2EE /
+  # zero-knowledge claims that contradict the Path A data-residency
+  # decision (`.planning/decisions/2026-05-02-data-residency.md` —
+  # E2EE deferred to v3.0). Allow-list covers v3.0 / decision / ADR
+  # references. Per-line override: `ALLOW-E2EE-CLAIM: <reason>`.
+  #
+  # Runs on every PR regardless of changed paths because user-facing
+  # copy regressions can land in either backend or mobile changes.
+  # Stdlib-only Python, runtime ~50 ms.
+  truth-in-crypto:
+    name: Truth-in-crypto sweep (Phase 52.3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run no-E2EE-overclaim lint
+        run: python3 tools/checks/no_e2ee_overclaim.py
 
   # ─── Phase 32 Plan 32-05 / D-12 §2: mint-routes CLI DRY_RUN tests ─
   # Runs pytest on tests/tools/test_mint_routes.py (14 cases, Plan 02

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 tools/checks/landing_no_financial_core.py
 
+      # ─── Phase 52.3 / TRUTH-CRYPTO: no false E2EE / zero-knowledge claim ──
+      - name: Truth-in-crypto sweep — no E2EE over-claim (Phase 52.3)
+        working-directory: ${{ github.workspace }}
+        run: python3 tools/checks/no_e2ee_overclaim.py
+
       - name: Run tests
         env:
           TESTING: "1"

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -3489,7 +3489,7 @@
   "benchmarkBelowRange": "Deine Situation liegt unter dem typischen Bereich.",
   "benchmarkTypicalRange": "Typischer Bereich: {low} – {high}",
   "authGateDocScanTitle": "Sichere deine Dokumente",
-  "authGateDocScanMessage": "Deine Zertifikate enthalten sensible Daten. Erstelle ein Konto, um sie mit Ende-zu-Ende-Verschlüsselung zu schützen.",
+  "authGateDocScanMessage": "Deine Zertifikate enthalten sensible Daten. Erstelle ein Konto, um sie auf unseren Servern zu verschlüsseln und von deinen Geräten abzurufen — du kannst jederzeit alles lokal behalten unter Datenschutz.",
   "authGateSalaryTitle": "Schütze deine Finanzdaten",
   "authGateSalaryMessage": "Dein Gehalt und deine Finanzdaten verdienen einen sicheren Tresor.",
   "authGateCoachTitle": "Der Coach muss dich kennenlernen",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -3489,7 +3489,7 @@
   "benchmarkBelowRange": "Your situation is below the typical range.",
   "benchmarkTypicalRange": "Typical range: {low} – {high}",
   "authGateDocScanTitle": "Secure your documents",
-  "authGateDocScanMessage": "Your certificates contain sensitive data. Create an account to protect them with end-to-end encryption.",
+  "authGateDocScanMessage": "Your certificates contain sensitive data. Create an account to encrypt them on our servers and access them from your devices — you can keep everything on-device at any time from Privacy.",
   "authGateSalaryTitle": "Protect your financial data",
   "authGateSalaryMessage": "Your salary and financial data deserve a secure vault.",
   "authGateCoachTitle": "The coach needs to know you",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -3489,7 +3489,7 @@
   "benchmarkBelowRange": "Tu situación está por debajo del rango típico.",
   "benchmarkTypicalRange": "Rango típico: {low} – {high}",
   "authGateDocScanTitle": "Protege tus documentos",
-  "authGateDocScanMessage": "Tus certificados contienen datos sensibles. Crea una cuenta para protegerlos con cifrado de extremo a extremo.",
+  "authGateDocScanMessage": "Tus certificados contienen datos sensibles. Crea una cuenta para cifrarlos en nuestros servidores y acceder a ellos desde tus dispositivos — puedes mantener todo en local en cualquier momento desde Privacidad.",
   "authGateSalaryTitle": "Protege tus datos financieros",
   "authGateSalaryMessage": "Tu salario y tus datos financieros merecen una caja fuerte segura.",
   "authGateCoachTitle": "El coach necesita conocerte",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -3782,7 +3782,7 @@
     }
   },
   "authGateDocScanTitle": "Sécurise tes documents",
-  "authGateDocScanMessage": "Tes certificats contiennent des données sensibles. Crée un compte pour les protéger avec un chiffrement de bout en bout.",
+  "authGateDocScanMessage": "Tes certificats contiennent des données sensibles. Crée un compte pour les chiffrer sur nos serveurs et les retrouver depuis tes appareils — tu peux à tout moment garder tout en local depuis Confidentialité.",
   "authGateSalaryTitle": "Protège tes données financières",
   "authGateSalaryMessage": "Ton salaire et tes données financières méritent un coffre-fort sécurisé.",
   "authGateCoachTitle": "Le coach a besoin de te connaître",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -3489,7 +3489,7 @@
   "benchmarkBelowRange": "La tua situazione è al di sotto della fascia tipica.",
   "benchmarkTypicalRange": "Fascia tipica: {low} – {high}",
   "authGateDocScanTitle": "Proteggi i tuoi documenti",
-  "authGateDocScanMessage": "I tuoi certificati contengono dati sensibili. Crea un account per proteggerli con crittografia end-to-end.",
+  "authGateDocScanMessage": "I tuoi certificati contengono dati sensibili. Crea un account per cifrarli sui nostri server e accedervi dai tuoi dispositivi — puoi mantenere tutto in locale in qualsiasi momento da Privacy.",
   "authGateSalaryTitle": "Proteggi i tuoi dati finanziari",
   "authGateSalaryMessage": "Il tuo stipendio e i tuoi dati finanziari meritano una cassaforte sicura.",
   "authGateCoachTitle": "Il coach ha bisogno di conoscerti",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -13347,7 +13347,7 @@ abstract class S {
   /// No description provided for @authGateDocScanMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Tes certificats contiennent des données sensibles. Crée un compte pour les protéger avec un chiffrement de bout en bout.'**
+  /// **'Tes certificats contiennent des données sensibles. Crée un compte pour les chiffrer sur nos serveurs et les retrouver depuis tes appareils — tu peux à tout moment garder tout en local depuis Confidentialité.'**
   String get authGateDocScanMessage;
 
   /// No description provided for @authGateSalaryTitle.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -7526,7 +7526,7 @@ class SDe extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'Deine Zertifikate enthalten sensible Daten. Erstelle ein Konto, um sie mit Ende-zu-Ende-Verschlüsselung zu schützen.';
+      'Deine Zertifikate enthalten sensible Daten. Erstelle ein Konto, um sie auf unseren Servern zu verschlüsseln und von deinen Geräten abzurufen — du kannst jederzeit alles lokal behalten unter Datenschutz.';
 
   @override
   String get authGateSalaryTitle => 'Schütze deine Finanzdaten';

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -7464,7 +7464,7 @@ class SEn extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'Your certificates contain sensitive data. Create an account to protect them with end-to-end encryption.';
+      'Your certificates contain sensitive data. Create an account to encrypt them on our servers and access them from your devices — you can keep everything on-device at any time from Privacy.';
 
   @override
   String get authGateSalaryTitle => 'Protect your financial data';

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -7511,7 +7511,7 @@ class SEs extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'Tus certificados contienen datos sensibles. Crea una cuenta para protegerlos con cifrado de extremo a extremo.';
+      'Tus certificados contienen datos sensibles. Crea una cuenta para cifrarlos en nuestros servidores y acceder a ellos desde tus dispositivos — puedes mantener todo en local en cualquier momento desde Privacidad.';
 
   @override
   String get authGateSalaryTitle => 'Protege tus datos financieros';

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -7511,7 +7511,7 @@ class SFr extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'Tes certificats contiennent des données sensibles. Crée un compte pour les protéger avec un chiffrement de bout en bout.';
+      'Tes certificats contiennent des données sensibles. Crée un compte pour les chiffrer sur nos serveurs et les retrouver depuis tes appareils — tu peux à tout moment garder tout en local depuis Confidentialité.';
 
   @override
   String get authGateSalaryTitle => 'Protège tes données financières';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -7522,7 +7522,7 @@ class SIt extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'I tuoi certificati contengono dati sensibili. Crea un account per proteggerli con crittografia end-to-end.';
+      'I tuoi certificati contengono dati sensibili. Crea un account per cifrarli sui nostri server e accedervi dai tuoi dispositivi — puoi mantenere tutto in locale in qualsiasi momento da Privacy.';
 
   @override
   String get authGateSalaryTitle => 'Proteggi i tuoi dati finanziari';

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -7505,7 +7505,7 @@ class SPt extends S {
 
   @override
   String get authGateDocScanMessage =>
-      'Os teus certificados contêm dados sensíveis. Cria uma conta para os proteger com encriptação ponto a ponto.';
+      'Os teus certificados contêm dados sensíveis. Cria uma conta para os cifrar nos nossos servidores e aceder-lhes a partir dos teus dispositivos — podes manter tudo localmente a qualquer momento em Privacidade.';
 
   @override
   String get authGateSalaryTitle => 'Protege os teus dados financeiros';

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -3489,7 +3489,7 @@
   "benchmarkBelowRange": "A tua situação está abaixo da faixa típica.",
   "benchmarkTypicalRange": "Faixa típica: {low} – {high}",
   "authGateDocScanTitle": "Protege os teus documentos",
-  "authGateDocScanMessage": "Os teus certificados contêm dados sensíveis. Cria uma conta para os proteger com encriptação ponto a ponto.",
+  "authGateDocScanMessage": "Os teus certificados contêm dados sensíveis. Cria uma conta para os cifrar nos nossos servidores e aceder-lhes a partir dos teus dispositivos — podes manter tudo localmente a qualquer momento em Privacidade.",
   "authGateSalaryTitle": "Protege os teus dados financeiros",
   "authGateSalaryMessage": "O teu salário e os teus dados financeiros merecem um cofre seguro.",
   "authGateCoachTitle": "O coach precisa de te conhecer",

--- a/tools/checks/no_e2ee_overclaim.py
+++ b/tools/checks/no_e2ee_overclaim.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Lint user-facing strings for false end-to-end-encryption (E2EE) claims.
+
+MINT v2.x runs Path A per `.planning/decisions/2026-05-02-data-residency.md`:
+data is encrypted at rest with operator-held DEK on Railway. E2EE (Path C,
+zero-knowledge with client-side keys) is deferred to v3.0. Therefore any
+user-facing string promising « end-to-end encryption » / « chiffrement de
+bout en bout » / « Ende-zu-Ende-Verschlüsselung » / « cifrado de extremo
+a extremo » / « crittografia end-to-end » / « encriptação ponto a ponto »
+/ « zero-knowledge » is a false claim and a regulatory transparency risk
+under nFADP art. 19 / LSFin art. 8.
+
+Origin: Phase 52.3 truth-in-crypto sweep, after the Adversarial Trust
+Reviewer (T-52-08 follow-up panel) caught the claim live in 6 ARB locales
+on the document-scan auth gate (`authGateDocScanMessage`).
+
+Usage:
+
+    python3 tools/checks/no_e2ee_overclaim.py
+    python3 tools/checks/no_e2ee_overclaim.py --paths file1.arb file2.md
+
+Exit 0 on clean. Exit 1 with `::error` line diagnostics on hit. Per-line
+override: append `// ALLOW-E2EE-CLAIM: reason` (or `<!-- -->` for md) on
+the offending line. Use sparingly — only for backlog/ADR/decision contexts
+that explicitly mark the claim as deferred-future.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# What we lint: user-facing string surfaces.
+USER_FACING_GLOBS = (
+    "apps/mobile/lib/l10n/app_*.arb",
+    "apps/mobile/lib/screens/**/*.dart",
+    "apps/mobile/lib/widgets/**/*.dart",
+)
+
+# Docs are linted only for non-allowlisted promises (the v3.0 roadmap entry
+# itself is fine; a doc that says « MINT uses E2EE today » is not).
+DOC_GLOBS = (
+    "docs/**/*.md",
+    "README.md",
+)
+
+# E2EE / zero-knowledge claim patterns, multilingual. Case-insensitive.
+# Word boundaries are loose because « end-to-end » / « bout en bout » are
+# multi-token; we match the loaded phrases verbatim.
+PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"\bend[- ]to[- ]end\s+encrypt", re.I), "EN E2EE claim"),
+    (re.compile(r"\bchiffrement\s+de\s+bout\s+en\s+bout\b", re.I), "FR E2EE claim"),
+    (re.compile(r"\bEnde[- ]zu[- ]Ende[- ]Verschl[üu]sselung\b", re.I), "DE E2EE claim"),
+    (re.compile(r"\bcifrado\s+de\s+extremo\s+a\s+extremo\b", re.I), "ES E2EE claim"),
+    (re.compile(r"\bcrittografia\s+end[- ]to[- ]end\b", re.I), "IT E2EE claim"),
+    (re.compile(r"\bcrittografia\s+da\s+capo\s+a\s+capo\b", re.I), "IT E2EE claim (alt)"),
+    (re.compile(r"\bencripta[çc][ãa]o\s+ponto\s+a\s+ponto\b", re.I), "PT E2EE claim"),
+    (re.compile(r"\bE2EE\b", re.I), "E2EE acronym"),
+    (re.compile(r"\bzero[- ]knowledge\b", re.I), "zero-knowledge claim"),
+]
+
+# Allow-list patterns: legitimate references that MUST stay (roadmap /
+# decision artifacts that explicitly defer the feature). Each element is a
+# regex matched against the LINE; if any allow-list pattern matches the
+# offending line, the hit is suppressed.
+ALLOW_LINE_PATTERNS: list[re.Pattern] = [
+    re.compile(r"v3\.0", re.I),
+    re.compile(r"deferred", re.I),
+    re.compile(r"defer\s+(?:to|until)", re.I),
+    re.compile(r"reporté", re.I),
+    re.compile(r"future\s+release", re.I),
+    re.compile(r"backlog", re.I),
+    re.compile(r"ADR-", re.I),
+    re.compile(r"ALLOW-E2EE-CLAIM", re.I),
+    re.compile(r"//\s*ALLOW-E2EE", re.I),
+]
+
+# Files where E2EE is discussed as future-state and therefore allowed
+# wholesale (decision artifacts, ROADMAP, ADRs, this lint itself).
+ALLOW_FILE_PATTERNS: list[re.Pattern] = [
+    re.compile(r"\.planning/decisions/.*data-residency", re.I),
+    re.compile(r"\.planning/decisions/.*e2ee", re.I),
+    re.compile(r"docs/ROADMAP", re.I),
+    re.compile(r"docs/.*ADR", re.I),
+    re.compile(r"decisions/.*ADR-", re.I),
+    re.compile(r"tools/checks/no_e2ee_overclaim\.py$"),
+    re.compile(r"\.planning/phases/52\.3"),
+    re.compile(r"\.planning/reports/SESSION-"),
+    re.compile(r"\.planning/reviews/"),
+]
+
+
+def _iter_files(globs: tuple[str, ...]) -> list[Path]:
+    out: list[Path] = []
+    for pattern in globs:
+        out.extend(sorted(REPO.glob(pattern)))
+    return out
+
+
+def _file_allowed(path: Path) -> bool:
+    try:
+        rel = path.relative_to(REPO).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    return any(p.search(rel) for p in ALLOW_FILE_PATTERNS)
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return [(lineno, label, line_content)] of hits not on the allow-list."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    hits: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for pat, label in PATTERNS:
+            if not pat.search(line):
+                continue
+            if any(allow.search(line) for allow in ALLOW_LINE_PATTERNS):
+                continue
+            hits.append((lineno, label, line.strip()))
+            break
+    return hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", nargs="*", help="Specific files to scan")
+    args = parser.parse_args()
+
+    if args.paths:
+        files = [Path(p).resolve() for p in args.paths]
+    else:
+        files = _iter_files(USER_FACING_GLOBS) + _iter_files(DOC_GLOBS)
+
+    failures = 0
+    for path in files:
+        if not path.exists() or _file_allowed(path):
+            continue
+        for lineno, label, snippet in _scan_file(path):
+            rel = path.relative_to(REPO).as_posix() if REPO in path.parents else path.name
+            print(
+                f"::error file={rel},line={lineno}::"
+                f"E2EE over-claim ({label}). MINT v2.x is Path A per "
+                f"data-residency decision; E2EE deferred to v3.0. "
+                f"Either fix the copy or add `ALLOW-E2EE-CLAIM: <reason>` "
+                f"on the line. Hit: {snippet}"
+            )
+            failures += 1
+
+    if failures:
+        print(
+            f"\n{failures} E2EE over-claim hit(s). Fix the copy to reflect "
+            f"actual state (encrypted at rest with per-user DEK on the "
+            f"server side; cloud-sync-OFF keeps data local).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

The post-Phase-52.2 close-out panel surfaced a P0 trust regression: the document-scan auth gate (`authGateDocScanMessage`) tells users in 6 locales that their certificates will be protected with **« end-to-end encryption »** — at the precise moment they are asked to create an account to upload sensitive Swiss tax/LPP documents.

This contradicts:
- `.planning/decisions/2026-05-02-data-residency.md:24,67` — explicitly defers E2EE to v3.0 (« Premature E2EE before PMF. Substantial engineering investment (5-6 months)... Deferred to v3.0. »)
- `docs/DPA_TECHNICAL_ANNEX.md:101` — Railway hosting is « encrypted at rest » with operator-held DEK, not zero-knowledge
- `docs/LEGAL_SIGNOFF_V27.md:27` — `evidence_text` is « encrypted at rest with per-user DEK » (server holds the key)

Same family as the Phase 52 « privacy toggle does nothing » BLOCK that triggered Phase 52.1: false claim at the moment of consent on the most sensitive document type. nFADP art. 19 (transparency) + LSFin art. 8 (no misleading information) quotable contradiction.

## Summary

- **6 ARB strings** (`authGateDocScanMessage` in fr/en/de/es/it/pt) replaced with truthful copy anchored to the data-residency decision artifact's brand language: « chiffrer sur nos serveurs et les retrouver depuis tes appareils — tu peux à tout moment garder tout en local depuis Confidentialité »
- **Regenerated l10n** — `flutter gen-l10n`
- **New lint** `tools/checks/no_e2ee_overclaim.py`: multilingual pattern matching for E2EE / « bout en bout » / « Ende-zu-Ende » / « extremo a extremo » / « end-to-end » / « ponto a ponto » / « E2EE » / « zero-knowledge » with allow-list for legitimate v3.0 / decision / ADR references. Per-line override `ALLOW-E2EE-CLAIM: <reason>` available
- **CI wired** — lint runs in the backend job alongside the other compliance checks

## Pre-push checklist (per `feedback_pre_push_checklist.md`)

- [x] Sweep callers: `authGateDocScanMessage` referenced only in `auth_gate.dart:136` — no other consumers
- [x] Regenerate artifacts: `flutter gen-l10n` ran (7 generated `.dart` files updated)
- [x] Lints: `accent_lint_fr` clean, `no_e2ee_overclaim` clean (full-repo + smoke-tested with synthetic violation), `flutter analyze lib/widgets/auth/auth_gate.dart lib/l10n/` no issues
- [x] ARB key counts unchanged (8724 per locale + 9130 in fr with @meta entries)

## Test plan

- [x] `python3 tools/checks/no_e2ee_overclaim.py` → exit 0 (full repo clean)
- [x] Lint smoke-tested with synthetic violation → exit 1 with `::error` diagnostic; allow-list smoke-tested with « v3.0 » mention → exit 0
- [x] `flutter analyze lib/widgets/auth/auth_gate.dart lib/l10n/` → no issues
- [ ] CI green on dev (Backend tests + new truth-in-crypto sweep gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)