### PR TITLE
feat(phase-53-01): screen_registry_parity lint + 41-route gap inventory

### DIFF
--- a/.planning/phases/53-architecture-parity-and-sequence-wiring/SCREEN-REGISTRY-COVERAGE.md
+++ b/.planning/phases/53-architecture-parity-and-sequence-wiring/SCREEN-REGISTRY-COVERAGE.md
@@ -1,0 +1,88 @@
+# Phase 53-01 — ScreenRegistry × app.dart coverage map
+
+**Source of truth (extracted 2026-05-04):**
+- `apps/mobile/lib/app.dart` — 153 `path:` literals
+- `apps/mobile/lib/services/navigation/screen_registry.dart` — 105 `ScreenEntry` routes (after query-param normalization)
+
+After `_NOT_CHAT_ROUTABLE` (13) + `_NESTED_PROFILE_CHILDREN` (7) exemptions: **41 paths in app.dart absent from MintScreenRegistry**, **0 ghost ScreenEntries**.
+
+**Classification target:**
+- **ROUTABLE** — needs full `ScreenEntry` row (chat-routable surface)
+- **NOT_CHAT_ROUTABLE** — needs `ScreenEntry` with `preferFromChat: false` (LLM should know about it but not surface it)
+- **ALLOWLIST** — add to `_NOT_CHAT_ROUTABLE` in the lint (intentionally absent from registry — auth, shell, dev-only)
+- **DEFER_DEAD** — orphan / dead route; flag for Phase 55+ deletion plan
+
+## Triage table
+
+| # | Route | Class | Proposed `intentTag` | Proposed `behavior` | Notes |
+|---|---|---|---|---|---|
+| 1 | `/about` | ALLOWLIST | — | — | About / legal screen; not chat-routable |
+| 2 | `/advisor` | ROUTABLE | `advisor_handoff` | `decisionCanvas` | Human-advisor handoff; chat may surface |
+| 3 | `/advisor/plan-30-days` | ROUTABLE | `advisor_30_day_plan` | `decisionCanvas` | Coach can route after action plan generation |
+| 4 | `/advisor/wizard` | ROUTABLE | `advisor_wizard` | `progressiveDisclosure` | Wizard for handoff |
+| 5 | `/arbitrage/calendrier-retraits` | ROUTABLE | `withdrawal_calendar` | `decisionCanvas` | Multi-year withdrawal planning |
+| 6 | `/arbitrage/rachat-vs-marche` | ROUTABLE | `lpp_buyback_vs_market` | `decisionCanvas` | LPP rachat vs market arbitrage |
+| 7 | `/arbitrage/rente-vs-capital` | ROUTABLE | `rente_vs_capital_arbitrage` | `decisionCanvas` | Sibling of `/rente-vs-capital`; arbitrage variant |
+| 8 | `/budget/setup` | ROUTABLE | `budget_setup` | `progressiveDisclosure` | First-time budget config from chat |
+| 9 | `/coach/agir` | NOT_CHAT_ROUTABLE | `coach_action_log` | `conversationPure` | « Agir » tab — surfaced by tab bar, not chat |
+| 10 | `/coach/dashboard` | NOT_CHAT_ROUTABLE | `coach_dashboard` | `conversationPure` | Coach overview dashboard — tab |
+| 11 | `/coach/decaissement` | ROUTABLE | `decaissement_plan` | `decisionCanvas` | Coach-driven decaissement planning |
+| 12 | `/coach/succession` | ROUTABLE | `succession_planning` | `decisionCanvas` | Coach-driven succession planning |
+| 13 | `/disability/gap` | ROUTABLE | `disability_gap_check` | `decisionCanvas` | Invalidité gap analysis |
+| 14 | `/document-scan` | ROUTABLE | `document_scan_entry` | `progressiveDisclosure` | Doc scan entry surface (post-auth) |
+| 15 | `/document-scan/avs-guide` | ROUTABLE | `avs_extract_guide` | `progressiveDisclosure` | AVS extract guided scan |
+| 16 | `/explore` | NOT_CHAT_ROUTABLE | `explore_tab` | `conversationPure` | Shell tab — tab bar surfaces it |
+| 17 | `/household` | ROUTABLE | `household_overview` | `decisionCanvas` | Couple/household management |
+| 18 | `/household/accept` | ROUTABLE | `household_accept_invite` | `progressiveDisclosure` | Partner-invite acceptance flow |
+| 19 | `/life-event/divorce` | ROUTABLE | `life_event_divorce` | `decisionCanvas` | High-priority life-event canvas |
+| 20 | `/life-event/succession` | ROUTABLE | `life_event_succession` | `decisionCanvas` | Sibling of `/coach/succession`; verify dedup |
+| 21 | `/lpp-deep/epl` | ROUTABLE | `lpp_deep_epl` | `decisionCanvas` | EPL deep-dive (LPP tier) |
+| 22 | `/lpp-deep/libre-passage` | ROUTABLE | `lpp_deep_libre_passage` | `decisionCanvas` | Libre-passage deep-dive |
+| 23 | `/mon-argent` | NOT_CHAT_ROUTABLE | `mon_argent_tab` | `conversationPure` | Shell tab |
+| 24 | `/mortgage/affordability` | ROUTABLE | `mortgage_affordability_v2` | `decisionCanvas` | Sibling of `/affordability`; verify dedup or supersedes |
+| 25 | `/onboarding/enrichment` | ALLOWLIST | — | — | Onboarding flow — not chat-routable post-onboard |
+| 26 | `/onboarding/intent` | ALLOWLIST | — | — | Onboarding intent capture — pre-chat |
+| 27 | `/onboarding/minimal` | ALLOWLIST | — | — | Minimal onboarding — pre-chat |
+| 28 | `/onboarding/plan` | ALLOWLIST | — | — | Onboarding plan presentation |
+| 29 | `/onboarding/promise` | ALLOWLIST | — | — | Onboarding promise screen |
+| 30 | `/onboarding/quick-start` | ALLOWLIST | — | — | Quick-start onboarding |
+| 31 | `/onboarding/smart` | ALLOWLIST | — | — | Smart onboarding variant |
+| 32 | `/report` | ROUTABLE | `report_overview` | `progressiveDisclosure` | Report aperçu surface |
+| 33 | `/report/v2` | ROUTABLE | `report_v2` | `progressiveDisclosure` | Report v2 (aperçu financier) |
+| 34 | `/retirement` | ROUTABLE | `retirement_overview` | `decisionCanvas` | Retirement-overview surface (sibling of `/retraite`) |
+| 35 | `/retirement/projection` | ROUTABLE | `retirement_projection` | `decisionCanvas` | Retirement projection variant |
+| 36 | `/settings/confidentialite` | NOT_CHAT_ROUTABLE | `settings_privacy` | `conversationPure` | Phase 52 privacy settings — chat may DEEPLINK from a privacy nudge but tab is canonical |
+| 37 | `/settings/langue` | NOT_CHAT_ROUTABLE | `settings_language` | `conversationPure` | Settings → language |
+| 38 | `/simulator/3a` | ROUTABLE | `simulator_3a` | `decisionCanvas` | 3a simulator (sibling of `/pilier-3a` deep) |
+| 39 | `/simulator/disability-gap` | ROUTABLE | `simulator_disability_gap` | `decisionCanvas` | Disability simulator (sibling of `/disability/gap`) |
+| 40 | `/simulator/rente-capital` | ROUTABLE | `simulator_rente_capital` | `decisionCanvas` | Sibling of `/rente-vs-capital` |
+| 41 | `/tools` | NOT_CHAT_ROUTABLE | `tools_tab` | `conversationPure` | Shell tab — surfaced by tab bar |
+
+## Counts
+
+| Class | Count | Action in T-53-01-03 |
+|---|---|---|
+| ROUTABLE | 24 | Add `ScreenEntry` rows with `preferFromChat: true`, fill `requiredFields` per code-read |
+| NOT_CHAT_ROUTABLE | 9 | Add `ScreenEntry` rows with `preferFromChat: false` (mirrors existing `_authLogin` pattern) |
+| ALLOWLIST | 8 | Add to `_NOT_CHAT_ROUTABLE` set in `screen_registry_parity.py` + document in KNOWN-MISSES.md |
+| DEFER_DEAD | 0 | None identified in this audit |
+| **Total** | **41** | — |
+
+## Sibling deduplication candidates
+
+Several ROUTABLE entries are siblings of existing entries (different paths, same intent). Two reasonable resolutions:
+
+| Existing entry | New sibling | Resolution |
+|---|---|---|
+| `/rente-vs-capital` (`rente_vs_capital`) | `/arbitrage/rente-vs-capital`, `/simulator/rente-capital` | Different intentTags above (`*_arbitrage` vs `simulator_*`) — keep as separate registry entries; map via redirect in app.dart only if product confirms semantic dedup |
+| `/affordability` (`mortgage_affordability`) | `/mortgage/affordability` | New entry uses `mortgage_affordability_v2` to disambiguate |
+| `/retraite` (`retirement_choice`) | `/retirement`, `/retirement/projection` | Different intent surfaces — keep separate |
+| `/coach/succession` | `/life-event/succession` | Same intent split across two paths — flag for product review post-T-53-01-03 |
+
+The dedup decision is OUT OF SCOPE for Plan 53-01 (registry-only audit). Flagged here for Phase 55+ navigation cleanup.
+
+## What this map does NOT do
+
+- **Does NOT delete any route** — registry audit only; orphan-route deletion is Phase 55+.
+- **Does NOT verify the proposed `requiredFields`** — that requires reading each screen's `initState` / `Provider` consumers. T-53-01-03 will use placeholder `requiredFields: []` + `// TODO 53-01: classify` for surfaces not obviously mapped, and a follow-up plan addresses the placeholders.
+- **Does NOT add new `ScreenIntent` enum values** — proposed `intentTag` strings are free-form (the field type is `String`, see `screen_registry.dart:64`). If any proposed intentTag collides with an existing one, T-53-01-03 will resolve by adding a `_v2` suffix and flagging for Phase 55+ rationalization.

--- a/tools/checks/screen_registry_parity-KNOWN-MISSES.md
+++ b/tools/checks/screen_registry_parity-KNOWN-MISSES.md
@@ -1,0 +1,94 @@
+# Screen registry parity — KNOWN-MISSES allow-list rationale
+
+Companion to `tools/checks/screen_registry_parity.py`. When a route in
+`apps/mobile/lib/app.dart` is intentionally NOT enforced for parity with
+`MintScreenRegistry`, the rationale lives here. The lint reads the
+allow-list constants in the script; this doc is the human audit trail.
+
+---
+
+## Categories
+
+### Category A — Not chat-routable (`_NOT_CHAT_ROUTABLE`)
+
+Routes the LLM should never surface from the coach chat. Either pre-auth
+flows, shell tabs accessible from the bottom navigation, dev-only admin
+surfaces, or the chat itself (you don't route INTO the chat from the chat).
+
+| Route | Reason |
+|---|---|
+| `/` | Root landing — pre-auth, no chat surface yet |
+| `/start` | Anonymous wedge entry — pre-chat |
+| `/onb` | Onboarding root — pre-chat |
+| `/auth/login` | Auth flow — never surfaced from chat |
+| `/auth/register` | Same |
+| `/auth/forgot-password` | Same |
+| `/auth/verify-email` | Same |
+| `/auth/verify` | Same |
+| `/anonymous/intent` | Anonymous wedge — pre-auth |
+| `/anonymous/chat` | Anonymous chat — different surface than authenticated coach chat |
+| `/admin/routes` | Phase 32 admin shell — dev-only, tree-shaken in prod (D-06 + D-10) |
+| `/admin/observability` | Phase 31 admin observability — dev-only |
+| `/admin/analytics` | Phase 32 admin analytics — dev-only |
+| `/achievements` | Achievements grid — surfaced by tab bar; an entry exists in registry with `preferFromChat: false` |
+| `/coach` | Coach root — same redirect target as `/coach/chat` |
+| `/coach/chat` | The chat itself; coach can't route to itself |
+
+Adding a route here requires a one-line entry in this table explaining why
+the route should not appear in `MintScreenRegistry`.
+
+**Note on registry presence:** several of these routes ALSO have a
+`ScreenEntry` declared in `screen_registry.dart` (e.g. `_authLogin`,
+`_achievements`, `_home`) — that's intentional. The LLM's `IntentResolver`
+needs to know about them so it can refer to them by intent tag without
+actually navigating users there (the entries carry `preferFromChat: false`).
+The lint exempts these routes from BOTH sides of the comparison so the
+KNOWN-MISSES allow-list signals « do not enforce parity » rather than
+« must be absent from registry ».
+
+### Category B — Nested profile children (`_NESTED_PROFILE_CHILDREN`)
+
+GoRouter declares child routes as bare segments under a parent
+`/profile` path; the registry stores the composed `/profile/<segment>`
+form. The regex captures the bare segment (left side); the registry
+stores the composed (right side). Both sides are exempted from
+comparison to prevent false-positive drift.
+
+| Bare segment in `app.dart` | Composed form in registry |
+|---|---|
+| `admin-observability` | `/profile/admin-observability` |
+| `admin-analytics` | `/profile/admin-analytics` |
+| `byok` | `/profile/byok` |
+| `slm` | `/profile/slm` |
+| `bilan` | `/profile/bilan` |
+| `privacy-control` | `/profile/privacy-control` |
+| `privacy` | `/profile/privacy` |
+
+Adding a new nested child requires both the lint constant AND this table.
+
+---
+
+## Maintenance policy
+
+When the parity lint reports drift:
+
+1. **First, fix the code.** Add the missing `ScreenEntry` to the registry
+   OR remove the stale entry. The default is « parity must hold ».
+2. **Only allow-list when the route is structurally exempt.** Auth flows,
+   dev-only admin surfaces, shell tabs whose UX makes chat-routing
+   nonsensical. NOT « we'll add this later » — that's a backlog ticket,
+   not an allow-list entry.
+3. **Document the reason.** A one-line entry in this table is part of the
+   PR. A reviewer should be able to read « why is this route exempt? »
+   in 10 seconds without consulting other docs.
+4. **Keep the lint script and this doc in sync.** A code reviewer who
+   sees a new entry in `_NOT_CHAT_ROUTABLE` must find the matching
+   table row here, or block the PR.
+
+## Origin
+
+Plan 53-01 (Phase 53 — architecture parity + sequence wiring), spawned
+from the 5-expert MINT panel synthesis at
+`.planning/decisions/2026-05-04-phase-53-target.md`. Mirrors the
+`tools/checks/route_registry_parity-KNOWN-MISSES.md` discipline established
+in Phase 32-04 (MAP-04).

--- a/tools/checks/screen_registry_parity.py
+++ b/tools/checks/screen_registry_parity.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Phase 53-01 — ScreenRegistry × app.dart parity lint.
+
+Compares path literals extracted from `apps/mobile/lib/app.dart` (via
+`GoRoute|ScopedGoRoute(path: ...)` regex) against the `route:` literals
+declared inside `ScreenEntry(...)` constructor calls in
+`apps/mobile/lib/services/navigation/screen_registry.dart`.
+
+Mirror of `tools/checks/route_registry_parity.py` (Phase 32-04 / MAP-04)
+applied to the SemanTIc screen registry instead of the route metadata
+registry. The two registries serve different purposes:
+  * `kRouteMetadata` (route_registry_parity.py) — telemetry / admin / breadcrumbs
+  * `MintScreenRegistry` (this lint)             — chat → intent → screen routing
+
+Both must stay in sync with `app.dart`.
+
+Exits:
+  0 — parity holds (after KNOWN-MISSES exemption).
+  1 — drift detected (registry missing a route OR ghost entry with no route).
+  2 — usage / argument / missing-file error (sysexits.h EX_USAGE).
+
+Usage:
+    python3 tools/checks/screen_registry_parity.py
+    python3 tools/checks/screen_registry_parity.py --extract-only apps
+    python3 tools/checks/screen_registry_parity.py --extract-only registry
+
+Python 3.9-compatible (dev 3.9.6, CI 3.11). stdlib-only.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Set, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_DART = REPO_ROOT / "apps" / "mobile" / "lib" / "app.dart"
+REGISTRY_DART = (
+    REPO_ROOT / "apps" / "mobile" / "lib" / "services" / "navigation" / "screen_registry.dart"
+)
+
+# ---------------------------------------------------------------------------
+# KNOWN-MISSES allow-lists
+# (See tools/checks/screen_registry_parity-KNOWN-MISSES.md for rationale.)
+# ---------------------------------------------------------------------------
+# Routes present in app.dart that are intentionally NOT in the chat-routable
+# screen registry. Examples: shell tabs, auth flows, landing, achievements,
+# admin-only surfaces, dev-only debug screens.
+#
+# A route belongs here when ScreenEntry would have `preferFromChat: false`
+# AND opening it from the chat surface would be either nonsensical (auth) or
+# undesirable (admin). Adding here requires a one-line entry in the
+# KNOWN-MISSES.md doc explaining WHY it's not chat-routable.
+_NOT_CHAT_ROUTABLE: Set[str] = {
+    # Shell + landing + tab routes
+    "/",
+    "/start",
+    "/onb",
+    # Auth flows
+    "/auth/login",
+    "/auth/register",
+    "/auth/forgot-password",
+    "/auth/verify-email",
+    "/auth/verify",
+    # Anonymous wedge (pre-auth)
+    "/anonymous/intent",
+    "/anonymous/chat",
+    # Admin / dev-only
+    "/admin/routes",
+    "/admin/observability",
+    "/admin/analytics",
+    # Achievements / progress
+    "/achievements",
+    # Coach surface itself (the chat is the SOURCE of routing; you don't route INTO it)
+    "/coach",
+    "/coach/chat",
+}
+
+# Routes that belong to the registry but use a dynamic / parametric form
+# in app.dart that the regex doesn't reliably extract (e.g. `path: '/profile'`
+# with nested `routes: [...]` children). The lint sees the bare segment in
+# app.dart but the registry stores the composed form. Both halves are
+# exempted from comparison here.
+#
+# Format: (segment_in_app_dart, composed_form_in_registry).
+_NESTED_PROFILE_CHILDREN: Set[Tuple[str, str]] = {
+    ("admin-observability", "/profile/admin-observability"),
+    ("admin-analytics", "/profile/admin-analytics"),
+    ("byok", "/profile/byok"),
+    ("slm", "/profile/slm"),
+    ("bilan", "/profile/bilan"),
+    ("privacy-control", "/profile/privacy-control"),
+    ("privacy", "/profile/privacy"),
+}
+
+# ---------------------------------------------------------------------------
+# Regex library
+# ---------------------------------------------------------------------------
+# Matches `path: '...'` inside GoRoute(...) or ScopedGoRoute(...) declarations
+# in app.dart. DOTALL lets the regex cross newlines between `(` and `path:`.
+# The non-greedy `[^)]*?` prevents swallowing the whole route list.
+_GOROUTE_RE = re.compile(
+    r"""(?:GoRoute|ScopedGoRoute)\s*\(       # constructor
+        [^)]*?                                 # any preceding kwargs (scope:, name:, ...)
+        path\s*:\s*                            # path kwarg
+        (?P<q>['"])(?P<path>[^'"]+?)(?P=q)     # captured path literal
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# Matches `route: '/...'` literals inside ScreenEntry(...) constructors in
+# screen_registry.dart. Less complex than the GoRoute regex because every
+# ScreenEntry has a flat `route:` field (no nested routes concept here).
+# Anchored on the `route:` field name to avoid false positives on other
+# string fields (intentTag, fallbackRoute also use string literals).
+_SCREEN_ENTRY_ROUTE_RE = re.compile(
+    r"""ScreenEntry\s*\(             # constructor
+        [^)]*?                          # any preceding kwargs
+        \broute\s*:\s*                  # route kwarg (word-boundary excludes fallbackRoute)
+        (?P<q>['"])(?P<path>[^'"]+?)(?P=q)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+def extract_app_paths(src: str) -> Set[str]:
+    return {m.group("path") for m in _GOROUTE_RE.finditer(src)}
+
+
+def extract_registry_routes(src: str) -> Set[str]:
+    """Extract registry route literals, normalizing query strings.
+
+    `ScreenEntry(route: '/coach/chat?topic=foo')` is a parameter-bearing
+    shortcut — the actual GoRouter target is the bare `/coach/chat`.
+    Strip `?...` so the comparison against app.dart's path declarations
+    matches the routing reality.
+    """
+    raw = {m.group("path") for m in _SCREEN_ENTRY_ROUTE_RE.finditer(src)}
+    return {p.split("?", 1)[0] for p in raw}
+
+
+def _apply_known_misses(
+    app_paths: Set[str], reg_routes: Set[str]
+) -> Tuple[Set[str], Set[str]]:
+    """Strip KNOWN-MISSES exemptions from both sides before comparison.
+
+    Returns (app_paths_cleaned, reg_routes_cleaned).
+    """
+    # Not-chat-routable: exempt from BOTH sides. The registry intentionally
+    # holds entries for some non-chat-routable surfaces (auth, achievements,
+    # shell tabs) so the LLM can refer to them by intent without actually
+    # navigating users there (gated by `preferFromChat: false`). The lint
+    # should not enforce parity in either direction for these — they're
+    # known by the system but exempted from chat-route discipline.
+    app_cleaned = set(app_paths) - _NOT_CHAT_ROUTABLE
+    reg_cleaned = set(reg_routes) - _NOT_CHAT_ROUTABLE
+
+    # Nested children: bare segment from app side, composed from registry side.
+    nested_segments = {seg for seg, _ in _NESTED_PROFILE_CHILDREN}
+    nested_composed = {composed for _, composed in _NESTED_PROFILE_CHILDREN}
+    app_cleaned = app_cleaned - nested_segments
+    reg_cleaned = reg_cleaned - nested_composed
+
+    return app_cleaned, reg_cleaned
+
+
+# ---------------------------------------------------------------------------
+# Core comparison
+# ---------------------------------------------------------------------------
+def run_parity(app_src: str, registry_src: str) -> int:
+    app_paths = extract_app_paths(app_src)
+    reg_routes = extract_registry_routes(registry_src)
+
+    app_cmp, reg_cmp = _apply_known_misses(app_paths, reg_routes)
+    missing_in_registry = app_cmp - reg_cmp
+    ghost_in_registry = reg_cmp - app_cmp
+
+    sys.stderr.write(
+        "[info] extracted {n} path literal(s) from app.dart\n".format(n=len(app_paths))
+    )
+    sys.stderr.write(
+        "[info] registry has {n} ScreenEntry route(s); "
+        "{a} not-chat-routable + {p} nested-profile entries "
+        "exempted per KNOWN-MISSES.md\n".format(
+            n=len(reg_routes),
+            a=len(_NOT_CHAT_ROUTABLE & app_paths),
+            p=len(_NESTED_PROFILE_CHILDREN),
+        )
+    )
+
+    if not missing_in_registry and not ghost_in_registry:
+        print(
+            "[OK] {n} routes parity OK (after KNOWN-MISSES exemption).".format(
+                n=len(app_cmp)
+            )
+        )
+        return 0
+
+    if missing_in_registry:
+        sys.stderr.write(
+            "[FAIL] {n} path(s) present in app.dart but absent from MintScreenRegistry:\n".format(
+                n=len(missing_in_registry)
+            )
+        )
+        for p in sorted(missing_in_registry):
+            sys.stderr.write("  + {p}\n".format(p=p))
+        sys.stderr.write(
+            "  Fix: add a `static const _name = ScreenEntry(route: '<path>', ...)` "
+            "entry to apps/mobile/lib/services/navigation/screen_registry.dart "
+            "AND register it in the master `entries` list (~line 1487). OR, if the "
+            "route is intentionally not chat-routable (auth flow / shell tab / "
+            "admin-only), add it to `_NOT_CHAT_ROUTABLE` in this script AND "
+            "document the reason in tools/checks/screen_registry_parity-KNOWN-MISSES.md.\n"
+        )
+
+    if ghost_in_registry:
+        sys.stderr.write(
+            "[FAIL] {n} ScreenEntry route(s) declared in registry but absent from app.dart (ghost):\n".format(
+                n=len(ghost_in_registry)
+            )
+        )
+        for p in sorted(ghost_in_registry):
+            sys.stderr.write("  - {p}\n".format(p=p))
+        sys.stderr.write(
+            "  Fix: remove the stale ScreenEntry OR restore the GoRoute/ScopedGoRoute "
+            "declaration in app.dart.\n"
+        )
+
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: list) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--extract-only",
+        choices=["app", "registry"],
+        default=None,
+        help="Print extracted path literals from app.dart OR registry, sorted, then exit 0.",
+    )
+    args = parser.parse_args(argv)
+
+    if not APP_DART.exists():
+        sys.stderr.write(
+            "[FAIL] app.dart not found at {p}\n".format(p=APP_DART)
+        )
+        return 2
+    if not REGISTRY_DART.exists():
+        sys.stderr.write(
+            "[FAIL] screen_registry.dart not found at {p}\n".format(p=REGISTRY_DART)
+        )
+        return 2
+
+    app_src = APP_DART.read_text(encoding="utf-8")
+    registry_src = REGISTRY_DART.read_text(encoding="utf-8")
+
+    if args.extract_only == "app":
+        for p in sorted(extract_app_paths(app_src)):
+            print(p)
+        return 0
+    if args.extract_only == "registry":
+        for p in sorted(extract_registry_routes(registry_src)):
+            print(p)
+        return 0
+
+    return run_parity(app_src, registry_src)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Plan 53-01 — first PR (T-01 + T-02)

Phase 53's first sub-plan ships in two PRs. This is **PR-1** (lint + inventory). PR-2 (gap fill + CI wiring) follows directly.

## What this ships

- `tools/checks/screen_registry_parity.py` — mirror of the Phase 32-04 / MAP-04 `route_registry_parity.py` pattern, scoped to `MintScreenRegistry` × `app.dart` parity. Stdlib-only Python 3.9-compatible. Two CLI modes: full parity check + `--extract-only {app|registry}`.
- `tools/checks/screen_registry_parity-KNOWN-MISSES.md` — companion allow-list rationale, mirrors the Phase 32-04 doc structure.
- `.planning/phases/53-architecture-parity-and-sequence-wiring/SCREEN-REGISTRY-COVERAGE.md` — first-run inventory of the 41-route gap with per-route classification (24 ROUTABLE / 9 NOT_CHAT_ROUTABLE / 8 ALLOWLIST / 0 DEFER_DEAD).

## What this does NOT ship

- **No CI wiring yet** — the lint currently exits 1 (drift detected) on dev tip. Wiring it as a CI gate would immediately fail every PR. Wiring lands in PR-2 once the gap is closed and the lint exits 0.
- **No registry edits** — those land in PR-2 (T-03 fill).

## Why split

PR-1 is a 458-line read (3 new files, no edits to existing code). PR-2 will touch `screen_registry.dart` (~250 lines added, 41 new `ScreenEntry` rows). Splitting reduces blast radius — if the registry edits have issues, the lint and inventory are already in place to validate the fix.

## Test plan

- [x] `python3 tools/checks/screen_registry_parity.py` → exits 1 with diagnostic listing 41 missing routes (expected pre-PR-2)
- [x] `python3 tools/checks/screen_registry_parity.py --extract-only app | wc -l` → 153
- [x] `python3 tools/checks/screen_registry_parity.py --extract-only registry | wc -l` → 105
- [x] `python3 tools/checks/screen_registry_parity.py --extract-only app | head` → sorted path list
- [ ] CI green on dev (this PR doesn't add a new CI job, so existing checks should be unaffected)

## References

- Plan: `.planning/phases/53-architecture-parity-and-sequence-wiring/53-01-PLAN.md`
- Decision: `.planning/decisions/2026-05-04-phase-53-target.md`
- Pattern source: `tools/checks/route_registry_parity.py` (Phase 32-04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)