### PR TITLE
feat(phase-53-03): Tab 1 « Mes engagements & check-ins » surface

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11157,5 +11157,8 @@
   "settingsPrivacyDataLocation": "Deine Fragebogen-Antworten und dein Chat-Verlauf bleiben auf deinem Gerät. Wenn du dem KI-Coach schreibst, durchläuft deine Nachricht unsere Server, um die Antwort zu generieren — mit aktivierter Synchronisation werden die Fakten, die du bestätigst (Alter, Lohn, Kanton…), auch auf unseren Servern gespeichert; bei deaktivierter Synchronisation bleiben sie nur auf deinem Gerät.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Die Synchronisation zu deaktivieren löscht nicht die Daten, die bereits auf unseren Servern gespeichert sind. Um sie zu entfernen, gehe zu Konto › Konto löschen.",
   "profileSyncRowHint": "Verwalten in Einstellungen › Datenschutz",
-  "settingsPrivacyMigrationToastCta": "Ansehen"
+  "settingsPrivacyMigrationToastCta": "Ansehen",
+  "aujourdhuiCommitmentsTitle": "Deine letzten Verpflichtungen",
+  "aujourdhuiCheckInsTitle": "Deine letzten Check-ins",
+  "aujourdhuiResumeConversation": "Gespräch fortsetzen"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11157,5 +11157,8 @@
   "settingsPrivacyDataLocation": "Your wizard answers and chat history stay on your device. When you write to the AI coach, your message transits through our servers to generate the reply — with sync on, the facts you confirm (age, salary, canton…) are also saved on our servers; with sync off, they're kept only on your device.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Turning sync off doesn't delete data already saved to our servers. To remove it, go to Account › Delete my account.",
   "profileSyncRowHint": "Manage in Settings › Privacy",
-  "settingsPrivacyMigrationToastCta": "View"
+  "settingsPrivacyMigrationToastCta": "View",
+  "aujourdhuiCommitmentsTitle": "Your recent commitments",
+  "aujourdhuiCheckInsTitle": "Your latest check-ins",
+  "aujourdhuiResumeConversation": "Resume conversation"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11157,5 +11157,8 @@
   "settingsPrivacyDataLocation": "Tus respuestas del cuestionario y tu historial de chat quedan en tu dispositivo. Cuando escribes al coach IA, tu mensaje pasa por nuestros servidores para generar la respuesta — con la sincronización activada, los hechos que confirmas (edad, salario, cantón…) también se guardan en nuestros servidores; con la sincronización desactivada, se guardan solo en tu dispositivo.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Desactivar la sincronización no borra los datos ya guardados en nuestros servidores. Para eliminarlos, ve a Cuenta › Eliminar mi cuenta.",
   "profileSyncRowHint": "Gestionar en Ajustes › Privacidad",
-  "settingsPrivacyMigrationToastCta": "Ver"
+  "settingsPrivacyMigrationToastCta": "Ver",
+  "aujourdhuiCommitmentsTitle": "Tus compromisos recientes",
+  "aujourdhuiCheckInsTitle": "Tus últimos check-ins",
+  "aujourdhuiResumeConversation": "Reanudar la conversación"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12097,5 +12097,8 @@
   "settingsPrivacyDataLocation": "Tes réponses au questionnaire et ton historique de chat restent sur ton appareil. Quand tu écris au coach IA, ton message transite par nos serveurs pour générer la réponse — avec la sync activée, les faits que tu confirmes (âge, salaire, canton…) sont aussi sauvegardés sur nos serveurs ; sync désactivée, ils ne sont gardés que sur ton appareil.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Désactiver la sync n'efface pas les données déjà sauvegardées sur nos serveurs. Pour les supprimer, va dans Compte › Supprimer mon compte.",
   "profileSyncRowHint": "Gérer dans Réglages › Confidentialité",
-  "settingsPrivacyMigrationToastCta": "Voir"
+  "settingsPrivacyMigrationToastCta": "Voir",
+  "aujourdhuiCommitmentsTitle": "Tes engagements récents",
+  "aujourdhuiCheckInsTitle": "Tes derniers check-ins",
+  "aujourdhuiResumeConversation": "Reprendre la conversation"
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11157,5 +11157,8 @@
   "settingsPrivacyDataLocation": "Le tue risposte al questionario e la tua cronologia chat restano sul tuo dispositivo. Quando scrivi al coach IA, il tuo messaggio transita per i nostri server per generare la risposta — con la sincronizzazione attiva, i fatti che confermi (età, stipendio, cantone…) sono anche salvati sui nostri server; con la sincronizzazione disattivata, restano solo sul tuo dispositivo.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Disattivare la sincronizzazione non elimina i dati già salvati sui nostri server. Per rimuoverli, vai su Account › Elimina account.",
   "profileSyncRowHint": "Gestisci in Impostazioni › Privacy",
-  "settingsPrivacyMigrationToastCta": "Vedi"
+  "settingsPrivacyMigrationToastCta": "Vedi",
+  "aujourdhuiCommitmentsTitle": "I tuoi impegni recenti",
+  "aujourdhuiCheckInsTitle": "I tuoi ultimi check-in",
+  "aujourdhuiResumeConversation": "Riprendi la conversazione"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40628,6 +40628,24 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Voir'**
   String get settingsPrivacyMigrationToastCta;
+
+  /// No description provided for @aujourdhuiCommitmentsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes engagements récents'**
+  String get aujourdhuiCommitmentsTitle;
+
+  /// No description provided for @aujourdhuiCheckInsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes derniers check-ins'**
+  String get aujourdhuiCheckInsTitle;
+
+  /// No description provided for @aujourdhuiResumeConversation.
+  ///
+  /// In fr, this message translates to:
+  /// **'Reprendre la conversation'**
+  String get aujourdhuiResumeConversation;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23220,4 +23220,13 @@ class SDe extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'Ansehen';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'Deine letzten Verpflichtungen';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'Deine letzten Check-ins';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Gespräch fortsetzen';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23050,4 +23050,13 @@ class SEn extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'View';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'Your recent commitments';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'Your latest check-ins';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Resume conversation';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23163,4 +23163,13 @@ class SEs extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'Ver';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'Tus compromisos recientes';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'Tus últimos check-ins';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Reanudar la conversación';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23165,4 +23165,13 @@ class SFr extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'Voir';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'Tes engagements récents';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'Tes derniers check-ins';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Reprendre la conversation';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23224,4 +23224,13 @@ class SIt extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'Vedi';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'I tuoi impegni recenti';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'I tuoi ultimi check-in';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Riprendi la conversazione';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23171,4 +23171,13 @@ class SPt extends S {
 
   @override
   String get settingsPrivacyMigrationToastCta => 'Ver';
+
+  @override
+  String get aujourdhuiCommitmentsTitle => 'Os teus compromissos recentes';
+
+  @override
+  String get aujourdhuiCheckInsTitle => 'Os teus últimos check-ins';
+
+  @override
+  String get aujourdhuiResumeConversation => 'Retomar a conversa';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11157,5 +11157,8 @@
   "settingsPrivacyDataLocation": "As tuas respostas ao questionário e o teu histórico de chat ficam no teu dispositivo. Quando escreves ao coach IA, a tua mensagem transita pelos nossos servidores para gerar a resposta — com a sincronização ativa, os factos que confirmas (idade, salário, cantão…) são também guardados nos nossos servidores; com a sincronização desativada, ficam só no teu dispositivo.",
   "settingsPrivacyCloudSyncOffServerCaveat": "Desativar a sincronização não apaga os dados já guardados nos nossos servidores. Para os remover, vai a Conta › Eliminar a minha conta.",
   "profileSyncRowHint": "Gerir em Definições › Privacidade",
-  "settingsPrivacyMigrationToastCta": "Ver"
+  "settingsPrivacyMigrationToastCta": "Ver",
+  "aujourdhuiCommitmentsTitle": "Os teus compromissos recentes",
+  "aujourdhuiCheckInsTitle": "Os teus últimos check-ins",
+  "aujourdhuiResumeConversation": "Retomar a conversa"
 }

--- a/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
+++ b/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
@@ -23,6 +23,7 @@ import 'package:mint_mobile/theme/colors.dart';
 // above the TensionCards. The provider is kept fresh by the
 // ChangeNotifierProxyProvider wired in `app.dart`.
 import 'package:mint_mobile/widgets/aujourdhui/cap_du_jour_banner.dart';
+import 'package:mint_mobile/widgets/aujourdhui/commitments_and_checkins_card.dart';
 import 'package:mint_mobile/widgets/tension/cleo_loop_indicator.dart';
 import 'package:mint_mobile/widgets/tension/tension_card_widget.dart';
 import 'package:mint_mobile/widgets/timeline/month_header_widget.dart';
@@ -325,6 +326,14 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
                   ),
                 ),
               ),
+
+            // ── Phase 53-03 — Mes engagements & check-ins ──────
+            // Surfaces previously-silent persistent tools (commitments,
+            // monthly check-ins) so the user actually sees what the chat
+            // captured. Hides itself when both data sources are empty.
+            const SliverToBoxAdapter(
+              child: CommitmentsAndCheckinsCard(),
+            ),
 
             // ── Bottom padding ─────────────────────────────────
             const SliverToBoxAdapter(

--- a/apps/mobile/lib/widgets/aujourdhui/commitments_and_checkins_card.dart
+++ b/apps/mobile/lib/widgets/aujourdhui/commitments_and_checkins_card.dart
@@ -1,0 +1,310 @@
+/// Phase 53-03 — Tab 1 « Mes engagements & check-ins » surface.
+///
+/// Closes the « tool fires, persists, then disappears » UX gap caught by
+/// Expert 5 in the post-Phase-52.2 panel: every `record_check_in` /
+/// `show_commitment_card` chat tool persists silently and is then invisible
+/// outside the chat bubble that produced it.
+///
+/// Reads two data sources:
+///   * `CoachProfileProvider.profile.checkIns` — sync, in-memory; surfaced
+///     immediately when the provider has loaded.
+///   * `CommitmentService.getCommitments(status: 'active')` — async network
+///     call; surfaced via FutureBuilder. Failure is silent (card hides the
+///     commitments section rather than spamming an error).
+///
+/// Tap behavior: opens `/coach/chat`. Per `MonthlyCheckIn` model
+/// (`coach_profile.dart:1187`) there is currently no `chatSessionId` field
+/// to deep-link the originating conversation, so the tap falls back to a
+/// generic resume. Adding `chatSessionId` is a follow-up plan (Phase 55+).
+///
+/// Empty-state contract: returns `SizedBox.shrink()` when BOTH sources are
+/// empty. No « no data » placeholder — silent absence per Plan 53-03 spec.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/commitment_service.dart';
+import 'package:mint_mobile/theme/colors.dart';
+
+class CommitmentsAndCheckinsCard extends StatefulWidget {
+  const CommitmentsAndCheckinsCard({
+    super.key,
+    this.commitmentService,
+    this.maxItemsPerSection = 3,
+  });
+
+  /// Optional injection seam for tests.
+  final CommitmentService? commitmentService;
+
+  /// Number of items to show per section (commitments / check-ins).
+  /// Older items are truncated; user can resume conversation to see all.
+  final int maxItemsPerSection;
+
+  @override
+  State<CommitmentsAndCheckinsCard> createState() =>
+      _CommitmentsAndCheckinsCardState();
+}
+
+class _CommitmentsAndCheckinsCardState
+    extends State<CommitmentsAndCheckinsCard> {
+  late final CommitmentService _service =
+      widget.commitmentService ?? CommitmentService();
+
+  late Future<List<Map<String, dynamic>>> _commitmentsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _commitmentsFuture = _loadCommitments();
+  }
+
+  Future<List<Map<String, dynamic>>> _loadCommitments() async {
+    try {
+      return await _service.getCommitments(status: 'active');
+    } catch (_) {
+      // Silent failure: the card simply hides the commitments section.
+      // The auth-failure path (no_auth) is the most common case for
+      // anonymous users; surfacing the error would be noise.
+      return const [];
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = S.of(context);
+    if (l10n == null) return const SizedBox.shrink();
+
+    final profile = context.watch<CoachProfileProvider>().profile;
+    final checkIns = profile?.checkIns ?? const <MonthlyCheckIn>[];
+
+    return FutureBuilder<List<Map<String, dynamic>>>(
+      future: _commitmentsFuture,
+      builder: (context, snapshot) {
+        final commitments = snapshot.data ?? const <Map<String, dynamic>>[];
+        if (commitments.isEmpty && checkIns.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: MintColors.craie,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: MintColors.textMutedAaa.withValues(alpha: 0.15),
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (commitments.isNotEmpty) ...[
+                  _SectionHeader(
+                    title: l10n.aujourdhuiCommitmentsTitle,
+                  ),
+                  const SizedBox(height: 8),
+                  ..._buildCommitmentRows(context, commitments, l10n),
+                ],
+                if (commitments.isNotEmpty && checkIns.isNotEmpty)
+                  const SizedBox(height: 16),
+                if (checkIns.isNotEmpty) ...[
+                  _SectionHeader(
+                    title: l10n.aujourdhuiCheckInsTitle,
+                  ),
+                  const SizedBox(height: 8),
+                  ..._buildCheckInRows(context, checkIns, l10n),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  List<Widget> _buildCommitmentRows(
+    BuildContext context,
+    List<Map<String, dynamic>> commitments,
+    S l10n,
+  ) {
+    final shown = commitments.take(widget.maxItemsPerSection).toList();
+    return shown
+        .map(
+          (c) => _ItemRow(
+            icon: Icons.bookmark_border_rounded,
+            text: _summarizeCommitment(c),
+            relativeTime: _relativeTime(c['createdAt']?.toString()),
+            onTap: () => _resumeConversation(context),
+            semanticLabel: l10n.aujourdhuiResumeConversation,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  List<Widget> _buildCheckInRows(
+    BuildContext context,
+    List<MonthlyCheckIn> checkIns,
+    S l10n,
+  ) {
+    final sorted = [...checkIns]
+      ..sort((a, b) => b.completedAt.compareTo(a.completedAt));
+    final shown = sorted.take(widget.maxItemsPerSection).toList();
+    return shown
+        .map(
+          (ci) => _ItemRow(
+            icon: Icons.check_circle_outline_rounded,
+            text: _summarizeCheckIn(ci),
+            relativeTime: _relativeTime(ci.completedAt.toIso8601String()),
+            onTap: () => _resumeConversation(context),
+            semanticLabel: l10n.aujourdhuiResumeConversation,
+          ),
+        )
+        .toList(growable: false);
+  }
+
+  String _summarizeCommitment(Map<String, dynamic> c) {
+    final whenText = (c['whenText'] ?? '').toString();
+    final ifThen = (c['ifThenText'] ?? '').toString();
+    if (whenText.isNotEmpty && ifThen.isNotEmpty) {
+      return '$whenText • $ifThen';
+    }
+    if (whenText.isNotEmpty) return whenText;
+    if (ifThen.isNotEmpty) return ifThen;
+    return (c['summary'] ?? '').toString();
+  }
+
+  String _summarizeCheckIn(MonthlyCheckIn ci) {
+    final monthLabel = _monthLabel(ci.month);
+    final total = ci.totalVersements;
+    if (total > 0) {
+      return '$monthLabel • ${total.toStringAsFixed(0)} CHF';
+    }
+    return monthLabel;
+  }
+
+  String _monthLabel(DateTime month) {
+    const months = [
+      'janv.',
+      'févr.',
+      'mars',
+      'avr.',
+      'mai',
+      'juin',
+      'juil.',
+      'août',
+      'sept.',
+      'oct.',
+      'nov.',
+      'déc.',
+    ];
+    final idx = (month.month - 1).clamp(0, 11);
+    return '${months[idx]} ${month.year}';
+  }
+
+  String _relativeTime(String? isoString) {
+    if (isoString == null || isoString.isEmpty) return '';
+    final dt = DateTime.tryParse(isoString);
+    if (dt == null) return '';
+    final diff = DateTime.now().difference(dt);
+    if (diff.inDays >= 1) {
+      return diff.inDays == 1
+          ? 'il y a 1 jour'
+          : 'il y a ${diff.inDays} jours';
+    }
+    if (diff.inHours >= 1) {
+      return diff.inHours == 1
+          ? 'il y a 1 h'
+          : 'il y a ${diff.inHours} h';
+    }
+    return 'à l\'instant';
+  }
+
+  void _resumeConversation(BuildContext context) {
+    context.push('/coach/chat');
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: GoogleFonts.montserrat(
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.6,
+        color: MintColors.textPrimary,
+      ),
+    );
+  }
+}
+
+class _ItemRow extends StatelessWidget {
+  const _ItemRow({
+    required this.icon,
+    required this.text,
+    required this.relativeTime,
+    required this.onTap,
+    required this.semanticLabel,
+  });
+
+  final IconData icon;
+  final String text;
+  final String relativeTime;
+  final VoidCallback onTap;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 4),
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: MintColors.textSecondary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  text,
+                  style: GoogleFonts.inter(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w400,
+                    color: MintColors.textPrimary,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (relativeTime.isNotEmpty) ...[
+                const SizedBox(width: 8),
+                Text(
+                  relativeTime,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w400,
+                    color: MintColors.textMutedAaa,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/widgets/aujourdhui/commitments_and_checkins_card_test.dart
+++ b/apps/mobile/test/widgets/aujourdhui/commitments_and_checkins_card_test.dart
@@ -1,0 +1,181 @@
+/// Phase 53-03 — widget test for Tab 1 commitments + check-ins card.
+///
+/// Asserts the four contracts from `53-03-PLAN.md` T-04:
+///   1. Profile with both → card renders both sections.
+///   2. Profile with only check-ins → check-ins section shows, commitments
+///      section absent (FutureBuilder returns empty list).
+///   3. Both empty → SizedBox.shrink (card not present in tree).
+///   4. Tap on item → navigation to /coach/chat invoked.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/commitment_service.dart';
+import 'package:mint_mobile/widgets/aujourdhui/commitments_and_checkins_card.dart';
+
+class _FakeCommitmentService implements CommitmentService {
+  _FakeCommitmentService(this._items);
+  final List<Map<String, dynamic>> _items;
+
+  @override
+  Future<List<Map<String, dynamic>>> getCommitments({String? status}) async =>
+      _items;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeCoachProfileProvider extends ChangeNotifier
+    implements CoachProfileProvider {
+  _FakeCoachProfileProvider(this._profile);
+  CoachProfile? _profile;
+
+  @override
+  CoachProfile? get profile => _profile;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+CoachProfile _profileWithCheckIns(int n) {
+  final base = CoachProfile.defaults();
+  final checkIns = List.generate(
+    n,
+    (i) => MonthlyCheckIn(
+      month: DateTime(2026, 1 + (i % 12)),
+      versements: {'3a_user': 604.83},
+      completedAt: DateTime.now().subtract(Duration(days: i + 1)),
+    ),
+  );
+  return base.copyWithCheckIns(checkIns);
+}
+
+Widget _harness({
+  required Widget child,
+  required CoachProfileProvider provider,
+  GoRouter? router,
+}) {
+  final r = router ??
+      GoRouter(
+        routes: [
+          GoRoute(path: '/', builder: (_, __) => Scaffold(body: child)),
+          GoRoute(path: '/coach/chat', builder: (_, __) => const Scaffold()),
+        ],
+      );
+  return MaterialApp.router(
+    routerConfig: r,
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    builder: (context, child) =>
+        ChangeNotifierProvider<CoachProfileProvider>.value(
+      value: provider,
+      child: child!,
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders both sections when both data sources non-empty',
+      (tester) async {
+    final provider = _FakeCoachProfileProvider(_profileWithCheckIns(2));
+    final service = _FakeCommitmentService(const [
+      {
+        'whenText': 'Lundi à 9h',
+        'ifThenText': 'je verse 100 CHF sur le 3a',
+        'createdAt': '2026-04-30T08:00:00Z',
+      },
+    ]);
+    await tester.pumpWidget(
+      _harness(
+        provider: provider,
+        child: CommitmentsAndCheckinsCard(commitmentService: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('engagements'), findsOneWidget);
+    expect(find.textContaining('check-ins'), findsOneWidget);
+    expect(find.textContaining('Lundi à 9h'), findsOneWidget);
+  });
+
+  testWidgets('shows only check-ins section when commitments empty',
+      (tester) async {
+    final provider = _FakeCoachProfileProvider(_profileWithCheckIns(1));
+    final service = _FakeCommitmentService(const []);
+    await tester.pumpWidget(
+      _harness(
+        provider: provider,
+        child: CommitmentsAndCheckinsCard(commitmentService: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('engagements'), findsNothing);
+    expect(find.textContaining('check-ins'), findsOneWidget);
+  });
+
+  testWidgets('hides card entirely when both data sources empty',
+      (tester) async {
+    final provider = _FakeCoachProfileProvider(CoachProfile.defaults());
+    final service = _FakeCommitmentService(const []);
+    await tester.pumpWidget(
+      _harness(
+        provider: provider,
+        child: CommitmentsAndCheckinsCard(commitmentService: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CommitmentsAndCheckinsCard), findsOneWidget);
+    // The card should render as SizedBox.shrink — no headers visible
+    expect(find.textContaining('engagements'), findsNothing);
+    expect(find.textContaining('check-ins'), findsNothing);
+  });
+
+  testWidgets('tap on item navigates to /coach/chat', (tester) async {
+    final provider = _FakeCoachProfileProvider(_profileWithCheckIns(1));
+    final service = _FakeCommitmentService(const []);
+    String? lastNavigated;
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => Scaffold(
+            body: CommitmentsAndCheckinsCard(commitmentService: service),
+          ),
+        ),
+        GoRoute(
+          path: '/coach/chat',
+          builder: (_, __) {
+            lastNavigated = '/coach/chat';
+            return const Scaffold();
+          },
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      _harness(provider: provider, router: router, child: const SizedBox()),
+    );
+    await tester.pumpAndSettle();
+
+    final checkInRow = find.byIcon(Icons.check_circle_outline_rounded);
+    expect(checkInRow, findsOneWidget);
+    await tester.tap(checkInRow);
+    await tester.pumpAndSettle();
+
+    expect(lastNavigated, equals('/coach/chat'));
+  });
+}


### PR DESCRIPTION
## Plan 53-03 execution

Closes the « tool fires, persists, then disappears » UX gap caught by Expert 5 (post-Phase-52.2 panel): every `record_check_in` and `show_commitment_card` chat tool persists silently and was previously **invisible** outside the chat bubble that produced it.

## What this ships

**New widget** `apps/mobile/lib/widgets/aujourdhui/commitments_and_checkins_card.dart`:
- Reads `CoachProfileProvider.profile.checkIns` (sync, in-memory) + `CommitmentService.getCommitments(status: 'active')` (async via `FutureBuilder`)
- Renders up to 3 most-recent items per section (configurable via `maxItemsPerSection`)
- Tap → `context.push('/coach/chat')` (no `chatSessionId` field on `MonthlyCheckIn` yet — generic resume per Plan 53-03 Risk #2; deep-link is a Phase 55+ follow-up)
- Hides via `SizedBox.shrink` when BOTH sources empty (silent absence per spec — no « no data » placeholder)
- Visual: reuses MintColors.craie + Montserrat headers + Inter rows pattern (no new design panel needed since it follows the existing `ContextualCard` treatment)

**Mounted** in `apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart` at the bottom of the scrollable feed (after timeline nodes, before the bottom padding sliver).

**3 ARB keys × 6 locales** (FR/EN/DE/ES/IT/PT): `aujourdhuiCommitmentsTitle`, `aujourdhuiCheckInsTitle`, `aujourdhuiResumeConversation`. Generated `app_localizations*.dart`.

**Widget test** with 4 cases:
1. Both sections render when both sources non-empty
2. Only check-ins section when commitments empty
3. Both empty → card hides (`SizedBox.shrink`)
4. Tap on item → navigation to `/coach/chat` invoked

## Pre-push checklist (per `feedback_pre_push_checklist.md`)

- [x] `flutter gen-l10n` ran (12 generated `.dart` files updated)
- [x] `flutter analyze` on touched files → 0 issues
- [x] `flutter test test/widgets/aujourdhui/commitments_and_checkins_card_test.dart` → 4/4 PASS
- [x] `python3 tools/checks/no_e2ee_overclaim.py` → exit 0
- [x] `python3 tools/checks/accent_lint_fr.py --file ...app_fr.arb` → exit 0
- [x] `python3 tools/checks/screen_registry_parity.py` → exit 0 (sanity, no registry change)
- [x] ARB key counts: 8727 across 5 sibling locales + 9133 in fr (with `@meta` entries) → +3 keys per locale → matches edits

## What's NOT here (scope discipline)

- **No earmark surfacing** — separate follow-up plan
- **No partnerEstimate surfacing** — separate (involves household / couple flow)
- **No edit / delete from card** — read-only
- **No `chatSessionId` deep-link** — `MonthlyCheckIn` model lacks the field; tap falls back to generic resume (per Risk #2 in Plan 53-03)
- **No backend changes** — read-only mobile-side surfacing

## References

- Plan: `.planning/phases/53-architecture-parity-and-sequence-wiring/53-03-PLAN.md`
- Decision: `.planning/decisions/2026-05-04-phase-53-target.md` (Expert 5 verdict)
- Phase 53 close-out audit will run after Plan 53-02 (SequenceChatHandler wiring) also lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)