### PR TITLE
fix(phase-52.4): vault-metaphor truth sweep — close Phase 52.3 lint scope gap

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -3491,7 +3491,7 @@
   "authGateDocScanTitle": "Sichere deine Dokumente",
   "authGateDocScanMessage": "Deine Zertifikate enthalten sensible Daten. Erstelle ein Konto, um sie auf unseren Servern zu verschlüsseln und von deinen Geräten abzurufen — du kannst jederzeit alles lokal behalten unter Datenschutz.",
   "authGateSalaryTitle": "Schütze deine Finanzdaten",
-  "authGateSalaryMessage": "Dein Gehalt und deine Finanzdaten verdienen einen sicheren Tresor.",
+  "authGateSalaryMessage": "Erstelle ein Konto, um dein Gehalt und deine Finanzdaten auf unseren Servern zu verschlüsseln und von deinen Geräten abzurufen — du kannst jederzeit alles lokal behalten unter Datenschutz.",
   "authGateCoachTitle": "Der Coach muss dich kennenlernen",
   "authGateCoachMessage": "Um dir personalisierte Antworten zu geben, braucht der Coach ein Konto.",
   "authGateGoalTitle": "Verfolge deine Fortschritte",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -3491,7 +3491,7 @@
   "authGateDocScanTitle": "Secure your documents",
   "authGateDocScanMessage": "Your certificates contain sensitive data. Create an account to encrypt them on our servers and access them from your devices — you can keep everything on-device at any time from Privacy.",
   "authGateSalaryTitle": "Protect your financial data",
-  "authGateSalaryMessage": "Your salary and financial data deserve a secure vault.",
+  "authGateSalaryMessage": "Create an account to encrypt your salary and financial data on our servers and access them from your devices — you can keep everything on-device at any time from Privacy.",
   "authGateCoachTitle": "The coach needs to know you",
   "authGateCoachMessage": "To give you personalised answers, the coach needs an account.",
   "authGateGoalTitle": "Track your progress",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -3491,7 +3491,7 @@
   "authGateDocScanTitle": "Protege tus documentos",
   "authGateDocScanMessage": "Tus certificados contienen datos sensibles. Crea una cuenta para cifrarlos en nuestros servidores y acceder a ellos desde tus dispositivos — puedes mantener todo en local en cualquier momento desde Privacidad.",
   "authGateSalaryTitle": "Protege tus datos financieros",
-  "authGateSalaryMessage": "Tu salario y tus datos financieros merecen una caja fuerte segura.",
+  "authGateSalaryMessage": "Crea una cuenta para cifrar tu salario y tus datos financieros en nuestros servidores y acceder a ellos desde tus dispositivos — puedes mantener todo en local en cualquier momento desde Privacidad.",
   "authGateCoachTitle": "El coach necesita conocerte",
   "authGateCoachMessage": "Para darte respuestas personalizadas, el coach necesita una cuenta.",
   "authGateGoalTitle": "Sigue tu progreso",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -3784,7 +3784,7 @@
   "authGateDocScanTitle": "Sécurise tes documents",
   "authGateDocScanMessage": "Tes certificats contiennent des données sensibles. Crée un compte pour les chiffrer sur nos serveurs et les retrouver depuis tes appareils — tu peux à tout moment garder tout en local depuis Confidentialité.",
   "authGateSalaryTitle": "Protège tes données financières",
-  "authGateSalaryMessage": "Ton salaire et tes données financières méritent un coffre-fort sécurisé.",
+  "authGateSalaryMessage": "Crée un compte pour chiffrer ton salaire et tes données financières sur nos serveurs et y accéder depuis tes appareils — tu peux à tout moment limiter à ton appareil dans Confidentialité.",
   "authGateCoachTitle": "Le coach a besoin de te connaître",
   "authGateCoachMessage": "Pour te donner des réponses personnalisées, le coach a besoin d'un compte.",
   "authGateGoalTitle": "Suis tes progrès",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -3491,7 +3491,7 @@
   "authGateDocScanTitle": "Proteggi i tuoi documenti",
   "authGateDocScanMessage": "I tuoi certificati contengono dati sensibili. Crea un account per cifrarli sui nostri server e accedervi dai tuoi dispositivi — puoi mantenere tutto in locale in qualsiasi momento da Privacy.",
   "authGateSalaryTitle": "Proteggi i tuoi dati finanziari",
-  "authGateSalaryMessage": "Il tuo stipendio e i tuoi dati finanziari meritano una cassaforte sicura.",
+  "authGateSalaryMessage": "Crea un account per cifrare il tuo stipendio e i tuoi dati finanziari sui nostri server e accedervi dai tuoi dispositivi — puoi mantenere tutto in locale in qualsiasi momento da Privacy.",
   "authGateCoachTitle": "Il coach ha bisogno di conoscerti",
   "authGateCoachMessage": "Per darti risposte personalizzate, il coach ha bisogno di un account.",
   "authGateGoalTitle": "Segui i tuoi progressi",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -13359,7 +13359,7 @@ abstract class S {
   /// No description provided for @authGateSalaryMessage.
   ///
   /// In fr, this message translates to:
-  /// **'Ton salaire et tes données financières méritent un coffre-fort sécurisé.'**
+  /// **'Crée un compte pour chiffrer ton salaire et tes données financières sur nos serveurs et y accéder depuis tes appareils — tu peux à tout moment limiter à ton appareil dans Confidentialité.'**
   String get authGateSalaryMessage;
 
   /// No description provided for @authGateCoachTitle.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -7533,7 +7533,7 @@ class SDe extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'Dein Gehalt und deine Finanzdaten verdienen einen sicheren Tresor.';
+      'Erstelle ein Konto, um dein Gehalt und deine Finanzdaten auf unseren Servern zu verschlüsseln und von deinen Geräten abzurufen — du kannst jederzeit alles lokal behalten unter Datenschutz.';
 
   @override
   String get authGateCoachTitle => 'Der Coach muss dich kennenlernen';

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -7471,7 +7471,7 @@ class SEn extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'Your salary and financial data deserve a secure vault.';
+      'Create an account to encrypt your salary and financial data on our servers and access them from your devices — you can keep everything on-device at any time from Privacy.';
 
   @override
   String get authGateCoachTitle => 'The coach needs to know you';

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -7518,7 +7518,7 @@ class SEs extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'Tu salario y tus datos financieros merecen una caja fuerte segura.';
+      'Crea una cuenta para cifrar tu salario y tus datos financieros en nuestros servidores y acceder a ellos desde tus dispositivos — puedes mantener todo en local en cualquier momento desde Privacidad.';
 
   @override
   String get authGateCoachTitle => 'El coach necesita conocerte';

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -7518,7 +7518,7 @@ class SFr extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'Ton salaire et tes données financières méritent un coffre-fort sécurisé.';
+      'Crée un compte pour chiffrer ton salaire et tes données financières sur nos serveurs et y accéder depuis tes appareils — tu peux à tout moment limiter à ton appareil dans Confidentialité.';
 
   @override
   String get authGateCoachTitle => 'Le coach a besoin de te connaître';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -7529,7 +7529,7 @@ class SIt extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'Il tuo stipendio e i tuoi dati finanziari meritano una cassaforte sicura.';
+      'Crea un account per cifrare il tuo stipendio e i tuoi dati finanziari sui nostri server e accedervi dai tuoi dispositivi — puoi mantenere tutto in locale in qualsiasi momento da Privacy.';
 
   @override
   String get authGateCoachTitle => 'Il coach ha bisogno di conoscerti';

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -7512,7 +7512,7 @@ class SPt extends S {
 
   @override
   String get authGateSalaryMessage =>
-      'O teu salário e os teus dados financeiros merecem um cofre seguro.';
+      'Cria uma conta para cifrar o teu salário e os teus dados financeiros nos nossos servidores e aceder-lhes a partir dos teus dispositivos — podes manter tudo localmente a qualquer momento em Privacidade.';
 
   @override
   String get authGateCoachTitle => 'O coach precisa de te conhecer';

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -3491,7 +3491,7 @@
   "authGateDocScanTitle": "Protege os teus documentos",
   "authGateDocScanMessage": "Os teus certificados contêm dados sensíveis. Cria uma conta para os cifrar nos nossos servidores e aceder-lhes a partir dos teus dispositivos — podes manter tudo localmente a qualquer momento em Privacidade.",
   "authGateSalaryTitle": "Protege os teus dados financeiros",
-  "authGateSalaryMessage": "O teu salário e os teus dados financeiros merecem um cofre seguro.",
+  "authGateSalaryMessage": "Cria uma conta para cifrar o teu salário e os teus dados financeiros nos nossos servidores e aceder-lhes a partir dos teus dispositivos — podes manter tudo localmente a qualquer momento em Privacidade.",
   "authGateCoachTitle": "O coach precisa de te conhecer",
   "authGateCoachMessage": "Para te dar respostas personalizadas, o coach precisa de uma conta.",
   "authGateGoalTitle": "Acompanha o teu progresso",

--- a/tools/checks/no_e2ee_overclaim.py
+++ b/tools/checks/no_e2ee_overclaim.py
@@ -50,6 +50,18 @@ DOC_GLOBS = (
 # E2EE / zero-knowledge claim patterns, multilingual. Case-insensitive.
 # Word boundaries are loose because « end-to-end » / « bout en bout » are
 # multi-token; we match the loaded phrases verbatim.
+#
+# Phase 52.4 expansion: VAULT_METAPHOR family. The previous Phase 52.3
+# sweep caught the literal « end-to-end encryption » class but missed
+# « secure vault / coffre-fort sécurisé / sicherer Tresor / cassaforte
+# sicura / caja fuerte segura / cofre seguro », which carries the same
+# zero-knowledge implication for users familiar with Bitwarden /
+# 1Password / Threema. Any reader who associates « vault » with the
+# password-manager category will infer that MINT cannot decrypt their
+# data — which contradicts Path A (operator-held DEK on Railway).
+# Allow-listed via `ALLOW-VAULT-METAPHOR` per-line override OR by
+# co-occurring « operator-held / chiffré côté serveur / Path A » on
+# the same line (handled by ALLOW_LINE_PATTERNS).
 PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bend[- ]to[- ]end\s+encrypt", re.I), "EN E2EE claim"),
     (re.compile(r"\bchiffrement\s+de\s+bout\s+en\s+bout\b", re.I), "FR E2EE claim"),
@@ -60,6 +72,13 @@ PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r"\bencripta[çc][ãa]o\s+ponto\s+a\s+ponto\b", re.I), "PT E2EE claim"),
     (re.compile(r"\bE2EE\b", re.I), "E2EE acronym"),
     (re.compile(r"\bzero[- ]knowledge\b", re.I), "zero-knowledge claim"),
+    # ── VAULT_METAPHOR family (Phase 52.4) ──────────────────────────
+    (re.compile(r"\bsecure\s+vault\b", re.I), "EN vault metaphor"),
+    (re.compile(r"\bcoffre[- ]fort\s+s[ée]curis[ée]\b", re.I), "FR vault metaphor"),
+    (re.compile(r"\bsicheren?\s+Tresor\b", re.I), "DE vault metaphor"),
+    (re.compile(r"\bcassaforte\s+sicura\b", re.I), "IT vault metaphor"),
+    (re.compile(r"\bcaja\s+fuerte\s+segura\b", re.I), "ES vault metaphor"),
+    (re.compile(r"\bcofre\s+seguro\b", re.I), "PT vault metaphor"),
 ]
 
 # Allow-list patterns: legitimate references that MUST stay (roadmap /
@@ -76,6 +95,14 @@ ALLOW_LINE_PATTERNS: list[re.Pattern] = [
     re.compile(r"ADR-", re.I),
     re.compile(r"ALLOW-E2EE-CLAIM", re.I),
     re.compile(r"//\s*ALLOW-E2EE", re.I),
+    re.compile(r"ALLOW-VAULT-METAPHOR", re.I),
+    re.compile(r"//\s*ALLOW-VAULT", re.I),
+    # Path A truthful framing: if the line co-mentions « operator-held »
+    # or « chiffré côté serveur » or « Path A », the vault metaphor is
+    # contextualized and not a zero-knowledge overclaim.
+    re.compile(r"operator[- ]held", re.I),
+    re.compile(r"chiffr[ée]\s+c[ôo]t[ée]\s+serveur", re.I),
+    re.compile(r"\bPath\s+A\b", re.I),
 ]
 
 # Files where E2EE is discussed as future-state and therefore allowed
@@ -88,6 +115,7 @@ ALLOW_FILE_PATTERNS: list[re.Pattern] = [
     re.compile(r"decisions/.*ADR-", re.I),
     re.compile(r"tools/checks/no_e2ee_overclaim\.py$"),
     re.compile(r"\.planning/phases/52\.3"),
+    re.compile(r"\.planning/phases/52\.4"),
     re.compile(r"\.planning/reports/SESSION-"),
     re.compile(r"\.planning/reviews/"),
 ]


### PR DESCRIPTION
## Context

Caught by the post-Phase-53 5-expert panel's Adversarial Trust Reviewer. Phase 52.3 plugged the « end-to-end encryption » overclaim at the document-scan auth gate but left an identical vault metaphor live in 6 locales at the **salary** auth gate — and the new `no_e2ee_overclaim.py` lint had zero patterns that would catch it, so the regression bar Plan 52.3 promised was fictitious for this class.

`apps/mobile/lib/l10n/app_fr.arb:3787` (and 5 sibling locales) said:
- FR: « coffre-fort sécurisé »
- EN: « secure vault »
- DE: « sicherer Tresor »
- IT: « cassaforte sicura »
- ES: « caja fuerte segura »
- PT: « cofre seguro »

These all imply zero-knowledge encryption (Bitwarden / 1Password / Threema mental model) — contradicting Path A per `.planning/decisions/2026-05-02-data-residency.md:24`: « Pure plaintext-on-cloud is the highest-blast-radius posture for a financial app; Bitwarden-style zero-knowledge is feasible but should not precede PMF. »

Wired at `apps/mobile/lib/widgets/auth/auth_gate.dart:138` — the gate captures **the highest-sensitivity single field in the app**.

## Summary

- 6 ARB strings (`authGateSalaryMessage`) replaced with truthful Path A copy
- `tools/checks/no_e2ee_overclaim.py` expanded with **VAULT_METAPHOR family** (6 multilingual patterns)
- ALLOW_LINE_PATTERNS extended with `ALLOW-VAULT-METAPHOR` override + Path A contextual co-occurrence terms (`operator-held` / `chiffré côté serveur` / `Path A`) so legitimate Path A-anchored copy passes
- Regenerated `app_localizations*.dart` via `flutter gen-l10n`

## Pre-push checklist

- [x] `python3 tools/checks/no_e2ee_overclaim.py` → exit 0 (full repo clean)
- [x] Smoke-test: synthetic « secure vault » string → exit 1 with `EN vault metaphor` diagnostic; allow-list smoke-tested
- [x] `flutter analyze lib/l10n/ lib/widgets/auth/auth_gate.dart` → 0 issues
- [x] ARB key counts unchanged: 8727 across 5 sibling locales + 9133 in fr (with @meta entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)