### PR TITLE
feat(phase-54-02): chip wiring on proactive trigger + ARB-route Plan 53-02 strings

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11160,5 +11160,10 @@
   "settingsPrivacyMigrationToastCta": "Ansehen",
   "aujourdhuiCommitmentsTitle": "Deine letzten Verpflichtungen",
   "aujourdhuiCheckInsTitle": "Deine letzten Check-ins",
-  "aujourdhuiResumeConversation": "Gespräch fortsetzen"
+  "aujourdhuiResumeConversation": "Gespräch fortsetzen",
+  "coachSequenceNextStepLabel": "Nächster Schritt: {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "Du hast diese geführte Sequenz abgeschlossen."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11160,5 +11160,10 @@
   "settingsPrivacyMigrationToastCta": "View",
   "aujourdhuiCommitmentsTitle": "Your recent commitments",
   "aujourdhuiCheckInsTitle": "Your latest check-ins",
-  "aujourdhuiResumeConversation": "Resume conversation"
+  "aujourdhuiResumeConversation": "Resume conversation",
+  "coachSequenceNextStepLabel": "Next step: {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "You've completed this guided sequence."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11160,5 +11160,10 @@
   "settingsPrivacyMigrationToastCta": "Ver",
   "aujourdhuiCommitmentsTitle": "Tus compromisos recientes",
   "aujourdhuiCheckInsTitle": "Tus últimos check-ins",
-  "aujourdhuiResumeConversation": "Reanudar la conversación"
+  "aujourdhuiResumeConversation": "Reanudar la conversación",
+  "coachSequenceNextStepLabel": "Siguiente paso: {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "Has completado esta secuencia guiada."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12100,5 +12100,10 @@
   "settingsPrivacyMigrationToastCta": "Voir",
   "aujourdhuiCommitmentsTitle": "Tes engagements récents",
   "aujourdhuiCheckInsTitle": "Tes derniers check-ins",
-  "aujourdhuiResumeConversation": "Reprendre la conversation"
+  "aujourdhuiResumeConversation": "Reprendre la conversation",
+  "coachSequenceNextStepLabel": "Étape suivante : {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée."
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11160,5 +11160,10 @@
   "settingsPrivacyMigrationToastCta": "Vedi",
   "aujourdhuiCommitmentsTitle": "I tuoi impegni recenti",
   "aujourdhuiCheckInsTitle": "I tuoi ultimi check-in",
-  "aujourdhuiResumeConversation": "Riprendi la conversazione"
+  "aujourdhuiResumeConversation": "Riprendi la conversazione",
+  "coachSequenceNextStepLabel": "Prossimo passo: {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "Hai completato questa sequenza guidata."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40646,6 +40646,18 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Reprendre la conversation'**
   String get aujourdhuiResumeConversation;
+
+  /// No description provided for @coachSequenceNextStepLabel.
+  ///
+  /// In fr, this message translates to:
+  /// **'Étape suivante : {label}.'**
+  String coachSequenceNextStepLabel(String label);
+
+  /// No description provided for @coachSequenceCompletedMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tu as terminé cette séquence guidée.'**
+  String get coachSequenceCompletedMessage;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23229,4 +23229,13 @@ class SDe extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Gespräch fortsetzen';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Nächster Schritt: $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'Du hast diese geführte Sequenz abgeschlossen.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23059,4 +23059,13 @@ class SEn extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Resume conversation';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Next step: $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'You\'ve completed this guided sequence.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23172,4 +23172,13 @@ class SEs extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Reanudar la conversación';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Siguiente paso: $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'Has completado esta secuencia guiada.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23174,4 +23174,13 @@ class SFr extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Reprendre la conversation';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Étape suivante : $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'Tu as terminé cette séquence guidée.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23233,4 +23233,13 @@ class SIt extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Riprendi la conversazione';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Prossimo passo: $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'Hai completato questa sequenza guidata.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23180,4 +23180,13 @@ class SPt extends S {
 
   @override
   String get aujourdhuiResumeConversation => 'Retomar a conversa';
+
+  @override
+  String coachSequenceNextStepLabel(String label) {
+    return 'Próximo passo: $label.';
+  }
+
+  @override
+  String get coachSequenceCompletedMessage =>
+      'Concluíste esta sequência guiada.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11160,5 +11160,10 @@
   "settingsPrivacyMigrationToastCta": "Ver",
   "aujourdhuiCommitmentsTitle": "Os teus compromissos recentes",
   "aujourdhuiCheckInsTitle": "Os teus últimos check-ins",
-  "aujourdhuiResumeConversation": "Retomar a conversa"
+  "aujourdhuiResumeConversation": "Retomar a conversa",
+  "coachSequenceNextStepLabel": "Próximo passo: {label}.",
+  "@coachSequenceNextStepLabel": {
+    "placeholders": {"label": {"type": "String"}}
+  },
+  "coachSequenceCompletedMessage": "Concluíste esta sequência guiada."
 }

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -461,13 +461,21 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     if (!mounted) return;
     final action = result.action;
 
+    final l10n = S.of(context);
+
     if (action is AdvanceAction) {
       // Render the next step as a coach-side suggestion: a route
       // suggestion card pointing at the next step's screen.
+      // Phase 54-02 T-04: route the \u00ab \u00c9tape suivante : \u2026 \u00bb string
+      // through ARB so all 6 locales render correctly + the
+      // accent_lint_fr / no_hardcoded_fr lints don't regress.
+      final nextStepText = l10n != null
+          ? l10n.coachSequenceNextStepLabel(action.progressLabel)
+          : '\u00c9tape suivante : ${action.progressLabel}.';
       setState(() {
         _messages.add(ChatMessage(
           role: 'assistant',
-          content: '\u00c9tape suivante : ${action.progressLabel}.',
+          content: nextStepText,
           timestamp: DateTime.now(),
           richToolCalls: [
             RagToolCall(
@@ -486,10 +494,13 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     }
 
     if (action is CompleteAction) {
+      // Phase 54-02 T-04: ARB-route the completion string.
+      final completionText = l10n?.coachSequenceCompletedMessage ??
+          'Tu as termin\u00e9 cette s\u00e9quence guid\u00e9e.';
       setState(() {
         _messages.add(ChatMessage(
           role: 'assistant',
-          content: 'Tu as termin\u00e9 cette s\u00e9quence guid\u00e9e.',
+          content: completionText,
           timestamp: DateTime.now(),
         ));
       });
@@ -570,8 +581,31 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
 
   /// Appends a coach-authored opening message to the conversation.
   /// Dismisses the silent opener so the chat feels like a live conversation.
-  void _addCoachOpenerMessage(String content) {
+  ///
+  /// Phase 54-02: when [intentTag] is non-null AND maps to a ScreenRegistry
+  /// entry, also emit a `route_to_screen` rich tool call so the existing
+  /// `widget_renderer._buildRouteSuggestion` path renders a tappable
+  /// `RouteSuggestionCard`. Without [intentTag], behavior is unchanged
+  /// (plain text bubble — legacy callers).
+  void _addCoachOpenerMessage(
+    String content, {
+    String? intentTag,
+    String? routeHint,
+    String? contextMessage,
+  }) {
     if (!mounted) return;
+    final richCalls = <RagToolCall>[];
+    if (intentTag != null && intentTag.isNotEmpty) {
+      richCalls.add(RagToolCall(
+        name: 'route_to_screen',
+        input: <String, dynamic>{
+          'intent': intentTag,
+          if (routeHint != null && routeHint.isNotEmpty) 'route': routeHint,
+          'context_message': contextMessage ?? content,
+          'prefill': const <String, dynamic>{},
+        },
+      ));
+    }
     setState(() {
       _showSilentOpener = false;
       _messages.add(ChatMessage(
@@ -579,6 +613,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         content: content,
         timestamp: DateTime.now(),
         tier: ChatTier.none,
+        richToolCalls: richCalls,
       ));
     });
     _scrollToBottom();
@@ -625,7 +660,18 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     if (trigger == null) return;
     _proactiveTriggerShownThisSession = true;
     final opener = _resolveProactiveOpener(S.of(context)!, trigger);
-    _addCoachOpenerMessage(opener);
+    // Phase 54-02: pass intentTag through so the opener renders a
+    // tappable chip via RouteSuggestionCard. The existing chip path
+    // (widget_renderer._buildRouteSuggestion) consumes p['intent'] +
+    // resolves the route via ChatToolDispatcher when no explicit
+    // route is provided. Falls back to plain bubble if intentTag is
+    // null (default for some trigger types per
+    // ProactiveTrigger.intentTag nullable contract).
+    _addCoachOpenerMessage(
+      opener,
+      intentTag: trigger.intentTag,
+      contextMessage: opener,
+    );
     AnalyticsService().trackEvent('coach_proactive_trigger_shown', data: {
       'type': trigger.type.name,
       'has_intent_tag': trigger.intentTag != null,


### PR DESCRIPTION
## Plan 54-02 — first PR (T-01 + T-02 + T-04)

3 of 6 tasks. T-03 (precomputed insight surfacing on chat-open), T-05 (single nav lock), T-06 (HTML evidence) ship in a follow-up PR to keep diff focused.

## What this ships

### T-01 — `_addCoachOpenerMessage` refactored

New optional parameters (`intentTag`, `routeHint`, `contextMessage`). When `intentTag` is non-empty, the method also emits a `route_to_screen` `RagToolCall` in `richToolCalls` so the existing `widget_renderer._buildRouteSuggestion` path renders a `RouteSuggestionCard` chip (with all the Plan 53-02 wiring: tap fires `SequenceChatHandler.startSequence`, then `context.push`).

Without `intentTag`, plain bubble — legacy callers (e.g. `_addInitialGreeting` silent opener flow) untouched.

### T-02 — Proactive trigger plumbed end-to-end

`_maybeShowProactiveTrigger` now passes `trigger.intentTag` through `_addCoachOpenerMessage`. Was dropped on the floor before — Expert 4 evidence per `.planning/decisions/2026-05-04-phase-54-target.md`.

7/8 `ProactiveTrigger` types populate `intentTag` (lifecycle, weekly recap, goal milestone, cantonal seasonal, inactivity, confidence-up, contract deadline) — all surface tappable chips now.

### T-04 — ARB-route Plan 53-02 hardcoded « Étape suivante »

Plan 53-02's `_injectSequencePrompt` hardcoded FR strings (caught by post-Phase-53 Adversarial reviewer):
- `« Étape suivante : ${label}. »` → `coachSequenceNextStepLabel(label)` ARB key with placeholder
- `« Tu as terminé cette séquence guidée. »` → `coachSequenceCompletedMessage`

3 keys × 6 locales (8730 keys + 9136 fr with @meta entries). Regenerated `app_localizations*.dart`.

## Pre-push checklist

- [x] `flutter gen-l10n` ran (12 generated `.dart` files updated)
- [x] `flutter analyze` on touched files → 0 NEW issues (5 pre-existing warnings unchanged)
- [x] `python3 tools/checks/no_e2ee_overclaim.py` → exit 0
- [x] `python3 tools/checks/accent_lint_fr.py --file ...app_fr.arb` → exit 0
- [x] `python3 tools/checks/screen_registry_three_way_parity.py` → exit 0 (sanity, no contract change)
- [x] ARB parity unchanged: +3 keys per locale, counts match (8730 / 9136)

## What's NOT here (deferred to PR-2 of Plan 54-02)

- T-03: PrecomputedInsight surfacing on chat-open (needs `getCachedInsight` consumed in `_addInitialGreeting` flow)
- T-05: 500ms navigation lock to dedupe chip tap vs LLM tool dispatch
- T-06: Phase 54 verification HTML report initialization

## References

- Plan: `.planning/phases/54-testflight-gate-closure/54-02-PLAN.md`
- Decision: `.planning/decisions/2026-05-04-phase-54-target.md` (Expert 4 verdict — pivot from chat-vivant scenes)
- Adversarial trust regression closure: « hardcoded FR string in Plan 53-02 newly-shipped code » class

🤖 Generated with [Claude Code](https://claude.com/claude-code)