### PR TITLE
feat(phase-54-01): walker catalog + dry-run harness + smoke tests (PR-1)

### DIFF
--- a/tools/simulator/audit_tap_render_rows.tsv
+++ b/tools/simulator/audit_tap_render_rows.tsv
@@ -1,0 +1,49 @@
+id	section	surface_file	surface_line	element	expected	tap_strategy	tap_x	tap_y	wait_max	skip_reason	notes
+4.1	ProfileDrawer	profile_drawer.dart	40	"Mon profil"	Navigates to `/profile`	centered_tap	195	400	6		
+4.2	ProfileDrawer	profile_drawer.dart	48	"Mon bilan"	Navigates to `/profile/bilan`	centered_tap	195	400	6		
+4.3	ProfileDrawer	profile_drawer.dart	57	"Couple" (visible only if `profile.isCouple`)	Navigates to `/couple`	centered_tap	195	400	6		Visible only when profile.isCouple == true
+4.4	ProfileDrawer	profile_drawer.dart	65	"Mes documents" — main tap	Navigates to `/documents`	centered_tap	195	400	6		
+4.5	ProfileDrawer	profile_drawer.dart	67	"Mes documents" — camera trailing action	Navigates to `/scan`	centered_tap	195	400	6		
+4.6	ProfileDrawer	profile_drawer.dart	75	"Historique coach"	Navigates to `/coach/history`	centered_tap	195	400	6		
+4.7	ProfileDrawer	profile_drawer.dart	98	"Clé API" (BYOK)	Navigates to `/profile/byok`	centered_tap	195	400	6		
+4.8	ProfileDrawer	profile_drawer.dart	104	"Confidentialité" (consent)	Navigates to `/profile/consent`	centered_tap	195	400	6		
+4.9	ProfileDrawer	profile_drawer.dart	110	"Langue"	**Known stub** — TODO inline language picker. Should at minimum no-op gracefully or surface a placeholder.	centered_tap	195	400	6	Known stub per scaffold line 113 — TODO inline language picker	
+4.10	ProfileDrawer	profile_drawer.dart	118	"Transparence des données"	Navigates to `/profile/data-transparency`	centered_tap	195	400	6		
+4.11	ProfileDrawer	profile_drawer.dart	124	"Contrôle confidentialité"	Navigates to `/profile/privacy-control`	centered_tap	195	400	6		
+4.12	ProfileDrawer	profile_drawer.dart	134	"Déconnexion"	Pops drawer + `context.go('/')` to landing	centered_tap	195	400	6		
+1.1	Tab1_Aujourdhui	mint_home_screen.dart	151	Premier éclairage card tap	Opens premier éclairage detail / triggers coach handoff	centered_tap	195	400	6		
+1.2	Tab1_Aujourdhui	mint_home_screen.dart	258	Premier éclairage CTA button	Triggers the éclairage primary action	centered_tap	195	400	6		
+1.3	Tab1_Aujourdhui	mint_home_screen.dart	340	Coach handoff card	Switches to Coach tab with payload	centered_tap	195	400	6		
+1.4	Tab1_Aujourdhui	mint_home_screen.dart	475	Hero card tap	`context.push(hero.route)` — opens hero target screen	centered_tap	195	400	6		
+1.5	Tab1_Aujourdhui	mint_home_screen.dart	484	Progress milestone card tap	`context.push(progress.route)` — opens progress detail	centered_tap	195	400	6		
+1.6	Tab1_Aujourdhui	mint_home_screen.dart	488	Action opportunity card tap	`context.push(action.route)` — opens action target	centered_tap	195	400	6		
+1.7	Tab1_Aujourdhui	mint_home_screen.dart	547	"Simuler" button on plan card	Runs simulation flow	centered_tap	195	400	6		
+1.8	Tab1_Aujourdhui	mint_home_screen.dart	569	"Parler au coach" button on plan card	Switches to Coach tab	centered_tap	195	400	6		
+1.9	Tab1_Aujourdhui	mint_home_screen.dart	663	Coach input bar — submit on enter	Sends message + switches to Coach tab	centered_tap	195	400	6		
+1.10	Tab1_Aujourdhui	mint_home_screen.dart	684	Coach input bar — send button	Sends message + switches to Coach tab	centered_tap	195	400	6		
+1.11	Tab1_Aujourdhui	mint_home_screen.dart	730	First check-in CTA card	Switches to Coach tab in check-in mode	centered_tap	195	400	6		Renders only when profile has no check-ins yet
+1.12	Tab1_Aujourdhui	mint_home_screen.dart	743	Anticipation signal card	Switches to Coach tab with anticipation payload	centered_tap	195	400	6		Renders only when AnticipationEngine has fresh signals
+1.13	Tab1_Aujourdhui	mint_home_screen.dart	758	Plan reality card	Switches to Coach tab with plan reality context	centered_tap	195	400	6		
+1.14	Tab1_Aujourdhui	mint_home_screen.dart	780	Generic contextual card wrapper	Routes to bound onTap handler	centered_tap	195	400	6		
+1.15	Tab1_Aujourdhui	mint_home_screen.dart	897	Contextual overflow card (more)	Expands or routes via intent tag	centered_tap	195	400	6		
+2.1	Tab2_Coach	coach_chat_screen.dart		Chat composer — text field submit	Sends message, streams response	centered_tap	195	400	6		
+2.2	Tab2_Coach	coach_chat_screen.dart		Chat composer — send button	Sends message, streams response	centered_tap	195	400	6		
+2.3	Tab2_Coach	coach_chat_screen.dart	1491	Suggestion chip in coach action panel	Routes to handler — opens screen, runs tool, or sends prompt	centered_tap	195	400	6		
+2.4	Tab2_Coach	coach_chat_screen.dart	1578	Intensity selector chip (check-in)	Selects intensity, advances flow	centered_tap	195	400	6		
+2.5	Tab2_Coach	(rendered via widget_renderer.dart)		`route_to_screen` tool result chip	Opens the routed screen	centered_tap	195	400	6	LLM-dependent: requires route_to_screen fixture	
+2.6	Tab2_Coach	(rendered via widget_renderer.dart)		`generate_document` tool result chip	Triggers document generation	centered_tap	195	400	6	LLM-dependent: requires generate_document fixture	
+2.7	Tab2_Coach	(rendered via widget_renderer.dart)		`generate_financial_plan` tool result widget	Shows the generated plan card	centered_tap	195	400	6	LLM-dependent: requires generate_financial_plan fixture	
+2.8	Tab2_Coach	(rendered via widget_renderer.dart	450)	`record_check_in` tool result widget	Shows confirmation, persists check-in	centered_tap	195	400	6	LLM-dependent: requires record_check_in fixture	
+2.9	Tab2_Coach	coach_chat_screen.dart		Conversation history button (app bar)	Opens `/coach/history`	centered_tap	195	400	6		
+2.10	Tab2_Coach	coach_chat_screen.dart		Lightning menu (widget shortcut)	Opens contextual widget picker	centered_tap	195	400	6		
+3.1	Tab3_Explorer	explore_tab.dart	488	Search bar — onChanged	Filters hub list / shows search results	centered_tap	195	400	6		
+3.2	Tab3_Explorer	explore_tab.dart	613	Search result tile tap	`context.push(entry.route)` — opens deep link	centered_tap	195	400	6		
+3.3	Tab3_Explorer	explore_tab.dart	576	Hub card — Retraite	`context.push('/explore/retraite')`	centered_tap	195	400	6		
+3.4	Tab3_Explorer	explore_tab.dart	576	Hub card — Famille	`context.push('/explore/famille')`	centered_tap	195	400	6		
+3.5	Tab3_Explorer	explore_tab.dart	576	Hub card — Travail & Statut	`context.push('/explore/travail')`	centered_tap	195	400	6		
+3.6	Tab3_Explorer	explore_tab.dart	576	Hub card — Logement	`context.push('/explore/logement')`	centered_tap	195	400	6		
+3.7	Tab3_Explorer	explore_tab.dart	576	Hub card — Fiscalité	`context.push('/explore/fiscalite')`	centered_tap	195	400	6		
+3.8	Tab3_Explorer	explore_tab.dart	576	Hub card — Patrimoine & Succession	`context.push('/explore/patrimoine')`	centered_tap	195	400	6		
+3.9	Tab3_Explorer	explore_tab.dart	576	Hub card — Santé & Protection	`context.push('/explore/sante')`	centered_tap	195	400	6		
+3.10	Tab3_Explorer	explore_tab.dart	577	"Blocked hub" bottom sheet — when readiness=blocked	Shows blocked sheet listing missing fields	centered_tap	195	400	6		Renders only when a hub is in 'blocked' readiness state
+3.11	Tab3_Explorer	explore_tab.dart	347	App bar action (menu / refresh)	Opens corresponding action	centered_tap	195	400	6		

--- a/tools/simulator/regen_audit_tap_render_catalog.py
+++ b/tools/simulator/regen_audit_tap_render_catalog.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Phase 54-01 — regenerate the AUDIT_TAP_RENDER walker catalog (TSV).
+
+Parses `.planning/milestones/v2.1-phases/07-stabilisation-v2-0/
+AUDIT_TAP_RENDER.md` (the canonical scaffold contract — 48 primary-depth
+interactive elements across 3 tabs + drawer) and emits a machine-readable
+TSV at `tools/simulator/audit_tap_render_rows.tsv` consumable by
+`walker_audit_tap_render.sh`.
+
+The TSV columns:
+  id              row id (1.1, 2.3, etc.)
+  section         Tab 1 / Tab 2 / Tab 3 / ProfileDrawer
+  surface_file    e.g. mint_home_screen.dart
+  surface_line    e.g. 151 (or empty for « unspecified » rows like 2.1)
+  element         human-readable element name (the Element column)
+  expected        what tapping should do (the Expected column)
+  tap_strategy    centered_tap | scroll_tap | text_match (default centered_tap)
+  tap_x           sim x coordinate placeholder (default 195)
+  tap_y           sim y coordinate placeholder (default 400)
+  wait_max        max polls to wait for UI quiescence (default 6)
+  skip_reason     non-empty → walker SKIPs the row with this reason
+  notes           free-form notes column
+
+Output is sorted by id. Stable diff target — committed to the repo.
+
+The regeneration is idempotent: running the script twice produces the
+same TSV. CI gate `tools/checks/audit_tap_render_catalog_drift.py` (TBD
+in Plan 54-01 PR-2) will assert the TSV matches the markdown.
+
+Usage:
+    python3 tools/simulator/regen_audit_tap_render_catalog.py
+    python3 tools/simulator/regen_audit_tap_render_catalog.py --check
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCAFFOLD = (
+    REPO
+    / ".planning"
+    / "milestones"
+    / "v2.1-phases"
+    / "07-stabilisation-v2-0"
+    / "AUDIT_TAP_RENDER.md"
+)
+OUTPUT = REPO / "tools" / "simulator" / "audit_tap_render_rows.tsv"
+
+# Default placeholder coordinates (centered tap on iPhone 17 Pro 1206x2622).
+# Walker calibration in Plan 54-01 PR-2 will refine per-row coordinates
+# from a clean « landing » screenshot baseline.
+DEFAULT_TAP_X = 195
+DEFAULT_TAP_Y = 400
+DEFAULT_WAIT_MAX = 6
+
+SECTIONS = {
+    "Tab 1: Aujourd'hui": ("Tab1_Aujourdhui", "mint_home_screen.dart"),
+    "Tab 2: Coach": ("Tab2_Coach", "coach_chat_screen.dart"),
+    "Tab 3: Explorer": ("Tab3_Explorer", "explore_tab.dart"),
+    "ProfileDrawer": ("ProfileDrawer", "profile_drawer.dart"),
+}
+
+# Rows known to require special handling — encoded as skip rationale or
+# a non-default tap strategy. Edit here when the scaffold contract evolves.
+SPECIAL_ROWS: dict[str, dict[str, str]] = {
+    # Coach tab tool-result rows depend on LLM emitting the right tool —
+    # cannot reliably auto-tap without LLM fixture injection. SKIP for
+    # PR-1; PR-2 wires a fixture-driven path.
+    "2.5": {"skip_reason": "LLM-dependent: requires route_to_screen fixture"},
+    "2.6": {"skip_reason": "LLM-dependent: requires generate_document fixture"},
+    "2.7": {"skip_reason": "LLM-dependent: requires generate_financial_plan fixture"},
+    "2.8": {"skip_reason": "LLM-dependent: requires record_check_in fixture"},
+    # Profile-state-dependent rows: only render when profile carries a
+    # specific shape. The walker's swiss_native archetype seed covers
+    # most but not all; mark for manual verification in walker run.
+    "1.11": {"notes": "Renders only when profile has no check-ins yet"},
+    "1.12": {"notes": "Renders only when AnticipationEngine has fresh signals"},
+    "3.10": {"notes": "Renders only when a hub is in 'blocked' readiness state"},
+    "4.3": {"notes": "Visible only when profile.isCouple == true"},
+    # Known stub per the scaffold's « Known issue » block at line 113.
+    "4.9": {"skip_reason": "Known stub per scaffold line 113 — TODO inline language picker"},
+}
+
+# Markdown table row pattern.
+# Format: | 1.1 | Element name | file.dart:151 | Expected description | TODO ... | TODO |
+_ROW_RE = re.compile(
+    r"^\|\s*(?P<id>\d+\.\d+)\s*"
+    r"\|\s*(?P<element>[^|]+?)\s*"
+    r"\|\s*(?P<file_line>[^|]+?)\s*"
+    r"\|\s*(?P<expected>[^|]+?)\s*"
+    r"\|\s*[^|]+?\s*"  # actual column
+    r"\|\s*[^|]+?\s*\|"  # verdict column
+)
+
+
+def parse_scaffold(text: str) -> list[dict]:
+    """Walk the scaffold text section by section, emit row dicts."""
+    rows: list[dict] = []
+    current_section: tuple[str, str] | None = None
+    for line in text.splitlines():
+        # Section header detection (« ## Tab 1: Aujourd'hui ... »).
+        if line.startswith("## "):
+            for header, sec_tuple in SECTIONS.items():
+                if header in line:
+                    current_section = sec_tuple
+                    break
+            else:
+                current_section = None
+            continue
+        if current_section is None:
+            continue
+        m = _ROW_RE.match(line)
+        if not m:
+            continue
+        section_name, default_file = current_section
+        row_id = m.group("id").strip()
+        file_line_raw = m.group("file_line").strip()
+        # Parse « file.dart:151 » or « file.dart » or « file.dart:151 (note) »
+        file_part = file_line_raw
+        line_part = ""
+        # Strip optional parenthetical
+        paren_idx = file_part.find("(")
+        if paren_idx > 0:
+            file_part = file_part[:paren_idx].strip()
+        # Split on colon for line number
+        if ":" in file_part:
+            file_only, _, line_only = file_part.partition(":")
+            file_part = file_only.strip()
+            # Line may have arrow chains (« :576 → :380 ») — take first.
+            line_first = line_only.split()[0] if line_only.split() else ""
+            line_part = line_first.lstrip(":").strip()
+        # Fallback to section default file if file part is empty / unparseable.
+        if not file_part or file_part.lower() == "rendered via widget_renderer.dart":
+            file_part = default_file
+        special = SPECIAL_ROWS.get(row_id, {})
+        rows.append({
+            "id": row_id,
+            "section": section_name,
+            "surface_file": file_part,
+            "surface_line": line_part,
+            "element": m.group("element").strip(),
+            "expected": m.group("expected").strip(),
+            "tap_strategy": "centered_tap",
+            "tap_x": str(DEFAULT_TAP_X),
+            "tap_y": str(DEFAULT_TAP_Y),
+            "wait_max": str(DEFAULT_WAIT_MAX),
+            "skip_reason": special.get("skip_reason", ""),
+            "notes": special.get("notes", ""),
+        })
+    return rows
+
+
+_TSV_HEADER = [
+    "id", "section", "surface_file", "surface_line", "element",
+    "expected", "tap_strategy", "tap_x", "tap_y", "wait_max",
+    "skip_reason", "notes",
+]
+
+
+def render_tsv(rows: list[dict]) -> str:
+    """Stable TSV: sorted by (section, id-as-tuple)."""
+    def key(r: dict) -> tuple:
+        major, minor = r["id"].split(".")
+        return (r["section"], int(major), int(minor))
+
+    sorted_rows = sorted(rows, key=key)
+    lines = ["\t".join(_TSV_HEADER)]
+    for row in sorted_rows:
+        cells = [row[col].replace("\t", " ").replace("\n", " ") for col in _TSV_HEADER]
+        lines.append("\t".join(cells))
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true",
+                        help="Exit 1 if the TSV would change. No write.")
+    args = parser.parse_args()
+
+    if not SCAFFOLD.exists():
+        sys.stderr.write(f"[FAIL] scaffold not found at {SCAFFOLD}\n")
+        return 2
+
+    text = SCAFFOLD.read_text(encoding="utf-8")
+    rows = parse_scaffold(text)
+    sys.stderr.write(
+        f"[info] parsed {len(rows)} rows across {len(SECTIONS)} sections\n"
+    )
+    if not rows:
+        sys.stderr.write("[FAIL] zero rows parsed — scaffold format changed?\n")
+        return 2
+
+    new_content = render_tsv(rows)
+    existing = OUTPUT.read_text(encoding="utf-8") if OUTPUT.exists() else ""
+
+    if existing == new_content:
+        print(f"[OK] {OUTPUT.relative_to(REPO).as_posix()} up to date "
+              f"({len(rows)} rows)")
+        return 0
+
+    if args.check:
+        sys.stderr.write(
+            f"::error file={OUTPUT.relative_to(REPO).as_posix()}::"
+            f"would change — run python3 "
+            f"tools/simulator/regen_audit_tap_render_catalog.py\n"
+        )
+        return 1
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(new_content, encoding="utf-8")
+    print(f"[wrote] {OUTPUT.relative_to(REPO).as_posix()} ({len(rows)} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/simulator/test_walker_audit_tap_render.sh
+++ b/tools/simulator/test_walker_audit_tap_render.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tools/simulator/test_walker_audit_tap_render.sh
+#
+# Phase 54-01 — smoke-test harness for walker_audit_tap_render.sh + the
+# regen_audit_tap_render_catalog.py generator.
+#
+# Pure shell, no flutter / sim / backend dependencies — runs in any
+# POSIX-ish environment (CI, dev mac, Linux). Asserts the CLI contract +
+# catalog shape without booting a simulator.
+#
+# Usage:
+#   bash tools/simulator/test_walker_audit_tap_render.sh
+#
+# Exit code: number of failing test functions. 0 = all pass.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+
+# ─── helpers ──────────────────────────────────────────────────────────
+test_help_lists_all_4_sections() {
+  local out
+  out=$(bash tools/simulator/walker_audit_tap_render.sh --help 2>&1)
+  echo "$out" | grep -q "Tab1_Aujourdhui" || return 1
+  echo "$out" | grep -q "Tab2_Coach" || return 1
+  echo "$out" | grep -q "Tab3_Explorer" || return 1
+  echo "$out" | grep -q "ProfileDrawer" || return 1
+}
+
+test_dry_run_enumerates_48_rows() {
+  local out
+  out=$(bash tools/simulator/walker_audit_tap_render.sh --dry-run 2>&1)
+  # 48 rows: each prints either WOULD-TAP or SKIP
+  local n
+  n=$(echo "$out" | grep -cE "^\[[0-9]+\.[0-9]+\] (WOULD-TAP|SKIP) ")
+  [ "$n" = "48" ] || { echo "  -> got $n rows enumerated, expected 48"; return 1; }
+}
+
+test_dry_run_tab_filter_works() {
+  local out
+  out=$(bash tools/simulator/walker_audit_tap_render.sh --dry-run --tab 1 2>&1)
+  local n
+  n=$(echo "$out" | grep -cE "^\[1\.[0-9]+\] (WOULD-TAP|SKIP) ")
+  [ "$n" = "15" ] || { echo "  -> got $n rows for Tab1, expected 15"; return 1; }
+  # No Tab2/Tab3/Drawer rows should appear
+  ! echo "$out" | grep -qE "^\[(2|3|4)\."
+}
+
+test_dry_run_drawer_filter_works() {
+  local out
+  out=$(bash tools/simulator/walker_audit_tap_render.sh --dry-run --tab drawer 2>&1)
+  local n
+  n=$(echo "$out" | grep -cE "^\[4\.[0-9]+\] (WOULD-TAP|SKIP) ")
+  [ "$n" = "12" ] || { echo "  -> got $n rows for Drawer, expected 12"; return 1; }
+}
+
+test_dry_run_row_filter_works() {
+  local out
+  out=$(bash tools/simulator/walker_audit_tap_render.sh --dry-run --row 1.4 2>&1)
+  local n
+  n=$(echo "$out" | grep -cE "^\[1\.4\] (WOULD-TAP|SKIP) ")
+  [ "$n" = "1" ] || return 1
+}
+
+test_unknown_row_fails() {
+  ! bash tools/simulator/walker_audit_tap_render.sh --dry-run --row 99.99 >/dev/null 2>&1
+}
+
+test_unknown_tab_fails() {
+  ! bash tools/simulator/walker_audit_tap_render.sh --dry-run --tab xyz >/dev/null 2>&1
+}
+
+test_no_dry_run_without_archetype_fails() {
+  ! bash tools/simulator/walker_audit_tap_render.sh --no-dry-run 2>&1 | grep -q "implemented in Plan 54-01 PR-2"
+  ! bash tools/simulator/walker_audit_tap_render.sh --no-dry-run >/dev/null 2>&1
+}
+
+test_catalog_regen_idempotent() {
+  python3 tools/simulator/regen_audit_tap_render_catalog.py --check >/dev/null 2>&1
+}
+
+test_catalog_has_48_rows_plus_header() {
+  local n
+  n=$(wc -l < tools/simulator/audit_tap_render_rows.tsv | tr -d ' ')
+  [ "$n" = "49" ] || { echo "  -> got $n lines, expected 49 (1 header + 48 rows)"; return 1; }
+}
+
+test_catalog_has_correct_section_counts() {
+  local tab1 tab2 tab3 drawer
+  tab1=$(tail -n +2 tools/simulator/audit_tap_render_rows.tsv | cut -f2 | grep -c "Tab1_Aujourdhui")
+  tab2=$(tail -n +2 tools/simulator/audit_tap_render_rows.tsv | cut -f2 | grep -c "Tab2_Coach")
+  tab3=$(tail -n +2 tools/simulator/audit_tap_render_rows.tsv | cut -f2 | grep -c "Tab3_Explorer")
+  drawer=$(tail -n +2 tools/simulator/audit_tap_render_rows.tsv | cut -f2 | grep -c "ProfileDrawer")
+  [ "$tab1" = "15" ] && [ "$tab2" = "10" ] && [ "$tab3" = "11" ] && [ "$drawer" = "12" ]
+}
+
+test_catalog_skip_rows_have_reasons() {
+  # 5 rows are pre-marked SKIP (2.5, 2.6, 2.7, 2.8, 4.9) per SPECIAL_ROWS
+  # in the regen script. All must have a non-empty skip_reason cell.
+  local n
+  n=$(awk -F'\t' 'NR>1 && $11 != "" {print $1}' tools/simulator/audit_tap_render_rows.tsv | wc -l | tr -d ' ')
+  [ "$n" = "5" ] || { echo "  -> got $n SKIP rows, expected 5"; return 1; }
+}
+
+# ─── runner ───────────────────────────────────────────────────────────
+for fn in \
+    test_help_lists_all_4_sections \
+    test_dry_run_enumerates_48_rows \
+    test_dry_run_tab_filter_works \
+    test_dry_run_drawer_filter_works \
+    test_dry_run_row_filter_works \
+    test_unknown_row_fails \
+    test_unknown_tab_fails \
+    test_no_dry_run_without_archetype_fails \
+    test_catalog_regen_idempotent \
+    test_catalog_has_48_rows_plus_header \
+    test_catalog_has_correct_section_counts \
+    test_catalog_skip_rows_have_reasons; do
+  if $fn; then
+    echo "PASS $fn"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $fn"
+    FAIL=$((FAIL+1))
+  fi
+done
+
+echo "Total: $PASS passed, $FAIL failed."
+exit "$FAIL"

--- a/tools/simulator/walker_audit_tap_render.sh
+++ b/tools/simulator/walker_audit_tap_render.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# tools/simulator/walker_audit_tap_render.sh
+#
+# Phase 54-01 — autonomous walker for STAB-17 AUDIT_TAP_RENDER scaffold.
+#
+# Reads the row catalog at tools/simulator/audit_tap_render_rows.tsv
+# (regenerated from .planning/.../AUDIT_TAP_RENDER.md by
+# regen_audit_tap_render_catalog.py) and drives an iOS simulator
+# through every primary-depth interactive element.
+#
+# Per-row execution:
+#   1. Boot/reuse simulator (ch.mint.app on iPhone 17 Pro).
+#   2. Navigate to the row's tab (1..3) or open the drawer (section=ProfileDrawer).
+#   3. Tap at the row's (tap_x, tap_y) coordinates via cliclick.
+#   4. wait_for_ui quiescence.
+#   5. Capture screenshot to screenshots/audit-tap-render/<archetype>/<id>.png.
+#   6. Compare sha256 to pre-tap screenshot — distinct == PASS, identical == FAIL.
+#   7. Match optional Sentry breadcrumb (TBD Plan 54-01 PR-2).
+#
+# PR-1 scope: --dry-run mode + row enumeration. Real tap execution
+# requires sim + cliclick + idb (lands in Plan 54-01 PR-2 alongside
+# the screenshot diff + breadcrumb match logic).
+#
+# Usage:
+#   bash tools/simulator/walker_audit_tap_render.sh --help
+#   bash tools/simulator/walker_audit_tap_render.sh --dry-run
+#   bash tools/simulator/walker_audit_tap_render.sh --dry-run --tab 1
+#   bash tools/simulator/walker_audit_tap_render.sh --dry-run --row 1.4
+#   bash tools/simulator/walker_audit_tap_render.sh --archetype swiss_native --all   # PR-2: real run
+#
+# Required env (PR-2 real run only):
+#   SENTRY_DSN_STAGING (Railway staging)
+#
+# Reuses helpers from tools/simulator/walker.sh when invoked in real mode.
+# DRY-RUN mode is pure-shell (no sim, no flutter, no curl).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CATALOG="$REPO_ROOT/tools/simulator/audit_tap_render_rows.tsv"
+RESULTS_DIR="$REPO_ROOT/.planning/phases/54-testflight-gate-closure"
+RESULTS_FILE="$RESULTS_DIR/AUDIT_TAP_RENDER_RESULTS.md"
+
+# Defaults
+ARCHETYPE=""
+TAB_FILTER=""
+ROW_FILTER=""
+DRY_RUN=1   # default to dry-run; explicit --no-dry-run for real (Plan 54-01 PR-2)
+RUN_ALL=0
+SHOW_HELP=0
+
+# ─── help text ─────────────────────────────────────────────────────────
+print_help() {
+  cat <<EOF
+walker_audit_tap_render.sh — STAB-17 autonomous walker (Phase 54-01)
+
+Sections covered (from audit_tap_render_rows.tsv):
+  Tab1_Aujourdhui   (15 rows: 1.1 .. 1.15)
+  Tab2_Coach        (10 rows: 2.1 .. 2.10)
+  Tab3_Explorer     (11 rows: 3.1 .. 3.11)
+  ProfileDrawer     (12 rows: 4.1 .. 4.12)
+
+Modes:
+  --dry-run               (default) print what would be tapped, no sim/build
+  --no-dry-run            real tap execution (requires sim, Plan 54-01 PR-2)
+  --all                   exercise every row in the catalog
+  --tab <N>               filter to Tab1..Tab3 or 'drawer' (1/2/3/drawer)
+  --row <X.Y>             single row by id (e.g. 1.4)
+  --archetype <slug>      seed archetype (swiss_native, expat_eu, ...) — required for --no-dry-run
+  --help                  this text
+
+Outputs:
+  Dry-run prints planned actions. Real run writes
+  .planning/phases/54-testflight-gate-closure/AUDIT_TAP_RENDER_RESULTS.md
+  with PASS/FAIL/SKIP per row + screenshot links.
+
+Exit codes:
+  0 — clean dry-run / real run with 0 unaddressed FAILs
+  1 — usage error / parse error
+  2 — real run completed with FAILs (triage tickets created)
+EOF
+}
+
+# ─── argv parsing ──────────────────────────────────────────────────────
+_args=("$@")
+i=0
+while [ "$i" -lt "${#_args[@]}" ]; do
+  a="${_args[$i]}"
+  case "$a" in
+    --help|-h) SHOW_HELP=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --no-dry-run) DRY_RUN=0 ;;
+    --all) RUN_ALL=1 ;;
+    --tab)
+      i=$((i+1))
+      TAB_FILTER="${_args[$i]:-}"
+      ;;
+    --tab=*)
+      TAB_FILTER="${a#--tab=}"
+      ;;
+    --row)
+      i=$((i+1))
+      ROW_FILTER="${_args[$i]:-}"
+      ;;
+    --row=*)
+      ROW_FILTER="${a#--row=}"
+      ;;
+    --archetype)
+      i=$((i+1))
+      ARCHETYPE="${_args[$i]:-}"
+      ;;
+    --archetype=*)
+      ARCHETYPE="${a#--archetype=}"
+      ;;
+    *)
+      echo "ERROR: unknown flag '$a' (try --help)" >&2
+      exit 1
+      ;;
+  esac
+  i=$((i+1))
+done
+
+if [ "$SHOW_HELP" = "1" ]; then
+  print_help
+  exit 0
+fi
+
+# ─── catalog availability ──────────────────────────────────────────────
+if [ ! -f "$CATALOG" ]; then
+  echo "ERROR: catalog not found at $CATALOG" >&2
+  echo "Run: python3 tools/simulator/regen_audit_tap_render_catalog.py" >&2
+  exit 1
+fi
+
+# ─── filter resolution ─────────────────────────────────────────────────
+SECTION_FILTER=""
+case "$TAB_FILTER" in
+  "") ;;
+  1) SECTION_FILTER="Tab1_Aujourdhui" ;;
+  2) SECTION_FILTER="Tab2_Coach" ;;
+  3) SECTION_FILTER="Tab3_Explorer" ;;
+  drawer|4) SECTION_FILTER="ProfileDrawer" ;;
+  *)
+    echo "ERROR: --tab must be 1|2|3|drawer (got '$TAB_FILTER')" >&2
+    exit 1
+    ;;
+esac
+
+# ─── real-run preflight ────────────────────────────────────────────────
+if [ "$DRY_RUN" = "0" ]; then
+  if [ -z "$ARCHETYPE" ]; then
+    echo "ERROR: --no-dry-run requires --archetype <slug>" >&2
+    exit 1
+  fi
+  echo "ERROR: real-run mode is implemented in Plan 54-01 PR-2" >&2
+  echo "       For now, use --dry-run to preview the catalog walk." >&2
+  exit 1
+fi
+
+# ─── dry-run output ────────────────────────────────────────────────────
+echo "[walker] catalog: $(wc -l < "$CATALOG") lines (1 header + 48 rows expected)"
+echo "[walker] mode: dry-run"
+[ -n "$SECTION_FILTER" ] && echo "[walker] section filter: $SECTION_FILTER"
+[ -n "$ROW_FILTER" ] && echo "[walker] row filter: $ROW_FILTER"
+echo ""
+
+# Skip header line, iterate rows.
+total=0
+shown=0
+skipped=0
+while IFS=$'\t' read -r id section surface_file surface_line element expected tap_strategy tap_x tap_y wait_max skip_reason notes; do
+  [ "$id" = "id" ] && continue   # skip header
+  total=$((total+1))
+  if [ -n "$SECTION_FILTER" ] && [ "$section" != "$SECTION_FILTER" ]; then continue; fi
+  if [ -n "$ROW_FILTER" ] && [ "$id" != "$ROW_FILTER" ]; then continue; fi
+  shown=$((shown+1))
+  if [ -n "$skip_reason" ]; then
+    echo "[$id] SKIP $section/$surface_file:$surface_line — $skip_reason"
+    skipped=$((skipped+1))
+  else
+    echo "[$id] WOULD-TAP $section/$surface_file:$surface_line at ($tap_x,$tap_y) wait=$wait_max"
+    [ -n "$notes" ] && echo "       note: $notes"
+  fi
+done < "$CATALOG"
+
+echo ""
+echo "[walker] dry-run complete: $shown of $total rows enumerated ($skipped marked SKIP)"
+
+# Filter sanity check.
+if [ -n "$ROW_FILTER" ] && [ "$shown" = "0" ]; then
+  echo "ERROR: --row $ROW_FILTER did not match any catalog row" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Plan 54-01 — first PR (catalog + dry-run + smoke tests)

Foundation work for the autonomous walker walkthrough across STAB-17's `AUDIT_TAP_RENDER` scaffold (48 primary-depth interactive elements across 3 tabs + drawer). Per `.planning/MILESTONES.md:109` + `.planning/backlog/STAB-carryover.md:38` this is the literal TestFlight blocker — Plan 54-01 + 54-03 close it.

PR-1 ships the catalog + dry-run harness so the contract is locked + the walker design is exercisable without sim access. Real tap execution + screenshot diff + Sentry breadcrumb match lands in PR-2.

## What this ships

- **`tools/simulator/regen_audit_tap_render_catalog.py`** — Python regex parser of `AUDIT_TAP_RENDER.md`, emits stable TSV with 12 columns. `--check` mode for CI drift detection.
- **`tools/simulator/audit_tap_render_rows.tsv`** — generated catalog: 48 rows.
  - Tab1_Aujourdhui: 15 rows (1.1 .. 1.15)
  - Tab2_Coach: 10 rows (2.1 .. 2.10)
  - Tab3_Explorer: 11 rows (3.1 .. 3.11)
  - ProfileDrawer: 12 rows (4.1 .. 4.12)
  - 5 rows pre-marked SKIP with rationale: 4 LLM-tool-result chips (2.5-2.8) require fixture injection, 1 known stub (4.9 language picker per scaffold line 113).
- **`tools/simulator/walker_audit_tap_render.sh`** — Bash harness with full argv parser (`--help`, `--dry-run`, `--tab`, `--row`, `--archetype`, `--all`, `--no-dry-run`). Dry-run mode is pure shell. Real-run mode (`--no-dry-run`) is gated until PR-2 with explicit error message.
- **`tools/simulator/test_walker_audit_tap_render.sh`** — 12-test smoke harness covering CLI contract + catalog shape.

## Pre-push checklist

- [x] `python3 tools/simulator/regen_audit_tap_render_catalog.py` → wrote 48 rows
- [x] `python3 tools/simulator/regen_audit_tap_render_catalog.py --check` → exit 0 (idempotent)
- [x] `bash tools/simulator/test_walker_audit_tap_render.sh` → **12/12 PASS**

## Sample dry-run

```
$ bash tools/simulator/walker_audit_tap_render.sh --dry-run --tab 1
[walker] catalog: 49 lines (1 header + 48 rows expected)
[walker] mode: dry-run
[walker] section filter: Tab1_Aujourdhui

[1.1] WOULD-TAP Tab1_Aujourdhui/mint_home_screen.dart:151 at (195,400) wait=6
[1.2] WOULD-TAP Tab1_Aujourdhui/mint_home_screen.dart:258 at (195,400) wait=6
... (15 rows total)

[walker] dry-run complete: 15 of 48 rows enumerated (0 marked SKIP)
```

## What's NOT here (deferred to PR-2)

- Real tap execution via cliclick + idb integration
- Screenshot capture + sha256 diff for PASS/FAIL verdict
- Sentry breadcrumb match
- `AUDIT_TAP_RENDER_RESULTS.md` write-back
- FAIL triage ticket auto-creation in `triage/F-XX-*.md`
- `walker_nightly.yml` scheduled CI workflow
- Per-row tap coordinate calibration from a clean « landing » screenshot baseline (current values are placeholder 195/400)

## Sequencing reminder (CONTEXT D-02)

Plan 54-02 chip wiring (PR #450 already merged) ships BEFORE Plan 54-01 walker run, so the walker has chips to tap on the proactive openers. PR-1 doesn't yet exercise that path (real tap is PR-2 work) but the order is preserved.

## References

- Plan: `.planning/phases/54-testflight-gate-closure/54-01-PLAN.md`
- Decision: `.planning/decisions/2026-05-04-phase-54-target.md` (Expert 5 verdict)
- Scaffold contract: `.planning/milestones/v2.1-phases/07-stabilisation-v2-0/AUDIT_TAP_RENDER.md`
- Walker primitives reused in PR-2: `tools/simulator/walker.sh` + `test_walker_archetype.sh` (PR #443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)