### PR TITLE
fix(lsfin): auto-fix 228 accent violations + lint slug guard (B3 ship blocker)

### DIFF
--- a/apps/mobile/lib/data/education_content.dart
+++ b/apps/mobile/lib/data/education_content.dart
@@ -24,7 +24,7 @@ class EducationTopicContent {
 
   static const String disclaimer =
       'Contenu a visee pedagogique. Ne constitue pas un conseil financier, '
-      'fiscal ou juridique (LSFin). Consulte un\u00b7e specialiste pour ta situation.';
+      'fiscal ou juridique (LSFin). Consulte un\u00b7e spécialiste pour ta situation.';
 }
 
 class QuizQuestion {
@@ -422,7 +422,7 @@ class EducationContentData {
         correctIndex: 1,
         explanation:
             'La date limite est le 30 novembre. Ta nouvelle caisse doit '
-            'avoir recu ta demande avant cette date. Astuce : les primes '
+            'avoir reçu ta demande avant cette date. Astuce : les primes '
             'sont annoncees fin septembre — compare des octobre.',
       ),
       funFact:

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -314,7 +314,7 @@ class PrevoyanceProfile {
   final double? avoirLppObligatoire; // part obligatoire (taux min 6.8%)
   final double? avoirLppSurobligatoire; // part surobligatoire (taux caisse)
   final double? rachatMaximum; // lacune de rachat totale
-  final double? rachatEffectue; // deja rachete (montant CHF cumulé)
+  final double? rachatEffectue; // déjà rachete (montant CHF cumulé)
   /// Historique daté des rachats LPP (ordre chronologique, plus récent en
   /// dernier). swiss-brain Q4 2026-04-18 : le blocage 3 ans (LPP art. 79b
   /// al. 3, confirmé par ATF 142 II 399 + ATF 148 II 189) part de la date

--- a/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/avs_guide_screen.dart
@@ -27,7 +27,7 @@ import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 //
 //  Actions:
 //    - "Ouvrir ahv-iv.ch" (url_launcher)
-//    - "J'ai deja mon extrait -> Scanner"
+//    - "J'ai déjà mon extrait -> Scanner"
 //    - "Utiliser un exemple AVS" (debug / QA)
 //
 //  Reference:

--- a/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_impact_screen.dart
@@ -60,7 +60,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
   late int _newConfidence;
   late int _deltaPoints;
 
-  // Premier eclairage state
+  // Premier éclairage state
   Map<String, dynamic>? _premierEclairage;
   bool _premierEclairageLoading = true;
   bool _premierEclairageFailed = false;
@@ -476,7 +476,7 @@ class _DocumentImpactScreenState extends State<DocumentImpactScreen>
     );
   }
 
-  // ── Premier Eclairage (4-layer insight from document) ─────
+  // ── Premier Éclairage (4-layer insight from document) ─────
 
   Widget _buildPremierEclairageSection() {
     return Opacity(

--- a/apps/mobile/lib/screens/fiscal_comparator_screen.dart
+++ b/apps/mobile/lib/screens/fiscal_comparator_screen.dart
@@ -95,7 +95,7 @@ class _FiscalComparatorScreenState extends State<FiscalComparatorScreen>
     _tabController = TabController(length: 3, vsync: this);
     _initFromProfile();
     _recalculate();
-    // Charge les donnees communales (si pas deja chargees)
+    // Charge les donnees communales (si pas déjà chargees)
     if (!CommuneData.isLoaded) {
       CommuneData.load().then((_) {
         if (mounted) setState(() {});

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -462,7 +462,7 @@ class CoachLlmService {
     buffer
         .writeln('- Tu NE donnes JAMAIS de conseil financier. Tu es educatif.');
     buffer.writeln(
-        '- Tu dis toujours "consulte un·e specialiste" pour les decisions importantes.');
+        '- Tu dis toujours "consulte un·e spécialiste" pour les decisions importantes.');
     buffer.writeln('- Tu parles en francais, tu tutoies.');
     buffer.writeln(
         '- Tu cites TOUJOURS tes sources legales (LPP art. X, OPP3 art. Y, LIFD art. Z, etc.).');

--- a/apps/mobile/lib/services/coach_narrative_service.dart
+++ b/apps/mobile/lib/services/coach_narrative_service.dart
@@ -408,7 +408,7 @@ class CoachNarrativeService {
           );
         } catch (e) {
           debugPrint('CoachNarrative: $e');
-          // Resilience: garde le narratif statique deja genere
+          // Resilience: garde le narratif statique déjà genere
         }
       }
     }

--- a/apps/mobile/lib/services/debt_prevention_service.dart
+++ b/apps/mobile/lib/services/debt_prevention_service.dart
@@ -349,7 +349,7 @@ class RepaymentPlanner {
     double totalInterets = 0;
     double totalPaye = 0;
     int mois = 0;
-    const maxMois = 600; // Securite : 50 ans max
+    const maxMois = 600; // Sécurité : 50 ans max
 
     // Verifier que le budget couvre au moins les mensualites min
     final sumMin = dettes.fold<double>(0, (s, d) => s + d.mensualiteMin);

--- a/apps/mobile/lib/services/document_service.dart
+++ b/apps/mobile/lib/services/document_service.dart
@@ -1196,7 +1196,7 @@ class DocumentService {
       return null;
     }
   }
-  /// Fetch premier eclairage (4-layer insight) for extracted document data.
+  /// Fetch premier éclairage (4-layer insight) for extracted document data.
   /// Returns parsed JSON response or null on failure.
   static Future<Map<String, dynamic>?> fetchPremierEclairage({
     required String documentType,

--- a/apps/mobile/lib/services/donation_service.dart
+++ b/apps/mobile/lib/services/donation_service.dart
@@ -320,7 +320,7 @@ class DonationService {
         'ne constitue pas un conseil juridique, fiscal ou notarial '
         'personnalise au sens de la LSFin. Le droit des donations '
         'et successions comporte de nombreuses subtilites cantonales. '
-        'Consulte un·e specialiste (notaire) pour ta situation.';
+        'Consulte un·e spécialiste (notaire) pour ta situation.';
 
     // ── Sources ──
     const sources = [

--- a/apps/mobile/lib/services/expat_service.dart
+++ b/apps/mobile/lib/services/expat_service.dart
@@ -31,7 +31,7 @@ class ExpatService {
       'Estimations simplifiees a but educatif — ne constitue pas '
       'un conseil fiscal ou juridique. Les montants dependent de nombreux '
       'facteurs (deductions, commune, fortune, convention internationale, etc.). '
-      'Consulte un-e specialiste fiscal-e pour une analyse personnalisee.';
+      'Consulte un-e spécialiste fiscal-e pour une analyse personnalisee.';
 
   // ════════════════════════════════════════════════════════════
   //  FRONTALIER — SOURCE TAX (Bareme C) BY CANTON
@@ -419,7 +419,7 @@ class ExpatService {
           'Risque fiscal — l\'imposition peut basculer vers ton pays de residence. '
           'Avec $riskDays jours de home office, tu depasses le seuil de 90 jours. '
           'Ton employeur pourrait devoir cotiser dans ton pays de residence. '
-          'Consulte un-e specialiste en fiscalite internationale.';
+          'Consulte un-e spécialiste en fiscalite internationale.';
     }
 
     return {

--- a/apps/mobile/lib/services/financial_core/tax_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/tax_calculator.dart
@@ -212,7 +212,7 @@ class RetirementTaxCalculator {
   /// NOT taxable income. Never double-tax capital.
   static const String renteLppTaxDisclaimer =
       'La rente LPP est imposee comme revenu (LIFD art. 22). '
-      'Consulte un·e specialiste fiscal·e pour une estimation personnalisee.';
+      'Consulte un·e spécialiste fiscal·e pour une estimation personnalisee.';
 
   /// Progressive capital withdrawal tax (LIFD art. 38).
   ///

--- a/apps/mobile/lib/services/financial_core/withdrawal_sequencing_service.dart
+++ b/apps/mobile/lib/services/financial_core/withdrawal_sequencing_service.dart
@@ -108,7 +108,7 @@ class WithdrawalSequencingService {
       'Simulation pedagogique de la sequence de retrait en capital. '
       "L'optimisation fiscale depend de la legislation cantonale et "
       'de la situation personnelle. Base legale : LIFD art. 38, OPP3 art. 3. '
-      'Consulte un ou une specialiste avant toute decision. '
+      'Consulte un ou une spécialiste avant toute decision. '
       'Cette simulation ne constitue pas un conseil financier au sens de la LSFin.';
 
   static const List<String> _sources = [
@@ -130,10 +130,10 @@ class WithdrawalSequencingService {
     final currentYear = DateTime.now().year;
     final currentAge = profile.age;
 
-    // Guard: si la personne est deja a l'age de retraite ou au-dela,
+    // Guard: si la personne est déjà a l'age de retraite ou au-dela,
     // aucune optimisation de sequencage n'est possible.
     if (currentAge >= retirementAge) {
-      // Personne deja a l'age de retraite ou au-dela
+      // Personne déjà a l'age de retraite ou au-dela
       return const WithdrawalSequencingResult(
         optimizedSequence: [],
         naiveSequence: [],

--- a/apps/mobile/lib/services/financial_fitness_service.dart
+++ b/apps/mobile/lib/services/financial_fitness_service.dart
@@ -576,7 +576,7 @@ class FinancialFitnessService {
         if (profile.dettes.hasDette) {
           return 'Priorite : reduire tes dettes de consommation avant d\'optimiser.';
         }
-        return 'Des progres a faire, mais tu es sur la bonne voie. Un pas a la fois.';
+        return 'Des progrès a faire, mais tu es sur la bonne voie. Un pas a la fois.';
       case FitnessLevel.critique:
         return 'Commencons par les fondamentaux : budget, fonds d\'urgence, et reduction des dettes.';
     }

--- a/apps/mobile/lib/services/forecaster_service.dart
+++ b/apps/mobile/lib/services/forecaster_service.dart
@@ -324,7 +324,7 @@ class ForecasterService {
       disclaimer: l?.forecasterDisclaimer ??
           'Projections educatives basees sur des hypotheses de rendement. '
           'Ne constitue pas un conseil financier. Les rendements passes ne '
-          'presagent pas des rendements futurs. Consulte un·e specialiste '
+          'presagent pas des rendements futurs. Consulte un·e spécialiste '
           'pour un plan personnalise. LSFin.',
       sources: [
         'LAVS art. 21-29 (rente AVS)',
@@ -481,7 +481,7 @@ class ForecasterService {
   ///
   /// Ce KPI represente l'effort du mois valide (somme des versements),
   /// et non une valeur future composee jusqu'a la retraite.
-  /// La valeur future est deja couverte par la projection complete.
+  /// La valeur future est déjà couverte par la projection complete.
   static double calculateMonthlyDelta({
     required CoachProfile profile,
     required Map<String, double> versements,

--- a/apps/mobile/lib/services/housing_sale_service.dart
+++ b/apps/mobile/lib/services/housing_sale_service.dart
@@ -292,7 +292,7 @@ class HousingSaleService {
         'personnalise au sens de la LSFin. Les taux d\'imposition '
         'sont simplifies et peuvent varier selon la commune et les '
         'deductions applicables. ${!cantonExplicit ? "Le bareme utilise est celui de VD par defaut. " : ""}'
-        'Consulte un·e specialiste pour ta situation personnelle.';
+        'Consulte un·e spécialiste pour ta situation personnelle.';
 
     // ── Sources ──
     const sources = [

--- a/apps/mobile/lib/services/mortgage_service.dart
+++ b/apps/mobile/lib/services/mortgage_service.dart
@@ -208,7 +208,7 @@ class AffordabilityCalculator {
           'Le taux theorique de 5% est utilise pour le calcul de tenue '
           '(pratique ASB), pas le taux reel du marche. '
           'Base legale : directive ASB sur le credit hypothecaire. '
-          'Consultez un ou une specialiste avant toute decision.',
+          'Consultez un ou une spécialiste avant toute decision.',
     );
   }
 }
@@ -509,7 +509,7 @@ class ImputedRentalCalculator {
           'differer significativement de cette estimation. Les deductions '
           'dependent de la situation personnelle. '
           'Base legale : LIFD art. 21 al. 1 let. b, art. 32 (deductions). '
-          'Consultez un ou une specialiste en fiscalite.',
+          'Consultez un ou une spécialiste en fiscalite.',
     );
   }
 }
@@ -661,7 +661,7 @@ class AmortizationCalculator {
           'du rendement 3a et des conditions hypothecaires. '
           'Le nantissement du 3a doit etre accepte par le preteur. '
           'Base legale : OPP3, pratique hypothecaire suisse. '
-          'Consultez un ou une specialiste avant toute decision.',
+          'Consultez un ou une spécialiste avant toute decision.',
     );
   }
 }
@@ -854,7 +854,7 @@ class EplCombinedCalculator {
           'et communale, et de la situation personnelle. '
           'Le retrait LPP est soumis a l\'accord du conjoint (si marie). '
           'Base legale : LPP art. 30c (EPL), OPP3, LIFD art. 38. '
-          'Consultez un ou une specialiste avant toute decision.',
+          'Consultez un ou une spécialiste avant toute decision.',
     );
   }
 

--- a/apps/mobile/lib/services/pillar_3a_deep_service.dart
+++ b/apps/mobile/lib/services/pillar_3a_deep_service.dart
@@ -180,7 +180,7 @@ class StaggeredWithdrawalSimulator {
           'personnelle et du montant total retire dans l\'annee fiscale. '
           'Les taux utilises sont des moyennes cantonales simplifiees. '
           'Base legale : OPP3, LIFD art. 38. '
-          'Consultez un ou une specialiste en prevoyance avant toute decision.',
+          'Consultez un ou une spécialiste en prevoyance avant toute decision.',
     );
   }
 
@@ -647,7 +647,7 @@ class ProviderComparator {
           'Le choix d\'un prestataire 3a depend de ta situation personnelle, '
           'de ton profil de risque et de ton horizon de placement. '
           'MINT n\'est pas un intermediaire financier et ne fournit aucun '
-          'conseil en placement. Consultez un ou une specialiste.',
+          'conseil en placement. Consultez un ou une spécialiste.',
     );
   }
 

--- a/apps/mobile/lib/services/premier_eclairage_selector.dart
+++ b/apps/mobile/lib/services/premier_eclairage_selector.dart
@@ -226,9 +226,9 @@ class PremierEclairageSelector {
       title: 'Ta reserve de liquidite',
       subtitle: profile.liquidityMonths < 1
           ? 'Moins d\'un mois de reserves. '
-              'Les experts recommandent 3 a 6 mois de depenses en epargne de securite.'
+              'Les experts recommandent 3 a 6 mois de depenses en epargne de sécurité.'
           : '${profile.liquidityMonths.toStringAsFixed(1)} mois de reserves. '
-              'Les experts recommandent 3 a 6 mois de depenses en epargne de securite.',
+              'Les experts recommandent 3 a 6 mois de depenses en epargne de sécurité.',
       iconName: 'warning_amber',
       colorKey: 'error',
     );

--- a/apps/mobile/lib/services/reengagement_engine.dart
+++ b/apps/mobile/lib/services/reengagement_engine.dart
@@ -10,7 +10,7 @@
 ///
 /// BANNED:
 /// - "Tu n'as pas utilise MINT depuis X jours"
-/// - "Reviens decouvrir nos nouvelles fonctionnalites!"
+/// - "Reviens découvrir nos nouvelles fonctionnalites!"
 /// - "Tu nous manques!"
 ///
 /// Sources:

--- a/apps/mobile/lib/services/report_persistence_service.dart
+++ b/apps/mobile/lib/services/report_persistence_service.dart
@@ -63,7 +63,7 @@ class ReportPersistenceService {
       'mini_onboarding_cohort_metrics_v1';
   static const String _selectedIntentKey = 'selected_onboarding_intent_v1';
 
-  // ── Premier Eclairage persistence keys (D-09) ──
+  // ── Premier Éclairage persistence keys (D-09) ──
   static const String _hasSeenPremierEclairageKey =
       'has_seen_premier_eclairage_v1';
   static const String _premierEclairageSnapshotKey =
@@ -108,7 +108,7 @@ class ReportPersistenceService {
     return variant;
   }
 
-  /// Indique si l'exposition a l'experience onboarding a deja ete trackee.
+  /// Indique si l'exposition a l'experience onboarding a déjà ete trackee.
   static Future<bool> isMiniOnboardingExposureTracked() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_miniOnboardingExposureTrackedKey) ?? false;
@@ -206,10 +206,10 @@ class ReportPersistenceService {
   }
 
   // ═══════════════════════════════════════════════════════════
-  //  PREMIER ECLAIRAGE PERSISTENCE (D-09)
+  //  PREMIER Éclairage PERSISTENCE (D-09)
   // ═══════════════════════════════════════════════════════════
 
-  /// Saves a premier eclairage snapshot to SharedPreferences.
+  /// Saves a premier éclairage snapshot to SharedPreferences.
   ///
   /// [data] MUST contain only display fields:
   ///   value (formatted string), title, subtitle, colorKey, suggestedRoute.
@@ -220,7 +220,7 @@ class ReportPersistenceService {
     await prefs.setString(_premierEclairageSnapshotKey, json.encode(data));
   }
 
-  /// Loads the premier eclairage snapshot. Returns null if not set or on error.
+  /// Loads the premier éclairage snapshot. Returns null if not set or on error.
   static Future<Map<String, dynamic>?> loadPremierEclairageSnapshot() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_premierEclairageSnapshotKey);
@@ -232,13 +232,13 @@ class ReportPersistenceService {
     }
   }
 
-  /// Returns true if the user has already seen their premier eclairage card.
+  /// Returns true if the user has already seen their premier éclairage card.
   static Future<bool> hasSeenPremierEclairage() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_hasSeenPremierEclairageKey) ?? false;
   }
 
-  /// Marks the premier eclairage card as seen (one-shot flag per D-09).
+  /// Marks the premier éclairage card as seen (one-shot flag per D-09).
   static Future<void> markPremierEclairageSeen() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_hasSeenPremierEclairageKey, true);
@@ -471,7 +471,7 @@ class ReportPersistenceService {
     // Charger l'historique existant
     List<Map<String, dynamic>> history = await loadScoreHistory();
 
-    // Remplacer l'entree du mois en cours si elle existe deja
+    // Remplacer l'entree du mois en cours si elle existe déjà
     final existingIndex =
         history.indexWhere((entry) => entry['month'] == monthKey);
     if (existingIndex >= 0) {

--- a/apps/mobile/lib/services/response_card_service.dart
+++ b/apps/mobile/lib/services/response_card_service.dart
@@ -937,7 +937,7 @@ class ResponseCardService {
 
     if (total <= 0) return null;
 
-    // Coussin securite: 3-6 mois de charges
+    // Coussin sécurité: 3-6 mois de charges
     final chargesMensuelles = profile.depenses.totalMensuel > 0
         ? profile.depenses.totalMensuel
         : profile.salaireBrutMensuel * 0.65; // estimation

--- a/apps/mobile/lib/services/retirement_projection_service.dart
+++ b/apps/mobile/lib/services/retirement_projection_service.dart
@@ -265,7 +265,7 @@ class RetirementProjectionService {
           'Ne constitue pas un conseil financier ou en prevoyance. '
           'Les montants sont des estimations qui peuvent varier selon '
           'l\'evolution legale et ta situation personnelle. '
-          'Consulte un·e specialiste pour un plan personnalise. LSFin.',
+          'Consulte un·e spécialiste pour un plan personnalise. LSFin.',
       sources: [
         'LAVS art. 21-29 (rente AVS, anticipation, ajournement)',
         'LPP art. 14 (taux de conversion minimum 6.8%)',

--- a/apps/mobile/lib/services/visibility_score_service.dart
+++ b/apps/mobile/lib/services/visibility_score_service.dart
@@ -13,15 +13,15 @@ import 'package:mint_mobile/services/financial_core/financial_core.dart';
 //  C'est une mesure de CLARTE : "tu vois X% de ta situation."
 //
 //  4 axes avec ponderation contextuelle (Phase 1) :
-//    Liquidite — Budget, epargne, dettes, coussin securite
+//    Liquidite — Budget, epargne, dettes, coussin sécurité
 //    Fiscalite — Canton, 3a, rachats, taux marginal
 //    Retraite  — AVS, LPP, 3a, age retraite
-//    Securite  — Assurances, protection famille, succession
+//    Sécurité  — Assurances, protection famille, succession
 //
 //  Phase 1 : poids dynamiques selon age et archetype.
-//    - 50+ : Retraite 30, Securite 25, Fiscalite 25, Liquidite 20
-//    - Independant : Securite +5, Liquidite +5
-//    - < 35 : Liquidite 30, Fiscalite 25, Retraite 20, Securite 25
+//    - 50+ : Retraite 30, Sécurité 25, Fiscalite 25, Liquidite 20
+//    - Independant : Sécurité +5, Liquidite +5
+//    - < 35 : Liquidite 30, Fiscalite 25, Retraite 20, Sécurité 25
 //
 //  Utilise ConfidenceScorer (financial_core) comme moteur —
 //  ne duplique AUCUNE logique de calcul.
@@ -122,8 +122,8 @@ class VisibilityScoreService {
   /// Les 4 axes sont ponderes differemment selon le profil :
   ///   - 50+ ans → retraite surponderee (35 pts)
   ///   - < 35 ans → liquidite/budget surponderee (30 pts)
-  ///   - independant → securite surponderee (30 pts)
-  ///   - expat → securite + fiscalite surponderees
+  ///   - independant → sécurité surponderee (30 pts)
+  ///   - expat → sécurité + fiscalite surponderees
   static VisibilityScore compute(CoachProfile profile, {S? l}) {
     final (:blocs, :confidence) = ConfidenceScorer.scoreWithBlocs(profile);
 
@@ -137,10 +137,10 @@ class VisibilityScoreService {
         maxScore: weights.fiscalite, l: l);
     final retraite = _computeRetraiteAxis(blocs, profile,
         maxScore: weights.retraite, l: l);
-    final securite = _computeSecuriteAxis(blocs, profile,
-        maxScore: weights.securite, l: l);
+    final sécurité = _computeSecuriteAxis(blocs, profile,
+        maxScore: weights.sécurité, l: l);
 
-    final axes = [liquidite, retraite, fiscalite, securite];
+    final axes = [liquidite, retraite, fiscalite, sécurité];
     final total = axes.fold<double>(0, (sum, a) => sum + a.score);
     final percentage = total.round().clamp(0, 100);
 
@@ -272,12 +272,12 @@ class VisibilityScoreService {
 
     // Archetype-driven adjustments
     if (isIndep) {
-      // Independants : securite cruciale (pas de filet employeur)
+      // Independants : sécurité cruciale (pas de filet employeur)
       wSec += 5;
       wRet -= 5;
     }
     if (isExpat) {
-      // Expat : fiscalite + securite (conventions, FATCA, etc.)
+      // Expat : fiscalite + sécurité (conventions, FATCA, etc.)
       wFisc += 3;
       wSec += 2;
       wLiq -= 3;
@@ -298,7 +298,7 @@ class VisibilityScoreService {
       liquidite: wLiq,
       fiscalite: wFisc,
       retraite: wRet,
-      securite: wSec,
+      sécurité: wSec,
     );
   }
 
@@ -431,7 +431,7 @@ class VisibilityScoreService {
     double maxScore = 25,
     S? l,
   }) {
-    // Securite = menage (15) + archetype (5) + foreign_pension (2) = 22 pts max
+    // Sécurité = menage (15) + archetype (5) + foreign_pension (2) = 22 pts max
     // Normalise sur maxScore (contextual)
     final menage = blocs['compositionMenage']?.score ?? 0;
     final archetype = blocs['archetype']?.score ?? 0;
@@ -448,7 +448,7 @@ class VisibilityScoreService {
             : 'missing';
 
     return VisibilityAxis(
-      id: 'securite',
+      id: 'sécurité',
       label: l?.visibilityAxisLabelSecurite ?? 'Sécurité',
       icon: 'shield',
       score: normalized,
@@ -565,12 +565,12 @@ class _AxisWeights {
   final double liquidite;
   final double fiscalite;
   final double retraite;
-  final double securite;
+  final double sécurité;
 
   const _AxisWeights({
     required this.liquidite,
     required this.fiscalite,
     required this.retraite,
-    required this.securite,
+    required this.sécurité,
   });
 }

--- a/apps/mobile/lib/services/visibility_score_service.dart
+++ b/apps/mobile/lib/services/visibility_score_service.dart
@@ -13,15 +13,15 @@ import 'package:mint_mobile/services/financial_core/financial_core.dart';
 //  C'est une mesure de CLARTE : "tu vois X% de ta situation."
 //
 //  4 axes avec ponderation contextuelle (Phase 1) :
-//    Liquidite — Budget, epargne, dettes, coussin sécurité
+//    Liquidite — Budget, epargne, dettes, coussin securite
 //    Fiscalite — Canton, 3a, rachats, taux marginal
 //    Retraite  — AVS, LPP, 3a, age retraite
-//    Sécurité  — Assurances, protection famille, succession
+//    Securite  — Assurances, protection famille, succession
 //
 //  Phase 1 : poids dynamiques selon age et archetype.
-//    - 50+ : Retraite 30, Sécurité 25, Fiscalite 25, Liquidite 20
-//    - Independant : Sécurité +5, Liquidite +5
-//    - < 35 : Liquidite 30, Fiscalite 25, Retraite 20, Sécurité 25
+//    - 50+ : Retraite 30, Securite 25, Fiscalite 25, Liquidite 20
+//    - Independant : Securite +5, Liquidite +5
+//    - < 35 : Liquidite 30, Fiscalite 25, Retraite 20, Securite 25
 //
 //  Utilise ConfidenceScorer (financial_core) comme moteur —
 //  ne duplique AUCUNE logique de calcul.
@@ -122,8 +122,8 @@ class VisibilityScoreService {
   /// Les 4 axes sont ponderes differemment selon le profil :
   ///   - 50+ ans → retraite surponderee (35 pts)
   ///   - < 35 ans → liquidite/budget surponderee (30 pts)
-  ///   - independant → sécurité surponderee (30 pts)
-  ///   - expat → sécurité + fiscalite surponderees
+  ///   - independant → securite surponderee (30 pts)
+  ///   - expat → securite + fiscalite surponderees
   static VisibilityScore compute(CoachProfile profile, {S? l}) {
     final (:blocs, :confidence) = ConfidenceScorer.scoreWithBlocs(profile);
 
@@ -137,10 +137,10 @@ class VisibilityScoreService {
         maxScore: weights.fiscalite, l: l);
     final retraite = _computeRetraiteAxis(blocs, profile,
         maxScore: weights.retraite, l: l);
-    final sécurité = _computeSecuriteAxis(blocs, profile,
-        maxScore: weights.sécurité, l: l);
+    final securite = _computeSecuriteAxis(blocs, profile,
+        maxScore: weights.securite, l: l);
 
-    final axes = [liquidite, retraite, fiscalite, sécurité];
+    final axes = [liquidite, retraite, fiscalite, securite];
     final total = axes.fold<double>(0, (sum, a) => sum + a.score);
     final percentage = total.round().clamp(0, 100);
 
@@ -272,12 +272,12 @@ class VisibilityScoreService {
 
     // Archetype-driven adjustments
     if (isIndep) {
-      // Independants : sécurité cruciale (pas de filet employeur)
+      // Independants : securite cruciale (pas de filet employeur)
       wSec += 5;
       wRet -= 5;
     }
     if (isExpat) {
-      // Expat : fiscalite + sécurité (conventions, FATCA, etc.)
+      // Expat : fiscalite + securite (conventions, FATCA, etc.)
       wFisc += 3;
       wSec += 2;
       wLiq -= 3;
@@ -298,7 +298,7 @@ class VisibilityScoreService {
       liquidite: wLiq,
       fiscalite: wFisc,
       retraite: wRet,
-      sécurité: wSec,
+      securite: wSec,
     );
   }
 
@@ -431,7 +431,7 @@ class VisibilityScoreService {
     double maxScore = 25,
     S? l,
   }) {
-    // Sécurité = menage (15) + archetype (5) + foreign_pension (2) = 22 pts max
+    // Securite = menage (15) + archetype (5) + foreign_pension (2) = 22 pts max
     // Normalise sur maxScore (contextual)
     final menage = blocs['compositionMenage']?.score ?? 0;
     final archetype = blocs['archetype']?.score ?? 0;
@@ -448,7 +448,7 @@ class VisibilityScoreService {
             : 'missing';
 
     return VisibilityAxis(
-      id: 'sécurité',
+      id: 'securite',
       label: l?.visibilityAxisLabelSecurite ?? 'Sécurité',
       icon: 'shield',
       score: normalized,
@@ -565,12 +565,12 @@ class _AxisWeights {
   final double liquidite;
   final double fiscalite;
   final double retraite;
-  final double sécurité;
+  final double securite;
 
   const _AxisWeights({
     required this.liquidite,
     required this.fiscalite,
     required this.retraite,
-    required this.sécurité,
+    required this.securite,
   });
 }

--- a/apps/mobile/lib/widgets/coach/response_card_widget.dart
+++ b/apps/mobile/lib/widgets/coach/response_card_widget.dart
@@ -232,12 +232,12 @@ class ResponseCardWidget extends StatelessWidget {
   // them. Each slot is wrapped in `_S4BodySlot` with a Semantics label
   // `s4-slot-N` so the microtypography test can count them precisely.
   //   (1) label/category   — header row (icon + title + subtitle + deadline)
-  //   (2) current state    — premier eclairage (number + explanation)
+  //   (2) current state    — premier éclairage (number + explanation)
   //   (3) without change   — MTC slot (per D-07) OR silent placeholder
   //   (4) next action      — CTA + optional proof access
   //
   // AESTH-03 Aesop rule: sentence carries rhythm, not the number — the
-  // premier eclairage renders at bodyLarge w500, NOT displayMedium.
+  // premier éclairage renders at bodyLarge w500, NOT displayMedium.
 
   Widget _buildSheet(BuildContext context) {
     return Column(

--- a/apps/mobile/lib/widgets/pulse/visibility_score_card.dart
+++ b/apps/mobile/lib/widgets/pulse/visibility_score_card.dart
@@ -161,7 +161,7 @@ class VisibilityScoreCard extends StatelessWidget {
       'liquidite' => Icons.account_balance_wallet_outlined,
       'fiscalite' => Icons.receipt_long_outlined,
       'retraite' => Icons.beach_access_outlined,
-      'securite' => Icons.shield_outlined,
+      'sécurité' => Icons.shield_outlined,
       _ => Icons.info_outline,
     };
   }

--- a/apps/mobile/lib/widgets/retirement/tornado_chart.dart
+++ b/apps/mobile/lib/widgets/retirement/tornado_chart.dart
@@ -29,7 +29,7 @@ class TornadoChart extends StatelessWidget {
   /// Revenu mensuel de base (CHF/mois) — ligne centrale.
   final double baseCase;
 
-  /// Variables de sensibilite, deja triees par swing decroissant.
+  /// Variables de sensibilite, déjà triees par swing decroissant.
   final List<TornadoVariable> variables;
 
   /// Nombre maximum de variables affichees (defaut 10).

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -122,7 +122,7 @@ def build_discovery_system_prompt(
         "- Jamais de langage absolu ou prescriptif. Utilise le conditionnel.",
         "- Reponse courte (3-5 phrases max).",
         "",
-        "Objectif : surprendre la personne avec un eclairage qu'elle ne connaissait pas.",
+        "Objectif : surprendre la personne avec un éclairage qu'elle ne connaissait pas.",
     ])
 
     return "\n".join(prompt_parts)

--- a/services/backend/app/api/v1/endpoints/budget.py
+++ b/services/backend/app/api/v1/endpoints/budget.py
@@ -177,22 +177,22 @@ def _build_response(
         )
 
     if income == 0:
-        eclairage = (
+        éclairage = (
             "On ne peut pas tracer ta marge sans revenu connu. "
             "Dis-moi ton salaire net mensuel pour démarrer."
         )
     elif free_margin < 0:
-        eclairage = (
+        éclairage = (
             f"Tu vis à crédit à hauteur de {abs(free_margin):.0f} CHF/mois — "
             "on regarde quelles dépenses sont compressibles ?"
         )
     elif savings_rate >= 0.20:
-        eclairage = (
+        éclairage = (
             f"Taux d'épargne {savings_rate*100:.0f}% — solide. "
             "On peut réfléchir à où placer ce flux (3a max ? rachat LPP ?)."
         )
     else:
-        eclairage = (
+        éclairage = (
             f"Marge libre {free_margin:.0f} CHF/mois pour {income:.0f} de "
             f"revenu. Cible savings rate ≥10% (actuellement "
             f"{savings_rate*100:.0f}%)."
@@ -213,7 +213,7 @@ def _build_response(
         free_margin_monthly=free_margin,
         savings_rate=savings_rate,
         risk_level=risk,
-        premier_eclairage=eclairage,
+        premier_eclairage=éclairage,
         alertes=alertes,
         updated_at=updated_dt,
     )

--- a/services/backend/app/api/v1/endpoints/confidence.py
+++ b/services/backend/app/api/v1/endpoints/confidence.py
@@ -44,7 +44,7 @@ _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Le score de confiance mesure "
     "la qualite des donnees fournies, pas la fiabilite des projections. "
-    "Consulte un-e specialiste pour ta situation personnelle (LSFin art. 3)."
+    "Consulte un-e spécialiste pour ta situation personnelle (LSFin art. 3)."
 )
 
 _SOURCES = [
@@ -144,7 +144,7 @@ def get_enrichments(request: Request, body: EnrichmentRequest) -> EnrichmentResp
     """Retourne les top actions pour ameliorer la precision du profil.
 
     Classe les actions d'enrichissement par impact decroissant.
-    Les actions deja completees sont exclues ou ont un impact reduit.
+    Les actions déjà completees sont exclues ou ont un impact reduit.
 
     Returns:
         EnrichmentResponse avec prompts, current confidence, disclaimer.

--- a/services/backend/app/api/v1/endpoints/document_parser.py
+++ b/services/backend/app/api/v1/endpoints/document_parser.py
@@ -64,7 +64,7 @@ router = APIRouter()
 _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Les valeurs extraites sont indicatives "
-    "et doivent etre verifiees. Consulte un-e specialiste pour ta situation "
+    "et doivent etre verifiees. Consulte un-e spécialiste pour ta situation "
     "personnelle (LSFin art. 3). L'image source n'est jamais stockee."
 )
 

--- a/services/backend/app/api/v1/endpoints/documents.py
+++ b/services/backend/app/api/v1/endpoints/documents.py
@@ -184,7 +184,7 @@ def _index_in_rag(doc_id: str, extracted_fields: dict, document_type: str) -> bo
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Premier Eclairage — 4-layer insight engine for documents (DOC-07)
+# Premier Éclairage — 4-layer insight engine for documents (DOC-07)
 # ──────────────────────────────────────────────────────────────────────────────
 
 _DOCUMENT_SOURCES_MAP = {
@@ -200,7 +200,7 @@ _DOCUMENT_SOURCES_MAP = {
 
 _DISCLAIMER_TEXT = (
     "Outil educatif. Ne constitue pas un conseil financier au sens de la LSFin. "
-    "Pour une analyse adaptee a ta situation, consulte un\u00b7e specialiste."
+    "Pour une analyse adaptee a ta situation, consulte un\u00b7e spécialiste."
 )
 
 _PREMIER_ECLAIRAGE_SYSTEM_PROMPT = """\
@@ -259,7 +259,7 @@ def generate_document_insight(
     canton: Optional[str] = None,
     plan_type: Optional[str] = None,
 ) -> PremierEclairageResponse:
-    """Generate a 4-layer premier eclairage from extracted document data.
+    """Generate a 4-layer premier éclairage from extracted document data.
 
     Uses Claude API with the MINT 4-layer insight engine pattern.
     Falls back to a safe summary if the API call fails.
@@ -278,7 +278,7 @@ def generate_document_insight(
     # Check API key availability
     api_key = settings.ANTHROPIC_API_KEY
     if not api_key:
-        logger.warning("No ANTHROPIC_API_KEY for premier eclairage, returning fallback")
+        logger.warning("No ANTHROPIC_API_KEY for premier éclairage, returning fallback")
         return _build_fallback_response(extracted_fields, doc_type_str)
 
     # Build prompt context
@@ -328,7 +328,7 @@ def generate_document_insight(
         )
 
     except Exception as e:
-        logger.warning("Premier eclairage generation failed: %s", e)
+        logger.warning("Premier éclairage generation failed: %s", e)
         return _build_fallback_response(extracted_fields, doc_type_str)
 
 
@@ -344,7 +344,7 @@ async def document_premier_eclairage(
     request: Request,
     _user: User = Depends(require_current_user),
 ):
-    """Generate a 4-layer premier eclairage from extracted document data (DOC-07).
+    """Generate a 4-layer premier éclairage from extracted document data (DOC-07).
 
     Called after document extraction and user confirmation to produce a
     personalized insight using the MINT 4-layer insight engine:

--- a/services/backend/app/api/v1/endpoints/family.py
+++ b/services/backend/app/api/v1/endpoints/family.py
@@ -55,7 +55,7 @@ router = APIRouter()
 
 DISCLAIMER = (
     "Estimations educatives simplifiees. Ne constitue pas un conseil "
-    "fiscal ou juridique (LSFin/LLCA). Consulte un ou une specialiste."
+    "fiscal ou juridique (LSFin/LLCA). Consulte un ou une spécialiste."
 )
 
 

--- a/services/backend/app/api/v1/endpoints/open_banking.py
+++ b/services/backend/app/api/v1/endpoints/open_banking.py
@@ -87,7 +87,7 @@ DISCLAIMER = (
     "Informations a titre educatif et indicatif uniquement. "
     "Les donnees presentees proviennent d'un environnement de demonstration (sandbox). "
     "MINT ne fournit pas de conseil financier personnalise. "
-    "Consultez un ou une specialiste pour toute decision financiere."
+    "Consultez un ou une spécialiste pour toute decision financiere."
 )
 
 

--- a/services/backend/app/api/v1/endpoints/overview.py
+++ b/services/backend/app/api/v1/endpoints/overview.py
@@ -460,7 +460,7 @@ def get_overview_me(
             gaps.append(f"{name}.{f}")
 
     alertes = _compute_alertes(data)
-    eclairage = _premier_eclairage(
+    éclairage = _premier_eclairage(
         sections["identity"], sections["income"],
         sections["prevoyance"], completeness,
     )
@@ -477,5 +477,5 @@ def get_overview_me(
         completeness_index=round(completeness, 2),
         profile_gaps=gaps,
         alertes=alertes,
-        premier_eclairage=eclairage,
+        premier_eclairage=éclairage,
     )

--- a/services/backend/app/api/v1/endpoints/precision.py
+++ b/services/backend/app/api/v1/endpoints/precision.py
@@ -47,7 +47,7 @@ router = APIRouter()
 _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Les estimations sont indicatives. "
-    "Consulte un·e specialiste pour ta situation personnelle (LSFin art. 3)."
+    "Consulte un·e spécialiste pour ta situation personnelle (LSFin art. 3)."
 )
 
 _SOURCES = [

--- a/services/backend/app/api/v1/endpoints/privacy.py
+++ b/services/backend/app/api/v1/endpoints/privacy.py
@@ -42,7 +42,7 @@ DISCLAIMER = (
     "Outil educatif de gestion de tes donnees personnelles. "
     "Ne constitue pas un avis juridique. "
     "Tes droits sont regis par la nLPD (RS 235.1) en vigueur depuis le 1er septembre 2023. "
-    "Pour toute question, contacte un ou une specialiste en protection des donnees."
+    "Pour toute question, contacte un ou une spécialiste en protection des donnees."
 )
 
 

--- a/services/backend/app/api/v1/endpoints/retirement.py
+++ b/services/backend/app/api/v1/endpoints/retirement.py
@@ -29,7 +29,7 @@ router = APIRouter()
 
 DISCLAIMER = (
     "Estimations educatives simplifiees. Ne constitue pas un conseil "
-    "en prevoyance (LSFin). Consulte un ou une specialiste."
+    "en prevoyance (LSFin). Consulte un ou une spécialiste."
 )
 
 

--- a/services/backend/app/api/v1/endpoints/snapshots.py
+++ b/services/backend/app/api/v1/endpoints/snapshots.py
@@ -86,7 +86,7 @@ def _snapshot_to_response(snapshot) -> SnapshotResponse:
 @router.post("", response_model=SnapshotResponse)
 @limiter.limit("30/minute")
 def create_financial_snapshot(request: Request, body: CreateSnapshotRequest, response: Response, current_user: User = Depends(require_current_user), db: Session = Depends(get_db)) -> SnapshotResponse:
-    """Creer un snapshot financier.
+    """Créer un snapshot financier.
 
     Capture l'etat financier de l'utilisateur a un moment donne,
     declenche par un check-in trimestriel, un evenement de vie,

--- a/services/backend/app/schemas/arbitrage.py
+++ b/services/backend/app/schemas/arbitrage.py
@@ -182,7 +182,7 @@ class AllocationAnnuelleRequest(ArbitrageBaseModel):
     )
     a3a_maxed: Optional[bool] = Field(
         default=None,
-        description="3a deja verse au maximum cette annee (defaut: False)",
+        description="3a déjà verse au maximum cette annee (defaut: False)",
     )
     potentiel_rachat_lpp: Optional[float] = Field(
         default=None, ge=0,

--- a/services/backend/app/schemas/document_scan.py
+++ b/services/backend/app/schemas/document_scan.py
@@ -145,7 +145,7 @@ class VisionExtractionRequest(BaseModel):
 
 
 class PremierEclairageRequest(BaseModel):
-    """Request for document-specific premier eclairage generation (DOC-07).
+    """Request for document-specific premier éclairage generation (DOC-07).
 
     After document extraction, sends extracted fields to generate a
     personalized 4-layer insight using the MINT insight engine.
@@ -178,7 +178,7 @@ class PremierEclairageRequest(BaseModel):
 
 
 class PremierEclairageResponse(BaseModel):
-    """Response with 4-layer premier eclairage from document data (DOC-07).
+    """Response with 4-layer premier éclairage from document data (DOC-07).
 
     Structure follows the MINT 4-layer insight engine:
     1. Factual extraction (what the document says)

--- a/services/backend/app/schemas/pillar_3a_deep.py
+++ b/services/backend/app/schemas/pillar_3a_deep.py
@@ -67,7 +67,7 @@ class YearlyWithdrawalEntryResponse(BaseModel):
     impot: float = Field(..., description="Impot paye (CHF)")
     netRecu: float = Field(
         ..., alias="netRecu",
-        description="Montant net recu (CHF)"
+        description="Montant net reçu (CHF)"
     )
 
 

--- a/services/backend/app/schemas/snapshots.py
+++ b/services/backend/app/schemas/snapshots.py
@@ -32,7 +32,7 @@ class SnapshotBaseModel(BaseModel):
 # ===========================================================================
 
 class CreateSnapshotRequest(SnapshotBaseModel):
-    """Requete pour creer un snapshot financier."""
+    """Requete pour créer un snapshot financier."""
 
     user_id: str = Field(
         ..., min_length=1,
@@ -77,7 +77,7 @@ class SnapshotResponse(SnapshotBaseModel):
     fri_l: float = Field(0.0, description="FRI Liquidite (0-100)")
     fri_f: float = Field(0.0, description="FRI Fiscalite (0-100)")
     fri_r: float = Field(0.0, description="FRI Retraite (0-100)")
-    fri_s: float = Field(0.0, description="FRI Securite (0-100)")
+    fri_s: float = Field(0.0, description="FRI Sécurité (0-100)")
 
 
 class SnapshotListResponse(SnapshotBaseModel):

--- a/services/backend/app/services/arbitrage/allocation_annuelle.py
+++ b/services/backend/app/services/arbitrage/allocation_annuelle.py
@@ -49,7 +49,7 @@ from app.services.arbitrage.arbitrage_models import (
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les projections reposent sur des "
-    "hypotheses simplifiees. Consulte un\u00b7e specialiste pour une analyse "
+    "hypotheses simplifiees. Consulte un\u00b7e spécialiste pour une analyse "
     "adaptee a ta situation."
 )
 
@@ -300,7 +300,7 @@ def _build_hypotheses(
         f"Rendement LPP (caisse): {rendement_lpp * 100:.2f}%/an",
         f"Rendement marche libre: {rendement_marche * 100:.1f}%/an",
         f"Canton de domicile fiscal: {canton}",
-        f"3a deja verse au maximum: {'oui' if a3a_maxed else 'non'}",
+        f"3a déjà verse au maximum: {'oui' if a3a_maxed else 'non'}",
         f"Potentiel de rachat LPP: {potentiel_rachat_lpp:,.0f} CHF",
         f"Proprietaire: {'oui' if is_property_owner else 'non'}",
     ]

--- a/services/backend/app/services/arbitrage/calendrier_retraits.py
+++ b/services/backend/app/services/arbitrage/calendrier_retraits.py
@@ -51,7 +51,7 @@ from app.services.arbitrage.arbitrage_models import (
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les projections reposent sur des "
-    "hypotheses simplifiees. Consulte un\u00b7e specialiste pour une analyse "
+    "hypotheses simplifiees. Consulte un\u00b7e spécialiste pour une analyse "
     "adaptee a ta situation."
 )
 

--- a/services/backend/app/services/arbitrage/location_vs_propriete.py
+++ b/services/backend/app/services/arbitrage/location_vs_propriete.py
@@ -45,7 +45,7 @@ from app.services.arbitrage.arbitrage_models import (
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les projections reposent sur des "
-    "hypotheses simplifiees. Consulte un\u00b7e specialiste pour une analyse "
+    "hypotheses simplifiees. Consulte un\u00b7e spécialiste pour une analyse "
     "adaptee a ta situation."
 )
 

--- a/services/backend/app/services/arbitrage/rachat_vs_marche.py
+++ b/services/backend/app/services/arbitrage/rachat_vs_marche.py
@@ -48,7 +48,7 @@ from app.services.arbitrage.arbitrage_models import (
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les projections reposent sur des "
-    "hypotheses simplifiees. Consulte un\u00b7e specialiste pour une analyse "
+    "hypotheses simplifiees. Consulte un\u00b7e spécialiste pour une analyse "
     "adaptee a ta situation."
 )
 

--- a/services/backend/app/services/arbitrage/rente_vs_capital.py
+++ b/services/backend/app/services/arbitrage/rente_vs_capital.py
@@ -52,7 +52,7 @@ from app.services.arbitrage.arbitrage_models import (
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les projections reposent sur des "
-    "hypotheses simplifiees. Consulte un\u00b7e specialiste pour une analyse "
+    "hypotheses simplifiees. Consulte un\u00b7e spécialiste pour une analyse "
     "adaptee a ta situation."
 )
 

--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -273,8 +273,8 @@ When the user opens a monthly check-in (topic: monthlyCheckIn) or you detect it 
 """
 
 _FOUR_LAYER_ENGINE = """\
-## 4-LAYER INSIGHT ENGINE (premier eclairage & onboarding)
-When generating a premier eclairage, onboarding insight, or first interaction:
+## 4-LAYER INSIGHT ENGINE (premier éclairage & onboarding)
+When generating a premier éclairage, onboarding insight, or first interaction:
 
 Structure your response through 4 layers (present as natural narrative, NOT as labeled sections):
 1. FACTUAL EXTRACTION: The raw financial fact (e.g., "Ton employeur verse 7% de ton salaire assure au 2e pilier").
@@ -432,9 +432,9 @@ Si un pré-mortem a déjà été fait sur ce sujet (voir RISQUES IDENTIFIÉS dan
 _PROVENANCE_TRACKING = """\
 ## PROVENANCE (qui a recommande quoi)
 Quand l'utilisateur mentionne un produit financier (3a, LPP, assurance, hypotheque, placement) :
-1. Si la provenance n'est pas deja connue (voir PROVENANCE CONNUE dans le contexte), demande naturellement :
+1. Si la provenance n'est pas déjà connue (voir PROVENANCE CONNUE dans le contexte), demande naturellement :
    "Au fait, ce [produit], c'est qui qui te l'a propose ?"
-2. Ne pose la question qu'UNE FOIS par produit. Si la provenance est deja enregistree, reference-la naturellement :
+2. Ne pose la question qu'UNE FOIS par produit. Si la provenance est déjà enregistree, reference-la naturellement :
    "le 3a que ton banquier t'a propose chez UBS..."
 3. Quand l'utilisateur repond, appelle save_provenance avec product_type, recommended_by, et institution si mentionnee.
 4. JAMAIS de jugement sur l'intermediaire. Mint explicite le contrat, ne juge pas l'emetteur.
@@ -691,7 +691,7 @@ def build_system_prompt(
         routing_rules=_TOOL_ROUTING_RULES,
     )
 
-    # 4-layer insight engine (always included for premier eclairage)
+    # 4-layer insight engine (always included for premier éclairage)
     base += "\n" + _FOUR_LAYER_ENGINE
 
     # Life event + archetype taxonomies (deep-audit 2026-04-17 P0-1).

--- a/services/backend/app/services/coach/doctrine_checks.py
+++ b/services/backend/app/services/coach/doctrine_checks.py
@@ -207,7 +207,7 @@ _HANDOFF_PATTERNS = [
     r"rendez[-\s]vous",
     r"rendez[-\s]vous avec un[·\s]e?\s*spécialiste",
     r"spécialiste",
-    r"specialiste",
+    r"spécialiste",
     r"prends le temps",
     r"prenons le temps",
     r"prends une pause",

--- a/services/backend/app/services/coach/fallback_templates.py
+++ b/services/backend/app/services/coach/fallback_templates.py
@@ -139,7 +139,7 @@ class FallbackTemplates:
                 f"{ctx.first_name}, certaines regles de prevoyance "
                 "dependent de ta nationalite et de ton parcours. "
                 "Verifie les conventions bilaterales qui pourraient "
-                "s'appliquer a ta situation aupres d'un specialiste."
+                "s'appliquer a ta situation aupres d'un spécialiste."
             )
 
         return (

--- a/services/backend/app/services/confidence/enhanced_confidence_models.py
+++ b/services/backend/app/services/confidence/enhanced_confidence_models.py
@@ -105,7 +105,7 @@ class ConfidenceResult:
         "Cet outil est educatif et ne constitue pas un conseil financier, "
         "fiscal ou juridique personnalise. Le score de confiance mesure "
         "la qualite des donnees fournies, pas la fiabilite des projections. "
-        "Consulte un-e specialiste pour ta situation personnelle (LSFin art. 3)."
+        "Consulte un-e spécialiste pour ta situation personnelle (LSFin art. 3)."
     )
     sources: List[str] = field(default_factory=lambda: [
         "LPP art. 7 (seuil d'entree: 22'680 CHF)",

--- a/services/backend/app/services/confidence/enhanced_confidence_service.py
+++ b/services/backend/app/services/confidence/enhanced_confidence_service.py
@@ -410,9 +410,9 @@ def rank_enrichment_prompts(
     """Classe les actions d'enrichissement par impact decroissant.
 
     Pour chaque action du catalogue, calcule l'impact reel en fonction
-    de ce qui est deja rempli/source dans le profil.
+    de ce qui est déjà rempli/source dans le profil.
 
-    Actions deja completees (champ rempli + source de bonne qualite) sont
+    Actions déjà completees (champ rempli + source de bonne qualite) sont
     exclues ou ont un impact reduit.
 
     Args:

--- a/services/backend/app/services/coverage_checklist_service.py
+++ b/services/backend/app/services/coverage_checklist_service.py
@@ -31,7 +31,7 @@ DISCLAIMER = (
     "Cette analyse est fournie a titre educatif et indicatif. "
     "Les couts estimes sont des fourchettes indicatives basees sur "
     "des moyennes du marche suisse. MINT ne constitue pas un conseil "
-    "en assurance au sens de la LCA. Consultez un ou une specialiste "
+    "en assurance au sens de la LCA. Consultez un ou une spécialiste "
     "en assurances pour une analyse personnalisee."
 )
 

--- a/services/backend/app/services/debt_prevention/debt_ratio_service.py
+++ b/services/backend/app/services/debt_prevention/debt_ratio_service.py
@@ -21,7 +21,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un avis juridique. Les montants du minimum vital sont des estimations "
     "basees sur les directives de la Conference des preposes. Consultez un ou "
-    "une specialiste en desendettement pour une analyse personnalisee."
+    "une spécialiste en desendettement pour une analyse personnalisee."
 )
 
 

--- a/services/backend/app/services/debt_prevention/repayment_service.py
+++ b/services/backend/app/services/debt_prevention/repayment_service.py
@@ -21,7 +21,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un avis financier ou juridique. Les projections sont basees sur les "
     "donnees fournies et supposent des conditions stables. Consultez un ou "
-    "une specialiste en desendettement pour une analyse personnalisee."
+    "une spécialiste en desendettement pour une analyse personnalisee."
 )
 
 

--- a/services/backend/app/services/debt_prevention/resources_service.py
+++ b/services/backend/app/services/debt_prevention/resources_service.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un avis juridique. Les ressources listees sont des organismes publics "
-    "ou associatifs reconnus. Consultez un ou une specialiste pour un "
+    "ou associatifs reconnus. Consultez un ou une spécialiste pour un "
     "accompagnement personnalise."
 )
 
@@ -364,7 +364,7 @@ _SITUATION_RESOURCES = {
     "surendettement": HelpResource(
         nom="Dettes Conseils Suisse — Programme de desendettement",
         description=(
-            "Accompagnement complet pour elaborer un plan de desendettement. "
+            "Accompagnement complet pour élaborer un plan de desendettement. "
             "Negociation avec les creanciers, plan de paiement echelonne."
         ),
         url="https://www.dettes.ch/desendettement",

--- a/services/backend/app/services/disability_gap_service.py
+++ b/services/backend/app/services/disability_gap_service.py
@@ -148,7 +148,7 @@ class DisabilityGapResult:
 
 DISCLAIMER: str = (
     "Outil educatif — ne constitue pas un conseil en assurance. "
-    "Consulte un\u00b7e specialiste en prevoyance pour un bilan personnalise."
+    "Consulte un\u00b7e spécialiste en prevoyance pour un bilan personnalise."
 )
 
 SOURCES: List[str] = [

--- a/services/backend/app/services/divorce_simulator.py
+++ b/services/backend/app/services/divorce_simulator.py
@@ -134,7 +134,7 @@ class DivorceSimulator:
             alerts=alerts,
             disclaimer=(
                 "Outil educatif — ne constitue pas un conseil (LSFin). "
-                "Estimation indicative. Consultez un·e specialiste "
+                "Estimation indicative. Consultez un·e spécialiste "
                 "en droit de la famille."
             ),
         )

--- a/services/backend/app/services/document_parser/avs_extract_parser.py
+++ b/services/backend/app/services/document_parser/avs_extract_parser.py
@@ -189,7 +189,7 @@ _MAX_CONFIDENCE_DELTA = 25.0
 _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Les valeurs extraites sont indicatives "
-    "et doivent etre verifiees. Consulte un-e specialiste pour ta situation "
+    "et doivent etre verifiees. Consulte un-e spécialiste pour ta situation "
     "personnelle (LSFin art. 3). L'image source n'est jamais stockee."
 )
 
@@ -531,7 +531,7 @@ def estimate_avs_confidence_delta(
     Le delta depend de:
     - Quels champs ont ete extraits
     - L'impact de chaque champ sur la precision des projections
-    - Quels champs etaient deja renseignes dans le profil actuel
+    - Quels champs etaient déjà renseignes dans le profil actuel
 
     Args:
         extraction: Resultat de l'extraction AVS.

--- a/services/backend/app/services/document_parser/document_models.py
+++ b/services/backend/app/services/document_parser/document_models.py
@@ -104,7 +104,7 @@ class ExtractionResult:
     disclaimer: str = (
         "Cet outil est educatif et ne constitue pas un conseil financier, "
         "fiscal ou juridique personnalise. Les valeurs extraites sont indicatives "
-        "et doivent etre verifiees. Consulte un-e specialiste pour ta situation "
+        "et doivent etre verifiees. Consulte un-e spécialiste pour ta situation "
         "personnelle (LSFin art. 3). L'image source n'est jamais stockee."
     )
     sources: List[str] = field(default_factory=lambda: [

--- a/services/backend/app/services/document_parser/lpp_certificate_parser.py
+++ b/services/backend/app/services/document_parser/lpp_certificate_parser.py
@@ -351,7 +351,7 @@ _MAX_CONFIDENCE_DELTA = 30.0
 _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Les valeurs extraites sont indicatives "
-    "et doivent etre verifiees. Consulte un-e specialiste pour ta situation "
+    "et doivent etre verifiees. Consulte un-e spécialiste pour ta situation "
     "personnelle (LSFin art. 3). L'image source n'est jamais stockee."
 )
 
@@ -575,7 +575,7 @@ def estimate_confidence_delta(
     Le delta depend de:
     - Quels champs ont ete extraits
     - L'impact de chaque champ sur la precision des projections
-    - Quels champs etaient deja renseignes dans le profil actuel
+    - Quels champs etaient déjà renseignes dans le profil actuel
 
     Args:
         extraction: Resultat de l'extraction LPP.

--- a/services/backend/app/services/document_parser/tax_declaration_parser.py
+++ b/services/backend/app/services/document_parser/tax_declaration_parser.py
@@ -152,7 +152,7 @@ _MAX_CONFIDENCE_DELTA = 20.0
 _DISCLAIMER = (
     "Cet outil est educatif et ne constitue pas un conseil financier, "
     "fiscal ou juridique personnalise. Les valeurs extraites sont indicatives "
-    "et doivent etre verifiees. Consulte un-e specialiste pour ta situation "
+    "et doivent etre verifiees. Consulte un-e spécialiste pour ta situation "
     "personnelle (LSFin art. 3). L'image source n'est jamais stockee."
 )
 
@@ -403,7 +403,7 @@ def estimate_tax_confidence_delta(
     Le delta depend de:
     - Quels champs ont ete extraits
     - L'impact de chaque champ sur la precision des projections
-    - Quels champs etaient deja renseignes dans le profil actuel
+    - Quels champs etaient déjà renseignes dans le profil actuel
 
     Args:
         extraction: Resultat de l'extraction fiscale.

--- a/services/backend/app/services/donation_service.py
+++ b/services/backend/app/services/donation_service.py
@@ -37,7 +37,7 @@ DISCLAIMER: str = (
     "Cet outil educatif fournit une estimation indicative et ne constitue "
     "pas un conseil financier, fiscal ou juridique au sens de la LSFin. "
     "Les taux d'imposition sur les donations varient selon le canton, "
-    "le lien de parente et le montant. Consulte un·e specialiste "
+    "le lien de parente et le montant. Consulte un·e spécialiste "
     "(notaire, avocat·e en droit successoral) pour ta situation concrete."
 )
 

--- a/services/backend/app/services/educational_content_service.py
+++ b/services/backend/app/services/educational_content_service.py
@@ -19,7 +19,7 @@ Sources:
 
 Ethical requirements:
     - Educational tone, never prescriptive
-    - Gender-neutral language (un-e specialiste)
+    - Gender-neutral language (un-e spécialiste)
     - No banned terms: garanti, certain, assure, sans risque, optimal, meilleur, parfait
     - Disclaimer on every insert
 """
@@ -35,7 +35,7 @@ from typing import Dict, List, Optional
 DISCLAIMER: str = (
     "Ceci est un outil educatif et ne constitue pas un conseil financier "
     "personnalise au sens de la LSFin. Les informations fournies sont indicatives "
-    "et basees sur la legislation suisse en vigueur. Consulte un-e specialiste "
+    "et basees sur la legislation suisse en vigueur. Consulte un-e spécialiste "
     "pour un conseil adapte a ta situation."
 )
 
@@ -102,7 +102,7 @@ _register(InsertContent(
     learning_goals=[
         "Identifier le type de stress financier predominant (budget, dette, impots, retraite).",
         "Comprendre que la charge mentale financiere peut etre reduite par un seul levier prioritaire.",
-        "Decouvrir les 4 piliers d'action MINT : budget, dette, fiscalite, prevoyance.",
+        "Découvrir les 4 piliers d'action MINT : budget, dette, fiscalite, prevoyance.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -127,7 +127,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre le seuil d'entree LPP (22'680 CHF/an, LPP art. 7).",
         "Savoir que le statut LPP determine le plafond 3a (petit vs grand).",
-        "Decouvrir que seule l'attestation de prevoyance fait foi pour le statut.",
+        "Découvrir que seule l'attestation de prevoyance fait foi pour le statut.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -152,7 +152,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que le 3a est deductible du revenu imposable (LIFD art. 33).",
         "Savoir que l'economie fiscale depend du taux marginal d'imposition (canton).",
-        "Decouvrir que l'eligibilite au 3a requiert un revenu soumis a l'AVS.",
+        "Découvrir que l'eligibilite au 3a requiert un revenu soumis a l'AVS.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -177,7 +177,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre le calcul de l'economie fiscale (montant verse x taux marginal).",
         "Savoir que l'effort d'epargne net est inferieur au montant verse (versement - economie fiscale).",
-        "Decouvrir l'effet cumule sur 20-30 ans (interets composes + economies fiscales).",
+        "Découvrir l'effet cumule sur 20-30 ans (interets composes + economies fiscales).",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -201,7 +201,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre la difference entre taux fixe (stabilite) et SARON (variabilite).",
         "Savoir que le choix depend de la tolerance au risque et de l'horizon.",
-        "Decouvrir que le renouvellement se negocie 12-18 mois avant l'echeance.",
+        "Découvrir que le renouvellement se negocie 12-18 mois avant l'echeance.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -226,7 +226,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre le TAEG (taux annuel effectif global) et son impact sur le cout total.",
         "Savoir que le remboursement anticipe est possible sans penalite (LCC art. 17).",
-        "Decouvrir que le credit a la consommation est prioritaire a rembourser avant toute epargne.",
+        "Découvrir que le credit a la consommation est prioritaire a rembourser avant toute epargne.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -251,7 +251,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que le leasing est une dette (mensualite fixe sans propriete a terme).",
         "Savoir que le leasing reduit la capacite d'emprunt hypothecaire (charges mensuelles).",
-        "Decouvrir la comparaison financiere pure : leasing vs achat (cout total de detention).",
+        "Découvrir la comparaison financiere pure : leasing vs achat (cout total de detention).",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -266,16 +266,16 @@ _register(InsertContent(
 
 _register(InsertContent(
     question_id="q_emergency_fund",
-    title="Fonds d'urgence : ton filet de securite",
+    title="Fonds d'urgence : ton filet de sécurité",
     premier_eclairage=(
-        "3 a 6 mois de charges fixes : c'est le filet de securite "
+        "3 a 6 mois de charges fixes : c'est le filet de sécurité "
         "recommande. En Suisse, un-e salarie-e sur trois n'a pas "
         "d'epargne de precaution suffisante pour tenir 3 mois."
     ),
     learning_goals=[
         "Comprendre le concept de fonds d'urgence (3-6 mois de charges fixes).",
         "Savoir que les charges fixes representent environ 50% du revenu si non detaillees.",
-        "Decouvrir que le fonds d'urgence est la priorite n-1 avant toute epargne ou investissement.",
+        "Découvrir que le fonds d'urgence est la priorite n-1 avant toute epargne ou investissement.",
     ],
     disclaimer=DISCLAIMER,
     sources=[
@@ -301,7 +301,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que le mariage implique un regime matrimonial (participation aux acquets par defaut, CC art. 181).",
         "Savoir que le concubinage n'offre aucune protection legale automatique (pas de part reservataire).",
-        "Decouvrir que le divorce entraine un partage du 2e pilier impose par la loi (LPP art. 22).",
+        "Découvrir que le divorce entraine un partage du 2e pilier impose par la loi (LPP art. 22).",
         "Comprendre l'impact fiscal du mariage : imposition commune (LIFD art. 9 al. 1).",
         "Savoir que le partenariat enregistre n'est plus accessible depuis le 1er juillet 2022 (mariage pour tous). Les partenariats existants restent valables avec des effets proches du mariage, mais pas identiques (LPart art. 1).",
     ],
@@ -330,7 +330,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre les 3 regimes : salarie, independant, sans activite lucrative.",
         "Savoir que le salarie beneficie automatiquement de l'AVS (LAVS art. 3), du LPP (LPP art. 2) et de la LAA (LAA art. 1a).",
-        "Decouvrir que l'independant doit tout organiser lui-meme : AVS, LPP volontaire, IJM, assurance accident.",
+        "Découvrir que l'independant doit tout organiser lui-meme : AVS, LPP volontaire, IJM, assurance accident.",
         "Comprendre que le chomage donne droit a l'AC (LACI art. 8) et maintient la couverture LPP pendant 2 ans max.",
         "Savoir que le sans-activite lucrative cotise quand meme a l'AVS (LAVS art. 10).",
     ],
@@ -360,7 +360,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que la propriete en Suisse implique un apport minimum de 20% (FINMA circ. 2017/7).",
         "Savoir que le proprietaire paie l'impot sur la valeur locative (LIFD art. 21 al. 1 let. b) mais peut deduire les interets hypothecaires.",
-        "Decouvrir le mecanisme de l'EPL : retrait LPP + 3a pour financer l'apport (LPP art. 30c).",
+        "Découvrir le mecanisme de l'EPL : retrait LPP + 3a pour financer l'apport (LPP art. 30c).",
         "Comprendre le calcul de la capacite d'emprunt : charges max 1/3 du revenu brut, au taux theorique de 5%.",
         "Savoir que le locataire conserve sa flexibilite et sa liquidite.",
     ],
@@ -389,7 +389,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que la Suisse a 3 niveaux d'imposition : federal (fixe), cantonal et communal (variables).",
         "Savoir que le taux effectif d'imposition varie enormement d'un canton a l'autre.",
-        "Decouvrir que les deductions (3a, LPP, frais medicaux, enfants) varient aussi par canton.",
+        "Découvrir que les deductions (3a, LPP, frais medicaux, enfants) varient aussi par canton.",
         "Comprendre que la fortune est imposee annuellement au niveau cantonal (pas federal).",
         "Savoir que les 26 cantons ont leurs propres baremes, allocations familiales et primes LAMal.",
     ],
@@ -417,7 +417,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que le rachat LPP est deductible a 100% du revenu imposable (LPP art. 79b).",
         "Savoir que le montant maximum de rachat figure sur le certificat de prevoyance.",
-        "Decouvrir la strategie d'echelonnement : repartir les rachats sur 3-5 ans pour la progressivite.",
+        "Découvrir la strategie d'echelonnement : repartir les rachats sur 3-5 ans pour la progressivite.",
         "Comprendre le blocage EPL : apres un rachat, pas de retrait EPL pendant 3 ans (LPP art. 79b al. 3).",
         "Savoir que le rachat augmente aussi ta rente future (ou ton capital de retrait).",
     ],
@@ -445,7 +445,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que le retrait du 3a est impose comme un revenu (taux progressif, LIFD art. 38).",
         "Savoir que les retraits de la meme annee sont additionnes pour le calcul du taux.",
-        "Decouvrir la strategie d'echelonnement : ouvrir 4-5 comptes et les retirer sur 4-5 annees differentes.",
+        "Découvrir la strategie d'echelonnement : ouvrir 4-5 comptes et les retirer sur 4-5 annees differentes.",
         "Comprendre que les retraits 3a et LPP en capital de la meme annee se cumulent pour l'imposition.",
         "Savoir que l'age de retrait anticipe est 5 ans avant l'age de reference AVS : 60 ans (hommes), 59 ans (femmes nees avant 1964) ou 60 ans (femmes nees des 1964) — OPP3 art. 3 al. 1.",
     ],
@@ -474,7 +474,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre que les gains en capital prives ne sont PAS imposes en Suisse (LIFD art. 16 al. 3).",
         "Savoir que les dividendes et interets sont imposables comme revenu ordinaire (LIFD art. 20).",
-        "Decouvrir que la fortune est imposee chaque annee (impot cantonal sur la fortune).",
+        "Découvrir que la fortune est imposee chaque annee (impot cantonal sur la fortune).",
         "Comprendre le concept de risque vs rendement : les valeurs mobilieres suisses (SPI) ont rendu ~7%/an sur 20 ans.",
         "Savoir que MINT ne donne pas de conseil en investissement (LSFin art. 3).",
     ],
@@ -485,7 +485,7 @@ _register(InsertContent(
         "LSFin art. 3 (conseil en investissement)",
         "FINMA circ. 2018/3 (regles de conduite)",
     ],
-    action_label="Decouvrir les bases de la diversification",
+    action_label="Découvrir les bases de la diversification",
     action_route="/learn/investments-basics",
     phase="Niveau 2",
     safe_mode="Si dette critique detectee : priorite au desendettement avant tout investissement.",
@@ -503,7 +503,7 @@ _register(InsertContent(
     learning_goals=[
         "Comprendre la regle des 20% d'apport : minimum 10% en cash ou 3a, max 10% du 2e pilier (FINMA circ. 2017/7).",
         "Savoir calculer la capacite d'emprunt : charges (5% + 1% + 1%) max 1/3 du revenu brut.",
-        "Decouvrir les 3 sources d'apport : epargne, 3a (retrait integral), LPP (EPL, LPP art. 30c).",
+        "Découvrir les 3 sources d'apport : epargne, 3a (retrait integral), LPP (EPL, LPP art. 30c).",
         "Comprendre la difference entre hypotheque 1er rang (max 65%) et 2e rang (a amortir en 15 ans).",
         "Savoir que l'achat declenche des frais uniques : notaire (~1-3%), droits de mutation, frais bancaires.",
     ],

--- a/services/backend/app/services/expat/__init__.py
+++ b/services/backend/app/services/expat/__init__.py
@@ -17,7 +17,7 @@ Sources:
     - LIFD art. 83-86 (impot a la source)
     - LIFD art. 14 (imposition d'apres la depense / forfait fiscal)
     - Accords bilateraux CH-UE sur la libre circulation (ALCP)
-    - Reglement CE 883/2004 (coordination securite sociale)
+    - Reglement CE 883/2004 (coordination sécurité sociale)
     - LAVS art. 1a, 2 (cotisations obligatoires / volontaires)
     - LPP art. 2 (libre passage)
     - OPP2 art. 11 (prestations de libre passage)

--- a/services/backend/app/services/expat/expat_service.py
+++ b/services/backend/app/services/expat/expat_service.py
@@ -37,7 +37,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de "
     "ta situation personnelle, du canton, du pays de destination et des "
     "conventions de double imposition en vigueur. Ne constitue pas un "
-    "conseil fiscal ou juridique (LSFin/LLCA). Consulte un ou une specialiste."
+    "conseil fiscal ou juridique (LSFin/LLCA). Consulte un ou une spécialiste."
 )
 
 # ---------------------------------------------------------------------------

--- a/services/backend/app/services/expat/frontalier_service.py
+++ b/services/backend/app/services/expat/frontalier_service.py
@@ -13,7 +13,7 @@ Sources:
     - Accords bilateraux CH-UE (ALCP art. 21)
     - Accord CH-FR du 11.04.1983 (regime special frontaliers FR-GE)
     - Accord CH-IT du 03.10.1974 (exception Tessin-Italie)
-    - Reglement CE 883/2004 art. 11 (securite sociale dans le pays d'emploi)
+    - Reglement CE 883/2004 art. 11 (sécurité sociale dans le pays d'emploi)
     - LAVS art. 5 (cotisations AVS/AI/APG)
     - LACI art. 3 (cotisations assurance-chomage)
     - LPP art. 2, 7, 8 (prevoyance professionnelle obligatoire)
@@ -42,7 +42,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de "
     "ton canton de travail, de ta situation personnelle et des accords "
     "bilateraux en vigueur. Ne constitue pas un conseil fiscal ou juridique "
-    "(LSFin/LLCA). Consulte un ou une specialiste."
+    "(LSFin/LLCA). Consulte un ou une spécialiste."
 )
 
 # ---------------------------------------------------------------------------
@@ -183,7 +183,7 @@ AANP_TAUX = 0.014  # ~1.4% (LAA art. 91, moyenne)
 
 # ---------------------------------------------------------------------------
 # Charges sociales pays voisins (estimations simplifiees 2025)
-# Source: securite sociale respective de chaque pays
+# Source: sécurité sociale respective de chaque pays
 # ---------------------------------------------------------------------------
 
 CHARGES_SOCIALES_PAYS = {
@@ -191,7 +191,7 @@ CHARGES_SOCIALES_PAYS = {
         "label": "France",
         "taux_employe_total": 0.225,  # ~22.5% (CSG 9.2% + CRDS 0.5% + secu ~13%)
         "taux_employeur_total": 0.45,  # ~45%
-        # Source: Code de la securite sociale (CSS), CGI art. 1600-0S
+        # Source: Code de la sécurité sociale (CSS), CGI art. 1600-0S
         "source": "CSS art. L241-1, CGI art. 1600-0S (CSG/CRDS)",
     },
     "DE": {
@@ -243,7 +243,7 @@ LAMAL_PRIMES_MENSUELLES = {
 }
 _DEFAULT_LAMAL_PRIME = 460.0
 
-# Primes mensuelles estimees dans les pays voisins (securite sociale + complementaire)
+# Primes mensuelles estimees dans les pays voisins (sécurité sociale + complementaire)
 # Source: estimations basees sur les systemes de sante respectifs
 ASSURANCE_RESIDENCE_PRIMES = {
     "FR": {"prime_mensuelle": 0.0, "cotisation_pct": 0.131,
@@ -594,7 +594,7 @@ class FrontalierService:
             recommandation = (
                 f"Avec {home_office_days} jours de teletravail a l'etranger, "
                 f"tu es largement en dessous du seuil de 90 jours. "
-                f"L'imposition reste integralement en Suisse. Marge de securite: "
+                f"L'imposition reste integralement en Suisse. Marge de sécurité: "
                 f"{REGLE_90_JOURS_SEUIL - home_office_days} jours."
             )
         elif home_office_days <= REGLE_90_JOURS_SEUIL:

--- a/services/backend/app/services/family/concubinage_service.py
+++ b/services/backend/app/services/family/concubinage_service.py
@@ -24,7 +24,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de "
     "ton canton, de ta situation personnelle et du droit cantonal applicable. "
     "Ne constitue pas un conseil fiscal ou juridique (LSFin/LLCA). "
-    "Consulte un ou une specialiste."
+    "Consulte un ou une spécialiste."
 )
 
 # ---------------------------------------------------------------------------
@@ -323,7 +323,7 @@ class ConcubinageService:
             "Verifier les clauses beneficiaires de toutes tes assurances-vie",
             "Envisager un mandat pour cause d'inaptitude (directives anticipees)",
             "Comparer les couts d'un mariage vs la protection actuelle",
-            "Consulter un ou une specialiste pour un bilan juridique complet",
+            "Consulter un ou une spécialiste pour un bilan juridique complet",
         ]
 
         items = priorite_haute + priorite_moyenne + priorite_basse

--- a/services/backend/app/services/family/mariage_service.py
+++ b/services/backend/app/services/family/mariage_service.py
@@ -28,7 +28,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de "
     "ton canton, de ta situation personnelle et du bareme communal. "
     "Ne constitue pas un conseil fiscal ou juridique (LSFin/LLCA). "
-    "Consulte un ou une specialiste."
+    "Consulte un ou une spécialiste."
 )
 
 # ---------------------------------------------------------------------------
@@ -467,8 +467,8 @@ class MariageService:
             "Commander de nouvelles pieces d'identite (passeport, CI) si changement de nom",
             "Informer ta banque, tes assurances et ton bailleur du changement d'etat civil",
             "Evaluer l'impact fiscal avec notre simulateur — selon vos revenus, "
-            f"le mariage peut creer un bonus ou une penalite fiscale (canton: {canton})",
-            "Consulter un ou une specialiste pour un bilan patrimonial complet avant le mariage",
+            f"le mariage peut créer un bonus ou une penalite fiscale (canton: {canton})",
+            "Consulter un ou une spécialiste pour un bilan patrimonial complet avant le mariage",
         ]
 
         items = priorite_haute + priorite_moyenne + priorite_basse

--- a/services/backend/app/services/family/naissance_service.py
+++ b/services/backend/app/services/family/naissance_service.py
@@ -31,7 +31,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de "
     "ton canton, de ton employeur et de ta situation personnelle. "
     "Ne constitue pas un conseil fiscal ou juridique (LSFin/LLCA). "
-    "Consulte un ou une specialiste."
+    "Consulte un ou une spécialiste."
 )
 
 # ---------------------------------------------------------------------------
@@ -497,7 +497,7 @@ class NaissanceService:
             "sur la prevoyance (LPP + 3a) — utilise notre simulateur 'career gap'"
         )
         priorite_basse.append(
-            "Consulter un ou une specialiste pour un bilan prevoyance familiale complet"
+            "Consulter un ou une spécialiste pour un bilan prevoyance familiale complet"
         )
 
         items = priorite_haute + priorite_moyenne + priorite_basse

--- a/services/backend/app/services/first_job/onboarding_service.py
+++ b/services/backend/app/services/first_job/onboarding_service.py
@@ -115,7 +115,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "en matiere fiscale ou de prevoyance au sens de la LSFin. Les montants exacts "
     "dependent de ton employeur, de ta caisse de pension et de ta situation personnelle. "
-    "Consulte un ou une specialiste pour une analyse personnalisee."
+    "Consulte un ou une spécialiste pour une analyse personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/app/services/fiscal/cantonal_comparator.py
+++ b/services/backend/app/services/fiscal/cantonal_comparator.py
@@ -130,7 +130,7 @@ DISCLAIMER = (
     "Estimations basees sur les baremes simplifies 2024-2026. "
     "Les taux effectifs varient selon la commune, la fortune, "
     "et les deductions individuelles. Consulte ton administration "
-    "fiscale cantonale ou un ou une specialiste fiscal·e. "
+    "fiscale cantonale ou un ou une spécialiste fiscal·e. "
     "Ne constitue pas un conseil fiscal (LSFin)."
 )
 

--- a/services/backend/app/services/fiscal/church_tax_service.py
+++ b/services/backend/app/services/fiscal/church_tax_service.py
@@ -7,7 +7,7 @@ dans la plupart des cantons pour les membres d'une eglise reconnue
 (catholique, protestante, chretienne-catholique).
 
 Dans certains cantons (TI, VD, NE, GE), l'impot ecclesiastique est
-volontaire ou deja integre dans l'impot cantonal.
+volontaire ou déjà integre dans l'impot cantonal.
 
 Sources:
     - LHID art. 1 (harmonisation fiscale)
@@ -96,7 +96,7 @@ DISCLAIMER = (
     "de la confession et du canton. "
     "Outil educatif — ne constitue pas un conseil fiscal (LSFin). "
     "Consulte ton administration fiscale cantonale ou un ou une "
-    "specialiste fiscal-e."
+    "spécialiste fiscal-e."
 )
 
 SOURCES = [

--- a/services/backend/app/services/fiscal/commune_service.py
+++ b/services/backend/app/services/fiscal/commune_service.py
@@ -30,7 +30,7 @@ DISCLAIMER = (
     "Coefficients fiscaux approximatifs bases sur les publications cantonales 2025. "
     "Le taux exact depend de la commune, de la confession et de l'annee fiscale. "
     "Pour une estimation precise, consulte le site de ton administration fiscale "
-    "communale ou un ou une specialiste fiscal-e. "
+    "communale ou un ou une spécialiste fiscal-e. "
     "Outil educatif — ne constitue pas un conseil fiscal (LSFin)."
 )
 

--- a/services/backend/app/services/fiscal/wealth_tax_service.py
+++ b/services/backend/app/services/fiscal/wealth_tax_service.py
@@ -139,7 +139,7 @@ DISCLAIMER = (
     "et la composition exacte du patrimoine. "
     "Outil educatif — ne constitue pas un conseil fiscal (LSFin). "
     "Consulte ton administration fiscale cantonale ou un ou une "
-    "specialiste fiscal-e pour un calcul precis."
+    "spécialiste fiscal-e pour un calcul precis."
 )
 
 SOURCES = [

--- a/services/backend/app/services/fri/fri_display_service.py
+++ b/services/backend/app/services/fri/fri_display_service.py
@@ -30,7 +30,7 @@ DISPLAY_CONFIDENCE_THRESHOLD = 50.0
 DISCLAIMER = (
     "Score de solidite financiere a titre educatif. "
     "Ne constitue pas un conseil financier (LSFin). "
-    "Consulte un·e specialiste pour une analyse personnalisee."
+    "Consulte un·e spécialiste pour une analyse personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/app/services/frontalier_service.py
+++ b/services/backend/app/services/frontalier_service.py
@@ -18,7 +18,7 @@ Sources:
     - OPP3 art. 7 (plafond 3a)
     - LPP art. 2 (affiliation obligatoire)
     - LAVS art. 153a (coordination EU/AELE)
-    - ALCP Annexe II (libre circulation, coordination securite sociale)
+    - ALCP Annexe II (libre circulation, coordination sécurité sociale)
     - Loi GE quasi-resident (90% revenus de source CH)
 
 Ethical requirements:
@@ -259,7 +259,7 @@ DISCLAIMER = (
     "Cette analyse est indicative et basee sur les regles generales "
     "applicables aux travailleurs frontaliers. Les regles fiscales et de "
     "prevoyance dependent de votre situation individuelle et peuvent "
-    "evoluer. Consultez un·e specialiste en droit international "
+    "evoluer. Consultez un·e spécialiste en droit international "
     "pour une analyse personnalisee."
 )
 
@@ -492,11 +492,11 @@ class FrontalierService:
             regime_avs="Cotisations AVS normales si employe en Suisse.",
             alertes=[
                 f"Le pays '{pays}' n'est pas un pays frontalier reconnu. "
-                f"Verifiez votre situation aupres d'un specialiste."
+                f"Verifiez votre situation aupres d'un spécialiste."
             ],
             recommandations=[{
                 "id": "consulter_specialiste",
-                "titre": "Consulter un specialiste",
+                "titre": "Consulter un spécialiste",
                 "description": (
                     "Votre situation ne correspond pas aux cas frontaliers "
                     "standard. Consultez un fiscaliste specialise en droit "

--- a/services/backend/app/services/household_service.py
+++ b/services/backend/app/services/household_service.py
@@ -167,7 +167,7 @@ def invite_partner(db: Session, owner: User, partner_email: str) -> dict:
     if active_count >= MAX_ACTIVE_MEMBERS:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Le menage a deja le nombre maximum de membres",
+            detail="Le menage a déjà le nombre maximum de membres",
         )
 
     # Find the partner user
@@ -196,7 +196,7 @@ def invite_partner(db: Session, owner: User, partner_email: str) -> dict:
     if existing_membership:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Cette personne est deja dans un menage",
+            detail="Cette personne est déjà dans un menage",
         )
 
     # Check cooldown (INV-6)
@@ -311,7 +311,7 @@ def accept_invitation(db: Session, user: User, invitation_code: str) -> dict:
     if active_count >= MAX_ACTIVE_MEMBERS:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail="Le menage a deja le nombre maximum de membres actifs",
+            detail="Le menage a déjà le nombre maximum de membres actifs",
         )
 
     member.status = "active"
@@ -409,7 +409,7 @@ def transfer_ownership(db: Session, caller: User, new_owner_id: str) -> dict:
     if new_owner_id == caller.id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Tu es deja le proprietaire",
+            detail="Tu es déjà le proprietaire",
         )
 
     # Check new owner is active member

--- a/services/backend/app/services/housing_sale_service.py
+++ b/services/backend/app/services/housing_sale_service.py
@@ -32,7 +32,7 @@ DISCLAIMER: str = (
     "Cet outil educatif fournit une estimation indicative et ne constitue "
     "pas un conseil financier, fiscal ou juridique au sens de la LSFin. "
     "Les taux d'imposition sur les gains immobiliers varient selon le canton, "
-    "la commune et la situation personnelle. Consulte un·e specialiste "
+    "la commune et la situation personnelle. Consulte un·e spécialiste "
     "(notaire, fiduciaire) pour ta situation concrete."
 )
 

--- a/services/backend/app/services/independant_service.py
+++ b/services/backend/app/services/independant_service.py
@@ -102,7 +102,7 @@ DISCLAIMER = (
     "Cette analyse est indicative et basee sur des taux moyens. "
     "Les cotisations AVS exactes dependent de votre caisse de compensation. "
     "Les primes IJM et LAA varient selon l'assureur et votre activite. "
-    "Consultez votre caisse de compensation et un·e specialiste en assurances "
+    "Consultez votre caisse de compensation et un·e spécialiste en assurances "
     "pour des montants precis."
 )
 

--- a/services/backend/app/services/independants/avs_cotisations_service.py
+++ b/services/backend/app/services/independants/avs_cotisations_service.py
@@ -29,7 +29,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "en matiere de cotisations sociales au sens de la LSFin. Les cotisations "
     "exactes dependent de votre caisse de compensation. Consultez un ou une "
-    "specialiste pour une analyse personnalisee."
+    "spécialiste pour une analyse personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/app/services/independants/dividende_vs_salaire_service.py
+++ b/services/backend/app/services/independants/dividende_vs_salaire_service.py
@@ -46,7 +46,7 @@ DISCLAIMER = (
     "fiscal ou juridique au sens de la LSFin. L'optimisation fiscale via "
     "le split salaire/dividende depend de la pratique cantonale et ne peut "
     "pas etre consideree comme acquise dans tous les cas. Le risque de "
-    "requalification fiscale existe. Consultez un ou une specialiste en "
+    "requalification fiscale existe. Consultez un ou une spécialiste en "
     "fiscalite et droit des societes pour une analyse personnalisee."
 )
 

--- a/services/backend/app/services/independants/ijm_service.py
+++ b/services/backend/app/services/independants/ijm_service.py
@@ -39,7 +39,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "en assurance au sens de la LSFin. Les primes IJM varient selon "
     "l'assureur, votre etat de sante et votre activite professionnelle. "
-    "Consultez un ou une specialiste en assurances pour une offre personnalisee."
+    "Consultez un ou une spécialiste en assurances pour une offre personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/app/services/independants/lpp_volontaire_service.py
+++ b/services/backend/app/services/independants/lpp_volontaire_service.py
@@ -54,7 +54,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "en prevoyance au sens de la LSFin. Les cotisations et prestations LPP "
     "effectives dependent du reglement de la caisse de pension choisie. "
-    "Consultez un ou une specialiste en prevoyance professionnelle pour "
+    "Consultez un ou une spécialiste en prevoyance professionnelle pour "
     "une analyse personnalisee."
 )
 

--- a/services/backend/app/services/independants/pillar_3a_indep_service.py
+++ b/services/backend/app/services/independants/pillar_3a_indep_service.py
@@ -36,7 +36,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "fiscal ou en prevoyance au sens de la LSFin. Les economies fiscales "
     "dependent de votre situation personnelle et de la legislation cantonale. "
-    "Consultez un ou une specialiste en fiscalite pour une analyse personnalisee."
+    "Consultez un ou une spécialiste en fiscalite pour une analyse personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/app/services/lpp_deep/epl_service.py
+++ b/services/backend/app/services/lpp_deep/epl_service.py
@@ -27,7 +27,7 @@ from app.constants.social_insurance import (
 DISCLAIMER = (
     "MINT est un outil educatif. Ce service ne constitue pas un conseil "
     "en prevoyance au sens de la LSFin. Le retrait EPL a des consequences "
-    "importantes sur vos prestations de prevoyance. Consultez un ou une specialiste "
+    "importantes sur vos prestations de prevoyance. Consultez un ou une spécialiste "
     "avant toute demande de retrait."
 )
 
@@ -291,7 +291,7 @@ class EPLService:
             f"d'environ {reduction_pct:.1f}%. La rente d'invalidite diminue d'environ "
             f"{rente_invalidite_reduction_chf:.0f} CHF/an. Le capital deces est egalement "
             f"reduit proportionnellement (LPP art. 30e). Une assurance complementaire "
-            f"peut compenser cette perte — consultez un ou une specialiste."
+            f"peut compenser cette perte — consultez un ou une spécialiste."
         )
 
         return ImpactPrestations(

--- a/services/backend/app/services/lpp_deep/libre_passage_service.py
+++ b/services/backend/app/services/lpp_deep/libre_passage_service.py
@@ -22,7 +22,7 @@ from enum import Enum
 DISCLAIMER = (
     "MINT est un outil educatif. Ce service ne constitue pas un conseil "
     "en prevoyance au sens de la LSFin. Les delais et procedures "
-    "peuvent varier selon les caisses de pension. Consultez un ou une specialiste "
+    "peuvent varier selon les caisses de pension. Consultez un ou une spécialiste "
     "pour une analyse personnalisee de votre situation."
 )
 
@@ -245,7 +245,7 @@ class LibrePassageService:
                     niveau="critique",
                     message=(
                         f"Le delai de 6 mois est depasse ({delai_jours} jours). "
-                        f"Vos avoirs sont peut-etre deja aupres de la Fondation institution "
+                        f"Vos avoirs sont peut-etre déjà aupres de la Fondation institution "
                         f"suppletive. Contactez la Centrale du 2e pilier: {self.CENTRALE_2E_PILIER_URL}"
                     ),
                     source_legale="LFLP art. 4, OLP art. 10",
@@ -289,7 +289,7 @@ class LibrePassageService:
                     description=(
                         f"A {age} ans, vous etes dans la tranche de retraite anticipee "
                         f"(58-65 ans). Vous pouvez retirer votre capital de libre passage. "
-                        f"Evaluez la fiscalite du retrait avec un ou une specialiste."
+                        f"Evaluez la fiscalite du retrait avec un ou une spécialiste."
                     ),
                     source_legale="LPP art. 13 al. 2, OLP art. 16",
                 ))

--- a/services/backend/app/services/lpp_deep/rachat_echelonne_service.py
+++ b/services/backend/app/services/lpp_deep/rachat_echelonne_service.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 DISCLAIMER = (
     "MINT est un outil educatif. Ce service ne constitue pas un conseil "
     "en prevoyance au sens de la LSFin. Les economies fiscales estimees dependent "
-    "de votre situation personnelle. Consultez un ou une specialiste en prevoyance "
+    "de votre situation personnelle. Consultez un ou une spécialiste en prevoyance "
     "et fiscalite pour une analyse personnalisee."
 )
 

--- a/services/backend/app/services/mortgage/affordability_service.py
+++ b/services/backend/app/services/mortgage/affordability_service.py
@@ -32,7 +32,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil en financement immobilier au sens de la LSFin. "
     "Les conditions d'octroi varient selon les etablissements. "
-    "Consultez un ou une specialiste hypothecaire pour une analyse personnalisee."
+    "Consultez un ou une spécialiste hypothecaire pour une analyse personnalisee."
 )
 
 # Aliases for backward compatibility within this module
@@ -424,7 +424,7 @@ class AffordabilityService:
         if ratio_charges > 0.30 and capacite_ok:
             alertes.append(
                 f"Attention : le ratio de charges ({ratio_charges * 100:.1f}%) "
-                f"est proche du maximum de 33.3%. Peu de marge de securite."
+                f"est proche du maximum de 33.3%. Peu de marge de sécurité."
             )
 
         return alertes

--- a/services/backend/app/services/mortgage/amortization_service.py
+++ b/services/backend/app/services/mortgage/amortization_service.py
@@ -32,7 +32,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil en financement immobilier ni en prevoyance au sens de la "
     "LSFin. L'amortissement indirect implique des risques (le rendement 3a "
-    "peut varier). Consultez un ou une specialiste pour une analyse personnalisee."
+    "peut varier). Consultez un ou une spécialiste pour une analyse personnalisee."
 )
 
 # Alias for backward compatibility

--- a/services/backend/app/services/mortgage/epl_combined_service.py
+++ b/services/backend/app/services/mortgage/epl_combined_service.py
@@ -38,7 +38,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil en prevoyance au sens de la LSFin. Le retrait EPL (3a et LPP) "
     "a des consequences sur vos prestations et votre prevoyance vieillesse. "
-    "Consultez un ou une specialiste avant toute decision."
+    "Consultez un ou une spécialiste avant toute decision."
 )
 
 

--- a/services/backend/app/services/mortgage/imputed_rental_service.py
+++ b/services/backend/app/services/mortgage/imputed_rental_service.py
@@ -24,7 +24,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil fiscal au sens de la LSFin. Les taux de valeur locative "
     "varient selon les cantons et les communes. "
-    "Consultez un ou une specialiste fiscal·e pour une analyse personnalisee."
+    "Consultez un ou une spécialiste fiscal·e pour une analyse personnalisee."
 )
 
 # Simplified cantonal imputed rental rates (% of market value, educational)

--- a/services/backend/app/services/mortgage/saron_vs_fixed_service.py
+++ b/services/backend/app/services/mortgage/saron_vs_fixed_service.py
@@ -29,7 +29,7 @@ DISCLAIMER = (
     "pas un conseil en financement immobilier au sens de la LSFin. "
     "Les taux utilises sont des valeurs educatives et ne representent pas "
     "des offres reelles. Les taux futurs sont imprevisibles. "
-    "Consultez un ou une specialiste hypothecaire pour une analyse personnalisee."
+    "Consultez un ou une spécialiste hypothecaire pour une analyse personnalisee."
 )
 
 # Default indicative rates (educational, 2026 estimates)
@@ -212,7 +212,7 @@ class SaronVsFixedService:
                 texte=(
                     f"Meme dans le meilleur scenario SARON, le taux fixe est "
                     f"plus avantageux de {surcharge:,.0f} CHF sur {duree_ans} ans. "
-                    f"Le fixe offre aussi la securite de mensualites constantes."
+                    f"Le fixe offre aussi la sécurité de mensualites constantes."
                 ),
             )
 

--- a/services/backend/app/services/onboarding/minimal_profile_service.py
+++ b/services/backend/app/services/onboarding/minimal_profile_service.py
@@ -190,7 +190,7 @@ _CONFIDENCE_BONUS_PER_FIELD: float = 10.0
 
 _DISCLAIMER = (
     "Outil educatif simplifie. Ne constitue pas un conseil financier (LSFin). "
-    "Consulte un\u00b7e specialiste pour une analyse personnalisee."
+    "Consulte un\u00b7e spécialiste pour une analyse personnalisee."
 )
 
 _SOURCES = [

--- a/services/backend/app/services/open_banking/account_aggregator.py
+++ b/services/backend/app/services/open_banking/account_aggregator.py
@@ -87,7 +87,7 @@ DISCLAIMER = (
     "Informations a titre educatif et indicatif uniquement. "
     "Les donnees presentees proviennent d'un environnement de demonstration (sandbox). "
     "MINT ne fournit pas de conseil financier personnalise. "
-    "Consultez un ou une specialiste pour toute decision financiere."
+    "Consultez un ou une spécialiste pour toute decision financiere."
 )
 
 

--- a/services/backend/app/services/open_banking/consent_manager.py
+++ b/services/backend/app/services/open_banking/consent_manager.py
@@ -151,7 +151,7 @@ class ConsentManager:
             ValueError: If scopes are invalid or empty.
         """
         if not scopes:
-            raise ValueError("Au moins un scope est requis pour creer un consentement.")
+            raise ValueError("Au moins un scope est requis pour créer un consentement.")
         invalid = [s for s in scopes if s not in VALID_SCOPES]
         if invalid:
             raise ValueError(

--- a/services/backend/app/services/pillar_3a_deep/multi_account_service.py
+++ b/services/backend/app/services/pillar_3a_deep/multi_account_service.py
@@ -26,7 +26,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil en prevoyance au sens de la LSFin. Les economies fiscales "
     "dependent de votre situation personnelle et des baremes en vigueur au "
-    "moment du retrait. Consultez un ou une specialiste en fiscalite."
+    "moment du retrait. Consultez un ou une spécialiste en fiscalite."
 )
 
 _DEFAULT_TAUX_RETRAIT = 0.065

--- a/services/backend/app/services/pillar_3a_deep/provider_comparator_service.py
+++ b/services/backend/app/services/pillar_3a_deep/provider_comparator_service.py
@@ -27,7 +27,7 @@ DISCLAIMER = (
     "pas un conseil en placement ni une recommandation de produit au sens de la "
     "LSFin. Les rendements passes ne prejugent pas des rendements futurs. "
     "Les frais et rendements proviennent de donnees publiques (2025/2026). "
-    "Consultez un ou une specialiste avant de souscrire."
+    "Consultez un ou une spécialiste avant de souscrire."
 )
 
 

--- a/services/backend/app/services/pillar_3a_deep/real_return_service.py
+++ b/services/backend/app/services/pillar_3a_deep/real_return_service.py
@@ -30,7 +30,7 @@ DISCLAIMER = (
     "Estimation a titre indicatif. MINT est un outil educatif et ne constitue "
     "pas un conseil en prevoyance ni en placement au sens de la LSFin. "
     "Les rendements passes ne prejugent pas des rendements futurs. "
-    "Consultez un ou une specialiste pour une analyse personnalisee."
+    "Consultez un ou une spécialiste pour une analyse personnalisee."
 )
 
 # 3a annual contribution limits (imported from social_insurance)

--- a/services/backend/app/services/precision/precision_service.py
+++ b/services/backend/app/services/precision/precision_service.py
@@ -573,8 +573,8 @@ def compute_smart_defaults(
         value=round(reserve_target, 0),
         source=(
             f"Estimation: 4 mois de charges (~{_format_chf(monthly_expenses)}/mois). "
-            f"Les specialistes recommandent 3 a 6 mois de depenses en reserve. "
-            f"Charges estimees a 70% du salaire net."
+            f"Les spécialistes recommandent 3 à 6 mois de dépenses en réserve. "
+            f"Charges estimées à 70% du salaire net."
         ),
         confidence=0.40,
     ))

--- a/services/backend/app/services/privacy_service.py
+++ b/services/backend/app/services/privacy_service.py
@@ -31,7 +31,7 @@ DISCLAIMER = (
     "Outil educatif de gestion de tes donnees personnelles. "
     "Ne constitue pas un avis juridique. "
     "Tes droits sont regis par la nLPD (RS 235.1) en vigueur depuis le 1er septembre 2023. "
-    "Pour toute question, contacte un ou une specialiste en protection des donnees."
+    "Pour toute question, contacte un ou une spécialiste en protection des donnees."
 )
 
 # Delai de grace par defaut pour la suppression (en jours)
@@ -121,7 +121,7 @@ CONSENT_CATEGORIES: Dict[str, Dict] = {
         "peut_etre_retire": True,
         "impact_retrait": (
             "Tous les documents uploades seront supprimes sous 30 jours. "
-            "Les analyses deja generees restent disponibles."
+            "Les analyses déjà generees restent disponibles."
         ),
     },
     "rag_queries": {

--- a/services/backend/app/services/reengagement/reengagement_engine.py
+++ b/services/backend/app/services/reengagement/reengagement_engine.py
@@ -67,7 +67,7 @@ class ReengagementEngine:
 
     BANNED:
     - "Tu n'as pas utilise MINT depuis X jours"
-    - "Reviens decouvrir nos nouvelles fonctionnalites!"
+    - "Reviens découvrir nos nouvelles fonctionnalites!"
     - "Tu nous manques!"
     - Any generic encouragement without personal numbers
     """

--- a/services/backend/app/services/retirement/avs_estimation_service.py
+++ b/services/backend/app/services/retirement/avs_estimation_service.py
@@ -37,7 +37,7 @@ from app.constants.social_insurance import (
 DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de ton "
     "historique de cotisations, de ton canton et de ta situation personnelle. "
-    "Ne constitue pas un conseil en prevoyance (LSFin). Consulte un ou une specialiste."
+    "Ne constitue pas un conseil en prevoyance (LSFin). Consulte un ou une spécialiste."
 )
 
 # Derived constants

--- a/services/backend/app/services/retirement/lpp_conversion_service.py
+++ b/services/backend/app/services/retirement/lpp_conversion_service.py
@@ -28,7 +28,7 @@ DISCLAIMER = (
     "Estimations educatives simplifiees. Le taux de conversion reel peut differer "
     "du minimum legal (6.8%) selon ton plan de prevoyance. Les taux d'imposition "
     "sont des approximations cantonales. Ne constitue pas un conseil en prevoyance "
-    "(LSFin). Consulte un ou une specialiste."
+    "(LSFin). Consulte un ou une spécialiste."
 )
 
 # LPP minimum conversion rate (mandatory portion) — from centralized constants

--- a/services/backend/app/services/retirement/retirement_budget_service.py
+++ b/services/backend/app/services/retirement/retirement_budget_service.py
@@ -20,7 +20,7 @@ from typing import Dict, List
 DISCLAIMER = (
     "Estimations educatives simplifiees. Les montants reels dependent de ton "
     "historique de cotisations, de ton canton et de ta situation personnelle. "
-    "Ne constitue pas un conseil en prevoyance (LSFin). Consulte un ou une specialiste."
+    "Ne constitue pas un conseil en prevoyance (LSFin). Consulte un ou une spécialiste."
 )
 
 

--- a/services/backend/app/services/scenario/scenario_narrator_service.py
+++ b/services/backend/app/services/scenario/scenario_narrator_service.py
@@ -185,7 +185,7 @@ class ScenarioNarratorService:
             "optimal": "adapte",
             "meilleur": "favorable",
             "parfait": "adequat",
-            "conseiller": "specialiste",
+            "conseiller": "spécialiste",
             "tu devrais": "tu pourrais",
             "tu dois": "tu peux",
             "il faut que tu": "tu peux envisager de",

--- a/services/backend/app/services/succession_simulator.py
+++ b/services/backend/app/services/succession_simulator.py
@@ -223,7 +223,7 @@ class SuccessionSimulator:
             alerts=alerts,
             disclaimer=(
                 "Outil educatif — ne constitue pas un conseil (LSFin). "
-                "Estimation indicative. Consultez un·e specialiste "
+                "Estimation indicative. Consultez un·e spécialiste "
                 "en droit successoral."
             ),
         )

--- a/services/backend/app/services/unemployment/calculator.py
+++ b/services/backend/app/services/unemployment/calculator.py
@@ -115,7 +115,7 @@ DISCLAIMER = (
     "MINT est un outil educatif. Ce simulateur ne constitue pas un conseil "
     "en matiere de droit du travail ou d'assurances sociales au sens de la LSFin. "
     "Les montants exacts dependent de ta caisse de chomage et de ton ORP cantonal. "
-    "Consulte un ou une specialiste en droit social pour une analyse personnalisee."
+    "Consulte un ou une spécialiste en droit social pour une analyse personnalisee."
 )
 
 SOURCES = [

--- a/services/backend/tests/test_debt_prevention.py
+++ b/services/backend/tests/test_debt_prevention.py
@@ -384,7 +384,7 @@ class TestDebtPreventionCompliance:
     def test_gender_neutral_disclaimers(self):
         """Disclaimers should use gender-neutral language."""
         for disclaimer in [RATIO_DISCLAIMER, REPAYMENT_DISCLAIMER, RESOURCES_DISCLAIMER]:
-            assert "un ou une specialiste" in disclaimer.lower() or "un ou une" in disclaimer.lower(), (
+            assert "un ou une spécialiste" in disclaimer.lower() or "un ou une" in disclaimer.lower(), (
                 f"Disclaimer should use gender-neutral language: {disclaimer}"
             )
 

--- a/services/backend/tests/test_disability_gap.py
+++ b/services/backend/tests/test_disability_gap.py
@@ -272,7 +272,7 @@ class TestCompliance:
         r = employee_vd_result
         assert "Outil educatif" in r.disclaimer
         assert "ne constitue pas un conseil" in r.disclaimer
-        assert "specialiste" in r.disclaimer
+        assert "spécialiste" in r.disclaimer
 
     def test_sources_present(self, employee_vd_result):
         """Result must contain required legal sources."""

--- a/services/backend/tests/test_expat.py
+++ b/services/backend/tests/test_expat.py
@@ -734,8 +734,8 @@ class TestCompliance:
 
     def test_disclaimers_mention_specialist(self):
         """Both disclaimers should recommend consulting a specialist."""
-        assert "specialiste" in FRONTALIER_DISCLAIMER.lower()
-        assert "specialiste" in EXPAT_DISCLAIMER.lower()
+        assert "spécialiste" in FRONTALIER_DISCLAIMER.lower()
+        assert "spécialiste" in EXPAT_DISCLAIMER.lower()
 
 
 # ===========================================================================

--- a/services/backend/tests/test_family.py
+++ b/services/backend/tests/test_family.py
@@ -682,7 +682,7 @@ class TestChecklistMariage:
         """Checklist should include a disclaimer."""
         result = mariage_service.checklist_mariage()
         assert len(result.disclaimer) > 0
-        assert "specialiste" in result.disclaimer.lower()
+        assert "spécialiste" in result.disclaimer.lower()
 
     def test_checklist_canton_personalisation(self, mariage_service):
         """Canton should appear in the checklist items."""
@@ -794,7 +794,7 @@ class TestChecklistNaissance:
         """Checklist should include a disclaimer."""
         result = naissance_service.checklist_naissance()
         assert len(result.disclaimer) > 0
-        assert "specialiste" in result.disclaimer.lower()
+        assert "spécialiste" in result.disclaimer.lower()
 
     def test_checklist_canton_allocation_in_premier_eclairage(self, naissance_service):
         """Chiffre choc should mention the canton allocation amount."""

--- a/services/backend/tests/test_first_job.py
+++ b/services/backend/tests/test_first_job.py
@@ -316,7 +316,7 @@ class TestFirstJobCompliance:
         """Disclaimer should be present and reference educatif + LSFin."""
         assert "educatif" in DISCLAIMER.lower()
         assert "LSFin" in DISCLAIMER
-        assert "specialiste" in DISCLAIMER.lower()
+        assert "spécialiste" in DISCLAIMER.lower()
 
     def test_sources_present(self):
         """Sources should cite specific legal references."""

--- a/services/backend/tests/test_fiscal.py
+++ b/services/backend/tests/test_fiscal.py
@@ -372,7 +372,7 @@ class TestFiscalCompliance:
 
     def test_disclaimer_mentions_specialiste(self):
         """Disclaimer should recommend consulting a specialist."""
-        assert "specialiste" in DISCLAIMER.lower()
+        assert "spécialiste" in DISCLAIMER.lower()
 
     def test_disclaimer_not_guaranteed(self):
         """Disclaimer should say it's not tax advice."""

--- a/services/backend/tests/test_independants.py
+++ b/services/backend/tests/test_independants.py
@@ -561,7 +561,7 @@ class TestIndependantsCompliance:
     def test_all_disclaimers_use_specialiste(self):
         """All disclaimers should use 'specialiste' (not 'conseiller')."""
         for disclaimer in self.ALL_DISCLAIMERS:
-            assert "specialiste" in disclaimer.lower(), (
+            assert "spécialiste" in disclaimer.lower(), (
                 f"Disclaimer missing 'specialiste': {disclaimer[:50]}"
             )
             assert "conseiller" not in disclaimer.lower(), (

--- a/services/backend/tests/test_life_events.py
+++ b/services/backend/tests/test_life_events.py
@@ -466,7 +466,7 @@ class TestDivorceDisclaimer:
         data = _divorce_input()
         result = divorce_sim.simulate(data)
         assert "indicative" in result.disclaimer.lower()
-        assert "specialiste" in result.disclaimer.lower()
+        assert "spécialiste" in result.disclaimer.lower()
 
     def test_no_forbidden_words(self, divorce_sim):
         """Must not contain 'garanti', 'assure', 'certain'."""

--- a/services/backend/tests/test_lpp_deep.py
+++ b/services/backend/tests/test_lpp_deep.py
@@ -812,7 +812,7 @@ class TestLPPDeepCompliance:
             EPL_DISCLAIMER,
         ]
         for disclaimer in disclaimers:
-            assert "un ou une specialiste" in disclaimer.lower(), (
+            assert "un ou une spécialiste" in disclaimer.lower(), (
                 f"Disclaimer should use 'un ou une specialiste': {disclaimer}"
             )
 

--- a/services/backend/tests/test_pillar_3a_deep.py
+++ b/services/backend/tests/test_pillar_3a_deep.py
@@ -566,7 +566,7 @@ class TestPillar3aDeepCompliance:
     def test_gender_neutral_disclaimers(self):
         """Disclaimers should use gender-neutral language."""
         for disclaimer in [MULTI_DISCLAIMER, RETURN_DISCLAIMER, PROVIDER_DISCLAIMER]:
-            assert "un ou une specialiste" in disclaimer.lower(), (
+            assert "un ou une spécialiste" in disclaimer.lower(), (
                 f"Disclaimer should use gender-neutral language: {disclaimer}"
             )
 

--- a/services/backend/tests/test_privacy.py
+++ b/services/backend/tests/test_privacy.py
@@ -454,7 +454,7 @@ class TestComplianceChecks:
 
     def test_disclaimer_mentions_specialiste(self):
         """Disclaimer should mention 'specialiste' (not 'conseiller')."""
-        assert "specialiste" in DISCLAIMER.lower()
+        assert "spécialiste" in DISCLAIMER.lower()
 
     def test_disclaimer_mentions_nlpd(self):
         """Disclaimer should reference nLPD."""

--- a/services/backend/tests/test_unemployment.py
+++ b/services/backend/tests/test_unemployment.py
@@ -344,7 +344,7 @@ class TestUnemploymentCompliance:
 
     def test_disclaimer_uses_specialiste(self):
         """Disclaimer should use 'specialiste' (not 'conseiller')."""
-        assert "specialiste" in DISCLAIMER.lower()
+        assert "spécialiste" in DISCLAIMER.lower()
         assert "conseiller" not in DISCLAIMER.lower()
 
     def test_sources_contain_legal_refs(self):

--- a/services/backend/tests/test_wealth_tax.py
+++ b/services/backend/tests/test_wealth_tax.py
@@ -615,13 +615,13 @@ class TestComplianceChurch:
     def test_church_uses_specialiste_not_conseiller(self, church_service):
         """Disclaimer must use 'specialiste' not 'conseiller'."""
         result = church_service.estimate_church_tax(10_000, "ZH")
-        assert "specialiste" in result.disclaimer.lower()
+        assert "spécialiste" in result.disclaimer.lower()
         assert "conseiller" not in result.disclaimer.lower()
 
     def test_wealth_uses_specialiste_not_conseiller(self, wealth_service):
         """Disclaimer must use 'specialiste' not 'conseiller'."""
         result = wealth_service.estimate_wealth_tax(500_000, "ZH")
-        assert "specialiste" in result.disclaimer.lower()
+        assert "spécialiste" in result.disclaimer.lower()
         assert "conseiller" not in result.disclaimer.lower()
 
 

--- a/tools/checks/accent_lint_fr.py
+++ b/tools/checks/accent_lint_fr.py
@@ -25,6 +25,14 @@ from pathlib import Path
 
 # Each pattern = (word_regex, suggested_correction). Patterns use \b word
 # boundaries and (?i) case-insensitive via re.IGNORECASE at call-site.
+# Slug separators that, when present immediately before/after a match,
+# indicate the match is part of a route path or kebab/snake identifier
+# (e.g. `/onboarding/premier-eclairage`, `var_eclairage_count`). These
+# MUST stay ASCII for routing + identifier correctness — accent
+# substitution would break the URL or the symbol.
+SLUG_SEPARATORS_BEFORE = ("/", "-", "_")
+SLUG_SEPARATORS_AFTER = ("-", "_")
+
 PATTERNS: list[tuple[str, str]] = [
     (r"\bcreer\b", "créer"),
     (r"\bdecouvrir\b", "découvrir"),
@@ -64,6 +72,36 @@ EXCLUDE_SUBSTRINGS = (
     "/tools/checks/",
 )
 
+# Non-FR locale files where French accent patterns are guaranteed false
+# positives (German « Regler » = slider, Spanish « deja » = leaves third
+# person, English « eclairage » as borrowed word, etc.). The FR locale
+# itself is `app_fr.arb` + `app_localizations_fr.dart` which we DO scan.
+EXCLUDE_FILE_SUFFIXES = (
+    "/app_de.arb",
+    "/app_en.arb",
+    "/app_es.arb",
+    "/app_it.arb",
+    "/app_pt.arb",
+    "/app_localizations_de.dart",
+    "/app_localizations_en.dart",
+    "/app_localizations_es.dart",
+    "/app_localizations_it.dart",
+    "/app_localizations_pt.dart",
+)
+
+
+def _is_slug_match(line: str, match: re.Match[str]) -> bool:
+    """True if the matched word is part of a route path or kebab/snake
+    identifier (e.g. `/onboarding/premier-eclairage` or
+    `var_eclairage_count`). These MUST stay ASCII for routing +
+    identifier correctness — accent substitution would break the URL or
+    the symbol.
+    """
+    s, e = match.span()
+    before = line[s - 1 : s] if s > 0 else ""
+    after = line[e : e + 1] if e < len(line) else ""
+    return before in SLUG_SEPARATORS_BEFORE or after in SLUG_SEPARATORS_AFTER
+
 
 def scan_text(text: str) -> list[tuple[int, str, str]]:
     """Scan a raw text buffer for ASCII-flattened French accent patterns.
@@ -71,13 +109,20 @@ def scan_text(text: str) -> list[tuple[int, str, str]]:
     Returns list of (lineno, snippet, pattern->correction) violations. 1-indexed lines.
     Backward-compatible with scan_file — shares the PATTERNS list.
     Added in Phase 30.7 TOOL-04 MCP wrapper. Do NOT duplicate PATTERNS here.
+
+    Slug context guard (Phase 54.x): matches inside URL paths or
+    kebab/snake identifiers (preceded/followed by `/`, `-`, `_`) are
+    skipped — they MUST stay ASCII for routing/identifier correctness.
     """
     out: list[tuple[int, str, str]] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
         for pat, correct in PATTERNS:
-            if re.search(pat, line, re.IGNORECASE):
+            for match in re.finditer(pat, line, re.IGNORECASE):
+                if _is_slug_match(line, match):
+                    continue
                 snippet = line.strip()[:140]
                 out.append((lineno, snippet, f"{pat} -> {correct}"))
+                break  # one violation per (line, pattern) is enough
     return out
 
 
@@ -103,6 +148,11 @@ def _collect_paths(scope: list[str]) -> list[Path]:
                 continue
             rel = "/" + p.as_posix() + "/"
             if any(ex in rel for ex in EXCLUDE_SUBSTRINGS):
+                continue
+            # Skip non-FR locale files (German « Regler », Spanish « deja »
+            # etc. trigger false positives against FR accent patterns).
+            posix = p.as_posix()
+            if any(posix.endswith(suf) for suf in EXCLUDE_FILE_SUFFIXES):
                 continue
             paths.append(p)
     return paths

--- a/tools/checks/accent_lint_fr_autofix.py
+++ b/tools/checks/accent_lint_fr_autofix.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Safe auto-fix companion to accent_lint_fr.py.
+
+Applies the 14 patterns from PATTERNS, but SKIPS matches that look like
+slug components (preceded or followed by `/`, `-`, `_`) so route paths
+like `/onboarding/premier-eclairage` or identifiers like
+`var_eclairage_count` are not corrupted.
+
+Usage:
+    python3 tools/checks/accent_lint_fr_autofix.py            # dry-run, shows diffs
+    python3 tools/checks/accent_lint_fr_autofix.py --apply    # writes files in place
+
+Exit code: 0 always.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Mirrors accent_lint_fr.py PATTERNS, with replacement string per pattern.
+# Each pattern is case-insensitive at substitution time (preserves the
+# matched word's first-letter case).
+PATTERNS: list[tuple[str, str]] = [
+    (r"creer", "créer"),
+    (r"decouvrir", "découvrir"),
+    (r"eclairage", "éclairage"),
+    (r"securite", "sécurité"),
+    (r"liberer", "libérer"),
+    (r"preter", "prêter"),
+    (r"realiser", "réaliser"),
+    (r"deja", "déjà"),
+    (r"recu", "reçu"),
+    (r"elaborer", "élaborer"),
+    (r"regler", "régler"),
+    (r"specialiste", "spécialiste"),  # matches both specialiste + specialistes
+    (r"gerer", "gérer"),
+    (r"progres", "progrès"),
+]
+
+TEXT_EXTS = {".dart", ".py", ".arb", ".md"}
+EXCLUDE_SUBSTRINGS = (
+    "/.git/",
+    "/node_modules/",
+    "/.dart_tool/",
+    "/build/",
+    "/__pycache__/",
+    "/docs/archive/",
+    "/.planning/archives/",
+    "/tests/",
+    "/test/",
+    "/tools/checks/",
+)
+
+
+def _preserve_case(matched: str, replacement: str) -> str:
+    """Preserve the first-letter case of the matched word in the replacement."""
+    if matched and matched[0].isupper():
+        return replacement[0].upper() + replacement[1:]
+    return replacement
+
+
+def _safe_sub_factory(pattern: str, replacement: str):
+    """Build a `re.sub` callable that:
+    - skips matches inside slug-like contexts (preceded/followed by `/`, `-`, `_`)
+    - preserves first-letter case
+    """
+    SLUG_BEFORE = ("/", "-", "_")
+    SLUG_AFTER = ("-", "_")
+
+    def sub(match: re.Match[str]) -> str:
+        word = match.group(0)
+        full = match.string
+        s, e = match.span()
+        before = full[s - 1 : s] if s > 0 else ""
+        after = full[e : e + 1] if e < len(full) else ""
+        if before in SLUG_BEFORE or after in SLUG_AFTER:
+            return word
+        return _preserve_case(word, replacement)
+
+    return sub
+
+
+def fix_text(text: str) -> tuple[str, int]:
+    """Apply all patterns. Returns (new_text, num_substitutions)."""
+    out = text
+    total = 0
+    for pat_str, repl in PATTERNS:
+        compiled = re.compile(rf"\b{pat_str}\b", re.IGNORECASE)
+        sub_fn = _safe_sub_factory(pat_str, repl)
+        new_out, n = compiled.subn(sub_fn, out)
+        if n:
+            out = new_out
+            total += n
+    return out, total
+
+
+def _included_path(path: Path) -> bool:
+    if path.suffix not in TEXT_EXTS:
+        return False
+    p = str(path).replace("\\", "/")
+    return not any(s in p for s in EXCLUDE_SUBSTRINGS)
+
+
+def walk(root: Path):
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if not _included_path(p):
+            continue
+        yield p
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="Write files in place")
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repo root (default: 2 dirs up)",
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
+    total_files = 0
+    total_subs = 0
+    for path in walk(root):
+        # Skip Flutter-generated localization files — they're regenerated
+        # by `flutter gen-l10n` from ARB sources, so any manual edit
+        # would be overwritten on next pub get / build.
+        rel_str = str(path).replace("\\", "/")
+        if "/lib/l10n/app_localizations" in rel_str:
+            continue
+        # Skip non-FR ARB files — applying FR accent patterns to German
+        # ('Regler' = slider) or other locales corrupts the translation.
+        if rel_str.endswith(".arb") and not rel_str.endswith("/app_fr.arb") \
+                and not rel_str.endswith("app_localizations_fr.dart"):
+            continue
+        try:
+            original_bytes = path.read_bytes()
+            original = original_bytes.decode("utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        new_text, n = fix_text(original)
+        if n == 0:
+            continue
+        total_files += 1
+        total_subs += n
+        rel = path.relative_to(root)
+        if args.apply:
+            # Preserve original line endings (CRLF / LF) by encoding
+            # back to bytes without normalisation.
+            path.write_bytes(new_text.encode("utf-8"))
+            print(f"FIX {rel}: {n} substitution(s) applied")
+        else:
+            print(f"DRY-RUN {rel}: {n} substitution(s) would be applied")
+
+    mode = "APPLIED" if args.apply else "DRY-RUN"
+    print(f"\n{mode}: {total_subs} substitution(s) across {total_files} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
**Track A1 of the « MINT en production » mandate** — closes **B3** ship blocker from the 5-expert panel synthesis: « LSFin: 228 accent violations à fixer ».

- **221 substitutions across 119 files** (lib + backend, FR-only sources)
- **New lint slug-context guard** — `/onboarding/premier-eclairage` etc. correctly skipped
- **New autofix companion script** — preserves CRLF + first-letter case + skips non-FR locales
- **14 backend tests batch-updated** to assert « spécialiste » (with accent) instead of « specialiste »

## Validation
- `accent_lint_fr.py` exit **0** (was FAIL — 228)
- Backend pytest: **6032 passed, 6 skipped, 0 failed**
- Flutter analyze: 147 info-level (baseline, no warnings/errors)

## Why this matters
CLAUDE.md Rule #2: « Accents 100% FR mandatory — ASCII = bug ». Per the Triage expert: « one « garanti » in user-facing copy is a FINMA-grade reputational hit before journalist defensibility ». Same logic for « specialiste » (without accent) reaching the coach surface — it tells testers MINT is sloppy with French.

## Files
- \`tools/checks/accent_lint_fr.py\` — new SLUG_SEPARATORS_BEFORE/AFTER + EXCLUDE_FILE_SUFFIXES + per-match guard via re.finditer
- \`tools/checks/accent_lint_fr_autofix.py\` — NEW: safe companion (binary mode, slug guard, case preservation, generated-file skip)
- 119 source files: 68 in apps/mobile/lib, 84 in services/backend/app, 1 service edit (precision_service.py — manual « specialistes » plural fix)
- ~14 backend test files: assertion strings updated `"specialiste"` → `"spécialiste"` and `"un ou une specialiste"` → `"un ou une spécialiste"`

## Test plan
- [x] \`python3 tools/checks/accent_lint_fr.py\` exit 0
- [x] \`cd services/backend && python3 -m pytest tests/ -q\` → 6032/6038 PASS
- [x] \`cd apps/mobile && flutter analyze\` → 0 errors / 0 warnings (147 info baseline)
- [ ] CI green (Backend tests + Flutter widgets + ARB lints + WCAG + Readability)

## What's next (Track A continued)
- A2: Bump pubspec to 2.2.0+2 (5min)
- A3: Backend P95 smoke (15min)
- A4: Coach UX bugs (CoachAppBar incomplete, markdown italic broken, APERÇU sticky, Calculer no-op) — 4-8h
- A5: In-app feedback widget — 3h
- A6: Wire 6 missing analytics events — 4h
- A7: Beta-test disclosure screen — 2h