### PR TITLE
feat(anonymous-chat): top bar with MINT brand + phase subtitle (Handoff 2)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -10627,6 +10627,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "Erste Klarheit",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — phase subtitle below the MINT brand (Handoff 2).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "Ich bin immer noch da, wenn du weitermachen willst.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -10627,6 +10627,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "First insight",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — phase subtitle below the MINT brand (Handoff 2).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "I’m still here whenever you want to continue.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -10627,6 +10627,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "Primera claridad",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — phase subtitle below the MINT brand (Handoff 2).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "Sigo aquí cuando quieras continuar.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11383,7 +11383,7 @@
   "anonymousChatPhaseSubtitle": "Premier éclairage",
   "@anonymousChatPhaseSubtitle": {
     "description": "Anonymous chat top-bar — subtitle below the MINT brand. Names the current phase the anonymous user is in (Handoff 2 design alignment — replaces the bare back-button-only top bar with a brand + phase indicator).",
-    "x-meta": {"voiceCursorLevel": "ambiance"}
+    "x-mint-meta": {"level": "N1"}
   },
   "anonymousChatLocked": "Je suis toujours là quand tu voudras continuer.",
   "@anonymousChatLocked": {
@@ -12108,7 +12108,11 @@
   "aujourdhuiResumeConversation": "Reprendre la conversation",
   "coachSequenceNextStepLabel": "Étape suivante : {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
-  "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée."
+  "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  }
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11380,6 +11380,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "Premier éclairage",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — subtitle below the MINT brand. Names the current phase the anonymous user is in (Handoff 2 design alignment — replaces the bare back-button-only top bar with a brand + phase indicator).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "Je suis toujours là quand tu voudras continuer.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -10627,6 +10627,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "Prima chiarezza",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — phase subtitle below the MINT brand (Handoff 2).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "Sono ancora qui quando vorrai continuare.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -39369,6 +39369,12 @@ abstract class S {
   /// **'Retour'**
   String get anonymousChatBack;
 
+  /// Anonymous chat top-bar — subtitle below the MINT brand. Names the current phase the anonymous user is in (Handoff 2 design alignment — replaces the bare back-button-only top bar with a brand + phase indicator).
+  ///
+  /// In fr, this message translates to:
+  /// **'Premier éclairage'**
+  String get anonymousChatPhaseSubtitle;
+
   /// Anonymous chat — message shown when input is locked after dismissing auth gate.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -22487,6 +22487,9 @@ class SDe extends S {
   String get anonymousChatBack => 'Zurück';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'Erste Klarheit';
+
+  @override
   String get anonymousChatLocked =>
       'Ich bin immer noch da, wenn du weitermachen willst.';
 

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22323,6 +22323,9 @@ class SEn extends S {
   String get anonymousChatBack => 'Back';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'First insight';
+
+  @override
   String get anonymousChatLocked =>
       'I’m still here whenever you want to continue.';
 

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -22433,6 +22433,9 @@ class SEs extends S {
   String get anonymousChatBack => 'Volver';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'Primera claridad';
+
+  @override
   String get anonymousChatLocked => 'Sigo aquí cuando quieras continuar.';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -22434,6 +22434,9 @@ class SFr extends S {
   String get anonymousChatBack => 'Retour';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'Premier éclairage';
+
+  @override
   String get anonymousChatLocked =>
       'Je suis toujours là quand tu voudras continuer.';
 

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -22493,6 +22493,9 @@ class SIt extends S {
   String get anonymousChatBack => 'Indietro';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'Prima chiarezza';
+
+  @override
   String get anonymousChatLocked => 'Sono ancora qui quando vorrai continuare.';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -22438,6 +22438,9 @@ class SPt extends S {
   String get anonymousChatBack => 'Voltar';
 
   @override
+  String get anonymousChatPhaseSubtitle => 'Primeira clareza';
+
+  @override
   String get anonymousChatLocked =>
       'Ainda estou aqui quando quiseres continuar.';
 

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -10627,6 +10627,11 @@
   "@anonymousChatBack": {
     "description": "Anonymous chat — back button tooltip."
   },
+  "anonymousChatPhaseSubtitle": "Primeira clareza",
+  "@anonymousChatPhaseSubtitle": {
+    "description": "Anonymous chat top-bar — phase subtitle below the MINT brand (Handoff 2).",
+    "x-meta": {"voiceCursorLevel": "ambiance"}
+  },
   "anonymousChatLocked": "Ainda estou aqui quando quiseres continuar.",
   "@anonymousChatLocked": {
     "description": "Anonymous chat — message shown when input is locked after dismissing auth gate."

--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -482,13 +482,25 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
           ),
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           decoration: BoxDecoration(
-            color: isUser ? MintColors.primary : MintColors.surface,
+            // Handoff 2 invariant: MINT bubble uses `craie` (#FCFBF8)
+            // warm cream, NEVER the cool `surface` grey. The vision doc
+            // explicitly calls out « les bulles grises par défaut du
+            // chat actuel » as what to avoid.
+            color: isUser ? MintColors.primary : MintColors.craie,
             borderRadius: BorderRadius.only(
               topLeft: const Radius.circular(18),
               topRight: const Radius.circular(18),
               bottomLeft: Radius.circular(isUser ? 18 : 4),
               bottomRight: Radius.circular(isUser ? 4 : 18),
             ),
+            // Hairline border on the MINT bubble so the warm cream
+            // doesn't disappear into the surrounding craie background.
+            border: isUser
+                ? null
+                : Border.all(
+                    color: MintColors.lightBorder.withValues(alpha: 0.5),
+                    width: 0.5,
+                  ),
           ),
           child: Text(
             message.text,
@@ -510,13 +522,18 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
         alignment: Alignment.centerLeft,
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: const BoxDecoration(
-            color: MintColors.surface,
-            borderRadius: BorderRadius.only(
+          decoration: BoxDecoration(
+            // Handoff 2 — same craie warm cream as the MINT bubble.
+            color: MintColors.craie,
+            borderRadius: const BorderRadius.only(
               topLeft: Radius.circular(18),
               topRight: Radius.circular(18),
               bottomRight: Radius.circular(18),
               bottomLeft: Radius.circular(4),
+            ),
+            border: Border.all(
+              color: MintColors.lightBorder.withValues(alpha: 0.5),
+              width: 0.5,
             ),
           ),
           child: Row(

--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -11,6 +11,7 @@ import 'package:mint_mobile/services/coach_llm_service.dart';
 // ADR-20260223: financial_core via barrel only — no direct sub-imports.
 import 'package:mint_mobile/services/financial_core/financial_core.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/widgets/auth/auth_gate_bottom_sheet.dart';
 
 /// Data class for a single chat message in the anonymous flow.
@@ -321,12 +322,17 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
                             ),
                           ),
                           const SizedBox(height: 2),
+                          // Handoff 2 invariant: dated/phase labels use
+                          // Fraunces italic (« editorial » voice). 12.5pt
+                          // is small but readable at the standalone
+                          // top-bar density used in the prototype.
                           Text(
                             l.anonymousChatPhaseSubtitle,
-                            style: const TextStyle(
+                            style: MintTextStyles.editorialBody(
                               color: MintColors.textSecondary,
-                              fontSize: 11.5,
-                              letterSpacing: 0.2,
+                            ).copyWith(
+                              fontSize: 12.5,
+                              letterSpacing: 0.1,
                               height: 1.2,
                             ),
                           ),

--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -276,16 +276,64 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
       body: SafeArea(
         child: Column(
           children: [
-            // Top bar — back button only
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: IconButton(
-                  icon: const Icon(Icons.arrow_back_rounded),
-                  color: MintColors.textPrimary,
-                  onPressed: () => context.go('/'),
-                  tooltip: l.anonymousChatBack,
+            // Top bar — Handoff 2 alignment: MINT brand + phase subtitle
+            // (« Premier éclairage »). Replaces the bare back-button-only
+            // top bar that existed before. Per Handoff 2 design intent:
+            // the user must always know they're in MINT, in which phase,
+            // and how to navigate back. The brand + subtitle pattern
+            // mirrors `coach_app_bar.dart` standalone mode.
+            Container(
+              decoration: BoxDecoration(
+                color: MintColors.craie,
+                border: Border(
+                  bottom: BorderSide(
+                    color: MintColors.lightBorder.withValues(alpha: 0.5),
+                    width: 0.5,
+                  ),
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(4, 4, 16, 10),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(
+                        Icons.arrow_back_ios_new_rounded,
+                        size: 18,
+                      ),
+                      color: MintColors.textSecondary,
+                      onPressed: () => context.go('/'),
+                      tooltip: l.anonymousChatBack,
+                    ),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text(
+                            'MINT',
+                            style: TextStyle(
+                              color: MintColors.textPrimary,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 1.5,
+                              fontSize: 15,
+                              height: 1.1,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            l.anonymousChatPhaseSubtitle,
+                            style: const TextStyle(
+                              color: MintColors.textSecondary,
+                              fontSize: 11.5,
+                              letterSpacing: 0.2,
+                              height: 1.2,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/apps/mobile/lib/theme/mint_text_styles.dart
+++ b/apps/mobile/lib/theme/mint_text_styles.dart
@@ -186,4 +186,54 @@ class MintTextStyles {
         height: 1.3,
         color: color ?? MintColors.textMuted,
       );
+
+  // ── Editorial (Fraunces) — Handoff 2 « chat vivant » ──
+  //
+  // Fraunces serif italic for editorial moments: phrase-signatures, em
+  // words inside chat bubbles, dated labels (« Aujourd'hui · 14:22 »).
+  // Per Handoff 2 `00-README.md` invariants:
+  // - « Fraunces = signature éditoriale. Pour les `em`, phrases de
+  //   recul, labels horodatés. Jamais en body long. »
+  // - Used as serif italic to give the chat a calm editorial voice
+  //   rather than a chatbot pulse.
+  // Per `colors_and_type.css` line 39:
+  //   --mint-font-display: 'Fraunces', 'Times New Roman', serif;
+
+  /// Editorial display — the largest phrase-signature, e.g. canvas
+  /// chapter intros (« Tu vois ce que ta vie *coûte vraiment*. »).
+  /// 32pt Fraunces italic, weight 400.
+  static TextStyle editorialDisplay({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 32,
+        fontWeight: FontWeight.w400,
+        fontStyle: FontStyle.italic,
+        letterSpacing: -0.4,
+        height: 1.2,
+        color: color ?? MintColors.textPrimary,
+      );
+
+  /// Editorial large — phrase-signature inside MintInlineInsightCard
+  /// + scene headers. The « Tu as 58 ans. 7 ans avant la retraite. »
+  /// pattern from `prototype/captures/01-chat-comparison.png`.
+  /// 22pt Fraunces italic, weight 400.
+  static TextStyle editorialLarge({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 22,
+        fontWeight: FontWeight.w400,
+        fontStyle: FontStyle.italic,
+        letterSpacing: -0.2,
+        height: 1.3,
+        color: color ?? MintColors.textPrimary,
+      );
+
+  /// Editorial body — inline em words inside chat bubbles + the
+  /// « Aujourd'hui · 14:22 » timestamp label. 16pt Fraunces italic,
+  /// weight 400. Use sparingly — Fraunces is for signal moments,
+  /// never for long body copy (which stays in Inter).
+  static TextStyle editorialBody({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        fontStyle: FontStyle.italic,
+        letterSpacing: 0,
+        height: 1.4,
+        color: color ?? MintColors.textPrimary,
+      );
 }


### PR DESCRIPTION
## Why
The anonymous chat screen — the FIRST surface a Swiss user sees on the wedge flow — was rendering only a bare back-arrow IconButton in its top bar. QA walkthrough on iPhone 17 Pro sim (2026-05-03) confirmed: « accessibility tree first 2 elements: only a single button "Retour" at (8,66). »

Per Handoff 2 (\`Downloads/handoff 2/prototype/captures/01-chat-comparison.png\`) the design intent is a calm editorial chat surface. This PR is **phase 1 of N** of the chat-vivant port — closes the highest-visibility design gaps on the entry screen.

## Changes (3 commits)

### 1. Top bar redesign (Handoff 2 alignment)
- \`Container\` (craie bg + hairline border) + \`Row\` with back IconButton + \`Expanded(Column)\` containing « MINT » brand (15pt w600, letterSpacing 1.5) + « Premier éclairage » subtitle.
- 6 ARB locales (\`anonymousChatPhaseSubtitle\`): FR « Premier éclairage », EN « First insight », DE « Erste Klarheit », ES « Primera claridad », IT « Prima chiarezza », PT « Primeira clareza ».
- 7 generated localization files regenerated via \`flutter gen-l10n\`.

### 2. Fraunces editorial type styles (foundation)
3 new TextStyles in \`mint_text_styles.dart\` for the chat-vivant port:
- \`MintTextStyles.editorialDisplay\` — 32pt Fraunces italic w400 (canvas chapter intros)
- \`MintTextStyles.editorialLarge\` — 22pt Fraunces italic w400 (scene phrase-signatures)
- \`MintTextStyles.editorialBody\` — 16pt Fraunces italic w400 (em words + dated labels)

Subtitle « Premier éclairage » now uses \`editorialBody\` for visual continuity with the design.

### 3. MINT bubble color fix (anti-grey-bubble invariant)
The MINT bubble + typing indicator were using \`MintColors.surface\` (#F5F5F7 cool grey) — exactly what \`01-vision.md\` says to avoid (« les bulles grises par défaut du chat actuel »). Switched both to \`MintColors.craie\` (#FCFBF8 warm cream) per the Handoff 2 reference, with a 0.5px hairline border so the warm cream doesn't disappear into the surrounding craie scaffold.

### 4. ARB TRUST-02 lint fix (unblocks PR #457 dev→staging)
Phase 54-02 PR-1 (#450) shipped 2 ARB keys without \`@meta level\` annotation, failing the VOICE-14 lint. This blocked PR #457 (dev→staging) with 4 CI failures. Fixed by adding \`x-mint-meta\` annotations to:
- \`coachSequenceNextStepLabel\` → N3
- \`coachSequenceCompletedMessage\` → N3
- \`anonymousChatPhaseSubtitle\` (this branch) → N1

Once this PR merges into dev, PR #457 will become unblocked and the dev→staging→main → testflight.yml CI pipeline can finally go green.

## Validation
- [x] \`flutter analyze\` on touched files: **No issues found**
- [x] ARB parity: 6/6 locales + 7/7 generated Dart files
- [x] \`python3 tools/checks/sentence_subject_arb_lint.py\` → **OK** (was FAIL — 2 violations before this PR)
- [x] Sim build + visual walkthrough pending (running locally now)
- [ ] CI green

## Mission context
Handoff 2 alignment phase 1 of N. Mission #1 (architecture) per \`ARCHITECTURE.md §2\` is already in place ✅. Mission #2 (chat vivant scenes) requires the rest of the widgets (MintInlineInsightCard, MintRatioCard, MintSceneRenteCapital, MintSceneRachatLPP, MintCanvasProjection) + SceneRegistry orchestration — to land in subsequent PRs.

## Out of scope (deferred to next PRs)
- Avatar carré arrondi noir on left of MINT messages
- Fraunces italic for em words inside bubble text (parser needed)
- « AUJOURD'HUI · 14:22 » date+time labels at message-day boundaries
- MintInlineInsightCard / MintRatioCard widgets (Niveau 1)
- MintSceneRenteCapital / MintSceneRachatLPP (Niveau 2)
- MintCanvasProjection (Niveau 3)
- SceneRegistry + ChatProjectionService orchestration