### PR TITLE
fix(anonymous-chat): MINT bubbles render markdown italic + bold (QA P1)

### DIFF
--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -436,14 +437,52 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen> {
               bottomRight: Radius.circular(isUser ? 4 : 18),
             ),
           ),
-          child: Text(
-            message.text,
-            style: GoogleFonts.inter(
-              fontSize: 15,
-              color: isUser ? MintColors.white : MintColors.textPrimary,
-              height: 1.4,
-            ),
-          ),
+          // QA walkthrough 2026-05-03 caught: `*avant*` rendered as
+          // literal asterisks in MINT bubbles instead of italic. The
+          // CoachMessageBubble (route /coach/chat) already uses
+          // MarkdownBody for em/strong support; AnonymousChatScreen was
+          // missing it. User messages stay as Text (user input doesn't
+          // typically contain markdown + GoogleFonts.inter is the
+          // existing pattern preserved for backward visual compat).
+          child: isUser
+              ? Text(
+                  message.text,
+                  style: GoogleFonts.inter(
+                    fontSize: 15,
+                    color: MintColors.white,
+                    height: 1.4,
+                  ),
+                )
+              : MarkdownBody(
+                  data: message.text,
+                  shrinkWrap: true,
+                  softLineBreak: true,
+                  selectable: true,
+                  styleSheet: MarkdownStyleSheet(
+                    p: GoogleFonts.inter(
+                      fontSize: 15,
+                      color: MintColors.textPrimary,
+                      height: 1.4,
+                    ),
+                    em: GoogleFonts.inter(
+                      fontSize: 15,
+                      color: MintColors.textPrimary,
+                      height: 1.4,
+                      fontStyle: FontStyle.italic,
+                    ),
+                    strong: GoogleFonts.inter(
+                      fontSize: 15,
+                      color: MintColors.textPrimary,
+                      height: 1.4,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    listBullet: GoogleFonts.inter(
+                      fontSize: 15,
+                      color: MintColors.textPrimary,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
         ),
       ),
     );


### PR DESCRIPTION
## Why
QA walkthrough on iPhone 17 Pro sim (2026-05-03) caught: coach responses on the **first chat surface a Swiss user sees** (route \`/anonymous/chat\`) render \`*avant*\` and \`_Outil éducatif simplifié_\` as **literal asterisks/underscores** instead of italic. The CoachMessageBubble (route \`/coach/chat\`) already uses MarkdownBody — but AnonymousChatScreen was using raw \`Text(message.text)\`.

Every coach response on the wedge entry screen was visually broken.

## Fix
Switch the MINT bubble to \`MarkdownBody\` with full styleSheet (p / em / strong / listBullet, all GoogleFonts.inter 15pt). User bubbles stay as Text. Pattern mirrors \`coach_message_bubble.dart:87-117\`.

## Files
- \`apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart\` — add \`flutter_markdown\` import + split \`_buildMessageBubble\` into user/coach branches.

## Validation
- [x] \`flutter analyze\` → No issues found
- [ ] CI green (Flutter widgets job)

## Mission context — \"MINT en production\" coach UX bugs (5 P0/P1)
| # | Bug (QA-confirmed) | Status |
|---|---|---|
| 1 | CoachAppBar incomplete | ✅ #459 |
| 2 | MINT bubble grey not craie | ✅ #459 |
| 3 | **Markdown italic broken** | ✅ **this PR** |
| 4 | APERÇU card sticky at bottom | ⏳ next PR |
| 5 | Calculer button no-op | ⏳ next PR |
| 6 | Landing anim rejouée 3.2s | ⏳ deferred (non-blocking) |