### PR TITLE
feat(handoff2,beta): align hero/sheet to Handoff 2 palette + B4 beta disclosure

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11165,5 +11165,42 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "Du hast diese geführte Sequenz abgeschlossen."
+  "coachSequenceCompletedMessage": "Du hast diese geführte Sequenz abgeschlossen.",
+  "betaDisclosureEyebrow": "MINT in der Beta",
+  "@betaDisclosureEyebrow": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "Du testest eine Version, die",
+  "@betaDisclosureHeadlinePrefix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineEm": "mit dir lernt",
+  "@betaDisclosureHeadlineEm": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoAdvice": "MINT ist keine Finanzberatung im Sinne des FIDLEG — es ist nur ein Bildungswerkzeug.",
+  "@betaDisclosureBulletNoAdvice": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoBank": "Keine Bankdaten werden bei uns gespeichert. Deine Daten bleiben auf deinem Gerät, ausser du stimmst ausdrücklich zu.",
+  "@betaDisclosureBulletNoBank": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletDataLocal": "Dein Feedback während der Beta hilft uns, MINT zu verbessern. Wir lesen alles.",
+  "@betaDisclosureBulletDataLocal": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureCta": "Verstanden, los geht's",
+  "@betaDisclosureCta": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureLearnMore": "Mehr erfahren",
+  "@betaDisclosureLearnMore": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureSemanticsLabel": "Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11165,5 +11165,42 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "You've completed this guided sequence."
+  "coachSequenceCompletedMessage": "You've completed this guided sequence.",
+  "betaDisclosureEyebrow": "MINT in beta",
+  "@betaDisclosureEyebrow": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "You're testing a version that",
+  "@betaDisclosureHeadlinePrefix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineEm": "learns with you",
+  "@betaDisclosureHeadlineEm": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoAdvice": "MINT is not financial advice under FinSA — it's an educational tool only.",
+  "@betaDisclosureBulletNoAdvice": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoBank": "No banking data is stored on our side. Your data stays on this device unless you explicitly opt in.",
+  "@betaDisclosureBulletNoBank": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletDataLocal": "Your feedback during the beta helps us improve MINT. We read every word.",
+  "@betaDisclosureBulletDataLocal": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureCta": "Got it, let's go",
+  "@betaDisclosureCta": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureLearnMore": "Learn more",
+  "@betaDisclosureLearnMore": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureSemanticsLabel": "Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11165,5 +11165,42 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "Has completado esta secuencia guiada."
+  "coachSequenceCompletedMessage": "Has completado esta secuencia guiada.",
+  "betaDisclosureEyebrow": "MINT en beta",
+  "@betaDisclosureEyebrow": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "Estás probando una versión que",
+  "@betaDisclosureHeadlinePrefix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineEm": "aprende contigo",
+  "@betaDisclosureHeadlineEm": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoAdvice": "MINT no es asesoramiento financiero según la LSFin — solo es una herramienta educativa.",
+  "@betaDisclosureBulletNoAdvice": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoBank": "No almacenamos ningún dato bancario. Tus datos permanecen en tu dispositivo salvo que des tu consentimiento explícito.",
+  "@betaDisclosureBulletNoBank": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletDataLocal": "Tus comentarios durante la beta nos ayudan a mejorar MINT. Te leemos.",
+  "@betaDisclosureBulletDataLocal": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureCta": "Entendido, vamos",
+  "@betaDisclosureCta": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureLearnMore": "Saber más",
+  "@betaDisclosureLearnMore": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureSemanticsLabel": "Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12105,5 +12105,46 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée."
+  "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée.",
+  "betaDisclosureEyebrow": "MINT en test",
+  "@betaDisclosureEyebrow": {
+    "description": "Beta disclosure sheet — uppercase eyebrow.",
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "Tu testes une version qui",
+  "@betaDisclosureHeadlinePrefix": {
+    "description": "Beta disclosure sheet — phrase signature prefix (before italic em)."
+  },
+  "betaDisclosureHeadlineEm": "apprend avec toi",
+  "@betaDisclosureHeadlineEm": {
+    "description": "Beta disclosure sheet — italicised em portion of the headline."
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "description": "Beta disclosure sheet — punctuation after the em."
+  },
+  "betaDisclosureBulletNoAdvice": "MINT n'est pas un conseil financier au sens de la LSFin — outil éducatif uniquement.",
+  "@betaDisclosureBulletNoAdvice": {
+    "description": "Beta disclosure sheet — first bullet (LSFin disclaimer)."
+  },
+  "betaDisclosureBulletNoBank": "Aucune donnée bancaire stockée chez nous. Les données restent sur ton appareil sauf opt-in explicite.",
+  "@betaDisclosureBulletNoBank": {
+    "description": "Beta disclosure sheet — second bullet (data sovereignty / nLPD)."
+  },
+  "betaDisclosureBulletDataLocal": "Tes retours pendant la bêta nous aident à améliorer MINT. On te lit.",
+  "@betaDisclosureBulletDataLocal": {
+    "description": "Beta disclosure sheet — third bullet (feedback loop)."
+  },
+  "betaDisclosureCta": "Je comprends, on y va",
+  "@betaDisclosureCta": {
+    "description": "Beta disclosure sheet — primary acknowledgement CTA."
+  },
+  "betaDisclosureLearnMore": "En savoir plus",
+  "@betaDisclosureLearnMore": {
+    "description": "Beta disclosure sheet — secondary CTA opening the privacy URL."
+  },
+  "betaDisclosureSemanticsLabel": "Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l'appareil par défaut.",
+  "@betaDisclosureSemanticsLabel": {
+    "description": "Beta disclosure sheet — accessibility container label."
+  }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11165,5 +11165,42 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "Hai completato questa sequenza guidata."
+  "coachSequenceCompletedMessage": "Hai completato questa sequenza guidata.",
+  "betaDisclosureEyebrow": "MINT in beta",
+  "@betaDisclosureEyebrow": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "Stai testando una versione che",
+  "@betaDisclosureHeadlinePrefix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineEm": "impara con te",
+  "@betaDisclosureHeadlineEm": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoAdvice": "MINT non è consulenza finanziaria ai sensi della LSerFi — è solo uno strumento educativo.",
+  "@betaDisclosureBulletNoAdvice": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoBank": "Nessun dato bancario è memorizzato da noi. I tuoi dati restano sul tuo dispositivo salvo consenso esplicito.",
+  "@betaDisclosureBulletNoBank": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletDataLocal": "I tuoi feedback durante la beta ci aiutano a migliorare MINT. Ti leggiamo.",
+  "@betaDisclosureBulletDataLocal": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureCta": "Capito, andiamo",
+  "@betaDisclosureCta": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureLearnMore": "Scopri di più",
+  "@betaDisclosureLearnMore": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureSemanticsLabel": "Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40658,6 +40658,66 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Tu as terminé cette séquence guidée.'**
   String get coachSequenceCompletedMessage;
+
+  /// Beta disclosure sheet — uppercase eyebrow.
+  ///
+  /// In fr, this message translates to:
+  /// **'MINT en test'**
+  String get betaDisclosureEyebrow;
+
+  /// Beta disclosure sheet — phrase signature prefix (before italic em).
+  ///
+  /// In fr, this message translates to:
+  /// **'Tu testes une version qui'**
+  String get betaDisclosureHeadlinePrefix;
+
+  /// Beta disclosure sheet — italicised em portion of the headline.
+  ///
+  /// In fr, this message translates to:
+  /// **'apprend avec toi'**
+  String get betaDisclosureHeadlineEm;
+
+  /// Beta disclosure sheet — punctuation after the em.
+  ///
+  /// In fr, this message translates to:
+  /// **'.'**
+  String get betaDisclosureHeadlineSuffix;
+
+  /// Beta disclosure sheet — first bullet (LSFin disclaimer).
+  ///
+  /// In fr, this message translates to:
+  /// **'MINT n\'est pas un conseil financier au sens de la LSFin — outil éducatif uniquement.'**
+  String get betaDisclosureBulletNoAdvice;
+
+  /// Beta disclosure sheet — second bullet (data sovereignty / nLPD).
+  ///
+  /// In fr, this message translates to:
+  /// **'Aucune donnée bancaire stockée chez nous. Les données restent sur ton appareil sauf opt-in explicite.'**
+  String get betaDisclosureBulletNoBank;
+
+  /// Beta disclosure sheet — third bullet (feedback loop).
+  ///
+  /// In fr, this message translates to:
+  /// **'Tes retours pendant la bêta nous aident à améliorer MINT. On te lit.'**
+  String get betaDisclosureBulletDataLocal;
+
+  /// Beta disclosure sheet — primary acknowledgement CTA.
+  ///
+  /// In fr, this message translates to:
+  /// **'Je comprends, on y va'**
+  String get betaDisclosureCta;
+
+  /// Beta disclosure sheet — secondary CTA opening the privacy URL.
+  ///
+  /// In fr, this message translates to:
+  /// **'En savoir plus'**
+  String get betaDisclosureLearnMore;
+
+  /// Beta disclosure sheet — accessibility container label.
+  ///
+  /// In fr, this message translates to:
+  /// **'Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l\'appareil par défaut.'**
+  String get betaDisclosureSemanticsLabel;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23238,4 +23238,38 @@ class SDe extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'Du hast diese geführte Sequenz abgeschlossen.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT in der Beta';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'Du testest eine Version, die';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'mit dir lernt';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT ist keine Finanzberatung im Sinne des FIDLEG — es ist nur ein Bildungswerkzeug.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'Keine Bankdaten werden bei uns gespeichert. Deine Daten bleiben auf deinem Gerät, ausser du stimmst ausdrücklich zu.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'Dein Feedback während der Beta hilft uns, MINT zu verbessern. Wir lesen alles.';
+
+  @override
+  String get betaDisclosureCta => 'Verstanden, los geht\'s';
+
+  @override
+  String get betaDisclosureLearnMore => 'Mehr erfahren';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23068,4 +23068,38 @@ class SEn extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'You\'ve completed this guided sequence.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT in beta';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'You\'re testing a version that';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'learns with you';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT is not financial advice under FinSA — it\'s an educational tool only.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'No banking data is stored on our side. Your data stays on this device unless you explicitly opt in.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'Your feedback during the beta helps us improve MINT. We read every word.';
+
+  @override
+  String get betaDisclosureCta => 'Got it, let\'s go';
+
+  @override
+  String get betaDisclosureLearnMore => 'Learn more';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23181,4 +23181,38 @@ class SEs extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'Has completado esta secuencia guiada.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT en beta';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'Estás probando una versión que';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'aprende contigo';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT no es asesoramiento financiero según la LSFin — solo es una herramienta educativa.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'No almacenamos ningún dato bancario. Tus datos permanecen en tu dispositivo salvo que des tu consentimiento explícito.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'Tus comentarios durante la beta nos ayudan a mejorar MINT. Te leemos.';
+
+  @override
+  String get betaDisclosureCta => 'Entendido, vamos';
+
+  @override
+  String get betaDisclosureLearnMore => 'Saber más';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23183,4 +23183,38 @@ class SFr extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'Tu as terminé cette séquence guidée.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT en test';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'Tu testes une version qui';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'apprend avec toi';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT n\'est pas un conseil financier au sens de la LSFin — outil éducatif uniquement.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'Aucune donnée bancaire stockée chez nous. Les données restent sur ton appareil sauf opt-in explicite.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'Tes retours pendant la bêta nous aident à améliorer MINT. On te lit.';
+
+  @override
+  String get betaDisclosureCta => 'Je comprends, on y va';
+
+  @override
+  String get betaDisclosureLearnMore => 'En savoir plus';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l\'appareil par défaut.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23242,4 +23242,38 @@ class SIt extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'Hai completato questa sequenza guidata.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT in beta';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'Stai testando una versione che';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'impara con te';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT non è consulenza finanziaria ai sensi della LSerFi — è solo uno strumento educativo.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'Nessun dato bancario è memorizzato da noi. I tuoi dati restano sul tuo dispositivo salvo consenso esplicito.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'I tuoi feedback durante la beta ci aiutano a migliorare MINT. Ti leggiamo.';
+
+  @override
+  String get betaDisclosureCta => 'Capito, andiamo';
+
+  @override
+  String get betaDisclosureLearnMore => 'Scopri di più';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23189,4 +23189,38 @@ class SPt extends S {
   @override
   String get coachSequenceCompletedMessage =>
       'Concluíste esta sequência guiada.';
+
+  @override
+  String get betaDisclosureEyebrow => 'MINT em beta';
+
+  @override
+  String get betaDisclosureHeadlinePrefix => 'Estás a testar uma versão que';
+
+  @override
+  String get betaDisclosureHeadlineEm => 'aprende contigo';
+
+  @override
+  String get betaDisclosureHeadlineSuffix => '.';
+
+  @override
+  String get betaDisclosureBulletNoAdvice =>
+      'MINT não é aconselhamento financeiro nos termos da LSFin — é apenas uma ferramenta educativa.';
+
+  @override
+  String get betaDisclosureBulletNoBank =>
+      'Nenhum dado bancário é armazenado do nosso lado. Os teus dados permanecem no teu dispositivo salvo consentimento explícito.';
+
+  @override
+  String get betaDisclosureBulletDataLocal =>
+      'O teu feedback durante a beta ajuda-nos a melhorar a MINT. Lemos tudo.';
+
+  @override
+  String get betaDisclosureCta => 'Entendido, vamos';
+
+  @override
+  String get betaDisclosureLearnMore => 'Saber mais';
+
+  @override
+  String get betaDisclosureSemanticsLabel =>
+      'Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11165,5 +11165,42 @@
   "@coachSequenceNextStepLabel": {
     "placeholders": {"label": {"type": "String"}}
   },
-  "coachSequenceCompletedMessage": "Concluíste esta sequência guiada."
+  "coachSequenceCompletedMessage": "Concluíste esta sequência guiada.",
+  "betaDisclosureEyebrow": "MINT em beta",
+  "@betaDisclosureEyebrow": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlinePrefix": "Estás a testar uma versão que",
+  "@betaDisclosureHeadlinePrefix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineEm": "aprende contigo",
+  "@betaDisclosureHeadlineEm": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureHeadlineSuffix": ".",
+  "@betaDisclosureHeadlineSuffix": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoAdvice": "MINT não é aconselhamento financeiro nos termos da LSFin — é apenas uma ferramenta educativa.",
+  "@betaDisclosureBulletNoAdvice": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletNoBank": "Nenhum dado bancário é armazenado do nosso lado. Os teus dados permanecem no teu dispositivo salvo consentimento explícito.",
+  "@betaDisclosureBulletNoBank": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureBulletDataLocal": "O teu feedback durante a beta ajuda-nos a melhorar a MINT. Lemos tudo.",
+  "@betaDisclosureBulletDataLocal": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureCta": "Entendido, vamos",
+  "@betaDisclosureCta": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureLearnMore": "Saber mais",
+  "@betaDisclosureLearnMore": {
+    "x-mint-meta": {"level": "N1"}
+  },
+  "betaDisclosureSemanticsLabel": "Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito."
 }

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
+import 'package:mint_mobile/widgets/beta/beta_program_disclosure_sheet.dart';
 
 class LandingScreen extends StatefulWidget {
   const LandingScreen({super.key});
@@ -71,6 +72,10 @@ class _LandingScreenState extends State<LandingScreen>
       } else {
         _controller.forward();
       }
+      // First-launch beta disclosure (Apple TestFlight beta review +
+      // FINMA fintech sandbox). One-shot per device install.
+      // No-op when SharedPreferences flag is already set.
+      BetaProgramDisclosureSheet.maybeShow(context);
     });
   }
 

--- a/apps/mobile/lib/theme/colors.dart
+++ b/apps/mobile/lib/theme/colors.dart
@@ -46,6 +46,43 @@ class MintColors {
   static const Color porcelaine = Color(0xFFF7F4EE);
   /// Cream white — coach chat background, subtle warmth.
   static const Color craie = Color(0xFFFCFBF8);
+
+  // ── Handoff 2 source-of-truth tokens (~/Downloads/handoff 2/colors_and_type.css) ──
+  // Added 2026-05-03 to align hero / sheet / disclosure surfaces with the
+  // editorial Handoff 2 spec (porcelaine + ink warm + sauge + forest signal).
+  // NEW tokens — legacy `porcelaine` / `craie` / `primary` / `textPrimary`
+  // remain untouched so the 6000+ existing surfaces keep their AAA contrast
+  // tests green. New Handoff 2 surfaces should use these tokens explicitly.
+
+  /// Hero / disclosure / sheet surface — warm porcelain cream.
+  /// Source: `--mint-porcelaine: #F4F1EC`. Replaces cool `surface #F5F5F7`.
+  static const Color porcelaineHero = Color(0xFFF4F1EC);
+
+  /// Coach / conversation surface — slightly warmer than legacy `craie`.
+  /// Source: `--mint-craie: #F8F5F0`.
+  static const Color craieHandoff = Color(0xFFF8F5F0);
+
+  /// Near-black ink — warm primary text & CTA fills (Handoff 2).
+  /// Source: `--mint-text-primary: #1A1A1A`. Replaces cool `primary #1D1D1F`
+  /// on Handoff 2 hero / sheet / CTA surfaces.
+  static const Color inkPrimary = Color(0xFF1A1A1A);
+
+  /// Warm hairline divider — replaces cool `border #D2D2D7` on Handoff 2 surfaces.
+  /// Source: `--mint-border-subtle: #E8E4DE`.
+  static const Color borderSubtle = Color(0xFFE8E4DE);
+
+  /// Deep forest signal — the strong-emphasis accent (selection chip, success
+  /// confirmation, positive icon tint). Source: `--mint-primary: #2F5F3F`.
+  /// Use sparingly per Handoff 2 grammaire "réservé pour emphase forte".
+  static const Color mintForest = Color(0xFF2F5F3F);
+
+  /// Sauge positive — calmer green for surface tints / outlined chips.
+  /// Source: `--mint-sauge: #B8C9B4`.
+  static const Color sauge = Color(0xFFB8C9B4);
+
+  /// Terracotta — rare CTA highlight, "creuser" / milestone warmth.
+  /// Source: `--mint-terracotta: #B8735A`.
+  static const Color terracotta = Color(0xFFB8735A);
   /// Sage green — success surfaces, cap cards, positive signals.
   static const Color saugeClaire = Color(0xFFD8E4DB);
   /// Air blue — coach bubbles, info surfaces.

--- a/apps/mobile/lib/theme/mint_text_styles.dart
+++ b/apps/mobile/lib/theme/mint_text_styles.dart
@@ -186,4 +186,39 @@ class MintTextStyles {
         height: 1.3,
         color: color ?? MintColors.textMuted,
       );
+
+  // ── Editorial (Handoff 2 Fraunces — italique 2 écrans max) ──
+  // Source: ~/Downloads/handoff 2/colors_and_type.css §Typography.
+  // Use ONLY on hero / disclosure / first-screen surfaces. Italic
+  // is the single emphasis lever — apply via TextSpan italic on the
+  // 1-3 mots clés that carry the meaning.
+
+  /// Editorial display headline (32pt Fraunces). Hero numbers in
+  /// situational scenes. Hand off 2 §grammaire « Une idée / écran ».
+  static TextStyle editorialDisplay({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 32,
+        fontWeight: FontWeight.w500,
+        height: 1.25,
+        letterSpacing: -0.5,
+        color: color ?? MintColors.inkPrimary,
+      );
+
+  /// Editorial large headline (22pt Fraunces). Disclosure headline,
+  /// first-onboarding question, beta sheet headline.
+  static TextStyle editorialLarge({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 22,
+        fontWeight: FontWeight.w500,
+        height: 1.3,
+        letterSpacing: -0.3,
+        color: color ?? MintColors.inkPrimary,
+      );
+
+  /// Editorial body (16pt Fraunces). Coach message in conversion
+  /// sheets, 1-2 lines max. Italic em on key words via TextSpan.
+  static TextStyle editorialBody({Color? color}) => GoogleFonts.fraunces(
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        height: 1.45,
+        color: color ?? MintColors.inkPrimary,
+      );
 }

--- a/apps/mobile/lib/widgets/auth/auth_gate_bottom_sheet.dart
+++ b/apps/mobile/lib/widgets/auth/auth_gate_bottom_sheet.dart
@@ -23,12 +23,18 @@ class AuthGateBottomSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = S.of(context)!;
 
+    // Handoff 2 alignment 2026-05-03 :
+    //  - sheet bg : porcelaineHero (#F4F1EC) au lieu de surface cool grey
+    //  - hairline : borderSubtle (#E8E4DE) warm
+    //  - coach icon halo : sauge (positive signal) au lieu de slate
+    //  - primary CTA : inkPrimary (#1A1A1A) warm près-noir, pas anthracite cool
+    //  - coach message : Fraunces editorial italic (Handoff 2 §grammaire)
     return Container(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.55,
       ),
       decoration: const BoxDecoration(
-        color: MintColors.surface,
+        color: MintColors.porcelaineHero,
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
       child: SafeArea(
@@ -38,46 +44,47 @@ class AuthGateBottomSheet extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // Handle bar
+              // Handle bar — warm hairline
               Container(
                 width: 36,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: MintColors.border,
+                  color: MintColors.borderSubtle,
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
               const SizedBox(height: 24),
 
-              // Coach avatar
+              // Coach avatar — sauge halo, forest icon (positive signal)
               Container(
                 padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
-                  color: MintColors.coachBubble,
+                  color: MintColors.craieHandoff,
                   shape: BoxShape.circle,
                   border: Border.all(
-                    color: MintColors.coachAccent.withValues(alpha: 0.15),
+                    color: MintColors.sauge,
+                    width: 1.2,
                   ),
                 ),
                 child: const Icon(
                   Icons.chat_bubble_outline_rounded,
-                  color: MintColors.coachAccent,
+                  color: MintColors.mintForest,
                   size: 28,
                 ),
               ),
               const SizedBox(height: 20),
 
-              // Coach message — conversational, not system-like
+              // Coach message — editorial italic (Fraunces) per Handoff 2.
               Text(
                 l.authGateConversionMessage,
                 textAlign: TextAlign.center,
-                style: MintTextStyles.bodyLarge(
-                  color: MintColors.textPrimary,
+                style: MintTextStyles.editorialBody(
+                  color: MintColors.inkPrimary,
                 ),
               ),
               const SizedBox(height: 28),
 
-              // Primary CTA — Create account
+              // Primary CTA — warm near-black ink (Handoff 2 ink-primary).
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
@@ -86,7 +93,7 @@ class AuthGateBottomSheet extends StatelessWidget {
                     context.push('/auth/register?redirect=/home');
                   },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: MintColors.primary,
+                    backgroundColor: MintColors.inkPrimary,
                     foregroundColor: MintColors.white,
                     elevation: 0,
                     padding: const EdgeInsets.symmetric(vertical: 16),
@@ -103,7 +110,7 @@ class AuthGateBottomSheet extends StatelessWidget {
               ),
               const SizedBox(height: 12),
 
-              // Secondary CTA — Login
+              // Secondary CTA — outlined, warm hairline.
               SizedBox(
                 width: double.infinity,
                 child: TextButton(
@@ -112,17 +119,17 @@ class AuthGateBottomSheet extends StatelessWidget {
                     context.push('/auth/login?redirect=/home');
                   },
                   style: TextButton.styleFrom(
-                    foregroundColor: MintColors.textPrimary,
+                    foregroundColor: MintColors.inkPrimary,
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(14),
-                      side: const BorderSide(color: MintColors.border),
+                      side: const BorderSide(color: MintColors.borderSubtle),
                     ),
                   ),
                   child: Text(
                     l.authGateLogin,
                     style:
-                        MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                        MintTextStyles.bodyMedium(color: MintColors.inkPrimary)
                             .copyWith(fontWeight: FontWeight.w600),
                   ),
                 ),
@@ -138,7 +145,7 @@ class AuthGateBottomSheet extends StatelessWidget {
                 child: Text(
                   l.authGateLater,
                   style: MintTextStyles.bodyMedium(
-                    color: MintColors.textMuted,
+                    color: MintColors.textSecondaryAaa,
                   ),
                 ),
               ),

--- a/apps/mobile/lib/widgets/beta/beta_program_disclosure_sheet.dart
+++ b/apps/mobile/lib/widgets/beta/beta_program_disclosure_sheet.dart
@@ -1,0 +1,241 @@
+// ────────────────────────────────────────────────────────────────────
+//  BetaProgramDisclosureSheet — first-launch beta disclosure
+// ────────────────────────────────────────────────────────────────────
+//
+//  Per Apple App Store Review Guideline 5.1.1 (data collection
+//  consent) + 1.2 (developer responsibility for beta content) +
+//  TestFlight beta review criteria : MINT must inform first-launch
+//  users that the app is in beta, what's expected of testers, and
+//  what data is collected before any LLM call.
+//
+//  Per FINMA fintech sandbox + the Triage Expert verdict
+//  (.planning/phases/54-testflight-gate-closure/54-VERIFICATION-REPORT.html
+//  panel synthesis 2026-05-03) :
+//   « MINT est en test, aucun conseil financier, aucune donnée
+//     bancaire stockée chez nous, vos données restent sur l'appareil
+//     sauf opt-in »
+//
+//  Design — minimal modal sheet on top of the landing screen :
+//   • One-shot per device (SharedPreferences flag).
+//   • Calm Handoff 2 voice — Fraunces italic em on key words.
+//   • Single CTA « Je comprends, on y va » dismisses.
+//   • « En savoir plus » deeplinks to the Privacy Center URL.
+//   • A11y semantics with announced label for screen readers.
+//
+//  Usage :
+//   await BetaProgramDisclosureSheet.maybeShow(context);
+//  Returns immediately if already acknowledged this device.
+// ────────────────────────────────────────────────────────────────────
+
+library;
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/theme/mint_text_styles.dart';
+
+const String _kBetaDisclosureSeenKey = 'mint_beta_disclosure_seen';
+
+/// First-launch beta disclosure sheet. One-shot per device install.
+/// Apple TestFlight beta review + FINMA fintech sandbox compliance.
+class BetaProgramDisclosureSheet extends StatelessWidget {
+  /// Optional override of the « En savoir plus » deeplink URL.
+  /// Defaults to https://mint.ch/privacy.
+  final Uri privacyUrl;
+
+  // Non-const ctor: Uri.parse is not a const expression. Surface this
+  // as a regular ctor so callers don't try to const-instantiate it.
+  BetaProgramDisclosureSheet({
+    super.key,
+    Uri? privacyUrl,
+  }) : privacyUrl = privacyUrl ?? _defaultPrivacyUrl;
+
+  static final Uri _defaultPrivacyUrl = Uri.parse('https://mint.ch/privacy');
+
+  /// Show the sheet if it hasn't been acknowledged on this device yet.
+  /// No-op when the SharedPreferences flag is already set.
+  ///
+  /// Returns true if the sheet was shown (and the user dismissed it),
+  /// false if already acked / context unmounted.
+  static Future<bool> maybeShow(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    final seen = prefs.getBool(_kBetaDisclosureSeenKey) ?? false;
+    if (seen) return false;
+    if (!context.mounted) return false;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => BetaProgramDisclosureSheet(),
+    );
+    return true;
+  }
+
+  /// Mark the disclosure as acknowledged. Public so callers can
+  /// re-trigger the sheet for testing or QA verification.
+  static Future<void> markAcknowledged() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kBetaDisclosureSeenKey, true);
+  }
+
+  /// Reset the flag (test helper / settings « show me again » CTA).
+  @visibleForTesting
+  static Future<void> resetForTest() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kBetaDisclosureSeenKey);
+  }
+
+  Future<void> _openPrivacyUrl(BuildContext context) async {
+    if (await canLaunchUrl(privacyUrl)) {
+      await launchUrl(privacyUrl, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _onAcknowledge(BuildContext context) async {
+    await markAcknowledged();
+    if (context.mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    // Handoff 2 alignment 2026-05-03 :
+    //  - sheet bg : porcelaineHero (#F4F1EC) au lieu de craie cool
+    //  - hairline : borderSubtle (#E8E4DE) warm
+    //  - eyebrow : mintForest (#2F5F3F) signal vert handoff 2 (pas corail)
+    //  - bullets « ▪ » : sauge (#B8C9B4) calme positif
+    //  - primary CTA : inkPrimary (#1A1A1A) warm près-noir
+    return Semantics(
+      container: true,
+      label: l.betaDisclosureSemanticsLabel,
+      child: SafeArea(
+        top: false,
+        child: Container(
+          decoration: const BoxDecoration(
+            color: MintColors.porcelaineHero,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Drag handle — warm hairline.
+              Center(
+                child: Container(
+                  width: 36,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 24),
+                  decoration: BoxDecoration(
+                    color: MintColors.borderSubtle,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              // Eyebrow — uppercase, deep forest signal (Handoff 2).
+              Text(
+                l.betaDisclosureEyebrow,
+                style: MintTextStyles.labelMedium(
+                  color: MintColors.mintForest,
+                ).copyWith(
+                  fontSize: 10.5,
+                  letterSpacing: 1.4,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              // Headline — editorial Fraunces italic em on warm ink.
+              Text.rich(
+                TextSpan(
+                  style: MintTextStyles.editorialLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(height: 1.3),
+                  children: [
+                    TextSpan(text: l.betaDisclosureHeadlinePrefix),
+                    const TextSpan(text: ' '),
+                    TextSpan(
+                      text: l.betaDisclosureHeadlineEm,
+                      style: const TextStyle(fontStyle: FontStyle.italic),
+                    ),
+                    TextSpan(text: l.betaDisclosureHeadlineSuffix),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              // Bullets — sauge calme positif sur tous les points.
+              _bulletPoint(l.betaDisclosureBulletNoAdvice),
+              const SizedBox(height: 6),
+              _bulletPoint(l.betaDisclosureBulletNoBank),
+              const SizedBox(height: 6),
+              _bulletPoint(l.betaDisclosureBulletDataLocal),
+              const SizedBox(height: 20),
+              // Primary CTA — warm near-black ink (Handoff 2 ink-primary).
+              FilledButton(
+                onPressed: () => _onAcknowledge(context),
+                style: FilledButton.styleFrom(
+                  backgroundColor: MintColors.inkPrimary,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+                child: Text(
+                  l.betaDisclosureCta,
+                  style: MintTextStyles.titleMedium(color: Colors.white),
+                ),
+              ),
+              const SizedBox(height: 8),
+              // Secondary — Privacy URL.
+              TextButton(
+                onPressed: () => _openPrivacyUrl(context),
+                style: TextButton.styleFrom(
+                  foregroundColor: MintColors.textSecondaryAaa,
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                ),
+                child: Text(
+                  l.betaDisclosureLearnMore,
+                  style: MintTextStyles.bodySmall(
+                    color: MintColors.textSecondaryAaa,
+                  ).copyWith(decoration: TextDecoration.underline),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _bulletPoint(String text) {
+    // Per Handoff 2 invariant : aucun emoji. For bullets, use « ▪ ».
+    // Sauge positif Handoff 2 — calme, pas alerte.
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 5, right: 8),
+          child: Text(
+            '▪',
+            style: MintTextStyles.bodySmall(
+              color: MintColors.mintForest,
+            ).copyWith(fontSize: 12, height: 1.0),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            text,
+            style: MintTextStyles.bodyMedium(
+              color: MintColors.textSecondaryAaa,
+            ).copyWith(height: 1.5),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/test/widgets/beta/beta_program_disclosure_sheet_test.dart
+++ b/apps/mobile/test/widgets/beta/beta_program_disclosure_sheet_test.dart
@@ -1,0 +1,157 @@
+// ────────────────────────────────────────────────────────────────────
+//  BetaProgramDisclosureSheet widget tests
+// ────────────────────────────────────────────────────────────────────
+//
+//  Covers :
+//   • maybeShow no-op when SharedPreferences flag is set
+//   • maybeShow shows sheet when flag is unset, persists flag on dismiss
+//   • CTA tap dismisses sheet + sets flag
+//   • « En savoir plus » TextButton renders + is tappable
+//   • Headline renders Fraunces italic em (TextSpan walk)
+//   • Semantics label is announced for screen readers
+//
+//  Note: url_launcher isn't mocked in widget tests — the canLaunchUrl
+//  guard in _openPrivacyUrl prevents crashes during test runs.
+// ────────────────────────────────────────────────────────────────────
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/widgets/beta/beta_program_disclosure_sheet.dart';
+
+const String _kFlag = 'mint_beta_disclosure_seen';
+
+Widget _harness({Widget? home}) {
+  return MaterialApp(
+    locale: const Locale('fr'),
+    supportedLocales: S.supportedLocales,
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    home: home ??
+        Builder(
+          builder: (ctx) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => BetaProgramDisclosureSheet.maybeShow(ctx),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+  );
+}
+
+bool _treeContainsText(WidgetTester tester, String needle) {
+  final lower = needle.toLowerCase();
+  for (final t in tester.widgetList<Text>(find.byType(Text))) {
+    final data = t.data ?? t.textSpan?.toPlainText() ?? '';
+    if (data.toLowerCase().contains(lower)) return true;
+  }
+  return false;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('maybeShow is a no-op when the flag is already set',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({_kFlag: true});
+
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Sheet should not be present — only the "open" button remains.
+    expect(find.byType(BetaProgramDisclosureSheet), findsNothing);
+  });
+
+  testWidgets('maybeShow renders the sheet when the flag is unset',
+      (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BetaProgramDisclosureSheet), findsOneWidget);
+    // Headline pieces are visible.
+    expect(_treeContainsText(tester, 'apprend avec toi'), isTrue);
+    // CTA + secondary visible.
+    expect(_treeContainsText(tester, 'Je comprends'), isTrue);
+    expect(_treeContainsText(tester, 'En savoir plus'), isTrue);
+  });
+
+  testWidgets('CTA tap dismisses sheet and persists the flag',
+      (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BetaProgramDisclosureSheet), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Je comprends, on y va'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BetaProgramDisclosureSheet), findsNothing);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(_kFlag), isTrue);
+  });
+
+  testWidgets('headline renders an italic emphasis TextSpan', (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Walk every Text widget; assert at least one TextSpan child has italic.
+    bool foundItalic = false;
+    for (final t in tester.widgetList<Text>(find.byType(Text))) {
+      final span = t.textSpan;
+      if (span is TextSpan) {
+        for (final child in span.children ?? const <InlineSpan>[]) {
+          if (child is TextSpan &&
+              child.style?.fontStyle == FontStyle.italic) {
+            foundItalic = true;
+            break;
+          }
+        }
+      }
+      if (foundItalic) break;
+    }
+    expect(foundItalic, isTrue,
+        reason: 'Editorial italic em on headline must be present');
+  });
+
+  testWidgets('Semantics label exposes beta disclosure context',
+      (tester) async {
+    await tester.pumpWidget(_harness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final semantics = tester.getSemantics(find.byType(BetaProgramDisclosureSheet));
+    // Label is composed of the disclosure semantics — check substring.
+    expect(semantics.label.toLowerCase(), contains('bêta'));
+  });
+
+  test('resetForTest clears the persisted flag', () async {
+    SharedPreferences.setMockInitialValues({_kFlag: true});
+    await BetaProgramDisclosureSheet.resetForTest();
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(_kFlag), isNull);
+  });
+
+  test('markAcknowledged sets the persisted flag', () async {
+    await BetaProgramDisclosureSheet.markAcknowledged();
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(_kFlag), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Surface debt audit caught it: the **auth gate sheet** (and the new **beta disclosure**) were rendering with cool Apple anthracite + cool surface — pure black/white with no warmth — instead of the Handoff 2 warm porcelaine + ink primary + sauge/forest signal grammar Julien spec'd.

Two intertwined fixes shipped together:

1. **Handoff 2 palette alignment** — additive new tokens (legacy untouched, AAA contrast tests still 18/18 green).
2. **B4 beta disclosure** (Apple TestFlight beta review + FINMA fintech sandbox ship blocker) — first-launch one-shot modal sheet using the new tokens.

## Handoff 2 token alignment

Source of truth: `~/Downloads/handoff 2/colors_and_type.css` §:root.

| New token | Hex | Role | Replaces (on hero/sheet only) |
|---|---|---|---|
| `porcelaineHero` | `#F4F1EC` | hero / sheet warm surface | `surface #F5F5F7` (cool) |
| `craieHandoff` | `#F8F5F0` | coach surface (warmer) | `craie #FCFBF8` (too white) |
| `inkPrimary` | `#1A1A1A` | warm near-black CTA / text | `primary #1D1D1F` (cool anthracite) |
| `borderSubtle` | `#E8E4DE` | warm hairline | `border #D2D2D7` (cool) |
| `mintForest` | `#2F5F3F` | strong-emphasis signal accent | (new) |
| `sauge` | `#B8C9B4` | calm positive surface tint | (new) |
| `terracotta` | `#B8735A` | rare CTA highlight | (new) |

Editorial Fraunces type tokens (Handoff 2 « italique : 2 écrans max »):
- `MintTextStyles.editorialDisplay` (32pt) · `editorialLarge` (22pt) · `editorialBody` (16pt)

## Surfaces rewired

- **`auth_gate_bottom_sheet.dart`** — bg porcelaine, sauge halo + forest icon, Fraunces editorial body, ink CTA, warm hairline outline, `textSecondaryAaa` for « Plus tard ».
- **`beta_program_disclosure_sheet.dart`** — same tokens, `mintForest` eyebrow + bullets « ▪ », editorial italic em on « apprend avec toi », ink CTA.

## B4 beta disclosure

- `BetaProgramDisclosureSheet.maybeShow(context)` — one-shot per device install (`SharedPreferences` flag `mint_beta_disclosure_seen`).
- 9 ARB keys × 6 locales (FR/EN/DE/ES/IT/PT) with `x-mint-meta: {"level": "N1"}` for VOICE-14 lint.
- Wired into `LandingScreen.initState` `addPostFrameCallback` (after the existing animation forward).
- `« En savoir plus »` deeplink to https://mint.ch/privacy via `url_launcher`.

## Test plan

- [x] `flutter analyze` (touched files): 0 errors
- [x] `flutter test test/widgets/beta/`: 7/7 passed (no-op when flag set, render when unset, CTA persists flag, italic em headline, semantics label, reset/markAcknowledged)
- [x] `flutter test test/theme/aaa_tokens_contrast_test.dart`: 18/18 passed (legacy AAA tokens untouched)
- [x] `accent_lint_fr.py` on touched files: clean
- [ ] Visual sim screenshot to confirm Handoff 2 palette renders (next step after merge)