### PR TITLE
chore(compliance): align jargonAvsTooltip × 6 locales + LSFin banned-terms ARB lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,15 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 tools/checks/sentence_subject_arb_lint.py
 
+      # ─── CLAUDE.md TOP rule #1: LSFin banned-terms ARB lint ────────
+      # Blocks positive « garanti / guaranteed / garantiert / garantizado /
+      # garantito / garantido » uses across all 6 ARB files. Negation-form
+      # disclaimers (« pas de... garanti », « not guaranteed », « kein
+      # garantierter ») are allowlisted.
+      - name: LSFin banned-terms ARB lint (CLAUDE.md TOP rule #1)
+        working-directory: ${{ github.workspace }}
+        run: python3 tools/checks/banned_terms_arb.py
+
       # ─── Phase 9 / ALERT-07: no LLM-driven alert objects ────────────
       - name: No LLM-driven alert objects (ALERT-07)
         working-directory: ${{ github.workspace }}

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -9826,7 +9826,7 @@
   "jargonReplacementRateTooltip": "Die Ersatzquote misst, welchen Anteil deines aktuellen Einkommens du im Ruhestand behältst. Beispiel: 65% bedeutet, du erhältst 65% deines aktuellen Lohns.",
   "jargonLppTooltip": "Das BVG (Bundesgesetz über die berufliche Vorsorge) ist die 2. Säule. Du und dein Arbeitgeber zahlen gemeinsam für deine Pension ein.",
   "jargon3aTooltip": "Die Säule 3a ist freiwilliges Alterssparen mit Steuervorteil. Die Obergrenze beträgt CHF 7'258/Jahr (Angestellte mit BVG).",
-  "jargonAvsTooltip": "Die AHV (Alters- und Hinterlassenenversicherung) ist die 1. Säule. Sie garantiert ein Grundeinkommen im Ruhestand.",
+  "jargonAvsTooltip": "Die AHV (Alters- und Hinterlassenenversicherung) ist die 1. Säule. Sie soll ein Grundeinkommen im Ruhestand bereitstellen.",
   "jargonRamdTooltip": "Das RAMD bestimmt die Höhe deiner AHV-Rente. Es wird aus deinen beitragspflichtigen Einkommen berechnet.",
   "confidenceDetailsTooltip": "Basierend auf: Alter, Einkommen, Kanton, Zivilstand, Nationalität, deklarierte BVG und 3a. Je mehr Daten du angibst, desto genauer die Projektion.",
   "replacementRateContextGood": "Das ist ein gutes Niveau — über 80%.",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -9826,7 +9826,7 @@
   "jargonReplacementRateTooltip": "The replacement rate measures the share of your current income you will keep in retirement. Example: 65% means you will receive 65% of your current salary.",
   "jargonLppTooltip": "The LPP (Occupational Pensions Act) is the 2nd pillar. You and your employer contribute together toward your retirement.",
   "jargon3aTooltip": "Pillar 3a is voluntary retirement savings with tax benefits. The ceiling is CHF 7,258/year (employed with LPP).",
-  "jargonAvsTooltip": "AVS (Old-age and Survivors’ Insurance) is the 1st pillar. It guarantees a basic retirement income.",
+  "jargonAvsTooltip": "AVS (Old-age and Survivors’ Insurance) is the 1st pillar. It is designed to provide a basic retirement income.",
   "jargonRamdTooltip": "The RAMD determines your AVS pension amount. It is calculated from your contribution-liable income.",
   "confidenceDetailsTooltip": "Based on: age, income, canton, civil status, nationality, declared LPP and 3a. The more data you provide, the more accurate the projection.",
   "replacementRateContextGood": "That’s a good level — above 80%.",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -9826,7 +9826,7 @@
   "jargonReplacementRateTooltip": "La tasa de reemplazo mide la parte de tu ingreso actual que conservarás en la jubilación. Ejemplo: 65% significa que recibirás el 65% de tu salario actual.",
   "jargonLppTooltip": "La LPP (Ley de Previsión Profesional) es el 2.º pilar. Tú y tu empleador cotizáis juntos para tu jubilación.",
   "jargon3aTooltip": "El pilar 3a es un ahorro voluntario para la jubilación con ventajas fiscales. El límite es de CHF 7.258/año (asalariados con LPP).",
-  "jargonAvsTooltip": "El AVS (Seguro de Vejez y Supervivientes) es el 1.er pilar. Garantiza un ingreso básico en la jubilación.",
+  "jargonAvsTooltip": "El AVS (Seguro de Vejez y Supervivientes) es el 1.er pilar. Su objetivo es proporcionar un ingreso básico en la jubilación.",
   "jargonRamdTooltip": "El RAMD determina el monto de tu pensión AVS. Se calcula a partir de tus ingresos sujetos a cotización.",
   "confidenceDetailsTooltip": "Basado en: edad, ingresos, cantón, estado civil, nacionalidad, LPP y 3a declarados. Cuantos más datos proporcionas, más precisa es la proyección.",
   "replacementRateContextGood": "Es un buen nivel — por encima del 80%.",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10290,7 +10290,7 @@
   "jargonReplacementRateTooltip": "Le taux de remplacement mesure la part de ton revenu actuel que tu conserveras à la retraite. Exemple : 65 % signifie que tu toucheras 65 % de ton salaire actuel.",
   "jargonLppTooltip": "La LPP (Loi sur la prévoyance professionnelle) est le 2e pilier. Ton employeur et toi cotisez ensemble pour ta retraite.",
   "jargon3aTooltip": "Le pilier 3a est une épargne retraite volontaire avec avantage fiscal. Le plafond est de 7 258 CHF/an (salarié avec LPP).",
-  "jargonAvsTooltip": "L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.",
+  "jargonAvsTooltip": "L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle vise à fournir un revenu de base à la retraite.",
   "jargonRamdTooltip": "Le RAMD détermine le montant de ta rente AVS. Il est calculé à partir de tes revenus soumis à cotisation.",
   "confidenceDetailsTooltip": "Basé sur : âge, revenu, canton, statut civil, nationalité, LPP et 3a déclarés. Plus tu fournis de données, plus la projection est fiable.",
   "replacementRateContextGood": "C’est un bon niveau — au-dessus de 80 %.",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -9826,7 +9826,7 @@
   "jargonReplacementRateTooltip": "Il tasso di sostituzione misura la quota del tuo reddito attuale che manterrai in pensione. Esempio: 65% significa che riceverai il 65% del tuo stipendio attuale.",
   "jargonLppTooltip": "La LPP (Legge sulla previdenza professionale) è il 2° pilastro. Tu e il tuo datore di lavoro contribuite insieme per la tua pensione.",
   "jargon3aTooltip": "Il pilastro 3a è un risparmio pensionistico volontario con vantaggi fiscali. Il tetto è di CHF 7'258/anno (dipendenti con LPP).",
-  "jargonAvsTooltip": "L'AVS (Assicurazione vecchiaia e superstiti) è il 1° pilastro. Garantisce un reddito di base in pensione.",
+  "jargonAvsTooltip": "L'AVS (Assicurazione vecchiaia e superstiti) è il 1° pilastro. Mira a fornire un reddito di base in pensione.",
   "jargonRamdTooltip": "Il RAMD determina l'importo della tua rendita AVS. È calcolato in base ai redditi soggetti a contribuzione.",
   "confidenceDetailsTooltip": "Basato su: età, reddito, cantone, stato civile, nazionalità, LPP e 3a dichiarati. Più dati fornisci, più accurata è la proiezione.",
   "replacementRateContextGood": "È un buon livello — sopra l'80%.",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -36858,7 +36858,7 @@ abstract class S {
   /// No description provided for @jargonAvsTooltip.
   ///
   /// In fr, this message translates to:
-  /// **'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.'**
+  /// **'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle vise à fournir un revenu de base à la retraite.'**
   String get jargonAvsTooltip;
 
   /// No description provided for @jargonRamdTooltip.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -20996,7 +20996,7 @@ class SDe extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'Die AHV (Alters- und Hinterlassenenversicherung) ist die 1. Säule. Sie garantiert ein Grundeinkommen im Ruhestand.';
+      'Die AHV (Alters- und Hinterlassenenversicherung) ist die 1. Säule. Sie soll ein Grundeinkommen im Ruhestand bereitstellen.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -20842,7 +20842,7 @@ class SEn extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'AVS (Old-age and Survivors’ Insurance) is the 1st pillar. It guarantees a basic retirement income.';
+      'AVS (Old-age and Survivors’ Insurance) is the 1st pillar. It is designed to provide a basic retirement income.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -20950,7 +20950,7 @@ class SEs extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'El AVS (Seguro de Vejez y Supervivientes) es el 1.er pilar. Garantiza un ingreso básico en la jubilación.';
+      'El AVS (Seguro de Vejez y Supervivientes) es el 1.er pilar. Su objetivo es proporcionar un ingreso básico en la jubilación.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -20947,7 +20947,7 @@ class SFr extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.';
+      'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle vise à fournir un revenu de base à la retraite.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -21007,7 +21007,7 @@ class SIt extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'L\'AVS (Assicurazione vecchiaia e superstiti) è il 1° pilastro. Garantisce un reddito di base in pensione.';
+      'L\'AVS (Assicurazione vecchiaia e superstiti) è il 1° pilastro. Mira a fornire un reddito di base in pensione.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -20954,7 +20954,7 @@ class SPt extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'O AVS (Seguro de Velhice e Sobreviventes) é o 1.º pilar. Garante um rendimento básico na reforma.';
+      'O AVS (Seguro de Velhice e Sobreviventes) é o 1.º pilar. Tem como objetivo fornecer um rendimento básico na reforma.';
 
   @override
   String get jargonRamdTooltip =>

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -9826,7 +9826,7 @@
   "jargonReplacementRateTooltip": "A taxa de substituição mede a parte do teu rendimento atual que manterás na reforma. Exemplo: 65% significa que receberás 65% do teu salário atual.",
   "jargonLppTooltip": "A LPP (Lei sobre a Previdência Profissional) é o 2.º pilar. Tu e o teu empregador contribuem juntos para a tua reforma.",
   "jargon3aTooltip": "O pilar 3a é uma poupança voluntária para a reforma com vantagens fiscais. O limite é de CHF 7'258/ano (assalariados com LPP).",
-  "jargonAvsTooltip": "O AVS (Seguro de Velhice e Sobreviventes) é o 1.º pilar. Garante um rendimento básico na reforma.",
+  "jargonAvsTooltip": "O AVS (Seguro de Velhice e Sobreviventes) é o 1.º pilar. Tem como objetivo fornecer um rendimento básico na reforma.",
   "jargonRamdTooltip": "O RAMD determina o montante da tua pensão AVS. É calculado a partir dos teus rendimentos sujeitos a contribuição.",
   "confidenceDetailsTooltip": "Baseado em: idade, rendimento, cantão, estado civil, nacionalidade, LPP e 3a declarados. Quanto mais dados forneceres, mais precisa é a projeção.",
   "replacementRateContextGood": "É um bom nível — acima de 80%.",

--- a/tools/checks/banned_terms_arb.py
+++ b/tools/checks/banned_terms_arb.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""LSFin banned-terms ARB lint.
+
+V1 scope (this PR) : the « garanti / guaranteed / garantiert / garantizado
+/ garantito / garantido » family is the most-prosecuted LSFin Rule #1
+violation per CLAUDE.md TOP rule #1. It's also the lowest false-positive-
+rate term — it appears in finance writing only as a promise.
+
+Negation contexts (« pas de... garanti », « not guaranteed »,
+« kein garantierter »…) are allowlisted because LSFin permits
+*disclaiming* a guarantee — it bans *claiming* one.
+
+Other LSFin-adjacent vocabulary (« optimal », « meilleur », « parfait »,
+« sans risque », « assuré (rendement) ») has too many colloquial uses
+in everyday FR/EN/DE/ES/IT/PT to mechanically lint here without semantic
+context. Track those via a separate advisory sweep + manual review.
+
+Per `feedback_public_repo_discipline.md`, the public MINT-IA/MINT repo
+cannot ship strings that violate this rule. A reporter `grep`-ing the
+public mirror would find the contradiction in 10 seconds.
+
+Exit codes :
+   0 = clean (no positive « garanti* » uses)
+   1 = violation found (CI must fail)
+   2 = malformed ARB (CI must fail)
+
+Usage : python3 tools/checks/banned_terms_arb.py [--locale fr|en|de|es|it|pt]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ARB_DIR = REPO_ROOT / "apps" / "mobile" / "lib" / "l10n"
+
+# Per-locale banned-token regex and the negation-window guard pattern.
+# Each entry is (regex_for_banned_root, regex_for_negation_within_30_chars_before).
+# Negation-before window: any of the negation lemmas listed must appear in
+# the 30 characters preceding the banned root. If yes, the banned use is a
+# permitted disclaimer ("not guaranteed") — skip. Otherwise, flag.
+LOCALE_RULES: dict[str, list[tuple[str, str]]] = {
+    "fr": [
+        (
+            r"garanti(?:t|e|es|s)?\b",
+            r"\b(?:pas|aucun(?:e)?|jamais|sans|n[' ]est pas|non|aucune)\b[^.!?]{0,30}$",
+        ),
+    ],
+    "en": [
+        (
+            r"\bguarantee(?:s|d)?\b",
+            r"\b(?:not|no|never|without|isn[' ]t|aren[' ]t|won[' ]t|nothing)\b[^.!?]{0,30}$",
+        ),
+    ],
+    "de": [
+        (
+            r"garantier(?:t|en|te|ter|tes)?\b",
+            r"\b(?:nicht|kein(?:e|en|er)?|ohne|niemals)\b[^.!?]{0,30}$",
+        ),
+    ],
+    "es": [
+        (
+            r"garantiz(?:a|an|ada|adas|ado|ados)?\b",
+            r"\b(?:no|sin|ning[uú]n(?:a|os|as)?|nunca|jam[áa]s)\b[^.!?]{0,30}$",
+        ),
+    ],
+    "it": [
+        (
+            r"garant(?:isce|iscono|ito|ita|iti|ite)\b",
+            r"\b(?:non|nessun(?:o|a|i|e)?|senza|mai)\b[^.!?]{0,30}$",
+        ),
+    ],
+    "pt": [
+        (
+            r"garant(?:e|em|ido|ida|idos|idas)\b",
+            r"\b(?:n[ãa]o|sem|nenhum(?:a|s|as)?|nunca|jamais)\b[^.!?]{0,30}$",
+        ),
+    ],
+}
+
+
+def scan_locale(arb_path: Path, locale: str) -> list[tuple[str, str, str]]:
+    """Return list of (key, value, matched_term) violations for one ARB file."""
+    rules = LOCALE_RULES.get(locale, [])
+    if not rules:
+        return []
+    try:
+        data = json.loads(arb_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        print(f"ERROR: malformed ARB {arb_path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    violations: list[tuple[str, str, str]] = []
+    for key, value in data.items():
+        if key.startswith("@"):
+            continue  # @meta blocks
+        if not isinstance(value, str):
+            continue
+        for banned_re, negation_re in rules:
+            for m in re.finditer(banned_re, value, flags=re.IGNORECASE):
+                pre = value[: m.start()]
+                # Allowlist 1 : disclaimer-style negation in the 30 chars before.
+                if re.search(negation_re, pre, flags=re.IGNORECASE):
+                    continue
+                # Allowlist 2 : "ne ... pas" two-clause French negation
+                # ("ne sont pas garantis"). Negation_re only covers one half,
+                # but if "ne " appears anywhere in the same sentence before,
+                # treat it as covered. Same logic for "n'est pas".
+                if locale == "fr" and re.search(r"\bn(?:e|')\b[^.!?]{0,40}\bpas\b", pre, flags=re.IGNORECASE):
+                    continue
+                # Allowlist 3 : explicit negation later in the same value
+                # ("X n'est pas garanti" — caught above) but also short forms.
+                violations.append((key, value, m.group(0)))
+                break  # one violation per key per rule is enough
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--locale", choices=list(LOCALE_RULES) + ["all"], default="all")
+    args = parser.parse_args()
+
+    locales = list(LOCALE_RULES) if args.locale == "all" else [args.locale]
+    total_violations: list[tuple[str, str, str, str]] = []
+    for locale in locales:
+        arb_path = ARB_DIR / f"app_{locale}.arb"
+        if not arb_path.exists():
+            print(f"WARN: missing ARB {arb_path}", file=sys.stderr)
+            continue
+        for key, value, term in scan_locale(arb_path, locale):
+            total_violations.append((locale, key, value, term))
+
+    if not total_violations:
+        print(f"OK — {len(locales)} locale(s) clean (no positive LSFin banned-term uses).")
+        return 0
+
+    print("LSFin banned-term violations found in ARB files:\n", file=sys.stderr)
+    for locale, key, value, term in total_violations:
+        snippet = value if len(value) <= 140 else value[:137] + "..."
+        print(f"  [{locale}] {key} → matched « {term} »", file=sys.stderr)
+        print(f"      {snippet}", file=sys.stderr)
+    print(
+        f"\n{len(total_violations)} violation(s). Per CLAUDE.md TOP rule #1, "
+        "rewrite using permitted vocabulary (« vise à fournir », "
+        "« est conçue pour », « has the role of providing », …).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/test_banned_terms_arb.py
+++ b/tools/checks/test_banned_terms_arb.py
@@ -1,0 +1,151 @@
+"""Self-tests for tools/checks/banned_terms_arb.py.
+
+Runs in pure-Python (no Flutter / no pytest dep). Invoked from CI as
+`python3 tools/checks/test_banned_terms_arb.py` and prints PASS/FAIL.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import importlib.util
+
+THIS = Path(__file__).resolve()
+LINT_PATH = THIS.parent / "banned_terms_arb.py"
+
+spec = importlib.util.spec_from_file_location("banned_terms_arb", LINT_PATH)
+assert spec and spec.loader
+lint = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lint)
+
+
+def _arb(content: dict) -> Path:
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".arb", delete=False, encoding="utf-8"
+    )
+    json.dump(content, f, ensure_ascii=False)
+    f.flush()
+    return Path(f.name)
+
+
+def _scan(locale: str, content: dict):
+    return lint.scan_locale(_arb(content), locale)
+
+
+def _expect(name, cond, detail=""):
+    if cond:
+        print(f"  PASS — {name}")
+        return True
+    print(f"  FAIL — {name}{(' :: ' + detail) if detail else ''}")
+    return False
+
+
+def main():
+    n_pass = 0
+    n_total = 0
+
+    # ── FR ──
+    n_total += 1
+    n_pass += _expect(
+        "FR positive « garantit » → flagged",
+        len(_scan("fr", {"k": "L'AVS garantit un revenu de base à la retraite."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "FR negation « pas de taux garanti » → allowed",
+        len(_scan("fr", {"k": "Pas de taux de conversion garanti — projection en capital."})) == 0,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "FR « ne sont pas garantis » two-clause negation → allowed",
+        len(_scan("fr", {"k": "Les rendements ne sont pas garantis. Hypothèses pédagogiques."})) == 0,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "FR @meta block ignored",
+        len(_scan("fr", {"@k": {"description": "garantit"}})) == 0,
+    )
+
+    # ── EN ──
+    n_total += 1
+    n_pass += _expect(
+        "EN positive « guarantees » → flagged",
+        len(_scan("en", {"k": "AVS guarantees a basic retirement income."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "EN « not guaranteed » → allowed",
+        len(_scan("en", {"k": "Educational projection — results not guaranteed."})) == 0,
+    )
+
+    # ── DE ──
+    n_total += 1
+    n_pass += _expect(
+        "DE positive « garantiert » → flagged",
+        len(_scan("de", {"k": "Die AHV garantiert ein Grundeinkommen im Ruhestand."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "DE « nicht garantiert » → allowed",
+        len(_scan("de", {"k": "Bildungsprojektion. Ergebnisse nicht garantiert."})) == 0,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "DE « kein garantierter » → allowed",
+        len(_scan("de", {"k": "1e-Plan erkannt. Kein garantierter Umwandlungssatz."})) == 0,
+    )
+
+    # ── ES ──
+    n_total += 1
+    n_pass += _expect(
+        "ES positive « garantiza » → flagged",
+        len(_scan("es", {"k": "El AVS garantiza un ingreso básico en la jubilación."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "ES « sin tasa garantizada » → allowed",
+        len(_scan("es", {"k": "Sin tasa de conversión garantizada — proyección solo en capital."})) == 0,
+    )
+
+    # ── IT ──
+    n_total += 1
+    n_pass += _expect(
+        "IT positive « garantisce » → flagged",
+        len(_scan("it", {"k": "L'AVS garantisce un reddito di base in pensione."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "IT « nessun ... garantito » → allowed",
+        len(_scan("it", {"k": "Nessun tasso di conversione garantito — proiezione solo in capitale."})) == 0,
+    )
+
+    # ── PT ──
+    n_total += 1
+    n_pass += _expect(
+        "PT positive « garante » → flagged",
+        len(_scan("pt", {"k": "O AVS garante um rendimento básico na reforma."})) == 1,
+    )
+
+    n_total += 1
+    n_pass += _expect(
+        "PT « não garante » → allowed",
+        len(_scan("pt", {"k": "O desempenho passado não garante resultados futuros."})) == 0,
+    )
+
+    print(f"\n{n_pass}/{n_total} tests passed")
+    return 0 if n_pass == n_total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Aligns the AVS jargon tooltip across all 6 locales with the project's LSFin discipline framework (CLAUDE.md TOP rule #1). The verb « garantit / guarantees / garantiert / garantiza / garantisce / garante » in a financial-projection context conflicts with the rule; the rewritten copy uses permitted vocabulary.

Adds `tools/checks/banned_terms_arb.py` as a CI lint that walks every ARB file for positive uses of the « garanti* » family. Negation-form disclaimers (« pas de... garanti », « not guaranteed », « kein garantierter ») are allowlisted.

## Copy diffs

| Locale | Before | After |
|---|---|---|
| FR | « Elle **garantit** un revenu de base à la retraite. » | « Elle **vise à fournir** un revenu de base à la retraite. » |
| EN | « It **guarantees** a basic retirement income. » | « It **is designed to provide** a basic retirement income. » |
| DE | « Sie **garantiert** ein Grundeinkommen im Ruhestand. » | « Sie **soll** ein Grundeinkommen im Ruhestand **bereitstellen**. » |
| ES | « **Garantiza** un ingreso básico en la jubilación. » | « **Su objetivo es proporcionar** un ingreso básico en la jubilación. » |
| IT | « **Garantisce** un reddito di base in pensione. » | « **Mira a fornire** un reddito di base in pensione. » |
| PT | « **Garante** um rendimento básico na reforma. » | « **Tem como objetivo fornecer** um rendimento básico na reforma. » |

## Lint scope (V1)

| Term family | V1 verdict |
|---|---|
| `garanti*` / `guaranteed` / `garantiert` / `garantiza*` / `garant(isce|e)` / `garante` | **Blocking** (this PR) |
| `optimal` / `meilleur` / `best` / `parfait` / `mejor` / `melhor` | Tracked, follow-up advisory sweep (too many colloquial uses) |
| `sans risque` / `riskless` / `risikofrei` | Tracked, follow-up |

Negation allowlist: « pas/sans/aucun/jamais/n'est pas/non »… per locale (regex captures « ne ... pas » two-clause French negation too).

## Wiring

`.github/workflows/ci.yml` runs the lint after the existing TRUST-02 + ALERT-02 ARB lint, on every PR touching `apps/mobile/`.

## Test plan

- [x] `python3 tools/checks/banned_terms_arb.py`: 6 locales clean
- [x] `python3 tools/checks/test_banned_terms_arb.py`: 15/15 passed (positive flagged + negation allowlist + @meta ignored × 6 locales)
- [x] `flutter gen-l10n`: ✓ regenerated all 6 locale Dart files
- [x] Generated `app_localizations_*.dart` audit: only safe negation-form « garanti* » remain (3 keys: 1 DE `futurDisclaimer` + 2 DE/IT `docLpp1eWarning`)

## Next

PR #468 — FATCA archetype widget test (panel finding #3, separate concern from compliance lint). Then walker `--no-dry-run --archetype swiss_native --all` + Plan 54-03 → TestFlight GATE-01.