### PR TITLE
chore(pubspec): bump version to 2.9.0+1 for TestFlight staging cut

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.2.0+1
+version: 2.9.0+1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary

Catches up the build version after the late-session arc shipped 5 PRs (#463/#466/#467/#468/#469).

`apps/mobile/pubspec.yaml` : `2.2.0+1` → `2.9.0+1`.

## Why now

Staging is currently **187 commits behind dev**. This PR lands the version bump on dev so the next dev → staging merge fires `testflight.yml` with a fresh build number that won't collide with anything previously uploaded to App Store Connect.

## Test plan

- [x] One-line version bump, no functional change
- [ ] Post-merge: open PR dev → staging → testflight.yml auto-fires → build uploads to ASC

## Stack

After this lands → PR dev → staging → TestFlight build → GATE-01 closed.