### PR TITLE
fix(arb): add VOICE-14 @meta level annotations to coachSequence keys × 6 locales

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11163,9 +11163,13 @@
   "aujourdhuiResumeConversation": "Gespräch fortsetzen",
   "coachSequenceNextStepLabel": "Nächster Schritt: {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "Du hast diese geführte Sequenz abgeschlossen.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT in der Beta",
   "@betaDisclosureEyebrow": {
     "x-mint-meta": {"level": "N1"}

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11163,9 +11163,13 @@
   "aujourdhuiResumeConversation": "Resume conversation",
   "coachSequenceNextStepLabel": "Next step: {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "You've completed this guided sequence.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT in beta",
   "@betaDisclosureEyebrow": {
     "x-mint-meta": {"level": "N1"}

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11163,9 +11163,13 @@
   "aujourdhuiResumeConversation": "Reanudar la conversación",
   "coachSequenceNextStepLabel": "Siguiente paso: {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "Has completado esta secuencia guiada.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT en beta",
   "@betaDisclosureEyebrow": {
     "x-mint-meta": {"level": "N1"}

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12103,9 +12103,13 @@
   "aujourdhuiResumeConversation": "Reprendre la conversation",
   "coachSequenceNextStepLabel": "Étape suivante : {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "Tu as terminé cette séquence guidée.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT en test",
   "@betaDisclosureEyebrow": {
     "description": "Beta disclosure sheet — uppercase eyebrow.",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11163,9 +11163,13 @@
   "aujourdhuiResumeConversation": "Riprendi la conversazione",
   "coachSequenceNextStepLabel": "Prossimo passo: {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "Hai completato questa sequenza guidata.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT in beta",
   "@betaDisclosureEyebrow": {
     "x-mint-meta": {"level": "N1"}

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11163,9 +11163,13 @@
   "aujourdhuiResumeConversation": "Retomar a conversa",
   "coachSequenceNextStepLabel": "Próximo passo: {label}.",
   "@coachSequenceNextStepLabel": {
-    "placeholders": {"label": {"type": "String"}}
+    "placeholders": {"label": {"type": "String"}},
+    "x-mint-meta": {"level": "N3"}
   },
   "coachSequenceCompletedMessage": "Concluíste esta sequência guiada.",
+  "@coachSequenceCompletedMessage": {
+    "x-mint-meta": {"level": "N3"}
+  },
   "betaDisclosureEyebrow": "MINT em beta",
   "@betaDisclosureEyebrow": {
     "x-mint-meta": {"level": "N1"}


### PR DESCRIPTION
Unblocks PR #457 dev → staging.

CI Gate failure: tools/checks/sentence_subject_arb_lint.py flagged 2 violations:
- coachSequenceNextStepLabel (missing @meta level)
- coachSequenceCompletedMessage (missing @meta level)

Both keys are step-progression announcements ("Étape suivante: X", "Tu as terminé cette séquence guidée") — N3 (calme), standard coach narration register.

Validation:
- python3 tools/checks/sentence_subject_arb_lint.py → OK
- flutter gen-l10n → ✓ (no Dart change needed; @meta is JSON-only metadata)