### PR TITLE
fix(land-01): whitelist beta_program_disclosure_sheet import on landing_screen

### DIFF
--- a/tools/checks/landing_no_financial_core.py
+++ b/tools/checks/landing_no_financial_core.py
@@ -30,6 +30,10 @@ WHITELIST = (
     "package:mint_mobile/l10n/app_localizations.dart",
     "package:mint_mobile/theme/colors.dart",
     "package:mint_mobile/theme/mint_text_styles.dart",
+    # B4 first-launch beta disclosure sheet (Apple TestFlight beta review +
+    # FINMA fintech sandbox compliance). UI sheet, not financial_core /
+    # services / providers / models — does not violate LAND-01 spirit.
+    "package:mint_mobile/widgets/beta/beta_program_disclosure_sheet.dart",
 )
 
 FORBIDDEN_SUBSTRINGS = (


### PR DESCRIPTION
Unblocks PR #457 dev → staging.

Phase 7 LAND-01 gate (tools/checks/landing_no_financial_core.py) rejected landing_screen.dart:16 import of B4 beta disclosure sheet because it wasn't in the whitelist.

The sheet is a UI-only widget (StatelessWidget + SharedPreferences flag for one-shot flow) — no financial_core / services / providers / models coupling, so it does not violate the LAND-01 spirit. Required by Apple TestFlight beta review + FINMA fintech sandbox.

Validation: python3 tools/checks/landing_no_financial_core.py → OK