### PR TITLE
fix(consent): catch ApiException to prevent fatal crash on session expiry (Sentry 6f9002…)

### DIFF
--- a/apps/mobile/lib/services/consent/consent_service.dart
+++ b/apps/mobile/lib/services/consent/consent_service.dart
@@ -125,11 +125,36 @@ class ConsentService {
   /// Entry-point guard: if any required purpose is not granted at the current
   /// policy version, show the ConsentSheet. Returns true only if all purposes
   /// are (now) granted.
+  ///
+  /// Crash-safety (Sentry fatal `6f9002...` 2026-05-04 ch.mint.app@2.9.0+37):
+  /// when `list(force: true)` hit a 401 → `ApiException.sessionExpired` →
+  /// uncaught propagation through `_onGalleryPressed` → fatal via
+  /// `PlatformDispatcher.onError`. We now catch any `ApiException` from the
+  /// list/grant calls, surface a friendly snackbar, and return `false` so the
+  /// caller treats it like a denied consent (= no-op + early return). The
+  /// AuthService.logout() inside `ApiService.get` already cleared the stale
+  /// token; the next user-driven nav back through a guarded route will
+  /// trigger re-auth via the existing GoRouter redirect.
   Future<bool> requireGrantedOrPrompt(
     BuildContext context,
     List<ConsentPurpose> required,
   ) async {
-    final consents = await list(force: true);
+    final List<ConsentReceipt> consents;
+    try {
+      consents = await list(force: true);
+    } on ApiException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.errorCode == ApiErrorCode.sessionExpired
+                ? 'Session expirée. Reconnecte-toi pour continuer.'
+                : 'Connexion indisponible. Réessaie dans un instant.'),
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+      return false;
+    }
     final missing = required
         .where((p) => !_isGrantedNow(consents, p))
         .toList(growable: false);
@@ -139,8 +164,22 @@ class ConsentService {
     final accepted = await ConsentSheet.show(context, purposes: missing);
     if (accepted != true) return false;
 
-    for (final p in missing) {
-      await grant(p);
+    try {
+      for (final p in missing) {
+        await grant(p);
+      }
+    } on ApiException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.errorCode == ApiErrorCode.sessionExpired
+                ? 'Session expirée pendant l’enregistrement. Reconnecte-toi.'
+                : 'Impossible d’enregistrer le consentement maintenant.'),
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
## Summary

Sentry fatal **6f9002809fdb4b219d9dcc4dab49d29f** reproduced on `ch.mint.app@2.9.0+37` (production, iOS 26.4.2, iPhone 17 Pro, 2026-05-04 17:47 UTC) — 8 min after the TestFlight build went live.

```
ApiException: Session expired
  at ApiService.get                        (api_service.dart:309)
  at ConsentService.list                   (consent_service.dart:85)
  at ConsentService.requireGrantedOrPrompt (consent_service.dart:132)
  at _DocumentScanScreenState._onGalleryPressed
                                (document_scan_screen.dart:498)
```

## Root cause

`requireGrantedOrPrompt` did not catch `ApiException` from its internal `list(force: true)` / `grant()` calls. When the user's session expired between launch and the « Galerie » tap on /scan, the 401 → `ApiException.sessionExpired` propagated unhandled through `_onGalleryPressed` → `PlatformDispatcher.onError` → fatal crash.

`ApiService.get` already calls `AuthService.logout()` at the 401 branch (api_service.dart:308), so the stale token is gone by the time we surface — the next guarded route triggers re-auth via the existing GoRouter redirect.

## Fix

Wrap both `list()` and the `grant()` loop in `try/catch ApiException`:
- Surface a friendly FR snackbar (« Session expirée. Reconnecte-toi pour continuer. » or generic offline copy depending on `errorCode`)
- Return `false` — the single caller (`_onGalleryPressed`) already short-circuits on `!granted`

## Test plan

- [x] `flutter analyze lib/services/consent/consent_service.dart` → 0 issues
- [x] Single caller verified : `document_scan_screen.dart:498` already handles `if (!granted) return;` — recovery is symmetric, no caller-side change needed

## Deferred

Widget test for the snackbar path. `ConsentService` uses the static `ApiService.get` which is hard to mock without a refactor — queued for a follow-up that introduces an injectable HTTP client.