### PR TITLE
chore(staging): hotfix cut — ConsentService session-expired crash protection (2.9.0+38)

### DIFF
--- a/apps/mobile/lib/services/consent/consent_service.dart
+++ b/apps/mobile/lib/services/consent/consent_service.dart
@@ -125,11 +125,36 @@ class ConsentService {
   /// Entry-point guard: if any required purpose is not granted at the current
   /// policy version, show the ConsentSheet. Returns true only if all purposes
   /// are (now) granted.
+  ///
+  /// Crash-safety (Sentry fatal `6f9002...` 2026-05-04 ch.mint.app@2.9.0+37):
+  /// when `list(force: true)` hit a 401 → `ApiException.sessionExpired` →
+  /// uncaught propagation through `_onGalleryPressed` → fatal via
+  /// `PlatformDispatcher.onError`. We now catch any `ApiException` from the
+  /// list/grant calls, surface a friendly snackbar, and return `false` so the
+  /// caller treats it like a denied consent (= no-op + early return). The
+  /// AuthService.logout() inside `ApiService.get` already cleared the stale
+  /// token; the next user-driven nav back through a guarded route will
+  /// trigger re-auth via the existing GoRouter redirect.
   Future<bool> requireGrantedOrPrompt(
     BuildContext context,
     List<ConsentPurpose> required,
   ) async {
-    final consents = await list(force: true);
+    final List<ConsentReceipt> consents;
+    try {
+      consents = await list(force: true);
+    } on ApiException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.errorCode == ApiErrorCode.sessionExpired
+                ? 'Session expirée. Reconnecte-toi pour continuer.'
+                : 'Connexion indisponible. Réessaie dans un instant.'),
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+      return false;
+    }
     final missing = required
         .where((p) => !_isGrantedNow(consents, p))
         .toList(growable: false);
@@ -139,8 +164,22 @@ class ConsentService {
     final accepted = await ConsentSheet.show(context, purposes: missing);
     if (accepted != true) return false;
 
-    for (final p in missing) {
-      await grant(p);
+    try {
+      for (final p in missing) {
+        await grant(p);
+      }
+    } on ApiException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.errorCode == ApiErrorCode.sessionExpired
+                ? 'Session expirée pendant l’enregistrement. Reconnecte-toi.'
+                : 'Impossible d’enregistrer le consentement maintenant.'),
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
Stacks the consent-session-expired hotfix (PR #475) on top of the 2.9.0+37 cut that just shipped to TestFlight.

Changes since #457 merge:
- #475 — `fix(consent)`: catch ApiException in requireGrantedOrPrompt → snackbar + return false instead of fatal crash. Resolves Sentry fatal `6f9002…` reproduced 8 min after the +37 build went live.

App Store Connect will auto-increment build number to 2.9.0+38 on the next upload. testflight.yml auto-fires on push to staging.