### PR TITLE
fix(sprint-0): wire MintBreadcrumbs.sessionExpired across 5 ApiService 401 paths + DocumentService graceful-degrade

### DIFF
--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/models/profile.dart';
 import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart' as chf;
 import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// P2-18: Error codes for i18n — UI layer maps these to AppLocalizations.
@@ -306,6 +307,10 @@ class ApiService {
         // FIX-048: After refresh failure + still 401, clear auth state.
         // User must re-login. Don't leave stale token in secure storage.
         await AuthService.logout();
+        MintBreadcrumbs.sessionExpired(
+          surface: 'ApiService.get',
+          refreshAttempted: true,
+        );
         throw ApiException.sessionExpired();
       } else {
         throw ApiException('GET $endpoint failed: ${response.body}', statusCode: response.statusCode);
@@ -336,6 +341,10 @@ class ApiService {
       } else if (response.statusCode == 401) {
         // P1-11: Clear auth state on 401 after refresh failure.
         await AuthService.logout();
+        MintBreadcrumbs.sessionExpired(
+          surface: 'ApiService.getText',
+          refreshAttempted: true,
+        );
         throw ApiException.sessionExpired();
       }
       throw ApiException(
@@ -371,6 +380,10 @@ class ApiService {
       } else if (response.statusCode == 401) {
         // P1-11: Clear auth state on 401 after refresh failure.
         await AuthService.logout();
+        MintBreadcrumbs.sessionExpired(
+          surface: 'ApiService.post',
+          refreshAttempted: true,
+        );
         throw ApiException.sessionExpired();
       } else {
         throw ApiException(
@@ -407,6 +420,10 @@ class ApiService {
       } else if (response.statusCode == 401) {
         // P1-11: Clear auth state on 401 after refresh failure.
         await AuthService.logout();
+        MintBreadcrumbs.sessionExpired(
+          surface: 'ApiService.put',
+          refreshAttempted: true,
+        );
         throw ApiException.sessionExpired();
       } else {
         throw ApiException(
@@ -438,6 +455,10 @@ class ApiService {
       if (response.statusCode == 401) {
         // P1-11: Clear auth state on 401 after refresh failure.
         await AuthService.logout();
+        MintBreadcrumbs.sessionExpired(
+          surface: 'ApiService.delete',
+          refreshAttempted: true,
+        );
         throw ApiException.sessionExpired();
       }
       if (response.statusCode != 200 && response.statusCode != 204) {

--- a/apps/mobile/lib/services/document_service.dart
+++ b/apps/mobile/lib/services/document_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/models/document_event.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
 import 'package:uuid/uuid.dart';
 
 /// v2.7 Task 7 — client-generated UUID v4 for Idempotency-Key header on
@@ -1187,6 +1188,16 @@ class DocumentService {
         throw const DocumentServiceException(
           code: 'not_financial',
           message: 'Document classified as non-financial',
+        );
+      }
+      // Sprint 0 — surface session expiry so it's auditable in Sentry.
+      // Vision endpoint bypasses ApiService and currently graceful-degrades
+      // to null on any non-200/422; without this breadcrumb the 401 was
+      // invisible to ops (degrades silently while the user keeps tapping).
+      if (response.statusCode == 401) {
+        MintBreadcrumbs.sessionExpired(
+          surface: 'DocumentService.extractWithVision',
+          refreshAttempted: false,
         );
       }
       return null;

--- a/apps/mobile/lib/services/sentry_breadcrumbs.dart
+++ b/apps/mobile/lib/services/sentry_breadcrumbs.dart
@@ -150,6 +150,36 @@ class MintBreadcrumbs {
     ));
   }
 
+  /// Sprint 0 — auth session-expired breadcrumb.
+  ///
+  /// Emitted from `ApiService` when a 401 persists after the auto-refresh
+  /// attempt failed (i.e. the user's session is genuinely gone) AND from
+  /// `DocumentService.extractWithVision` when its manual HTTP call
+  /// observes a 401 (currently graceful-degrades to null — invisible
+  /// without this breadcrumb).
+  ///
+  /// category = `mint.auth.session.expired`
+  /// level    = warning
+  /// data     = { 'surface': String, 'refresh_attempted': bool? }
+  ///
+  /// [surface] is a callsite identifier (e.g. `'ApiService.get'`,
+  /// `'DocumentService.extractWithVision'`) — NEVER a user-generated path
+  /// or query string. PII discipline (Pitfall 6) — Sprint 0 keeps the
+  /// payload to ENUM/BOOL like the rest of the helper.
+  static void sessionExpired({
+    required String surface,
+    bool? refreshAttempted,
+  }) {
+    Sentry.addBreadcrumb(Breadcrumb(
+      category: 'mint.auth.session.expired',
+      level: SentryLevel.warning,
+      data: <String, dynamic>{
+        'surface': surface,
+        if (refreshAttempted != null) 'refresh_attempted': refreshAttempted,
+      },
+    ));
+  }
+
   /// Phase 32 D-09 §4 — admin tool access processing record (nLPD Art. 12).
   ///
   /// category = `mint.admin.routes.viewed`

--- a/apps/mobile/test/services/sentry_breadcrumbs_session_expired_test.dart
+++ b/apps/mobile/test/services/sentry_breadcrumbs_session_expired_test.dart
@@ -1,0 +1,129 @@
+// Sprint 0 — MintBreadcrumbs.sessionExpired live assertion.
+//
+// Adds an auditable trail in Sentry for the « 401 → graceful logout +
+// throw » path that produced fatal `c89b8ad8efc74f30b155508a8a8cf11c` on
+// `/scan` 2026-05-04 (PR #475 added the catch + snackbar; this Sprint 0
+// commit makes the underlying session-expiry observable so we know how
+// often it happens, on which surface, and whether refresh was attempted).
+//
+// Discipline (D-03 4-level + Pitfall 6 PII): the [surface] arg is a
+// callsite literal (`'ApiService.get'` etc.) — NEVER a request path,
+// query string, or any user-generated string. Test fuzzes obvious PII
+// patterns to confirm none reach the emitted breadcrumb data.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
+
+const _fakeDsn = 'https://abc@def.ingest.sentry.io/1234567';
+
+const _surfaces = <String>[
+  'ApiService.get',
+  'ApiService.getText',
+  'ApiService.post',
+  'ApiService.put',
+  'ApiService.delete',
+  'DocumentService.extractWithVision',
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final captured = <Breadcrumb>[];
+
+  setUp(() async {
+    captured.clear();
+    await Sentry.init(
+      (options) {
+        options.dsn = _fakeDsn;
+        options.beforeBreadcrumb = (crumb, hint) {
+          if (crumb != null) captured.add(crumb);
+          return null;
+        };
+        options.beforeSend = (event, hint) => null;
+      },
+    );
+  });
+
+  tearDown(() async {
+    await Sentry.close();
+  });
+
+  group('MintBreadcrumbs.sessionExpired (D-03 4-level + Pitfall 6 PII)', () {
+    test('emits category mint.auth.session.expired at warning level', () async {
+      MintBreadcrumbs.sessionExpired(
+        surface: 'ApiService.get',
+        refreshAttempted: true,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(captured, hasLength(1));
+      final c = captured.single;
+      expect(c.category, 'mint.auth.session.expired');
+      expect(c.level, SentryLevel.warning);
+      expect(c.data!['surface'], 'ApiService.get');
+      expect(c.data!['refresh_attempted'], isTrue);
+    });
+
+    test('omits refresh_attempted key when not provided', () async {
+      MintBreadcrumbs.sessionExpired(surface: 'DocumentService.extractWithVision');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(captured, hasLength(1));
+      final data = captured.single.data!;
+      expect(data['surface'], 'DocumentService.extractWithVision');
+      expect(data.containsKey('refresh_attempted'), isFalse);
+    });
+
+    test('refresh_attempted=false propagates explicit value', () async {
+      MintBreadcrumbs.sessionExpired(
+        surface: 'DocumentService.extractWithVision',
+        refreshAttempted: false,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(captured.single.data!['refresh_attempted'], isFalse);
+    });
+
+    test('emits one breadcrumb per call across all callsite surfaces', () async {
+      for (final s in _surfaces) {
+        MintBreadcrumbs.sessionExpired(
+          surface: s,
+          refreshAttempted: s.startsWith('ApiService'),
+        );
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(captured, hasLength(_surfaces.length));
+      for (var i = 0; i < _surfaces.length; i++) {
+        expect(captured[i].category, 'mint.auth.session.expired');
+        expect(captured[i].data!['surface'], _surfaces[i]);
+      }
+    });
+
+    test('PII discipline — emitted payload contains only enum strings + bool',
+        () async {
+      // Pitfall 6: verify only ENUM/BOOL reach the payload.
+      // The surface arg is a callsite literal — if a future caller passes a
+      // user-generated string (request path, query, etc.) the emitted
+      // payload would carry it. This test guards against that by assuming
+      // the discipline at the call site, but also asserts the *type* set
+      // is restricted to the documented surface.
+      MintBreadcrumbs.sessionExpired(
+        surface: 'ApiService.get',
+        refreshAttempted: true,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final data = captured.single.data!;
+      expect(data.keys.toSet(), {'surface', 'refresh_attempted'});
+      expect(data['surface'], isA<String>());
+      expect(data['refresh_attempted'], isA<bool>());
+      // No CHF amounts, AVS numbers, IBANs in the surface string.
+      final s = data['surface'] as String;
+      expect(RegExp(r'CHF[- ]?\d+', caseSensitive: false).hasMatch(s), isFalse);
+      expect(RegExp(r'756\.\d{4}').hasMatch(s), isFalse);
+      expect(RegExp(r'CH\d{2}[A-Z0-9]{4,}').hasMatch(s), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the observability gap left by PR #475. PR #475 added the catch + snackbar so users no longer see the fatal crash on \`/scan\`. But ops was still blind to the underlying session-expiry transition — Sentry only saw the rethrown \`ApiException\` at the top of the call stack, never the 401 → \`AuthService.logout()\` → throw chain that produced it.

This PR adds an auditable breadcrumb trail :

- **\`MintBreadcrumbs.sessionExpired(surface, refreshAttempted?)\`** — new helper on the existing \`MintBreadcrumbs\` class. 4-level D-03 category \`mint.auth.session.expired\`, level \`warning\`, payload ENUM/BOOL only (Pitfall 6 PII discipline preserved).
- **5 \`ApiService\` callsites instrumented** — \`get\`, \`getText\`, \`post\`, \`put\`, \`delete\`. Each emits the breadcrumb between the \`AuthService.logout()\` call and the \`throw ApiException.sessionExpired()\`. \`refreshAttempted: true\` everywhere (refresh always tried before this branch).
- **\`DocumentService.extractWithVision\`** — was bypassing \`ApiService\` and silently returning \`null\` on 401 (\`return null;\` fallthrough). Now emits the breadcrumb with \`refreshAttempted: false\` before returning null. Graceful UX preserved (vision fails-soft, scan continues), but ops can finally measure how often this fires.
- **\`HouseholdService\` ruled out** — its 401 paths throw generic \`ApiException\` not \`sessionExpired\` and don't flow through \`AuthService.logout()\`. Separate refactor if needed.

## Why now (Sprint 0 of the TestFlight 7-day plan)

Today's Sentry production crash on iPhone 17 Pro / iOS 26.4.2 / ch.mint.app@2.9.0+37 was the trigger. PR #475 stopped the bleeding (catch + snackbar) ; this PR makes the wound visible so we can monitor the rate of session expiry across surfaces and drive prioritisation of the next FIX layer (refresh-token freshness, proactive re-auth, etc.).

## Test plan

- [x] \`flutter test test/services/sentry_breadcrumbs_session_expired_test.dart\` — 5/5 green
- [x] \`flutter test test/services/\` — 5313/5313 green (no regression)
- [x] \`flutter analyze\` on the 4 touched files — no issues
- [x] PII fuzz via existing \`sentry_breadcrumbs_pii_test.dart\` pattern — surface arg restricted to callsite literals, no CHF/AVS/IBAN regex matches in payload
- [ ] Sentry dashboard post-deploy : confirm \`category:mint.auth.session.expired\` shows up + per-surface aggregate

## Notes

- Builds on PR #475 (which was a hot-fix on top of 2.9.0+37 within 8 minutes of the live crash).
- Sprint 0 of the 5-sprint TestFlight plan ; remaining sprints : nav audit, compliance gate, mockup landing v3, birth-year onboarding, TestFlight 2.10.0.
- No app code path changed beyond the new breadcrumb call sites — graceful UX of PR #475 remains the contract for the user.