### PR TITLE
feat(phase-57,pr-c): backend anonymous_eclairage_prompt + coach_chat tier branch

### DIFF
--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -235,11 +235,29 @@ async def anonymous_chat(
     # --- Step 3: Scrub PII from input (T-13-02) ---
     clean_message = _scrub_pii(body.message)
 
-    # --- Step 4: Build discovery system prompt (T-13-05) ---
-    discovery_prompt = build_discovery_system_prompt(
-        intent=body.intent,
-        language=body.language,
-    )
+    # --- Step 4: Build system prompt — Phase 57 PR-C "Premier éclairage" ---
+    # The anonymous tier is THIS endpoint (coach_chat requires auth, see
+    # _user: User = Depends(require_current_user)). When the request opts in
+    # to the structured "Premier éclairage" experience (or by default in
+    # Phase 57+), use the upgraded prompt that targets ONE insight in 3-5
+    # messages, asks ONE structured question at a time, and never requests
+    # KYC-level data. The legacy `build_discovery_system_prompt` is kept as a
+    # fallback for tests / opt-out via the `X-Mint-Variant: discovery` header.
+    variant_header = (request.headers.get("X-Mint-Variant") or "").strip().lower()
+    if variant_header == "discovery":
+        # Legacy Phase 13 felt-state pill flow — preserved for back-compat.
+        discovery_prompt = build_discovery_system_prompt(
+            intent=body.intent,
+            language=body.language,
+        )
+    else:
+        from app.services.coach.anonymous_eclairage_prompt import (
+            build_anonymous_system_prompt,
+        )
+        discovery_prompt = build_anonymous_system_prompt(
+            intent=body.intent,
+            locale=body.language,
+        )
 
     # --- Step 5: Call LLM ---
     server_key = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -2359,6 +2359,14 @@ async def coach_chat(
     # Memory block is PII-scrubbed and wrapped in prompt injection armor.
     # Commitment memory block (CMIT-06/LOOP-02) injects active engagements
     # and pre-mortem entries so the LLM can reference them naturally.
+    #
+    # Phase 57 PR-C — TIER NOTE: this endpoint is auth-only (require_current_user
+    # above). The anonymous "Premier éclairage" tier is served by
+    # `anonymous_chat.py` (POST /api/v1/anonymous/chat) which uses
+    # `app.services.coach.anonymous_eclairage_prompt.build_anonymous_system_prompt`.
+    # If you ever relax auth on coach_chat, branch on the absence of `_user`
+    # and call build_anonymous_system_prompt() instead of
+    # _build_system_prompt_with_memory().
     # ------------------------------------------------------------------
     commitment_block = _build_commitment_memory_block(str(_user.id), db)
     intelligence_block = _build_intelligence_memory_block(str(_user.id), db)

--- a/services/backend/app/services/coach/anonymous_eclairage_prompt.py
+++ b/services/backend/app/services/coach/anonymous_eclairage_prompt.py
@@ -1,0 +1,266 @@
+"""
+Anonymous "Premier éclairage" system prompt — Phase 57 PR-C.
+
+Goal: when a user lands on MINT WITHOUT an account (anonymous tier) and starts
+chatting from Landing → Anonymous Chat, the LLM should aim for ONE actionable
+insight ("éclairage") in 3-5 messages max, ask ONE structured question at a
+time, and never request KYC-level data (AVS, IBAN, fiscal détails).
+
+This module is intentionally SEPARATE from `anonymous_chat.build_discovery_system_prompt`
+which served the original Phase 13 "découverte" pill. PR-C upgrades that flow:
+the new prompt is contextualized by intent (rente_vs_capital, rachat_lpp,
+mariage, premier_emploi, etc.) and shaped around the 4-layer MINT moteur from
+docs/MINT_IDENTITY.md (extraction → traduction → mise en perspective → questions
+à poser).
+
+Design choices (intentional, documented per CLAUDE.md):
+    * No banned terms (LSFin) — phrasing strictly conditionnel.
+    * No PII request — anonymous tier ≠ KYC.
+    * Marker string "Premier éclairage" present in every variant so a downstream
+      audit can verify the route branched correctly (test_coach_chat_anonymous_uses_eclairage_prompt).
+    * Bilingue FR/EN; locales hors scope retombent sur FR (default app locale).
+    * Termine sur une CTA implicite "créer un compte pour aller plus loin" sans
+      pousser ni promettre.
+
+Compliance:
+    - LSFin art. 3 (information financière) + art. 8 (no perso reco)
+    - LPD art. 6 (no PII collection in anonymous tier)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Public marker — used by tests and the dispatcher to detect the variant.
+# ---------------------------------------------------------------------------
+
+ECLAIRAGE_MARKER_FR = "Premier éclairage"
+ECLAIRAGE_MARKER_EN = "First insight"
+
+# ---------------------------------------------------------------------------
+# Intent contextualization table.
+# Keys map to mobile life-event intents (cf. ScreenRegistry / RoutePlanner).
+# Each value is a single line appended to the prompt to focus the LLM on the
+# user's situation WITHOUT inventing facts.
+# ---------------------------------------------------------------------------
+
+_INTENT_CONTEXT_FR: dict[str, str] = {
+    "rente_vs_capital": (
+        "La personne se demande si elle prendra sa rente LPP en rente ou en "
+        "capital. Aide-la à voir ce qui change dans la vraie vie (souplesse, "
+        "fiscalité, durée), sans trancher à sa place."
+    ),
+    "rachat_lpp": (
+        "La personne pense à un rachat LPP. Aide-la à comprendre ce qu'elle "
+        "bloque (liquidité), ce qu'elle gagne (impôt, rente projetée) et ce "
+        "qui dépend de sa stabilité de vie."
+    ),
+    "mariage": (
+        "La personne projette un mariage ou une mise en couple. Aide-la à voir "
+        "les implications fiscales, prévoyance et patrimoine, sans dramatiser."
+    ),
+    "premier_emploi": (
+        "La personne commence sa vie professionnelle en Suisse. Aide-la à voir "
+        "ce qui se met en place automatiquement (LPP, AVS, impôt) et ce qui "
+        "reste à sa main (3a, assurance maladie)."
+    ),
+    "achat_logement": (
+        "La personne envisage un achat immobilier. Aide-la à voir les "
+        "engagements (durée, charges, fonds propres), sans recommander un type "
+        "de financement."
+    ),
+    "expat": (
+        "La personne est expatriée ou frontalière. Aide-la à voir les angles "
+        "morts spécifiques (LPP libre passage, fiscalité source, AVS années "
+        "manquantes), sans citer de canton ou produit spécifique."
+    ),
+    "independant": (
+        "La personne est indépendante ou y pense. Aide-la à voir ce qui change "
+        "(pas de LPP automatique, 3a élargi possible, AVS calculée différemment), "
+        "sans recommander une structure juridique."
+    ),
+    "divorce": (
+        "La personne traverse une séparation. Aide-la à voir ce qui se partage "
+        "(LPP acquis, biens), sans prendre parti, avec calme."
+    ),
+    "deces_proche": (
+        "La personne fait face au décès d'un proche. Reste très en retrait, "
+        "explicite seulement les 1-2 priorités administratives qui ne peuvent "
+        "pas attendre."
+    ),
+    "fiscalite": (
+        "La personne s'interroge sur sa fiscalité. Aide-la à voir les leviers "
+        "courants (3a, rachat LPP, déductions) sans promettre d'économie chiffrée."
+    ),
+}
+
+_INTENT_CONTEXT_EN: dict[str, str] = {
+    "rente_vs_capital": (
+        "The person is wondering whether to take their LPP as a pension or as "
+        "capital. Help them see what changes in real life (flexibility, "
+        "taxation, duration), without deciding for them."
+    ),
+    "rachat_lpp": (
+        "The person is considering an LPP buyback. Help them see what they "
+        "lock up (liquidity), what they gain (tax, projected pension) and "
+        "what depends on their life stability."
+    ),
+    "mariage": (
+        "The person is planning a marriage or moving in together. Help them "
+        "see the tax, pension and wealth implications, without dramatizing."
+    ),
+    "premier_emploi": (
+        "The person is starting their professional life in Switzerland. Help "
+        "them see what gets set up automatically (LPP, AVS, tax) and what "
+        "stays in their own hands (3a, health insurance)."
+    ),
+    "achat_logement": (
+        "The person is considering buying a home. Help them see the "
+        "commitments (duration, costs, equity) without recommending a "
+        "specific financing path."
+    ),
+    "expat": (
+        "The person is an expat or cross-border worker. Help them see the "
+        "specific blind spots (LPP vested benefits, source tax, missing AVS "
+        "years), without naming a canton or specific product."
+    ),
+    "independant": (
+        "The person is self-employed or thinking about it. Help them see what "
+        "changes (no automatic LPP, expanded 3a possible, AVS computed "
+        "differently), without recommending a legal structure."
+    ),
+    "divorce": (
+        "The person is going through a separation. Help them see what gets "
+        "split (vested LPP, assets), without taking sides, calmly."
+    ),
+    "deces_proche": (
+        "The person is dealing with a close bereavement. Stay very low-key, "
+        "explain only the 1-2 administrative priorities that cannot wait."
+    ),
+    "fiscalite": (
+        "The person is wondering about their tax situation. Help them see the "
+        "common levers (3a, LPP buyback, deductions) without promising a "
+        "specific saving amount."
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Base prompt constants (FR + EN). Marked "Premier éclairage" so downstream
+# inspection tooling can verify the variant was selected.
+# ---------------------------------------------------------------------------
+
+ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR = """Tu es MINT, un compagnon de lucidité financière suisse.
+
+Contexte : la personne te parle pour la première fois, sans compte. C'est son
+Premier éclairage. Elle veut voir UN angle qu'elle n'avait pas vu — pas un cours.
+
+Ta mission, en 3 à 5 messages au maximum :
+1. Clarifie son sujet par UNE seule question structurée (pas une rafale).
+2. Donne UN éclairage actionnable : un fait, sa traduction humaine, ce que ça
+   change pour elle. Suis le moteur 4 couches MINT (fait → traduction → mise
+   en perspective → question à poser avant de signer).
+3. Termine en lui laissant le choix d'aller plus loin avec son propre dossier.
+
+Règles strictes :
+- Tutoie. Ton calme, précis, fin, rassurant, net.
+- Une question à la fois. Pas de batterie de questions.
+- Conditionnel uniquement (« pourrait », « envisager », « selon ta situation »).
+  Pas de « garanti », « optimal », « meilleur », « certain », « sans risque »,
+  « parfait », « idéal ».
+- Jamais de recommandation produit nommé, jamais de classement, jamais de
+  comparaison sociale (« top X% »).
+- Ne demande JAMAIS d'AVS, IBAN, numéro fiscal, NPA précis, employeur, nom de
+  famille. Anonymous ≠ KYC.
+- Reste sur des ordres de grandeur ; pas de chiffre faussement précis.
+- Réponses courtes (3 à 6 phrases). Pas de listes à rallonge.
+
+Clôture, à partir du 3e message OU dès qu'un éclairage utile a été donné :
+- Mentionne sobrement qu'un compte permettrait de poser ses propres chiffres
+  et d'aller plus loin. Pas de pression, pas de promesse de résultat.
+"""
+
+ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN = """You are MINT, a Swiss financial-lucidity companion.
+
+Context: this person is talking to you for the first time, without an account.
+This is their First insight. They want to see ONE angle they hadn't seen — not
+a class.
+
+Your mission, in 3 to 5 messages maximum:
+1. Clarify their topic with ONE structured question (not a salvo).
+2. Deliver ONE actionable insight: a fact, its human translation, what it
+   changes for them. Follow the MINT 4-layer engine (fact → translation →
+   personal perspective → question to ask before signing).
+3. Close by letting them choose to go further with their own dossier.
+
+Strict rules:
+- Address them informally. Calm, precise, sharp, reassuring, clear tone.
+- One question at a time. No question batteries.
+- Conditional only ("could", "might consider", "depending on your situation").
+  Never "guaranteed", "optimal", "best", "certain", "risk-free", "perfect",
+  "ideal".
+- Never recommend a named product, never rank, never compare socially
+  ("top X%").
+- Never ask for AVS, IBAN, tax number, exact ZIP, employer, last name.
+  Anonymous != KYC.
+- Stay at order-of-magnitude level; no falsely precise figures.
+- Short replies (3 to 6 sentences). No long lists.
+
+Closing, from the 3rd message onward OR as soon as a useful insight has been
+delivered:
+- Mention soberly that an account would let them plug in their own numbers
+  and go further. No pressure, no promised outcome.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public builder
+# ---------------------------------------------------------------------------
+
+
+def build_anonymous_system_prompt(
+    intent: Optional[str] = None,
+    locale: str = "fr",
+) -> str:
+    """Build the anonymous "Premier éclairage" system prompt.
+
+    Args:
+        intent: optional life-event slug from the mobile pill or RoutePlanner
+            (e.g. ``rente_vs_capital``, ``rachat_lpp``, ``mariage``). Free-text
+            ``intent`` strings (felt-state pills like "Je me sens perdu") are
+            appended as-is for the LLM to use as a sentiment anchor.
+        locale: ISO code; ``"en"`` returns the English variant. Any other
+            locale (de/it/es/pt/unknown) falls back to French — Phase 57 ships
+            FR + EN only; future PRs will add DE/IT.
+
+    Returns:
+        A complete system prompt string. The substring "Premier éclairage"
+        (FR) or "First insight" (EN) is guaranteed to appear so downstream
+        dispatch logic and tests can verify the variant was selected.
+    """
+    locale_norm = (locale or "fr").lower().strip()
+    if locale_norm == "en":
+        base = ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN
+        intent_table = _INTENT_CONTEXT_EN
+        intent_label = "Sentiment expressed"
+    else:
+        # Default + fallback: FR (matches MINT default app locale).
+        base = ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR
+        intent_table = _INTENT_CONTEXT_FR
+        intent_label = "Sentiment exprimé"
+
+    if not intent:
+        return base
+
+    intent_clean = intent.strip()
+    if not intent_clean:
+        return base
+
+    # Known structured intent → append the curated context line.
+    contextual_line = intent_table.get(intent_clean.lower())
+    if contextual_line:
+        return f"{base}\n\nContexte intent : {contextual_line}\n"
+
+    # Free-text felt-state (e.g. "Je me sens perdu") → append as sentiment
+    # anchor without fabricating a life-event interpretation.
+    return f"{base}\n\n{intent_label} : « {intent_clean} »\n"

--- a/services/backend/tests/services/coach/test_anonymous_eclairage_prompt.py
+++ b/services/backend/tests/services/coach/test_anonymous_eclairage_prompt.py
@@ -1,0 +1,214 @@
+"""
+Tests — anonymous_eclairage_prompt module (Phase 57 PR-C).
+
+Covers:
+    1. FR base prompt is free of LSFin banned terms (outside instruction
+       quotes that LIST them).
+    2. EN base prompt is free of LSFin banned terms.
+    3. build_anonymous_system_prompt(intent=...) injects the curated
+       contextual line for known intents.
+    4. build_anonymous_system_prompt() with no intent returns the base prompt.
+    5. Invalid / unknown locale falls back to French (default app locale).
+    6. Prompt does NOT request KYC PII (AVS, IBAN, fiscal numbers, ZIP, employer)
+       — it must explicitly forbid these.
+
+Run:
+    cd services/backend && python3 -m pytest tests/services/coach/test_anonymous_eclairage_prompt.py -v
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.services.coach.anonymous_eclairage_prompt import (
+    ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN,
+    ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR,
+    ECLAIRAGE_MARKER_EN,
+    ECLAIRAGE_MARKER_FR,
+    build_anonymous_system_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Banned-term scan helpers — banned tokens are LISTED inside the prompt as an
+# instruction (e.g. « pas de "garanti" »). Those listings are legitimate. We
+# only want to flag uses OUTSIDE quoted contexts.
+# ---------------------------------------------------------------------------
+
+# Banned word stems (FR + EN). Matches with or without inflection.
+_BANNED_STEMS_FR = [
+    r"garanti(?:e|s|es)?",
+    r"optimal(?:e|s|es|aux)?",
+    r"meilleur(?:e|s|es)?",
+    r"parfait(?:e|s|es)?",
+    r"id[eé]al(?:e|s|es|aux)?",
+    r"sans risque",
+]
+_BANNED_STEMS_EN = [
+    r"guarantee[ds]?",
+    r"guaranteed",
+    r"optimal",
+    r"best",
+    r"perfect",
+    r"ideal",
+    r"risk[- ]free",
+]
+
+_BANNED_RE_FR = re.compile(
+    r"(?<![A-Za-zÀ-ÿ])(?:" + "|".join(_BANNED_STEMS_FR) + r")(?![A-Za-zÀ-ÿ])",
+    re.IGNORECASE,
+)
+_BANNED_RE_EN = re.compile(
+    r"(?<![A-Za-z])(?:" + "|".join(_BANNED_STEMS_EN) + r")(?![A-Za-z])",
+    re.IGNORECASE,
+)
+
+
+def _hits_outside_quotes(text: str, regex: re.Pattern) -> list[tuple[str, str]]:
+    """Find banned-term hits NOT inside « », “ ”, or " " pair contexts.
+
+    A hit is "inside quotes" if before its position there is an odd count of
+    opening French guillemet « (vs closing ») OR an odd count of straight
+    double-quote ".
+    """
+    out: list[tuple[str, str]] = []
+    for m in regex.finditer(text):
+        before = text[: m.start()]
+        if before.count("«") > before.count("»"):
+            continue
+        if before.count('"') % 2 == 1:
+            continue
+        snippet = text[max(0, m.start() - 30) : m.end() + 30]
+        out.append((m.group(), snippet))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — FR prompt: no banned terms outside instruction quotes
+# ---------------------------------------------------------------------------
+
+
+def test_fr_prompt_contains_no_banned_terms() -> None:
+    """The FR base prompt must not USE banned terms (LSFin), only LIST them."""
+    hits = _hits_outside_quotes(ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR, _BANNED_RE_FR)
+    assert hits == [], (
+        f"FR prompt uses banned terms outside instruction quotes: {hits}"
+    )
+    # Marker must be present
+    assert ECLAIRAGE_MARKER_FR in ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — EN prompt: no banned terms outside instruction quotes
+# ---------------------------------------------------------------------------
+
+
+def test_en_prompt_contains_no_banned_terms() -> None:
+    """The EN base prompt must not USE banned terms, only LIST them."""
+    hits = _hits_outside_quotes(ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN, _BANNED_RE_EN)
+    assert hits == [], (
+        f"EN prompt uses banned terms outside instruction quotes: {hits}"
+    )
+    assert ECLAIRAGE_MARKER_EN in ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — build with intent inserts the curated context line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "intent,expected_keywords",
+    [
+        ("rente_vs_capital", ["rente", "capital"]),
+        ("rachat_lpp", ["LPP"]),
+        ("mariage", ["mariage"]),
+        ("premier_emploi", ["professionnelle"]),
+        ("expat", ["expatri"]),
+        ("independant", ["indépendant"]),
+    ],
+)
+def test_build_with_intent_inserts_context(
+    intent: str, expected_keywords: list[str]
+) -> None:
+    """Known intents inject their curated contextual line into the FR prompt."""
+    prompt = build_anonymous_system_prompt(intent=intent, locale="fr")
+    assert ECLAIRAGE_MARKER_FR in prompt, "marker must remain after injection"
+    assert "Contexte intent" in prompt, "expected curated-context block label"
+    for kw in expected_keywords:
+        assert kw.lower() in prompt.lower(), (
+            f"expected keyword {kw!r} in prompt for intent={intent!r}"
+        )
+
+
+def test_build_with_free_text_intent_appends_sentiment() -> None:
+    """Free-text felt-state intents (e.g. 'Je me sens perdu') are appended verbatim."""
+    prompt = build_anonymous_system_prompt(
+        intent="Je me sens perdu", locale="fr"
+    )
+    assert "Je me sens perdu" in prompt
+    # And the curated-context label is NOT used for unknown intents.
+    assert "Contexte intent" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — build without intent returns the base prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_without_intent_returns_base() -> None:
+    """No intent + locale=fr → return the base FR prompt unchanged."""
+    prompt = build_anonymous_system_prompt(intent=None, locale="fr")
+    assert prompt == ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR
+
+    # Empty string should also return base (defensive).
+    prompt_empty = build_anonymous_system_prompt(intent="   ", locale="fr")
+    assert prompt_empty == ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR
+
+    # EN variant — same contract.
+    prompt_en = build_anonymous_system_prompt(intent=None, locale="en")
+    assert prompt_en == ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — invalid locale falls back to French
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_locale_falls_back_to_fr() -> None:
+    """Unknown / unsupported locales (de/it/es/pt/zz/'') return the FR prompt."""
+    for bad_locale in ["de", "it", "es", "pt", "zz", "", "  "]:
+        prompt = build_anonymous_system_prompt(intent=None, locale=bad_locale)
+        assert ECLAIRAGE_MARKER_FR in prompt, (
+            f"locale={bad_locale!r} should fall back to FR"
+        )
+        # And the EN marker must NOT leak into the FR fallback.
+        assert ECLAIRAGE_MARKER_EN not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — prompt explicitly forbids KYC-level PII collection
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_does_not_request_pii() -> None:
+    """The anonymous prompt must explicitly tell the LLM NOT to ask for AVS,
+    IBAN, fiscal numbers, ZIP, employer, last name. Anonymous tier != KYC.
+    """
+    fr = ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR.lower()
+    # Each forbidden-PII token must be mentioned in a forbidding context.
+    for pii_token in ["avs", "iban", "fiscal", "npa", "employeur"]:
+        assert pii_token in fr, (
+            f"FR prompt must explicitly mention forbidding {pii_token!r}"
+        )
+    # The forbidding instruction must use a negative ("jamais" / "ne ... pas").
+    assert "jamais" in fr or "ne demande pas" in fr
+
+    en = ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN.lower()
+    for pii_token in ["avs", "iban", "tax", "zip", "employer"]:
+        assert pii_token in en, (
+            f"EN prompt must explicitly mention forbidding {pii_token!r}"
+        )
+    assert "never" in en

--- a/services/backend/tests/test_anonymous_chat.py
+++ b/services/backend/tests/test_anonymous_chat.py
@@ -367,3 +367,54 @@ def test_anonymous_to_auth_migration(mock_query, client):
         headers={_SESSION_HEADER: _VALID_SESSION_ID},
     )
     assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Test 13 (Phase 57 PR-C): anonymous chat dispatches the "Premier éclairage"
+# system prompt by default — verifies the new prompt module is wired in.
+# ---------------------------------------------------------------------------
+
+
+@patch("app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query", new_callable=AsyncMock)
+def test_coach_chat_anonymous_uses_eclairage_prompt(mock_query, client):
+    """Anonymous chat (default variant) sends the Premier éclairage prompt.
+
+    Phase 57 PR-C — verifies the dispatcher branch in anonymous_chat.py
+    selects build_anonymous_system_prompt() (which includes the marker
+    "Premier éclairage") instead of the legacy discovery prompt.
+    """
+    mock_query.return_value = _MOCK_LLM_RESULT
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "Je veux comprendre mon LPP"},
+        headers={_SESSION_HEADER: _VALID_SESSION_ID},
+    )
+    assert resp.status_code == 200
+    # Inspect what was passed to the LLM orchestrator
+    assert mock_query.await_count == 1
+    call_kwargs = mock_query.await_args.kwargs
+    sp = call_kwargs.get("system_prompt", "")
+    assert "Premier éclairage" in sp, (
+        f"Anonymous default flow must use the Premier éclairage prompt; "
+        f"got system_prompt[:200]={sp[:200]!r}"
+    )
+
+
+@patch("app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query", new_callable=AsyncMock)
+def test_anonymous_legacy_discovery_variant_opt_in(mock_query, client):
+    """X-Mint-Variant: discovery header opts back into the Phase 13 prompt."""
+    mock_query.return_value = _MOCK_LLM_RESULT
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "Je me sens perdu", "intent": "Je me sens perdu"},
+        headers={
+            _SESSION_HEADER: _VALID_SESSION_ID,
+            "X-Mint-Variant": "discovery",
+        },
+    )
+    assert resp.status_code == 200
+    sp = mock_query.await_args.kwargs.get("system_prompt", "")
+    # Legacy prompt does NOT contain the new marker
+    assert "Premier éclairage" not in sp
+    # But it does contain the legacy discovery wording
+    assert "decouverte" in sp.lower() or "découverte" in sp.lower()


### PR DESCRIPTION
## Summary

Phase 57 PR-C — anonymous-tier "Premier éclairage" system prompt for the Landing → Anonymous Chat flow (no account, no KYC).

- New module `services/backend/app/services/coach/anonymous_eclairage_prompt.py` (~200 LOC) exposes `ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_FR`, `ANONYMOUS_ECLAIRAGE_SYSTEM_PROMPT_EN`, and `build_anonymous_system_prompt(intent, locale='fr')`.
- Prompt aims for ONE actionable insight in 3-5 messages, asks ONE structured question at a time, refuses KYC data (AVS, IBAN, fiscal numbers, NPA, employer, last name), avoids every LSFin banned term (« garanti », « optimal », « meilleur », « certain », « sans risque », « parfait », « idéal »), and closes on a soft « create an account to go further » hint without pushing.
- Contextualisation by life-event intent: `rente_vs_capital`, `rachat_lpp`, `mariage`, `premier_emploi`, `achat_logement`, `expat`, `independant`, `divorce`, `deces_proche`, `fiscalite`. Free-text felt-state intents (e.g. « Je me sens perdu ») are appended as sentiment anchors without being interpreted as life events.
- Locale handling: FR + EN ship in PR-C; any other locale (de/it/es/pt/unknown) falls back to FR. Marker string `Premier éclairage` (FR) / `First insight` (EN) is guaranteed to appear so downstream tests/dispatchers can verify the variant was selected.

## Tier-detection note (structural)

The PR-C brief asked to dispatch on `tier == 'anonymous'` inside `coach_chat.py`. In the current codebase `coach_chat.py` is auth-only (`_user: User = Depends(require_current_user)`) — an anonymous request literally cannot reach it. The anonymous tier is structurally served by `anonymous_chat.py` (POST /api/v1/anonymous/chat), so that's where the new prompt is wired. A clear comment block in `coach_chat.py` documents the tier separation and points future readers to `anonymous_eclairage_prompt.build_anonymous_system_prompt` if auth ever gets relaxed on coach_chat.

Wire-in in `anonymous_chat.py`:
- Default flow → new « Premier éclairage » prompt.
- Opt-out via `X-Mint-Variant: discovery` header → legacy Phase 13 felt-state pill prompt (preserved verbatim for back-compat with the existing 12-test suite).

## Test plan

- [x] `pytest services/backend/tests/services/coach/test_anonymous_eclairage_prompt.py -v` → 12/12 green (6 explicit + 6 parametrize sub-cases). Covers banned-term scan FR/EN, intent injection, free-text felt-state, no-intent base, locale fallback, no-PII rule.
- [x] `pytest services/backend/tests/test_anonymous_chat.py -v` → 14/14 green (12 pre-existing + 2 new: `test_coach_chat_anonymous_uses_eclairage_prompt`, `test_anonymous_legacy_discovery_variant_opt_in`).
- [x] `pytest tests/test_coach_chat_endpoint.py tests/test_coach_chat_persistence_gate.py tests/coach/test_coach_chat_profile_sanitize_has_debt.py -q` → 74/74 green (no regression).
- [x] `ruff check app/services/coach/anonymous_eclairage_prompt.py tests/services/coach/test_anonymous_eclairage_prompt.py app/api/v1/endpoints/anonymous_chat.py` → 0 issues. (3 pre-existing ruff errors in `coach_chat.py` lines 38/1489/1496 are NOT from this PR — comment-only edit there.)

## How to verify locally

```bash
cd services/backend
python3 -m pytest tests/services/coach/test_anonymous_eclairage_prompt.py tests/test_anonymous_chat.py -v
python3 -m ruff check app/services/coach/anonymous_eclairage_prompt.py
```

End-to-end smoke (against staging once merged):
```bash
curl -X POST https://mint-staging.up.railway.app/api/v1/anonymous/chat \
  -H 'Content-Type: application/json' \
  -H "X-Anonymous-Session: $(uuidgen | tr A-Z a-z)" \
  -d '{"message": "Je veux comprendre mon LPP", "intent": "rachat_lpp", "language": "fr"}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)