### PR TITLE
feat(phase-70a,v2.10): wire LSFin banned-terms + no-legal-admission lints blocking pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,6 +25,38 @@ pre-commit:
       glob: "*.{dart,py}"
       tags: [map, agents]
 
+    lsfin-banned-terms-arb:
+      # Phase 70a — milestone v2.10 COMP-01. LSFin Rule #1 « garanti »-
+      # family blocking on the 6 ARB locales. V1 scope per docstring of
+      # banned_terms_arb.py — the « optimal / parfait / sans risque /
+      # idéal / il faut / vous économiserez / rentable / opportunité »
+      # expanded list lives as a runtime check in the coach prompt
+      # pipeline (check_banned_terms MCP, called from
+      # services/backend/app/services/coach/anonymous_eclairage_prompt.py
+      # at request time), NOT in this static lint, because those terms
+      # have too many colloquial uses across FR/EN/DE/IT/ES/PT to lint
+      # mechanically without false positives. This pre-commit gate
+      # catches the most-prosecuted family (« garanti / guaranteed /
+      # garantiert / garantizado / garantito / garantido ») where false
+      # positive rate is near zero. Per memory feedback_public_repo_
+      # discipline.md : the public MINT-IA/MINT mirror must never ship
+      # a positive « garanti* » use.
+      run: python3 tools/checks/banned_terms_arb.py
+      glob: "apps/mobile/lib/l10n/app_*.arb"
+      tags: [compliance, lsfin, milestone-v2.10]
+
+    no-legal-admission-public-docs:
+      # Phase 70a — milestone v2.10 COMP-02. Repo MINT-IA/MINT is
+      # PUBLIC. Forensic / personal-liability framing in committed
+      # markdown reads as adverse admission when quoted out of context.
+      # Per memory feedback_public_repo_discipline.md. Per-line override
+      # via `<!-- ALLOW-LEGAL-ADMISSION: reason -->` comment on the
+      # offending line for legitimate cited references (e.g. citing
+      # nFADP art. 6 in a compliance doc).
+      run: python3 tools/checks/no_legal_admission_in_public_docs.py
+      glob: "{.planning,decisions,docs}/**/*.md"
+      tags: [compliance, public-repo, milestone-v2.10]
+
 skip:
   - merge
   - rebase


### PR DESCRIPTION
## Summary

Phase 70a of milestone v2.10 « Le Premier Éclairage (Cleo-grade) ». Wires two pre-commit blocking gates (REQUIREMENTS.md COMP-01 + COMP-02).

### Wired blocking
- **lsfin-banned-terms-arb** — `tools/checks/banned_terms_arb.py` on `apps/mobile/lib/l10n/app_*.arb`. Blocks « garanti / guaranteed / garantiert / garantizado / garantito / garantido » family. Negation contexts allowlisted.
- **no-legal-admission-public-docs** — `tools/checks/no_legal_admission_in_public_docs.py` on `{.planning,decisions,docs}/**/*.md`. Blocks forensic / personal-liability framing in public-repo committed markdown.

### COMP-01 V1 vs full scope note (3-piliers panel revision)
8 expanded LSFin terms (idéal / il faut / vous économiserez / rentable / profiter de / opportunité / sûr / avantage fiscal seul) NOT linted statically — too many colloquial uses across 6 locales for mechanical detection. They're caught at runtime by `check_banned_terms` MCP from the coach prompt path. Static lint here = hardest violations, runtime = soft.

## Test plan
- [x] Both lints passed clean before wiring : 0 / 0 violations across 6 ARBs + 446 markdown docs
- [x] **Fail-closed verified** : injected « rendement garanti à vie » into `app_fr.arb`, ran `lefthook run pre-commit` → `🥊 lsfin-banned-terms-arb ❯ exit status 1`. Reverted before commit.
- [x] `lefthook.yml` syntax valid (lefthook v2.1.6 parses without error)
- [x] Hooks fire on correct glob ; skip cleanly when no staged matching files
- [ ] Phase 70b PR triage (close conflicting PRs on `anonymous_chat_screen.dart`) — separate PR, in progress

Refs : milestone v2.10 setup PR #483, REQUIREMENTS.md COMP-01/02, panel revisions log commit e67b317b.