### PR TITLE
feat(phase-73,v2.10): landing v3 éditorial — Fraunces italic « Voir clair, décider seul. » + RoundedRectangleBorder(14) CTA

### DIFF
--- a/.planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md
+++ b/.planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md
@@ -1,0 +1,80 @@
+# Phase 73 — Landing v3 éditorial — Panel Verdict
+
+> **Date :** 2026-05-05
+> **Panel :** 2-pers (Brand strategist Apple/Linear + Swiss editorial Le Temps/NZZ)
+> **Verdict :** APPROVE-WITH-NEW-LINE-D — locked for implementation.
+
+## 1. Brand line LOCKED = option D (new)
+
+**« Voir clair, décider seul. »**
+
+A, B, C rejetées :
+- A « L'argent, en clair. » + « Ta Suisse financière, traduite. » → « traduite » technocratic, sub-title duplique sans amplifier
+- B « Ce que ta caisse de pension ne t'expliquera jamais. » → adversarial, journalist-bait, viole pivot 2026-04-12 retraite-frame
+- C « La finance suisse, sans les angles morts. » → métaphore visuelle absente du produit, pan-locale fragile (« tote Winkel » DE = jargon routier)
+
+D justifié : two verbs, two beats, hero-shaped. Voice = Linear/Stripe (verb-led pas feature-led). Pas de promesse de résultat, juste de capacité (LSFin-safe). Sobriété romande, traduit clean DE/IT/EN/ES/PT, autorité calme, zéro retraite-frame, 18-99 universel, tient sous scrutiny journaliste.
+
+## 2. Hero strings × 6 locales (LOCKED)
+
+| locale | hero |
+|---|---|
+| FR | Voir clair, décider seul. |
+| EN | See clearly. Decide for yourself. |
+| DE | Klar sehen. Selbst entscheiden. |
+| IT | Vedere chiaro, decidere da sé. |
+| ES | Ver claro, decidir por ti. |
+| PT | Ver claro, decidir sozinho. |
+
+ARB key = `landingV3Hero`. **Pas de sub-title** — la ligne porte tout.
+
+## 3. Layout (top-to-bottom code-ready)
+
+```
+Scaffold BG = MintColors.warmWhite (#FAF8F5)
+SafeArea + Center + ConstrainedBox(maxWidth: 480)  ← descendu de 560
+Padding global : EdgeInsets.symmetric(horizontal: 28, vertical: 24)
+
+Column children :
+  1. Wordmark MINT — Align(centerLeft), MintTextStyles.brandLogo()
+     override letterSpacing: 2 (pas 4), inkPrimary. Long-press → /auth/login
+  2. Spacer(flex: 3)
+  3. Hero phrase — l10n.landingV3Hero
+     GoogleFonts.fraunces(fontSize: 40, fontStyle: italic, fontWeight: w400,
+                          height: 1.2, letterSpacing: -0.4, color: inkPrimary)
+     textAlign: center
+  4. Spacer(flex: 4)
+  5. CTA primaire — FilledButton
+     backgroundColor: inkPrimary, foregroundColor: porcelaineHero
+     minimumSize: Size.fromHeight(54)
+     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14))
+     ← PAS StadiumBorder (fix du mockup)
+     textStyle: MintTextStyles.titleMedium(color: porcelaineHero)
+  6. SizedBox(height: 16)
+  7. Login link — l10n.landingV2LoginLink
+     MintTextStyles.bodySmall(color: textSecondaryAaa), no underline
+     tap → /auth/login. Semantics(button: true)
+  8. Spacer(flex: 1)
+  9. Legal footer — landingV2Legal
+     MintTextStyles.labelSmall(color: textMutedAaa), center
+  10. SizedBox(height: 8)
+```
+
+Animations existantes (line1 / paragraph / cta / legal opacity) conservées, re-câbler `_paragraphOpacity` sur le hero.
+
+## 4. Decisions LOCKED
+
+1. Brand line = D « Voir clair, décider seul. » (ne pas re-débattre)
+2. **Pas de sub-title** — single line porte tout
+3. Hero typo = **Fraunces italic 40pt w400**, `inkPrimary`. Italic ON.
+4. CTA = `RoundedRectangleBorder(14)`, **PAS StadiumBorder**
+5. BG = `MintColors.warmWhite` (landing-specific token, pas porcelaineHero)
+6. Wordmark `letterSpacing: 2` (pas 4), `centerLeft`, `inkPrimary`. Long-press to `/auth/login` conservé.
+7. maxWidth card = 480 (descendu de 560), padding horizontal = 28
+8. Login link sans underline, `textSecondaryAaa`, 16px gap sous CTA
+9. Deprecation plan : `landingV2PromiseSober` reste 1 release rollback-safety, retiré v2.11. `landingV2Paragraph` déjà mort, à purger.
+10. Pre-push : `flutter gen-l10n` après ajout `landingV3Hero` × 6 ; `validate_arb_parity()` MCP ; `check_banned_terms("Voir clair, décider seul.")` (clean) ; golden tests Julien+Lauren regen.
+
+---
+
+**Panel verdict :** ship.

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -10512,7 +10512,6 @@
   "mtcSummaryWeakAccuracy": "Eine Schlüsselzahl beruht auf einer fragilen Annahme — Mint bleibt vorsichtig.",
   "mtcSummaryWeakFreshness": "Daten vor einiger Zeit erhoben — Mint sagt es lieber noch einmal.",
   "mtcSummaryWeakUnderstanding": "Die Rechnung steht, die Idee verdient noch ein Gespräch.",
-  "landingV2Paragraph": "Mint sagt dir, was dir sonst niemand sagen will. Über deine Versicherungen, deine 3a, deinen Lohn, deinen Mietvertrag, deine Beziehung, deine Steuern. Ruhig. Ohne dir irgendetwas zu verkaufen.",
   "landingV2Cta": "Weiter (ohne Konto)",
   "landingV2Privacy": "Nichts verlässt dein Handy, bis du es entscheidest.",
   "landingV2Legal": "Bildungstool. Keine Finanzberatung im Sinne des FIDLEG.",
@@ -10532,6 +10531,10 @@
   },
   "landingV2PromiseSober": "Wir klären auf. Du entscheidest.",
   "landingV2CtaSober": "Sprich mit Mint",
+  "landingV3Hero": "Klar sehen. Selbst entscheiden.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 editorial hero. Brand line locked by panel."
+  },
   "tonChooserTitle": "Wähle, wie Mint mit dir spricht",
   "@tonChooserTitle": {
     "description": "Phase 12-01."

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -10512,7 +10512,6 @@
   "mtcSummaryWeakAccuracy": "One key figure rests on a fragile assumption — Mint stays cautious.",
   "mtcSummaryWeakFreshness": "Data gathered a while ago — Mint would rather double-check.",
   "mtcSummaryWeakUnderstanding": "The math is settled, the idea still deserves a conversation.",
-  "landingV2Paragraph": "Mint tells you what no one else has any interest in telling you. About your insurance, your 3a, your salary, your lease, your partner, your taxes. Calmly. Without selling you anything.",
   "landingV2Cta": "Continue (no account)",
   "landingV2Privacy": "Nothing leaves your phone until you decide it does.",
   "landingV2Legal": "Educational tool. Not financial advice under LSFin.",
@@ -10532,6 +10531,10 @@
   },
   "landingV2PromiseSober": "We clarify. You decide.",
   "landingV2CtaSober": "Talk to Mint",
+  "landingV3Hero": "See clearly. Decide for yourself.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 editorial hero. Brand line locked by panel."
+  },
   "tonChooserTitle": "Pick how Mint speaks to you",
   "@tonChooserTitle": {
     "description": "Phase 12-01 — TonChooserSheet title."

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -10512,7 +10512,6 @@
   "mtcSummaryWeakAccuracy": "Una cifra clave se apoya en una hipótesis frágil — Mint se mantiene prudente.",
   "mtcSummaryWeakFreshness": "Datos recogidos hace un tiempo — Mint prefiere repetirlo.",
   "mtcSummaryWeakUnderstanding": "El cálculo está hecho, la idea aún merece una conversación.",
-  "landingV2Paragraph": "Mint te dice lo que nadie tiene interés en decirte. Sobre tus seguros, tu 3a, tu salario, tu alquiler, tu pareja, tus impuestos. Con calma. Sin venderte nada.",
   "landingV2Cta": "Continuar (sin cuenta)",
   "landingV2Privacy": "Nada sale de tu teléfono hasta que tú lo decidas.",
   "landingV2Legal": "Herramienta educativa. No constituye asesoramiento financiero según la LSFin.",
@@ -10532,6 +10531,10 @@
   },
   "landingV2PromiseSober": "Nosotros aclaramos. Tú decides.",
   "landingV2CtaSober": "Habla con Mint",
+  "landingV3Hero": "Ver claro, decidir por ti.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 editorial hero. Brand line locked by panel."
+  },
   "tonChooserTitle": "Elige cómo te habla Mint",
   "@tonChooserTitle": {
     "description": "Phase 12-01."

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11217,10 +11217,6 @@
   "@mtcSummaryWeakUnderstanding": {
     "description": "MTC one-line summary when understanding is the weakest axis."
   },
-  "landingV2Paragraph": "Mint te dit ce que personne n'a intérêt à te dire. Sur tes assurances, ton 3a, ton salaire, ton bail, ton couple, tes impôts. Calmement. Sans te vendre quoi que ce soit.",
-  "@landingV2Paragraph": {
-    "description": "Landing v2 paragraphe-mère (LOCKED master text per CONTEXT.md D-01). Anti-shame, calm, six life-domains, no retirement framing."
-  },
   "landingV2Cta": "Continuer (sans compte)",
   "@landingV2Cta": {
     "description": "Landing v2 primary CTA (LOCKED per D-02). Routes to /onboarding/intent. Parenthetical '(sans compte)' is load-bearing."
@@ -11284,6 +11280,10 @@
   "landingV2CtaSober": "Parle à Mint",
   "@landingV2CtaSober": {
     "description": "Landing v2 CTA — conversational, not generic. Phase 5 POLISH-01."
+  },
+  "landingV3Hero": "Voir clair, décider seul.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 éditorial hero. Brand line option D locked by 2-pers panel (PANEL-VERDICT.md §1). Two verbs, two beats, hero-shaped. LSFin-safe (capacity, not result). Voice = Linear/Stripe verb-led. Rendered in Fraunces italic 40pt w400."
   },
   "tonChooserTitle": "Choisis le ton de Mint",
   "@tonChooserTitle": {

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -10512,7 +10512,6 @@
   "mtcSummaryWeakAccuracy": "Una cifra chiave poggia su un'ipotesi fragile — Mint resta prudente.",
   "mtcSummaryWeakFreshness": "Dati raccolti un po' di tempo fa — Mint preferisce ridirlo.",
   "mtcSummaryWeakUnderstanding": "Il calcolo è fatto, l'idea merita ancora una conversazione.",
-  "landingV2Paragraph": "Mint ti dice quello che nessuno ha interesse a dirti. Sulle tue assicurazioni, sul tuo 3a, sul tuo stipendio, sul tuo contratto d'affitto, sulla tua coppia, sulle tue imposte. Con calma. Senza venderti nulla.",
   "landingV2Cta": "Continua (senza account)",
   "landingV2Privacy": "Niente esce dal tuo telefono finché non lo decidi tu.",
   "landingV2Legal": "Strumento educativo. Non costituisce consulenza finanziaria ai sensi della LSerFi.",
@@ -10532,6 +10531,10 @@
   },
   "landingV2PromiseSober": "Noi chiariamo. Tu decidi.",
   "landingV2CtaSober": "Parla con Mint",
+  "landingV3Hero": "Vedere chiaro, decidere da sé.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 editorial hero. Brand line locked by panel."
+  },
   "tonChooserTitle": "Scegli come Mint ti parla",
   "@tonChooserTitle": {
     "description": "Phase 12-01."

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -67,7 +67,7 @@ import 'app_localizations_pt.dart';
 /// property.
 abstract class S {
   S(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -89,11 +89,11 @@ abstract class S {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -102,7 +102,7 @@ abstract class S {
     Locale('en'),
     Locale('es'),
     Locale('it'),
-    Locale('pt')
+    Locale('pt'),
   ];
 
   /// No description provided for @landingFeature1Title.
@@ -6230,7 +6230,10 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{betterJob} vaut {annualDelta}/an de plus en rente viagère, soit {monthlyDelta}/mois À VIE après la retraite.'**
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta);
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  );
 
   /// No description provided for @jobCompareLifetime20Years.
   ///
@@ -9879,7 +9882,10 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Simulation incluant l\'intérêt de la caisse ({fundRate} %) et l\'économie d\'impôt lissée sur {staggeringYears} ans pour un revenu imposable de CHF {taxableIncome}. Le rendement réel est calculé sur ton effort net réel.'**
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome);
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  );
 
   /// No description provided for @simRealInterestTitle.
   ///
@@ -10360,7 +10366,10 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Comparaison forfait fiscal. Imposition ordinaire : {ordinary}. Forfait fiscal : {forfait}. Économie : {savings}.'**
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings);
+    String ordinary,
+    String forfait,
+    String savings,
+  );
 
   /// No description provided for @forfaitFiscalOrdinaryLabel.
   ///
@@ -14123,7 +14132,9 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Les banques suisses calculent avec un taux théorique de 5 % (directive ASB), même si le taux réel du marché est bien plus bas. C\'est un test de résistance : elles vérifient que tu pourrais assumer les charges si les taux remontaient. Tes charges théoriques : {chargesTheoriques}/mois. Au taux réel (~1,5 %) : {chargesReelles}/mois.'**
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles);
+    String chargesTheoriques,
+    String chargesReelles,
+  );
 
   /// No description provided for @affordabilityInsightEquityTitle.
   ///
@@ -23514,15 +23525,16 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{name}\n{ssn}\n{address}\n{postalCity}\n\n{avsOrg}\n{avsAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nJe vous prie de bien vouloir m\'adresser un extrait de mon compte individuel AVS (CI) afin de vérifier l\'état de mes cotisations et d\'identifier d\'éventuelles lacunes.\n\nJe vous remercie par avance de votre diligence.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}'**
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject);
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  );
 
   /// No description provided for @agentLetterAvsOrg.
   ///
@@ -23571,31 +23583,33 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{name}\n{address}\n{postalCity}\n\n{caisseSource}\n{caisseCurrentAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nEn raison de la cessation de mes rapports de travail / de mon départ de Suisse (biffer la mention inutile), je vous prie de bien vouloir procéder au transfert de mon avoir de libre passage.\n\nMontant à transférer : la totalité de mon avoir de libre passage à la date de sortie.\n\nEtablissement de destination :\nNom : {toComplete}\nIBAN ou numéro de compte : {toComplete}\nAdresse : {toComplete}\n\nDate de sortie : {toComplete}\n\nJe vous remercie de votre diligence et de me confirmer la bonne exécution de ce transfert.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}'**
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete);
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  );
 
   /// No description provided for @agentLetterPensionFundBody.
   ///
   /// In fr, this message translates to:
   /// **'{name}\n{address}\n{postalCity}\n\n{caisse}\n{caisseAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nPar la présente, je me permets de vous adresser les demandes suivantes concernant mon dossier de prévoyance professionnelle :\n\n1. Certificat de prévoyance actualisé {year} (avoir de vieillesse, prestations couvertes, taux de conversion applicable)\n\n2. Confirmation de ma capacité de rachat (montant maximal selon l\'art. 79b LPP)\n\n3. Simulation de retraite anticipée (projection de l\'avoir et de la rente à 63 et 64 ans, le cas échéant)\n\nJe vous remercie par avance de votre diligence et reste à votre disposition pour tout complément d\'information.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}\n{policeNumber}'**
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber);
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  );
 
   /// No description provided for @agentLetterPensionSubject.
   ///
@@ -26944,7 +26958,10 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'AI {aiAmount} + LPP {lppAmount} = {totalAmount} CHF/mois'**
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount);
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  );
 
   /// No description provided for @disabilityGapAct3Duration.
   ///
@@ -33425,7 +33442,9 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Revenu estimé à la retraite : {totalMonthly} CHF/mois vs {currentMonthly} CHF/mois actuellement'**
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly);
+    String totalMonthly,
+    String currentMonthly,
+  );
 
   /// No description provided for @rcReplacementRateSubtitle.
   ///
@@ -34157,8 +34176,13 @@ abstract class S {
   ///
   /// In fr, this message translates to:
   /// **'Score de forme financière. {score} sur 100. Niveau {level}. Budget {budget}, Prévoyance {prevoyance}, Patrimoine {patrimoine}.'**
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine);
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  );
 
   /// No description provided for @scoreGaugeSubtitle.
   ///
@@ -34303,7 +34327,11 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{label} : {status}. Fourchette typique {low} à {high}'**
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high);
+    String label,
+    String status,
+    String low,
+    String high,
+  );
 
   /// No description provided for @semanticsBenchmarkToggle.
   ///
@@ -39129,12 +39157,6 @@ abstract class S {
   /// **'Le calcul est posé, l\'idée mérite encore qu\'on en parle.'**
   String get mtcSummaryWeakUnderstanding;
 
-  /// Landing v2 paragraphe-mère (LOCKED master text per CONTEXT.md D-01). Anti-shame, calm, six life-domains, no retirement framing.
-  ///
-  /// In fr, this message translates to:
-  /// **'Mint te dit ce que personne n\'a intérêt à te dire. Sur tes assurances, ton 3a, ton salaire, ton bail, ton couple, tes impôts. Calmement. Sans te vendre quoi que ce soit.'**
-  String get landingV2Paragraph;
-
   /// Landing v2 primary CTA (LOCKED per D-02). Routes to /onboarding/intent. Parenthetical '(sans compte)' is load-bearing.
   ///
   /// In fr, this message translates to:
@@ -39230,6 +39252,12 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Parle à Mint'**
   String get landingV2CtaSober;
+
+  /// Phase 73 v2.10 — Landing v3 éditorial hero. Brand line option D locked by 2-pers panel (PANEL-VERDICT.md §1). Two verbs, two beats, hero-shaped. LSFin-safe (capacity, not result). Voice = Linear/Stripe verb-led. Rendered in Fraunces italic 40pt w400.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voir clair, décider seul.'**
+  String get landingV3Hero;
 
   /// Phase 12-01 — TonChooserSheet title (first launch). Word 'curseur' BANNED in user-facing copy.
   ///
@@ -40730,13 +40758,13 @@ class _SDelegate extends LocalizationsDelegate<S> {
 
   @override
   bool isSupported(Locale locale) => <String>[
-        'de',
-        'en',
-        'es',
-        'fr',
-        'it',
-        'pt'
-      ].contains(locale.languageCode);
+    'de',
+    'en',
+    'es',
+    'fr',
+    'it',
+    'pt',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_SDelegate old) => false;
@@ -40760,8 +40788,9 @@ S lookupS(Locale locale) {
   }
 
   throw FlutterError(
-      'S.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'S.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -3396,7 +3396,10 @@ class SDe extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob bringt $annualDelta/Jahr mehr Leibrente, also $monthlyDelta/Monat LEBENSLANG nach der Pensionierung.';
   }
 
@@ -5454,7 +5457,10 @@ class SDe extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulation inklusive Kassenzins ($fundRate %) und Steuerersparnis, geglättet über $staggeringYears Jahre für ein steuerbares Einkommen von CHF $taxableIncome. Die reale Rendite wird auf deinen tatsächlichen Nettoaufwand berechnet.';
   }
 
@@ -5646,7 +5652,10 @@ class SDe extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'Du verlierst $amount/Monat lebenslang. Aber du gewinnst $years Jahr$plural Freiheit.';
   }
 
@@ -5744,7 +5753,10 @@ class SDe extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Vergleich Pauschalbesteuerung. Ordentliche Besteuerung: $ordinary. Pauschalbesteuerung: $forfait. Ersparnis: $savings.';
   }
 
@@ -6634,24 +6646,21 @@ class SDe extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'Januar',
-        '2': 'Februar',
-        '3': 'März',
-        '4': 'April',
-        '5': 'Mai',
-        '6': 'Juni',
-        '7': 'Juli',
-        '8': 'August',
-        '9': 'September',
-        '10': 'Oktober',
-        '11': 'November',
-        '12': 'Dezember',
-        'other': 'Monat',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'Januar',
+      '2': 'Februar',
+      '3': 'März',
+      '4': 'April',
+      '5': 'Mai',
+      '6': 'Juni',
+      '7': 'Juli',
+      '8': 'August',
+      '9': 'September',
+      '10': 'Oktober',
+      '11': 'November',
+      '12': 'Dezember',
+      'other': 'Monat',
+    });
     return '$_temp0';
   }
 
@@ -7968,7 +7977,9 @@ class SDe extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Schweizer Banken rechnen mit einem theoretischen Zinssatz von 5 % (ASB-Richtlinie), auch wenn der aktuelle Marktzins deutlich tiefer ist. Es ist ein Belastungstest: Sie prüfen, ob du die Kosten tragen könntest, falls die Zinsen steigen. Deine theoretischen Kosten: $chargesTheoriques/Mt. Zum Marktzins (~1,5 %): $chargesReelles/Mt.';
   }
 
@@ -13252,15 +13263,16 @@ class SDe extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\nbitte senden Sie mir einen Auszug meines individuellen AHV-Kontos (IK), um den Stand meiner Beiträge zu prüfen und eventuelle Lücken zu identifizieren.\n\nIch danke Ihnen im Voraus für Ihre Sorgfalt.\n\nMit freundlichen Grüssen\n\n$name';
   }
 
@@ -13288,30 +13300,32 @@ class SDe extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\naufgrund der Beendigung meines Arbeitsverhältnisses / meines Wegzugs aus der Schweiz (Nichtzutreffendes streichen) bitte ich Sie, mein Freizügigkeitsguthaben zu übertragen.\n\nZu übertragender Betrag: das gesamte Freizügigkeitsguthaben per Austrittsdatum.\n\nZielinstitution:\nName: $toComplete\nIBAN oder Kontonummer: $toComplete\nAdresse: $toComplete\n\nAustrittsdatum: $toComplete\n\nIch danke Ihnen für Ihre Sorgfalt und bitte um eine Bestätigung der Ausführung.\n\nMit freundlichen Grüssen\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\nhiermit erlaube ich mir, folgende Anfragen bezüglich meiner beruflichen Vorsorge zu stellen:\n\n1. Aktualisierter Vorsorgeausweis $year (Altersguthaben, gedeckte Leistungen, anwendbarer Umwandlungssatz)\n\n2. Bestätigung meiner Einkaufskapazität (Maximalbetrag gemäss Art. 79b BVG)\n\n3. Simulation Frühpensionierung (Projektion des Guthabens und der Rente mit 63 und 64 Jahren, falls zutreffend)\n\nIch danke Ihnen im Voraus für Ihre Sorgfalt und stehe Ihnen für Rückfragen gerne zur Verfügung.\n\nMit freundlichen Grüssen\n\n$name\n$policeNumber';
   }
 
@@ -15301,7 +15315,10 @@ class SDe extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'IV $aiAmount + BVG $lppAmount = $totalAmount CHF/Monat';
   }
 
@@ -19017,7 +19034,9 @@ class SDe extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Geschätztes Renteneinkommen: $totalMonthly CHF/Monat vs $currentMonthly CHF/Monat heute';
   }
 
@@ -19437,8 +19456,13 @@ class SDe extends S {
   String get scoreGaugeSectionPrevoyance => 'Vorsorge';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Finanzielle Fitness. $score von 100. Stufe $level. Budget $budget, Vorsorge $prevoyance, Vermögen $patrimoine.';
   }
 
@@ -19527,7 +19551,11 @@ class SDe extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label: $status. Typische Spanne $low bis $high';
   }
 
@@ -22355,10 +22383,6 @@ class SDe extends S {
       'Die Rechnung steht, die Idee verdient noch ein Gespräch.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint sagt dir, was dir sonst niemand sagen will. Über deine Versicherungen, deine 3a, deinen Lohn, deinen Mietvertrag, deine Beziehung, deine Steuern. Ruhig. Ohne dir irgendetwas zu verkaufen.';
-
-  @override
   String get landingV2Cta => 'Weiter (ohne Konto)';
 
   @override
@@ -22411,6 +22435,9 @@ class SDe extends S {
 
   @override
   String get landingV2CtaSober => 'Sprich mit Mint';
+
+  @override
+  String get landingV3Hero => 'Klar sehen. Selbst entscheiden.';
 
   @override
   String get tonChooserTitle => 'Wähle, wie Mint mit dir spricht';

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -3363,7 +3363,10 @@ class SEn extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob is worth $annualDelta/year more in life annuity, i.e. $monthlyDelta/month FOR LIFE after retirement.';
   }
 
@@ -5411,7 +5414,10 @@ class SEn extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulation including fund interest ($fundRate%) and tax savings staggered over $staggeringYears years for a taxable income of CHF $taxableIncome. Real return is calculated on your actual net effort.';
   }
 
@@ -5602,7 +5608,10 @@ class SEn extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'You lose $amount/month for life. But you gain $years year$plural of freedom.';
   }
 
@@ -5700,7 +5709,10 @@ class SEn extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Lump-sum tax comparison. Ordinary taxation: $ordinary. Lump-sum tax: $forfait. Savings: $savings.';
   }
 
@@ -6580,24 +6592,21 @@ class SEn extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'January',
-        '2': 'February',
-        '3': 'March',
-        '4': 'April',
-        '5': 'May',
-        '6': 'June',
-        '7': 'July',
-        '8': 'August',
-        '9': 'September',
-        '10': 'October',
-        '11': 'November',
-        '12': 'December',
-        'other': 'month',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'January',
+      '2': 'February',
+      '3': 'March',
+      '4': 'April',
+      '5': 'May',
+      '6': 'June',
+      '7': 'July',
+      '8': 'August',
+      '9': 'September',
+      '10': 'October',
+      '11': 'November',
+      '12': 'December',
+      'other': 'month',
+    });
     return '$_temp0';
   }
 
@@ -7901,7 +7910,9 @@ class SEn extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Swiss banks use a theoretical 5% interest rate (ASB directive), even though the actual market rate is much lower. It\'s a stress test: they check you could handle the charges if rates rose. Your theoretical charges: $chargesTheoriques/mo. At market rate (~1.5%): $chargesReelles/mo.';
   }
 
@@ -13158,15 +13169,16 @@ class SEn extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nI kindly request that you send me an extract of my individual AVS account (CI) in order to verify my contribution record and identify any gaps.\n\nThank you in advance for your diligence.\n\nYours faithfully,\n\n$name';
   }
 
@@ -13195,30 +13207,32 @@ class SEn extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nDue to the termination of my employment / my departure from Switzerland (delete as applicable), I kindly request that you transfer my vested benefits.\n\nAmount to transfer: the full amount of my vested benefits at the date of departure.\n\nDestination institution:\nName: $toComplete\nIBAN or account number: $toComplete\nAddress: $toComplete\n\nDeparture date: $toComplete\n\nThank you for your diligence and please confirm the successful completion of this transfer.\n\nYours faithfully,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nI hereby wish to submit the following requests regarding my occupational pension file:\n\n1. Updated pension certificate $year (retirement assets, covered benefits, applicable conversion rate)\n\n2. Confirmation of my buyback capacity (maximum amount pursuant to Art. 79b LPP)\n\n3. Early retirement simulation (projection of assets and pension at 63 and 64, if applicable)\n\nThank you in advance for your diligence. I remain at your disposal for any further information.\n\nYours faithfully,\n\n$name\n$policeNumber';
   }
 
@@ -15192,7 +15206,10 @@ class SEn extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'DI $aiAmount + LPP $lppAmount = $totalAmount CHF/month';
   }
 
@@ -18882,7 +18899,9 @@ class SEn extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Estimated retirement income: $totalMonthly CHF/month vs $currentMonthly CHF/month today';
   }
 
@@ -19300,8 +19319,13 @@ class SEn extends S {
   String get scoreGaugeSectionPrevoyance => 'Pension';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Financial fitness score. $score out of 100. Level $level. Budget $budget, Pension $prevoyance, Assets $patrimoine.';
   }
 
@@ -19390,7 +19414,11 @@ class SEn extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label: $status. Typical range $low to $high';
   }
 
@@ -22192,10 +22220,6 @@ class SEn extends S {
       'The math is settled, the idea still deserves a conversation.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint tells you what no one else has any interest in telling you. About your insurance, your 3a, your salary, your lease, your partner, your taxes. Calmly. Without selling you anything.';
-
-  @override
   String get landingV2Cta => 'Continue (no account)';
 
   @override
@@ -22248,6 +22272,9 @@ class SEn extends S {
 
   @override
   String get landingV2CtaSober => 'Talk to Mint';
+
+  @override
+  String get landingV3Hero => 'See clearly. Decide for yourself.';
 
   @override
   String get tonChooserTitle => 'Pick how Mint speaks to you';

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -3383,7 +3383,10 @@ class SEs extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob vale $annualDelta/año más en renta vitalicia, es decir $monthlyDelta/mes DE POR VIDA tras la jubilación.';
   }
 
@@ -5444,7 +5447,10 @@ class SEs extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulación que incluye el interés de la caja ($fundRate %) y el ahorro fiscal repartido en $staggeringYears años para una renta imponible de CHF $taxableIncome. El rendimiento real se calcula sobre tu esfuerzo neto real.';
   }
 
@@ -5639,7 +5645,10 @@ class SEs extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'Pierdes $amount/mes de por vida. Pero ganas $years año$plural de libertad.';
   }
 
@@ -5737,7 +5746,10 @@ class SEs extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Comparación forfait fiscal. Imposición ordinaria: $ordinary. Forfait fiscal: $forfait.';
   }
 
@@ -6620,24 +6632,21 @@ class SEs extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'enero',
-        '2': 'febrero',
-        '3': 'marzo',
-        '4': 'abril',
-        '5': 'mayo',
-        '6': 'junio',
-        '7': 'julio',
-        '8': 'agosto',
-        '9': 'septiembre',
-        '10': 'octubre',
-        '11': 'noviembre',
-        '12': 'diciembre',
-        'other': 'mes',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'enero',
+      '2': 'febrero',
+      '3': 'marzo',
+      '4': 'abril',
+      '5': 'mayo',
+      '6': 'junio',
+      '7': 'julio',
+      '8': 'agosto',
+      '9': 'septiembre',
+      '10': 'octubre',
+      '11': 'noviembre',
+      '12': 'diciembre',
+      'other': 'mes',
+    });
     return '$_temp0';
   }
 
@@ -7950,7 +7959,9 @@ class SEs extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Los bancos suizos calculan con una tasa teórica del 5 % (directiva ASB), aunque la tasa real del mercado es mucho menor. Es una prueba de resistencia: verifican que podrías asumir los cargos si las tasas subieran. Tus cargos teóricos: $chargesTheoriques/mes. A tasa de mercado (~1,5 %): $chargesReelles/mes.';
   }
 
@@ -13223,15 +13234,16 @@ class SEs extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nLes solicito que me remitan un extracto de mi cuenta individual AVS (CI) para verificar el estado de mis cotizaciones e identificar posibles lagunas.\n\nLes agradezco de antemano su diligencia.\n\nAtentamente,\n\n$name';
   }
 
@@ -13259,30 +13271,32 @@ class SEs extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nDebido a la terminación de mi relación laboral / mi salida de Suiza (tachar lo que no corresponda), les solicito que procedan a la transferencia de mi haber de libre paso.\n\nImporte a transferir: la totalidad del haber de libre paso a la fecha de salida.\n\nEntidad de destino:\nNombre: $toComplete\nIBAN o número de cuenta: $toComplete\nDirección: $toComplete\n\nFecha de salida: $toComplete\n\nLes agradezco su diligencia y les ruego que confirmen la correcta ejecución de esta transferencia.\n\nAtentamente,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nPor medio de la presente, me permito dirigirles las siguientes solicitudes en relación con mi expediente de previsión profesional:\n\n1. Certificado de previsión actualizado $year (haber de vejez, prestaciones cubiertas, tasa de conversión aplicable)\n\n2. Confirmación de mi capacidad de rescate (importe máximo según el art. 79b LPP)\n\n3. Simulación de jubilación anticipada (proyección del haber y de la renta a los 63 y 64 años, en su caso)\n\nLes agradezco de antemano su diligencia y quedo a su disposición para cualquier información adicional.\n\nAtentamente,\n\n$name\n$policeNumber';
   }
 
@@ -15275,7 +15289,10 @@ class SEs extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mes';
   }
 
@@ -18979,7 +18996,9 @@ class SEs extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Ingresos estimados en la jubilación: $totalMonthly CHF/mes vs $currentMonthly CHF/mes actualmente';
   }
 
@@ -19396,8 +19415,13 @@ class SEs extends S {
   String get scoreGaugeSectionPrevoyance => 'Previsión';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Puntuación de forma financiera. $score de 100. Nivel $level. Presupuesto $budget, Previsión $prevoyance, Patrimonio $patrimoine.';
   }
 
@@ -19486,7 +19510,11 @@ class SEs extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label: $status. Rango típico de $low a $high';
   }
 
@@ -22304,10 +22332,6 @@ class SEs extends S {
       'El cálculo está hecho, la idea aún merece una conversación.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint te dice lo que nadie tiene interés en decirte. Sobre tus seguros, tu 3a, tu salario, tu alquiler, tu pareja, tus impuestos. Con calma. Sin venderte nada.';
-
-  @override
   String get landingV2Cta => 'Continuar (sin cuenta)';
 
   @override
@@ -22360,6 +22384,9 @@ class SEs extends S {
 
   @override
   String get landingV2CtaSober => 'Habla con Mint';
+
+  @override
+  String get landingV3Hero => 'Ver claro, decidir por ti.';
 
   @override
   String get tonChooserTitle => 'Elige cómo te habla Mint';

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -3381,7 +3381,10 @@ class SFr extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob vaut $annualDelta/an de plus en rente viagère, soit $monthlyDelta/mois À VIE après la retraite.';
   }
 
@@ -5447,7 +5450,10 @@ class SFr extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulation incluant l\'intérêt de la caisse ($fundRate %) et l\'économie d\'impôt lissée sur $staggeringYears ans pour un revenu imposable de CHF $taxableIncome. Le rendement réel est calculé sur ton effort net réel.';
   }
 
@@ -5641,7 +5647,10 @@ class SFr extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'Tu perds $amount/mois à vie. Mais tu gagnes $years an$plural de liberté.';
   }
 
@@ -5739,7 +5748,10 @@ class SFr extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Comparaison forfait fiscal. Imposition ordinaire : $ordinary. Forfait fiscal : $forfait. Économie : $savings.';
   }
 
@@ -6622,24 +6634,21 @@ class SFr extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'janvier',
-        '2': 'février',
-        '3': 'mars',
-        '4': 'avril',
-        '5': 'mai',
-        '6': 'juin',
-        '7': 'juillet',
-        '8': 'août',
-        '9': 'septembre',
-        '10': 'octobre',
-        '11': 'novembre',
-        '12': 'décembre',
-        'other': 'mois',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'janvier',
+      '2': 'février',
+      '3': 'mars',
+      '4': 'avril',
+      '5': 'mai',
+      '6': 'juin',
+      '7': 'juillet',
+      '8': 'août',
+      '9': 'septembre',
+      '10': 'octobre',
+      '11': 'novembre',
+      '12': 'décembre',
+      'other': 'mois',
+    });
     return '$_temp0';
   }
 
@@ -7951,7 +7960,9 @@ class SFr extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Les banques suisses calculent avec un taux théorique de 5 % (directive ASB), même si le taux réel du marché est bien plus bas. C\'est un test de résistance : elles vérifient que tu pourrais assumer les charges si les taux remontaient. Tes charges théoriques : $chargesTheoriques/mois. Au taux réel (~1,5 %) : $chargesReelles/mois.';
   }
 
@@ -13224,15 +13235,16 @@ class SFr extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nJe vous prie de bien vouloir m\'adresser un extrait de mon compte individuel AVS (CI) afin de vérifier l\'état de mes cotisations et d\'identifier d\'éventuelles lacunes.\n\nJe vous remercie par avance de votre diligence.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name';
   }
 
@@ -13261,30 +13273,32 @@ class SFr extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nEn raison de la cessation de mes rapports de travail / de mon départ de Suisse (biffer la mention inutile), je vous prie de bien vouloir procéder au transfert de mon avoir de libre passage.\n\nMontant à transférer : la totalité de mon avoir de libre passage à la date de sortie.\n\nEtablissement de destination :\nNom : $toComplete\nIBAN ou numéro de compte : $toComplete\nAdresse : $toComplete\n\nDate de sortie : $toComplete\n\nJe vous remercie de votre diligence et de me confirmer la bonne exécution de ce transfert.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nPar la présente, je me permets de vous adresser les demandes suivantes concernant mon dossier de prévoyance professionnelle :\n\n1. Certificat de prévoyance actualisé $year (avoir de vieillesse, prestations couvertes, taux de conversion applicable)\n\n2. Confirmation de ma capacité de rachat (montant maximal selon l\'art. 79b LPP)\n\n3. Simulation de retraite anticipée (projection de l\'avoir et de la rente à 63 et 64 ans, le cas échéant)\n\nJe vous remercie par avance de votre diligence et reste à votre disposition pour tout complément d\'information.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name\n$policeNumber';
   }
 
@@ -15265,7 +15279,10 @@ class SFr extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mois';
   }
 
@@ -18967,7 +18984,9 @@ class SFr extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Revenu estimé à la retraite : $totalMonthly CHF/mois vs $currentMonthly CHF/mois actuellement';
   }
 
@@ -19391,8 +19410,13 @@ class SFr extends S {
   String get scoreGaugeSectionPrevoyance => 'Prévoyance';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Score de forme financière. $score sur 100. Niveau $level. Budget $budget, Prévoyance $prevoyance, Patrimoine $patrimoine.';
   }
 
@@ -19481,7 +19505,11 @@ class SFr extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label : $status. Fourchette typique $low à $high';
   }
 
@@ -22303,10 +22331,6 @@ class SFr extends S {
       'Le calcul est posé, l\'idée mérite encore qu\'on en parle.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint te dit ce que personne n\'a intérêt à te dire. Sur tes assurances, ton 3a, ton salaire, ton bail, ton couple, tes impôts. Calmement. Sans te vendre quoi que ce soit.';
-
-  @override
   String get landingV2Cta => 'Continuer (sans compte)';
 
   @override
@@ -22359,6 +22383,9 @@ class SFr extends S {
 
   @override
   String get landingV2CtaSober => 'Parle à Mint';
+
+  @override
+  String get landingV3Hero => 'Voir clair, décider seul.';
 
   @override
   String get tonChooserTitle => 'Choisis le ton de Mint';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -3393,7 +3393,10 @@ class SIt extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob vale $annualDelta/anno in più di rendita vitalizia, ovvero $monthlyDelta/mese A VITA dopo il pensionamento.';
   }
 
@@ -5453,7 +5456,10 @@ class SIt extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulazione comprendente l\'interesse della cassa ($fundRate %) e il risparmio fiscale distribuito su $staggeringYears anni per un reddito imponibile di CHF $taxableIncome. Il rendimento reale è calcolato sul tuo sforzo netto reale.';
   }
 
@@ -5647,7 +5653,10 @@ class SIt extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'Perdi $amount/mese a vita. Ma guadagni $years ann$plural di libertà.';
   }
 
@@ -5745,7 +5754,10 @@ class SIt extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Confronto forfait fiscale. Imposizione ordinaria: $ordinary. Forfait fiscale: $forfait.';
   }
 
@@ -6631,24 +6643,21 @@ class SIt extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'gennaio',
-        '2': 'febbraio',
-        '3': 'marzo',
-        '4': 'aprile',
-        '5': 'maggio',
-        '6': 'giugno',
-        '7': 'luglio',
-        '8': 'agosto',
-        '9': 'settembre',
-        '10': 'ottobre',
-        '11': 'novembre',
-        '12': 'dicembre',
-        'other': 'mese',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'gennaio',
+      '2': 'febbraio',
+      '3': 'marzo',
+      '4': 'aprile',
+      '5': 'maggio',
+      '6': 'giugno',
+      '7': 'luglio',
+      '8': 'agosto',
+      '9': 'settembre',
+      '10': 'ottobre',
+      '11': 'novembre',
+      '12': 'dicembre',
+      'other': 'mese',
+    });
     return '$_temp0';
   }
 
@@ -7960,7 +7969,9 @@ class SIt extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Le banche svizzere calcolano con un tasso teorico del 5 % (direttiva ASB), anche se il tasso reale di mercato è molto più basso. È un test di resistenza: verificano che potresti sostenere gli oneri se i tassi salissero. I tuoi oneri teorici: $chargesTheoriques/mese. Al tasso di mercato (~1,5 %): $chargesReelles/mese.';
   }
 
@@ -13248,15 +13259,16 @@ class SIt extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nLa prego di volermi inviare un estratto del mio conto individuale AVS (CI) al fine di verificare lo stato dei miei contributi e identificare eventuali lacune.\n\nLa ringrazio anticipatamente per la Sua diligenza.\n\nDistinti saluti,\n\n$name';
   }
 
@@ -13285,30 +13297,32 @@ class SIt extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nA seguito della cessazione del mio rapporto di lavoro / della mia partenza dalla Svizzera (depennare la voce non applicabile), La prego di procedere al trasferimento del mio avere di libero passaggio.\n\nImporto da trasferire: l\'intero avere di libero passaggio alla data di uscita.\n\nIstituto di destinazione:\nNome: $toComplete\nIBAN o numero di conto: $toComplete\nIndirizzo: $toComplete\n\nData di uscita: $toComplete\n\nLa ringrazio per la Sua diligenza e La prego di confermare la buona esecuzione di questo trasferimento.\n\nDistinti saluti,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nCon la presente, mi permetto di sottoporLe le seguenti richieste relative alla mia previdenza professionale:\n\n1. Certificato di previdenza aggiornato $year (avere di vecchiaia, prestazioni coperte, aliquota di conversione applicabile)\n\n2. Conferma della mia capacità di riscatto (importo massimo ai sensi dell\'art. 79b LPP)\n\n3. Simulazione di pensionamento anticipato (proiezione dell\'avere e della rendita a 63 e 64 anni, se applicabile)\n\nLa ringrazio anticipatamente per la Sua diligenza e rimango a disposizione per qualsiasi informazione aggiuntiva.\n\nDistinti saluti,\n\n$name\n$policeNumber';
   }
 
@@ -15309,7 +15323,10 @@ class SIt extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mese';
   }
 
@@ -19024,7 +19041,9 @@ class SIt extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Reddito stimato alla pensione: $totalMonthly CHF/mese vs $currentMonthly CHF/mese attualmente';
   }
 
@@ -19445,8 +19464,13 @@ class SIt extends S {
   String get scoreGaugeSectionPrevoyance => 'Previdenza';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Punteggio di forma finanziaria. $score su 100. Livello $level. Budget $budget, Previdenza $prevoyance, Patrimonio $patrimoine.';
   }
 
@@ -19535,7 +19559,11 @@ class SIt extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label: $status. Intervallo tipico da $low a $high';
   }
 
@@ -22362,10 +22390,6 @@ class SIt extends S {
       'Il calcolo è fatto, l\'idea merita ancora una conversazione.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint ti dice quello che nessuno ha interesse a dirti. Sulle tue assicurazioni, sul tuo 3a, sul tuo stipendio, sul tuo contratto d\'affitto, sulla tua coppia, sulle tue imposte. Con calma. Senza venderti nulla.';
-
-  @override
   String get landingV2Cta => 'Continua (senza account)';
 
   @override
@@ -22418,6 +22442,9 @@ class SIt extends S {
 
   @override
   String get landingV2CtaSober => 'Parla con Mint';
+
+  @override
+  String get landingV3Hero => 'Vedere chiaro, decidere da sé.';
 
   @override
   String get tonChooserTitle => 'Scegli come Mint ti parla';

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -3382,7 +3382,10 @@ class SPt extends S {
 
   @override
   String jobCompareRetirementBody(
-      String betterJob, String annualDelta, String monthlyDelta) {
+    String betterJob,
+    String annualDelta,
+    String monthlyDelta,
+  ) {
     return '$betterJob vale mais $annualDelta/ano em renda vitalícia, ou seja, $monthlyDelta/mês PARA A VIDA após a reforma.';
   }
 
@@ -5441,7 +5444,10 @@ class SPt extends S {
 
   @override
   String simLppBuybackDisclaimer(
-      String fundRate, int staggeringYears, String taxableIncome) {
+    String fundRate,
+    int staggeringYears,
+    String taxableIncome,
+  ) {
     return 'Simulação incluindo o juro da caixa ($fundRate %) e a poupança fiscal distribuída ao longo de $staggeringYears anos para um rendimento tributável de CHF $taxableIncome. O rendimento real é calculado sobre o teu esforço líquido real.';
   }
 
@@ -5634,7 +5640,10 @@ class SPt extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-      String amount, int years, String plural) {
+    String amount,
+    int years,
+    String plural,
+  ) {
     return 'Perdes $amount/mês para a vida. Mas ganhas $years ano$plural de liberdade.';
   }
 
@@ -5732,7 +5741,10 @@ class SPt extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-      String ordinary, String forfait, String savings) {
+    String ordinary,
+    String forfait,
+    String savings,
+  ) {
     return 'Comparação forfait fiscal. Tributação ordinária: $ordinary. Forfait fiscal: $forfait.';
   }
 
@@ -6617,24 +6629,21 @@ class SPt extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(
-      month,
-      {
-        '1': 'janeiro',
-        '2': 'fevereiro',
-        '3': 'março',
-        '4': 'abril',
-        '5': 'maio',
-        '6': 'junho',
-        '7': 'julho',
-        '8': 'agosto',
-        '9': 'setembro',
-        '10': 'outubro',
-        '11': 'novembro',
-        '12': 'dezembro',
-        'other': 'mês',
-      },
-    );
+    String _temp0 = intl.Intl.selectLogic(month, {
+      '1': 'janeiro',
+      '2': 'fevereiro',
+      '3': 'março',
+      '4': 'abril',
+      '5': 'maio',
+      '6': 'junho',
+      '7': 'julho',
+      '8': 'agosto',
+      '9': 'setembro',
+      '10': 'outubro',
+      '11': 'novembro',
+      '12': 'dezembro',
+      'other': 'mês',
+    });
     return '$_temp0';
   }
 
@@ -7944,7 +7953,9 @@ class SPt extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-      String chargesTheoriques, String chargesReelles) {
+    String chargesTheoriques,
+    String chargesReelles,
+  ) {
     return 'Os bancos suíços calculam com uma taxa teórica de 5 % (diretiva ASB), mesmo que a taxa real do mercado seja muito mais baixa. É um teste de resistência: verificam que poderias assumir os encargos se as taxas subissem. Os teus encargos teóricos: $chargesTheoriques/mês. À taxa de mercado (~1,5 %): $chargesReelles/mês.';
   }
 
@@ -13217,15 +13228,16 @@ class SPt extends S {
 
   @override
   String agentLetterAvsExtractBody(
-      String name,
-      String ssn,
-      String address,
-      String postalCity,
-      String avsOrg,
-      String avsAddress,
-      String date,
-      String dateFormatted,
-      String subject) {
+    String name,
+    String ssn,
+    String address,
+    String postalCity,
+    String avsOrg,
+    String avsAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+  ) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nSolicito que me enviem um extrato da minha conta individual AVS (CI) para verificar o estado das minhas contribuições e identificar eventuais lacunas.\n\nAgradeço antecipadamente a vossa diligência.\n\nCom os melhores cumprimentos,\n\n$name';
   }
 
@@ -13253,30 +13265,32 @@ class SPt extends S {
 
   @override
   String agentLetterLppTransferBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisseSource,
-      String caisseCurrentAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String toComplete) {
+    String name,
+    String address,
+    String postalCity,
+    String caisseSource,
+    String caisseCurrentAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String toComplete,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nEm virtude da cessação do meu contrato de trabalho / da minha saída da Suíça (riscar o que não se aplica), solicito que procedam à transferência do meu ter de livre passagem.\n\nMontante a transferir: a totalidade do ter de livre passagem à data de saída.\n\nInstituição de destino:\nNome: $toComplete\nIBAN ou número de conta: $toComplete\nEndereço: $toComplete\n\nData de saída: $toComplete\n\nAgradeço a vossa diligência e solicito confirmação da boa execução desta transferência.\n\nCom os melhores cumprimentos,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-      String name,
-      String address,
-      String postalCity,
-      String caisse,
-      String caisseAddress,
-      String date,
-      String dateFormatted,
-      String subject,
-      String year,
-      String policeNumber) {
+    String name,
+    String address,
+    String postalCity,
+    String caisse,
+    String caisseAddress,
+    String date,
+    String dateFormatted,
+    String subject,
+    String year,
+    String policeNumber,
+  ) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nVenho por este meio submeter os seguintes pedidos relativos ao meu processo de previdência profissional:\n\n1. Certificado de previdência atualizado $year (ter de velhice, prestações cobertas, taxa de conversão aplicável)\n\n2. Confirmação da minha capacidade de resgate (montante máximo nos termos do art. 79b LPP)\n\n3. Simulação de reforma antecipada (projeção do ter e da renda aos 63 e 64 anos, se aplicável)\n\nAgradeço antecipadamente a vossa diligência e fico à disposição para qualquer informação adicional.\n\nCom os melhores cumprimentos,\n\n$name\n$policeNumber';
   }
 
@@ -15268,7 +15282,10 @@ class SPt extends S {
 
   @override
   String disabilityGapAct3Detail(
-      String aiAmount, String lppAmount, String totalAmount) {
+    String aiAmount,
+    String lppAmount,
+    String totalAmount,
+  ) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mês';
   }
 
@@ -18976,7 +18993,9 @@ class SPt extends S {
 
   @override
   String rcReplacementRateExplanation(
-      String totalMonthly, String currentMonthly) {
+    String totalMonthly,
+    String currentMonthly,
+  ) {
     return 'Rendimento estimado na reforma: $totalMonthly CHF/mês vs $currentMonthly CHF/mês atualmente';
   }
 
@@ -19397,8 +19416,13 @@ class SPt extends S {
   String get scoreGaugeSectionPrevoyance => 'Previdência';
 
   @override
-  String scoreGaugeSemanticsLabel(String score, String level, String budget,
-      String prevoyance, String patrimoine) {
+  String scoreGaugeSemanticsLabel(
+    String score,
+    String level,
+    String budget,
+    String prevoyance,
+    String patrimoine,
+  ) {
     return 'Pontuação de forma financeira. $score de 100. Nível $level. Orçamento $budget, Previdência $prevoyance, Património $patrimoine.';
   }
 
@@ -19487,7 +19511,11 @@ class SPt extends S {
 
   @override
   String semanticsBenchmarkMetric(
-      String label, String status, String low, String high) {
+    String label,
+    String status,
+    String low,
+    String high,
+  ) {
     return '$label: $status. Intervalo típico de $low a $high';
   }
 
@@ -22309,10 +22337,6 @@ class SPt extends S {
       'O cálculo está feito, a ideia ainda merece conversa.';
 
   @override
-  String get landingV2Paragraph =>
-      'Mint diz-te o que mais ninguém tem interesse em dizer-te. Sobre os teus seguros, o teu 3a, o teu salário, o teu arrendamento, o teu casal, os teus impostos. Calmamente. Sem te vender nada.';
-
-  @override
   String get landingV2Cta => 'Continuar (sem conta)';
 
   @override
@@ -22365,6 +22389,9 @@ class SPt extends S {
 
   @override
   String get landingV2CtaSober => 'Fala com o Mint';
+
+  @override
+  String get landingV3Hero => 'Ver claro, decidir sozinho.';
 
   @override
   String get tonChooserTitle => 'Escolhe como o Mint te fala';

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -10512,7 +10512,6 @@
   "mtcSummaryWeakAccuracy": "Um número-chave assenta numa hipótese frágil — Mint mantém-se prudente.",
   "mtcSummaryWeakFreshness": "Dados recolhidos há algum tempo — Mint prefere voltar a dizer.",
   "mtcSummaryWeakUnderstanding": "O cálculo está feito, a ideia ainda merece conversa.",
-  "landingV2Paragraph": "Mint diz-te o que mais ninguém tem interesse em dizer-te. Sobre os teus seguros, o teu 3a, o teu salário, o teu arrendamento, o teu casal, os teus impostos. Calmamente. Sem te vender nada.",
   "landingV2Cta": "Continuar (sem conta)",
   "landingV2Privacy": "Nada sai do teu telemóvel até que tu o decidas.",
   "landingV2Legal": "Ferramenta educativa. Não constitui aconselhamento financeiro nos termos da LSFin.",
@@ -10532,6 +10531,10 @@
   },
   "landingV2PromiseSober": "Nós esclarecemos. Tu decides.",
   "landingV2CtaSober": "Fala com o Mint",
+  "landingV3Hero": "Ver claro, decidir sozinho.",
+  "@landingV3Hero": {
+    "description": "Phase 73 v2.10 — Landing v3 editorial hero. Brand line locked by panel."
+  },
   "tonChooserTitle": "Escolhe como o Mint te fala",
   "@tonChooserTitle": {
     "description": "Phase 12-01."

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -1,15 +1,18 @@
 // Phase 7 — L1.7 Landing v2 "calm promise surface".
+// Phase 73 — Landing v3 éditorial (2-pers panel locked, PANEL-VERDICT.md).
 //
 // NON-NEGOTIABLE invariants (enforced by CI gates in tools/checks/):
 //   • No `financial_core` / services / providers / models imports.
 //   • No digits anywhere in this file.
 //   • No retirement / banned-term vocabulary.
 //
-// Spec: .planning/phases/07-l1.7-landing-v2/CONTEXT.md §2 D-01..D-13.
-// Copy is LOCKED in ARB (landingV2Paragraph/Cta/Privacy/Legal).
+// Spec: .planning/phases/07-l1.7-landing-v2/CONTEXT.md §2 D-01..D-13
+//       .planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md §1-§4 (locked).
+// Copy is LOCKED in ARB (landingV3Hero, landingV2CtaSober, landingV2LoginLink, landingV2Legal).
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -88,125 +91,130 @@ class _LandingScreenState extends State<LandingScreen>
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context)!;
-    final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
       backgroundColor: MintColors.warmWhite,
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 560),
+            // Phase 73 PANEL-VERDICT §3: maxWidth 480 (descendu de 560).
+            constraints: const BoxConstraints(maxWidth: 480),
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32),
+              // Phase 73 PANEL-VERDICT §3: padding horizontal 28, vertical 24.
+              padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 24),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  const Spacer(flex: 2),
-                  // Wordmark — long-press routes to /auth/login (D-12 hidden affordance).
-                  Center(
-                    child: Semantics(
-                      header: true,
-                      label: 'MINT',
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onLongPress: () => context.go('/auth/login'),
-                        child: Text(
-                          'MINT',
-                          style: textTheme.titleMedium?.copyWith(
-                            color: MintColors.textPrimary,
-                            fontWeight: FontWeight.w600,
-                            letterSpacing: 4,
+                  // 1. Wordmark — Align(centerLeft), letterSpacing 2 (pas 4),
+                  // inkPrimary. Long-press → /auth/login (D-12 hidden affordance).
+                  FadeTransition(
+                    opacity: _line1Opacity,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Semantics(
+                        header: true,
+                        label: 'MINT',
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onLongPress: () => context.go('/auth/login'),
+                          child: Text(
+                            'MINT',
+                            style: MintTextStyles.brandLogo(
+                              color: MintColors.inkPrimary,
+                            ).copyWith(letterSpacing: 2),
                           ),
                         ),
                       ),
                     ),
                   ),
-                  const SizedBox(height: 40),
-                  // Landing opener (single line — retired the follow-up in
-                  // 2026-04-17; the promise below carries the setup).
-                  FadeTransition(
-                    opacity: _line1Opacity,
-                    child: Text(
-                      l10n.anonymousIntentLine1,
-                      textAlign: TextAlign.center,
-                      style: MintTextStyles.bodyLarge(
-                        color: MintColors.textSecondary,
-                      ),
-                    ),
-                  ),
-                  const Spacer(flex: 2),
-                  // Promise — single sentence (POLISH-01).
+                  // 2. Spacer flex 3.
+                  const Spacer(flex: 3),
+                  // 3. Hero phrase — l10n.landingV3Hero, Fraunces italic 40pt
+                  // w400, height 1.2, letterSpacing -0.4, inkPrimary, center.
                   FadeTransition(
                     opacity: _paragraphOpacity,
                     child: SlideTransition(
                       position: _paragraphOffset,
                       child: Semantics(
                         container: true,
-                        label: l10n.landingV2PromiseSober,
+                        label: l10n.landingV3Hero,
                         child: Text(
-                          l10n.landingV2PromiseSober,
+                          l10n.landingV3Hero,
                           textAlign: TextAlign.center,
-                          style: textTheme.headlineSmall?.copyWith(
-                            color: MintColors.textPrimary,
-                            fontWeight: FontWeight.w500,
-                            height: 1.45,
-                            letterSpacing: -0.2,
+                          style: GoogleFonts.fraunces(
+                            fontSize: 40,
+                            fontStyle: FontStyle.italic,
+                            fontWeight: FontWeight.w400,
+                            height: 1.2,
+                            letterSpacing: -0.4,
+                            color: MintColors.inkPrimary,
                           ),
                         ),
                       ),
                     ),
                   ),
-                  const Spacer(flex: 1),
-                  // CTA (POLISH-01 — no privacy subtitle).
+                  // 4. Spacer flex 4.
+                  const Spacer(flex: 4),
+                  // 5. CTA primaire — FilledButton, RoundedRectangleBorder(14)
+                  // (PAS StadiumBorder), 54pt, ink/porcelaine.
                   FadeTransition(
                     opacity: _ctaOpacity,
                     child: Semantics(
                       button: true,
                       label: l10n.landingV2CtaSober,
                       child: FilledButton(
-                        // Handoff 2 sweep 2026-05-04: warm ink CTA + warm
-                        // porcelaine foreground for the « commencer » primary.
                         style: FilledButton.styleFrom(
                           backgroundColor: MintColors.inkPrimary,
                           foregroundColor: MintColors.porcelaineHero,
-                          minimumSize: const Size.fromHeight(56),
-                          shape: const StadiumBorder(),
-                          textStyle: textTheme.labelLarge,
+                          minimumSize: const Size.fromHeight(54),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                          textStyle: MintTextStyles.titleMedium(
+                            color: MintColors.porcelaineHero,
+                          ),
                         ),
                         onPressed: () => context.go('/start'),
                         child: Text(l10n.landingV2CtaSober),
                       ),
                     ),
                   ),
-                  const Spacer(flex: 2),
-                  // Legal footer (D-04).
+                  // 6. SizedBox 16.
+                  const SizedBox(height: 16),
+                  // 7. Login link — bodySmall(textSecondaryAaa), no underline.
+                  FadeTransition(
+                    opacity: _ctaOpacity,
+                    child: Semantics(
+                      button: true,
+                      label: l10n.landingV2LoginLink,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => context.go('/auth/login'),
+                        child: Text(
+                          l10n.landingV2LoginLink,
+                          textAlign: TextAlign.center,
+                          style: MintTextStyles.bodySmall(
+                            color: MintColors.textSecondaryAaa,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  // 8. Spacer flex 1.
+                  const Spacer(flex: 1),
+                  // 9. Legal footer — labelSmall(textMutedAaa), center.
                   FadeTransition(
                     opacity: _legalOpacity,
                     child: Text(
                       l10n.landingV2Legal,
                       textAlign: TextAlign.center,
-                      style: textTheme.bodySmall?.copyWith(
+                      style: MintTextStyles.labelSmall(
                         color: MintColors.textMutedAaa,
                       ),
                     ),
                   ),
-                  const SizedBox(height: 16),
-                  // AUTH-01: Visible login entry point
-                  FadeTransition(
-                    opacity: _legalOpacity,
-                    child: GestureDetector(
-                      onTap: () => context.go('/auth/login'),
-                      child: Text(
-                        l10n.landingV2LoginLink,
-                        textAlign: TextAlign.center,
-                        style: textTheme.bodySmall?.copyWith(
-                          color: MintColors.textPrimary,
-                          decoration: TextDecoration.underline,
-                          decorationColor: MintColors.textPrimary,
-                        ),
-                      ),
-                    ),
-                  ),
+                  // 10. SizedBox 8.
+                  const SizedBox(height: 8),
                 ],
               ),
             ),

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -1,8 +1,9 @@
 // Phase 7 — Landing v2 smoke + anti-regression tests.
+// Phase 73 — Updated for Landing v3 éditorial (PANEL-VERDICT.md):
+//   hero now `landingV3Hero` « Voir clair, décider seul. ».
 //
 // Asserts:
-//   • The 4 text surfaces render (wordmark, paragraphe-mère, CTA, legal).
-//   • Privacy micro-phrase is present.
+//   • The text surfaces render (wordmark, hero, CTA, legal, login link).
 //   • No banned term (retirement framing, aggressive CTAs) is rendered.
 //   • CTA navigates to /anonymous/intent (walk 2026-04-24 P0-1: pill picker first).
 //   • Reduced-motion fallback renders content on first pump (no wait).
@@ -74,28 +75,27 @@ Widget _wrap({MediaQueryData? mediaQuery}) {
 }
 
 void main() {
-  group('LandingScreen — calm promise surface', () {
-    testWidgets('renders 3 elements: wordmark + promise + CTA + legal',
+  group('LandingScreen — Phase 73 v3 éditorial surface', () {
+    testWidgets('renders elements: wordmark + hero + CTA + login + legal',
         (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
 
       // Wordmark
       expect(find.text('MINT'), findsOneWidget);
-      // Promise — single sentence (POLISH-01)
-      expect(
-        find.textContaining('\u00e9claire'),
-        findsOneWidget,
-      );
-      // CTA — "Commencer" (not "Continuer (sans compte)")
-      expect(find.text('Parle \u00e0 Mint'), findsOneWidget);
-      // No privacy subtitle
+      // Phase 73 hero — landingV3Hero option D, locked.
+      expect(find.text('Voir clair, décider seul.'), findsOneWidget);
+      // CTA — landingV2CtaSober kept (only the line changed, not button copy).
+      expect(find.text('Parle à Mint'), findsOneWidget);
+      // No privacy subtitle.
       expect(
         find.textContaining('Rien ne sort de ton téléphone'),
         findsNothing,
       );
-      // Legal footer
+      // Legal footer.
       expect(find.textContaining('LSFin'), findsOneWidget);
+      // Login link visible.
+      expect(find.text('J’ai déjà un compte'), findsOneWidget);
     });
 
     testWidgets('renders zero banned terms', (tester) async {
@@ -142,12 +142,9 @@ void main() {
       // One extra pump to flush the post-frame callback that jumps to end.
       await tester.pump();
 
-      // Paragraph is present immediately — no animation delay needed.
-      expect(
-        find.textContaining('\u00e9claire'),
-        findsOneWidget,
-      );
-      expect(find.text('Parle \u00e0 Mint'), findsOneWidget);
+      // Hero is present immediately — no animation delay needed.
+      expect(find.text('Voir clair, décider seul.'), findsOneWidget);
+      expect(find.text('Parle à Mint'), findsOneWidget);
     });
   });
 }

--- a/apps/mobile/test/screens/landing_v3_test.dart
+++ b/apps/mobile/test/screens/landing_v3_test.dart
@@ -1,0 +1,179 @@
+// Phase 73 — Landing v3 éditorial structural tests.
+//
+// Validates the panel-locked spec from
+// `.planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md` §3-§4 :
+//   • Hero phrase rendered with Fraunces italic.
+//   • CTA shape = RoundedRectangleBorder(14), NOT StadiumBorder.
+//   • Wordmark letterSpacing = 2 (not 4).
+//   • Long-press wordmark → /auth/login.
+//   • Tap login link → /auth/login.
+//   • Tap CTA → /start (which redirects per FeatureFlags).
+//   • Golden screenshot baseline for fr_CH (skipped first-run).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/screens/landing_screen.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
+
+GoRouter _buildRouter() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const LandingScreen(),
+      ),
+      GoRoute(
+        path: '/start',
+        redirect: (_, __) =>
+            FeatureFlags.enableMvpWedgeOnboarding ? '/onb' : '/anonymous/intent',
+      ),
+      GoRoute(
+        path: '/anonymous/intent',
+        builder: (_, __) => const Scaffold(
+          body: Center(child: Text('ANONYMOUS_INTENT_STUB')),
+        ),
+      ),
+      GoRoute(
+        path: '/onb',
+        builder: (_, __) => const Scaffold(
+          body: Center(child: Text('ONB_STUB')),
+        ),
+      ),
+      GoRoute(
+        path: '/auth/login',
+        builder: (_, __) => const Scaffold(
+          body: Center(child: Text('LOGIN_STUB')),
+        ),
+      ),
+    ],
+  );
+}
+
+Widget _wrap({Locale locale = const Locale('fr')}) {
+  return MaterialApp.router(
+    locale: locale,
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    routerConfig: _buildRouter(),
+  );
+}
+
+void main() {
+  group('Phase 73 — Landing v3 structural panel-lock', () {
+    testWidgets('Test 1: hero renders landingV3Hero in Fraunces italic',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      final heroFinder = find.text('Voir clair, décider seul.');
+      expect(heroFinder, findsOneWidget,
+          reason: 'Phase 73 hero copy must be the locked option D.');
+
+      final heroWidget = tester.widget<Text>(heroFinder);
+      final style = heroWidget.style;
+      expect(style, isNotNull);
+      expect(style!.fontStyle, FontStyle.italic,
+          reason: 'PANEL-VERDICT §3: italic ON.');
+      expect(style.fontSize, 40, reason: 'PANEL-VERDICT §3: fontSize 40.');
+      expect(style.fontWeight, FontWeight.w400,
+          reason: 'PANEL-VERDICT §3: w400.');
+      expect(style.height, closeTo(1.2, 0.001));
+      expect(style.letterSpacing, closeTo(-0.4, 0.001));
+      // Fraunces from Google Fonts ships fontFamily with the family in name.
+      expect(style.fontFamily, contains('Fraunces'),
+          reason: 'PANEL-VERDICT §3: typography = Fraunces.');
+    });
+
+    testWidgets(
+        'Test 2: CTA shape is RoundedRectangleBorder(14), NOT StadiumBorder',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      final filled = tester.widget<FilledButton>(find.byType(FilledButton));
+      final shape = filled.style?.shape?.resolve(<WidgetState>{});
+      expect(shape, isA<RoundedRectangleBorder>(),
+          reason: 'PANEL-VERDICT §4 decision 4: PAS StadiumBorder.');
+      final rounded = shape as RoundedRectangleBorder;
+      final radius = rounded.borderRadius.resolve(TextDirection.ltr).topLeft;
+      expect(radius.x, closeTo(14, 0.001),
+          reason: 'PANEL-VERDICT §4 decision 4: borderRadius 14.');
+    });
+
+    testWidgets('Test 3: wordmark letterSpacing = 2 (not 4)',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      final wordmark = tester.widget<Text>(find.text('MINT'));
+      final ls = wordmark.style?.letterSpacing;
+      expect(ls, isNotNull);
+      expect(ls!, closeTo(2, 0.001),
+          reason: 'PANEL-VERDICT §4 decision 6: letterSpacing 2 (descended from 4).');
+    });
+
+    testWidgets('Test 4: long-press wordmark navigates to /auth/login',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('MINT'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('LOGIN_STUB'), findsOneWidget,
+          reason: 'D-12 long-press hidden affordance preserved.');
+    });
+
+    testWidgets('Test 5: tap login link navigates to /auth/login',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('J’ai déjà un compte'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('LOGIN_STUB'), findsOneWidget);
+    });
+
+    testWidgets('Test 6: tap CTA navigates to /start → /anonymous/intent',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ANONYMOUS_INTENT_STUB'), findsOneWidget,
+          reason:
+              'CTA → /start, which redirects to /anonymous/intent under default FeatureFlags.');
+    });
+
+    // Test 7: Golden baseline. Skipped on first run; flip to false once
+    // a baseline PNG is committed (consistent with Phase 71a/72 pattern).
+    testWidgets('Test 7: landing_v3 golden (fr_CH, iPhone 13 width 390)',
+        (tester) async {
+      tester.view.physicalSize = const Size(390 * 3, 844 * 3);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(LandingScreen),
+        matchesGoldenFile('goldens/landing_v3.png'),
+      );
+    }, skip: true);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 73 of v2.10 — Landing v3 éditorial. Implements the 2-pers panel-locked spec from
[`.planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md`](.planning/phases/73-landing-v3-editorial/PANEL-VERDICT.md).

- **Brand line locked = option D** « Voir clair, décider seul. » (sub-title removed; single line carries everything).
- **Hero typo** = Fraunces italic 40pt w400, height 1.2, letterSpacing -0.4, `inkPrimary`. Italic ON.
- **CTA** = `RoundedRectangleBorder(14)`, NOT StadiumBorder (panel-locked fix).
- **Wordmark** = `Align(centerLeft)`, `letterSpacing: 2` (descendu de 4), `inkPrimary`. Long-press → `/auth/login` preserved.
- **Layout** = maxWidth 480 (descendu de 560), padding `EdgeInsets.symmetric(horizontal: 28, vertical: 24)`, 10 children top-to-bottom per PANEL-VERDICT §3.
- **i18n** = 6 ARB locales (FR/EN/DE/IT/ES/PT) all carry `landingV3Hero`. Orphan `landingV2Paragraph` purged. `landingV2PromiseSober` kept 1 release for rollback safety (retire v2.11).

## Tests

7 new structural tests in `test/screens/landing_v3_test.dart`:

1. Hero text + Fraunces italic + 40pt + w400 + height/letterSpacing/family asserted.
2. CTA shape introspection: `RoundedRectangleBorder(14)`, not StadiumBorder.
3. Wordmark `letterSpacing: 2`.
4. Long-press wordmark → `/auth/login`.
5. Tap login link → `/auth/login`.
6. Tap CTA → `/start` → `/anonymous/intent` (FeatureFlags-driven redirect).
7. Golden `landing_v3.png` (fr_CH, iPhone 13 width 390px) — `skip: true` first-run baseline (consistent with Phase 71a/72 pattern).

Existing `landing_screen_test.dart` updated to assert new hero copy + login-link visibility.

## Verification gates

- `flutter analyze lib/screens/landing_screen.dart test/screens/landing_v3_test.dart test/screens/landing_screen_test.dart` → **0 issues**.
- `flutter analyze lib/` → 15 pre-existing (coach/document_scan/fact_extraction), zero new from Phase 73.
- `python3 tools/checks/banned_terms_arb.py` → **OK — 6 locale(s) clean**.
- `flutter test test/screens/landing_v3_test.dart test/screens/landing_screen_test.dart` → **10/11 green** (1 golden skipped, baseline pending).
- `flutter gen-l10n` regenerated; all 6 `landingV3Hero` getters present.

## Test plan

- [ ] CI green on PR (Flutter analyze, pytest, ARB lint).
- [ ] Visual smoke on iOS sim (fr_CH) — wordmark left + Fraunces italic hero center + 14-radius CTA.
- [ ] Long-press on wordmark routes to `/auth/login`.
- [ ] CTA tap reaches `/anonymous/intent` (Phase 71a flow).
- [ ] Golden baseline regen scheduled for first-run iteration after PR review.