### PR TITLE
feat(phase-81,v2.11): backend eclairage contract — AnonymousChatRequest.archetype + AnonymousChatResponse.eclairage + deterministic emitter (anti phantom contract C2)

### DIFF
--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -42,7 +42,17 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.rate_limit import limiter
 from app.models.anonymous_session import AnonymousSession
-from app.schemas.anonymous_chat import AnonymousChatRequest, AnonymousChatResponse
+from app.schemas.anonymous_chat import (
+    AnonymousChatRequest,
+    AnonymousChatResponse,
+    EclairageSchema,
+)
+from app.services.coach.anonymous_eclairage_emitter import (
+    BannedTermLeak,
+    build_payload as build_eclairage_payload,
+    resolve_pinned_kind,
+    should_emit as should_emit_eclairage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -258,17 +268,48 @@ async def anonymous_chat(
         language=body.language,
     )
 
-    # --- Step 6: Increment message count ---
+    # --- Step 6: Phase 81 ECLB-03 — deterministic eclairage emitter gate ---
+    pre_increment_count = anon_session.message_count
+    pinned_kind = resolve_pinned_kind(body.forced_eclairage_kind)
+    eclairage: Optional[EclairageSchema] = None
+    if should_emit_eclairage(
+        archetype=body.archetype,
+        pre_increment_count=pre_increment_count,
+        pinned_kind=pinned_kind,
+    ):
+        try:
+            eclairage = build_eclairage_payload(
+                archetype=body.archetype,  # type: ignore[arg-type]
+                pinned_kind=pinned_kind,
+            )
+        except BannedTermLeak as leak:
+            # ECLB-04 enforcement — server-side bug, surface as 500 so it's
+            # caught by tests/CI rather than silently shipped to the user.
+            logger.error(
+                "eclairage banned-term leak",
+                extra={
+                    "term": leak.term,
+                    "field": leak.field,
+                    "archetype": body.archetype,
+                },
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Eclairage payload failed compliance check.",
+            )
+
+    # --- Step 7: Increment message count ---
     anon_session.message_count += 1
     db.commit()
 
     new_count = anon_session.message_count
     messages_remaining = MAX_ANONYMOUS_MESSAGES - new_count
 
-    # --- Step 7: Return response ---
+    # --- Step 8: Return response ---
     return AnonymousChatResponse(
         message=result["answer"],
         disclaimers=result["disclaimers"],
         messages_remaining=messages_remaining,
         tokens_used=result["tokens_used"],
+        eclairage=eclairage,
     )

--- a/services/backend/app/schemas/anonymous_chat.py
+++ b/services/backend/app/schemas/anonymous_chat.py
@@ -5,21 +5,132 @@ POST /api/v1/anonymous/chat — anonymous discovery chat with rate limiting.
 
 API convention: camelCase field names via alias_generator, ConfigDict.
 
+Phase 81 (v2.11) — Backend eclairage contract:
+    - AnonymousChatRequest accepts optional `archetype` body field (4 v2.10 slugs).
+    - AnonymousChatResponse carries optional `eclairage: EclairageSchema | None`.
+    - EclairageSchema mirrors `EclairageCardData` consumed by Flutter (Phase 80).
+
 Compliance:
     - LSFin art. 3 (information financiere)
+    - LSFin art. 7-10 (no promise of returns) — eclairage MUST use range, not absolute CHF.
     - LPD art. 6 (protection des donnees)
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
+
+
+# ---------------------------------------------------------------------------
+# Phase 81 — Eclairage payload (anti phantom contract C2)
+# ---------------------------------------------------------------------------
+
+# 4 v2.10 archetype slugs (locked spec REQUIREMENTS.md §ECLB-01).
+ArchetypeSlug = Literal[
+    "julien_swiss",
+    "couple_acheteurs_lausanne",
+    "jeune_diplome_zurich",
+    "cadre_40_55_lpp_rachat",
+]
+
+# Eclairage kinds shipped in v2.11. Extending requires updating the deterministic
+# emitter (services/coach/anonymous_eclairage_emitter.py) AND the Flutter
+# `EclairageCardData.kind` switch.
+EclairageKind = Literal[
+    "fiscal_margin_3a",
+    "lpp_rachat_3a_nantissement",
+]
+
+EclairageRangePeriod = Literal["year", "month", "lifetime"]
+
+
+class EclairageSchema(BaseModel):
+    """Premier Éclairage payload — Phase 81 ECLB-02 + ECLB-04.
+
+    Mirrors Flutter `EclairageCardData` (Phase 80 consumer contract). Field
+    names use snake_case at storage time but are serialized as camelCase via
+    `alias_generator=to_camel` (`chf_range_low` → `chfRangeLow`, etc.) so the
+    mobile client receives the same convention as every other MINT response.
+
+    LSFin compliance (ECLB-04, locked):
+        - chf_range_low + chf_range_high are ALWAYS both set OR both null —
+          a single absolute CHF figure is forbidden (no promise of returns).
+        - lsfin_disclaimer is non-optional (always rendered alongside the card).
+        - banned-terms enforcement is performed at emitter time
+          (anonymous_eclairage_emitter.build_payload), not in this schema —
+          the schema is the contract surface, not the guardrail.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    kind: EclairageKind = Field(
+        ...,
+        description="Insight family. Drives Flutter card template selection.",
+    )
+    headline: str = Field(
+        ...,
+        min_length=1,
+        max_length=80,
+        description="Headline phrase (≤80 chars). Renders as primary card title.",
+    )
+    body: str = Field(
+        ...,
+        min_length=1,
+        max_length=240,
+        description="Body copy (≤240 chars). Two-layer insight (fait + traduction humaine).",
+    )
+    chf_range_low: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Lower bound of conditional CHF range. None if range not applicable.",
+    )
+    chf_range_high: Optional[int] = Field(
+        None,
+        ge=0,
+        description="Upper bound of conditional CHF range. None if range not applicable.",
+    )
+    chf_range_period: EclairageRangePeriod = Field(
+        default="year",
+        description="Period the CHF range applies to.",
+    )
+    soft_account_hint: str = Field(
+        ...,
+        min_length=1,
+        max_length=80,
+        description="Soft hint copy nudging account creation. ≤80 chars, no hard CTA.",
+    )
+    lsfin_disclaimer: str = Field(
+        ...,
+        min_length=1,
+        max_length=240,
+        description="LSFin compliance disclaimer (always rendered, never optional).",
+    )
+
+    @field_validator("chf_range_high")
+    @classmethod
+    def validate_range_paired(cls, v: Optional[int], info) -> Optional[int]:
+        """Enforce ECLB-04: low+high must be both set or both null."""
+        low = info.data.get("chf_range_low")
+        if (low is None) != (v is None):
+            raise ValueError(
+                "chf_range_low and chf_range_high must both be set or both be null "
+                "(LSFin: never absolute CHF, always conditional range)."
+            )
+        if v is not None and low is not None and v < low:
+            raise ValueError("chf_range_high must be >= chf_range_low.")
+        return v
 
 
 class AnonymousChatRequest(BaseModel):
     """Request for anonymous discovery chat.
 
     No authentication required. Limited to 3 messages per device token.
+
+    Phase 81 ECLB-01: optional `archetype` field. When set, the orchestrator
+    consults `MINT_E2E_FORCE_ECLAIRAGE_KIND` (env or `forced_eclairage_kind`
+    body field) to determine whether to emit a deterministic eclairage payload
+    at coach turn 2.
     """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
@@ -47,12 +158,32 @@ class AnonymousChatRequest(BaseModel):
         default="fr",
         description="Langue de la reponse: 'fr', 'de', 'en', 'it'.",
     )
+    archetype: Optional[ArchetypeSlug] = Field(
+        None,
+        description=(
+            "Phase 81 ECLB-01: optional v2.10 archetype slug. When present "
+            "AND turn 2 AND emitter pinned (env or body), backend emits a "
+            "deterministic eclairage payload."
+        ),
+    )
+    forced_eclairage_kind: Optional[EclairageKind] = Field(
+        None,
+        description=(
+            "Phase 81 ECLB-03: optional emitter pin override. When set, takes "
+            "precedence over the MINT_E2E_FORCE_ECLAIRAGE_KIND env var. "
+            "Intended for E2E tests + walker runs."
+        ),
+    )
 
 
 class AnonymousChatResponse(BaseModel):
     """Response for anonymous discovery chat.
 
     Includes compliance disclaimers and remaining message count.
+
+    Phase 81 ECLB-02: optional `eclairage: EclairageSchema | None` field.
+    None when the orchestrator emits free-form prose (default behaviour).
+    Set when archetype is present + emitter is pinned at coach turn 2.
     """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
@@ -75,4 +206,12 @@ class AnonymousChatResponse(BaseModel):
         default=0,
         ge=0,
         description="Estimation de l'utilisation de tokens.",
+    )
+    eclairage: Optional[EclairageSchema] = Field(
+        default=None,
+        description=(
+            "Phase 81 ECLB-02: optional Premier Éclairage payload. None when "
+            "the response is free-form prose. Set when the deterministic "
+            "emitter fires at coach turn 2 with a pinned kind."
+        ),
     )

--- a/services/backend/app/services/coach/anonymous_eclairage_emitter.py
+++ b/services/backend/app/services/coach/anonymous_eclairage_emitter.py
@@ -1,0 +1,274 @@
+"""
+Phase 81 — Deterministic Premier Éclairage emitter (anti phantom contract C2).
+
+When the anonymous chat endpoint is called with:
+    - `archetype` body field set to one of the 4 v2.10 slugs, AND
+    - the coach turn is the 2nd anonymous message (i.e. session.message_count == 1
+      pre-increment), AND
+    - either `MINT_E2E_FORCE_ECLAIRAGE_KIND` env var OR the request body
+      `forced_eclairage_kind` field pins the kind,
+
+…this module returns a deterministic `EclairageSchema` payload. Otherwise the
+orchestrator falls back to free-form LLM prose (status quo).
+
+LSFin compliance (locked, ECLB-04):
+    - Never absolute CHF — always conditional range (low + high).
+    - LSFin disclaimer always present.
+    - Banned-terms list expanded (3-piliers panel) — emitter aborts if any
+      template renders a banned term.
+
+Banned terms (Phase 81, panel-locked superset):
+    Legacy V1: garanti / garantie / garantis / garantito / guaranteed / optimal /
+    optimale / parfait / parfaite / certain (context-aware) / assuré / assurée /
+    sans risque
+    3-piliers expansion: idéal / idéale / il faut / vous économiserez /
+    rentable / profiter de / opportunité / sûr (context-aware) / avantage fiscal seul
+
+References:
+    - .planning/REQUIREMENTS.md §ECLB-01..05
+    - .planning/ROADMAP.md §Phase 81
+"""
+
+from __future__ import annotations
+
+import os
+import unicodedata
+from typing import Optional
+
+from app.schemas.anonymous_chat import (
+    ArchetypeSlug,
+    EclairageKind,
+    EclairageSchema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Banned-terms (ECLB-04) — emitter-side enforcement
+# ---------------------------------------------------------------------------
+
+# Stored in normalized (NFC, lowercase) form. `_normalize` applies the same
+# transform before substring search to avoid accent/case bypasses.
+BANNED_TERMS_ECLAIRAGE: tuple[str, ...] = (
+    # Legacy V1 (LSFin top-3)
+    "garanti",
+    "garantie",
+    "garantis",
+    "garanties",
+    "garantito",
+    "guaranteed",
+    "optimal",
+    "optimale",
+    "optimaux",
+    "optimales",
+    "parfait",
+    "parfaite",
+    "parfaits",
+    "parfaites",
+    "assuré",
+    "assurée",
+    "assurés",
+    "assurées",
+    "sans risque",
+    "meilleur",
+    "meilleure",
+    "meilleurs",
+    "meilleures",
+    # 3-piliers expansion (Phase 81 panel-locked)
+    "idéal",
+    "idéale",
+    "idéaux",
+    "idéales",
+    "il faut",
+    "vous économiserez",
+    "tu économiseras",
+    "rentable",
+    "profiter de",
+    "opportunité",
+    "avantage fiscal seul",
+)
+
+
+def _normalize(text: str) -> str:
+    """Lowercase + NFC-normalize a string for banned-term substring search."""
+    return unicodedata.normalize("NFC", text).lower()
+
+
+class BannedTermLeak(ValueError):
+    """Raised when a deterministic eclairage template renders a banned term."""
+
+    def __init__(self, term: str, field: str, content: str) -> None:
+        self.term = term
+        self.field = field
+        super().__init__(
+            f"banned term '{term}' detected in eclairage.{field}: {content!r}"
+        )
+
+
+def _assert_clean(value: str, field: str) -> None:
+    """Assert ECLB-04 — no banned term in `value`. Raise BannedTermLeak otherwise."""
+    haystack = _normalize(value)
+    for term in BANNED_TERMS_ECLAIRAGE:
+        if _normalize(term) in haystack:
+            raise BannedTermLeak(term=term, field=field, content=value)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic templates
+# ---------------------------------------------------------------------------
+
+# Templates are LSFin-compliant by construction: every CHF reference is a
+# range (low+high), every payload carries the standard discovery disclaimer.
+# Headlines ≤ 80, body ≤ 240, soft_account_hint ≤ 80 enforced by the
+# `EclairageSchema` Pydantic validator.
+
+_LSFIN_DISCLAIMER_FR = (
+    "Information éducative uniquement. Ne constitue pas un conseil financier "
+    "personnalisé (LSFin art. 3). Les montants dépendent de ta situation."
+)
+
+
+def _template_fiscal_margin_3a() -> EclairageSchema:
+    """Deterministic template for `fiscal_margin_3a`.
+
+    3-piliers panel verdict: default insight when archetype == julien_swiss
+    or any archetype lacking an emitter pin.
+    """
+    payload = EclairageSchema(
+        kind="fiscal_margin_3a",
+        headline="Une marge fiscale 3a souvent invisible",
+        body=(
+            "Verser sur un 3a peut faire baisser ton revenu imposable cette "
+            "année. Selon ton revenu et ton canton, l'économie d'impôt "
+            "pourrait s'inscrire dans une fourchette annuelle conditionnelle."
+        ),
+        chf_range_low=600,
+        chf_range_high=2_400,
+        chf_range_period="year",
+        soft_account_hint="Crée un compte pour estimer ta fourchette personnelle.",
+        lsfin_disclaimer=_LSFIN_DISCLAIMER_FR,
+    )
+    _validate_payload(payload)
+    return payload
+
+
+def _template_lpp_rachat_3a_nantissement() -> EclairageSchema:
+    """Deterministic template for `lpp_rachat_3a_nantissement`.
+
+    Used by archetype `cadre_40_55_lpp_rachat` and explicit pin.
+    """
+    payload = EclairageSchema(
+        kind="lpp_rachat_3a_nantissement",
+        headline="Rachat LPP + 3a nantissement, l'angle mort",
+        body=(
+            "Un rachat LPP combiné à un 3a nanti pourrait, dans certains cas, "
+            "changer la fenêtre fiscale d'une année donnée. L'impact dépend "
+            "de ton 2e pilier, ton revenu et ton canton."
+        ),
+        chf_range_low=1_500,
+        chf_range_high=12_000,
+        chf_range_period="year",
+        soft_account_hint="Ouvre un compte pour cadrer la fenêtre.",
+        lsfin_disclaimer=_LSFIN_DISCLAIMER_FR,
+    )
+    _validate_payload(payload)
+    return payload
+
+
+_TEMPLATES = {
+    "fiscal_margin_3a": _template_fiscal_margin_3a,
+    "lpp_rachat_3a_nantissement": _template_lpp_rachat_3a_nantissement,
+}
+
+
+# ---------------------------------------------------------------------------
+# Archetype → default kind mapping
+# ---------------------------------------------------------------------------
+
+# When the request carries an archetype but no explicit emitter pin (env or
+# body), this map decides which deterministic kind to emit. v2.11 ships
+# `fiscal_margin_3a` for 3 of 4 archetypes (3-piliers panel verdict —
+# the « default insight » that surprises a new visitor) and the bespoke
+# rachat-LPP template for the cadre_40_55 archetype.
+_ARCHETYPE_DEFAULT_KIND: dict[ArchetypeSlug, EclairageKind] = {
+    "julien_swiss": "fiscal_margin_3a",
+    "couple_acheteurs_lausanne": "fiscal_margin_3a",
+    "jeune_diplome_zurich": "fiscal_margin_3a",
+    "cadre_40_55_lpp_rachat": "lpp_rachat_3a_nantissement",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API — called by the anonymous_chat endpoint
+# ---------------------------------------------------------------------------
+
+
+def resolve_pinned_kind(
+    forced_eclairage_kind_body: Optional[str],
+) -> Optional[EclairageKind]:
+    """Resolve the emitter pin from request body OR env var.
+
+    Body field takes precedence over env (matches Flutter client semantics
+    where dart-define and runtime override coexist). Returns None when neither
+    is set OR when the value is not a recognized kind.
+    """
+    if forced_eclairage_kind_body and forced_eclairage_kind_body in _TEMPLATES:
+        return forced_eclairage_kind_body  # type: ignore[return-value]
+    env_value = os.environ.get("MINT_E2E_FORCE_ECLAIRAGE_KIND")
+    if env_value and env_value in _TEMPLATES:
+        return env_value  # type: ignore[return-value]
+    return None
+
+
+def should_emit(
+    *,
+    archetype: Optional[ArchetypeSlug],
+    pre_increment_count: int,
+    pinned_kind: Optional[EclairageKind],
+) -> bool:
+    """Phase 81 ECLB-03 gate.
+
+    Emit deterministic payload only when:
+        1. archetype is set (one of the 4 v2.10 slugs), AND
+        2. the request is the 2nd anonymous message — `pre_increment_count == 1`
+           (0-based: 0 = turn 1, 1 = turn 2), AND
+        3. the emitter is pinned via env or body.
+    """
+    if archetype is None:
+        return False
+    if pre_increment_count != 1:
+        return False
+    if pinned_kind is None:
+        return False
+    return True
+
+
+def build_payload(
+    *,
+    archetype: ArchetypeSlug,
+    pinned_kind: Optional[EclairageKind] = None,
+) -> EclairageSchema:
+    """Build the deterministic eclairage payload.
+
+    Resolution order for `kind`:
+        1. explicit `pinned_kind` (env or body) if provided.
+        2. archetype default from `_ARCHETYPE_DEFAULT_KIND`.
+
+    LSFin enforcement (ECLB-04) is performed inside each template via
+    `_validate_payload`. A banned-term leak raises `BannedTermLeak` which the
+    endpoint promotes to a 500 (panel-locked: a leak is a server bug, not a
+    client error).
+    """
+    if pinned_kind is not None:
+        kind: EclairageKind = pinned_kind
+    else:
+        kind = _ARCHETYPE_DEFAULT_KIND[archetype]
+    builder = _TEMPLATES[kind]
+    return builder()
+
+
+def _validate_payload(payload: EclairageSchema) -> None:
+    """ECLB-04 enforcement — assert no banned term in any user-visible text."""
+    _assert_clean(payload.headline, "headline")
+    _assert_clean(payload.body, "body")
+    _assert_clean(payload.soft_account_hint, "soft_account_hint")
+    _assert_clean(payload.lsfin_disclaimer, "lsfin_disclaimer")

--- a/services/backend/tests/api/test_anonymous_chat_eclairage.py
+++ b/services/backend/tests/api/test_anonymous_chat_eclairage.py
@@ -1,0 +1,532 @@
+"""
+Phase 81 — Backend eclairage contract tests.
+
+Covers REQUIREMENTS.md §ECLB-01..05 (anti phantom contract C2):
+    - ECLB-01: AnonymousChatRequest accepts optional `archetype` Literal field.
+    - ECLB-02: AnonymousChatResponse carries optional `eclairage: EclairageSchema | None`.
+    - ECLB-03: Backend orchestrator emits deterministic payload at coach turn 2
+      when archetype is set AND emitter is pinned (env or body field).
+    - ECLB-04: LSFin compliance — never absolute CHF (always low+high range),
+      LSFin disclaimer always present, expanded banned-terms list rejected.
+    - ECLB-05: pytest asserts `POST /api/v1/anonymous/chat
+      {"message": "ok", "archetype": "julien_swiss"}` (turn 2) returns
+      `eclairage.kind == "fiscal_margin_3a"`.
+
+Run:
+    cd services/backend && python -m pytest tests/api/test_anonymous_chat_eclairage.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ["TESTING"] = "1"
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-anonymous-key")
+
+from app.core.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas.anonymous_chat import (  # noqa: E402
+    AnonymousChatRequest,
+    AnonymousChatResponse,
+    EclairageSchema,
+)
+from app.services.coach.anonymous_eclairage_emitter import (  # noqa: E402
+    BannedTermLeak,
+    BANNED_TERMS_ECLAIRAGE,
+    build_payload,
+    resolve_pinned_kind,
+    should_emit,
+    _validate_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test DB setup — isolated SQLite per-file (mirrors test_anonymous_chat.py)
+# ---------------------------------------------------------------------------
+
+TEST_DB_URL = "sqlite:///./test_anonymous_chat_eclairage.db"
+test_engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
+
+
+def override_get_db():
+    db = TestSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=test_engine)
+    app.dependency_overrides[get_db] = override_get_db
+    yield
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=test_engine)
+
+
+@pytest.fixture(autouse=True)
+def clear_force_eclairage_env(monkeypatch):
+    """Ensure MINT_E2E_FORCE_ECLAIRAGE_KIND is never inherited from the shell."""
+    monkeypatch.delenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", raising=False)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+_MOCK_LLM_RESULT = {
+    "answer": "En Suisse, le 2e pilier reste un actif sous-estime.",
+    "sources": [],
+    "disclaimers": ["Outil educatif, ne constitue pas un conseil financier (LSFin)."],
+    "tokens_used": 100,
+}
+
+_SESSION_HEADER = "X-Anonymous-Session"
+_SESSION_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+# ---------------------------------------------------------------------------
+# ECLB-01 — Request schema accepts archetype Literal
+# ---------------------------------------------------------------------------
+
+
+def test_eclb01_request_accepts_archetype_literal():
+    """Optional archetype field accepts the 4 v2.10 slugs."""
+    for slug in [
+        "julien_swiss",
+        "couple_acheteurs_lausanne",
+        "jeune_diplome_zurich",
+        "cadre_40_55_lpp_rachat",
+    ]:
+        req = AnonymousChatRequest(message="ok", archetype=slug)
+        assert req.archetype == slug
+
+
+def test_eclb01_request_rejects_unknown_archetype():
+    """Unknown archetype slug raises Pydantic validation error."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AnonymousChatRequest(message="ok", archetype="unknown_archetype")
+
+
+def test_eclb01_request_archetype_is_optional():
+    """Archetype is optional and defaults to None."""
+    req = AnonymousChatRequest(message="ok")
+    assert req.archetype is None
+
+
+def test_eclb01_request_accepts_camelcase_archetype_alias():
+    """camelCase serialization round-trip works (alias_generator=to_camel)."""
+    req = AnonymousChatRequest.model_validate({
+        "message": "ok",
+        "archetype": "julien_swiss",
+    })
+    dumped = req.model_dump(by_alias=True)
+    assert dumped["archetype"] == "julien_swiss"
+
+
+# ---------------------------------------------------------------------------
+# ECLB-02 — Response schema carries optional eclairage payload
+# ---------------------------------------------------------------------------
+
+
+def test_eclb02_response_eclairage_optional():
+    """Eclairage field is optional and defaults to None."""
+    resp = AnonymousChatResponse(
+        message="hi",
+        disclaimers=[],
+        messages_remaining=2,
+    )
+    assert resp.eclairage is None
+
+
+def test_eclb02_response_eclairage_round_trip_camelcase():
+    """EclairageSchema serializes with camelCase aliases for Flutter consumer."""
+    payload = EclairageSchema(
+        kind="fiscal_margin_3a",
+        headline="Une marge fiscale 3a souvent invisible",
+        body="Verser sur un 3a peut faire baisser ton revenu imposable.",
+        chf_range_low=600,
+        chf_range_high=2_400,
+        chf_range_period="year",
+        soft_account_hint="Crée un compte pour ta fourchette personnelle.",
+        lsfin_disclaimer="Information educative uniquement.",
+    )
+    resp = AnonymousChatResponse(
+        message="hi",
+        disclaimers=[],
+        messages_remaining=1,
+        eclairage=payload,
+    )
+    dumped = resp.model_dump(by_alias=True)
+    assert dumped["eclairage"]["kind"] == "fiscal_margin_3a"
+    assert dumped["eclairage"]["chfRangeLow"] == 600
+    assert dumped["eclairage"]["chfRangeHigh"] == 2_400
+    assert dumped["eclairage"]["chfRangePeriod"] == "year"
+    assert dumped["eclairage"]["softAccountHint"]
+    assert dumped["eclairage"]["lsfinDisclaimer"]
+
+
+def test_eclb02_eclairage_kind_literal_enforced():
+    """Unknown eclairage.kind raises Pydantic validation error."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        EclairageSchema(
+            kind="not_a_real_kind",
+            headline="x",
+            body="x",
+            chf_range_period="year",
+            soft_account_hint="x",
+            lsfin_disclaimer="x",
+        )
+
+
+# ---------------------------------------------------------------------------
+# ECLB-03 — Orchestrator emits at coach turn 2 when archetype + pin present
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query",
+    new_callable=AsyncMock,
+)
+def test_eclb03_emits_at_turn2_with_env_pin(mock_query, client, monkeypatch):
+    """Env-var pin + archetype + turn 2 → eclairage payload present."""
+    mock_query.return_value = _MOCK_LLM_RESULT
+    monkeypatch.setenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", "fiscal_margin_3a")
+
+    # Turn 1 — no eclairage (gate: pre_increment_count == 0)
+    resp1 = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok", "archetype": "julien_swiss"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert resp1.status_code == 200
+    assert resp1.json().get("eclairage") is None
+
+    # Turn 2 — emitter fires
+    resp2 = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok", "archetype": "julien_swiss"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert resp2.status_code == 200
+    eclairage = resp2.json().get("eclairage")
+    assert eclairage is not None
+    assert eclairage["kind"] == "fiscal_margin_3a"
+
+
+@patch(
+    "app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query",
+    new_callable=AsyncMock,
+)
+def test_eclb03_emits_at_turn2_with_body_pin(mock_query, client):
+    """Body `forcedEclairageKind` pin + archetype + turn 2 → eclairage emitted."""
+    mock_query.return_value = _MOCK_LLM_RESULT
+
+    # Burn turn 1
+    client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok", "archetype": "julien_swiss"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+
+    # Turn 2 with body pin (camelCase via alias_generator)
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={
+            "message": "ok",
+            "archetype": "cadre_40_55_lpp_rachat",
+            "forcedEclairageKind": "lpp_rachat_3a_nantissement",
+        },
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert resp.status_code == 200
+    eclairage = resp.json().get("eclairage")
+    assert eclairage is not None
+    assert eclairage["kind"] == "lpp_rachat_3a_nantissement"
+
+
+@patch(
+    "app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query",
+    new_callable=AsyncMock,
+)
+def test_eclb03_no_emit_without_archetype(mock_query, client, monkeypatch):
+    """Pin + no archetype → free-form response (eclairage None)."""
+    mock_query.return_value = _MOCK_LLM_RESULT
+    monkeypatch.setenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", "fiscal_margin_3a")
+
+    # Turn 1
+    client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    # Turn 2 — no archetype → no emission
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("eclairage") is None
+
+
+@patch(
+    "app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query",
+    new_callable=AsyncMock,
+)
+def test_eclb03_no_emit_without_pin(mock_query, client):
+    """Archetype but no pin → free-form (eclairage None)."""
+    mock_query.return_value = _MOCK_LLM_RESULT
+
+    # Turn 1
+    client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok", "archetype": "julien_swiss"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    # Turn 2, no pin
+    resp = client.post(
+        "/api/v1/anonymous/chat",
+        json={"message": "ok", "archetype": "julien_swiss"},
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert resp.status_code == 200
+    assert resp.json().get("eclairage") is None
+
+
+def test_eclb03_should_emit_gate_unit():
+    """Unit-test the should_emit gate matrix."""
+    assert should_emit(
+        archetype="julien_swiss",
+        pre_increment_count=1,
+        pinned_kind="fiscal_margin_3a",
+    )
+    # No archetype
+    assert not should_emit(
+        archetype=None,
+        pre_increment_count=1,
+        pinned_kind="fiscal_margin_3a",
+    )
+    # No pin
+    assert not should_emit(
+        archetype="julien_swiss",
+        pre_increment_count=1,
+        pinned_kind=None,
+    )
+    # Wrong turn
+    assert not should_emit(
+        archetype="julien_swiss",
+        pre_increment_count=0,
+        pinned_kind="fiscal_margin_3a",
+    )
+    assert not should_emit(
+        archetype="julien_swiss",
+        pre_increment_count=2,
+        pinned_kind="fiscal_margin_3a",
+    )
+
+
+def test_eclb03_resolve_pinned_kind_body_wins(monkeypatch):
+    """Body pin takes precedence over env pin."""
+    monkeypatch.setenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", "fiscal_margin_3a")
+    assert resolve_pinned_kind("lpp_rachat_3a_nantissement") == (
+        "lpp_rachat_3a_nantissement"
+    )
+
+
+def test_eclb03_resolve_pinned_kind_invalid_returns_none(monkeypatch):
+    """Invalid pin values resolve to None (defensive)."""
+    monkeypatch.setenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", "garbage_value")
+    assert resolve_pinned_kind(None) is None
+    assert resolve_pinned_kind("also_garbage") is None
+
+
+# ---------------------------------------------------------------------------
+# ECLB-04 — LSFin compliance
+# ---------------------------------------------------------------------------
+
+
+def test_eclb04_chf_range_pair_required():
+    """chf_range_low + chf_range_high must both be set or both null."""
+    from pydantic import ValidationError
+
+    # Only low set — invalid
+    with pytest.raises(ValidationError):
+        EclairageSchema(
+            kind="fiscal_margin_3a",
+            headline="x",
+            body="x",
+            chf_range_low=100,
+            chf_range_high=None,
+            chf_range_period="year",
+            soft_account_hint="x",
+            lsfin_disclaimer="x",
+        )
+    # Only high set — invalid
+    with pytest.raises(ValidationError):
+        EclairageSchema(
+            kind="fiscal_margin_3a",
+            headline="x",
+            body="x",
+            chf_range_low=None,
+            chf_range_high=200,
+            chf_range_period="year",
+            soft_account_hint="x",
+            lsfin_disclaimer="x",
+        )
+
+
+def test_eclb04_chf_range_high_must_be_gte_low():
+    """chf_range_high >= chf_range_low (sanity)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        EclairageSchema(
+            kind="fiscal_margin_3a",
+            headline="x",
+            body="x",
+            chf_range_low=500,
+            chf_range_high=100,
+            chf_range_period="year",
+            soft_account_hint="x",
+            lsfin_disclaimer="x",
+        )
+
+
+def test_eclb04_lsfin_disclaimer_non_empty():
+    """LSFin disclaimer is required (min_length=1)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        EclairageSchema(
+            kind="fiscal_margin_3a",
+            headline="x",
+            body="x",
+            chf_range_period="year",
+            soft_account_hint="x",
+            lsfin_disclaimer="",
+        )
+
+
+def test_eclb04_built_payload_always_carries_disclaimer():
+    """Every emitter template renders a non-empty LSFin disclaimer."""
+    for slug in [
+        "julien_swiss",
+        "couple_acheteurs_lausanne",
+        "jeune_diplome_zurich",
+        "cadre_40_55_lpp_rachat",
+    ]:
+        payload = build_payload(archetype=slug)
+        assert payload.lsfin_disclaimer
+        assert "LSFin" in payload.lsfin_disclaimer or "éducative" in payload.lsfin_disclaimer.lower()
+
+
+def test_eclb04_built_payload_always_uses_range():
+    """Every emitter template emits chf_range_low + chf_range_high paired."""
+    for slug in [
+        "julien_swiss",
+        "couple_acheteurs_lausanne",
+        "jeune_diplome_zurich",
+        "cadre_40_55_lpp_rachat",
+    ]:
+        payload = build_payload(archetype=slug)
+        assert payload.chf_range_low is not None
+        assert payload.chf_range_high is not None
+        assert payload.chf_range_high >= payload.chf_range_low
+
+
+def test_eclb04_banned_terms_expanded_panel_locked():
+    """Banned-terms list contains the panel-locked superset."""
+    expected_present = {
+        "garanti",
+        "optimal",
+        "parfait",
+        "sans risque",
+        "idéal",
+        "il faut",
+        "rentable",
+        "profiter de",
+        "opportunité",
+    }
+    norm = {t.lower() for t in BANNED_TERMS_ECLAIRAGE}
+    missing = expected_present - norm
+    assert not missing, f"missing banned terms: {missing}"
+
+
+def test_eclb04_emitter_rejects_banned_term_leak():
+    """A leaking template raises BannedTermLeak."""
+    leaky = EclairageSchema(
+        kind="fiscal_margin_3a",
+        headline="C'est idéal pour toi",  # banned: idéal
+        body="ok",
+        chf_range_low=1,
+        chf_range_high=2,
+        chf_range_period="year",
+        soft_account_hint="ok",
+        lsfin_disclaimer="ok",
+    )
+    with pytest.raises(BannedTermLeak) as exc_info:
+        _validate_payload(leaky)
+    assert exc_info.value.field == "headline"
+
+
+# ---------------------------------------------------------------------------
+# ECLB-05 — Locked spec assertion (REQUIREMENTS.md)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "app.api.v1.endpoints.anonymous_chat._NoRagOrchestrator.query",
+    new_callable=AsyncMock,
+)
+def test_eclb05_locked_spec_julien_swiss_turn2_returns_fiscal_margin_3a(
+    mock_query, client, monkeypatch
+):
+    """REQUIREMENTS.md §ECLB-05.
+
+    POST /api/v1/anonymous/chat with body {"message": "ok", "archetype":
+    "julien_swiss"} on coach turn 2 returns a response whose
+    eclairage.kind == "fiscal_margin_3a" (deterministic).
+
+    Pin is provided via env var MINT_E2E_FORCE_ECLAIRAGE_KIND, matching the
+    Railway-staging E2E setup described in the spec.
+    """
+    mock_query.return_value = _MOCK_LLM_RESULT
+    monkeypatch.setenv("MINT_E2E_FORCE_ECLAIRAGE_KIND", "fiscal_margin_3a")
+
+    body = {"message": "ok", "archetype": "julien_swiss"}
+
+    # Turn 1 — burns the first message, no eclairage emitted yet.
+    r1 = client.post(
+        "/api/v1/anonymous/chat",
+        json=body,
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert r1.status_code == 200
+
+    # Turn 2 — locked-spec assertion.
+    r2 = client.post(
+        "/api/v1/anonymous/chat",
+        json=body,
+        headers={_SESSION_HEADER: _SESSION_ID},
+    )
+    assert r2.status_code == 200
+    data = r2.json()
+    assert data.get("eclairage") is not None
+    assert data["eclairage"]["kind"] == "fiscal_margin_3a"
+    assert data["eclairage"]["chfRangeLow"] is not None
+    assert data["eclairage"]["chfRangeHigh"] is not None
+    assert data["eclairage"]["lsfinDisclaimer"]

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -1250,8 +1250,42 @@
         "type": "object"
       },
       "AnonymousChatRequest": {
-        "description": "Request for anonymous discovery chat.\n\nNo authentication required. Limited to 3 messages per device token.",
+        "description": "Request for anonymous discovery chat.\n\nNo authentication required. Limited to 3 messages per device token.\n\nPhase 81 ECLB-01: optional `archetype` field. When set, the orchestrator\nconsults `MINT_E2E_FORCE_ECLAIRAGE_KIND` (env or `forced_eclairage_kind`\nbody field) to determine whether to emit a deterministic eclairage payload\nat coach turn 2.",
         "properties": {
+          "archetype": {
+            "anyOf": [
+              {
+                "enum": [
+                  "julien_swiss",
+                  "couple_acheteurs_lausanne",
+                  "jeune_diplome_zurich",
+                  "cadre_40_55_lpp_rachat"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Phase 81 ECLB-01: optional v2.10 archetype slug. When present AND turn 2 AND emitter pinned (env or body), backend emits a deterministic eclairage payload.",
+            "title": "Archetype"
+          },
+          "forcedEclairageKind": {
+            "anyOf": [
+              {
+                "enum": [
+                  "fiscal_margin_3a",
+                  "lpp_rachat_3a_nantissement"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Phase 81 ECLB-03: optional emitter pin override. When set, takes precedence over the MINT_E2E_FORCE_ECLAIRAGE_KIND env var. Intended for E2E tests + walker runs.",
+            "title": "Forcedeclairagekind"
+          },
           "intent": {
             "anyOf": [
               {
@@ -1285,7 +1319,7 @@
         "type": "object"
       },
       "AnonymousChatResponse": {
-        "description": "Response for anonymous discovery chat.\n\nIncludes compliance disclaimers and remaining message count.",
+        "description": "Response for anonymous discovery chat.\n\nIncludes compliance disclaimers and remaining message count.\n\nPhase 81 ECLB-02: optional `eclairage: EclairageSchema | None` field.\nNone when the orchestrator emits free-form prose (default behaviour).\nSet when archetype is present + emitter is pinned at coach turn 2.",
         "properties": {
           "disclaimers": {
             "description": "Disclaimers de conformite.",
@@ -1294,6 +1328,17 @@
             },
             "title": "Disclaimers",
             "type": "array"
+          },
+          "eclairage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EclairageSchema"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Phase 81 ECLB-02: optional Premier Éclairage payload. None when the response is free-form prose. Set when the deterministic emitter fires at coach turn 2 with a pinned kind."
           },
           "message": {
             "description": "Reponse du coach en mode decouverte.",
@@ -8653,6 +8698,94 @@
           "disclaimer"
         ],
         "title": "EPLResponse",
+        "type": "object"
+      },
+      "EclairageSchema": {
+        "description": "Premier Éclairage payload — Phase 81 ECLB-02 + ECLB-04.\n\nMirrors Flutter `EclairageCardData` (Phase 80 consumer contract). Field\nnames use snake_case at storage time but are serialized as camelCase via\n`alias_generator=to_camel` (`chf_range_low` → `chfRangeLow`, etc.) so the\nmobile client receives the same convention as every other MINT response.\n\nLSFin compliance (ECLB-04, locked):\n    - chf_range_low + chf_range_high are ALWAYS both set OR both null —\n      a single absolute CHF figure is forbidden (no promise of returns).\n    - lsfin_disclaimer is non-optional (always rendered alongside the card).\n    - banned-terms enforcement is performed at emitter time\n      (anonymous_eclairage_emitter.build_payload), not in this schema —\n      the schema is the contract surface, not the guardrail.",
+        "properties": {
+          "body": {
+            "description": "Body copy (≤240 chars). Two-layer insight (fait + traduction humaine).",
+            "maxLength": 240,
+            "minLength": 1,
+            "title": "Body",
+            "type": "string"
+          },
+          "chfRangeHigh": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Upper bound of conditional CHF range. None if range not applicable.",
+            "title": "Chfrangehigh"
+          },
+          "chfRangeLow": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lower bound of conditional CHF range. None if range not applicable.",
+            "title": "Chfrangelow"
+          },
+          "chfRangePeriod": {
+            "default": "year",
+            "description": "Period the CHF range applies to.",
+            "enum": [
+              "year",
+              "month",
+              "lifetime"
+            ],
+            "title": "Chfrangeperiod",
+            "type": "string"
+          },
+          "headline": {
+            "description": "Headline phrase (≤80 chars). Renders as primary card title.",
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Headline",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Insight family. Drives Flutter card template selection.",
+            "enum": [
+              "fiscal_margin_3a",
+              "lpp_rachat_3a_nantissement"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "lsfinDisclaimer": {
+            "description": "LSFin compliance disclaimer (always rendered, never optional).",
+            "maxLength": 240,
+            "minLength": 1,
+            "title": "Lsfindisclaimer",
+            "type": "string"
+          },
+          "softAccountHint": {
+            "description": "Soft hint copy nudging account creation. ≤80 chars, no hard CTA.",
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Softaccounthint",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "headline",
+          "body",
+          "softAccountHint",
+          "lsfinDisclaimer"
+        ],
+        "title": "EclairageSchema",
         "type": "object"
       },
       "EmailVerificationConfirmRequest": {


### PR DESCRIPTION
## Summary

Phase 81 of milestone v2.11. Closes phantom contract **C2** identified in
audit B (2026-05-05) — the `eclairage` field assumed by PR #486 was never
actually shipped on `origin/dev`. This PR ships the concrete backend half
of the eclairage contract so the v2.11 walker (Phase 82) and the Phase 80
Flutter consumer can finally rely on a real surface.

- **Schemas** (`services/backend/app/schemas/anonymous_chat.py`): adds
  optional `archetype` Literal (4 v2.10 slugs) + optional
  `forced_eclairage_kind` to `AnonymousChatRequest`; adds optional
  `eclairage: EclairageSchema | None` to `AnonymousChatResponse`. Field
  names serialize as camelCase via `alias_generator=to_camel` (Flutter
  consumes `chfRangeLow`, `forcedEclairageKind`, etc.).
- **Deterministic emitter** (`services/backend/app/services/coach/anonymous_eclairage_emitter.py`):
  `should_emit` gate (archetype set + pre_increment_count == 1 + pin
  present); `resolve_pinned_kind` (body-field overrides
  `MINT_E2E_FORCE_ECLAIRAGE_KIND` env); LSFin-compliant templates for
  `fiscal_margin_3a` (default — 3 of 4 archetypes per 3-piliers panel
  verdict) and `lpp_rachat_3a_nantissement` (cadre_40_55 archetype).
- **Endpoint** (`services/backend/app/api/v1/endpoints/anonymous_chat.py`):
  pre-increment gate, `BannedTermLeak` → 500.
- **Tests** (`services/backend/tests/api/test_anonymous_chat_eclairage.py`):
  22 tests across ECLB-01..05 including the ECLB-05 locked-spec assertion.

Refs: `.planning/REQUIREMENTS.md` §ECLB-01..05 · `.planning/ROADMAP.md` §Phase 81 ·
audit B (2026-05-05) phantom contract C2.

## REQ checklist (REQUIREMENTS.md §ECLB)

- [x] **ECLB-01**: `AnonymousChatRequest` accepts optional
  `archetype: Literal["julien_swiss", "couple_acheteurs_lausanne", "jeune_diplome_zurich", "cadre_40_55_lpp_rachat"]`.
- [x] **ECLB-02**: `AnonymousChatResponse` carries optional
  `eclairage: EclairageSchema | None` with all 8 sub-fields per spec.
- [x] **ECLB-03**: orchestrator emits at coach turn 2 only when archetype
  is set AND emitter is pinned (env var OR body field); free-form prose
  otherwise.
- [x] **ECLB-04**: `chf_range_low` + `chf_range_high` paired-or-null
  validator; `lsfin_disclaimer` non-empty; banned-terms list expanded
  (legacy V1 + 3-piliers panel: idéal / il faut / vous économiserez /
  rentable / profiter de / opportunité / avantage fiscal seul); leak
  promoted to 500 server-side.
- [x] **ECLB-05**: pytest asserts `POST /api/v1/anonymous/chat
  {"message": "ok", "archetype": "julien_swiss"}` (turn 2) returns
  `eclairage.kind == "fiscal_margin_3a"`.

## Verification gates

- `pytest tests/api/test_anonymous_chat_eclairage.py -v` → **22/22 PASS**
- `pytest tests/test_anonymous_chat.py` → **12/12 PASS** (no regression)
- `pytest -q` (full suite excluding integration/llm) → **5938 PASS / 78 SKIP / 0 FAIL**
- `ruff check` on 4 changed files → **All checks passed!**
- `python3 tools/openapi/generate_canonical.py` regenerated; `AnonymousChatRequest` +
  `EclairageSchema` + `forcedEclairageKind` field visible in
  `tools/openapi/mint.openapi.canonical.json`.

## Phase 80 contract handoff

The Flutter consumer (Phase 80) should:

- Add `archetype` and `forcedEclairageKind` (camelCase) to its
  `/anonymous/chat` request body when `MINT_E2E_FORCE_ECLAIRAGE_KIND`
  dart-define is set.
- Parse `eclairage` from the response. All sub-fields are camelCase:
  `kind`, `headline`, `body`, `chfRangeLow`, `chfRangeHigh`,
  `chfRangePeriod`, `softAccountHint`, `lsfinDisclaimer`.

## Notes

- `MINT_E2E_FORCE_ECLAIRAGE_KIND` env var must be set on Railway staging
  for E2E walker runs to assert the deterministic kind.
- `BannedTermLeak` raises a 500 — this is intentional: a leak is a
  server-side bug we want to fail hard, not a client-side validation
  error.

## Test plan

- [ ] CI green on `dev` base
- [ ] OpenAPI parity job green
- [ ] Phase 80 Flutter consumer wires the new contract
- [ ] Phase 82 walker can hit Railway staging with
  `MINT_E2E_FORCE_ECLAIRAGE_KIND=fiscal_margin_3a` and assert
  `eclairage.kind` matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)