### PR TITLE
feat(phase-82,v2.11): walker coord-system overhaul — osascript anchor-derived taps + beta dismiss + ≥2 stable hashes (WALKC-01..06)

### DIFF
--- a/.planning/phases/74-walker-premier-eclairage/PANEL-VERDICT.md
+++ b/.planning/phases/74-walker-premier-eclairage/PANEL-VERDICT.md
@@ -1,0 +1,135 @@
+# Phase 74 — Walker Premier Éclairage — Panel Verdict
+
+> **Date :** 2026-05-05
+> **Panel :** 3-pers (E2E walker veteran + image-diff specialist + adversarial cynic)
+> **Verdict :** APPROVE-WITH-CHANGES — locked for implementation. Effort 4.0-4.5d.
+
+## 1. Walker scope (LOCKED)
+
+- **NEW file** `tools/simulator/walker_premier_eclairage.sh` — DO NOT extend `walker_audit_tap_render.sh` (wrong shape, tab-by-tab regression tool) and DO NOT source `walker.sh` (its argv parser eats ours, see line 250)
+- **Reuse pattern, not code :** copy helper trio (`tap_at`/`type_text`/`wait_for_ui`/`snap`) inline. Copy verbatim with `--no-codesign` flag (per memory `feedback_diff_against_existing_tool`).
+- **6 checkpoints (not 4) :**
+  1. `00-cold-launch.png` — post-`simctl launch`, ~6s sleep
+  2. `01-landing.png` — wait_for_ui after launch, snap before tap (golden anchor)
+  3. `02-anon-chat-opener.png` — tap landing CTA → wait 2.5s opener bubble + 3 chips
+  4. `03-after-turn1.png` — tap chip 1 OR `type_text` deterministic prompt → wait coach response (max 12s — staging Anthropic P95)
+  5. `04-eclairage-card.png` — second turn → ECL-01 hero card render (max 12s)
+  6. `05-register-cta.png` — scroll/snap with register CTA in viewport
+- **Timeout :** 180s wall-clock per archetype (NOT 120s — staging P95 hits 8-10s × 2 turns + boot)
+
+## 2. Image-diff stack (LOCKED)
+
+- **Pillow + scikit-image SSIM**, NOT perceptual hash, NOT imagemagick `compare`
+- pHash too lossy at 4% (font-hint drift swallowed = false negatives)
+- imagemagick produces overlays but PIL+numpy gives bounding box masking without 2nd binary dep
+- **NEW file** `tools/simulator/image_diff.py` (≤ 250 LOC). API :
+  ```python
+  diff(reference_png, candidate_png, hero_bbox=None, threshold_pct=4.0)
+    -> {"diff_pct": float, "passed": bool, "diff_png": "/path/diff.png"}
+  ```
+- **Hero bbox declarative**, NOT auto-detected. `tools/simulator/hero_bboxes.json` :
+  ```json
+  {
+    "01-landing":          {"x": 0,  "y": 800,  "w": 1179, "h": 1200},
+    "02-anon-chat-opener": {"x": 0,  "y": 200,  "w": 1179, "h": 1400},
+    "04-eclairage-card":   {"x": 60, "y": 600,  "w": 1059, "h": 1100},
+    "05-register-cta":     {"x": 60, "y": 1800, "w": 1059, "h": 600}
+  }
+  ```
+  Coords iPhone 17 Pro logical×3 (1179×2556).
+- **Diff algorithm :** crop to bbox → SSIM via `skimage.metrics.structural_similarity`. SSIM threshold ≥ 0.96 = pass. Fallback if scikit-image unavailable : numpy abs-diff over RGB with 8-value tolerance per channel.
+- **Output :** `diff.png` = 3-panel composite (ref | candidate | red overlay) + `result.json` per checkpoint
+
+## 3. Archetype seed format (LOCKED)
+
+- **Path** `tools/simulator/archetypes/<name>.json`
+- **Format :**
+  ```json
+  {
+    "slug": "couple_acheteurs_lausanne",
+    "label": "Couple acheteurs Lausanne",
+    "profile": {"age": 38, "canton": "VD", "salary_brut_year": 145000,
+                "has_lpp": true, "lpp_balance": 220000,
+                "has_3a": true, "3a_balance": 18000,
+                "marital_status": "married", "kids_count": 1,
+                "owns_property": false},
+    "expected_eclairage": {"kind": "lpp_rachat_3a_nantissement",
+                           "value_min": 8000, "value_max": 14000},
+    "deterministic_prompts": [
+      "Combien je peux mettre dans un 3a cette annee ?",
+      "Et avec un rachat LPP en plus ?"
+    ]
+  }
+  ```
+- **4 fixtures :** `julien_swiss.json`, `couple_acheteurs_lausanne.json`, `jeune_diplome_zurich.json`, `cadre_40_55_lpp_rachat.json`
+- These are NEW slugs — DO NOT match the 8 CONTEXT D-02 slugs (`swiss_native`/`expat_eu`/...). Walker whitelists these 4 separately.
+- **Wiring side :** `--dart-define=MINT_E2E_ARCHETYPE=<slug>` already plumbed in `coach_profile_seeds.dart`. Phase 74 PR adds the 4 new slugs to seed loader **AND** new `--dart-define=MINT_E2E_FORCE_ECLAIRAGE_KIND=<kind>` so eclairage payload is deterministic (LLM call still runs, but orchestrator pins `kind` post-tool-dispatch). Without this, image-diff doomed.
+
+## 4. Tolerance + failure mode
+
+- **Hard-fail (exit 2)** : SSIM < 0.96 inside hero bbox on ANY of 6 checkpoints
+- **Hard-fail (exit 2)** : capture rate < 6/6
+- **Hard-fail (exit 2)** : wall-clock > 180s per archetype
+- **Soft-warn (exit 0, log only)** : diff outside hero bbox > 4% (status bar / clock drift expected)
+- **Hard-fail (exit 3)** : registry CTA bbox SSIM < 0.96 (TestFlight reviewer taps this)
+
+## 5. Run-id archive structure
+
+- `run-id` = `YYYY-MM-DD-HHMMSS-<git-sha-short>` (NOT just SHA — multiple runs per commit during iteration)
+- ```
+  .planning/walker/<run-id>/
+  ├── summary.json
+  ├── walker.log
+  └── <archetype>/
+      ├── screenshots/00-cold-launch.png ... 05-register-cta.png
+      ├── diff/01-landing_diff.png ... 05-register-cta_diff.png
+      └── result.json
+  ```
+- Top-level `summary.json` = CI-readable artifact
+- NOT under `.planning/phases/74-…/` — `.planning/walker/` shared across phases
+
+## 6. Adversarial mitigations
+
+| # | Pattern | Mitigation |
+|---|---|---|
+| 1 | Font hint drift sim-to-sim | Pin sim runtime preflight : `xcrun simctl runtime list \| grep "iOS 18.2"` required, fail fast. SSIM ≥ 0.96 absorbs sub-pixel. |
+| 2 | Flaky tap coords (chat input scroll) | After `type_text`, send `cliclick "kp:return"` instead of send-button tap. -1 tap/archetype. |
+| 3 | Network latency variance | `wait_for_ui` polls SHA-quiescence. Bound 12s max per turn, then `_snap` + mark `degraded` if SSIM still passes. |
+| 4 | Keyboard covers chips | Before chip-tap, `cliclick "kp:esc"` to dismiss. Mandatory between turn 1 and turn 2. |
+| 5 | Sim runtime drift Mac mini ↔ CI | Goldens at `tools/simulator/goldens/<archetype>/<checkpoint>.png` valid only for iPhone 17 Pro / iOS 18.2. Walker hard-fails on mismatch. |
+
+## 7. Decisions LOCKED
+
+1. Walker = bash + Python (`image_diff.py`) — no Dart-side `integration_test` (doubles build time + breaks staging-only doctrine)
+2. Image-diff = Pillow + scikit-image SSIM with numpy fallback
+3. Archetype seed format = JSON @ `tools/simulator/archetypes/` + new `MINT_E2E_FORCE_ECLAIRAGE_KIND` dart-define for orchestrator pin
+4. Tap strategy = `cliclick` coords (existing walker pattern). Reject `idb` (extra dep, no a11y IDs wired). Reject `flutter integration_test` (per #1).
+5. Network = staging Railway always (`mint-staging.up.railway.app`) per memory `feedback_app_targets_staging_always`
+6. Run-id = `YYYY-MM-DD-HHMMSS-<sha7>` under `.planning/walker/`
+7. Failure mode = exit 2 on any hero-bbox SSIM < 0.96 OR missing checkpoint OR > 180s wall ; exit 3 on register CTA bbox specifically (TestFlight tap target)
+
+## 8. Effort + 3 hidden risks
+
+**Cynic-validated effort : 4.0-4.5 dev-days.**
+- 0.75d walker_premier_eclairage.sh skeleton + tap sequence + 6 capture
+- 1.0d image_diff.py SSIM + bbox + 3-panel diff PNG + JSON
+- 0.75d 4 archetype JSON fixtures + `MINT_E2E_FORCE_ECLAIRAGE_KIND` orchestrator pin (Flutter side, NON-trivial — coach_orchestrator.dart guard branch)
+- 0.5d golden screenshot regeneration + bbox calibration on real sim
+- 0.75d flake-debugging on first 4-archetype run (×2.5 not ×3 because chat-first narrowed surface)
+- 0.25d summary.json aggregator + CI integration smoke
+
+**Top 3 hidden risks :**
+1. **`MINT_E2E_FORCE_ECLAIRAGE_KIND` orchestrator pin doesn't exist yet** — Phase 74 needs Flutter-side patch in `coach_orchestrator.dart:1113` to short-circuit `kind` resolution from env. Skipping = image-diff fails every run. MUST be in Phase 74 PR scope. Single biggest hidden line item.
+2. **Anonymous chat seed wiring for 4 NEW archetypes** — `coach_profile_seeds.dart` only knows 8 CONTEXT D-02 slugs. 4 Phase-74 slugs need parallel registration path (or JSON-driven seed reader). Hidden 2-3h.
+3. **Register CTA position layout-dependent** — if ECL-01 card height varies (LPP-rachat taller than 3a-only), CTA bbox shifts off-screen. Mitigation : scroll-to-bottom before checkpoint 5, OR set min scroll offset per archetype in `hero_bboxes.json`. Decide at calibration, log as Phase-74 follow-up.
+
+## 9. Files to know
+
+- `tools/simulator/walker_audit_tap_render.sh` (helper trio source, lines 252-281)
+- `tools/simulator/walker.sh` (build flags + `--no-codesign`, lines 587-592)
+- `apps/mobile/lib/services/coach/coach_orchestrator.dart:1113` (orchestrator pin insertion point)
+- `apps/mobile/lib/widgets/onboarding/premier_eclairage_card.dart` (card render — bbox calibration target)
+
+---
+
+**Panel verdict :** ship.

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -121,6 +121,32 @@ class CoachOrchestrator {
       (SlmEngine.maxContextTokens * _charsPerToken).floor();
 
   // ══════════════════════════════════════════════════════════════
+  //  PHASE 74 — DETERMINISTIC ÉCLAIRAGE KIND OVERRIDE (E2E only)
+  // ══════════════════════════════════════════════════════════════
+
+  /// E2E-only override that pins the premier-éclairage `kind`
+  /// post-tool-dispatch so the walker's image-diff captures stay
+  /// deterministic across runs.
+  ///
+  /// Read from `--dart-define=MINT_E2E_FORCE_ECLAIRAGE_KIND=<kind>`.
+  /// Empty (the default) = no override, production behavior unchanged.
+  /// Non-empty = downstream callers (selector / persistence) read this
+  /// getter and substitute the resolved [PremierEclairageType] / payload
+  /// `kind` field with the env value.
+  ///
+  /// Phase 74 walker requirement (PANEL-VERDICT.md §3 + §8 hidden risk
+  /// #1). Without this hook the LLM tool-chain re-derives a different
+  /// kind every run and image-diff is doomed.
+  ///
+  /// Returns null when unset (production / non-E2E runs).
+  static const String _forcedEclairageKindEnv =
+      String.fromEnvironment('MINT_E2E_FORCE_ECLAIRAGE_KIND');
+
+  /// Phase-74 deterministic éclairage kind override. Null in production.
+  static String? get forcedEclairageKind =>
+      _forcedEclairageKindEnv.isEmpty ? null : _forcedEclairageKindEnv;
+
+  // ══════════════════════════════════════════════════════════════
   //  PUBLIC API — narrative (dashboard surface)
   // ══════════════════════════════════════════════════════════════
 

--- a/apps/mobile/lib/services/coach/coach_profile_seeds.dart
+++ b/apps/mobile/lib/services/coach/coach_profile_seeds.dart
@@ -1,0 +1,199 @@
+/// CoachProfileSeeds — E2E archetype seed loader (Phase 74).
+///
+/// Reads `--dart-define=MINT_E2E_ARCHETYPE=<slug>` and resolves it to a
+/// minimal seed [Map] used by the walker harness to drive the anonymous
+/// chat flow with realistic profile data.
+///
+/// In production builds the env var is empty → [activeSeed] returns null
+/// and there is zero behavior change. The seed is consumed only by
+/// E2E-aware code paths (Phase 74 walker_premier_eclairage.sh).
+///
+/// Slug catalog (12 total) :
+///   - 8 CONTEXT D-02 archetypes :
+///     swiss_native, expat_eu, expat_us, cross_border,
+///     independent_no_lpp, recent_arrival, near_retirement,
+///     young_starter
+///   - 4 Phase 74 walker archetypes (per archetype JSON fixtures
+///     under tools/simulator/archetypes/) :
+///     julien_swiss, couple_acheteurs_lausanne, jeune_diplome_zurich,
+///     cadre_40_55_lpp_rachat
+///
+/// The map values mirror the JSON fixtures so the seed loader stays
+/// hardcoded (no asset bundle lookup → no production runtime cost).
+/// When fixtures change, regenerate manually + add a TODO note.
+///
+/// References :
+///   - PANEL-VERDICT.md §3 + §8 hidden risk #2
+///   - tools/simulator/archetypes/*.json
+library;
+
+/// Coach profile seed used by the walker harness.
+///
+/// Fields are intentionally a flat [Map<String, Object>] to mirror the
+/// JSON fixture format (no schema drift between Dart and tooling).
+typedef CoachProfileSeed = Map<String, Object>;
+
+/// Static seed catalog for both legacy CONTEXT D-02 slugs and Phase 74
+/// walker archetypes.
+///
+/// Production callers MUST NOT branch on these — use [activeSeed] which
+/// only returns non-null when the dart-define is set.
+class CoachProfileSeeds {
+  CoachProfileSeeds._();
+
+  /// `--dart-define=MINT_E2E_ARCHETYPE=<slug>` — empty in production.
+  static const String _activeSlugEnv =
+      String.fromEnvironment('MINT_E2E_ARCHETYPE');
+
+  /// Resolved active slug, or null when no E2E override is set.
+  static String? get activeSlug =>
+      _activeSlugEnv.isEmpty ? null : _activeSlugEnv;
+
+  /// Returns the seed for [slug], or null if the slug is unknown.
+  static CoachProfileSeed? seedFor(String slug) => _seeds[slug];
+
+  /// Returns the seed for the active E2E archetype slug, or null when no
+  /// E2E override is set or the slug is unknown.
+  static CoachProfileSeed? get activeSeed {
+    final s = activeSlug;
+    if (s == null) return null;
+    return _seeds[s];
+  }
+
+  /// All registered slugs (D-02 + Phase 74).
+  static List<String> get knownSlugs => _seeds.keys.toList(growable: false);
+
+  // ── seed catalog ────────────────────────────────────────────────────
+  //
+  // 8 CONTEXT D-02 slugs : minimal stubs sufficient for archetype
+  //   selection in coach_context_builder. Full profiles live in
+  //   coach_models / coach_context_builder defaults.
+  // 4 Phase 74 slugs : mirror tools/simulator/archetypes/*.json for the
+  //   walker. Source of truth = JSON fixtures.
+  //
+  static final Map<String, CoachProfileSeed> _seeds = {
+    // ── CONTEXT D-02 (8) ─────────────────────────────────────────────
+    'swiss_native': {
+      'archetype': 'swiss_native',
+      'age': 32,
+      'canton': 'ZH',
+      'salary_brut_year': 95000,
+      'has_lpp': true,
+      'has_3a': true,
+    },
+    'expat_eu': {
+      'archetype': 'expat_eu',
+      'age': 30,
+      'canton': 'GE',
+      'salary_brut_year': 105000,
+      'has_lpp': true,
+      'has_3a': false,
+    },
+    'expat_us': {
+      'archetype': 'expat_us',
+      'age': 36,
+      'canton': 'ZG',
+      'salary_brut_year': 180000,
+      'has_lpp': true,
+      'has_3a': false,
+    },
+    'cross_border': {
+      'archetype': 'cross_border',
+      'age': 40,
+      'canton': 'GE',
+      'salary_brut_year': 88000,
+      'has_lpp': true,
+      'has_3a': false,
+    },
+    'independent_no_lpp': {
+      'archetype': 'independent_no_lpp',
+      'age': 42,
+      'canton': 'VD',
+      'salary_brut_year': 130000,
+      'has_lpp': false,
+      'has_3a': true,
+    },
+    'recent_arrival': {
+      'archetype': 'recent_arrival',
+      'age': 28,
+      'canton': 'BS',
+      'salary_brut_year': 75000,
+      'has_lpp': true,
+      'has_3a': false,
+    },
+    'near_retirement': {
+      'archetype': 'near_retirement',
+      'age': 58,
+      'canton': 'BE',
+      'salary_brut_year': 130000,
+      'has_lpp': true,
+      'has_3a': true,
+    },
+    'young_starter': {
+      'archetype': 'young_starter',
+      'age': 24,
+      'canton': 'ZH',
+      'salary_brut_year': 68000,
+      'has_lpp': true,
+      'has_3a': false,
+    },
+
+    // ── PHASE 74 walker archetypes (4) — mirror JSON fixtures ────────
+    'julien_swiss': {
+      'archetype': 'swiss_native',
+      'age': 34,
+      'canton': 'VD',
+      'salary_brut_year': 110000,
+      'has_lpp': true,
+      'lpp_balance': 95000,
+      'has_3a': true,
+      '3a_balance': 12500,
+      'marital_status': 'single',
+      'kids_count': 0,
+      'owns_property': false,
+      'expected_eclairage_kind': 'fiscal_margin_3a',
+    },
+    'couple_acheteurs_lausanne': {
+      'archetype': 'swiss_native',
+      'age': 38,
+      'canton': 'VD',
+      'salary_brut_year': 145000,
+      'has_lpp': true,
+      'lpp_balance': 220000,
+      'has_3a': true,
+      '3a_balance': 18000,
+      'marital_status': 'married',
+      'kids_count': 1,
+      'owns_property': false,
+      'expected_eclairage_kind': 'lpp_rachat_3a_nantissement',
+    },
+    'jeune_diplome_zurich': {
+      'archetype': 'young_starter',
+      'age': 26,
+      'canton': 'ZH',
+      'salary_brut_year': 82000,
+      'has_lpp': true,
+      'lpp_balance': 8500,
+      'has_3a': false,
+      '3a_balance': 0,
+      'marital_status': 'single',
+      'kids_count': 0,
+      'owns_property': false,
+      'expected_eclairage_kind': 'fiscal_margin_3a',
+    },
+    'cadre_40_55_lpp_rachat': {
+      'archetype': 'swiss_native',
+      'age': 48,
+      'canton': 'GE',
+      'salary_brut_year': 185000,
+      'has_lpp': true,
+      'lpp_balance': 410000,
+      'has_3a': true,
+      '3a_balance': 45000,
+      'marital_status': 'married',
+      'kids_count': 2,
+      'owns_property': true,
+      'expected_eclairage_kind': 'lpp_rachat_3a_nantissement',
+    },
+  };
+}

--- a/tools/simulator/archetypes/cadre_40_55_lpp_rachat.json
+++ b/tools/simulator/archetypes/cadre_40_55_lpp_rachat.json
@@ -1,0 +1,25 @@
+{
+  "slug": "cadre_40_55_lpp_rachat",
+  "label": "Cadre 40-55 ans avec marge de rachat LPP",
+  "profile": {
+    "age": 48,
+    "canton": "GE",
+    "salary_brut_year": 185000,
+    "has_lpp": true,
+    "lpp_balance": 410000,
+    "has_3a": true,
+    "3a_balance": 45000,
+    "marital_status": "married",
+    "kids_count": 2,
+    "owns_property": true
+  },
+  "expected_eclairage": {
+    "kind": "lpp_rachat_3a_nantissement",
+    "value_min": 14000,
+    "value_max": 28000
+  },
+  "deterministic_prompts": [
+    "Quel est l'avantage fiscal d'un rachat LPP ?",
+    "Et si je combine avec un 3a ?"
+  ]
+}

--- a/tools/simulator/archetypes/couple_acheteurs_lausanne.json
+++ b/tools/simulator/archetypes/couple_acheteurs_lausanne.json
@@ -1,0 +1,25 @@
+{
+  "slug": "couple_acheteurs_lausanne",
+  "label": "Couple acheteurs Lausanne",
+  "profile": {
+    "age": 38,
+    "canton": "VD",
+    "salary_brut_year": 145000,
+    "has_lpp": true,
+    "lpp_balance": 220000,
+    "has_3a": true,
+    "3a_balance": 18000,
+    "marital_status": "married",
+    "kids_count": 1,
+    "owns_property": false
+  },
+  "expected_eclairage": {
+    "kind": "lpp_rachat_3a_nantissement",
+    "value_min": 8000,
+    "value_max": 14000
+  },
+  "deterministic_prompts": [
+    "Combien je peux mettre dans un 3a cette annee ?",
+    "Et avec un rachat LPP en plus ?"
+  ]
+}

--- a/tools/simulator/archetypes/jeune_diplome_zurich.json
+++ b/tools/simulator/archetypes/jeune_diplome_zurich.json
@@ -1,0 +1,25 @@
+{
+  "slug": "jeune_diplome_zurich",
+  "label": "Jeune diplome Zurich",
+  "profile": {
+    "age": 26,
+    "canton": "ZH",
+    "salary_brut_year": 82000,
+    "has_lpp": true,
+    "lpp_balance": 8500,
+    "has_3a": false,
+    "3a_balance": 0,
+    "marital_status": "single",
+    "kids_count": 0,
+    "owns_property": false
+  },
+  "expected_eclairage": {
+    "kind": "fiscal_margin_3a",
+    "value_min": 1200,
+    "value_max": 2200
+  },
+  "deterministic_prompts": [
+    "C'est quoi le 3eme pilier ?",
+    "Combien je peux mettre cette annee ?"
+  ]
+}

--- a/tools/simulator/archetypes/julien_swiss.json
+++ b/tools/simulator/archetypes/julien_swiss.json
@@ -1,0 +1,25 @@
+{
+  "slug": "julien_swiss",
+  "label": "Julien — Suisse natif (canton VD)",
+  "profile": {
+    "age": 34,
+    "canton": "VD",
+    "salary_brut_year": 110000,
+    "has_lpp": true,
+    "lpp_balance": 95000,
+    "has_3a": true,
+    "3a_balance": 12500,
+    "marital_status": "single",
+    "kids_count": 0,
+    "owns_property": false
+  },
+  "expected_eclairage": {
+    "kind": "fiscal_margin_3a",
+    "value_min": 1800,
+    "value_max": 3200
+  },
+  "deterministic_prompts": [
+    "Combien je peux mettre dans un 3a cette annee ?",
+    "Et l'economie d'impots correspondante ?"
+  ]
+}

--- a/tools/simulator/hero_bboxes.json
+++ b/tools/simulator/hero_bboxes.json
@@ -1,9 +1,10 @@
 {
-  "_comment": "Phase 74 hero bounding boxes for image-diff. iPhone 17 Pro logical (393x852) x scale 3 = 1179x2556. Initial values from PANEL-VERDICT.md sec.2 — calibrate against real captures in Slice 74c.",
+  "_comment": "Phase 82 hero bounding boxes for image-diff. iPhone 17 Pro native = 1206x2622 px (audit A 2026-05-05). Dynamic Island excluded — no bbox starts before y=180. Calibration verified by tools/checks/hero_bboxes_sanity.py at script preflight (WALKC-02).",
   "_device": "iPhone 17 Pro",
-  "_resolution_px": [1179, 2556],
-  "01-landing":          {"x": 0,  "y": 800,  "w": 1179, "h": 1200},
-  "02-anon-chat-opener": {"x": 0,  "y": 200,  "w": 1179, "h": 1400},
-  "04-eclairage-card":   {"x": 60, "y": 600,  "w": 1059, "h": 1100},
-  "05-register-cta":     {"x": 60, "y": 1800, "w": 1059, "h": 600}
+  "_resolution_px": [1206, 2622],
+  "_dynamic_island_y_max": 180,
+  "01-landing":          {"x": 0,  "y": 820,  "w": 1206, "h": 1230},
+  "02-anon-chat-opener": {"x": 0,  "y": 220,  "w": 1206, "h": 1450},
+  "04-eclairage-card":   {"x": 60, "y": 620,  "w": 1086, "h": 1140},
+  "05-register-cta":     {"x": 60, "y": 1860, "w": 1086, "h": 620}
 }

--- a/tools/simulator/hero_bboxes.json
+++ b/tools/simulator/hero_bboxes.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Phase 74 hero bounding boxes for image-diff. iPhone 17 Pro logical (393x852) x scale 3 = 1179x2556. Initial values from PANEL-VERDICT.md sec.2 — calibrate against real captures in Slice 74c.",
+  "_device": "iPhone 17 Pro",
+  "_resolution_px": [1179, 2556],
+  "01-landing":          {"x": 0,  "y": 800,  "w": 1179, "h": 1200},
+  "02-anon-chat-opener": {"x": 0,  "y": 200,  "w": 1179, "h": 1400},
+  "04-eclairage-card":   {"x": 60, "y": 600,  "w": 1059, "h": 1100},
+  "05-register-cta":     {"x": 60, "y": 1800, "w": 1059, "h": 600}
+}

--- a/tools/simulator/image_diff.py
+++ b/tools/simulator/image_diff.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""image_diff.py — Phase 74 walker image diffing.
+
+Compares two PNG screenshots inside an optional hero bounding box and
+returns a structured pass/fail dict. Locked decisions (PANEL-VERDICT.md
+sec.2) :
+
+  - Pillow + scikit-image SSIM (numpy abs-diff fallback if scikit-image
+    is unavailable).
+  - SSIM threshold >= 0.96 inside hero bbox = pass.
+  - Outputs a 3-panel composite diff PNG (ref | candidate | red overlay)
+    plus a result.json keyed off the candidate filename.
+
+CLI usage (called by walker_premier_eclairage.sh) :
+
+    python3 tools/simulator/image_diff.py \\
+        --reference goldens/julien_swiss/01-landing.png \\
+        --candidate run/julien_swiss/screenshots/01-landing.png \\
+        --bbox-key 01-landing \\
+        --bboxes tools/simulator/hero_bboxes.json \\
+        --out-dir run/julien_swiss/diff
+
+Programmatic usage :
+
+    from image_diff import diff
+    result = diff(reference_png, candidate_png,
+                  hero_bbox={"x": 0, "y": 800, "w": 1179, "h": 1200},
+                  threshold_pct=4.0)
+    # -> {"diff_pct": 1.7, "passed": True, "diff_png": ".../diff.png", ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+try:
+    from skimage.metrics import structural_similarity as _ssim  # type: ignore
+    _HAS_SSIM = True
+except ImportError:  # pragma: no cover — fallback path covered by smoke test
+    _HAS_SSIM = False
+
+SSIM_PASS_THRESHOLD = 0.96
+ABS_DIFF_TOLERANCE = 8  # per-channel value tolerance for numpy fallback
+
+
+def _load_rgb(path: str) -> np.ndarray:
+    """Load PNG as HxWx3 uint8 RGB array."""
+    img = Image.open(path).convert("RGB")
+    return np.asarray(img, dtype=np.uint8)
+
+
+def _crop(arr: np.ndarray, bbox: Optional[dict]) -> np.ndarray:
+    """Crop array to bbox or return full array."""
+    if bbox is None:
+        return arr
+    x = max(0, int(bbox.get("x", 0)))
+    y = max(0, int(bbox.get("y", 0)))
+    w = int(bbox.get("w", arr.shape[1] - x))
+    h = int(bbox.get("h", arr.shape[0] - y))
+    h_max, w_max = arr.shape[:2]
+    x2 = min(w_max, x + w)
+    y2 = min(h_max, y + h)
+    return arr[y:y2, x:x2]
+
+
+def _numpy_diff_pct(a: np.ndarray, b: np.ndarray, tolerance: int) -> float:
+    """Fallback : percent of pixels with abs-diff > tolerance on any channel."""
+    if a.shape != b.shape:
+        return 100.0
+    delta = np.abs(a.astype(np.int16) - b.astype(np.int16))
+    differs = np.any(delta > tolerance, axis=-1)
+    return 100.0 * float(differs.sum()) / float(differs.size)
+
+
+def _ssim_score(a: np.ndarray, b: np.ndarray) -> float:
+    """Compute SSIM on RGB. Uses scikit-image when available."""
+    if a.shape != b.shape:
+        return 0.0
+    # channel_axis=2 (RGB last). data_range=255 for uint8.
+    return float(
+        _ssim(a, b, channel_axis=2, data_range=255)  # type: ignore[arg-type]
+    )
+
+
+def _compose_three_panel(
+    ref: np.ndarray,
+    cand: np.ndarray,
+    bbox: Optional[dict],
+    out_path: str,
+) -> None:
+    """Write 3-panel composite PNG : ref | candidate | red overlay."""
+    h, w = ref.shape[:2]
+    # Ensure same size for cand
+    if cand.shape != ref.shape:
+        cand_img = Image.fromarray(cand).resize((w, h))
+        cand = np.asarray(cand_img.convert("RGB"), dtype=np.uint8)
+    # Red overlay: pixels where abs diff > tolerance get marked red on ref
+    delta = np.abs(ref.astype(np.int16) - cand.astype(np.int16))
+    differs = np.any(delta > ABS_DIFF_TOLERANCE, axis=-1)
+    overlay = ref.copy()
+    overlay[differs] = [255, 0, 0]
+    # bbox outline on each panel
+    panels = []
+    for arr, label in ((ref, "REF"), (cand, "CAND"), (overlay, "DIFF")):
+        img = Image.fromarray(arr).convert("RGB")
+        draw = ImageDraw.Draw(img)
+        if bbox is not None:
+            x = int(bbox.get("x", 0))
+            y = int(bbox.get("y", 0))
+            bw = int(bbox.get("w", w - x))
+            bh = int(bbox.get("h", h - y))
+            draw.rectangle([(x, y), (x + bw, y + bh)], outline=(0, 255, 0), width=4)
+        try:
+            font = ImageFont.load_default()
+        except Exception:  # pragma: no cover
+            font = None
+        draw.text((24, 24), label, fill=(255, 255, 0), font=font)
+        panels.append(img)
+    composite = Image.new("RGB", (w * 3, h), (0, 0, 0))
+    for i, p in enumerate(panels):
+        composite.paste(p, (i * w, 0))
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    composite.save(out_path, format="PNG", optimize=True)
+
+
+def diff(
+    reference_png: str,
+    candidate_png: str,
+    hero_bbox: Optional[dict] = None,
+    threshold_pct: float = 4.0,
+    out_dir: Optional[str] = None,
+) -> dict:
+    """Diff two PNGs inside hero_bbox. Returns structured result.
+
+    Pass criterion :
+        SSIM (when available) >= SSIM_PASS_THRESHOLD inside bbox
+        OR fallback abs-diff pct <= threshold_pct.
+
+    Returned dict :
+        {
+          "diff_pct":   <0..100>,         # always populated
+          "ssim":       <0..1> or None,   # None if scikit-image missing
+          "passed":     bool,
+          "diff_png":   "<path>" or None, # written only if out_dir set
+          "reference":  "<path>",
+          "candidate":  "<path>",
+        }
+    """
+    ref = _load_rgb(reference_png)
+    cand = _load_rgb(candidate_png)
+    ref_crop = _crop(ref, hero_bbox)
+    cand_crop = _crop(cand, hero_bbox)
+
+    diff_pct = _numpy_diff_pct(ref_crop, cand_crop, ABS_DIFF_TOLERANCE)
+    ssim_score: Optional[float] = None
+    if _HAS_SSIM and ref_crop.size > 0 and cand_crop.size > 0:
+        ssim_score = _ssim_score(ref_crop, cand_crop)
+        passed = ssim_score >= SSIM_PASS_THRESHOLD
+    else:
+        passed = diff_pct <= threshold_pct
+
+    diff_png_path: Optional[str] = None
+    if out_dir is not None:
+        cand_basename = os.path.splitext(os.path.basename(candidate_png))[0]
+        diff_png_path = os.path.join(out_dir, f"{cand_basename}_diff.png")
+        _compose_three_panel(ref, cand, hero_bbox, diff_png_path)
+
+    return {
+        "diff_pct": round(diff_pct, 3),
+        "ssim": round(ssim_score, 4) if ssim_score is not None else None,
+        "passed": bool(passed),
+        "diff_png": diff_png_path,
+        "reference": os.path.abspath(reference_png),
+        "candidate": os.path.abspath(candidate_png),
+        "bbox": hero_bbox,
+        "ssim_threshold": SSIM_PASS_THRESHOLD,
+        "diff_pct_threshold": threshold_pct,
+    }
+
+
+# ── CLI ────────────────────────────────────────────────────────────────
+
+
+def _bbox_from_key(bboxes_path: str, key: str) -> Optional[dict]:
+    if not os.path.isfile(bboxes_path):
+        return None
+    with open(bboxes_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    val = data.get(key)
+    if not isinstance(val, dict):
+        return None
+    return {k: v for k, v in val.items() if k in {"x", "y", "w", "h"}}
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Phase 74 walker image diff (SSIM + bbox + 3-panel PNG)",
+    )
+    p.add_argument("--reference", required=True, help="reference PNG path")
+    p.add_argument("--candidate", required=True, help="candidate PNG path")
+    p.add_argument(
+        "--bbox-key",
+        default=None,
+        help="hero bbox key (e.g. 01-landing) — looked up in --bboxes",
+    )
+    p.add_argument(
+        "--bboxes",
+        default=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "hero_bboxes.json"
+        ),
+        help="path to hero_bboxes.json",
+    )
+    p.add_argument(
+        "--threshold-pct",
+        type=float,
+        default=4.0,
+        help="fallback abs-diff threshold (used when scikit-image absent)",
+    )
+    p.add_argument(
+        "--out-dir",
+        default=None,
+        help="if set, write diff.png + result.json under this directory",
+    )
+    args = p.parse_args(argv)
+
+    bbox = None
+    if args.bbox_key is not None:
+        bbox = _bbox_from_key(args.bboxes, args.bbox_key)
+
+    result = diff(
+        reference_png=args.reference,
+        candidate_png=args.candidate,
+        hero_bbox=bbox,
+        threshold_pct=args.threshold_pct,
+        out_dir=args.out_dir,
+    )
+
+    if args.out_dir is not None:
+        os.makedirs(args.out_dir, exist_ok=True)
+        cand_basename = os.path.splitext(os.path.basename(args.candidate))[0]
+        result_path = os.path.join(args.out_dir, f"{cand_basename}_result.json")
+        with open(result_path, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2, sort_keys=True)
+
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if result["passed"] else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/simulator/test_image_diff.py
+++ b/tools/simulator/test_image_diff.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Smoke test for image_diff.py — Phase 74.
+
+Synthesizes 2 PNGs in /tmp, diffs them, asserts result format. Exits 0
+on success, non-zero on assertion failure.
+
+Run :
+    python3 tools/simulator/test_image_diff.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import numpy as np
+from PIL import Image
+
+# Allow imports when invoked from repo root or alongside the script.
+HERE = os.path.dirname(os.path.abspath(__file__))
+if HERE not in sys.path:
+    sys.path.insert(0, HERE)
+
+import image_diff  # noqa: E402
+
+
+def _write_png(path: str, arr: np.ndarray) -> None:
+    Image.fromarray(arr).save(path, format="PNG")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        # 200x300 RGB, mostly mid-grey
+        ref = np.full((300, 200, 3), 128, dtype=np.uint8)
+        cand_identical = ref.copy()
+        cand_drift = ref.copy()
+        # Inject a 60x100 red rectangle at (60, 100) → 6000 / 60000 = 10%
+        # Big enough to fail both the SSIM (>=0.96) and the fallback
+        # numpy abs-diff threshold (4%) modes.
+        cand_drift[100:200, 60:120] = [255, 0, 0]
+
+        ref_path = os.path.join(tmp, "ref.png")
+        ident_path = os.path.join(tmp, "cand_identical.png")
+        drift_path = os.path.join(tmp, "cand_drift.png")
+        _write_png(ref_path, ref)
+        _write_png(ident_path, cand_identical)
+        _write_png(drift_path, cand_drift)
+
+        out_dir = os.path.join(tmp, "out")
+
+        # Identical case
+        r1 = image_diff.diff(
+            ref_path,
+            ident_path,
+            hero_bbox={"x": 0, "y": 0, "w": 200, "h": 300},
+            threshold_pct=4.0,
+            out_dir=out_dir,
+        )
+        assert isinstance(r1, dict), "diff() must return a dict"
+        for key in (
+            "diff_pct",
+            "ssim",
+            "passed",
+            "diff_png",
+            "reference",
+            "candidate",
+            "bbox",
+            "ssim_threshold",
+            "diff_pct_threshold",
+        ):
+            assert key in r1, f"missing key {key} in identical-case result"
+        assert r1["passed"] is True, f"identical PNGs should pass : {r1}"
+        assert r1["diff_pct"] == 0.0, f"identical PNGs diff_pct must be 0 : {r1}"
+        assert r1["diff_png"] is not None and os.path.isfile(r1["diff_png"]), (
+            f"diff PNG not written : {r1}"
+        )
+
+        # Drift case — 60x100 red rectangle = 10% of 200x300, > 4% threshold
+        r2 = image_diff.diff(
+            ref_path,
+            drift_path,
+            hero_bbox={"x": 0, "y": 0, "w": 200, "h": 300},
+            threshold_pct=4.0,
+            out_dir=out_dir,
+        )
+        assert r2["passed"] is False, f"red-square drift should fail : {r2}"
+        assert r2["diff_pct"] > 4.0, (
+            f"drift diff_pct should exceed threshold : {r2}"
+        )
+
+        # Bbox masking — same drift but bbox excludes the red square region
+        r3 = image_diff.diff(
+            ref_path,
+            drift_path,
+            hero_bbox={"x": 150, "y": 200, "w": 50, "h": 100},
+            threshold_pct=4.0,
+            out_dir=out_dir,
+        )
+        assert r3["passed"] is True, f"masked bbox should pass : {r3}"
+
+        print(
+            "[image_diff smoke] PASS — identical + drift + bbox-mask "
+            "all behaved as expected"
+        )
+        print(f"[image_diff smoke]   identical : {r1}")
+        print(f"[image_diff smoke]   drift     : {r2}")
+        print(f"[image_diff smoke]   masked    : {r3}")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/simulator/test_walker_helpers.py
+++ b/tools/simulator/test_walker_helpers.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+# tools/simulator/test_walker_helpers.py
+#
+# Phase 82 (v2.11) — unit tests for walker_premier_eclairage.sh helper
+# semantics, exercised via Python re-implementations + textual asserts on
+# the shipped bash source. Tests cover :
+#
+#   WALKC-01 : _anchor_to_desktop math (anchor% → desktop px) — Python
+#              port of the awk one-liner in the bash helper. Also asserts
+#              the bash source contains the anchor table + the osascript
+#              `bounds of window 1` call.
+#   WALKC-02 : hero_bboxes.json calibrated to 1206×2622 ; Dynamic Island
+#              excluded (every bbox y ≥ 180).
+#   WALKC-03 : _wait_for_ui requires ≥ 2 consecutive stable hashes (the
+#              triple-equality check `[ "$h0" = "$h1" ] && [ "$h1" = "$cur" ]`
+#              is present in the bash source).
+#   WALKC-04 : Each anchor-tap site activates the Simulator window first
+#              (osascript activate text appears in _activate_simulator
+#              and the helper is referenced from the tap helpers).
+#   WALKC-05 : _dismiss_beta_modal helper exists AND is called before
+#              the 01-landing capture step.
+#   WALKC-06 : _swipe / _swipe_anchor helpers use cliclick dd:/du:
+#              gestures, NOT tap-as-scroll.
+#
+# Runs with stdlib only — no Pillow, no scikit-image — because Phase 82
+# is shell-helper plumbing only.
+#
+# Usage : python3 tools/simulator/test_walker_helpers.py
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WALKER = ROOT / "tools" / "simulator" / "walker_premier_eclairage.sh"
+BBOXES = ROOT / "tools" / "simulator" / "hero_bboxes.json"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def anchor_to_desktop(
+    win_x: int, win_y: int, win_w: int, win_h: int,
+    pct_x: float, pct_y: float,
+) -> tuple[int, int]:
+    """Python port of the awk one-liner in _anchor_to_desktop().
+
+    Mirrors the bash printf "%d %d" → integer truncation semantics so
+    the test catches drift if the bash math ever changes.
+    """
+    return (int(win_x + win_w * pct_x), int(win_y + win_h * pct_y))
+
+
+# ── WALKC-01 — anchor → desktop math ────────────────────────────────────
+
+
+def test_walkc01_anchor_math_center():
+    # 1206×2622 sim window mounted at (100, 50) on the desktop.
+    x, y = anchor_to_desktop(100, 50, 1206, 2622, 0.50, 0.50)
+    assert x == 703, f"center-x expected 703 got {x}"
+    assert y == 1361, f"center-y expected 1361 got {y}"
+
+
+def test_walkc01_anchor_math_cta_landing():
+    # Anchor cta_landing = (0.50, 0.78).
+    x, y = anchor_to_desktop(0, 0, 1206, 2622, 0.50, 0.78)
+    assert x == 603
+    assert y == 2045
+
+
+def test_walkc01_anchor_math_swipe_endpoints():
+    # WALKC-06 — swipe_start (65% vh) → swipe_end (30% vh) must produce
+    # an upward delta (y2 < y1) in the sim coord system, i.e. drag up to
+    # scroll content up.
+    _, y1 = anchor_to_desktop(0, 0, 1206, 2622, 0.50, 0.65)
+    _, y2 = anchor_to_desktop(0, 0, 1206, 2622, 0.50, 0.30)
+    assert y2 < y1, f"swipe must drag UP : got y1={y1}, y2={y2}"
+
+
+def test_walkc01_anchor_math_offset_window():
+    # Sim window not at desktop origin — anchor math must add window x/y.
+    x, y = anchor_to_desktop(420, 110, 1206, 2622, 0.10, 0.20)
+    assert x == 540   # 420 + 1206*0.10
+    assert y == 634   # 110 + 2622*0.20
+
+
+def test_walkc01_bash_has_osascript_bounds_call():
+    src = _read(WALKER)
+    # The osascript heredoc reads `bounds of window 1` of the Simulator
+    # app — accept either the inline `get bounds` or the heredoc `set b
+    # to bounds` form.
+    assert "bounds of window 1" in src, \
+        "WALKC-01: walker must read sim-window bounds via osascript"
+    assert 'tell application "Simulator"' in src, \
+        "WALKC-01: walker must address the Simulator app explicitly"
+
+
+def test_walkc01_bash_has_anchor_table():
+    src = _read(WALKER)
+    for anchor in ("cta_landing", "input_field", "beta_dismiss",
+                   "swipe_start", "swipe_end"):
+        assert f"ANCHORS_X[{anchor}]" in src, f"anchor '{anchor}' missing"
+
+
+def test_walkc01_no_hardcoded_cliclick_taps_in_step_body():
+    # The script must not use raw `cliclick c:NNN,NNN` desktop literals
+    # in the step body. The deprecation shim _tap_at() may include the
+    # generic pattern via variable substitution, that's fine — we only
+    # forbid LITERAL coords like `cliclick c:590,2000`.
+    src = _read(WALKER)
+    bad = re.findall(r'cliclick\s+["\']?c:\d+,\d+', src)
+    assert not bad, f"WALKC-01 forbids hardcoded cliclick desktop px : {bad}"
+
+
+# ── WALKC-02 — hero_bboxes.json calibration ─────────────────────────────
+
+
+def test_walkc02_bboxes_resolution_1206_2622():
+    data = json.loads(_read(BBOXES))
+    assert data["_resolution_px"] == [1206, 2622], \
+        f"WALKC-02 expects [1206, 2622] got {data['_resolution_px']}"
+
+
+def test_walkc02_dynamic_island_excluded():
+    data = json.loads(_read(BBOXES))
+    di_max = data.get("_dynamic_island_y_max", 180)
+    for key, bbox in data.items():
+        if key.startswith("_"):
+            continue
+        assert bbox["y"] >= di_max, \
+            f"WALKC-02 bbox '{key}' y={bbox['y']} overlaps Dynamic Island"
+
+
+def test_walkc02_bboxes_within_screen():
+    data = json.loads(_read(BBOXES))
+    rw, rh = data["_resolution_px"]
+    for key, bbox in data.items():
+        if key.startswith("_"):
+            continue
+        assert bbox["x"] + bbox["w"] <= rw, f"{key} x-overflow"
+        assert bbox["y"] + bbox["h"] <= rh, f"{key} y-overflow"
+
+
+# ── WALKC-03 — ≥ 2 consecutive stable hashes ────────────────────────────
+
+
+def test_walkc03_wait_for_ui_requires_two_consecutive():
+    src = _read(WALKER)
+    # The triple-equality check is the load-bearing assertion.
+    assert '[ "$h0" = "$h1" ]' in src and '[ "$h1" = "$cur" ]' in src, \
+        "WALKC-03: _wait_for_ui must require h0==h1==cur (≥ 2 consecutive)"
+
+
+def test_walkc03_wait_for_ui_logs_seq_when_retry_gt_3():
+    src = _read(WALKER)
+    # The trace branch must reference both `retry` and the seq array.
+    assert 'wait_for_ui retry=' in src, \
+        "WALKC-03: hash sequence must be logged when retry > 3"
+    assert 'hash_seq=' in src, \
+        "WALKC-03: hash_seq= log key required"
+
+
+# ── WALKC-04 — Simulator activated before each tap ──────────────────────
+
+
+def test_walkc04_activate_simulator_present():
+    src = _read(WALKER)
+    assert 'tell application "Simulator" to activate' in src, \
+        "WALKC-04: osascript activate call missing"
+
+
+def test_walkc04_tap_helpers_call_activate():
+    src = _read(WALKER)
+    # _tap_at_anchor and _swipe + _type_text must each invoke
+    # _activate_simulator BEFORE issuing the cliclick action.
+    for helper in ("_tap_at_anchor()", "_swipe()", "_type_text()", "_dismiss_keyboard()"):
+        # Find the helper body : from helper-decl up to the closing brace.
+        idx = src.find(helper)
+        assert idx >= 0, f"helper '{helper}' not declared"
+        end = src.find("\n}\n", idx)
+        body = src[idx:end]
+        assert "_activate_simulator" in body, \
+            f"WALKC-04: helper '{helper}' must call _activate_simulator"
+
+
+# ── WALKC-05 — beta-disclosure dismiss step ─────────────────────────────
+
+
+def test_walkc05_dismiss_beta_modal_helper():
+    src = _read(WALKER)
+    assert "_dismiss_beta_modal()" in src, "WALKC-05 helper missing"
+    assert "anchor=beta_dismiss" in src or "beta_dismiss" in src, \
+        "WALKC-05 anchor reference missing"
+
+
+def test_walkc05_dismiss_called_before_landing_capture():
+    src = _read(WALKER)
+    # The call must precede the actual capture line, not the help-text
+    # reference. The capture is `_snap "$SHOTS_DIR/01-landing.png"`.
+    call_idx = src.find("_dismiss_beta_modal\n")
+    snap_idx = src.find('_snap "$SHOTS_DIR/01-landing.png"')
+    assert call_idx > 0, "WALKC-05: _dismiss_beta_modal call missing"
+    assert snap_idx > 0, "01-landing capture line missing"
+    assert call_idx < snap_idx, \
+        "WALKC-05: _dismiss_beta_modal must be called before 01-landing capture"
+
+
+# ── WALKC-06 — swipe gesture (not tap-as-scroll) ────────────────────────
+
+
+def test_walkc06_swipe_uses_cliclick_dd_du():
+    src = _read(WALKER)
+    assert "cliclick \"dd:" in src and "\"du:" in src, \
+        "WALKC-06: swipe must use cliclick dd:/du: gesture"
+
+
+def test_walkc06_scroll_step_uses_swipe_anchor():
+    src = _read(WALKER)
+    # The 05-register-cta capture step must use _swipe_anchor, not
+    # _tap_at. Anchor on the actual capture lines (not the help-text
+    # references) by matching the `_snap "$SHOTS_DIR/...png"` form.
+    a = src.find('_snap "$SHOTS_DIR/04-eclairage-card.png"')
+    b = src.find('_snap "$SHOTS_DIR/05-register-cta.png"', a)
+    assert a > 0 and b > a, "capture markers missing in step body"
+    segment = src[a:b]
+    assert "_swipe_anchor" in segment, \
+        "WALKC-06: register-CTA scroll step must call _swipe_anchor"
+
+
+# ── runner ──────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    tests = [v for k, v in globals().items() if k.startswith("test_") and callable(v)]
+    failures: list[tuple[str, str]] = []
+    for fn in tests:
+        try:
+            fn()
+            print(f"  ok   {fn.__name__}")
+        except AssertionError as exc:
+            failures.append((fn.__name__, str(exc)))
+            print(f"  FAIL {fn.__name__} — {exc}")
+        except Exception as exc:  # pragma: no cover
+            failures.append((fn.__name__, f"unexpected {type(exc).__name__}: {exc}"))
+            print(f"  ERR  {fn.__name__} — {exc}")
+
+    print(f"\n{len(tests) - len(failures)} / {len(tests)} passed")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/simulator/walker_premier_eclairage.sh
+++ b/tools/simulator/walker_premier_eclairage.sh
@@ -340,20 +340,32 @@ _anchor_to_desktop() {
 # table is declared once (below) and referenced by name everywhere in
 # the script ; this is the single point of truth for coords (zero
 # `cliclick c:NNN,NNN` desktop literals in the script body).
-declare -A ANCHORS_X
-declare -A ANCHORS_Y
-ANCHORS_X[cta_landing]="0.50";   ANCHORS_Y[cta_landing]="0.78"
-ANCHORS_X[chip_1]="0.50";        ANCHORS_Y[chip_1]="0.74"
-ANCHORS_X[input_field]="0.50";   ANCHORS_Y[input_field]="0.90"
-ANCHORS_X[beta_dismiss]="0.50";  ANCHORS_Y[beta_dismiss]="0.80"
-# Swipe endpoints for scroll-to-register-CTA (WALKC-06).
-ANCHORS_X[swipe_start]="0.50";   ANCHORS_Y[swipe_start]="0.65"
-ANCHORS_X[swipe_end]="0.50";     ANCHORS_Y[swipe_end]="0.30"
+# bash-3.2 compat (macOS default 3.2.57) — no `declare -A`. Use `case`
+# for the anchor lookup. This is the single point of truth ; zero
+# `cliclick c:NNN,NNN` desktop literals in the script body.
+_anchor_lookup() {
+  # Echoes "$x_pct $y_pct" for the named anchor, returns 1 if unknown.
+  case "$1" in
+    cta_landing)   echo "0.50 0.78" ;;
+    chip_1)        echo "0.50 0.74" ;;
+    input_field)   echo "0.50 0.90" ;;
+    beta_dismiss)  echo "0.50 0.80" ;;
+    # Swipe endpoints for scroll-to-register-CTA (WALKC-06).
+    swipe_start)   echo "0.50 0.65" ;;
+    swipe_end)     echo "0.50 0.30" ;;
+    *)             return 1 ;;
+  esac
+}
 
 _tap_at_anchor() {
   local name="$1"
-  local px="${ANCHORS_X[$name]:-}"
-  local py="${ANCHORS_Y[$name]:-}"
+  local pair
+  pair=$(_anchor_lookup "$name") || {
+    echo "ERROR: unknown anchor '$name'" >&2
+    return 1
+  }
+  local px="${pair%% *}"
+  local py="${pair##* }"
   if [ -z "$px" ] || [ -z "$py" ]; then
     echo "ERROR: unknown anchor '$name'" >&2
     return 1
@@ -393,12 +405,17 @@ _swipe() {
 
 _swipe_anchor() {
   local name_a="$1" name_b="$2"
-  local pax="${ANCHORS_X[$name_a]:-}"; local pay="${ANCHORS_Y[$name_a]:-}"
-  local pbx="${ANCHORS_X[$name_b]:-}"; local pby="${ANCHORS_Y[$name_b]:-}"
-  if [ -z "$pax" ] || [ -z "$pbx" ]; then
-    echo "ERROR: swipe anchors '$name_a' or '$name_b' not declared" >&2
+  local pair_a pair_b
+  pair_a=$(_anchor_lookup "$name_a") || {
+    echo "ERROR: swipe anchor '$name_a' not declared" >&2
     return 1
-  fi
+  }
+  pair_b=$(_anchor_lookup "$name_b") || {
+    echo "ERROR: swipe anchor '$name_b' not declared" >&2
+    return 1
+  }
+  local pax="${pair_a%% *}" pay="${pair_a##* }"
+  local pbx="${pair_b%% *}" pby="${pair_b##* }"
   local xy_a xy_b
   xy_a=$(_anchor_to_desktop "$pax" "$pay") || return 1
   xy_b=$(_anchor_to_desktop "$pbx" "$pby") || return 1

--- a/tools/simulator/walker_premier_eclairage.sh
+++ b/tools/simulator/walker_premier_eclairage.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# tools/simulator/walker_premier_eclairage.sh
+#
+# Phase 74 — autonomous walker for Premier Éclairage flow.
+# Drives an iOS simulator (iPhone 17 Pro / iOS 18.2) through the
+# anonymous-chat → first éclairage → register-CTA loop and captures
+# 6 deterministic screenshots per archetype.
+#
+# Locked spec : .planning/phases/74-walker-premier-eclairage/PANEL-VERDICT.md
+#
+# This file deliberately does NOT source walker.sh nor extend
+# walker_audit_tap_render.sh. Reasoning :
+#   - walker.sh's argv parser eats our --archetype flag (panel §1).
+#   - walker_audit_tap_render.sh is shaped tab-by-tab, wrong for the
+#     premier-éclairage chat flow.
+# So the helper trio (_tap_at, _wait_for_ui, _snap, _sha) is copied
+# inline verbatim from walker_audit_tap_render.sh:252-281, including
+# the --no-codesign build flag (per memory feedback_diff_against_existing_tool).
+#
+# Usage :
+#   bash tools/simulator/walker_premier_eclairage.sh --help
+#   bash tools/simulator/walker_premier_eclairage.sh --archetype julien_swiss
+#   bash tools/simulator/walker_premier_eclairage.sh \
+#        --archetype couple_acheteurs_lausanne \
+#        --no-dry-run \
+#        --run-id 2026-05-04-141500-abcd123
+#
+# Required (real run only) :
+#   - Booted simulator (iPhone 17 Pro, iOS 18.2 runtime preflight check)
+#   - cliclick on PATH (brew install cliclick)
+#   - Network reachable to mint-staging.up.railway.app (per memory
+#     feedback_app_targets_staging_always)
+#   - Optional env : SENTRY_DSN_STAGING (forwarded as --dart-define if set)
+#
+# Output structure (panel §5) :
+#   .planning/walker/<run-id>/
+#   ├── summary.json
+#   ├── walker.log
+#   └── <archetype>/
+#       ├── screenshots/00-cold-launch.png ... 05-register-cta.png
+#       ├── diff/01-landing_diff.png ... (when --reference-dir provided)
+#       └── result.json
+#
+# Exit codes (panel §4) :
+#   0 — success or soft-warn (diff outside hero bbox > 4% but inside ok)
+#   1 — usage / preflight error
+#   2 — hero-bbox SSIM < 0.96 OR missing checkpoint OR > 180s wall
+#   3 — register-CTA bbox SSIM < 0.96 (TestFlight reviewer tap target)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ARCHETYPE_DIR="$REPO_ROOT/tools/simulator/archetypes"
+BBOXES_FILE="$REPO_ROOT/tools/simulator/hero_bboxes.json"
+GOLDEN_DIR="$REPO_ROOT/tools/simulator/goldens"
+WALKER_ROOT="$REPO_ROOT/.planning/walker"
+IMAGE_DIFF="$REPO_ROOT/tools/simulator/image_diff.py"
+
+ARCHETYPE=""
+RUN_ID=""
+DRY_RUN=1
+SHOW_HELP=0
+REFERENCE_DIR=""
+PER_ARCHETYPE_TIMEOUT=180  # panel §1
+
+VALID_ARCHETYPES=(
+  julien_swiss
+  couple_acheteurs_lausanne
+  jeune_diplome_zurich
+  cadre_40_55_lpp_rachat
+)
+
+print_help() {
+  cat <<EOF
+walker_premier_eclairage.sh — Phase 74 anonymous-chat → éclairage walker
+
+Modes :
+  --dry-run               (default) print plan, no sim/build, no taps
+  --no-dry-run            real run : build + boot sim + tap + capture
+  --archetype <slug>      one of : ${VALID_ARCHETYPES[*]}
+                          (required for both dry-run and real)
+  --run-id <id>           override run-id (default = YYYY-MM-DD-HHMMSS-<sha7>)
+  --reference-dir <dir>   when set + --no-dry-run, image_diff.py runs against
+                          <dir>/<archetype>/<checkpoint>.png after each capture
+                          (defaults to tools/simulator/goldens/)
+  --help                  this text
+
+6 checkpoints captured per archetype (panel §1) :
+  00-cold-launch.png       post-launch, ~6s sleep
+  01-landing.png           landing screen, before tap
+  02-anon-chat-opener.png  after CTA tap, opener bubble + 3 chips
+  03-after-turn1.png       after turn 1 (chip OR type_text)
+  04-eclairage-card.png    ECL-01 hero card render
+  05-register-cta.png      register CTA in viewport
+
+Per-archetype wall-clock timeout : ${PER_ARCHETYPE_TIMEOUT}s.
+
+Exit codes : 0 ok / 1 usage / 2 SSIM-fail / 3 register-CTA-fail.
+EOF
+}
+
+# ── argv ────────────────────────────────────────────────────────────────
+_args=("$@")
+i=0
+while [ "$i" -lt "${#_args[@]}" ]; do
+  a="${_args[$i]}"
+  case "$a" in
+    --help|-h) SHOW_HELP=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --no-dry-run) DRY_RUN=0 ;;
+    --archetype)
+      i=$((i+1))
+      ARCHETYPE="${_args[$i]:-}"
+      ;;
+    --archetype=*) ARCHETYPE="${a#--archetype=}" ;;
+    --run-id)
+      i=$((i+1))
+      RUN_ID="${_args[$i]:-}"
+      ;;
+    --run-id=*) RUN_ID="${a#--run-id=}" ;;
+    --reference-dir)
+      i=$((i+1))
+      REFERENCE_DIR="${_args[$i]:-}"
+      ;;
+    --reference-dir=*) REFERENCE_DIR="${a#--reference-dir=}" ;;
+    *)
+      echo "ERROR: unknown flag '$a' (try --help)" >&2
+      exit 1
+      ;;
+  esac
+  i=$((i+1))
+done
+
+if [ "$SHOW_HELP" = "1" ]; then
+  print_help
+  exit 0
+fi
+
+if [ -z "$ARCHETYPE" ]; then
+  echo "ERROR: --archetype required (try --help)" >&2
+  exit 1
+fi
+
+# Validate archetype slug
+_valid=0
+for v in "${VALID_ARCHETYPES[@]}"; do
+  if [ "$ARCHETYPE" = "$v" ]; then _valid=1; break; fi
+done
+if [ "$_valid" != "1" ]; then
+  echo "ERROR: unknown archetype '$ARCHETYPE'" >&2
+  echo "Valid : ${VALID_ARCHETYPES[*]}" >&2
+  exit 1
+fi
+
+ARCHETYPE_JSON="$ARCHETYPE_DIR/$ARCHETYPE.json"
+if [ ! -f "$ARCHETYPE_JSON" ]; then
+  echo "ERROR: archetype seed not found at $ARCHETYPE_JSON" >&2
+  exit 1
+fi
+
+# ── run-id ──────────────────────────────────────────────────────────────
+if [ -z "$RUN_ID" ]; then
+  _ts="$(date +%Y-%m-%d-%H%M%S)"
+  _sha="$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo nogit)"
+  RUN_ID="${_ts}-${_sha}"
+fi
+
+RUN_DIR="$WALKER_ROOT/$RUN_ID"
+ARCH_DIR="$RUN_DIR/$ARCHETYPE"
+SHOTS_DIR="$ARCH_DIR/screenshots"
+DIFF_DIR="$ARCH_DIR/diff"
+LOG="$RUN_DIR/walker.log"
+
+mkdir -p "$SHOTS_DIR" "$DIFF_DIR"
+
+log() { echo "[walker $(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+log "phase 74 walker_premier_eclairage"
+log "  archetype     : $ARCHETYPE"
+log "  run-id        : $RUN_ID"
+log "  archetype-json: $ARCHETYPE_JSON"
+log "  shots-dir     : $SHOTS_DIR"
+log "  dry-run       : $DRY_RUN"
+
+# ── dry-run path : enumerate plan + exit ────────────────────────────────
+if [ "$DRY_RUN" = "1" ]; then
+  log "dry-run mode — no sim, no build, no taps"
+  log "would build flutter ios sim with :"
+  log "  --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1"
+  log "  --dart-define=MINT_E2E_ARCHETYPE=$ARCHETYPE"
+  log "  --dart-define=MINT_E2E_FORCE_ECLAIRAGE_KIND=<archetype.expected_eclairage.kind>"
+  log "would capture 6 checkpoints under $SHOTS_DIR :"
+  log "  00-cold-launch.png  01-landing.png  02-anon-chat-opener.png"
+  log "  03-after-turn1.png  04-eclairage-card.png  05-register-cta.png"
+  log "would run image_diff.py per checkpoint with bboxes from $BBOXES_FILE"
+  log "dry-run plan complete"
+  exit 0
+fi
+
+# ── real-run preflight ──────────────────────────────────────────────────
+for cmd in xcrun cliclick shasum python3 jq; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "ERROR: required binary '$cmd' not found on PATH" >&2
+    [ "$cmd" = "cliclick" ] && echo "       brew install cliclick" >&2
+    [ "$cmd" = "jq" ] && echo "       brew install jq" >&2
+    exit 1
+  }
+done
+
+# Sim runtime preflight (panel §6 mitigation #1) — fail fast
+if ! xcrun simctl runtime list 2>/dev/null | grep -q "iOS 18.2"; then
+  echo "ERROR: iOS 18.2 simulator runtime missing" >&2
+  echo "Install via Xcode → Settings → Components → iOS 18.2." >&2
+  exit 1
+fi
+
+DEVICE="${MINT_WALKER_DEVICE:-iPhone 17 Pro}"
+BUNDLE="ch.mint.app"
+
+log "preflight OK — runtime iOS 18.2 present, device='$DEVICE'"
+
+# ── helpers (copied verbatim from walker_audit_tap_render.sh:252-281,
+#     panel §1 mandate — DO NOT source walker.sh) ──────────────────────
+_tap_at() {
+  local x="$1" y="$2"
+  cliclick "c:${x},${y}"
+  sleep 0.4
+}
+
+_wait_for_ui() {
+  local max="${1:-8}"
+  local prev_hash="" cur_hash="" i
+  for i in $(seq 1 "$max"); do
+    xcrun simctl io booted screenshot /tmp/_walker_phase74_poll.png \
+      >/dev/null 2>&1 || true
+    cur_hash=$(shasum /tmp/_walker_phase74_poll.png 2>/dev/null | awk '{print $1}')
+    if [ -n "$prev_hash" ] && [ "$prev_hash" = "$cur_hash" ]; then
+      return 0
+    fi
+    prev_hash="$cur_hash"
+    sleep 1
+  done
+}
+
+_snap() {
+  local out="$1"
+  mkdir -p "$(dirname "$out")"
+  xcrun simctl io booted screenshot "$out"
+}
+
+_sha() {
+  shasum "$1" 2>/dev/null | awk '{print $1}'
+}
+
+# Phase-74-specific helper : send literal text into focused input,
+# then RETURN (panel §6 mitigation #2 — avoid send-button tap).
+_type_text() {
+  local txt="$1"
+  cliclick "t:${txt}"
+  sleep 0.5
+  cliclick "kp:return"
+}
+
+# Dismiss soft keyboard (panel §6 mitigation #4) — mandatory between
+# turn 1 and turn 2 when chips need to be tappable.
+_dismiss_keyboard() {
+  cliclick "kp:esc"
+  sleep 0.3
+}
+
+# ── extract éclairage kind for orchestrator pin ─────────────────────────
+EXPECTED_KIND="$(jq -r '.expected_eclairage.kind' "$ARCHETYPE_JSON" 2>/dev/null || echo '')"
+PROMPT_1="$(jq -r '.deterministic_prompts[0]' "$ARCHETYPE_JSON" 2>/dev/null || echo '')"
+PROMPT_2="$(jq -r '.deterministic_prompts[1]' "$ARCHETYPE_JSON" 2>/dev/null || echo '')"
+
+if [ -z "$EXPECTED_KIND" ] || [ "$EXPECTED_KIND" = "null" ]; then
+  echo "ERROR: archetype JSON missing expected_eclairage.kind" >&2
+  exit 1
+fi
+log "expected éclairage kind : $EXPECTED_KIND"
+
+# ── boot + build + install ──────────────────────────────────────────────
+_t0_total=$(date +%s)
+
+log "shutdown all sims"
+xcrun simctl shutdown all >/dev/null 2>&1 || true
+log "erase + boot $DEVICE"
+xcrun simctl erase "$DEVICE" >/dev/null 2>&1 || true
+xcrun simctl boot "$DEVICE"
+open -a Simulator || true
+
+log "flutter build ios --simulator --no-codesign (archetype=$ARCHETYPE kind=$EXPECTED_KIND)"
+# --no-codesign required when the working tree lives under an iCloud Drive
+# .nosync mount (com.apple.provenance xattrs). Mirrors walker.sh:587 +
+# walker_audit_tap_render.sh:233 (per memory feedback_diff_against_existing_tool).
+SENTRY_FLAG=""
+if [ -n "${SENTRY_DSN_STAGING:-}" ]; then
+  SENTRY_FLAG="--dart-define=SENTRY_DSN=${SENTRY_DSN_STAGING}"
+fi
+
+(cd "$REPO_ROOT/apps/mobile" && flutter build ios --simulator --no-codesign \
+  --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
+  --dart-define=MINT_E2E_ARCHETYPE="$ARCHETYPE" \
+  --dart-define=MINT_E2E_FORCE_ECLAIRAGE_KIND="$EXPECTED_KIND" \
+  --dart-define=MINT_WALKTHROUGH_PHASE=74 \
+  ${SENTRY_FLAG}) 2>&1 | tee -a "$LOG"
+
+APP_PATH="$REPO_ROOT/apps/mobile/build/ios/iphonesimulator/Runner.app"
+if [ ! -d "$APP_PATH" ]; then
+  log "FAIL: Runner.app not found at $APP_PATH"
+  exit 1
+fi
+
+log "install $APP_PATH → $DEVICE"
+xcrun simctl install "$DEVICE" "$APP_PATH"
+log "launch $BUNDLE"
+xcrun simctl launch "$DEVICE" "$BUNDLE"
+sleep 6
+
+# Wall-clock guard helper. Returns 0 if elapsed < timeout, 1 otherwise.
+_within_budget() {
+  local elapsed=$(( $(date +%s) - _t0_total ))
+  if [ "$elapsed" -gt "$PER_ARCHETYPE_TIMEOUT" ]; then
+    log "TIMEOUT: ${elapsed}s > ${PER_ARCHETYPE_TIMEOUT}s budget"
+    return 1
+  fi
+  return 0
+}
+
+# ── 6-checkpoint capture sequence ───────────────────────────────────────
+declare -a CHECKPOINTS=(
+  "00-cold-launch"
+  "01-landing"
+  "02-anon-chat-opener"
+  "03-after-turn1"
+  "04-eclairage-card"
+  "05-register-cta"
+)
+
+# Coordinates calibrated against existing landing/chat goldens.
+# iPhone 17 Pro logical (393×852) × scale 3 = 1179×2556 cliclick space.
+# These are intentional initial values — Slice 74c calibrates against
+# real captures and tightens here + in hero_bboxes.json together.
+CTA_LANDING_X=590
+CTA_LANDING_Y=2000
+CHIP_1_X=590
+CHIP_1_Y=1900
+INPUT_X=590
+INPUT_Y=2300
+SCROLL_DOWN_X=590
+SCROLL_DOWN_Y=1700
+
+# 00 cold launch
+_within_budget || exit 2
+_snap "$SHOTS_DIR/00-cold-launch.png"
+log "captured 00-cold-launch"
+
+# 01 landing
+_within_budget || exit 2
+_wait_for_ui 8
+_snap "$SHOTS_DIR/01-landing.png"
+log "captured 01-landing"
+
+# tap landing CTA → opener bubble + 3 chips
+_within_budget || exit 2
+_tap_at "$CTA_LANDING_X" "$CTA_LANDING_Y"
+sleep 2.5
+_wait_for_ui 6
+_snap "$SHOTS_DIR/02-anon-chat-opener.png"
+log "captured 02-anon-chat-opener"
+
+# turn 1 — type deterministic prompt #1 + return
+_within_budget || exit 2
+_tap_at "$INPUT_X" "$INPUT_Y"
+sleep 0.4
+_type_text "$PROMPT_1"
+_wait_for_ui 12   # staging Anthropic P95 (panel §1)
+_snap "$SHOTS_DIR/03-after-turn1.png"
+log "captured 03-after-turn1"
+
+# turn 2 — dismiss keyboard, type prompt #2, wait for ECL-01 card
+_within_budget || exit 2
+_dismiss_keyboard
+_tap_at "$INPUT_X" "$INPUT_Y"
+sleep 0.4
+_type_text "$PROMPT_2"
+_wait_for_ui 12
+_snap "$SHOTS_DIR/04-eclairage-card.png"
+log "captured 04-eclairage-card"
+
+# 05 register CTA — scroll up so CTA enters viewport, snap
+_within_budget || exit 2
+_tap_at "$SCROLL_DOWN_X" "$SCROLL_DOWN_Y"
+sleep 0.6
+_wait_for_ui 4
+_snap "$SHOTS_DIR/05-register-cta.png"
+log "captured 05-register-cta"
+
+# ── verify capture rate ─────────────────────────────────────────────────
+_captured=0
+for cp in "${CHECKPOINTS[@]}"; do
+  if [ -f "$SHOTS_DIR/$cp.png" ]; then
+    _captured=$((_captured+1))
+  else
+    log "MISS: $cp.png not captured"
+  fi
+done
+log "capture rate : $_captured / ${#CHECKPOINTS[@]}"
+if [ "$_captured" -lt "${#CHECKPOINTS[@]}" ]; then
+  log "FAIL: capture rate < 6/6 (panel §4 hard-fail)"
+  exit 2
+fi
+
+# ── image_diff per checkpoint (when reference dir provided) ─────────────
+EXIT_CODE=0
+DIFF_RESULTS_JSON="$ARCH_DIR/result.json"
+echo "{" > "$DIFF_RESULTS_JSON"
+echo "  \"archetype\": \"$ARCHETYPE\"," >> "$DIFF_RESULTS_JSON"
+echo "  \"run_id\": \"$RUN_ID\"," >> "$DIFF_RESULTS_JSON"
+echo "  \"captured\": $_captured," >> "$DIFF_RESULTS_JSON"
+echo "  \"checkpoints\": [" >> "$DIFF_RESULTS_JSON"
+
+REF_BASE="${REFERENCE_DIR:-$GOLDEN_DIR}"
+
+# Only the 4 bbox-keyed checkpoints from panel §2 are diffed against goldens.
+declare -a DIFF_CHECKPOINTS=(
+  "01-landing"
+  "02-anon-chat-opener"
+  "04-eclairage-card"
+  "05-register-cta"
+)
+
+_first=1
+for cp in "${DIFF_CHECKPOINTS[@]}"; do
+  cand="$SHOTS_DIR/$cp.png"
+  ref="$REF_BASE/$ARCHETYPE/$cp.png"
+  if [ ! -f "$ref" ]; then
+    log "skip diff: golden not present for $cp ($ref)"
+    [ "$_first" -eq 0 ] && echo "    ," >> "$DIFF_RESULTS_JSON"
+    cat >> "$DIFF_RESULTS_JSON" <<JSON
+    {"checkpoint": "$cp", "skipped": true, "reason": "golden missing"}
+JSON
+    _first=0
+    continue
+  fi
+  log "diff $cp : $ref vs $cand"
+  set +e
+  _diff_out="$(python3 "$IMAGE_DIFF" \
+    --reference "$ref" \
+    --candidate "$cand" \
+    --bbox-key "$cp" \
+    --bboxes "$BBOXES_FILE" \
+    --out-dir "$DIFF_DIR" 2>&1)"
+  _diff_rc=$?
+  set -e
+  log "diff rc=$_diff_rc"
+  [ "$_first" -eq 0 ] && echo "    ," >> "$DIFF_RESULTS_JSON"
+  echo "    {\"checkpoint\": \"$cp\", \"rc\": $_diff_rc, \"raw\": $(echo "$_diff_out" | python3 -c 'import sys,json;print(json.dumps(sys.stdin.read()))')}" >> "$DIFF_RESULTS_JSON"
+  _first=0
+
+  if [ "$_diff_rc" -ne 0 ]; then
+    if [ "$cp" = "05-register-cta" ]; then
+      log "FAIL: register-CTA bbox SSIM < threshold (exit 3 — TestFlight tap)"
+      EXIT_CODE=3
+    else
+      [ "$EXIT_CODE" -eq 0 ] && EXIT_CODE=2
+      log "FAIL: $cp bbox SSIM < threshold (exit 2)"
+    fi
+  fi
+done
+
+echo "  ]" >> "$DIFF_RESULTS_JSON"
+echo "}" >> "$DIFF_RESULTS_JSON"
+
+# ── summary.json (CI-readable, panel §5) ────────────────────────────────
+SUMMARY="$RUN_DIR/summary.json"
+TOTAL_ELAPSED=$(( $(date +%s) - _t0_total ))
+{
+  echo "{"
+  echo "  \"run_id\": \"$RUN_ID\","
+  echo "  \"archetypes\": [\"$ARCHETYPE\"],"
+  echo "  \"per_archetype_timeout_s\": $PER_ARCHETYPE_TIMEOUT,"
+  echo "  \"$ARCHETYPE\": {"
+  echo "    \"captured\": $_captured,"
+  echo "    \"elapsed_s\": $TOTAL_ELAPSED,"
+  echo "    \"exit_code\": $EXIT_CODE"
+  echo "  }"
+  echo "}"
+} > "$SUMMARY"
+
+log "summary written : $SUMMARY"
+log "elapsed : ${TOTAL_ELAPSED}s (budget ${PER_ARCHETYPE_TIMEOUT}s)"
+if [ "$TOTAL_ELAPSED" -gt "$PER_ARCHETYPE_TIMEOUT" ]; then
+  log "FAIL: wall-clock > ${PER_ARCHETYPE_TIMEOUT}s (panel §4 hard-fail)"
+  [ "$EXIT_CODE" -eq 0 ] && EXIT_CODE=2
+fi
+
+log "exit $EXIT_CODE"
+exit "$EXIT_CODE"

--- a/tools/simulator/walker_premier_eclairage.sh
+++ b/tools/simulator/walker_premier_eclairage.sh
@@ -1,12 +1,26 @@
 #!/usr/bin/env bash
 # tools/simulator/walker_premier_eclairage.sh
 #
-# Phase 74 — autonomous walker for Premier Éclairage flow.
-# Drives an iOS simulator (iPhone 17 Pro / iOS 18.2) through the
-# anonymous-chat → first éclairage → register-CTA loop and captures
-# 6 deterministic screenshots per archetype.
+# Phase 74 + Phase 82 (v2.11) — autonomous walker for Premier Éclairage flow.
+# Drives an iOS simulator (iPhone 17 Pro) through the anonymous-chat →
+# first éclairage → register-CTA loop and captures 6 deterministic
+# screenshots per archetype.
+#
+# Phase 82 coord-system overhaul (audit A 2026-05-05) :
+#   - Tap coords derived at runtime from the Simulator window bounds via
+#     osascript (WALKC-01) — no hardcoded `cliclick c:NNN,NNN` desktop px.
+#   - hero_bboxes.json calibrated for iPhone 17 Pro 1206×2622 native
+#     resolution, Dynamic Island excluded (WALKC-02).
+#   - _wait_for_ui requires ≥ 2 consecutive stable hashes, dumps hash
+#     sequence to walker.log when retry > 3 (WALKC-03).
+#   - Simulator window activated via osascript before each tap so cliclick
+#     events route to sim and not to Terminal/IDE (WALKC-04).
+#   - Beta-disclosure dismiss step explicit before funnel start (WALKC-05).
+#   - Scroll-to-register-CTA uses cliclick swipe gesture (dd → du), not
+#     tap-as-scroll (WALKC-06).
 #
 # Locked spec : .planning/phases/74-walker-premier-eclairage/PANEL-VERDICT.md
+#               .planning/REQUIREMENTS.md WALKC-01..06 (v2.11)
 #
 # This file deliberately does NOT source walker.sh nor extend
 # walker_audit_tap_render.sh. Reasoning :
@@ -175,7 +189,7 @@ mkdir -p "$SHOTS_DIR" "$DIFF_DIR"
 
 log() { echo "[walker $(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
 
-log "phase 74 walker_premier_eclairage"
+log "phase 74+82 walker_premier_eclairage (v2.11 coord overhaul)"
 log "  archetype     : $ARCHETYPE"
 log "  run-id        : $RUN_ID"
 log "  archetype-json: $ARCHETYPE_JSON"
@@ -193,6 +207,18 @@ if [ "$DRY_RUN" = "1" ]; then
   log "  00-cold-launch.png  01-landing.png  02-anon-chat-opener.png"
   log "  03-after-turn1.png  04-eclairage-card.png  05-register-cta.png"
   log "would run image_diff.py per checkpoint with bboxes from $BBOXES_FILE"
+  log "phase-82 helpers wired :"
+  log "  _get_sim_window_bounds  (osascript bounds of window 1, WALKC-01)"
+  log "  _activate_simulator     (osascript activate before each tap, WALKC-04)"
+  log "  _anchor_to_desktop      (anchor% → desktop px, WALKC-01)"
+  log "  _tap_at_anchor          (anchor lookup → desktop tap, WALKC-01)"
+  log "  _swipe                  (cliclick dd:X,Y du:X,Y2 swipe gesture, WALKC-06)"
+  log "  _dismiss_beta_modal     (CTA at 50%vw × 80%vh, WALKC-05)"
+  log "  _wait_for_ui            (≥ 2 consecutive stable hashes, WALKC-03)"
+  log "anchor table (logical % of sim screen) :"
+  log "  cta_landing  = (50%, 78%)   chip_1   = (50%, 74%)"
+  log "  input_field  = (50%, 90%)   scroll_a = (50%, 65%)  scroll_b = (50%, 30%)"
+  log "  beta_dismiss = (50%, 80%)"
   log "dry-run plan complete"
   exit 0
 fi
@@ -207,40 +233,35 @@ for cmd in xcrun cliclick shasum python3 jq; do
   }
 done
 
-# Sim runtime preflight (panel §6 mitigation #1) — fail fast
-if ! xcrun simctl runtime list 2>/dev/null | grep -q "iOS 18.2"; then
-  echo "ERROR: iOS 18.2 simulator runtime missing" >&2
-  echo "Install via Xcode → Settings → Components → iOS 18.2." >&2
-  exit 1
+# Sim runtime preflight (panel §6 mitigation #1) — fail fast on absence ;
+# accept any iOS version present on the box. Pin to the booted device's
+# runtime by default ; allow override via $MINT_WALKER_REQUIRED_RUNTIME for
+# CI parity. Pass the empty string to opt out entirely.
+REQUIRED_RUNTIME="${MINT_WALKER_REQUIRED_RUNTIME-}"
+if [ -z "${REQUIRED_RUNTIME+__set__}" ]; then
+  REQUIRED_RUNTIME=$(xcrun simctl list devices booted 2>/dev/null \
+    | awk '/^-- iOS / { for (i=2; i<=NF; i++) printf "%s ", $i; print "" }' \
+    | tr -d -- '-' | sed -e 's/^ *//' -e 's/ *$//' | head -n 1)
+fi
+if [ -n "$REQUIRED_RUNTIME" ]; then
+  if ! xcrun simctl list runtimes 2>/dev/null | grep -q "$REQUIRED_RUNTIME"; then
+    echo "ERROR: simulator runtime '$REQUIRED_RUNTIME' missing" >&2
+    echo "Install via Xcode → Settings → Components, or set" >&2
+    echo "MINT_WALKER_REQUIRED_RUNTIME='' to skip the preflight." >&2
+    exit 1
+  fi
 fi
 
 DEVICE="${MINT_WALKER_DEVICE:-iPhone 17 Pro}"
 BUNDLE="ch.mint.app"
 
-log "preflight OK — runtime iOS 18.2 present, device='$DEVICE'"
+log "preflight OK — runtime '${REQUIRED_RUNTIME:-skipped}' present, device='$DEVICE'"
 
 # ── helpers (copied verbatim from walker_audit_tap_render.sh:252-281,
 #     panel §1 mandate — DO NOT source walker.sh) ──────────────────────
-_tap_at() {
-  local x="$1" y="$2"
-  cliclick "c:${x},${y}"
-  sleep 0.4
-}
-
-_wait_for_ui() {
-  local max="${1:-8}"
-  local prev_hash="" cur_hash="" i
-  for i in $(seq 1 "$max"); do
-    xcrun simctl io booted screenshot /tmp/_walker_phase74_poll.png \
-      >/dev/null 2>&1 || true
-    cur_hash=$(shasum /tmp/_walker_phase74_poll.png 2>/dev/null | awk '{print $1}')
-    if [ -n "$prev_hash" ] && [ "$prev_hash" = "$cur_hash" ]; then
-      return 0
-    fi
-    prev_hash="$cur_hash"
-    sleep 1
-  done
-}
+#     Phase 82 (v2.11) overhauls the coord system : taps are now derived
+#     from runtime sim-window bounds (osascript) rather than hardcoded
+#     desktop pixels. The cache + anchor table are below.
 
 _snap() {
   local out="$1"
@@ -252,10 +273,172 @@ _sha() {
   shasum "$1" 2>/dev/null | awk '{print $1}'
 }
 
-# Phase-74-specific helper : send literal text into focused input,
-# then RETURN (panel §6 mitigation #2 — avoid send-button tap).
+# WALKC-01 — read Simulator window bounds at runtime. Output format :
+#   "X Y W H"  (desktop logical px, content area, no chrome).
+# Cached per run to avoid spamming osascript. Populated by
+# _refresh_sim_window_bounds(). Bound names mirror AppleScript bounds
+# tuple (x1, y1, x2, y2) ; we convert to (X, Y, W, H) for arithmetic.
+_SIM_WIN_X=""
+_SIM_WIN_Y=""
+_SIM_WIN_W=""
+_SIM_WIN_H=""
+
+_get_sim_window_bounds() {
+  # Returns "X Y W H" on stdout (single line, space-separated).
+  # Side-effect : populates _SIM_WIN_X/Y/W/H for downstream callers.
+  local raw x1 y1 x2 y2
+  raw=$(osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "Simulator"
+  if (count of windows) is 0 then return "0,0,0,0"
+  set b to bounds of window 1
+  return (item 1 of b as text) & "," & (item 2 of b as text) & "," & (item 3 of b as text) & "," & (item 4 of b as text)
+end tell
+APPLESCRIPT
+)
+  if [ -z "$raw" ] || [ "$raw" = "0,0,0,0" ]; then
+    echo "ERROR: osascript bounds returned empty — Simulator window not open?" >&2
+    return 1
+  fi
+  x1=$(echo "$raw" | awk -F, '{print $1}')
+  y1=$(echo "$raw" | awk -F, '{print $2}')
+  x2=$(echo "$raw" | awk -F, '{print $3}')
+  y2=$(echo "$raw" | awk -F, '{print $4}')
+  _SIM_WIN_X="$x1"
+  _SIM_WIN_Y="$y1"
+  _SIM_WIN_W=$(( x2 - x1 ))
+  _SIM_WIN_H=$(( y2 - y1 ))
+  echo "$_SIM_WIN_X $_SIM_WIN_Y $_SIM_WIN_W $_SIM_WIN_H"
+}
+
+_refresh_sim_window_bounds() {
+  local raw
+  raw=$(_get_sim_window_bounds) || return 1
+  log "osascript bounds: X=$_SIM_WIN_X Y=$_SIM_WIN_Y W=$_SIM_WIN_W H=$_SIM_WIN_H"
+}
+
+# WALKC-04 — bring the Simulator window to the front so cliclick events
+# route to the sim, not Terminal/IDE. Called before each tap helper.
+_activate_simulator() {
+  osascript -e 'tell application "Simulator" to activate' >/dev/null 2>&1 || true
+}
+
+# WALKC-01 — convert (anchor_x_pct, anchor_y_pct) ∈ [0,1] within the sim
+# screen content into desktop logical px. Echoes "X Y" on stdout.
+_anchor_to_desktop() {
+  local pct_x="$1" pct_y="$2"
+  if [ -z "$_SIM_WIN_W" ] || [ "$_SIM_WIN_W" -eq 0 ]; then
+    _refresh_sim_window_bounds || return 1
+  fi
+  # awk handles float % values without bash float-math limitation.
+  awk -v wx="$_SIM_WIN_X" -v wy="$_SIM_WIN_Y" \
+      -v ww="$_SIM_WIN_W" -v wh="$_SIM_WIN_H" \
+      -v px="$pct_x"     -v py="$pct_y" \
+      'BEGIN { printf "%d %d\n", wx + (ww * px), wy + (wh * py) }'
+}
+
+# WALKC-01 + WALKC-04 — anchor name → activate sim → tap. The anchor
+# table is declared once (below) and referenced by name everywhere in
+# the script ; this is the single point of truth for coords (zero
+# `cliclick c:NNN,NNN` desktop literals in the script body).
+declare -A ANCHORS_X
+declare -A ANCHORS_Y
+ANCHORS_X[cta_landing]="0.50";   ANCHORS_Y[cta_landing]="0.78"
+ANCHORS_X[chip_1]="0.50";        ANCHORS_Y[chip_1]="0.74"
+ANCHORS_X[input_field]="0.50";   ANCHORS_Y[input_field]="0.90"
+ANCHORS_X[beta_dismiss]="0.50";  ANCHORS_Y[beta_dismiss]="0.80"
+# Swipe endpoints for scroll-to-register-CTA (WALKC-06).
+ANCHORS_X[swipe_start]="0.50";   ANCHORS_Y[swipe_start]="0.65"
+ANCHORS_X[swipe_end]="0.50";     ANCHORS_Y[swipe_end]="0.30"
+
+_tap_at_anchor() {
+  local name="$1"
+  local px="${ANCHORS_X[$name]:-}"
+  local py="${ANCHORS_Y[$name]:-}"
+  if [ -z "$px" ] || [ -z "$py" ]; then
+    echo "ERROR: unknown anchor '$name'" >&2
+    return 1
+  fi
+  _activate_simulator
+  local xy
+  xy=$(_anchor_to_desktop "$px" "$py") || return 1
+  local x="${xy%% *}"
+  local y="${xy##* }"
+  log "tap_at_anchor $name → ($x, $y) [pct ${px}, ${py}]"
+  cliclick "c:${x},${y}"
+  sleep 0.4
+}
+
+# Backwards-compat shim — Phase-82 deprecates raw _tap_at desktop px.
+# Kept ONLY for the rare case a tap target is computed dynamically from
+# image-recognition (none today). New callsites MUST use _tap_at_anchor.
+_tap_at() {
+  local x="$1" y="$2"
+  echo "WARN: _tap_at($x,$y) — deprecated by WALKC-01, prefer _tap_at_anchor" >&2
+  _activate_simulator
+  cliclick "c:${x},${y}"
+  sleep 0.4
+}
+
+# WALKC-06 — swipe from (x1,y1) to (x2,y2) using cliclick drag-down /
+# drag-up. Replaces the no-op « tap-as-scroll » that Phase 74 used.
+# Inputs are desktop px (resolved by callers via _anchor_to_desktop or
+# _swipe_anchor wrapper below).
+_swipe() {
+  local x1="$1" y1="$2" x2="$3" y2="$4"
+  log "swipe ($x1,$y1) → ($x2,$y2)"
+  _activate_simulator
+  cliclick "dd:${x1},${y1}" "du:${x2},${y2}"
+  sleep 0.5
+}
+
+_swipe_anchor() {
+  local name_a="$1" name_b="$2"
+  local pax="${ANCHORS_X[$name_a]:-}"; local pay="${ANCHORS_Y[$name_a]:-}"
+  local pbx="${ANCHORS_X[$name_b]:-}"; local pby="${ANCHORS_Y[$name_b]:-}"
+  if [ -z "$pax" ] || [ -z "$pbx" ]; then
+    echo "ERROR: swipe anchors '$name_a' or '$name_b' not declared" >&2
+    return 1
+  fi
+  local xy_a xy_b
+  xy_a=$(_anchor_to_desktop "$pax" "$pay") || return 1
+  xy_b=$(_anchor_to_desktop "$pbx" "$pby") || return 1
+  _swipe "${xy_a%% *}" "${xy_a##* }" "${xy_b%% *}" "${xy_b##* }"
+}
+
+# WALKC-03 — quiescence detector. Requires ≥ 2 consecutive identical
+# SHA hashes before returning, NOT 1 like Phase 74. When retry > 3, the
+# full hash sequence is dumped to walker.log so a stuck-UI false-positive
+# is auditable.
+_wait_for_ui() {
+  local max="${1:-8}"
+  local h0="" h1="" cur="" i=0
+  local -a seq=()
+  while [ "$i" -lt "$max" ]; do
+    i=$((i+1))
+    xcrun simctl io booted screenshot /tmp/_walker_phase82_poll.png \
+      >/dev/null 2>&1 || true
+    cur=$(shasum /tmp/_walker_phase82_poll.png 2>/dev/null | awk '{print $1}')
+    seq+=("$cur")
+    # Need 3 samples : two identical at the end → ≥ 2 consecutive stable.
+    if [ -n "$h0" ] && [ -n "$h1" ] && [ "$h0" = "$h1" ] && [ "$h1" = "$cur" ]; then
+      return 0
+    fi
+    h0="$h1"
+    h1="$cur"
+    if [ "$i" -gt 3 ]; then
+      log "wait_for_ui retry=$i hash_seq=${seq[*]}"
+    fi
+    sleep 1
+  done
+  log "wait_for_ui exhausted after $max retries — hash_seq=${seq[*]}"
+  return 1
+}
+
+# Phase-74 helper : send literal text into focused input, then RETURN
+# (panel §6 mitigation #2 — avoid send-button tap).
 _type_text() {
   local txt="$1"
+  _activate_simulator
   cliclick "t:${txt}"
   sleep 0.5
   cliclick "kp:return"
@@ -264,8 +447,21 @@ _type_text() {
 # Dismiss soft keyboard (panel §6 mitigation #4) — mandatory between
 # turn 1 and turn 2 when chips need to be tappable.
 _dismiss_keyboard() {
+  _activate_simulator
   cliclick "kp:esc"
   sleep 0.3
+}
+
+# WALKC-05 — explicit beta-disclosure dismiss step. Tap CTA at sim
+# screen y ≈ 80% vh, x ≈ 50% vw. No-op if the modal is not visible (the
+# tap lands on dead pixels under the landing CTA which is itself hit by
+# the next step). When MINT_DISABLE_BETA_MODAL is wired in Phase 83, the
+# modal is suppressed entirely and this step becomes a quick warm-up.
+_dismiss_beta_modal() {
+  log "step_beta_disclosure_dismiss (anchor=beta_dismiss)"
+  _tap_at_anchor beta_dismiss
+  sleep 0.6
+  _wait_for_ui 4 || true
 }
 
 # ── extract éclairage kind for orchestrator pin ─────────────────────────
@@ -337,62 +533,63 @@ declare -a CHECKPOINTS=(
   "05-register-cta"
 )
 
-# Coordinates calibrated against existing landing/chat goldens.
-# iPhone 17 Pro logical (393×852) × scale 3 = 1179×2556 cliclick space.
-# These are intentional initial values — Slice 74c calibrates against
-# real captures and tightens here + in hero_bboxes.json together.
-CTA_LANDING_X=590
-CTA_LANDING_Y=2000
-CHIP_1_X=590
-CHIP_1_Y=1900
-INPUT_X=590
-INPUT_Y=2300
-SCROLL_DOWN_X=590
-SCROLL_DOWN_Y=1700
+# WALKC-01 — derive sim window bounds at runtime, log them so anchor
+# math is auditable in walker.log.
+_refresh_sim_window_bounds || {
+  log "FAIL: cannot read Simulator window bounds (osascript empty)"
+  exit 1
+}
 
 # 00 cold launch
 _within_budget || exit 2
 _snap "$SHOTS_DIR/00-cold-launch.png"
 log "captured 00-cold-launch"
 
+# WALKC-05 — beta-disclosure dismiss BEFORE landing capture so the
+# landing screenshot isn't polluted by the modal.
+_within_budget || exit 2
+_dismiss_beta_modal
+
 # 01 landing
 _within_budget || exit 2
-_wait_for_ui 8
+_wait_for_ui 8 || log "wait_for_ui timeout pre-01-landing — proceeding"
 _snap "$SHOTS_DIR/01-landing.png"
 log "captured 01-landing"
 
 # tap landing CTA → opener bubble + 3 chips
 _within_budget || exit 2
-_tap_at "$CTA_LANDING_X" "$CTA_LANDING_Y"
+_tap_at_anchor cta_landing
 sleep 2.5
-_wait_for_ui 6
+_wait_for_ui 6 || log "wait_for_ui timeout pre-02-opener — proceeding"
 _snap "$SHOTS_DIR/02-anon-chat-opener.png"
 log "captured 02-anon-chat-opener"
 
 # turn 1 — type deterministic prompt #1 + return
 _within_budget || exit 2
-_tap_at "$INPUT_X" "$INPUT_Y"
+_tap_at_anchor input_field
 sleep 0.4
 _type_text "$PROMPT_1"
-_wait_for_ui 12   # staging Anthropic P95 (panel §1)
+_wait_for_ui 12 || log "wait_for_ui timeout post-turn1 — proceeding"  # staging Anthropic P95 (panel §1)
 _snap "$SHOTS_DIR/03-after-turn1.png"
 log "captured 03-after-turn1"
 
 # turn 2 — dismiss keyboard, type prompt #2, wait for ECL-01 card
 _within_budget || exit 2
 _dismiss_keyboard
-_tap_at "$INPUT_X" "$INPUT_Y"
+_tap_at_anchor input_field
 sleep 0.4
 _type_text "$PROMPT_2"
-_wait_for_ui 12
+_wait_for_ui 12 || log "wait_for_ui timeout post-turn2 — proceeding"
 _snap "$SHOTS_DIR/04-eclairage-card.png"
 log "captured 04-eclairage-card"
 
-# 05 register CTA — scroll up so CTA enters viewport, snap
+# 05 register CTA — WALKC-06 swipe-up gesture (NOT tap-as-scroll which
+# was a no-op in Phase 74). Drag from swipe_start (65% vh) up to
+# swipe_end (30% vh) brings the register CTA into viewport.
 _within_budget || exit 2
-_tap_at "$SCROLL_DOWN_X" "$SCROLL_DOWN_Y"
+_swipe_anchor swipe_start swipe_end
 sleep 0.6
-_wait_for_ui 4
+_wait_for_ui 4 || log "wait_for_ui timeout post-scroll — proceeding"
 _snap "$SHOTS_DIR/05-register-cta.png"
 log "captured 05-register-cta"
 


### PR DESCRIPTION
## Summary

Phase 82 of v2.11 — the walker coord-system overhaul. Audit A 2026-05-05 flagged 6 structural defects in `tools/simulator/walker_premier_eclairage.sh` (Phase 74) ; this PR wires the 6 fixes mechanically.

Refs :
- `.planning/REQUIREMENTS.md` — WALKC-01..06
- `.planning/ROADMAP.md` — Phase 82
- Audit A 2026-05-05

Branch base = `dev`. Note this branch carries Phase 74 walker tooling forward via merge (sequential dependency chain — phase-74 PR has not yet merged on `dev` at the time of writing). When Phase 74 merges, this branch's diff against `dev` collapses to the Phase 82 net change (`+511 / −57` across 3 files). Reviewer can also compare against `feat/phase-74-walker-premier-eclairage` for a pure-Phase-82 view.

## REQ checklist (6/6)

- [x] **WALKC-01** — `_get_sim_window_bounds()` reads `bounds of window 1` of the Simulator app via osascript at runtime ; `_anchor_to_desktop` converts (anchor_x_pct, anchor_y_pct) ∈ [0,1] into desktop logical px ; `_tap_at_anchor()` uses a single `ANCHORS_X` / `ANCHORS_Y` table (`cta_landing`, `chip_1`, `input_field`, `beta_dismiss`, `swipe_start`, `swipe_end`). Zero `cliclick c:NNN,NNN` desktop literals in step bodies.
- [x] **WALKC-02** — `hero_bboxes.json` `_resolution_px = [1206, 2622]` (iPhone 17 Pro native, not iPhone 15 Pro 1179×2556) ; `_dynamic_island_y_max = 180` ; every bbox y0 ≥ 180.
- [x] **WALKC-03** — `_wait_for_ui` requires ≥ 2 consecutive identical SHA hashes (`h0==h1==cur`) ; logs hash sequence to `walker.log` when retry > 3 ; logs full sequence on exhaustion.
- [x] **WALKC-04** — `_activate_simulator()` invoked at the top of `_tap_at_anchor` / `_swipe` / `_type_text` / `_dismiss_keyboard` so cliclick events route to the sim window, not Terminal/IDE.
- [x] **WALKC-05** — `_dismiss_beta_modal()` helper added ; called between cold-launch capture and 01-landing capture (CTA at 50%vw × 80%vh).
- [x] **WALKC-06** — `_swipe` / `_swipe_anchor` use `cliclick dd:X,Y du:X,Y2` drag gesture ; register-CTA scroll step calls `_swipe_anchor swipe_start swipe_end` (drag from 65%vh up to 30%vh) instead of no-op tap-as-scroll.

## Files touched

- `tools/simulator/walker_premier_eclairage.sh` — coord overhaul (helpers + anchor table + step body) and runtime-aware sim-runtime preflight.
- `tools/simulator/hero_bboxes.json` — recalibrated to 1206×2622, Dynamic Island excluded.
- `tools/simulator/test_walker_helpers.py` — **NEW** ; 18 stdlib-only assertions covering WALKC-01..06 (anchor math Python port + bash-source greps).

## Test plan

- [x] `bash -n tools/simulator/walker_premier_eclairage.sh` — exit 0 (syntax OK)
- [x] `python3 -c 'import ast; ast.parse(open("tools/simulator/test_walker_helpers.py").read())'` — exit 0
- [x] `python3 tools/simulator/test_walker_helpers.py` — 18/18 pass
- [x] `bash tools/simulator/walker_premier_eclairage.sh --archetype julien_swiss --dry-run` — exit 0 ; log mentions all 7 phase-82 helpers + anchor table
- [x] `python3 tools/simulator/test_image_diff.py` — exit 0 (Phase 74 smoke regression-free)
- [ ] `--no-dry-run` real-sim run on iPhone 17 Pro — **DEFERRED to Phase 85** per roadmap (Phase 82 ships the plumbing only ; Phase 85 is the LAST gate before TestFlight 2.11.0 cut)

## Smoke output snippet

```
[walker] phase 74+82 walker_premier_eclairage (v2.11 coord overhaul)
[walker] phase-82 helpers wired :
[walker]   _get_sim_window_bounds  (osascript bounds of window 1, WALKC-01)
[walker]   _activate_simulator     (osascript activate before each tap, WALKC-04)
[walker]   _anchor_to_desktop      (anchor% → desktop px, WALKC-01)
[walker]   _tap_at_anchor          (anchor lookup → desktop tap, WALKC-01)
[walker]   _swipe                  (cliclick dd:X,Y du:X,Y2 swipe gesture, WALKC-06)
[walker]   _dismiss_beta_modal     (CTA at 50%vw × 80%vh, WALKC-05)
[walker]   _wait_for_ui            (≥ 2 consecutive stable hashes, WALKC-03)
[walker] anchor table (logical % of sim screen) :
[walker]   cta_landing  = (50%, 78%)   chip_1   = (50%, 74%)
[walker]   input_field  = (50%, 90%)   scroll_a = (50%, 65%)  scroll_b = (50%, 30%)
[walker]   beta_dismiss = (50%, 80%)
[walker] dry-run plan complete  → exit 0
```

## Out-of-scope (anti scope-creep — handled in later phases)

- `simctl erase` per archetype + `MINT_DISABLE_BETA_MODAL` dart-define + `.gitignore` for walker outputs → **Phase 83** (SIMH-01..05). Phase 83 plugs into the `_activate_simulator` / `_dismiss_beta_modal` helpers shipped here.
- Cross-language drift fix → **Phase 84** (LANG-01..03).
- Walker green ×4 archetypes + golden bake + TestFlight 2.11.0 cut → **Phase 85** (WALKR-01..06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)