### PR TITLE
chore(v2.12.0): bump pubspec 2.9.0+1 → 2.12.0+2 for TestFlight tag

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.9.0+1
+version: 2.12.0+2
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Pre-tag bump. v2.12 STAMP-PASS-2026-05-06 closed via PR #500. Next : tag v2.12.0 on dev tip after this merges → dev → staging triggers testflight.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)