### PR TITLE
fix(register): persistent top-bar back button (BUG-W2026-07)

### DIFF
--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -132,6 +132,37 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
     return Scaffold(
       backgroundColor: MintColors.white,
+      // BUG-W2026-07: persistent top-bar back button. Without this, the user
+      // is trapped 5 fields + 4 checkboxes deep before they reach the bottom
+      // "Retour" link, and iOS edge-swipe-back is unreliable from a `go` push.
+      // We match the sibling auth pattern (`forgot_password_screen` /
+      // `verify_email_screen`) — plain `AppBar`, MintColors.white, elevation 0
+      // — but skip the title to avoid duplicating the body's `MintEntrance`
+      // headline. Leading is an explicit IconButton: `Navigator.pop` if the
+      // route is poppable, otherwise `context.go('/auth/login')` because the
+      // landing→login→register entry path uses `context.go` (replaces the
+      // stack, so `canPop` is false).
+      appBar: AppBar(
+        backgroundColor: MintColors.white,
+        surfaceTintColor: MintColors.white,
+        elevation: 0,
+        leading: Semantics(
+          label: l10n.semanticsBack,
+          button: true,
+          child: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            tooltip: l10n.authBack,
+            color: MintColors.textPrimary,
+            onPressed: () {
+              if (Navigator.of(context).canPop()) {
+                Navigator.of(context).pop();
+              } else {
+                context.go('/auth/login');
+              }
+            },
+          ),
+        ),
+      ),
       body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(MintSpacing.lg),

--- a/apps/mobile/test/screens/auth_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/auth_screens_smoke_test.dart
@@ -347,6 +347,50 @@ void main() {
 
       expect(find.text('Retour'), findsOneWidget);
     });
+
+    // BUG-W2026-07: register screen had no persistent back affordance — user
+    // had to scroll past 5 fields + 4 checkboxes to reach the bottom "Retour"
+    // link. We now expose an `AppBar` with a leading back IconButton that
+    // stays pinned to the top regardless of scroll.
+    testWidgets(
+        'has persistent top-bar back button (BUG-W2026-07)',
+        (tester) async {
+      await tester.pumpWidget(buildAuthTestable(const RegisterScreen()));
+      await tester.pump();
+
+      // 1. AppBar exists.
+      expect(find.byType(AppBar), findsOneWidget);
+
+      // 2. Leading icon is the back arrow, and it lives inside the AppBar
+      //    (not somewhere else in the tree).
+      final backIconInAppBar = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.arrow_back),
+      );
+      expect(backIconInAppBar, findsOneWidget);
+
+      // 3. The back IconButton is tappable (i.e. has an onPressed wired).
+      final backButton = find.ancestor(
+        of: backIconInAppBar,
+        matching: find.byType(IconButton),
+      );
+      expect(backButton, findsOneWidget);
+      final iconButton = tester.widget<IconButton>(backButton);
+      expect(iconButton.onPressed, isNotNull);
+
+      // 4. Persistence: scroll the form to the bottom — the AppBar back
+      //    button must still be on screen.
+      await tester.drag(
+          find.byType(SingleChildScrollView), const Offset(0, -800));
+      await tester.pump();
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byIcon(Icons.arrow_back),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

Walker session 2026-05-07 caught **BUG-W2026-07**: the register screen had no
visible back affordance. The user had to scroll past 5 fields + 4 checkboxes
to reach a bottom « Retour » link, and iOS edge-swipe-back was unreliable
because the landing→login→register entry path uses `context.go` (replaces
the navigator stack, so `Navigator.canPop()` returns `false`).

This PR adds a persistent `AppBar` with a leading back arrow at the top of
the register screen, matching the existing sibling auth pattern
(`forgot_password_screen` / `verify_email_screen`).

## Fix

- `apps/mobile/lib/screens/auth/register_screen.dart`: add `appBar: AppBar(...)`
  with `MintColors.white` + elevation 0 + a leading `IconButton(Icons.arrow_back)`.
  Onpress: pop if poppable, else `context.go('/auth/login')` so the back
  affordance stays correct under both the `context.go` and `context.push`
  navigation paths.
- The bottom « Retour » link is intentionally left in place (out of scope —
  separate cleanup, per Karpathy practice 3 "surgical changes").

## i18n / strings

Zero new strings. Reuses existing ARB keys present in all 6 locales:
- `semanticsBack` (a11y label)
- `authBack` (tooltip)

No `flutter gen-l10n` needed.

## Test plan

New widget test in `apps/mobile/test/screens/auth_screens_smoke_test.dart`:
`RegisterScreen has persistent top-bar back button (BUG-W2026-07)`.

Asserts:
- [x] `AppBar` exists.
- [x] `Icons.arrow_back` lives inside the `AppBar` (not elsewhere in the tree).
- [x] The wrapping `IconButton` has a non-null `onPressed`.
- [x] After an 800px scroll drag, the back arrow is **still** in the `AppBar` (persistence).

## Local verification

```
$ flutter analyze lib/screens/auth/register_screen.dart test/screens/auth_screens_smoke_test.dart
No issues found! (ran in 6.4s)

$ flutter test test/screens/auth_screens_smoke_test.dart
00:02 +43: All tests passed!
```

`tools/checks/banned_terms_arb.py` and `tools/checks/accent_lint_fr.py --file ...register_screen.dart` both clean.

## Scope

Single bug, single commit, two files. No adjacent refactor. BUG-W2026-07
closed; no other walker findings touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)