### PR TITLE
fix(beta): drop "En savoir plus" Safari leak from disclosure sheet (BUG-W2026-02)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11179,9 +11179,5 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureLearnMore": "Mehr erfahren",
-  "@betaDisclosureLearnMore": {
-    "x-mint-meta": {"level": "N1"}
-  },
   "betaDisclosureSemanticsLabel": "Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät."
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11179,9 +11179,5 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureLearnMore": "Learn more",
-  "@betaDisclosureLearnMore": {
-    "x-mint-meta": {"level": "N1"}
-  },
   "betaDisclosureSemanticsLabel": "Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default."
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11179,9 +11179,5 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureLearnMore": "Saber más",
-  "@betaDisclosureLearnMore": {
-    "x-mint-meta": {"level": "N1"}
-  },
   "betaDisclosureSemanticsLabel": "Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto."
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12110,10 +12110,6 @@
   "@betaDisclosureCta": {
     "description": "Beta disclosure sheet — primary acknowledgement CTA."
   },
-  "betaDisclosureLearnMore": "En savoir plus",
-  "@betaDisclosureLearnMore": {
-    "description": "Beta disclosure sheet — secondary CTA opening the privacy URL."
-  },
   "betaDisclosureSemanticsLabel": "Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l'appareil par défaut.",
   "@betaDisclosureSemanticsLabel": {
     "description": "Beta disclosure sheet — accessibility container label."

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11179,9 +11179,5 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureLearnMore": "Scopri di più",
-  "@betaDisclosureLearnMore": {
-    "x-mint-meta": {"level": "N1"}
-  },
   "betaDisclosureSemanticsLabel": "Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita."
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40587,12 +40587,6 @@ abstract class S {
   /// **'Je comprends, on y va'**
   String get betaDisclosureCta;
 
-  /// Beta disclosure sheet — secondary CTA opening the privacy URL.
-  ///
-  /// In fr, this message translates to:
-  /// **'En savoir plus'**
-  String get betaDisclosureLearnMore;
-
   /// Beta disclosure sheet — accessibility container label.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23192,9 +23192,6 @@ class SDe extends S {
   String get betaDisclosureCta => 'Verstanden, los geht\'s';
 
   @override
-  String get betaDisclosureLearnMore => 'Mehr erfahren';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23024,9 +23024,6 @@ class SEn extends S {
   String get betaDisclosureCta => 'Got it, let\'s go';
 
   @override
-  String get betaDisclosureLearnMore => 'Learn more';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23138,9 +23138,6 @@ class SEs extends S {
   String get betaDisclosureCta => 'Entendido, vamos';
 
   @override
-  String get betaDisclosureLearnMore => 'Saber más';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23138,9 +23138,6 @@ class SFr extends S {
   String get betaDisclosureCta => 'Je comprends, on y va';
 
   @override
-  String get betaDisclosureLearnMore => 'En savoir plus';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l\'appareil par défaut.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23197,9 +23197,6 @@ class SIt extends S {
   String get betaDisclosureCta => 'Capito, andiamo';
 
   @override
-  String get betaDisclosureLearnMore => 'Scopri di più';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita.';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23146,9 +23146,6 @@ class SPt extends S {
   String get betaDisclosureCta => 'Entendido, vamos';
 
   @override
-  String get betaDisclosureLearnMore => 'Saber mais';
-
-  @override
   String get betaDisclosureSemanticsLabel =>
       'Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito.';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11179,9 +11179,5 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureLearnMore": "Saber mais",
-  "@betaDisclosureLearnMore": {
-    "x-mint-meta": {"level": "N1"}
-  },
   "betaDisclosureSemanticsLabel": "Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito."
 }

--- a/apps/mobile/lib/widgets/beta/beta_program_disclosure_sheet.dart
+++ b/apps/mobile/lib/widgets/beta/beta_program_disclosure_sheet.dart
@@ -19,8 +19,14 @@
 //   • One-shot per device (SharedPreferences flag).
 //   • Calm Handoff 2 voice — Fraunces italic em on key words.
 //   • Single CTA « Je comprends, on y va » dismisses.
-//   • « En savoir plus » deeplinks to the Privacy Center URL.
 //   • A11y semantics with announced label for screen readers.
+//
+//  BUG-W2026-02 (2026-05-07) — the secondary « En savoir plus » link
+//  was removed : it deeplinked to https://mint.ch/privacy via Safari
+//  but the destination has no actual « About MINT en test » article,
+//  so testers / journalists landed on a generic mint.ch page and lost
+//  trust. The 4-bullet content (no advice, no bank, data local) +
+//  semantics label are self-contained and explanatory enough.
 //
 //  Usage :
 //   await BetaProgramDisclosureSheet.maybeShow(context);
@@ -31,7 +37,6 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -42,18 +47,7 @@ const String _kBetaDisclosureSeenKey = 'mint_beta_disclosure_seen';
 /// First-launch beta disclosure sheet. One-shot per device install.
 /// Apple TestFlight beta review + FINMA fintech sandbox compliance.
 class BetaProgramDisclosureSheet extends StatelessWidget {
-  /// Optional override of the « En savoir plus » deeplink URL.
-  /// Defaults to https://mint.ch/privacy.
-  final Uri privacyUrl;
-
-  // Non-const ctor: Uri.parse is not a const expression. Surface this
-  // as a regular ctor so callers don't try to const-instantiate it.
-  BetaProgramDisclosureSheet({
-    super.key,
-    Uri? privacyUrl,
-  }) : privacyUrl = privacyUrl ?? _defaultPrivacyUrl;
-
-  static final Uri _defaultPrivacyUrl = Uri.parse('https://mint.ch/privacy');
+  const BetaProgramDisclosureSheet({super.key});
 
   /// Show the sheet if it hasn't been acknowledged on this device yet.
   /// No-op when the SharedPreferences flag is already set.
@@ -81,7 +75,7 @@ class BetaProgramDisclosureSheet extends StatelessWidget {
       isDismissible: false,
       enableDrag: false,
       backgroundColor: Colors.transparent,
-      builder: (ctx) => BetaProgramDisclosureSheet(),
+      builder: (ctx) => const BetaProgramDisclosureSheet(),
     );
     return true;
   }
@@ -98,12 +92,6 @@ class BetaProgramDisclosureSheet extends StatelessWidget {
   static Future<void> resetForTest() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_kBetaDisclosureSeenKey);
-  }
-
-  Future<void> _openPrivacyUrl(BuildContext context) async {
-    if (await canLaunchUrl(privacyUrl)) {
-      await launchUrl(privacyUrl, mode: LaunchMode.externalApplication);
-    }
   }
 
   Future<void> _onAcknowledge(BuildContext context) async {
@@ -198,21 +186,6 @@ class BetaProgramDisclosureSheet extends StatelessWidget {
                 child: Text(
                   l.betaDisclosureCta,
                   style: MintTextStyles.titleMedium(color: Colors.white),
-                ),
-              ),
-              const SizedBox(height: 8),
-              // Secondary — Privacy URL.
-              TextButton(
-                onPressed: () => _openPrivacyUrl(context),
-                style: TextButton.styleFrom(
-                  foregroundColor: MintColors.textSecondaryAaa,
-                  padding: const EdgeInsets.symmetric(vertical: 10),
-                ),
-                child: Text(
-                  l.betaDisclosureLearnMore,
-                  style: MintTextStyles.bodySmall(
-                    color: MintColors.textSecondaryAaa,
-                  ).copyWith(decoration: TextDecoration.underline),
                 ),
               ),
             ],

--- a/apps/mobile/test/widgets/beta/beta_program_disclosure_sheet_test.dart
+++ b/apps/mobile/test/widgets/beta/beta_program_disclosure_sheet_test.dart
@@ -6,12 +6,11 @@
 //   • maybeShow no-op when SharedPreferences flag is set
 //   • maybeShow shows sheet when flag is unset, persists flag on dismiss
 //   • CTA tap dismisses sheet + sets flag
-//   • « En savoir plus » TextButton renders + is tappable
+//   • « En savoir plus » link is NOT rendered (BUG-W2026-02 — link removed
+//     because mint.ch had no destination article ; users were leaking to
+//     Safari with no content. The 4-bullet copy is self-contained.)
 //   • Headline renders Fraunces italic em (TextSpan walk)
 //   • Semantics label is announced for screen readers
-//
-//  Note: url_launcher isn't mocked in widget tests — the canLaunchUrl
-//  guard in _openPrivacyUrl prevents crashes during test runs.
 // ────────────────────────────────────────────────────────────────────
 
 import 'package:flutter/material.dart';
@@ -85,9 +84,15 @@ void main() {
     expect(find.byType(BetaProgramDisclosureSheet), findsOneWidget);
     // Headline pieces are visible.
     expect(_treeContainsText(tester, 'apprend avec toi'), isTrue);
-    // CTA + secondary visible.
+    // Primary CTA visible.
     expect(_treeContainsText(tester, 'Je comprends'), isTrue);
-    expect(_treeContainsText(tester, 'En savoir plus'), isTrue);
+    // BUG-W2026-02 : the « En savoir plus » secondary link must NOT render.
+    // It used to deeplink https://mint.ch/privacy via Safari, but the
+    // destination has no « About MINT en test » article, so testers landed
+    // on a generic mint.ch page. Link dropped ; the 4-bullet copy (no
+    // advice / no bank / data local) + semantics label are self-contained.
+    expect(_treeContainsText(tester, 'En savoir plus'), isFalse);
+    expect(find.byType(TextButton), findsNothing);
   });
 
   testWidgets('CTA tap dismisses sheet and persists the flag',


### PR DESCRIPTION
## Bug — BUG-W2026-02

Walker walkthrough 2026-05-07 (cold launch + beta disclosure sheet) :

1. Tester opens MINT for the first time
2. Beta disclosure sheet appears : « MINT en test — Tu testes une version qui apprend avec toi. »
3. Tester taps « En savoir plus » (secondary link below the « Je comprends, on y va » CTA)
4. Safari opens at https://mint.ch/privacy → mint.ch shows a **generic start page with no actual « About MINT en test » article**
5. Tester / journalist lands on a blank Safari welcome screen, loses trust, exits the app

This is bad onboarding hygiene — the disclosure sheet is the moment we ask testers to grant trust ; sending them out of the app to a dead destination undoes that ask.

## Fix — Option A (drop the link)

The disclosure sheet's 4 bullets + semantics label already cover the disclosure substance :

- *Pas de conseil financier — outil éducatif*
- *Pas de données bancaires stockées chez nous*
- *Données restant sur l'appareil par défaut*
- A11y `betaDisclosureSemanticsLabel` repeats those points for screen readers

Adding a link to a non-existent destination doesn't add information, just a Safari leak. Surgical removal keeps the modal self-contained. This matches Karpathy practice 2 (« simplicity first ») and practice 3 (« surgical changes — touch only what you must »).

Options B (in-app modal) and C (static text) were considered and rejected :
- **B** : no « About MINT en test » in-app destination exists ; building one is out of scope and would still need authored content
- **C** : static text « Pour plus d'infos : mint.ch » still nudges testers to type the URL and land on the same dead destination

## Files touched (15)

| Path | Change |
| ---- | ------ |
| `apps/mobile/lib/widgets/beta/beta_program_disclosure_sheet.dart` | Drop secondary `TextButton`, `_openPrivacyUrl`, `privacyUrl` field + ctor, `_defaultPrivacyUrl`, `url_launcher` import. Ctor → `const`. Header doc references BUG-W2026-02. |
| `apps/mobile/test/widgets/beta/beta_program_disclosure_sheet_test.dart` | Flip « En savoir plus » assertion to `isFalse` ; add `find.byType(TextButton)` `findsNothing` to lock the link out by structure. |
| `apps/mobile/lib/l10n/app_{fr,en,de,es,it,pt}.arb` | Remove `betaDisclosureLearnMore` key + @-meta in all 6 locale ARBs (parity preserved). |
| `apps/mobile/lib/l10n/app_localizations*.dart` (7 generated files) | `flutter gen-l10n` re-run ; only the `betaDisclosureLearnMore` getter + abstract declaration are dropped. No formatter drift. |

Net diff : `+20 / -90` across 15 files.

## Verification

```
flutter test test/widgets/beta/beta_program_disclosure_sheet*.dart
  9 passed, 1 skipped (MINT_DISABLE_BETA_MODAL dart-define guard).

flutter analyze lib/widgets/beta/ lib/l10n/app_localizations.dart
  No issues found.

python3 tools/checks/banned_terms_arb.py
  OK — 6 locale(s) clean (no positive LSFin banned-term uses).

python3 tools/checks/accent_lint_fr.py --file <widget>
  exit 0.
```

## Test plan

- [ ] CI green : `flutter analyze` + `flutter test` + ARB lints
- [ ] Walker re-run on staging build : confirm sheet renders 3 bullets + 1 CTA only ; no secondary link ; no Safari handoff
- [ ] BUG-W2026-02 closed in `.planning/phases/A-USER-WALKTHROUGH/walkthrough-2026-05-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)