### PR TITLE
fix(coach): port « ordre de grandeur » qualifier rule from anon chat to auth coach (BUG-W2026-10)

### DIFF
--- a/services/backend/app/services/coach/claude_coach_service.py
+++ b/services/backend/app/services/coach/claude_coach_service.py
@@ -531,6 +531,18 @@ Tu opères sous régulation suisse (LSFin, FINMA Circular 2008/21).
 5. TOUJOURS appeler save_insight quand l'utilisateur partage un fait
    (âge, salaire, canton, situation, patrimoine). Voir l'exemple plus bas.
 
+6. ORDRE DE GRANDEUR pour les chiffres suisses non-canoniques.
+   Pour tout chiffre suisse cité que tu ne peux pas sourcer depuis le contexte
+   fourni (médiane de loyer cantonal/communal, taux d'imposition cantonal,
+   médiane salariale par branche, prélèvement anticipé, etc.), encadre-le
+   explicitement comme "ordre de grandeur" et ajoute la source si possible
+   ("selon l'OFS", "selon la fiche fiscale du canton", "donnée 2024").
+   N'avance JAMAIS une valeur exacte sans la qualifier. Préfère une fourchette
+   ("entre 2'000 et 2'400 CHF/mois") ou un arrondi explicite ("autour de
+   2'200 CHF, ordre de grandeur") plutôt qu'un chiffre précis non sourcé.
+   Cette règle ne s'applique PAS aux chiffres saisis par l'utilisateur ni aux
+   constantes injectées dans le contexte (pilier 3a plafond, AVS rente max, etc.).
+
 MOTEUR 4 COUCHES (structure CHAQUE réponse substantielle) :
 1. Extraction factuelle — les faits bruts : durée, frais, pénalités, conditions, flexibilité.
 2. Traduction humaine — reformule en langage courant : "ce produit te bloque X", "tu renonces à Y".

--- a/services/backend/tests/coach/test_claude_coach_prompt_has_ordre_de_grandeur_rule.py
+++ b/services/backend/tests/coach/test_claude_coach_prompt_has_ordre_de_grandeur_rule.py
@@ -1,0 +1,86 @@
+"""
+Tests — « ordre de grandeur » qualifier rule in the auth coach system prompt.
+
+Regression for BUG-W2026-10 (Walker 2026-05-07): the authenticated coach cited
+non-sourced Swiss medians (e.g. "la médiane des loyers tourne autour de
+2'200 CHF") without the « ordre de grandeur » qualifier present in the
+anonymous discovery prompt.
+
+Verifies:
+- The rule text appears in the system prompt returned by build_system_prompt
+  for both a typical authenticated context and the no-context base case.
+- The rule references concrete Swiss examples (médiane / taux d'imposition)
+  so the LLM understands the scope (Swiss-specific approximate citations,
+  not user-supplied amounts).
+- The rule sits inside the « RÈGLES DE CONFORMITÉ » section, not lost in
+  appended late blocks.
+"""
+
+from app.services.coach.claude_coach_service import build_system_prompt
+from app.services.coach.coach_context_builder import build_coach_context
+
+
+def _typical_ctx():
+    """A typical authenticated user context (canton + age, no debt)."""
+    return build_coach_context(has_debt=False, age=42, canton="VD")
+
+
+def test_ordre_de_grandeur_rule_present_with_typical_context():
+    prompt = build_system_prompt(ctx=_typical_ctx())
+    assert "ordre de grandeur" in prompt.lower()
+
+
+def test_ordre_de_grandeur_rule_present_with_no_context():
+    """Even without a CoachContext, the base prompt must carry the rule."""
+    prompt = build_system_prompt(ctx=None)
+    assert "ordre de grandeur" in prompt.lower()
+
+
+def test_ordre_de_grandeur_rule_cites_swiss_examples():
+    """Rule must mention Swiss-specific examples so the LLM scopes it correctly.
+
+    Without examples, the model could confuse this with user-supplied amounts.
+    """
+    prompt = build_system_prompt(ctx=_typical_ctx())
+    lower = prompt.lower()
+    # At least one of the canonical Swiss examples must appear in the rule's
+    # neighbourhood (médiane de loyer / taux d'imposition cantonal).
+    assert "médiane" in lower or "mediane" in lower
+    assert "taux d'imposition" in lower or "taux d imposition" in lower
+
+
+def test_ordre_de_grandeur_rule_lives_in_compliance_section():
+    """The rule must be inside RÈGLES DE CONFORMITÉ, not in an appended block.
+
+    Insertion location matters: rules in this section are read by the LLM as
+    non-negotiable, before the routing rules and tool catalogs.
+    """
+    prompt = build_system_prompt(ctx=_typical_ctx())
+    compliance_idx = prompt.find("RÈGLES DE CONFORMITÉ")
+    moteur_idx = prompt.find("MOTEUR 4 COUCHES")
+    rule_idx = prompt.lower().find("ordre de grandeur")
+
+    assert compliance_idx != -1, "RÈGLES DE CONFORMITÉ heading missing"
+    assert moteur_idx != -1, "MOTEUR 4 COUCHES heading missing"
+    assert rule_idx != -1, "ordre de grandeur rule missing"
+    assert compliance_idx < rule_idx < moteur_idx, (
+        "ordre de grandeur rule must sit inside the RÈGLES DE CONFORMITÉ "
+        "section (between the heading and MOTEUR 4 COUCHES)"
+    )
+
+
+def test_ordre_de_grandeur_rule_excludes_user_supplied_amounts():
+    """Rule must clarify scope: NOT user-supplied amounts, NOT injected constants.
+
+    Without this carve-out the LLM might over-qualify the user's own salary
+    or the canonical pilier 3a plafond, which would degrade UX.
+    """
+    prompt = build_system_prompt(ctx=_typical_ctx())
+    # Either the carve-out wording or one of its concrete anchors must appear.
+    lower = prompt.lower()
+    assert (
+        "saisis par l'utilisateur" in lower
+        or "saisis par l utilisateur" in lower
+        or "constantes injectées" in lower
+        or "constantes injectees" in lower
+    )


### PR DESCRIPTION
## Summary

- BUG-W2026-10 (Walker 2026-05-07): the authenticated coach cited « la médiane des loyers tourne autour de 2'200 CHF » without sourcing or qualification, while the anon discovery prompt holds the line on non-canonical Swiss figures.
- Surgical addition of rule #6 « ORDRE DE GRANDEUR » to `_BASE_SYSTEM_PROMPT` inside the existing `RÈGLES DE CONFORMITÉ` section of `claude_coach_service.py` (after rule #5 `save_insight`, before `MOTEUR 4 COUCHES`). No renumbering of existing rules. No refactor of adjacent code.
- Carve-out: rule does NOT apply to user-supplied amounts or canonical injected constants (3a plafond, AVS rente max), preventing over-qualification.

## New rule (FR, formal, matches surrounding tone)

> 6. ORDRE DE GRANDEUR pour les chiffres suisses non-canoniques.
>    Pour tout chiffre suisse cité que tu ne peux pas sourcer depuis le contexte fourni (médiane de loyer cantonal/communal, taux d'imposition cantonal, médiane salariale par branche, prélèvement anticipé, etc.), encadre-le explicitement comme "ordre de grandeur" et ajoute la source si possible ("selon l'OFS", "selon la fiche fiscale du canton", "donnée 2024"). N'avance JAMAIS une valeur exacte sans la qualifier. Préfère une fourchette ("entre 2'000 et 2'400 CHF/mois") ou un arrondi explicite ("autour de 2'200 CHF, ordre de grandeur") plutôt qu'un chiffre précis non sourcé.
>    Cette règle ne s'applique PAS aux chiffres saisis par l'utilisateur ni aux constantes injectées dans le contexte (pilier 3a plafond, AVS rente max, etc.).

## Compliance scan

- Banned-terms scan on the new rule body: **0 hits** (no « garanti », « optimal », « meilleur », « parfait », « certain », « assuré », « sans risque »).
- Accents preserved (é, è, à) — no ASCII regression.

## Test plan

- [x] `pytest services/backend/tests/coach/test_claude_coach_prompt_has_ordre_de_grandeur_rule.py` — 5/5 green
  - Rule reaches LLM via `build_system_prompt(ctx)` for typical auth ctx (VD, age 42, no debt)
  - Rule reaches LLM with `ctx=None` (base prompt path)
  - Rule references « médiane » + « taux d'imposition » so the LLM scopes it to Swiss approximations
  - Rule sits inside `RÈGLES DE CONFORMITÉ` (between heading and `MOTEUR 4 COUCHES`) — placement, not just presence
  - User-supplied / injected-constants carve-out present
- [x] Adjacent regression: `pytest services/backend/tests/coach/test_claude_coach_safe_mode_prompt.py` — 10/10 still green
- [ ] CI green on dev
- [ ] Walker re-run on next session: rephrase « 2'200 CHF » as « ordre de grandeur 2'000–2'400 CHF, médiane OFS 2024 »

## Walker reproducer

`.planning/phases/A-USER-WALKTHROUGH/walkthrough-2026-05-07.md` — BUG-W2026-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)