### PR TITLE
fix(alembic): add missing create-table migration for anonymous_sessions

### DIFF
--- a/services/backend/alembic/versions/p86_anonymous_session_eclairage_delivered.py
+++ b/services/backend/alembic/versions/p86_anonymous_session_eclairage_delivered.py
@@ -12,7 +12,7 @@ existing rows on staging/production back-fill cleanly without
 manual SQL.
 
 Revision ID: p86_eclairage_delivered
-Revises: 29_04_drop_auto_confirmed
+Revises: p86a_create_anonymous_sessions
 Create Date: 2026-05-06 11:30:00 UTC
 """
 
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 
 
 revision = "p86_eclairage_delivered"
-down_revision = "29_04_drop_auto_confirmed"
+down_revision = "p86a_create_anonymous_sessions"
 branch_labels = None
 depends_on = None
 

--- a/services/backend/alembic/versions/p86a_create_anonymous_sessions.py
+++ b/services/backend/alembic/versions/p86a_create_anonymous_sessions.py
@@ -1,0 +1,76 @@
+"""Create anonymous_sessions table (Phase 13 schema drift fix).
+
+The `AnonymousSession` SQLAlchemy model (introduced Phase 13 for
+anonymous chat rate limiting) was never paired with an alembic
+migration. Existing staging / production environments have the table
+because `Base.metadata.create_all()` ran at app boot before alembic was
+the source of truth — so they never noticed.
+
+CI fresh-database runs (Phase 95-03 TEST-03/04: `alembic upgrade head
+&& alembic downgrade base && alembic upgrade head`) hit
+`sqlalchemy.exc.NoSuchTableError: anonymous_sessions` because:
+- the chain reaches `p86_eclairage_delivered` which calls
+  `inspector.get_columns("anonymous_sessions")`
+- the table was never created via alembic, so it does not exist on a
+  fresh DB
+
+This migration ships the table creation idempotently. It is inserted
+BEFORE `p86_eclairage_delivered` in the chain. For prod / staging
+already at `p86_eclairage_delivered`, the upgrade direction is a no-op
+(alembic only walks forward when current != head). For the downgrade
+direction the chain becomes:
+
+    p86_eclairage_delivered → p86a_create_anonymous_sessions → 29_04_drop_auto_confirmed → ...
+
+Both directions are idempotent so the same code runs cleanly on:
+- fresh test_migration.db (creates table)
+- staging / prod (table already exists from create_all → no-op)
+- downgrade then upgrade (drop then re-create)
+
+Revision ID: p86a_create_anonymous_sessions
+Revises: 29_04_drop_auto_confirmed
+Create Date: 2026-05-07 08:10:00 UTC
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "p86a_create_anonymous_sessions"
+down_revision = "29_04_drop_auto_confirmed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create anonymous_sessions table if it does not already exist."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "anonymous_sessions" in inspector.get_table_names():
+        return  # already exists (prod / staging via create_all)
+
+    op.create_table(
+        "anonymous_sessions",
+        sa.Column("session_id", sa.String(length=36), primary_key=True),
+        sa.Column(
+            "message_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop anonymous_sessions table if it exists."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "anonymous_sessions" not in inspector.get_table_names():
+        return  # already gone
+
+    op.drop_table("anonymous_sessions")


### PR DESCRIPTION
## Summary
Schema drift on `dev`: `AnonymousSession` SQLAlchemy model existed since Phase 13 but no alembic migration created the table. CI fresh-DB runs failed with `NoSuchTableError: anonymous_sessions` because `p86_eclairage_delivered` inspected a table that didn't exist.

This is THE blocker on every backend PR's CI today.

## Fix
- New migration `p86a_create_anonymous_sessions` (idempotent, before p86)
- `p86_eclairage_delivered.down_revision` updated to chain through p86a

Idempotency means prod / staging (which have the table via `create_all`) are unaffected.

## Test plan
- [x] `alembic upgrade head` on fresh sqlite: green
- [x] `alembic downgrade base`: green
- [x] `alembic upgrade head` (replay): green
- [ ] CI green
- [ ] After merge → unblocks PRs #507 + #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)