### PR TITLE
fix(consent): unblock « Depuis la galerie » in mode local (P4 walkthrough)

### DIFF
--- a/apps/mobile/lib/services/consent/consent_service.dart
+++ b/apps/mobile/lib/services/consent/consent_service.dart
@@ -3,7 +3,20 @@
 // Mirrors backend ConsentPurpose enum and wraps /api/v1/consents endpoints.
 // Entry points that touch user data (upload, couple projection) MUST call
 // `requireGrantedOrPrompt` before proceeding.
+//
+// Local-mode fallback (P4 fix, walkthrough 2026-05-07): when the user is in
+// « Continuer en mode local » (no auth session), the backend `/consents`
+// endpoint returns 401. Instead of blocking the whole feature behind a stale
+// snackbar, we mirror the receipt list to a SharedPreferences-backed
+// `_LocalConsentStore` so the user can grant/revoke consent on-device.
+// The backend remains source-of-truth when authenticated; local store is a
+// disjoint additive set with the same `ConsentReceipt` JSON shape.
+
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/widgets/consent/consent_sheet.dart';
@@ -71,6 +84,81 @@ class ConsentReceipt {
             ? null
             : DateTime.parse(j['revokedAt'] as String),
       );
+
+  Map<String, dynamic> toJson() => {
+        'receiptId': receiptId,
+        'purpose': purpose.wire,
+        'policyVersion': policyVersion,
+        'consentTimestamp': consentTimestamp.toIso8601String(),
+        if (revokedAt != null) 'revokedAt': revokedAt!.toIso8601String(),
+      };
+}
+
+/// On-device consent storage used as a fallback when the user is in
+/// « Continuer en mode local » (no auth session) and the backend
+/// `/consents` endpoint is unreachable. Same JSON shape as the backend
+/// receipt so a single `ConsentReceipt.fromJson` deserializer works for
+/// both sources.
+///
+/// `@visibleForTesting` so the local-fallback contract can be unit-tested
+/// without needing an HTTP mock (the test asserts that grant() persists +
+/// load() round-trips, which is the contract surface that mode local
+/// depends on).
+@visibleForTesting
+class LocalConsentStoreForTests {
+  static Future<List<ConsentReceipt>> load() => _LocalConsentStore().load();
+  static Future<ConsentReceipt> grant(ConsentPurpose p) =>
+      _LocalConsentStore().grant(p);
+  static Future<void> clear() => _LocalConsentStore().clear();
+}
+
+class _LocalConsentStore {
+  static const String _prefsKey = 'mint.consent.local_receipts.v1';
+
+  Future<List<ConsentReceipt>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_prefsKey);
+    if (raw == null || raw.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return const [];
+      return decoded
+          .whereType<Map<String, dynamic>>()
+          .map(ConsentReceipt.fromJson)
+          .toList(growable: false);
+    } on FormatException catch (_) {
+      // Corrupt blob — clear it and start fresh. Better to re-prompt the
+      // user once than refuse all flows forever.
+      await prefs.remove(_prefsKey);
+      return const [];
+    }
+  }
+
+  Future<ConsentReceipt> grant(ConsentPurpose purpose) async {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = await load();
+    final receipt = ConsentReceipt(
+      receiptId: 'local-${DateTime.now().microsecondsSinceEpoch}',
+      purpose: purpose,
+      policyVersion: ConsentService.currentPolicyVersion,
+      consentTimestamp: DateTime.now().toUtc(),
+    );
+    // Replace any stale receipt for the same purpose.
+    final next = [
+      ...existing.where((c) => c.purpose != purpose),
+      receipt,
+    ];
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode(next.map((c) => c.toJson()).toList(growable: false)),
+    );
+    return receipt;
+  }
+
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+  }
 }
 
 class ConsentService {
@@ -79,25 +167,108 @@ class ConsentService {
   static const String currentPolicyVersion = 'v2.3.0';
 
   static List<ConsentReceipt>? _cache;
+  static final _LocalConsentStore _localStore = _LocalConsentStore();
 
+  /// Returns the union of backend receipts + local receipts. In mode local
+  /// (no auth) the backend call fails with `ApiException.sessionExpired` —
+  /// we then return the local-only receipts so the user can still grant /
+  /// be considered granted on-device.
   Future<List<ConsentReceipt>> list({bool force = false}) async {
     if (_cache != null && !force) return _cache!;
-    final resp = await ApiService.get('/consents');
-    final consents = (resp['consents'] as List? ?? [])
-        .whereType<Map<String, dynamic>>()
-        .map(ConsentReceipt.fromJson)
-        .toList();
-    _cache = consents;
-    return consents;
+    final local = await _localStore.load();
+    try {
+      final resp = await ApiService.get('/consents');
+      final remote = (resp['consents'] as List? ?? [])
+          .whereType<Map<String, dynamic>>()
+          .map(ConsentReceipt.fromJson)
+          .toList();
+      // Merge: remote wins per-purpose if both have a non-revoked grant at
+      // the current policy version (server is source-of-truth when
+      // authenticated). Local-only purposes (granted while in mode local
+      // before logging in) survive.
+      final merged = <ConsentReceipt>[
+        ...remote,
+        ...local.where((l) => !remote.any((r) => r.purpose == l.purpose)),
+      ];
+      _cache = merged;
+      return merged;
+    } on ApiException catch (e) {
+      if (_isAuthlessApiError(e)) {
+        _cache = local;
+        return local;
+      }
+      rethrow;
+    } on PlatformException catch (e) {
+      // `_authHeaders` reads the auth token from Keychain. On a fresh
+      // simulator (or any device where the user has never logged in),
+      // the Keychain item is absent and the platform channel raises
+      // `PlatformException(code: -34018, ...)` BEFORE the HTTP call ever
+      // happens. Other services that hit `_authHeaders` (RegulatorySync,
+      // Snapshot loader) already fall back gracefully on this error;
+      // ConsentService now does the same — treat as authless and use the
+      // on-device store.
+      if (_isAuthlessPlatformError(e)) {
+        _cache = local;
+        return local;
+      }
+      rethrow;
+    }
   }
 
+  /// Grant consent. Prefers backend storage; on auth-less / network failure
+  /// falls back to on-device storage so the user can still proceed in mode
+  /// local.
   Future<ConsentReceipt> grant(ConsentPurpose purpose) async {
-    final resp = await ApiService.post('/consents/grant', {
-      'purpose': purpose.wire,
-      'policyVersion': currentPolicyVersion,
-    });
-    _cache = null;
-    return ConsentReceipt.fromJson(resp);
+    try {
+      final resp = await ApiService.post('/consents/grant', {
+        'purpose': purpose.wire,
+        'policyVersion': currentPolicyVersion,
+      });
+      _cache = null;
+      return ConsentReceipt.fromJson(resp);
+    } on ApiException catch (e) {
+      if (_isAuthlessApiError(e)) {
+        final local = await _localStore.grant(purpose);
+        _cache = null;
+        return local;
+      }
+      rethrow;
+    } on PlatformException catch (e) {
+      if (_isAuthlessPlatformError(e)) {
+        final local = await _localStore.grant(purpose);
+        _cache = null;
+        return local;
+      }
+      rethrow;
+    }
+  }
+
+  /// True if the ApiException indicates the user has no usable auth session
+  /// (mode local) — distinct from a transient network failure where we'd
+  /// rather surface the error to the user.
+  bool _isAuthlessApiError(ApiException e) {
+    return e.errorCode == ApiErrorCode.sessionExpired || e.statusCode == 401;
+  }
+
+  /// True if the PlatformException indicates the device has no Keychain
+  /// entry (fresh sim / never-logged-in user). The relevant codes are
+  /// produced by `flutter_secure_storage` / iOS SecItemCopyMatching:
+  ///   -25300 errSecItemNotFound  — no token stored
+  ///   -34018 errSecMissingEntitlement — keychain access blocked
+  /// Both are equivalent for our purpose: there is no auth context.
+  bool _isAuthlessPlatformError(PlatformException e) {
+    final code = e.code;
+    if (code == '-25300' ||
+        code == '-34018' ||
+        code == 'Unexpected security result code') {
+      return true;
+    }
+    // Some impls bury the OSStatus in the message field instead of code.
+    final msg = e.message ?? '';
+    return msg.contains('-25300') ||
+        msg.contains('-34018') ||
+        msg.contains('errSecItemNotFound') ||
+        msg.contains('errSecMissingEntitlement');
   }
 
   Future<Map<String, dynamic>> revoke(String receiptId) async {
@@ -129,12 +300,16 @@ class ConsentService {
   /// Crash-safety (Sentry fatal `6f9002...` 2026-05-04 ch.mint.app@2.9.0+37):
   /// when `list(force: true)` hit a 401 → `ApiException.sessionExpired` →
   /// uncaught propagation through `_onGalleryPressed` → fatal via
-  /// `PlatformDispatcher.onError`. We now catch any `ApiException` from the
-  /// list/grant calls, surface a friendly snackbar, and return `false` so the
-  /// caller treats it like a denied consent (= no-op + early return). The
-  /// AuthService.logout() inside `ApiService.get` already cleared the stale
-  /// token; the next user-driven nav back through a guarded route will
-  /// trigger re-auth via the existing GoRouter redirect.
+  /// `PlatformDispatcher.onError`. We catch any `ApiException` from
+  /// list/grant calls, surface a friendly snackbar for transient errors, and
+  /// return `false` for non-recoverable cases.
+  ///
+  /// Mode local fallback (P4 fix, walkthrough 2026-05-07): `list()` and
+  /// `grant()` now route through `_LocalConsentStore` when the user has no
+  /// auth session, so this guard works the same in mode local as in
+  /// authenticated mode — sheet shows, user accepts, receipt is persisted
+  /// on-device. No silent failure on « Depuis la galerie » in mode local.
+  /// The catch below remains for true network/server errors only.
   Future<bool> requireGrantedOrPrompt(
     BuildContext context,
     List<ConsentPurpose> required,

--- a/apps/mobile/test/services/consent/consent_service_local_fallback_test.dart
+++ b/apps/mobile/test/services/consent/consent_service_local_fallback_test.dart
@@ -1,0 +1,117 @@
+// Regression: P4 walkthrough 2026-05-07 — « Depuis la galerie » silent fail
+// in mode local because `ConsentService.list()` threw on /consents 401 →
+// uncaught propagation through `_onGalleryPressed` → file picker never
+// opens.
+//
+// Asserts the local-fallback contract:
+//   * `LocalConsentStoreForTests.grant(p)` persists a `ConsentReceipt` to
+//     SharedPreferences with the current policy version.
+//   * `LocalConsentStoreForTests.load()` returns the persisted receipts on
+//     a fresh instance (cross-restart durability).
+//   * `ConsentReceipt.toJson` / `fromJson` round-trip is symmetric so the
+//     same deserializer can read both backend + local payloads.
+//
+// HTTP-level fallback (401 → local) is verified at the sim walker layer
+// (G1 gate, PERIMETERS.md). A proper unit test for the 401 path requires
+// `ApiService` to accept an injectable `http.Client`, which is its own
+// follow-up PR — out of scope for P4.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mint_mobile/services/consent/consent_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('ConsentService — local fallback (P4 walkthrough fix)', () {
+    test('grant() persists locally + load() returns it', () async {
+      await LocalConsentStoreForTests.grant(ConsentPurpose.visionExtraction);
+      final loaded = await LocalConsentStoreForTests.load();
+
+      expect(loaded.length, 1);
+      expect(loaded.first.purpose, ConsentPurpose.visionExtraction);
+      expect(loaded.first.policyVersion, ConsentService.currentPolicyVersion);
+      expect(loaded.first.isActive, isTrue);
+      expect(loaded.first.receiptId, startsWith('local-'));
+    });
+
+    test('grant() of same purpose replaces prior local receipt', () async {
+      final first =
+          await LocalConsentStoreForTests.grant(ConsentPurpose.visionExtraction);
+      await Future<void>.delayed(const Duration(microseconds: 1));
+      final second =
+          await LocalConsentStoreForTests.grant(ConsentPurpose.visionExtraction);
+
+      final loaded = await LocalConsentStoreForTests.load();
+      expect(loaded.length, 1, reason: 'Should not duplicate same purpose');
+      expect(loaded.first.receiptId, isNot(equals(first.receiptId)));
+      expect(loaded.first.receiptId, second.receiptId);
+    });
+
+    test('grant() of different purposes accumulates', () async {
+      await LocalConsentStoreForTests.grant(ConsentPurpose.visionExtraction);
+      await LocalConsentStoreForTests.grant(ConsentPurpose.persistence365d);
+      await LocalConsentStoreForTests.grant(ConsentPurpose.transferUsAnthropic);
+
+      final loaded = await LocalConsentStoreForTests.load();
+      expect(loaded.length, 3);
+      expect(
+        loaded.map((r) => r.purpose).toSet(),
+        {
+          ConsentPurpose.visionExtraction,
+          ConsentPurpose.persistence365d,
+          ConsentPurpose.transferUsAnthropic,
+        },
+      );
+    });
+
+    test('clear() empties the local store', () async {
+      await LocalConsentStoreForTests.grant(ConsentPurpose.visionExtraction);
+      await LocalConsentStoreForTests.clear();
+      final loaded = await LocalConsentStoreForTests.load();
+      expect(loaded, isEmpty);
+    });
+
+    test('load() returns empty list when SharedPreferences is fresh', () async {
+      final loaded = await LocalConsentStoreForTests.load();
+      expect(loaded, isEmpty);
+    });
+
+    test('ConsentReceipt round-trips through toJson/fromJson', () {
+      final ts = DateTime.utc(2026, 5, 7, 12, 0);
+      final receipt = ConsentReceipt(
+        receiptId: 'r1',
+        purpose: ConsentPurpose.transferUsAnthropic,
+        policyVersion: 'v2.3.0',
+        consentTimestamp: ts,
+      );
+      final restored = ConsentReceipt.fromJson(receipt.toJson());
+      expect(restored.receiptId, 'r1');
+      expect(restored.purpose, ConsentPurpose.transferUsAnthropic);
+      expect(restored.policyVersion, 'v2.3.0');
+      expect(restored.consentTimestamp.toUtc(), ts);
+      expect(restored.isActive, isTrue);
+      expect(restored.toJson()['revokedAt'], isNull);
+    });
+
+    test('ConsentReceipt with revokedAt round-trips', () {
+      final ts = DateTime.utc(2026, 5, 7, 12, 0);
+      final revoked = DateTime.utc(2026, 5, 7, 13, 0);
+      final receipt = ConsentReceipt(
+        receiptId: 'r2',
+        purpose: ConsentPurpose.coupleProjection,
+        policyVersion: 'v2.3.0',
+        consentTimestamp: ts,
+        revokedAt: revoked,
+      );
+      final restored = ConsentReceipt.fromJson(receipt.toJson());
+      expect(restored.isActive, isFalse);
+      expect(restored.revokedAt?.toUtc(), revoked);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Walker session 2026-05-07 caught: tap « Depuis la galerie » on Scanner screen → no UI change, no error, no log. iPhone repro confirmed: **PDFs silently fail to upload in mode local**.

Root cause: `_authHeaders` reads from Keychain. On a fresh sim / never-logged-in user, the Keychain item is absent → `PlatformException(-34018)`. The previous catch only handled `ApiException` so this propagated up silently.

## Fix
- New `_LocalConsentStore` (SharedPreferences-backed) mirrors backend receipts with the same JSON shape.
- `list()` and `grant()` catch `PlatformException` with Keychain error codes + `ApiException.sessionExpired` + 401 — all treated as authless, fall through to local store.
- ConsentSheet UX unchanged. Receipts persist on-device across restarts.

## Test plan
- [x] 7/7 unit tests pass in `test/services/consent/consent_service_local_fallback_test.dart`
- [x] Sim walker (iPhone 17 Pro, fresh install, mode local):
  - tap « Depuis la galerie » → ConsentSheet appears (was: silent fail)
  - tap « Accepter » → iOS Files picker opens (was: never reached)
- [ ] CI green on dev
- [ ] Manual: pick a real PDF, verify upload + extraction

## Follow-up (NOT in this PR)
- Refactor `ApiService` to accept injectable `http.Client` so the 401 → fallback path can be unit-tested via `http.MockClient`. Documented in PERIMETERS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)