### PR TITLE
fix(coach): honest tier-aware transparency footer (P2 walkthrough)

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -9972,6 +9972,7 @@
   "bankImportTransparency": "Dein Kontoauszug wird verschlüsselt an unseren Schweizer Server zur Analyse gesendet. Transaktionen werden kategorisiert, dann wird die Rohdatei gelöscht. Nur Kategorie-Zusammenfassungen bleiben in deinem Profil.",
   "coachTransparencySLM": "Antwort auf deinem Telefon generiert. Nichts an einen Server gesendet.",
   "coachTransparencyBYOK": "Antwort über deine Claude-API. Dein genaues Gehalt wird NICHT gesendet — nur Alter, Kanton und Archetyp werden geteilt.",
+  "coachTransparencyServer": "Antwort über die Claude-API (MINT-Serverschlüssel). Deine Nachricht wird wie eingegeben geteilt, um die Antwort zu personalisieren.",
   "dataTransparencyTitle": "Wie MINT deine Daten verwendet",
   "dataTransparencySalary": "Wenn du dein Gehalt eingibst",
   "dataTransparencySalaryDetail": "Nur auf deinem Telefon gespeichert. Nie gesendet.",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -9972,6 +9972,7 @@
   "bankImportTransparency": "Your statement is sent encrypted to our Swiss server for analysis. Transactions are categorized, then the raw file is deleted. Only category summaries are kept in your profile.",
   "coachTransparencySLM": "Response generated on your phone. Nothing sent to a server.",
   "coachTransparencyBYOK": "Response via your Claude API. Your exact salary is NOT sent — only your age, canton and archetype are shared.",
+  "coachTransparencyServer": "Response via the Claude API (MINT server key). Your message is shared as-is to personalize the response.",
   "dataTransparencyTitle": "How MINT uses your data",
   "dataTransparencySalary": "When you enter your salary",
   "dataTransparencySalaryDetail": "Stored only on your phone. Never sent.",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -9972,6 +9972,7 @@
   "bankImportTransparency": "Tu extracto se envía cifrado a nuestro servidor suizo para su análisis. Las transacciones se categorizan y luego el archivo original se elimina. Solo los resúmenes por categoría se conservan en tu perfil.",
   "coachTransparencySLM": "Respuesta generada en tu teléfono. Nada enviado a un servidor.",
   "coachTransparencyBYOK": "Respuesta a través de tu API Claude. Tu salario exacto NO se envía — solo tu edad, cantón y arquetipo se comparten.",
+  "coachTransparencyServer": "Respuesta a través de la API Claude (clave servidor MINT). Tu mensaje se comparte tal cual para personalizar la respuesta.",
   "dataTransparencyTitle": "Cómo MINT usa tus datos",
   "dataTransparencySalary": "Cuando introduces tu salario",
   "dataTransparencySalaryDetail": "Almacenado solo en tu teléfono. Nunca enviado.",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10480,6 +10480,7 @@
   "bankImportTransparency": "Ton relevé est envoyé à notre serveur suisse de manière chiffrée pour analyse. Les transactions sont catégorisées, puis le fichier brut est supprimé. Seuls les résumés par catégorie sont conservés dans ton profil.",
   "coachTransparencySLM": "Réponse générée sur ton téléphone. Rien n'est envoyé à un serveur.",
   "coachTransparencyBYOK": "Réponse via ton API Claude. Ton salaire exact n'est PAS envoyé — seuls ton âge, canton et archétype sont partagés.",
+  "coachTransparencyServer": "Réponse via l'API Claude (clé serveur MINT). Ton message est partagé tel quel pour personnaliser la réponse.",
   "dataTransparencyTitle": "Comment MINT utilise tes données",
   "dataTransparencySalary": "Quand tu entres ton salaire",
   "dataTransparencySalaryDetail": "Stocké uniquement sur ton téléphone. Jamais envoyé.",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -9972,6 +9972,7 @@
   "bankImportTransparency": "Il tuo estratto conto viene inviato criptato al nostro server svizzero per l'analisi. Le transazioni vengono categorizzate, poi il file originale viene eliminato. Solo i riepiloghi per categoria vengono conservati nel tuo profilo.",
   "coachTransparencySLM": "Risposta generata sul tuo telefono. Niente inviato a un server.",
   "coachTransparencyBYOK": "Risposta tramite la tua API Claude. Il tuo stipendio esatto NON viene inviato — solo età, cantone e archetipo sono condivisi.",
+  "coachTransparencyServer": "Risposta tramite l'API Claude (chiave server MINT). Il tuo messaggio è condiviso così com'è per personalizzare la risposta.",
   "dataTransparencyTitle": "Come MINT usa i tuoi dati",
   "dataTransparencySalary": "Quando inserisci il tuo stipendio",
   "dataTransparencySalaryDetail": "Salvato solo sul tuo telefono. Mai inviato.",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -37317,6 +37317,12 @@ abstract class S {
   /// **'Réponse via ton API Claude. Ton salaire exact n\'est PAS envoyé — seuls ton âge, canton et archétype sont partagés.'**
   String get coachTransparencyBYOK;
 
+  /// No description provided for @coachTransparencyServer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Réponse via l\'API Claude (clé serveur MINT). Ton message est partagé tel quel pour personnaliser la réponse.'**
+  String get coachTransparencyServer;
+
   /// No description provided for @dataTransparencyTitle.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -21280,6 +21280,10 @@ class SDe extends S {
       'Antwort über deine Claude-API. Dein genaues Gehalt wird NICHT gesendet — nur Alter, Kanton und Archetyp werden geteilt.';
 
   @override
+  String get coachTransparencyServer =>
+      'Antwort über die Claude-API (MINT-Serverschlüssel). Deine Nachricht wird wie eingegeben geteilt, um die Antwort zu personalisieren.';
+
+  @override
   String get dataTransparencyTitle => 'Wie MINT deine Daten verwendet';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -21122,6 +21122,10 @@ class SEn extends S {
       'Response via your Claude API. Your exact salary is NOT sent — only your age, canton and archetype are shared.';
 
   @override
+  String get coachTransparencyServer =>
+      'Response via the Claude API (MINT server key). Your message is shared as-is to personalize the response.';
+
+  @override
   String get dataTransparencyTitle => 'How MINT uses your data';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -21233,6 +21233,10 @@ class SEs extends S {
       'Respuesta a través de tu API Claude. Tu salario exacto NO se envía — solo tu edad, cantón y arquetipo se comparten.';
 
   @override
+  String get coachTransparencyServer =>
+      'Respuesta a través de la API Claude (clave servidor MINT). Tu mensaje se comparte tal cual para personalizar la respuesta.';
+
+  @override
   String get dataTransparencyTitle => 'Cómo MINT usa tus datos';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -21230,6 +21230,10 @@ class SFr extends S {
       'Réponse via ton API Claude. Ton salaire exact n\'est PAS envoyé — seuls ton âge, canton et archétype sont partagés.';
 
   @override
+  String get coachTransparencyServer =>
+      'Réponse via l\'API Claude (clé serveur MINT). Ton message est partagé tel quel pour personnaliser la réponse.';
+
+  @override
   String get dataTransparencyTitle => 'Comment MINT utilise tes données';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -21290,6 +21290,10 @@ class SIt extends S {
       'Risposta tramite la tua API Claude. Il tuo stipendio esatto NON viene inviato — solo età, cantone e archetipo sono condivisi.';
 
   @override
+  String get coachTransparencyServer =>
+      'Risposta tramite l\'API Claude (chiave server MINT). Il tuo messaggio è condiviso così com\'è per personalizzare la risposta.';
+
+  @override
   String get dataTransparencyTitle => 'Come MINT usa i tuoi dati';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -21237,6 +21237,10 @@ class SPt extends S {
       'Resposta via a tua API Claude. O teu salário exato NÃO é enviado — apenas a tua idade, cantão e arquétipo são partilhados.';
 
   @override
+  String get coachTransparencyServer =>
+      'Resposta via a API Claude (chave servidor MINT). A tua mensagem é partilhada tal como está para personalizar a resposta.';
+
+  @override
   String get dataTransparencyTitle => 'Como o MINT usa os teus dados';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -9972,6 +9972,7 @@
   "bankImportTransparency": "O teu extrato é enviado encriptado para o nosso servidor suíço para análise. As transações são categorizadas e depois o ficheiro original é eliminado. Apenas os resumos por categoria são mantidos no teu perfil.",
   "coachTransparencySLM": "Resposta gerada no teu telemóvel. Nada enviado para um servidor.",
   "coachTransparencyBYOK": "Resposta via a tua API Claude. O teu salário exato NÃO é enviado — apenas a tua idade, cantão e arquétipo são partilhados.",
+  "coachTransparencyServer": "Resposta via a API Claude (chave servidor MINT). A tua mensagem é partilhada tal como está para personalizar a resposta.",
   "dataTransparencyTitle": "Como o MINT usa os teus dados",
   "dataTransparencySalary": "Quando introduzes o teu salário",
   "dataTransparencySalaryDetail": "Guardado apenas no teu telemóvel. Nunca enviado.",

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -2293,9 +2293,23 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
                     Padding(
                       padding: const EdgeInsets.only(left: 42),
                       child: Text(
-                        msg.tier == ChatTier.slm
-                            ? S.of(context)!.coachTransparencySLM
-                            : S.of(context)!.coachTransparencyBYOK,
+                        // P2 walkthrough fix (2026-05-07): the binary
+                        // `slm ? SLM-copy : BYOK-copy` was wrong for
+                        // ChatTier.fallback (server-key path used by mode-
+                        // local + non-BYOK auth users) — it claimed « via
+                        // ton API Claude » when in fact the call goes via
+                        // the MINT server key, AND it claimed « ton salaire
+                        // exact n'est PAS envoyé » even though the user's
+                        // chat message (which may include CHF amounts) is
+                        // shipped verbatim. New `coachTransparencyServer`
+                        // copy is honest about the server-key path.
+                        switch (msg.tier) {
+                          ChatTier.slm => S.of(context)!.coachTransparencySLM,
+                          ChatTier.byok => S.of(context)!.coachTransparencyBYOK,
+                          ChatTier.fallback =>
+                            S.of(context)!.coachTransparencyServer,
+                          ChatTier.none => '',
+                        },
                         style: MintTextStyles.micro(
                           color: MintColors.textMuted.withValues(alpha: 0.5),
                         ).copyWith(

--- a/apps/mobile/test/l10n/coach_transparency_server_parity_test.dart
+++ b/apps/mobile/test/l10n/coach_transparency_server_parity_test.dart
@@ -1,0 +1,112 @@
+// P2 walkthrough fix (2026-05-07): the auth coach footer claimed
+// « Ton salaire exact n'est PAS envoyé » even when the user typed a
+// salary in plaintext, because the binary `slm ? SLM : BYOK` switch
+// in coach_chat_screen.dart routed `ChatTier.fallback` (server-key
+// path) to the BYOK copy.
+//
+// This test asserts the contract the fix relies on:
+//   * Every locale defines the new `coachTransparencyServer` key.
+//   * The copy is honest about the server-key path: it does NOT
+//     contain the misleading « pas envoyé » / « NOT sent » phrasing.
+//   * 6-locale parity preserved (no orphaned key).
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const locales = ['fr', 'en', 'de', 'es', 'it', 'pt'];
+
+  // From the test runner cwd (apps/mobile/), ARB files live at
+  // lib/l10n/app_<locale>.arb.
+  Map<String, String> _loadArb(String locale) {
+    final file = File('lib/l10n/app_$locale.arb');
+    expect(file.existsSync(), isTrue,
+        reason: 'ARB file missing: ${file.path}');
+    final raw = file.readAsStringSync();
+    final decoded = jsonDecode(raw);
+    expect(decoded, isA<Map<String, dynamic>>());
+    return Map<String, String>.fromEntries(
+      (decoded as Map<String, dynamic>)
+          .entries
+          .where((e) => e.value is String)
+          .map((e) => MapEntry(e.key, e.value as String)),
+    );
+  }
+
+  group('coachTransparencyServer (P2 walkthrough fix)', () {
+    test('exists in all 6 locales', () {
+      for (final loc in locales) {
+        final arb = _loadArb(loc);
+        expect(
+          arb.containsKey('coachTransparencyServer'),
+          isTrue,
+          reason:
+              'coachTransparencyServer missing from app_$loc.arb — required '
+              'for the 4-way ChatTier copy switch in coach_chat_screen.dart.',
+        );
+        expect(arb['coachTransparencyServer']!.isNotEmpty, isTrue,
+            reason: 'coachTransparencyServer is empty in app_$loc.arb');
+      }
+    });
+
+    test('FR copy does not claim « pas envoyé »', () {
+      final arb = _loadArb('fr');
+      final copy = arb['coachTransparencyServer']!;
+      expect(
+        RegExp(r"pas envoy", caseSensitive: false).hasMatch(copy),
+        isFalse,
+        reason:
+            'FR Server copy must not claim « pas envoyé » — the user message '
+            '(including any CHF amount) IS shipped to Anthropic via the MINT '
+            'server key. Honest copy required.',
+      );
+      // Sanity: the copy mentions « MINT » and the API → user understands.
+      expect(copy.toLowerCase(), contains('mint'),
+          reason: 'FR Server copy should disclose the MINT server key.');
+    });
+
+    test('EN copy does not claim « NOT sent »', () {
+      final arb = _loadArb('en');
+      final copy = arb['coachTransparencyServer']!;
+      expect(
+        RegExp(r"not sent", caseSensitive: false).hasMatch(copy),
+        isFalse,
+        reason:
+            'EN Server copy must not claim « NOT sent » — the user message '
+            'IS shared with Anthropic via the MINT server key.',
+      );
+      expect(copy.toLowerCase(), contains('mint'));
+    });
+
+    test('all 6 locales mention the API', () {
+      for (final loc in locales) {
+        final arb = _loadArb(loc);
+        final copy = arb['coachTransparencyServer']!;
+        expect(
+          RegExp(r"api", caseSensitive: false).hasMatch(copy),
+          isTrue,
+          reason:
+              'Server copy in $loc must mention API (Claude API / API Claude).',
+        );
+      }
+    });
+  });
+
+  group('ARB parity guard', () {
+    test('SLM + BYOK + Server keys all present in 6 locales', () {
+      for (final loc in locales) {
+        final arb = _loadArb(loc);
+        for (final key in const [
+          'coachTransparencySLM',
+          'coachTransparencyBYOK',
+          'coachTransparencyServer',
+        ]) {
+          expect(arb.containsKey(key), isTrue,
+              reason: '$key missing from app_$loc.arb');
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Walker 2026-05-07: auth coach footer claimed « Ton salaire exact n'est PAS envoyé — seuls ton âge, canton et archetype sont partagés » even when the user had typed a CHF amount in their chat message. Misleading.

Root cause: binary `msg.tier == ChatTier.slm ? SLM : BYOK` switch routed `ChatTier.fallback` (the server-key path used by mode-local users) to the BYOK copy.

## Fix
- New ARB `coachTransparencyServer` in all 6 locales — honest copy about the server-key path.
- Binary ternary → 4-way `switch (msg.tier)`.
- 5/5 unit tests pass (parity + copy-content assertions).
- Verified on iOS sim: footer now reads the new Server copy in mode local.

## Test plan
- [x] `test/l10n/coach_transparency_server_parity_test.dart` 5/5 green
- [x] Sim walker (mode local): footer copy is the new honest one
- [ ] CI green on dev

## Follow-up (NOT in this PR)
Backend `claude_coach_service.py` `_BIOGRAPHY_AWARENESS` rule causes the LLM to avoid using user-message CHF amounts in mode local. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)