### PR TITLE
fix(drawer): hide BYOK menu entry behind feature flag (P1 walkthrough)

### DIFF
--- a/apps/mobile/lib/services/feature_flags.dart
+++ b/apps/mobile/lib/services/feature_flags.dart
@@ -79,6 +79,15 @@ class FeatureFlags {
   /// Admin screens: observability, analytics
   static bool enableAdminScreens = false;
 
+  /// Bring-your-own-key (BYOK): user pastes their own Anthropic / OpenAI /
+  /// Mistral API key. Out-of-scope for MVP per `project_byok_scope.md` —
+  /// current builds use ServerKey (MINT's Anthropic key on Railway). The
+  /// settings entry was visible in v2.x QA builds and confused testers
+  /// (« do I need to bring a key? »). v2.14 hides the menu entry until
+  /// BYOK lands; the underlying screen + service remain available behind
+  /// `/profile/byok` for internal testing.
+  static bool enableByok = false;
+
   /// MVP wedge onboarding — storyboard v2 locked (2026-04-22).
   /// 9-step flow with 4 intents, dossier densification, and 3 N2 scenes
   /// (RenteTrouee / CapaciteAchat / 3aLevier) before magic-link sealing.

--- a/apps/mobile/lib/widgets/profile_drawer.dart
+++ b/apps/mobile/lib/widgets/profile_drawer.dart
@@ -9,6 +9,7 @@ import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/analytics_service.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/widgets/voice/ton_chooser.dart';
 
 /// Right-side drawer replacing DossierTab.
@@ -104,12 +105,19 @@ class ProfileDrawer extends StatelessWidget {
               ),
             ),
 
-            _buildSection(
-              context,
-              icon: Icons.key_outlined,
-              title: l10n.drawerApiKey,
-              onTap: () => _navigate(context, '/profile/byok'),
-            ),
+            // P1 walkthrough fix (2026-05-07): hide BYOK from the user-
+            // facing drawer until BYOK lands as a feature. Out-of-scope per
+            // `project_byok_scope.md`; current builds use ServerKey.
+            // Visible entry confused QA testers (« do I need to bring a key? »).
+            // Underlying screen + service remain at `/profile/byok` for
+            // internal testing.
+            if (FeatureFlags.enableByok)
+              _buildSection(
+                context,
+                icon: Icons.key_outlined,
+                title: l10n.drawerApiKey,
+                onTap: () => _navigate(context, '/profile/byok'),
+              ),
             _buildSection(
               context,
               icon: Icons.language_outlined,


### PR DESCRIPTION
## Summary
Walker 2026-05-07: profile drawer surfaced « Clé API (BYOK) » to QA testers, confusing them. BYOK is out-of-scope per `project_byok_scope.md` memory — current builds use ServerKey.

## Fix
- New `FeatureFlags.enableByok = false`
- Wrap drawer section in `if (FeatureFlags.enableByok)`
- Underlying screen + service remain at `/profile/byok` for internal testing

## Test plan
- [x] flutter analyze clean
- [x] Sim walker (post-merge): drawer no longer shows Clé API (BYOK) entry
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)