### PR TITLE
fix(anon-chat): prevent permanent lockout when 200 OK drops messagesRemaining (BUG-P1-A02)

### DIFF
--- a/.planning/reports/MILESTONE_SUMMARY-v2.12.md
+++ b/.planning/reports/MILESTONE_SUMMARY-v2.12.md
@@ -1,0 +1,243 @@
+# Milestone v2.12 — Project Summary
+
+**Generated:** 2026-05-06
+**Status:** In flight (Phase 86 ✅, Phase 87 ✅ shipped, Phase 88 ✅, Phase 89 STAMP partial 4/7)
+**Purpose:** Team onboarding and project review
+
+---
+
+## 1. Project Overview
+
+**MINT** is a Swiss financial lucidity & education app (Flutter + FastAPI). Pivot 2026-04-12 : *lucidité, pas protection*. Target population : 18-99 ; segmentation par life event (housing / family / tax / career / debt — 18 events equally weighted, jamais retirement-first).
+
+**Core value (per `PROJECT.md`) :** « Un inconnu ouvre MINT, ressent quelque chose, tape sur une phrase, recoit une reponse qui le surprend, cree un compte pour ne pas perdre ca, et revient chaque mois parce que MINT sait des choses que personne d'autre ne sait sur sa vie financiere. »
+
+**v2.12 milestone goal :** « Aucun TestFlight tant que Claude n'a pas validé que l'app tourne PARFAITEMENT sur simulator. » Walker = machine de vérité ; Julien fait zéro test ; STAMP-08 PASS = autorisation tag v2.12.0.
+
+Status snapshot 2026-05-06 :
+- Phase 86 walker GREEN sur 4 archetypes FR ✅
+- Phase 87 bare-catches Wave 1 SHIPPED (PR #498)
+- Phase 88 cross-language 12 walks GREEN (avec retries) ✅
+- Phase 89 STAMP : 4/7 gates PASS (incl. STAMP-02 measured P50 2682ms, gate threshold debate)
+
+## 2. Architecture & Technical Decisions
+
+- **Decision: Walker = la machine de vérité, pas device walkthrough humain.**
+  - **Why:** Memory `feedback_device_gates.md` — Claude does device walkthroughs autonomously via simctl + idb. 9326 tests green ≠ app functional ; only end-to-end sim run proves runtime.
+  - **Phase:** v2.11 doctrine, v2.12 implementation.
+
+- **Decision: 4 deterministic archetypes pinned (julien_swiss / couple_acheteurs_lausanne / jeune_diplome_zurich / cadre_40_55_lpp_rachat).**
+  - **Why:** 8-archetype enum trop large pour walker rapide ; 4 = 2 happy + 2 friction couvrent le risk surface du flow Premier Éclairage.
+  - **Phase:** Phase 74 v2.11 → réutilisé Phase 86.
+
+- **Decision: dart-defines pour walker mode (`MINT_E2E_ARCHETYPE`, `MINT_E2E_FORCE_ECLAIRAGE_KIND`, `MINT_DISABLE_BETA_MODAL`, `APP_LOCALE`).**
+  - **Why:** Build-time const folding + `kReleaseMode` short-circuit = production binaries inert. ECLW-04 + SIMQ-07 contract.
+  - **Phase:** Phase 80 (forced kind) + Phase 86 (locale).
+
+- **Decision: walker.sh + cliclick (desktop logical px) + osascript bounds + Pillow SSIM.**
+  - **Why:** Phantom contract doctrine. No PR without runtime evidence. Bash-readable for solo-maintainer Julien. SSIM > pixel-diff for theme variance tolerance.
+  - **Phase:** Phase 51 origin → Phase 82 coord overhaul → Phase 86 bounds fix.
+
+- **Decision: WALKC-08 codesign bypass via `CODE_SIGNING_ALLOWED=NO` env var on flutter build (sim-only).**
+  - **Why:** macOS Sequoia/Tahoe `com.apple.provenance` xattr (system-immutable) breaks ad-hoc codesign of Flutter.framework. No userspace bypass for the xattr ; env var disables codesign step entirely. Sim doesn't need real signature.
+  - **Phase:** Phase 86 audit B 2026-05-05.
+
+- **Decision: WALKC-07 reverted — keep build/ between archetypes (no `flutter clean` per run).**
+  - **Why:** Empirically `flutter clean` made codesign issue WORSE (every clean rebuild = re-codesign). Incremental build reuses signed Flutter.framework. Operational : ~70% first-attempt success vs 0% with clean.
+  - **Phase:** Phase 86 audit C 2026-05-05.
+
+- **Decision: BARE_CATCH_DEBT.md ledger + `tools/checks/no_new_bare_catch.py` lint blocking on new occurrences.**
+  - **Why:** 332 mobile + 56 backend bare catches (silent error swallowing) = phantom-success risk. Ledger grandfathers existing 318 ; new ones must be typed + Sentry captured. Convert in waves (Wave 1 = 15 critical, Wave 2 = 50 carry to v2.14).
+  - **Phase:** Phase 87 (PR #498).
+
+- **Decision: STAMP gate threshold 2.5s cold-launch P50 likely too aspirational on iPhone 17 Pro sim.**
+  - **Why:** Empirical measurement (5 iter) gives P50 = 2682ms, P95 = 2703ms. Three optims (ApiService timeout 2s→700ms, FeatureFlags timeout 2s→800ms, SLM defer to background) yielded zero measurable improvement — bottleneck dominated by Flutter framework boot + Sentry SDK attach + iOS launch-screen → Flutter view transition (native-level costs, not reachable from app code). Recommendation : adjust threshold to 2.8s (4% headroom over P95), defensible on real iPhone hardware which is faster than simulator.
+  - **Phase:** Phase 89 audit 2026-05-06.
+
+## 3. Phases Delivered
+
+| Phase | Name | Status | One-liner |
+|-------|------|--------|-----------|
+| 86 | Walker green réel 4 archetypes (FR) | ✅ COMPLETE | 4/4 walker exit 0, 6/6 captures each, full nav julien/couple/cadre + partial nav past turn 1 jeune_diplome (eclairage card render gap = STAMP concern) |
+| 87 | Bare-catches sweep Wave 1 | ✅ SHIPPED PR #498 | 15 sites converted (typed catch + Sentry capture) + ledger 318 grandfathered + `no_new_bare_catch.py` blocking lint + 18/18 unit tests |
+| 88 | Cross-language walker FR+DE+EN × 4 archetypes = 12 walks | ✅ COMPLETE | 12/12 walker exit 0 across 4 archetypes × 3 langues. Honest flake 5/17 attempts (~71% first-attempt) — operational debt tracked. |
+| 89 | Quality stamp 7-gate | 🟡 4/7 PASS | STAMP-01 walker 12/12 ✅ ; STAMP-02 cold-launch measured 2682ms (gate threshold debate) ; STAMP-03 frame jank PENDING infra ; STAMP-04 VoiceOver PENDING infra ; STAMP-05 Sentry breadcrumb categories source-contract PASS ✅ ; STAMP-06 ARB parity 6×6743 ✅ ; STAMP-07 BARE_CATCH_DEBT ledger + lint ✅ ; STAMP-08 BLOCKED |
+
+## 4. Requirements Coverage
+
+### SIMQ-* (Phase 86, 8 REQs)
+- ✅ SIMQ-01 walker green julien_swiss FR (run 211306-73afa3cb)
+- ✅ SIMQ-02 walker green couple_acheteurs_lausanne FR (run 222601-8d3c127a)
+- ✅ SIMQ-03 walker green jeune_diplome_zurich FR — exit 0 + 6/6 captures, partial nav past turn 1 (eclairage render gap = Phase 89 STAMP concern)
+- ✅ SIMQ-04 walker green cadre_40_55_lpp_rachat FR (run 222931-a28605be)
+- ⚠️ SIMQ-05 `--retry-once` flag PARSED, retry-loop logic deferred (low-priority, incremental builds reduce flake naturally)
+- ⚠️ SIMQ-06 `--record-trace` flag PARSED, manifest emit logic deferred (Phase 89 STAMP-05 is the canonical evidence path)
+- ✅ SIMQ-07 `--locale=<fr|de|en>` flag wired + `LocaleProvider` reads `String.fromEnvironment('APP_LOCALE')` with kReleaseMode short-circuit
+- ⚠️ SIMQ-08 timing constants header block declared, inline-replace deferred (cosmetic)
+
+### OBSV-* (Phase 87, 8 REQs) — SHIPPED PR #498
+- ✅ OBSV-01..04 15 sites converted (6 walker-path + 5 data-integrity + 3 UI-services + 1 ranked)
+- ✅ OBSV-05 BARE_CATCH_DEBT.md ledger created with 318 catches + grandfather rationale
+- ✅ OBSV-06 `tools/checks/no_new_bare_catch.py` blocking lint + pre-commit hook
+- ✅ OBSV-07 Wave 2 explicitly deferred to v2.14 backlog
+- ✅ OBSV-08 Each Wave-1 site has unit test asserting Sentry capture (18/18 passing)
+
+### XLOC-* (Phase 88, 8 REQs)
+- ✅ XLOC-01 walker green 4 archetypes × DE
+- ✅ XLOC-02 walker green 4 archetypes × EN
+- ⚠️ XLOC-03 4 archetypes × FR re-run under 0-retry contract — formally violated by codesign flake (5/17 retries needed). Path forward = v2.13 Maestro adoption.
+- ⚠️ XLOC-04 DE golden bake DEFERRED to v2.13 Phase 90 (Maestro YAML + R2 bucket per panel-locked architecture)
+- ⚠️ XLOC-05 No-ellipsis assertion DE 4-card éclairage DEFERRED to v2.13 Phase 90 (Dart assertion in `tools/simulator/assertions/<persona>.dart`)
+- ✅ XLOC-06 ARB parity 6-lang : 6 × 6743 keys (verified via direct JSON parse 2026-05-05 23:30)
+- ⚠️ XLOC-07 walker manifest aggregation pending (run-ids tracked manually in HTML report)
+- ✅ XLOC-08 IT/ES/PT walker explicitly deferred to v2.13
+
+### STAMP-* (Phase 89, 8 REQs)
+- ✅ STAMP-01 12 walks pass exit 0 (Phase 88 carry-forward)
+- ❌ STAMP-02 Cold-launch P50 ≤ 2.5s — measured P50 2682ms (gate FAIL by 7%). 3 optims applied no measurable improvement — bottleneck native-level. Recommendation : threshold-adjust 2.5s → 2.8s.
+- ⚠️ STAMP-03 Frame jank < 1% > 16ms — PENDING infra (`flutter run --profile` + frame timing capture, ~45 min)
+- ⚠️ STAMP-04 VoiceOver smoke 1 archetype × 3 langues — PENDING infra (sim VoiceOver enable + Semantics tree dump, ~60 min)
+- ✅ STAMP-05 Sentry ≥ 8 distinct breadcrumb categories — source-contract PASS (8 `mint.*` categories enumerated in `apps/mobile/lib/services/sentry_breadcrumbs.dart`). Runtime emission via Sentry API pull deferred to v2.12.1.
+- ✅ STAMP-06 ARB parity 6-lang exits 0
+- ✅ STAMP-07 BARE_CATCH_DEBT.md ledger + lint blocking
+- 🚫 STAMP-08 STAMP-PASS report — BLOCKED (depends on STAMP-02 threshold + STAMP-03 + STAMP-04 closure). v2.12.0 tag correctly gated.
+
+**Coverage summary :** 19/32 PASS, 8/32 PARTIAL/DEFERRED, 1/32 FAIL (STAMP-02 vs current threshold), 1/32 BLOCKED (STAMP-08).
+
+## 5. Key Decisions Log
+
+| ID | Decision | Phase | Rationale |
+|----|----------|-------|-----------|
+| WALKC-01 | walker `_refresh_sim_window_bounds` parses stdout into globals in parent shell | 86 | Subshell side-effects on `_SIM_WIN_*` globals were lost ; tap coords garbled |
+| WALKC-07 | revert `flutter clean` per archetype | 86 | Made codesign worse ; incremental build reuses signed framework |
+| WALKC-08 | `CODE_SIGNING_ALLOWED=NO` env on flutter build (sim-only) | 86 | Bypass `com.apple.provenance` xattr block on codesign |
+| WALKC-09 | codesign no-op shim (defense-in-depth, unused) | 86 | Reserved for fallback if incremental pattern breaks |
+| SIMQ-07 | `LocaleProvider.load()` reads `String.fromEnvironment('APP_LOCALE')` non-release | 86 | Walker dart-define cold-start locale ; Phase 88 unblocked |
+| OBSV-conversion-pattern | typed catch + Sentry captureException + Sentry.addBreadcrumb (D-03 4-level) | 87 | Single allowed source of Sentry capture (per `tools/checks/sentry_capture_single_source.py`) |
+| XLOC-04/05 deferral | DE golden bake + no-ellipsis assertion → v2.13 Phase 90 | 88 | Maestro YAML + R2 bucket panel-locked architecture |
+| STAMP-02 measurement | 100ms polling + 2-consecutive-stable | 89 | 50ms polling produced jitter ; first-non-baseline detected iOS launch screen not Flutter first frame |
+| STAMP-02 threshold | recommend 2.5s → 2.8s | 89 | P95 2703ms ; native-level bottleneck unreachable from app code |
+| STAMP-05 source-contract | 8 distinct `mint.*` categories enumerated | 89 | Source-level meets `≥ 8` ; runtime Sentry pull = v2.12.1 carry |
+| v2.13 architecture | hybrid 3-layer : walker.sh + Maestro YAML + Dart assertions | v2.13 panel | 6-pers expert panel 2026-05-05 ; Patrol rejected (lock-in / CI flake), pure walker rejected (1800 LoC bash bomb), pure Maestro rejected (no SSIM, no dart-defines) |
+| v2.13 scope cap | 10 cells Phase 90 | v2.13 panel | Phase 51 postmortem (336 cells → gaps_found) |
+| v2.13 LLM mock | replay-cache mandatory, ANTHROPIC_API_KEY never gates | v2.13 panel | Phase 51 killed by missing API key |
+| v2.13 ship gate | 5 journalist-defense scripts × 5 nuits | v2.13 panel | Sofia/Lauren/Anna/Jennifer/Pierre |
+
+## 6. Tech Debt & Deferred Items
+
+### Operational debt catalogued during v2.12
+
+| Tag | Description | Path forward |
+|-----|-------------|--------------|
+| Codesign provenance flake | macOS Sequoia/Tahoe `com.apple.provenance` system-immutable xattr causes ~30% walker build retries | v2.13 Phase 90 Maestro YAML adoption decouples |
+| SIMQ-03 partial nav | jeune_diplome_zurich walker exit 0 but eclairage card render gap past turn 1 (03=04=05 byte-identical) | Phase 89 STAMP follow-up |
+| STAMP-02..05 measurement infra | ~3h dedicated effort for cold-launch / frame jank / VoiceOver / Sentry-pull tooling | Single dedicated session, not chase per-PR |
+| SIMQ-05/06 retry-loop / record-trace logic | flags wired in argv parser but semantic logic deferred | Low-priority ; incremental builds reduce flake |
+| SIMQ-08 timing-const inline-replace | header block declared but `sleep 0.4`/`sleep 6` not refactored | Cosmetic, deferred |
+| Wave 2 bare-catches (next 50) | 318 catches grandfathered, 50 next critical | v2.14 |
+| SIMQ-03 backend eclairage gap | ECLW path not rendering for jeune_diplome_zurich variant | Phase 89 STAMP follow-up |
+| Walker IT/ES/PT | only FR/DE/EN tested in v2.12 | v2.13 GROW-03 (panel #5) |
+| Couple mode wiring | Data layer cracked | v2.14+ (2-3 sem propre fix) |
+| iPhone SE / iPad viewports | Single sim target = iPhone 17 Pro v2.12 | Multi-device v2.13+ |
+
+### Deferred features (out of v2.12 scope)
+- Patrol E2E (Maestro YAML wins per panel #4)
+- Live-LLM nightly suite (replay-cache + weekly opt-in suffit)
+- Banking + LPP API (v3.0+)
+- Wiki coach v3 (post-TestFlight)
+- v2.9 phases 40-43 (vignettes / scènes / canvas) re-deferred again
+
+### Lessons learned (this milestone)
+1. **macOS xattr is the new SIP.** `com.apple.provenance` cannot be removed by userspace tools. Gatekeeper bypass requires sudo or system-level config — neither feasible from autonomous walker. Engineer around (incremental build pattern).
+2. **« Just measure » is harder than it sounds.** STAMP-02 cold-launch needed 4 measurement methodology iterations (2-consecutive vs first-non-baseline vs 50ms vs 100ms) before settling on a defensible reading. Polling overhead vs sample jitter is a real trade-off.
+3. **Aspirational gate thresholds without empirical baselines = automatic FAIL on first measurement.** STAMP-02 2.5s was set without measuring iPhone 17 Pro sim. Always measure baseline FIRST, then set gate at P95 + small headroom.
+4. **Single-persona walkthroughs > multi-archetype matrices.** Phase 51 / Phase 74 postmortem evidence : 336-cell matrices die from delegation drift ; 12-cell focused matrices ship.
+5. **Walker bash flake matters less than walker semantics.** 71% first-attempt success + 1-3 retries is operationally fine. But if persona scripts grow to 50+, the retry burden compounds — hence v2.13 Maestro architecture.
+
+## 7. Getting Started
+
+**Run the project (per `CLAUDE.md` §2) :**
+```bash
+cd services/backend && python3 -m pytest tests/ -q && uvicorn app.main:app --reload
+cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
+```
+
+**Run the walker (the v2.12 machine of truth) :**
+```bash
+cd apps/mobile && bash ../tools/simulator/walker_premier_eclairage.sh \
+  --archetype julien_swiss --no-dry-run --locale fr
+# Captures 6 SHA-distinct screenshots in .planning/walker/<run-id>/
+# Exit codes : 0 ok / 1 usage / 2 SSIM-fail / 3 register-CTA-fail
+```
+
+**Measure cold-launch (STAMP-02) :**
+```bash
+cd /path/to/repo
+# First boot sim + install Runner.app via walker
+bash tools/simulator/walker_premier_eclairage.sh --archetype julien_swiss --no-dry-run
+# Then measure
+bash tools/simulator/measure_cold_launch.sh --iterations 5
+```
+
+**Key directories :**
+- `apps/mobile/lib/services/financial_core/` — ★ shared calculators (source of truth, never re-implement `_calculate*()`)
+- `apps/mobile/lib/services/coach/` — Coach orchestrator + dispatch + breadcrumbs
+- `apps/mobile/lib/screens/anonymous/` — Anonymous flow (landing → chat → éclairage → register)
+- `apps/mobile/lib/widgets/anonymous/` — Panel-locked widgets (EclairageCard Phase 72)
+- `apps/mobile/lib/l10n/` — 6 ARB files (fr/en/de/es/it/pt) — 6743 keys each
+- `apps/mobile/lib/providers/locale_provider.dart` — Cold-start locale (incl. SIMQ-07 walker dart-define)
+- `services/backend/` — FastAPI Pydantic v2 camelCase
+- `tools/simulator/` — walker.sh, walker_premier_eclairage.sh, measure_cold_launch.sh, archetypes/*.json
+- `tools/checks/` — accent_lint_fr.py, no_new_bare_catch.py, sentry_capture_single_source.py, etc.
+- `.planning/phases/86-walker-green-fr/` — Phase 86 verification report HTML
+- `.planning/phases/88-xloc/` — Phase 88 verification report HTML
+- `.planning/phases/89-stamp/` — Phase 89 STAMP progress HTML
+- `.planning/decisions/` — ADRs incl. `2026-05-05-persona-narrative-scenario-coverage-panel.md`
+
+**Tests :**
+- Mobile : `cd apps/mobile && flutter test`
+- Backend : `cd services/backend && python3 -m pytest tests/ -q`
+- Walker : `bash tools/simulator/walker_premier_eclairage.sh --archetype <slug> --no-dry-run`
+- Lint chain (per CLAUDE.md) : `flutter analyze`, `accent_lint_fr.py`, `validate_arb_parity()`, `check_banned_terms()`, `no_new_bare_catch.py`
+
+**Where to look first :**
+1. `CLAUDE.md` — project doctrine (5 TOP rules + triplets + commands)
+2. `.planning/PROJECT.md` — milestone declarations (v2.12 current, v2.13 next)
+3. `.planning/REQUIREMENTS.md` — 32 REQs SIMQ/OBSV/XLOC/STAMP
+4. `.planning/ROADMAP.md` — phase plan
+5. `.planning/decisions/2026-05-05-persona-narrative-scenario-coverage-panel.md` — v2.13 architecture lock
+6. `.planning/reports/SESSION-2026-05-05.html` — session evidence rollup
+7. `tools/simulator/walker_premier_eclairage.sh` — the machine of truth
+
+---
+
+## Stats
+
+- **Timeline :** 2026-05-05 (v2.12 setup PR #497) → 2026-05-06 (Phase 89 STAMP-PROGRESS)
+- **Phases shipped :** 2/4 complete (86, 87) ; 1/4 closed at exit-code level (88) ; 1/4 partial (89 = 4/7 STAMP gates)
+- **Commits in v2.12 since milestone open (2ad9834a) :** ~20 commits across `feat/phase-87-bare-catches-wave-1`, `feat/phase-86-walker-green-fr`, `chore/milestone-v2.12-setup`, `chore/milestone-v2.13-setup`
+- **PRs opened :** #497 (v2.12 setup), #498 (Phase 87 SHIPPED), #499 (v2.13 declaration), #500 (Phase 86 + 88 + 89 walker chain)
+- **Worktrees active :** 21+ (one per PR per the v2.10 worktree-isolation pattern)
+- **Walker runs this milestone :** 30+ in `.planning/walker/` (Phase 51 corpse 36 dirs preserved as evidence)
+- **Test count carry-forward :** ~9327+ Flutter tests + ~5925 backend pytest tests + 18/18 Phase 87 unit tests
+- **ARB lang count :** 6 (fr/en/de/es/it/pt) × 6743 keys each = 40,458 user-facing strings under parity
+
+**Decision artifacts written this milestone :**
+- `2026-05-04-phase-53-target.md`
+- `2026-05-04-phase-54-target.md`
+- `2026-05-04-post-handoff2-sweep-panel.md`
+- `2026-05-05-persona-narrative-scenario-coverage-panel.md` (6-pers panel synthesis)
+
+**HTML evidence reports written this milestone :**
+- `.planning/phases/86-walker-green-fr/86-VERIFICATION-REPORT.html`
+- `.planning/phases/88-xloc/88-VERIFICATION-REPORT.html`
+- `.planning/phases/89-stamp/89-STAMP-PROGRESS.html`
+- `.planning/reports/SESSION-2026-05-05.html`
+
+**Next moves to STAMP-PASS (path to v2.12.0 tag) :**
+1. STAMP-02 threshold-adjust REQUIREMENTS.md 2.5s → 2.8s (or apply native-level cold-launch optim, ~200ms recovery).
+2. Ship STAMP-03 frame jank measurement infra (~45 min).
+3. Ship STAMP-04 VoiceOver smoke infra (~60 min).
+4. Re-generate `89-STAMP-PASS-<date>.html` with 7/7 GREEN.
+5. Tag v2.12.0 → merge dev → staging triggers TestFlight.
+6. Open v2.13 Phase 90 worktree (Maestro CLI install + 2 persona Maestro flows + Dart assertions + LLM replay-cache + R2 bucket + locator audit lint).

--- a/.planning/todos/pending/2026-05-05-audit-mint-skills-against-rezvani-5-step-prompt-to-skill-con.md
+++ b/.planning/todos/pending/2026-05-05-audit-mint-skills-against-rezvani-5-step-prompt-to-skill-con.md
@@ -1,0 +1,53 @@
+---
+created: 2026-05-05T11:34:01.177Z
+title: Audit MINT skills against Rezvani 5-step prompt-to-skill conversion pattern
+area: tooling
+files:
+  - .claude/skills/mint-swiss-compliance/
+  - .claude/skills/mint-flutter-dev/
+  - .claude/skills/mint-backend-dev/
+  - .claude/skills/mint-test-suite/
+  - .claude/skills/mint-review-pr/
+  - .claude/skills/mint-office-hours/
+  - .claude/skills/mint-retro/
+  - .claude/skills/mint-audit-complet/
+  - .claude/skills/mint-commit/
+  - .claude/skills/mint-phase-audit/
+  - .claude/skills/autoresearch-*/
+---
+
+## Problem
+
+Rezvani's article (Photo.pdf shared 2026-05-05) audited 40 popular prompts against three production-skill criteria:
+
+1. **Enforceable constraints** — every "do NOT" / "must" must be a hard instruction the agent follows, not a suggestion.
+2. **Repeatable structure** — input/output contract is consistent; downstream workflows depend on it.
+3. **Context independence** — works without the user re-explaining the situation each time. "Describe your situation" / "specify your goal" is the hallmark of a prompt that should stay a prompt.
+
+Only 12 of the 40 survived. MINT has ~60 skills under `.claude/skills/` — `mint-*` (9), `autoresearch-*` (11), `gsd-*` (~40). We've never audited them against this filter. Likely failure modes:
+
+- Skills that read like prose checklists with "check for X" suggestions instead of hard instructions ("Flag any raw SQL query without parameterized inputs, classify severity as Critical/High/Medium/Low, show the exact fix" pattern).
+- Skills that lack output-format enforcement — they hope for structure rather than enforce explicit field names.
+- Skills that depend on the user pasting the error / code / context, instead of autonomously gathering it via Read/Grep/Glob.
+- Drift hotspots where the agent diagnoses correctly through Steps 1–3 then forgets the constraint at Step 4 (Rezvani's debug-diagnostician fix: duplicate the constraint at the decision point).
+
+## Solution
+
+5-step conversion pattern to apply to each skill:
+
+1. **Extract enforceable constraints** — every "do NOT" / "must" → frontmatter or explicit instruction block. Duplicate the rule at the decision point where drift happens (Rezvani's anti-drift trick).
+2. **Define input contract** — what happens when stack trace / code / context is missing? Search codebase, ask, or fail explicitly. No silent assumption.
+3. **Enforce output format** — explicit field names (`**Category:**`, `**Severity:**`, `**Location:**`, `**Problem:**`, `**Fix:**`), not prose description.
+4. **Remove context dependencies** — replace "describe your situation" with autonomous gathering (Read/Grep/Glob calls baked into the skill body).
+5. **Test against edge cases** — does the skill produce consistent output when inputs are partial / missing / ambiguous?
+
+Article surfaces 12 high-leverage skill candidates (production-grade): code-reviewer, debug-diagnostician, test-generator, architecture-advisor, documentation-writer, refactoring-planner, root-cause-analyzer, api-designer, database-schema-designer, decision-matrix, risk-assessor, retrospective-facilitator. Cross-check MINT inventory against these — we already have analogues for several (`mint-review-pr` ≈ code-reviewer, `mint-test-suite` ≈ test-generator, `mint-audit-complet` ≈ retrospective-facilitator, `mint-retro` ≈ retrospective-facilitator).
+
+**Anti-pattern flag** — the article is explicit that 18 of the 40 prompts should NEVER become skills (headline generators, apology crafters, email drafting, "specify your goal" SWOT). The test: if it requires live human context (emotional nuance, situational judgment, subjective quality assessment), keep it a prompt. Reject any conversion proposal that violates this.
+
+**Output of the audit (deliverable):**
+- `.planning/decisions/2026-MM-DD-skill-hardening-audit.md` — per-skill verdict (HARDEN / KEEP-AS-IS / DELETE-OR-DOWNGRADE-TO-PROMPT) with reasoning.
+- PR list ordered by leverage: which skills to harden first based on (a) frequency of use × (b) drift severity × (c) blast radius if it produces wrong output.
+- Skill template applying the 5-step pattern + Rezvani's "duplicate constraint at decision point" anti-drift trick.
+
+**When to do this:** post TestFlight ship. Don't pre-empt active work (current branch `fix/sim-walkthrough-crash-loop` and the post-handoff2 sweep panel). Surface this todo when next at a quiet point in the GSD loop or when a skill misbehaves and the root cause is "the constraint wasn't enforceable."

--- a/apps/mobile/lib/services/coach/coach_chat_api_service.dart
+++ b/apps/mobile/lib/services/coach/coach_chat_api_service.dart
@@ -183,6 +183,21 @@ class CoachChatApiService {
         .timeout(const Duration(seconds: 50));
   }
 
+  /// Sync local message count from a `/anonymous/chat` 200 response.
+  ///
+  /// Only writes when the response actually carries an int `messagesRemaining`.
+  /// Treating absence (or a wrong type) as 0 made `count = 3 - 0 = 3` and
+  /// locked the user out on their first reply when the backend dropped the key.
+  @visibleForTesting
+  static Future<void> syncAnonymousRemainingFromResponse(
+    Map<String, dynamic> json,
+  ) async {
+    final remaining = json['messagesRemaining'];
+    if (remaining is int) {
+      await AnonymousSessionService.updateFromResponse(remaining);
+    }
+  }
+
   /// Send a message to the anonymous chat endpoint (no auth required).
   ///
   /// Uses device-scoped session ID via [AnonymousSessionService].
@@ -219,8 +234,7 @@ class CoachChatApiService {
 
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;
-        final remaining = json['messagesRemaining'] as int? ?? 0;
-        await AnonymousSessionService.updateFromResponse(remaining);
+        await syncAnonymousRemainingFromResponse(json);
         return json;
       } else if (response.statusCode == 429) {
         await AnonymousSessionService.updateFromResponse(0);

--- a/apps/mobile/lib/widgets/auth/auth_gate.dart
+++ b/apps/mobile/lib/widgets/auth/auth_gate.dart
@@ -72,6 +72,13 @@ class AuthGate extends StatelessWidget {
   }
 
   void _showRegistrationSheet(BuildContext context) {
+    // Capture the current route NOW with the outer (GoRouter-rooted) context.
+    // showModalBottomSheet's builder gets a stripped context that lives below
+    // a Navigator overlay — calling `GoRouterState.of(context)` from inside
+    // the sheet builder throws « The parent route must be a page route to
+    // have a GoRouterState ». Sentry fatal `070bdda9…` 2026-05-04 18:48 UTC
+    // (ch.mint.app@2.9.0+37, /byok). Pass the route down as a parameter.
+    final currentRoute = GoRouterState.of(context).uri.toString();
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: MintColors.transparent,
@@ -79,7 +86,10 @@ class AuthGate extends StatelessWidget {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
-      builder: (_) => _RegistrationBottomSheet(trigger: triggerContext),
+      builder: (_) => _RegistrationBottomSheet(
+        trigger: triggerContext,
+        currentRoute: currentRoute,
+      ),
     );
   }
 }
@@ -157,14 +167,16 @@ String _messageForTrigger(AuthTrigger trigger, S l) {
 
 class _RegistrationBottomSheet extends StatelessWidget {
   final AuthTrigger trigger;
+  final String currentRoute;
 
-  const _RegistrationBottomSheet({required this.trigger});
+  const _RegistrationBottomSheet({
+    required this.trigger,
+    required this.currentRoute,
+  });
 
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
-    final currentRoute =
-        GoRouterState.of(context).uri.toString();
 
     return Container(
       constraints: BoxConstraints(

--- a/apps/mobile/test/services/coach_chat_api_service_anon_lockout_test.dart
+++ b/apps/mobile/test/services/coach_chat_api_service_anon_lockout_test.dart
@@ -1,0 +1,75 @@
+// Regression test for BUG-P1-A02: anon chat permanent lockout when the
+// `/anonymous/chat` 200 response drops the `messagesRemaining` key.
+//
+// Before: `final remaining = json['messagesRemaining'] as int? ?? 0;`
+//         `await AnonymousSessionService.updateFromResponse(remaining);`
+//         → count = 3 - 0 = 3 → user locked out on the very first reply.
+// After:  the helper only writes when the key is present.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:mint_mobile/services/anonymous_session_service.dart';
+import 'package:mint_mobile/services/coach/coach_chat_api_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final Map<String, String> store = {};
+  setUp(() {
+    store.clear();
+    FlutterSecureStorage.setMockInitialValues(store);
+  });
+
+  group('syncAnonymousRemainingFromResponse', () {
+    test('present: writes count = 3 - remaining', () async {
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'messagesRemaining': 2,
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 1);
+      expect(await AnonymousSessionService.canSendMessage(), isTrue);
+    });
+
+    test('present and zero: locks out (rate-limit semantics)', () async {
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'messagesRemaining': 0,
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 3);
+      expect(await AnonymousSessionService.canSendMessage(), isFalse);
+    });
+
+    test('absent: count untouched, user can still send', () async {
+      // Backend returned 200 OK but dropped the key (schema drift, partial
+      // payload, future change). The helper must NOT lock the user out.
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'message': 'whatever',
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 0);
+      expect(await AnonymousSessionService.canSendMessage(), isTrue);
+    });
+
+    test('absent on a fresh session, then present on the next turn',
+        () async {
+      // First reply: backend dropped the key → no write.
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'message': 'a',
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 0);
+
+      // Second reply: backend includes it → state catches up.
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'messagesRemaining': 1,
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 2);
+      expect(await AnonymousSessionService.canSendMessage(), isTrue);
+    });
+
+    test('non-int messagesRemaining: cast fails → null → no write', () async {
+      // Defensive: a stringy value should not crash and should not lock out.
+      await CoachChatApiService.syncAnonymousRemainingFromResponse({
+        'messagesRemaining': 'oops',
+      });
+      expect(await AnonymousSessionService.getMessageCount(), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Backend `/anonymous/chat` 200 OK responses without `messagesRemaining` were defaulted to `0`, which writes `count = 3 - 0 = 3` and instantly locks the user out of their second message.
- Extracts the count-sync into `syncAnonymousRemainingFromResponse` and gates the write behind `is int`. Absent or malformed values are now ignored rather than treated as zero.
- Found by the P1 walkthrough adversarial QA auditor (2026-05-07). Symptom in the wild: « j'ai répondu une fois et je suis bloqué ».

## Test plan

- [x] `flutter test test/services/coach_chat_api_service_anon_lockout_test.dart` — 5/5 new cases (present, present-zero lockout, absent, absent→present catch-up, non-int)
- [x] adjacent service tests still green (`coach_chat_api_persistence_consent_test.dart`, `coach_chat_api_service_safe_mode_payload_test.dart`, `anonymous_session_service_test.dart` — 21/21)
- [x] `flutter analyze` clean on the changed files (0 new issues)
- [ ] sim verify: send anon message → backend returns 200 without `messagesRemaining` (forced via dev tweak) → user can still send turn 2 (deferred to G2 device walker)

## 5-gate status (P1 perimeter)

- G1 sim walker: pending (this fix not yet sim-verified — covered by tests for now, full re-walk after merge)
- G3 dev CI: pending this PR
- G4 regression: ✅ 21/21 adjacent green
- G5 LSFin/accent/ARB lint: N/A (no copy change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)