### PR TITLE
chore(claude-md): 0-trust protocol — never trust your own claims (§ 9 + rule #6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,14 @@
 
 > Detail : [flutter](docs/AGENTS/flutter.md) · [backend](docs/AGENTS/backend.md) · [swiss-brain](docs/AGENTS/swiss-brain.md). Conflict : `rules.md` > this > `.claude/skills/*`.
 
-## 🚨 TOP — 5 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
+## 🚨 TOP — 6 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
 
 1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md).
 2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`, `decouvrir → découvrir`, `securite → sécurité`, `premier éclairage` (jamais `premier eclairage`). ASCII « e » à la place de « é » = bug. Lint : `tools/checks/accent_lint_fr.py`.
 3. **MINT ≠ retirement app** — 18 life events equally weighted (housing, family, tax, career, debt…). Never frame screens/prompts as « retraite-first ». Target : 18-99. Pivot 2026-04-12 : lucidité, pas protection.
 4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`.
 5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. Run `flutter gen-l10n`.
+6. **0-TRUST — never trust your own claims** — banned without deterministic citation in same message: « shipped », « closed », « ready », « works », « validated », « green », « PROVISIONALLY READY ». Citation = `path:line` / command output / `idb ui describe-all` snapshot / PR-merge timestamp / Julien confirmation. **PR opened ≠ shipped. Tests passing ≠ feature working.** End-to-end user flow on sim before any « ready ». Detail → § 9.
 
 ---
 
@@ -126,10 +127,114 @@ Git : `feature/S{XX}-<slug>` depuis `dev` ; PRs feature→dev squash, dev→stag
 
 **Anti-pattern (Karpathy practice 1)** : never write speculative agent-generated drafts into `~/.claude/projects/.../memory/` (curator vault). All Claude-generated content lives in `.planning/`.
 
-## 🚨 BOTTOM — 5 RULES CRITIQUES (duplicated intentionally, Liu 2024)
+## 7. BEHAVIOR FOUNDATION — Karpathy 4 (LLM coding pitfalls, [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills))
+
+> Karpathy : *« The models make wrong assumptions on your behalf and just run along with them without checking. They don't manage their confusion, don't seek clarifications, don't surface inconsistencies, don't present tradeoffs. They overcomplicate code, bloat abstractions, don't clean up dead code. »* These 4 principles override default speed bias when in doubt.
+
+### #1 Think Before Coding — *don't assume, surface tradeoffs*
+- State assumptions explicitly. If uncertain → ask (per memory `feedback_blockers_ask_dont_defer.md`).
+- Multiple interpretations exist → present them, don't pick silently.
+- Simpler approach exists → say so, push back when warranted.
+- Something unclear → stop, name what's confusing, ask.
+
+### #2 Simplicity First — *minimum code that solves the problem*
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No « flexibility » / « configurability » not requested.
+- No error handling for impossible scenarios.
+- 200 lines that could be 50 → rewrite. Test : *« Would a senior engineer say this is overcomplicated ? »*
+
+### #3 Surgical Changes — *touch only what you must, clean only your own mess*
+- Don't « improve » adjacent code, comments, formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- Notice unrelated dead code → mention, don't delete (unless asked).
+- Test : *« Every changed line traces directly to the user's request ? »*
+
+### #4 Goal-Driven Execution — *define success criteria, loop until verified*
+- « Add validation » → « Write tests for invalid inputs, then make them pass ».
+- « Fix the bug » → « Write a test that reproduces it, then make it pass ».
+- « Refactor X » → « Tests pass before AND after ».
+- Multi-step task → state plan with `verify:` per step. Strong success criteria let you loop independently. Weak criteria force constant clarification.
+
+**Working when :** fewer unnecessary diff lines, fewer overcomplication rewrites, clarifying questions BEFORE implementation rather than mistake post-mortems.
+
+## 9. 0-TRUST PROTOCOL — Never trust your own claims (grounded, 2026-05-07)
+
+> Anthropic 2026 ([Reduce hallucinations](https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)) : *« cite quotes and sources for each claim. If it can't find a quote, it must retract the claim. »*
+> [Ralphable 2026](https://ralphable.com/blog/claude-code-hallucination-problem-atomic-skills-reliable-output) : *« atomic tasks with explicit pass/fail criteria force the agent to ground each step in reality before proceeding. »*
+> [johnsonlee.io 2026](https://johnsonlee.io/2026/03/28/ground-truth-core-competency-of-ai-engineering.en/) : *« using a probabilistic tool to verify probabilistic output is the same as no verification. Ground truth must be deterministic. »*
+
+**Why this section exists** : 2026-05-07 session — opened 4 PRs, called « PROVISIONALLY READY » on P1/P2/P3, then Julien sent a sim screenshot showing « Aucune donnée pour l'instant » + « Définis ton budget ». **Tests green + PRs open != app works.** End-to-end user flow had never been run. This section is the operational fence around that failure mode.
+
+### 9.1 Banned phrases without deterministic citation (in the same message)
+
+`shipped`, `livré`, `closed`, `fermé`, `ready`, `prêt`, `works`, `marche`, `validated`, `validé`, `green`, `PROVISIONALLY READY`, `MVP working`, `feature complete`.
+
+Each requires a specific evidence type **in the same message** :
+
+| Claim | Required evidence |
+|---|---|
+| `shipped` / `livré` | `gh pr view <N> --json mergedAt` returns non-null **AND** post-merge sim run touched the changed surface |
+| `closed` / `fermé` | All 5 gates (G1 sim describe-all + G3 dev CI green sha + G4 test exit 0 + G5 lint exit 0 + G2 Julien confirmation) cited explicitly |
+| `ready` / `prêt` | End-to-end user flow run on sim by me, with `idb ui describe-all` final state OR a screenshot reviewed by Julien |
+| `works` / `marche` | I taped through the user flow on sim. Output of the final `idb ui describe-all` quoted. |
+| `validated` | Either Julien said « ok » in chat OR a deterministic checker (test, lint, type-check) returned exit 0 with the command output cited |
+| `green` (about CI) | `gh pr checks <N>` output pasted with all jobs ≠ `fail` and ≠ `pending` |
+
+If I cannot cite the evidence type → I do NOT use the claim word. I use **`unit tests green, end-to-end UNKNOWN`** or **`PR opened, merge + sim verification pending`** or **`I haven't checked`**. Honest > optimistic.
+
+### 9.2 Tests passing ≠ feature working
+
+A unit test green means « given input X, function returns Y ». A feature working means « a real user can complete the flow and see the expected result ». **The two are NEVER substitutes.** Stating « 7/7 tests green » does NOT entitle me to say « the feature works ». They're separate truths and they need separate citations.
+
+### 9.3 Strict Write Discipline on PERIMETERS.md & status fields
+
+- A perimeter STATUS = « PROVISIONALLY READY » requires G1 sim walker output **already present in the GATE LOG** for the LATEST fix on that perimeter (timestamp ≥ last fix-PR commit time).
+- Opening a PR is **starting** work. Not « shipping ». Not « closing ». Status remains 🟡 IN_FLIGHT until merged AND post-merge sim re-run logged.
+- A panel auditor's verdict (« PASS ») is a recommendation, not a gate. The gate is mechanical : sim output, CI exit code, lint exit code, Julien's eyes.
+
+### 9.4 End-of-turn 3-step self-audit (mandatory before any summary)
+
+Before every sentence that would contain one of the §9.1 banned words, run this :
+
+1. **Citation test** — name the file path / command output / `idb` snapshot / PR-merge timestamp that proves the claim. If I can't, retract the claim.
+2. **Sim survival test** — *« If Julien opens his sim right now, would my claim survive ? »* If the sim could plausibly show emptiness while I claim « shipped », retract.
+3. **Work vs value separation** — separate WORK DONE (PRs opened, tests passing, code edited, lints clean) from USER VALUE DELIVERED (end-to-end flow visibly works for Julien). State both, never conflate.
+
+### 9.5 The « PR opened ≠ shipped » trap (2026-05-07 lesson)
+
+The shipping pipeline has 4 stages : open PR → review → merge → user sees change. I called « shipped » at stage 1 of 4. The 4 stages are :
+
+| Stage | What I can claim | What I cannot claim |
+|---|---|---|
+| PR opened | « PR #N opened, awaiting CI » | « shipped », « ready », « closed » |
+| CI green | « CI green on PR #N » | « ready », « works » (still not merged) |
+| Merged | « Merged to dev as <sha> » | « works » (not yet sim-verified post-merge) |
+| Post-merge sim | « Sim describe-all shows X after merge » | now I can say « works » for that flow |
+
+### 9.6 The required claim format
+
+When I claim something works, the format is :
+
+```
+Evidence : <file path / command output / sim snapshot / PR sha>
+Caveat   : <what I have NOT checked>
+```
+
+NOT : `✅ shipped`, `✅ ready`, `✅ green`, `✅ closed`. The checkmark is the bullshit signal — the receipt is the citation.
+
+### 9.7 « I don't know » is the highest-quality answer
+
+When uncertain : « I don't know, I haven't checked » beats « should work » / « expected behavior » / « PROVISIONALLY READY ». The first triggers verification ; the second two trigger Julien-frustration-driven session restarts.
+
+---
+
+## 🚨 BOTTOM — 6 RULES CRITIQUES (duplicated intentionally, Liu 2024)
 
 1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur ». Use « pourrait », « envisager ».
 2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`. ASCII = bug.
 3. **MINT ≠ retirement app** — 18 life events equally weighted. Frame generically, pas « retraite-first ».
 4. **Financial_core reuse mandatory** — `lib/services/financial_core/`. Never re-implement `_calculate*()`.
 5. **i18n required** — `AppLocalizations.of(context)!.key`. 6 ARB files. Run `flutter gen-l10n`.
+6. **0-TRUST — never trust your own claims** — banned without deterministic citation : « shipped », « closed », « ready », « works », « validated », « green », « PROVISIONALLY READY ». PR opened ≠ shipped. Tests passing ≠ feature working. End-to-end sim run before any « ready ». Detail § 9.


### PR DESCRIPTION
## Why this PR exists

2026-05-07 session went off the rails : opened 4 PRs (#518 / #519 / #520 / #521), declared P1 / P2 / P3 « PROVISIONALLY READY », claimed « 4 PRs shippées en 1 session ». Julien sent a sim screenshot showing the app empty (« Aucune donnée pour l'instant » + « Définis ton budget ») and called out the gap : tests green + PRs open ≠ app works. End-to-end user flow had never been run.

This PR operationalises three 2026 anti-hallucination patterns into hard CLAUDE.md rules so future sessions cannot repeat the failure mode.

## Sources

- [Anthropic « Reduce hallucinations »](https://docs.claude.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations) — citation discipline
- [Ralphable Blog 2026 — Claude Code hallucination problem, atomic skills, reliable output](https://ralphable.com/blog/claude-code-hallucination-problem-atomic-skills-reliable-output)
- [johnsonlee.io 2026 — Ground Truth as the most undervalued competitive edge](https://johnsonlee.io/2026/03/28/ground-truth-core-competency-of-ai-engineering.en/)

## What lands

- **TOP / BOTTOM rule #6** : « 0-TRUST — never trust your own claims »
- **New § 9** : 0-TRUST PROTOCOL (107 lines) — banned phrases, citation table, 4-stage PR pipeline, end-of-turn self-audit, required claim format

## Test plan

- [x] No code change → no test plan
- [x] CLAUDE.md is auto-loaded into every Claude session in this repo
- [x] Memory companion `feedback_zero_trust_protocol.md` saved for cross-session persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)