### PR TITLE
feat(aujourdhui): bump pubspec 2.12.1+3 + memoize ConfidenceScorer

### DIFF
--- a/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
+++ b/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
@@ -15,6 +15,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/financial_plan.dart' show computeProfileHash;
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/providers/financial_plan_provider.dart';
 import 'package:mint_mobile/providers/timeline_provider.dart';
@@ -47,6 +48,16 @@ class AujourdhuiScreen extends StatefulWidget {
 
 class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
   final Set<String> _collapsedMonths = {};
+
+  // Memoization for ConfidenceScorer.scoreEnhanced — `now` is captured
+  // once per State and the result is keyed on the profile hash so a
+  // rebuild without profile change reuses the cached EnhancedConfidence.
+  // Without this, scoreEnhanced runs on every build with a fresh
+  // DateTime.now(), recomputing the freshness axis on each tick and
+  // invalidating MintTrameConfiance's bloom-storm guard.
+  late final DateTime _confidenceNow = DateTime.now();
+  EnhancedConfidence? _cachedConfidence;
+  String? _cachedConfidenceProfileHash;
   bool _initialCollapseSet = false;
 
   @override
@@ -98,7 +109,17 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
     final profile = context.watch<CoachProfileProvider>().profile;
     if (profile == null) return null;
 
-    final confidence = ConfidenceScorer.scoreEnhanced(profile);
+    // Memoize ConfidenceScorer.scoreEnhanced by profile hash. Reuse
+    // _confidenceNow so the freshness axis is stable across rebuilds.
+    final hash = computeProfileHash(profile);
+    if (_cachedConfidence == null || _cachedConfidenceProfileHash != hash) {
+      _cachedConfidence = ConfidenceScorer.scoreEnhanced(
+        profile,
+        now: _confidenceNow,
+      );
+      _cachedConfidenceProfileHash = hash;
+    }
+    final confidence = _cachedConfidence!;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.0+2
+version: 2.12.1+3
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary

Two changes bundled for the post-PR-#525 TestFlight ship chain :

1. **pubspec bump** `2.12.0+2 → 2.12.1+3` — mandatory: `2.12.0+2` already shipped 2026-05-06 (run 25430526108), App Store Connect rejects duplicate build numbers
2. **P0 memoization fix** on `aujourdhui_screen.dart:_buildPlanAndConfidenceSection` — `ConfidenceScorer.scoreEnhanced(profile)` previously ran inside `build()` with no memoization, recomputing freshness axis on every rebuild via internal `DateTime.now()`. Now cached by `computeProfileHash` + stable `_confidenceNow` per State

Per code-review audit of PR #525 wire (4 audits ran in parallel post-merge).

## Deferred to follow-up

P1 items from same audit, not ship-blockers for FR-first cohort :
- `FinancialPlanProvider` listener leak — needs `dispose()` override
- `financial_plan_card.dart` hardcoded `fr_CH`/`fr` formatters — needs `Localizations.localeOf(context)` for non-FR users

## Test plan

- [x] `flutter analyze lib/screens/aujourdhui/aujourdhui_screen.dart` → `No issues found! (ran in 1.9s)`
- [x] pubspec version verified: `2.12.1+3`
- [ ] CI green on this PR
- [ ] Sim run with active plan post-merge (G1 complete) — separate device session
- [ ] Julien device run on TestFlight build (G2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)