### PR TITLE
fix(coach): onboarding crisis hotfix — ventriloquy + salaire-first + canned reply + fake defaults (B1+B2+B3+B4)

### DIFF
--- a/.planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
+++ b/.planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
@@ -1,0 +1,246 @@
+---
+name: Coach onboarding redesign — 6-expert panel synthesis
+description: Strategic decision wiki — refonde l'onboarding auth-coach après TestFlight v2.12.1+3 G2 finding (4 P0 bugs B1-B4) + Julien design concern. 6 panel agents (UX/IA, behavioral, token, LSFin, adversarial, competitor) converge sur structured-first 3-bucket / 6-step OTP-style aligned avec MINT v2 design canvas (italique Gambarino, 1 idée / écran). Perimeter MVP-ONBOARDING-V2-AUTH-FIRST à ouvrir.
+type: decision
+date: 2026-05-08
+status: Proposed
+related:
+  - .planning/decisions/2026-05-08-anthropic-fsi-strategic/SYNTHESIS.md
+  - .planning/decisions/2026-05-08-office-hours-mon-dossier/DESIGN.md
+  - .planning/decisions/2026-05-08-wire-financial-plan-card-perimeter/CLOSE-OUT.md
+sources:
+  - PR #525 (wire FinancialPlanCard) merged 2026-05-08T16:05:55Z
+  - PR #529 (B1+B2+B3+B4+cleanup+B6 onboarding hotfix bundle) — in flight
+  - MINT v2 design canvas HTML (Julien shared 2026-05-08, Tweaks: Menthe-vive + slogan « clair »)
+  - 6 panel sub-agents (a39705af9 / a6f345199 / a26e15301 / abb4b4669 / ad1459c2e / aeee85dbf)
+---
+
+# Coach onboarding — refonte panel synthesis
+
+## TL;DR
+
+**Decision** : remplacer l'auth-coach « free-text from screen 1 » actuel par un **shell onboarding structuré 6 micro-steps** (OTP-style « 1 idée par micro-écran », italique Gambarino, eyebrow numéroté, sub anti-promiscuous). Collecte life-event + archetype + age + canton + statut + revenu BRACKET en ≤ 60 secondes, AVANT le premier appel LLM. Le coach reçoit un profile populated + démarre direct sur un **Premier Éclairage** (1 chiffre + ConfidenceBand 4-axis + 1 EnrichmentPrompt) — c'est le wedge MINT vs VZ.
+
+**Évidences chiffrées du panel** :
+- Token economy : -73% sur first-session (~$1 920/mo @ 10k MAU saved, O3)
+- Archetype safety : 1/8 archétypes works by accident, 7/8 break (O5) — ~35-45% des CH résidents mis-archétypés. **PR #529 commit B6 ferme cette dette critique** (FATCA bypass closed)
+- Compliance : défendable LSFin actuel + 2 gaps documentés (D10 Hero-Plan modal, nLPD register-of-processing) — O4
+- Habit retention : Hooked / Fogg / Cialdini — D-7 Sunday push + Premier Éclairage confidence ring delta (O2)
+- Wedge stratégique : « Swiss diagnostic upfront, monetise depth » inverse VZ funnel — aucun competitor n'a (a) life-event-first + (b) 8-archetype branching + (c) Swiss-law uncertainty bands AVANT data (O6)
+
+## Trigger
+
+Julien sur TestFlight v2.12.1+3 G2 device test (2026-05-08) :
+- B1 phantom user message (« Salut, je viens de créer mon compte »)
+- B2 framing salaire-first (« Premier pas, dis-moi ton salaire net mensuel »)
+- B3 canned non-response sur input revenu (« Je suis là pour t'aider… ») — RAG orchestrator empty-text bug
+- B4 hardcoded VD/célibataire/35 ans/swiss_native injectés dans LLM context comme « 3 pièces du puzzle »
+- Diagnostic Julien : « onboarding pas clean, pas clair, économiser tokens, structured »
+
+PR #529 fix B1+B2+B3+B4 + cleanup + B6 (audit completion archetype plumbing) → mergeable mais c'est un hotfix sur l'existant. Refonte structurelle = ce wiki.
+
+## Panel — 6 experts en parallèle
+
+| Agent | Angle | Verdict | Insight load-bearing |
+|---|---|---|---|
+| O1 | UX/IA flow architecture | Structured 3-screen auth-first | Le `/onb` 8-step shell est `RouteScope.public` only — le post-login auth-coach est le **trou architectural** où Julien tombe |
+| O2 | Behavioral econ / habit | 3-Q max + Premier Éclairage habit moment | Defer revenue (reveal-then-ask) ; Sunday 19h push (variable reward Hooked) ; 9-tour shell over-scoped per [Userpilot 2026 finance D7=17.6%] |
+| O3 | Token economy backend | -73% saving structured-first | Cost actuel 17 500 input + 400 output / turn ≈ $0.064 ; 7 fields déterministes coûtent 0 token, 1 LLM kickoff turn AFTER profile populated |
+| O4 | LSFin / FINMA / nLPD | Défendable + 2 gaps réels | **Salary BRACKET only, pas exact CHF** ; IBAN/ISIN/3a-CHF interdits qualifient « conseil en placement » LSFin art. 3 let. c ch. 4 |
+| O5 | Adversarial QA archetype | **1/8 works, 7/8 break** | Mes B4 fixes étaient INCOMPLETS Dart-side → **B6 commit immediate fix** ; FATCA bypass closed ; 5 promptfoo/Maestro tests proposés |
+| O6 | Competitive intel | Wedge MINT identifié | Cleo goal-tile-before-data ✅, Lunchmoney skip-button ✅, Monarch card-picker ✅ ; Cleo snark ❌, Revolut lifestyle-disguise ❌ ; **invert VZ funnel** = diagnose upfront monetise depth |
+
+## Convergence forte (5/6 alignés)
+
+Tous d'accord sur :
+- **Structured-first AVANT LLM** (O1 + O2 + O3 + O5 + O6 ; O4 confirme défendable)
+- **Life-event-first vs goal-first** (O1 + O6 : Cleo's tiles, MINT 18 events ≠ retraite-app)
+- **Archetype detection AVANT premier message** (O3 + O5 : sinon FATCA bypass + token waste)
+- **Reuse composants existants** (`_AgePicker` / `_RevenueStep` / canton picker / `updateFromSmartFlow()` `coach_profile_provider.dart:688`)
+- **Skip lever per screen** (O1 + O2 + Lunchmoney pattern via O6)
+- **Premier Éclairage en bout** (O2 habit + O6 wedge)
+
+## Tension résolue (panel ↔ MINT v2 canvas)
+
+Le panel propose 3 buckets logiques (life-event / archetype / facts). Le canvas MINT v2 (Julien shared 2026-05-08, eyebrow « 03 — PROFIL » + dots indicator) montre un OTP-style multi-step. **Pas de tension** : la grammaire v2 « 1 idée / écran » s'applique au **micro-step**, pas au bucket logique. Le canvas montre **un step parmi 5+**. Granularité différente, architecture compatible.
+
+## Décision finale — séquence onboarding 6 micro-steps
+
+Eyebrow numéroté + italique Gambarino + sub anti-promiscuous + CTA « Continuer ».
+
+| # | Eyebrow | Hero italique | Sub | Input | Source panel |
+|---|---|---|---|---|---|
+| **01** | INTENTION | « Qu'est-ce qui t'amène ? » | « Une raison qui t'a fait télécharger MINT. » | 6 chips life-event buckets : retraite/décumulation · acheter-déménager · famille · carrière · impôts-3a · je regarde d'abord | O1 + O6 wedge |
+| **02** | PROFIL | « Tu es né quand ? » | « Pour calibrer ton plan. Rien d'autre. » | 4-digit OTP-style (canvas existant) | O3 fact #1 |
+| **03** | PROFIL | « Tu vis où ? » | « Pour les règles fiscales et la LPP. » | Canton picker 26 entrées | O3 fact #2 |
+| **04** | PROFIL | « Tu fais quoi ? » | « Pour adapter le coach à ta situation. » | 3 chips : Salarié·e / Indépendant·e / Sans activité (étudiant·e, parent au foyer, retraité·e) — conditionnel reveal nationalité+permis si non-CH ou « ai vécu hors CH > 2 ans » | O5 archetype detection critical |
+| **05** | PROFIL | « Combien tu gagnes (à peu près) ? » | « Une fourchette suffit. On affinera ensemble. » | 5 brackets : <4k / 4-7k / 7-10k / 10-15k / >15k CHF/mois — **bracket pas exact CHF** + skip « Plus tard » | O3 fact #6 + O4 contrainte LSFin |
+| **06** | ÉCLAIRAGE | « Voilà ce qu'on voit. » | « Premier chiffre. Confiance basse, à clarifier. » | Premier Éclairage : 1 chiffre + ConfidenceBand 4-axis (`EnhancedConfidence` MANDATORY) + 1 EnrichmentPrompt + CTA « Continuer vers le coach » | O2 habit + O6 wedge |
+
+**Skip lever** : steps 04 (statut) + 05 (revenu) — texte-link bottom-left « Je remplirai plus tard ». Mark `archetype_confidence: low` et coach demande direct-target. Steps 01-03 requis (intent/age/canton minimum-viable).
+
+## Architecture technique
+
+**Path** : `apps/mobile/lib/screens/onboarding/auth_first/` (nouveau dossier, distinct de `mvp_wedge/` qui est le path anon `/onb`)
+
+**Routes** (GoRouter) :
+- `/onboarding/intent` → step 01
+- `/onboarding/profil/age` → step 02
+- `/onboarding/profil/canton` → step 03
+- `/onboarding/profil/statut` → step 04
+- `/onboarding/profil/revenu` → step 05
+- `/onboarding/eclairage` → step 06
+
+**Redirect logic** : `app.dart:283-301` ajouter `if (isLoggedIn && !coachProfile.hasMinimumViableFacts) return '/onboarding/intent'`. `hasMinimumViableFacts` = nouveau getter sur CoachProfile = (intent != null && age != null && canton != null).
+
+**Reuse** :
+- `_AgePicker` ([apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart:348-385](apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart))
+- canton list ([:391-418](apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart))
+- `_RevenueStep` slider — ADAPTER à brackets discrets per O4
+- `updateFromSmartFlow()` ([coach_profile_provider.dart:688](apps/mobile/lib/providers/coach_profile_provider.dart)) — déjà calcule archetype depuis nationality/permit/employment
+- `FinancialPlanProvider` (B5 wire just shipped via PR #525)
+- `EnhancedConfidence` 4-axis ([SOT.md:82-92, 111](SOT.md))
+- `MintTrameConfiance` ([widgets/trust/mint_trame_confiance.dart](apps/mobile/lib/widgets/trust/mint_trame_confiance.dart))
+
+**ARB keys nécessaires** (~30 clés × 6 langs) : `onboardingIntent*`, `onboardingProfilAge*`, `onboardingProfilCanton*`, `onboardingProfilStatut*`, `onboardingProfilRevenu*`, `onboardingEclairage*`. Run `flutter gen-l10n` après.
+
+## Token economy projetée (post-redesign)
+
+| Phase | Tokens | $/turn | Note |
+|---|---|---|---|
+| Steps 01-05 (formulaire pure) | 0 | $0 | Pas de LLM call |
+| Step 06 Premier Éclairage | ~17 500 input + 600 output ≈ 18.1k | $0.061 | 1 LLM call, profile populated |
+| First coach turn post-onboarding | ~17 500 input + 200 output ≈ 17.7k | $0.057 | Avec cache 90% sur static blocks → ~$0.012 |
+
+**vs current** : 5 onboarding turns × $0.064 = $0.32/user. Post-redesign : 1 turn = $0.061. **Saving 81% / first session, $2 590/mo @ 10k MAU.** Projection plus aggressive que O3 estimate (-73%) parce qu'O3 conservait 1 turn par fact ; ici on collecte 5 facts en formulaire 0-token.
+
+## Compliance LSFin alignement (O4)
+
+✅ Compliant :
+- Banned-terms via `ComplianceGuard` post-processor (50 lemmas)
+- `landingV2Legal` disclaimer pre-onboarding
+- `BetaProgramDisclosureSheet` data-residency
+- Salary BRACKET (pas exact CHF)
+- Pas d'IBAN/ISIN/3a-amount tied to identity
+
+⚠️ Gaps existants à traiter en parallèle :
+- D10 pre-Hero-Plan modal manquant (FINMA Circ. 2025/02 §III) — applicable à step 06
+- nLPD register-of-processing `save_fact` anon mirror dead
+
+## Adversarial QA tests à ajouter (O5)
+
+5 scenarios CI-blockers post-redesign :
+1. `promptfoo archetype_detection_freetext.yaml` — 8 fixtures (1/archetype) → assert backend `_detect_archetype` returns correct + `CoachContext.archetype` ≠ ""
+2. `Maestro walker_archetype_compound.yaml` — 8 walker fixtures → assert no banned response per archetype (e.g. no « 3a » imperative for expat_us)
+3. `pytest test_doctrine_checks_no_archetype_bypass.py` — assert `meta.archetype = ""` ne PASS plus (B6 fix livré dans PR #529 — test à écrire)
+4. `Flutter widget test coach_context_builder_archetype_required.dart` — assert build() warns when called without archetype (B6 part)
+5. `promptfoo fatca_3a_no_recommendation.yaml` — 5 prompts mentionnant US passport/green card → assert response contient FATCA/PFIC ET PAS « Verse 3a »
+
+## Counter-arguments and data gaps
+
+- **« Skip the walkthrough » trop facile = drop archetype detection** : O6 (Lunchmoney) propose un skip button. Mais skip sur step 04 = archetype default empty → B6 doctrine guard bloque réponses → user reçoit FAIL. Mitigation : skip mark `archetype_confidence: low` et coach **demande targeted** au step 06 (« Avant le diagnostic, j'ai besoin de savoir : Suisse / EU / Autre ? »). Re-collecte gracieusement.
+- **5 brackets revenu peuvent être trop fins ou trop grossiers** : O4 dit BRACKET, pas exact. Mais 4 vs 5 vs 7 brackets = data gap, pas testé. Mitigation : ship 5 brackets + instrumenter % par bracket post-MVP, ajuster.
+- **Step 06 Premier Éclairage = 1 LLM turn premium** : -73% to -81% saving estime que les autres turns sont ~même cost. Reality check post-redesign : si user fait 0 follow-up turn (juste Premier Éclairage + dropoff), le saving est moins fort. Calibrer post-data.
+- **« Une idée par écran » casse pour les conditional reveals** : step 04 a un conditional reveal (« si non-CH → permis »). Strictement, c'est 2 idées sur 1 écran. Tension v2 grammar. Mitigation : reveal animée smooth (pas instantané) signale au user qu'il y a une 2e idée.
+- **Le HTML que Julien a partagé est un canvas design system, pas un blueprint exhaustif** : on a la grammaire (8 règles) + identité (Supreme + Gambarino + 4 palettes) + 8 écrans labels. Les JSX externes (`screen-onboarding.jsx`, `tokens.jsx`, `primitives.jsx`) ne sont pas dans le HTML — content non reçu. Donc le mockup textuel ci-dessus est aligné avec la grammaire mais pas validé par Julien sur le contenu exact. À confirmer avec Julien post-redesign.
+- **Anti-pattern — on n'a pas testé en sim** : le mockup textuel n'a JAMAIS été rendu en Flutter ni testé en sim ni en device. C'est une décision design, pas une livraison. Le perimeter d'implémentation va découvrir des frictions UX qu'on ne voit pas en mockup.
+- **MINT a déjà `coach_profile_seeds.dart` + `proactive_trigger_service.dart` + `weekly_recap_service.dart`** — partial habit pipeline existe. Le redesign doit s'intégrer, pas remplacer.
+- **Données manquantes** : pas de benchmark D7 retention interne MINT, pas de mesure du % users actuellement avec FATCA / cross_border / indep en TestFlight. Toute l'argumentation O5 sur 35-45% mis-archétypés est extrapolation Swiss demographics, pas mesure interne.
+- **Mes 6 audits ont tous des biais distincts** : O1 favorise structure (UX bias), O2 favorise minimal (behavioral bias), O3 favorise structured (cost bias), O4 favorise compliance (legal bias), O5 favorise rigor (QA bias), O6 favorise wedge (PM bias). Convergence est forte mais peut être un effet de framing identique des prompts (j'ai cadré chaque agent vers structured-first dans l'instruction). Mitigation honnête : si un panel different (e.g. PM Apple-style minimal) avait été spawn, il aurait peut-être proposé 1-screen with skip-everything.
+
+## Approval gate
+
+**Recommandation finale (Critical PM, anti-sycophancy)** :
+
+1. ✅ **Adopter** la séquence 6 micro-steps comme blueprint pour le perimeter `MVP-ONBOARDING-V2-AUTH-FIRST`.
+2. ✅ **Ouvrir** le perimeter post-merge PR #529 (le hotfix B1-B6 ne dépend pas du redesign — peut ship en parallèle).
+3. ⏸ **Différer** D10 Hero-Plan modal + nLPD register au perimeter compliance dédié (O4 gaps).
+4. ⏸ **Reporter** le shell anon `/onb` 8-step refactor (RouteScope.public) à un perimeter séparé — pas le même path que le post-login auth-coach.
+5. ✅ **Ajouter** les 5 tests adversarial QA (O5) au perimeter d'implémentation comme acceptance.
+6. ❌ **Ne pas** essayer d'inclure le redesign dans PR #529 — bundle trop large, ship le hotfix d'abord.
+
+## Implementation perimeter outline (à ouvrir post PR #529 merge)
+
+`MVP-ONBOARDING-V2-AUTH-FIRST` perimeter :
+
+**Goal** : implémenter les 6 micro-steps onboarding aligné MINT v2 canvas, fermer le trou architectural post-login.
+
+**5 gates mécaniques** (per memory `feedback_perimeter_5_gates`) :
+- G1 sim walker — golden screenshot per step + 8 archetype scenarios (per O5)
+- G2 device par Julien sur TestFlight build
+- G3 dev CI — flutter analyze + pytest backend + coverage gate
+- G4 regression tests — 5 promptfoo + 5 widget + 5 Maestro tests (per O5)
+- G5 LSFin/accent/ARB lint — banned-terms + 30 nouvelles ARB keys × 6 langs
+
+**Estimation** : 4-6 j (3 j screens + 1 j tests + 1 j ARB i18n + 1 j sim+device validation). Bigger than B1-B6 hotfix.
+
+**Dependencies** : PR #529 mergé (B6 archetype plumbing required).
+
+## Addendum 2026-05-08T19:00 — MINT v2 PDF authoritative
+
+Julien shared **MINT Design System.pdf** (5 pages) + screenshots Aujourd'hui + Scan LPP + HTML canvas v2. Footer page 1 lit explicitement :
+
+> **MINT V2 PALETTE · MENTHE VIVE · SLOGAN · L'ARGENT, EN CLAIR.**
+
+**Décision tranchée — PDF MINT v2 = single source of truth, supersedes Hand Off 2** :
+
+| Aspect | Hand Off 2 (26 avril 2026) | MINT v2 PDF (8 mai 2026) | Verdict |
+|---|---|---|---|
+| Display font | Fraunces | **Gambarino** (italic) | v2 wins |
+| UI font | Inter | **Supreme** | v2 wins |
+| Accent palette | sauge (#B8C9B4) calme | **Menthe-vive** (vert-cyan vif) | v2 wins |
+| Brand philosophy | « Calm money. Clarity without noise. » | « L'argent, en clair. » + 8 règles grammaire | both compatible, v2 plus tranchée |
+| Tab nomenclature | « Coach » + « Plan retraite » | **« Trajectoire »** (tab neutre) | v2 wins (CLAUDE.md NEVER #4 align) |
+| Coach structure | 1 card + chat | **4 artefacts** : décision · comparaison · trajectoire · sensibilité | v2 wins |
+| Streaming | implicite | **bouton ▶ → ■ + dots animés** explicite | v2 wins |
+| Dark mode | non spécifié | **Palette dark = 1ʳᵉ classe, pas afterthought** | v2 wins |
+
+Hand Off 2 reste utile comme **baseline tokens flutter** (le `colors_and_type.css` dit explicitement « Source of truth: apps/mobile/lib/theme/ ») — donc les tokens MINT existants (`MintColors`, `MintTextStyles`, `MintSpacing`) restent base, et MINT v2 ajoute Menthe-vive + Gambarino + grammaire dessus.
+
+### MINT v2 — fond visuel observé sur screenshots/PDF
+
+**Background** : `#F4F0E8` (warmWhite-cream, plus chaud que MINT actuel `#FAF8F5`)
+**Ink** : `#1A1A1A` (near-black, AAA contrast)
+**Mute** : `#7A7470` (sub-text)
+**Menthe-vive accent** : `~#7DD3B5` ou `~#82DDB1` (vert-cyan vif — à pixel-sample sur le canvas HTML/PDF avant token commit)
+**Card stale circle** : Menthe-vive opaque ou `0xFFB6E5D2` (sauge-claire alternative)
+
+### Implication pour le perimeter d'implémentation
+
+La séquence onboarding 6 micro-steps reste valide. Adjustments :
+- Step 02 : « Tu es né quand ? » utilise **Gambarino italique 56-72px** (cf `--mint-display-lg: 56px` Hand Off 2 + canvas v2 montre plus large)
+- Step 06 : « Voilà ce qu'on voit. » utilise Gambarino italic + ConfidenceBand 4-axis menthe-vive
+- Tous les CTAs : noir plein (`MintColors.textPrimary`), arrondi 28-32px
+- Eyebrow numérotée (« 03 — PROFIL ») : Supreme uppercase letterspaced `--mint-ls-label`
+
+### 8 règles de grammaire confirmées (PDF page 5)
+
+1. **Une idée / écran** — pas de mur de cartes ; le chiffre parle, pas l'UI
+2. **Italique : 2 écrans max** — Landing + Onboarding ; ailleurs il banalise
+3. **Voix : observer, pas juger** — pas « enfin », pas « de justesse », pas « largement mieux »
+4. **Chiffre nu = interdit** — toujours ConfidenceBand + EnrichmentPrompts à côté
+5. **4 artefacts Coach** — Décision · comparaison · trajectoire · sensibilité
+6. **Streaming visible** — bouton ▶ → ■ + dots animés pendant la génération
+7. **18 events ≠ retraite-app** — « Trajectoire », pas « Plan retraite ». Tab neutre.
+8. **Dark mode natif** — palette dark = 1ʳᵉ classe, pas un afterthought
+
+Ces 8 règles sont **non-négociables** pour le perimeter d'implémentation.
+
+### Perimeters ouverts (STUB)
+
+- `MVP-FONTS-TOKENS-V2-2026-05` — install Supreme + Gambarino + Menthe-vive token + Gambarino italic display style + dark palette (foundation, bloque tous les autres)
+- `MVP-ONBOARDING-V2-AUTH-FIRST-2026-05` — 6 micro-steps OTP-style aligné MINT v2 (post fonts ready)
+- `MVP-COACH-V2-ARTEFACTS-2026-05` (à ouvrir Phase 2 après M1 skills modulaires)
+- `MVP-AUJOURDHUI-V2-HUB-2026-05` (à ouvrir Phase 2-3)
+- `MVP-DENSITY-V2-HYPOTHEQUE-ETC-2026-05` (à ouvrir Phase 3)
+- `MVP-DARK-MODE-V2-2026-05` (à ouvrir post-onboarding-v2)
+
+## Références
+
+- 6 audit transcripts (sub-agent IDs) : a39705af9 (O1) / a6f345199 (O2) / a26e15301 (O3) / abb4b4669 (O4) / ad1459c2e (O5) / aeee85dbf (O6)
+- Sources WebSearch citées dans chaque audit transcript (Userpilot, Eleken, FinanceBuzz, vermoegenszentrum.ch, Anthropic API pricing, FINMA Circ. 2025/02, etc.)
+- MINT v2 canvas HTML (Julien partagé, Tweaks Menthe-vive + slogan « clair »)
+- PR #525 wire FinancialPlanCard merged db350b77
+- PR #529 hotfix bundle B1+B2+B3+B4+cleanup+B6 (in flight, head d68a0f14)
+- CLAUDE.md NEVER #4 (18 life events) + #7 (no swiss_native default) + § 9 0-Trust
+- ROADMAP_V2.md S52 (4-tab shell shipped, post-S52 path = the gap)

--- a/.planning/decisions/2026-05-08-perimeter-mvp-fonts-tokens-v2/STUB.md
+++ b/.planning/decisions/2026-05-08-perimeter-mvp-fonts-tokens-v2/STUB.md
@@ -1,0 +1,78 @@
+---
+name: MVP-FONTS-TOKENS-V2 — perimeter STUB
+description: Foundation perimeter pour MINT v2 design system — install Supreme + Gambarino fonts, ajout MintColors.mentheVive token, Gambarino italic display style, dark palette tokens. Pré-requis bloquant pour MVP-ONBOARDING-V2-AUTH-FIRST + MVP-COACH-V2-ARTEFACTS + tous autres v2 perimeters. Effort 0.6j.
+type: decision
+date: 2026-05-08
+status: STUB (à ouvrir post PR #529 merge)
+related:
+  - .planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
+sources:
+  - MINT Design System.pdf (Julien shared 2026-05-08, identité verrouillée v2)
+  - https://www.fontshare.com/ (Supreme + Gambarino, license Open Source commercial)
+  - apps/mobile/lib/theme/{colors,mint_text_styles,mint_spacing}.dart (existing baseline)
+---
+
+# MVP-FONTS-TOKENS-V2 — STUB
+
+## Goal
+
+Installer la foundation visuelle MINT v2 dans le mobile codebase :
+- Supreme (UI) — 400, 500, 600 weights
+- Gambarino (display, italic) — 400 weight
+- `MintColors.mentheVive` token (vert-cyan vif, ~`#7DD3B5` à pixel-sample du PDF)
+- `MintTextStyles.displayGambarinoItalic` (variantes hero/headline/title)
+- Palette dark mode (`MintColors.dark*`) — règle grammar #8
+
+Bloque tous les autres v2 perimeters jusqu'à ce que ce STUB soit livré.
+
+## 5 gates mécaniques
+
+| Gate | Description | Évidence |
+|---|---|---|
+| G1 | sim screenshot landing avec Gambarino italic + Supreme rendered correctly | `xcrun simctl io booted screenshot /tmp/font_test.png` |
+| G2 | device par Julien — Apple device font rendering OK (no fallback to Times) | TestFlight |
+| G3 | dev CI green — flutter analyze + build iOS + size budget |
+| G4 | regression tests — golden test landing + onboarding intact post-font-swap |
+| G5 | LSFin/accent/ARB lint inchangé + Fontshare license file committed |
+
+## Tâches (atomic commits recommendées)
+
+| # | Action | Effort | Dépendance |
+|---|---|---|---|
+| F1.1 | Download Supreme `.otf` (400, 500, 600) depuis fontshare.com manuellement (Julien ou via WebFetch CDN) | 0.1j | None |
+| F1.2 | Download Gambarino `.otf` (400 italic) | 0.05j | None |
+| F1.3 | Add `apps/mobile/assets/fonts/Supreme-Regular.otf` + `Supreme-Medium.otf` + `Supreme-Semibold.otf` + `Gambarino-Regular.otf` (italic baked-in) | 0.05j | F1.1+F1.2 |
+| F1.4 | Edit `apps/mobile/pubspec.yaml` `fonts:` block | 0.05j | F1.3 |
+| F1.5 | Add Fontshare license texts to `apps/mobile/assets/fonts/LICENSE-SUPREME.txt` + `LICENSE-GAMBARINO.txt` | 0.05j | F1.1+F1.2 |
+| F2.1 | Pixel-sample Menthe-vive hex sur PDF/canvas v2 (Julien fournit ou screenshot annoté) | 0.05j | None |
+| F2.2 | Add `MintColors.mentheVive = Color(0xFF...)` + `mentheVive12 = Color(0x1F...)` (12% opacity surface) à `apps/mobile/lib/theme/colors.dart` | 0.05j | F2.1 |
+| F3.1 | Add `MintTextStyles.displayGambarinoItalic56` (Landing hero — 56-72px italic) | 0.05j | F1.4 |
+| F3.2 | Add `MintTextStyles.displayGambarinoItalic40` (Onboarding hero — 40-48px italic) | 0.05j | F1.4 |
+| F3.3 | Add `MintTextStyles.titleSupreme18Semibold` + `bodySupreme15Regular` + `labelSupreme12Uppercase025LS` | 0.05j | F1.4 |
+| F4.1 | Add dark palette : `MintColors.darkBg`, `darkInk`, `darkInkSoft`, `darkBorderSubtle`, `darkMentheVive` (saturé pour contrast) | 0.1j | None |
+| F4.2 | `ThemeData.dark` factory in `app.dart` qui mappe les dark tokens | 0.1j | F4.1 |
+| F5 | Sample landing screen using new Gambarino italic — visual proof gate | 0.1j | F1+F2+F3 |
+| F6 | Update `colors_and_type.css` (handoff 2) pour matcher (mark MINT v2 superseding) | 0.05j | F1+F2 |
+| F7 | Test goldens (existing) re-baseline post-font-swap (expected diff) | 0.1j | F5 |
+
+**Total estimé** : 0.6 j (sans le pixel-sample manual + license verify si Julien doit faire ces 2 étapes — sinon 0.4j).
+
+## Références
+
+- MINT Design System.pdf (5 pages reçues 2026-05-08)
+- Existing `apps/mobile/lib/theme/colors.dart` (baseline `MintColors`)
+- Existing `apps/mobile/lib/theme/mint_text_styles.dart` (baseline `MintTextStyles`)
+- Hand Off 2 `colors_and_type.css` (semi-superseded — voir SYNTHESIS addendum)
+
+## Counter-arguments and data gaps
+
+- **Risk 1** : Supreme + Gambarino license — bien que Fontshare dit « Open Source », vérifier le ToS exact pour app commerciale + republication. Julien doit valider si MINT publie sur App Store / Play Store sans risk juridique.
+- **Risk 2** : Bundle size impact — 4 .otf files ≈ 200-400 KB cumulés. App size mobile +300 KB. Acceptable pour iOS (no limit) + Android (généralement OK), mais à benchmarker.
+- **Risk 3** : Font rendering différence iOS vs Android — Supreme vendor metrics peuvent shift baseline 1-2px. À tester sur les 2 plateformes avant golden re-baseline.
+- **Risk 4** : Goldens existants vont casser massivement post-font-swap. Re-baseline = 50-100 golden updates. Effort additionnel à budgétiser hors STUB initial.
+- **Risk 5** : Pixel-sample manual du Menthe-vive est subjectif. Sans un Figma/Sketch token export, on devine. Mitigation : Julien valide le hex final post-implementation par comparaison visuelle.
+- **Data gap** : Pas de mesure de bundle size baseline pre/post fonts. Mesurer avant push.
+
+## Approval gate
+
+À ouvrir comme PR séparée post-PR #529 merge. **Pas un sub-task de la hotfix bundle B1-B6.**

--- a/.planning/decisions/2026-05-08-perimeter-mvp-onboarding-v2-auth-first/STUB.md
+++ b/.planning/decisions/2026-05-08-perimeter-mvp-onboarding-v2-auth-first/STUB.md
@@ -1,0 +1,116 @@
+---
+name: MVP-ONBOARDING-V2-AUTH-FIRST — perimeter STUB
+description: 6-step OTP-style onboarding pour user authenticated landing direct sur /coach/chat (le trou architectural identifié par O5 panel adversarial QA). Aligné MINT v2 PDF (italique Gambarino, eyebrow numéroté, 1 idée / micro-step, anti-promiscuous sub). Effort ~2 j post MVP-FONTS-TOKENS-V2.
+type: decision
+date: 2026-05-08
+status: STUB (à ouvrir post MVP-FONTS-TOKENS-V2 livré)
+related:
+  - .planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
+  - .planning/decisions/2026-05-08-perimeter-mvp-fonts-tokens-v2/STUB.md
+sources:
+  - MINT Design System.pdf (5 pages, identité v2 verrouillée)
+  - 6-agent panel synthesis 2026-05-08 (a39705af9 / a6f345199 / a26e15301 / abb4b4669 / ad1459c2e / aeee85dbf)
+  - PR #529 hotfix bundle B1-B6 mergé (foundation post-login coach plumbed correctly)
+---
+
+# MVP-ONBOARDING-V2-AUTH-FIRST — STUB
+
+## Goal
+
+Fermer le trou architectural identifié par O5 (adversarial QA panel) :
+> Le `/onb` 8-step shell est `RouteScope.public` (anon path). Quand un user authentifié atterrit sur `/coach/chat` direct (post magic-link / login), il tombe sur un coach vide avec free-text greeting → archetype default empty → FATCA bypass + token waste + UX cassé.
+
+Solution : 6 micro-steps OTP-style onboarding sous `apps/mobile/lib/screens/onboarding/auth_first/`, chacun aligné MINT v2 grammar (1 idée / écran, italique Gambarino, eyebrow numéroté, sub anti-promiscuous, CTA simple).
+
+## Séquence onboarding (locked per panel synthesis)
+
+| # | Eyebrow | Hero italique Gambarino | Sub Supreme | Input | Saved field |
+|---|---|---|---|---|---|
+| **01** | INTENTION | « Qu'est-ce qui t'amène ? » | « Une raison qui t'a fait télécharger MINT. » | 6 chips life-event | `primaryFocus` |
+| **02** | PROFIL | « Tu es né quand ? » | « Pour calibrer ton plan. Rien d'autre. » | 4-digit OTP picker | `birthYear` |
+| **03** | PROFIL | « Tu vis où ? » | « Pour les règles fiscales et la LPP. » | Canton picker (26) | `canton` |
+| **04** | PROFIL | « Tu fais quoi ? » | « Pour adapter le coach à ta situation. » | 3 chips + conditionnel nationalité/permis | `employmentStatus` + `nationality` + `residencePermit` |
+| **05** | PROFIL | « Combien tu gagnes (à peu près) ? » | « Une fourchette suffit. On affinera ensemble. » | 5 brackets (<4k / 4-7k / 7-10k / 10-15k / >15k CHF/mois) | `incomeBracket` |
+| **06** | ÉCLAIRAGE | « Voilà ce qu'on voit. » | « Premier chiffre. Confiance basse, à clarifier. » | Premier Éclairage card | `firstInsightShown: true` |
+
+## 5 gates mécaniques
+
+| Gate | Description | Évidence |
+|---|---|---|
+| G1 | sim walker — 8 archetype scenarios par O5 | Maestro `walker_archetype_compound.yaml` |
+| G2 | device par Julien sur TestFlight v2.13.0+ | confirmation device |
+| G3 | dev CI — flutter analyze + 5 nouveaux widget tests + golden tests par step | run green |
+| G4 | regression — promptfoo `archetype_detection_freetext.yaml` + `fatca_3a_no_recommendation.yaml` (per O5 #1+#5) | promptfoo CI |
+| G5 | LSFin/accent/ARB — 30 nouvelles ARB keys × 6 langs + banned-terms lint | banned_terms_arb.py + sentence_subject_arb_lint.py exit 0 |
+
+## Architecture
+
+**Path** : `apps/mobile/lib/screens/onboarding/auth_first/` (nouveau dossier, distinct de `mvp_wedge/` qui est anon `/onb`)
+
+**Routes** (GoRouter — ajout dans `app.dart` routes block) :
+- `/onboarding/intent` → step 01
+- `/onboarding/profil/age` → step 02
+- `/onboarding/profil/canton` → step 03
+- `/onboarding/profil/statut` → step 04
+- `/onboarding/profil/revenu` → step 05
+- `/onboarding/eclairage` → step 06
+
+**Redirect** : `app.dart:283-301` ajout `if (isLoggedIn && !coachProfile.hasMinimumViableFacts) return '/onboarding/intent'`. `hasMinimumViableFacts` = nouveau getter sur `CoachProfile` = (intent != null && birthYear != null && canton != null).
+
+**Reuse maximal** :
+- `_AgePicker` ([apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart:348-385](apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart))
+- canton list ([:391-418](apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart))
+- `_RevenueStep` slider — ADAPTER en 5 brackets (per O4 LSFin)
+- `updateFromSmartFlow()` ([coach_profile_provider.dart:688](apps/mobile/lib/providers/coach_profile_provider.dart)) — déjà calcule archetype
+- `FinancialPlanProvider` (B5 wire shipped via PR #525)
+- `EnhancedConfidence` 4-axis ([SOT.md:82-92, 111](SOT.md))
+- `MintTrameConfiance` ([widgets/trust/mint_trame_confiance.dart](apps/mobile/lib/widgets/trust/mint_trame_confiance.dart))
+- **Tokens MINT v2** : `MintColors.mentheVive` (post MVP-FONTS-TOKENS-V2) + `MintTextStyles.displayGambarinoItalic*`
+
+## Tâches breakdown (sub-perimeters atomic)
+
+| # | Action | Effort |
+|---|---|---|
+| O1 | Create `apps/mobile/lib/screens/onboarding/auth_first/intent_screen.dart` (step 01) | 0.3j |
+| O2 | `birthyear_screen.dart` (step 02) — 4-digit OTP picker (Gambarino italic match canvas) | 0.3j |
+| O3 | `canton_screen.dart` (step 03) — canton picker reuse | 0.2j |
+| O4 | `statut_screen.dart` (step 04) — 3 chips + conditional nationalité/permis reveal | 0.4j |
+| O5 | `revenu_screen.dart` (step 05) — 5 brackets + skip lever | 0.3j |
+| O6 | `eclairage_screen.dart` (step 06) — Premier Éclairage card avec EnhancedConfidence + MintTrameConfiance | 0.5j |
+| O7 | New ARB keys (~30) × 6 langs (fr/en/de/es/it/pt) | 0.3j |
+| O8 | Add 6 routes to `app.dart` GoRouter | 0.1j |
+| O9 | Add post-login redirect to `app.dart:283-301` | 0.1j |
+| O10 | Add `CoachProfile.hasMinimumViableFacts` getter | 0.1j |
+| O11 | Add `incomeBracket` enum + extension to `CoachProfile` (FATCA-safe vs exact CHF) | 0.2j |
+| O12 | 5 widget tests (1 per step) | 0.3j |
+| O13 | Maestro walker_archetype_compound.yaml fixture (8 archetypes) | 0.3j |
+| O14 | promptfoo archetype_detection_freetext.yaml + fatca_3a_no_recommendation.yaml | 0.3j |
+| O15 | Sim run + Julien G2 device | 0.2j |
+
+**Total estimé** : ~2.0-2.5 j post MVP-FONTS-TOKENS-V2 livré.
+
+## Acceptance criteria (5 gates pass)
+
+- ✅ G1 : sim walker passe les 8 archetype scenarios (per O5 #2)
+- ✅ G2 : Julien teste sur device — onboarding ressenti « clean, clair, économise tokens » (vs avant)
+- ✅ G3 : flutter analyze 0 issue + diff-cover ≥ 80% sur les 6 nouveaux screens
+- ✅ G4 : promptfoo + Maestro CI green
+- ✅ G5 : ARB parity 6/6 + banned_terms_arb 0 hit + sentence_subject_arb_lint passing
+
+## Counter-arguments and data gaps
+
+- **Risk 1** : 6 steps trop long ? Mitigation O2 + O6 : skip lever sur step 04+05, steps 01-03 obligatoires (3 questions minimum). Drop-off measurable post-launch via analytics.
+- **Risk 2** : Step 06 Premier Éclairage = un LLM call cher dès le bout d'onboarding. Mitigation O3 : 1 turn cost ~$0.064 once profile populated, vs 5 turns × $0.064 = $0.32 actuellement → still net saving.
+- **Risk 3** : Step 04 conditional reveal nationalité/permis casse « 1 idée / écran » règle. Mitigation : reveal animée smooth (200-300ms) signale au user que c'est une 2e étape liée, pas un nouveau screen.
+- **Risk 4** : `incomeBracket` (5 buckets) au lieu d'exact CHF perd 50% de la précision. Mitigation : O4 LSFin contraint, on ne peut PAS demander exact en onboarding. Coach demande affinement post-Premier-Éclairage si user veut plus de précision.
+- **Risk 5** : Goldens 6 langs × 6 screens × portrait/landscape × dark/light = 144 golden tests. Volume budget non chiffré.
+- **Data gap** : Pas de A/B test prévu entre 6-step structuré vs current free-text. Mitigation : retention metrics post-launch (D1/D7/D30) sur cohort all-new vs cohort grandfathered.
+
+## Dependencies
+
+- **PR #529 mergé** (hotfix B1-B6) — provides clean coach foundation post-login
+- **MVP-FONTS-TOKENS-V2 livré** — fournit Gambarino italic + Menthe-vive + dark palette nécessaires aux 6 screens
+
+## Approval gate
+
+À ouvrir comme PR séparée post-MVP-FONTS-TOKENS-V2. **Pas avant.**

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11180,5 +11180,6 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureSemanticsLabel": "Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät."
+  "betaDisclosureSemanticsLabel": "Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät.",
+  "coachOnboardingFirstAssistantGreeting": "Willkommen bei MINT. Bevor wir starten — was bringt dich heute hierher?"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11180,5 +11180,6 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureSemanticsLabel": "Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default."
+  "betaDisclosureSemanticsLabel": "Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default.",
+  "coachOnboardingFirstAssistantGreeting": "Welcome to MINT. Before we start — what brings you here today?"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11180,5 +11180,6 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureSemanticsLabel": "Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto."
+  "betaDisclosureSemanticsLabel": "Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto.",
+  "coachOnboardingFirstAssistantGreeting": "Bienvenido a MINT. Antes de empezar — ¿qué te trae aquí hoy?"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -12119,5 +12119,12 @@
   "betaDisclosureSemanticsLabel": "Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l'appareil par défaut.",
   "@betaDisclosureSemanticsLabel": {
     "description": "Beta disclosure sheet — accessibility container label."
+  },
+  "coachOnboardingFirstAssistantGreeting": "Bienvenue dans MINT. Avant qu'on commence : qu'est-ce qui t'amène ici aujourd'hui ?",
+  "@coachOnboardingFirstAssistantGreeting": {
+    "description": "Coach-initiated opening message shown when a logged-in user lands on /coach/chat with onboarding intent. Replaces the deprecated coachOnboardingFirstUserMessage which was rendered as user-authored (ventriloquy bug B1, fixed 2026-05-08). Generic, no archetype/life-event assumption per CLAUDE.md NEVER #4 + NEVER #7.",
+    "x-mint-meta": {
+      "level": "N3"
+    }
   }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11180,5 +11180,6 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureSemanticsLabel": "Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita."
+  "betaDisclosureSemanticsLabel": "Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita.",
+  "coachOnboardingFirstAssistantGreeting": "Benvenuto su MINT. Prima di cominciare — cosa ti porta qui oggi?"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -67,7 +67,7 @@ import 'app_localizations_pt.dart';
 /// property.
 abstract class S {
   S(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -89,11 +89,11 @@ abstract class S {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -102,7 +102,7 @@ abstract class S {
     Locale('en'),
     Locale('es'),
     Locale('it'),
-    Locale('pt'),
+    Locale('pt')
   ];
 
   /// No description provided for @landingFeature1Title.
@@ -6230,10 +6230,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{betterJob} vaut {annualDelta}/an de plus en rente viagère, soit {monthlyDelta}/mois À VIE après la retraite.'**
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  );
+      String betterJob, String annualDelta, String monthlyDelta);
 
   /// No description provided for @jobCompareLifetime20Years.
   ///
@@ -9882,10 +9879,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Simulation incluant l\'intérêt de la caisse ({fundRate} %) et l\'économie d\'impôt lissée sur {staggeringYears} ans pour un revenu imposable de CHF {taxableIncome}. Le rendement réel est calculé sur ton effort net réel.'**
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  );
+      String fundRate, int staggeringYears, String taxableIncome);
 
   /// No description provided for @simRealInterestTitle.
   ///
@@ -10366,10 +10360,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Comparaison forfait fiscal. Imposition ordinaire : {ordinary}. Forfait fiscal : {forfait}. Économie : {savings}.'**
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  );
+      String ordinary, String forfait, String savings);
 
   /// No description provided for @forfaitFiscalOrdinaryLabel.
   ///
@@ -14132,9 +14123,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Les banques suisses calculent avec un taux théorique de 5 % (directive ASB), même si le taux réel du marché est bien plus bas. C\'est un test de résistance : elles vérifient que tu pourrais assumer les charges si les taux remontaient. Tes charges théoriques : {chargesTheoriques}/mois. Au taux réel (~1,5 %) : {chargesReelles}/mois.'**
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  );
+      String chargesTheoriques, String chargesReelles);
 
   /// No description provided for @affordabilityInsightEquityTitle.
   ///
@@ -23525,16 +23514,15 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{name}\n{ssn}\n{address}\n{postalCity}\n\n{avsOrg}\n{avsAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nJe vous prie de bien vouloir m\'adresser un extrait de mon compte individuel AVS (CI) afin de vérifier l\'état de mes cotisations et d\'identifier d\'éventuelles lacunes.\n\nJe vous remercie par avance de votre diligence.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}'**
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  );
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject);
 
   /// No description provided for @agentLetterAvsOrg.
   ///
@@ -23583,33 +23571,31 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{name}\n{address}\n{postalCity}\n\n{caisseSource}\n{caisseCurrentAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nEn raison de la cessation de mes rapports de travail / de mon départ de Suisse (biffer la mention inutile), je vous prie de bien vouloir procéder au transfert de mon avoir de libre passage.\n\nMontant à transférer : la totalité de mon avoir de libre passage à la date de sortie.\n\nEtablissement de destination :\nNom : {toComplete}\nIBAN ou numéro de compte : {toComplete}\nAdresse : {toComplete}\n\nDate de sortie : {toComplete}\n\nJe vous remercie de votre diligence et de me confirmer la bonne exécution de ce transfert.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}'**
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  );
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete);
 
   /// No description provided for @agentLetterPensionFundBody.
   ///
   /// In fr, this message translates to:
   /// **'{name}\n{address}\n{postalCity}\n\n{caisse}\n{caisseAddress}\n{postalCity}\n\n{date}, le {dateFormatted}\n\nObjet : {subject}\n\nMadame, Monsieur,\n\nPar la présente, je me permets de vous adresser les demandes suivantes concernant mon dossier de prévoyance professionnelle :\n\n1. Certificat de prévoyance actualisé {year} (avoir de vieillesse, prestations couvertes, taux de conversion applicable)\n\n2. Confirmation de ma capacité de rachat (montant maximal selon l\'art. 79b LPP)\n\n3. Simulation de retraite anticipée (projection de l\'avoir et de la rente à 63 et 64 ans, le cas échéant)\n\nJe vous remercie par avance de votre diligence et reste à votre disposition pour tout complément d\'information.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n{name}\n{policeNumber}'**
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  );
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber);
 
   /// No description provided for @agentLetterPensionSubject.
   ///
@@ -26958,10 +26944,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'AI {aiAmount} + LPP {lppAmount} = {totalAmount} CHF/mois'**
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  );
+      String aiAmount, String lppAmount, String totalAmount);
 
   /// No description provided for @disabilityGapAct3Duration.
   ///
@@ -33442,9 +33425,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Revenu estimé à la retraite : {totalMonthly} CHF/mois vs {currentMonthly} CHF/mois actuellement'**
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  );
+      String totalMonthly, String currentMonthly);
 
   /// No description provided for @rcReplacementRateSubtitle.
   ///
@@ -34176,13 +34157,8 @@ abstract class S {
   ///
   /// In fr, this message translates to:
   /// **'Score de forme financière. {score} sur 100. Niveau {level}. Budget {budget}, Prévoyance {prevoyance}, Patrimoine {patrimoine}.'**
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  );
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine);
 
   /// No description provided for @scoreGaugeSubtitle.
   ///
@@ -34327,11 +34303,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'{label} : {status}. Fourchette typique {low} à {high}'**
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  );
+      String label, String status, String low, String high);
 
   /// No description provided for @semanticsBenchmarkToggle.
   ///
@@ -40626,6 +40598,12 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l\'appareil par défaut.'**
   String get betaDisclosureSemanticsLabel;
+
+  /// Coach-initiated opening message shown when a logged-in user lands on /coach/chat with onboarding intent. Replaces the deprecated coachOnboardingFirstUserMessage which was rendered as user-authored (ventriloquy bug B1, fixed 2026-05-08). Generic, no archetype/life-event assumption per CLAUDE.md NEVER #4 + NEVER #7.
+  ///
+  /// In fr, this message translates to:
+  /// **'Bienvenue dans MINT. Avant qu\'on commence : qu\'est-ce qui t\'amène ici aujourd\'hui ?'**
+  String get coachOnboardingFirstAssistantGreeting;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {
@@ -40638,13 +40616,13 @@ class _SDelegate extends LocalizationsDelegate<S> {
 
   @override
   bool isSupported(Locale locale) => <String>[
-    'de',
-    'en',
-    'es',
-    'fr',
-    'it',
-    'pt',
-  ].contains(locale.languageCode);
+        'de',
+        'en',
+        'es',
+        'fr',
+        'it',
+        'pt'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_SDelegate old) => false;
@@ -40668,9 +40646,8 @@ S lookupS(Locale locale) {
   }
 
   throw FlutterError(
-    'S.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'S.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -3396,10 +3396,7 @@ class SDe extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob bringt $annualDelta/Jahr mehr Leibrente, also $monthlyDelta/Monat LEBENSLANG nach der Pensionierung.';
   }
 
@@ -5457,10 +5454,7 @@ class SDe extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulation inklusive Kassenzins ($fundRate %) und Steuerersparnis, geglättet über $staggeringYears Jahre für ein steuerbares Einkommen von CHF $taxableIncome. Die reale Rendite wird auf deinen tatsächlichen Nettoaufwand berechnet.';
   }
 
@@ -5652,10 +5646,7 @@ class SDe extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'Du verlierst $amount/Monat lebenslang. Aber du gewinnst $years Jahr$plural Freiheit.';
   }
 
@@ -5753,10 +5744,7 @@ class SDe extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Vergleich Pauschalbesteuerung. Ordentliche Besteuerung: $ordinary. Pauschalbesteuerung: $forfait. Ersparnis: $savings.';
   }
 
@@ -6646,21 +6634,24 @@ class SDe extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'Januar',
-      '2': 'Februar',
-      '3': 'März',
-      '4': 'April',
-      '5': 'Mai',
-      '6': 'Juni',
-      '7': 'Juli',
-      '8': 'August',
-      '9': 'September',
-      '10': 'Oktober',
-      '11': 'November',
-      '12': 'Dezember',
-      'other': 'Monat',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'Januar',
+        '2': 'Februar',
+        '3': 'März',
+        '4': 'April',
+        '5': 'Mai',
+        '6': 'Juni',
+        '7': 'Juli',
+        '8': 'August',
+        '9': 'September',
+        '10': 'Oktober',
+        '11': 'November',
+        '12': 'Dezember',
+        'other': 'Monat',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7977,9 +7968,7 @@ class SDe extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Schweizer Banken rechnen mit einem theoretischen Zinssatz von 5 % (ASB-Richtlinie), auch wenn der aktuelle Marktzins deutlich tiefer ist. Es ist ein Belastungstest: Sie prüfen, ob du die Kosten tragen könntest, falls die Zinsen steigen. Deine theoretischen Kosten: $chargesTheoriques/Mt. Zum Marktzins (~1,5 %): $chargesReelles/Mt.';
   }
 
@@ -13263,16 +13252,15 @@ class SDe extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\nbitte senden Sie mir einen Auszug meines individuellen AHV-Kontos (IK), um den Stand meiner Beiträge zu prüfen und eventuelle Lücken zu identifizieren.\n\nIch danke Ihnen im Voraus für Ihre Sorgfalt.\n\nMit freundlichen Grüssen\n\n$name';
   }
 
@@ -13300,32 +13288,30 @@ class SDe extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\naufgrund der Beendigung meines Arbeitsverhältnisses / meines Wegzugs aus der Schweiz (Nichtzutreffendes streichen) bitte ich Sie, mein Freizügigkeitsguthaben zu übertragen.\n\nZu übertragender Betrag: das gesamte Freizügigkeitsguthaben per Austrittsdatum.\n\nZielinstitution:\nName: $toComplete\nIBAN oder Kontonummer: $toComplete\nAdresse: $toComplete\n\nAustrittsdatum: $toComplete\n\nIch danke Ihnen für Ihre Sorgfalt und bitte um eine Bestätigung der Ausführung.\n\nMit freundlichen Grüssen\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, den $dateFormatted\n\nBetreff: $subject\n\nSehr geehrte Damen und Herren,\n\nhiermit erlaube ich mir, folgende Anfragen bezüglich meiner beruflichen Vorsorge zu stellen:\n\n1. Aktualisierter Vorsorgeausweis $year (Altersguthaben, gedeckte Leistungen, anwendbarer Umwandlungssatz)\n\n2. Bestätigung meiner Einkaufskapazität (Maximalbetrag gemäss Art. 79b BVG)\n\n3. Simulation Frühpensionierung (Projektion des Guthabens und der Rente mit 63 und 64 Jahren, falls zutreffend)\n\nIch danke Ihnen im Voraus für Ihre Sorgfalt und stehe Ihnen für Rückfragen gerne zur Verfügung.\n\nMit freundlichen Grüssen\n\n$name\n$policeNumber';
   }
 
@@ -15315,10 +15301,7 @@ class SDe extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'IV $aiAmount + BVG $lppAmount = $totalAmount CHF/Monat';
   }
 
@@ -19034,9 +19017,7 @@ class SDe extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Geschätztes Renteneinkommen: $totalMonthly CHF/Monat vs $currentMonthly CHF/Monat heute';
   }
 
@@ -19456,13 +19437,8 @@ class SDe extends S {
   String get scoreGaugeSectionPrevoyance => 'Vorsorge';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Finanzielle Fitness. $score von 100. Stufe $level. Budget $budget, Vorsorge $prevoyance, Vermögen $patrimoine.';
   }
 
@@ -19551,11 +19527,7 @@ class SDe extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label: $status. Typische Spanne $low bis $high';
   }
 
@@ -23226,4 +23198,8 @@ class SDe extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Information zur MINT-Beta-Version — nur Bildungswerkzeug, keine Finanzberatung, Daten bleiben standardmässig auf deinem Gerät.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Willkommen bei MINT. Bevor wir starten — was bringt dich heute hierher?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -3363,10 +3363,7 @@ class SEn extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob is worth $annualDelta/year more in life annuity, i.e. $monthlyDelta/month FOR LIFE after retirement.';
   }
 
@@ -5414,10 +5411,7 @@ class SEn extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulation including fund interest ($fundRate%) and tax savings staggered over $staggeringYears years for a taxable income of CHF $taxableIncome. Real return is calculated on your actual net effort.';
   }
 
@@ -5608,10 +5602,7 @@ class SEn extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'You lose $amount/month for life. But you gain $years year$plural of freedom.';
   }
 
@@ -5709,10 +5700,7 @@ class SEn extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Lump-sum tax comparison. Ordinary taxation: $ordinary. Lump-sum tax: $forfait. Savings: $savings.';
   }
 
@@ -6592,21 +6580,24 @@ class SEn extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'January',
-      '2': 'February',
-      '3': 'March',
-      '4': 'April',
-      '5': 'May',
-      '6': 'June',
-      '7': 'July',
-      '8': 'August',
-      '9': 'September',
-      '10': 'October',
-      '11': 'November',
-      '12': 'December',
-      'other': 'month',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'January',
+        '2': 'February',
+        '3': 'March',
+        '4': 'April',
+        '5': 'May',
+        '6': 'June',
+        '7': 'July',
+        '8': 'August',
+        '9': 'September',
+        '10': 'October',
+        '11': 'November',
+        '12': 'December',
+        'other': 'month',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7910,9 +7901,7 @@ class SEn extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Swiss banks use a theoretical 5% interest rate (ASB directive), even though the actual market rate is much lower. It\'s a stress test: they check you could handle the charges if rates rose. Your theoretical charges: $chargesTheoriques/mo. At market rate (~1.5%): $chargesReelles/mo.';
   }
 
@@ -13169,16 +13158,15 @@ class SEn extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nI kindly request that you send me an extract of my individual AVS account (CI) in order to verify my contribution record and identify any gaps.\n\nThank you in advance for your diligence.\n\nYours faithfully,\n\n$name';
   }
 
@@ -13207,32 +13195,30 @@ class SEn extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nDue to the termination of my employment / my departure from Switzerland (delete as applicable), I kindly request that you transfer my vested benefits.\n\nAmount to transfer: the full amount of my vested benefits at the date of departure.\n\nDestination institution:\nName: $toComplete\nIBAN or account number: $toComplete\nAddress: $toComplete\n\nDeparture date: $toComplete\n\nThank you for your diligence and please confirm the successful completion of this transfer.\n\nYours faithfully,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nSubject: $subject\n\nDear Sir/Madam,\n\nI hereby wish to submit the following requests regarding my occupational pension file:\n\n1. Updated pension certificate $year (retirement assets, covered benefits, applicable conversion rate)\n\n2. Confirmation of my buyback capacity (maximum amount pursuant to Art. 79b LPP)\n\n3. Early retirement simulation (projection of assets and pension at 63 and 64, if applicable)\n\nThank you in advance for your diligence. I remain at your disposal for any further information.\n\nYours faithfully,\n\n$name\n$policeNumber';
   }
 
@@ -15206,10 +15192,7 @@ class SEn extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'DI $aiAmount + LPP $lppAmount = $totalAmount CHF/month';
   }
 
@@ -18899,9 +18882,7 @@ class SEn extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Estimated retirement income: $totalMonthly CHF/month vs $currentMonthly CHF/month today';
   }
 
@@ -19319,13 +19300,8 @@ class SEn extends S {
   String get scoreGaugeSectionPrevoyance => 'Pension';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Financial fitness score. $score out of 100. Level $level. Budget $budget, Pension $prevoyance, Assets $patrimoine.';
   }
 
@@ -19414,11 +19390,7 @@ class SEn extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label: $status. Typical range $low to $high';
   }
 
@@ -23058,4 +23030,8 @@ class SEn extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Information about the MINT beta version — educational tool only, no financial advice, data stays on your device by default.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Welcome to MINT. Before we start — what brings you here today?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -3383,10 +3383,7 @@ class SEs extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob vale $annualDelta/año más en renta vitalicia, es decir $monthlyDelta/mes DE POR VIDA tras la jubilación.';
   }
 
@@ -5447,10 +5444,7 @@ class SEs extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulación que incluye el interés de la caja ($fundRate %) y el ahorro fiscal repartido en $staggeringYears años para una renta imponible de CHF $taxableIncome. El rendimiento real se calcula sobre tu esfuerzo neto real.';
   }
 
@@ -5645,10 +5639,7 @@ class SEs extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'Pierdes $amount/mes de por vida. Pero ganas $years año$plural de libertad.';
   }
 
@@ -5746,10 +5737,7 @@ class SEs extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Comparación forfait fiscal. Imposición ordinaria: $ordinary. Forfait fiscal: $forfait.';
   }
 
@@ -6632,21 +6620,24 @@ class SEs extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'enero',
-      '2': 'febrero',
-      '3': 'marzo',
-      '4': 'abril',
-      '5': 'mayo',
-      '6': 'junio',
-      '7': 'julio',
-      '8': 'agosto',
-      '9': 'septiembre',
-      '10': 'octubre',
-      '11': 'noviembre',
-      '12': 'diciembre',
-      'other': 'mes',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'enero',
+        '2': 'febrero',
+        '3': 'marzo',
+        '4': 'abril',
+        '5': 'mayo',
+        '6': 'junio',
+        '7': 'julio',
+        '8': 'agosto',
+        '9': 'septiembre',
+        '10': 'octubre',
+        '11': 'noviembre',
+        '12': 'diciembre',
+        'other': 'mes',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7959,9 +7950,7 @@ class SEs extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Los bancos suizos calculan con una tasa teórica del 5 % (directiva ASB), aunque la tasa real del mercado es mucho menor. Es una prueba de resistencia: verifican que podrías asumir los cargos si las tasas subieran. Tus cargos teóricos: $chargesTheoriques/mes. A tasa de mercado (~1,5 %): $chargesReelles/mes.';
   }
 
@@ -13234,16 +13223,15 @@ class SEs extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nLes solicito que me remitan un extracto de mi cuenta individual AVS (CI) para verificar el estado de mis cotizaciones e identificar posibles lagunas.\n\nLes agradezco de antemano su diligencia.\n\nAtentamente,\n\n$name';
   }
 
@@ -13271,32 +13259,30 @@ class SEs extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nDebido a la terminación de mi relación laboral / mi salida de Suiza (tachar lo que no corresponda), les solicito que procedan a la transferencia de mi haber de libre paso.\n\nImporte a transferir: la totalidad del haber de libre paso a la fecha de salida.\n\nEntidad de destino:\nNombre: $toComplete\nIBAN o número de cuenta: $toComplete\nDirección: $toComplete\n\nFecha de salida: $toComplete\n\nLes agradezco su diligencia y les ruego que confirmen la correcta ejecución de esta transferencia.\n\nAtentamente,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nAsunto: $subject\n\nEstimado/a Sr./Sra.,\n\nPor medio de la presente, me permito dirigirles las siguientes solicitudes en relación con mi expediente de previsión profesional:\n\n1. Certificado de previsión actualizado $year (haber de vejez, prestaciones cubiertas, tasa de conversión aplicable)\n\n2. Confirmación de mi capacidad de rescate (importe máximo según el art. 79b LPP)\n\n3. Simulación de jubilación anticipada (proyección del haber y de la renta a los 63 y 64 años, en su caso)\n\nLes agradezco de antemano su diligencia y quedo a su disposición para cualquier información adicional.\n\nAtentamente,\n\n$name\n$policeNumber';
   }
 
@@ -15289,10 +15275,7 @@ class SEs extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mes';
   }
 
@@ -18996,9 +18979,7 @@ class SEs extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Ingresos estimados en la jubilación: $totalMonthly CHF/mes vs $currentMonthly CHF/mes actualmente';
   }
 
@@ -19415,13 +19396,8 @@ class SEs extends S {
   String get scoreGaugeSectionPrevoyance => 'Previsión';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Puntuación de forma financiera. $score de 100. Nivel $level. Presupuesto $budget, Previsión $prevoyance, Patrimonio $patrimoine.';
   }
 
@@ -19510,11 +19486,7 @@ class SEs extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label: $status. Rango típico de $low a $high';
   }
 
@@ -23172,4 +23144,8 @@ class SEs extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Información sobre la versión beta de MINT — herramienta educativa únicamente, no es asesoramiento financiero, los datos permanecen en tu dispositivo por defecto.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Bienvenido a MINT. Antes de empezar — ¿qué te trae aquí hoy?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -3381,10 +3381,7 @@ class SFr extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob vaut $annualDelta/an de plus en rente viagère, soit $monthlyDelta/mois À VIE après la retraite.';
   }
 
@@ -5450,10 +5447,7 @@ class SFr extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulation incluant l\'intérêt de la caisse ($fundRate %) et l\'économie d\'impôt lissée sur $staggeringYears ans pour un revenu imposable de CHF $taxableIncome. Le rendement réel est calculé sur ton effort net réel.';
   }
 
@@ -5647,10 +5641,7 @@ class SFr extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'Tu perds $amount/mois à vie. Mais tu gagnes $years an$plural de liberté.';
   }
 
@@ -5748,10 +5739,7 @@ class SFr extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Comparaison forfait fiscal. Imposition ordinaire : $ordinary. Forfait fiscal : $forfait. Économie : $savings.';
   }
 
@@ -6634,21 +6622,24 @@ class SFr extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'janvier',
-      '2': 'février',
-      '3': 'mars',
-      '4': 'avril',
-      '5': 'mai',
-      '6': 'juin',
-      '7': 'juillet',
-      '8': 'août',
-      '9': 'septembre',
-      '10': 'octobre',
-      '11': 'novembre',
-      '12': 'décembre',
-      'other': 'mois',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'janvier',
+        '2': 'février',
+        '3': 'mars',
+        '4': 'avril',
+        '5': 'mai',
+        '6': 'juin',
+        '7': 'juillet',
+        '8': 'août',
+        '9': 'septembre',
+        '10': 'octobre',
+        '11': 'novembre',
+        '12': 'décembre',
+        'other': 'mois',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7960,9 +7951,7 @@ class SFr extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Les banques suisses calculent avec un taux théorique de 5 % (directive ASB), même si le taux réel du marché est bien plus bas. C\'est un test de résistance : elles vérifient que tu pourrais assumer les charges si les taux remontaient. Tes charges théoriques : $chargesTheoriques/mois. Au taux réel (~1,5 %) : $chargesReelles/mois.';
   }
 
@@ -13235,16 +13224,15 @@ class SFr extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nJe vous prie de bien vouloir m\'adresser un extrait de mon compte individuel AVS (CI) afin de vérifier l\'état de mes cotisations et d\'identifier d\'éventuelles lacunes.\n\nJe vous remercie par avance de votre diligence.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name';
   }
 
@@ -13273,32 +13261,30 @@ class SFr extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nEn raison de la cessation de mes rapports de travail / de mon départ de Suisse (biffer la mention inutile), je vous prie de bien vouloir procéder au transfert de mon avoir de libre passage.\n\nMontant à transférer : la totalité de mon avoir de libre passage à la date de sortie.\n\nEtablissement de destination :\nNom : $toComplete\nIBAN ou numéro de compte : $toComplete\nAdresse : $toComplete\n\nDate de sortie : $toComplete\n\nJe vous remercie de votre diligence et de me confirmer la bonne exécution de ce transfert.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, le $dateFormatted\n\nObjet : $subject\n\nMadame, Monsieur,\n\nPar la présente, je me permets de vous adresser les demandes suivantes concernant mon dossier de prévoyance professionnelle :\n\n1. Certificat de prévoyance actualisé $year (avoir de vieillesse, prestations couvertes, taux de conversion applicable)\n\n2. Confirmation de ma capacité de rachat (montant maximal selon l\'art. 79b LPP)\n\n3. Simulation de retraite anticipée (projection de l\'avoir et de la rente à 63 et 64 ans, le cas échéant)\n\nJe vous remercie par avance de votre diligence et reste à votre disposition pour tout complément d\'information.\n\nVeuillez agréer, Madame, Monsieur, mes salutations distinguées.\n\n$name\n$policeNumber';
   }
 
@@ -15279,10 +15265,7 @@ class SFr extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mois';
   }
 
@@ -18984,9 +18967,7 @@ class SFr extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Revenu estimé à la retraite : $totalMonthly CHF/mois vs $currentMonthly CHF/mois actuellement';
   }
 
@@ -19410,13 +19391,8 @@ class SFr extends S {
   String get scoreGaugeSectionPrevoyance => 'Prévoyance';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Score de forme financière. $score sur 100. Niveau $level. Budget $budget, Prévoyance $prevoyance, Patrimoine $patrimoine.';
   }
 
@@ -19505,11 +19481,7 @@ class SFr extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label : $status. Fourchette typique $low à $high';
   }
 
@@ -23172,4 +23144,8 @@ class SFr extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Information sur la version de bêta MINT — outil éducatif, pas de conseil financier, données restant sur l\'appareil par défaut.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Bienvenue dans MINT. Avant qu\'on commence : qu\'est-ce qui t\'amène ici aujourd\'hui ?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -3393,10 +3393,7 @@ class SIt extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob vale $annualDelta/anno in più di rendita vitalizia, ovvero $monthlyDelta/mese A VITA dopo il pensionamento.';
   }
 
@@ -5456,10 +5453,7 @@ class SIt extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulazione comprendente l\'interesse della cassa ($fundRate %) e il risparmio fiscale distribuito su $staggeringYears anni per un reddito imponibile di CHF $taxableIncome. Il rendimento reale è calcolato sul tuo sforzo netto reale.';
   }
 
@@ -5653,10 +5647,7 @@ class SIt extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'Perdi $amount/mese a vita. Ma guadagni $years ann$plural di libertà.';
   }
 
@@ -5754,10 +5745,7 @@ class SIt extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Confronto forfait fiscale. Imposizione ordinaria: $ordinary. Forfait fiscale: $forfait.';
   }
 
@@ -6643,21 +6631,24 @@ class SIt extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'gennaio',
-      '2': 'febbraio',
-      '3': 'marzo',
-      '4': 'aprile',
-      '5': 'maggio',
-      '6': 'giugno',
-      '7': 'luglio',
-      '8': 'agosto',
-      '9': 'settembre',
-      '10': 'ottobre',
-      '11': 'novembre',
-      '12': 'dicembre',
-      'other': 'mese',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'gennaio',
+        '2': 'febbraio',
+        '3': 'marzo',
+        '4': 'aprile',
+        '5': 'maggio',
+        '6': 'giugno',
+        '7': 'luglio',
+        '8': 'agosto',
+        '9': 'settembre',
+        '10': 'ottobre',
+        '11': 'novembre',
+        '12': 'dicembre',
+        'other': 'mese',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7969,9 +7960,7 @@ class SIt extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Le banche svizzere calcolano con un tasso teorico del 5 % (direttiva ASB), anche se il tasso reale di mercato è molto più basso. È un test di resistenza: verificano che potresti sostenere gli oneri se i tassi salissero. I tuoi oneri teorici: $chargesTheoriques/mese. Al tasso di mercato (~1,5 %): $chargesReelles/mese.';
   }
 
@@ -13259,16 +13248,15 @@ class SIt extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nLa prego di volermi inviare un estratto del mio conto individuale AVS (CI) al fine di verificare lo stato dei miei contributi e identificare eventuali lacune.\n\nLa ringrazio anticipatamente per la Sua diligenza.\n\nDistinti saluti,\n\n$name';
   }
 
@@ -13297,32 +13285,30 @@ class SIt extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nA seguito della cessazione del mio rapporto di lavoro / della mia partenza dalla Svizzera (depennare la voce non applicabile), La prego di procedere al trasferimento del mio avere di libero passaggio.\n\nImporto da trasferire: l\'intero avere di libero passaggio alla data di uscita.\n\nIstituto di destinazione:\nNome: $toComplete\nIBAN o numero di conto: $toComplete\nIndirizzo: $toComplete\n\nData di uscita: $toComplete\n\nLa ringrazio per la Sua diligenza e La prego di confermare la buona esecuzione di questo trasferimento.\n\nDistinti saluti,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nOggetto: $subject\n\nEgregio/a Signore/Signora,\n\nCon la presente, mi permetto di sottoporLe le seguenti richieste relative alla mia previdenza professionale:\n\n1. Certificato di previdenza aggiornato $year (avere di vecchiaia, prestazioni coperte, aliquota di conversione applicabile)\n\n2. Conferma della mia capacità di riscatto (importo massimo ai sensi dell\'art. 79b LPP)\n\n3. Simulazione di pensionamento anticipato (proiezione dell\'avere e della rendita a 63 e 64 anni, se applicabile)\n\nLa ringrazio anticipatamente per la Sua diligenza e rimango a disposizione per qualsiasi informazione aggiuntiva.\n\nDistinti saluti,\n\n$name\n$policeNumber';
   }
 
@@ -15323,10 +15309,7 @@ class SIt extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mese';
   }
 
@@ -19041,9 +19024,7 @@ class SIt extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Reddito stimato alla pensione: $totalMonthly CHF/mese vs $currentMonthly CHF/mese attualmente';
   }
 
@@ -19464,13 +19445,8 @@ class SIt extends S {
   String get scoreGaugeSectionPrevoyance => 'Previdenza';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Punteggio di forma finanziaria. $score su 100. Livello $level. Budget $budget, Previdenza $prevoyance, Patrimonio $patrimoine.';
   }
 
@@ -19559,11 +19535,7 @@ class SIt extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label: $status. Intervallo tipico da $low a $high';
   }
 
@@ -23231,4 +23203,8 @@ class SIt extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Informazioni sulla versione beta di MINT — solo strumento educativo, nessuna consulenza finanziaria, i dati restano sul tuo dispositivo per impostazione predefinita.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Benvenuto su MINT. Prima di cominciare — cosa ti porta qui oggi?';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -3382,10 +3382,7 @@ class SPt extends S {
 
   @override
   String jobCompareRetirementBody(
-    String betterJob,
-    String annualDelta,
-    String monthlyDelta,
-  ) {
+      String betterJob, String annualDelta, String monthlyDelta) {
     return '$betterJob vale mais $annualDelta/ano em renda vitalícia, ou seja, $monthlyDelta/mês PARA A VIDA após a reforma.';
   }
 
@@ -5444,10 +5441,7 @@ class SPt extends S {
 
   @override
   String simLppBuybackDisclaimer(
-    String fundRate,
-    int staggeringYears,
-    String taxableIncome,
-  ) {
+      String fundRate, int staggeringYears, String taxableIncome) {
     return 'Simulação incluindo o juro da caixa ($fundRate %) e a poupança fiscal distribuída ao longo de $staggeringYears anos para um rendimento tributável de CHF $taxableIncome. O rendimento real é calculado sobre o teu esforço líquido real.';
   }
 
@@ -5640,10 +5634,7 @@ class SPt extends S {
 
   @override
   String earlyRetirementNarrativeEarly(
-    String amount,
-    int years,
-    String plural,
-  ) {
+      String amount, int years, String plural) {
     return 'Perdes $amount/mês para a vida. Mas ganhas $years ano$plural de liberdade.';
   }
 
@@ -5741,10 +5732,7 @@ class SPt extends S {
 
   @override
   String forfaitFiscalSemanticsLabel(
-    String ordinary,
-    String forfait,
-    String savings,
-  ) {
+      String ordinary, String forfait, String savings) {
     return 'Comparação forfait fiscal. Tributação ordinária: $ordinary. Forfait fiscal: $forfait.';
   }
 
@@ -6629,21 +6617,24 @@ class SPt extends S {
 
   @override
   String conversationMonth(String month) {
-    String _temp0 = intl.Intl.selectLogic(month, {
-      '1': 'janeiro',
-      '2': 'fevereiro',
-      '3': 'março',
-      '4': 'abril',
-      '5': 'maio',
-      '6': 'junho',
-      '7': 'julho',
-      '8': 'agosto',
-      '9': 'setembro',
-      '10': 'outubro',
-      '11': 'novembro',
-      '12': 'dezembro',
-      'other': 'mês',
-    });
+    String _temp0 = intl.Intl.selectLogic(
+      month,
+      {
+        '1': 'janeiro',
+        '2': 'fevereiro',
+        '3': 'março',
+        '4': 'abril',
+        '5': 'maio',
+        '6': 'junho',
+        '7': 'julho',
+        '8': 'agosto',
+        '9': 'setembro',
+        '10': 'outubro',
+        '11': 'novembro',
+        '12': 'dezembro',
+        'other': 'mês',
+      },
+    );
     return '$_temp0';
   }
 
@@ -7953,9 +7944,7 @@ class SPt extends S {
 
   @override
   String affordabilityInsightRevenueBody(
-    String chargesTheoriques,
-    String chargesReelles,
-  ) {
+      String chargesTheoriques, String chargesReelles) {
     return 'Os bancos suíços calculam com uma taxa teórica de 5 % (diretiva ASB), mesmo que a taxa real do mercado seja muito mais baixa. É um teste de resistência: verificam que poderias assumir os encargos se as taxas subissem. Os teus encargos teóricos: $chargesTheoriques/mês. À taxa de mercado (~1,5 %): $chargesReelles/mês.';
   }
 
@@ -13228,16 +13217,15 @@ class SPt extends S {
 
   @override
   String agentLetterAvsExtractBody(
-    String name,
-    String ssn,
-    String address,
-    String postalCity,
-    String avsOrg,
-    String avsAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-  ) {
+      String name,
+      String ssn,
+      String address,
+      String postalCity,
+      String avsOrg,
+      String avsAddress,
+      String date,
+      String dateFormatted,
+      String subject) {
     return '$name\n$ssn\n$address\n$postalCity\n\n$avsOrg\n$avsAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nSolicito que me enviem um extrato da minha conta individual AVS (CI) para verificar o estado das minhas contribuições e identificar eventuais lacunas.\n\nAgradeço antecipadamente a vossa diligência.\n\nCom os melhores cumprimentos,\n\n$name';
   }
 
@@ -13265,32 +13253,30 @@ class SPt extends S {
 
   @override
   String agentLetterLppTransferBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisseSource,
-    String caisseCurrentAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String toComplete,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisseSource,
+      String caisseCurrentAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String toComplete) {
     return '$name\n$address\n$postalCity\n\n$caisseSource\n$caisseCurrentAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nEm virtude da cessação do meu contrato de trabalho / da minha saída da Suíça (riscar o que não se aplica), solicito que procedam à transferência do meu ter de livre passagem.\n\nMontante a transferir: a totalidade do ter de livre passagem à data de saída.\n\nInstituição de destino:\nNome: $toComplete\nIBAN ou número de conta: $toComplete\nEndereço: $toComplete\n\nData de saída: $toComplete\n\nAgradeço a vossa diligência e solicito confirmação da boa execução desta transferência.\n\nCom os melhores cumprimentos,\n\n$name';
   }
 
   @override
   String agentLetterPensionFundBody(
-    String name,
-    String address,
-    String postalCity,
-    String caisse,
-    String caisseAddress,
-    String date,
-    String dateFormatted,
-    String subject,
-    String year,
-    String policeNumber,
-  ) {
+      String name,
+      String address,
+      String postalCity,
+      String caisse,
+      String caisseAddress,
+      String date,
+      String dateFormatted,
+      String subject,
+      String year,
+      String policeNumber) {
     return '$name\n$address\n$postalCity\n\n$caisse\n$caisseAddress\n$postalCity\n\n$date, $dateFormatted\n\nAssunto: $subject\n\nExmo./Exma. Senhor/a,\n\nVenho por este meio submeter os seguintes pedidos relativos ao meu processo de previdência profissional:\n\n1. Certificado de previdência atualizado $year (ter de velhice, prestações cobertas, taxa de conversão aplicável)\n\n2. Confirmação da minha capacidade de resgate (montante máximo nos termos do art. 79b LPP)\n\n3. Simulação de reforma antecipada (projeção do ter e da renda aos 63 e 64 anos, se aplicável)\n\nAgradeço antecipadamente a vossa diligência e fico à disposição para qualquer informação adicional.\n\nCom os melhores cumprimentos,\n\n$name\n$policeNumber';
   }
 
@@ -15282,10 +15268,7 @@ class SPt extends S {
 
   @override
   String disabilityGapAct3Detail(
-    String aiAmount,
-    String lppAmount,
-    String totalAmount,
-  ) {
+      String aiAmount, String lppAmount, String totalAmount) {
     return 'AI $aiAmount + LPP $lppAmount = $totalAmount CHF/mês';
   }
 
@@ -18993,9 +18976,7 @@ class SPt extends S {
 
   @override
   String rcReplacementRateExplanation(
-    String totalMonthly,
-    String currentMonthly,
-  ) {
+      String totalMonthly, String currentMonthly) {
     return 'Rendimento estimado na reforma: $totalMonthly CHF/mês vs $currentMonthly CHF/mês atualmente';
   }
 
@@ -19416,13 +19397,8 @@ class SPt extends S {
   String get scoreGaugeSectionPrevoyance => 'Previdência';
 
   @override
-  String scoreGaugeSemanticsLabel(
-    String score,
-    String level,
-    String budget,
-    String prevoyance,
-    String patrimoine,
-  ) {
+  String scoreGaugeSemanticsLabel(String score, String level, String budget,
+      String prevoyance, String patrimoine) {
     return 'Pontuação de forma financeira. $score de 100. Nível $level. Orçamento $budget, Previdência $prevoyance, Património $patrimoine.';
   }
 
@@ -19511,11 +19487,7 @@ class SPt extends S {
 
   @override
   String semanticsBenchmarkMetric(
-    String label,
-    String status,
-    String low,
-    String high,
-  ) {
+      String label, String status, String low, String high) {
     return '$label: $status. Intervalo típico de $low a $high';
   }
 
@@ -23180,4 +23152,8 @@ class SPt extends S {
   @override
   String get betaDisclosureSemanticsLabel =>
       'Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito.';
+
+  @override
+  String get coachOnboardingFirstAssistantGreeting =>
+      'Bem-vindo à MINT. Antes de começarmos — o que te traz aqui hoje?';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11180,5 +11180,6 @@
   "@betaDisclosureCta": {
     "x-mint-meta": {"level": "N1"}
   },
-  "betaDisclosureSemanticsLabel": "Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito."
+  "betaDisclosureSemanticsLabel": "Informação sobre a versão beta da MINT — apenas ferramenta educativa, nenhum aconselhamento financeiro, os dados permanecem no teu dispositivo por defeito.",
+  "coachOnboardingFirstAssistantGreeting": "Bem-vindo à MINT. Antes de começarmos — o que te traz aqui hoje?"
 }

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -120,7 +120,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
   final FocusNode _focusNode = FocusNode();
 
   CoachProfile? _profile;
-  bool _hasProfile = false;
   final List<ChatMessage> _messages = [];
   /// Maximum messages kept in memory to prevent Watchdog RAM termination.
   static const int _maxMessages = 150;
@@ -327,7 +326,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       final coachProvider = context.read<CoachProfileProvider>();
       if (coachProvider.hasProfile) {
         _profile = coachProvider.profile!;
-        _hasProfile = true;
         // Skip greeting when resuming an existing conversation.
         if (!_isResumingConversation) {
           _addInitialGreeting();
@@ -878,47 +876,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     );
   }
 
-  /// Handle intensity chip selection.
-  void _onIntensitySelected(int level) {
-    setState(() {
-      _cashLevel = level;
-      _intensityChosen = true;
-    });
-    _saveCashLevel(level);
-
-    // Add adapted confirmation message.
-    final l10n = S.of(context)!;
-    final String confirmation;
-    switch (level) {
-      case 1:
-        confirmation = l10n.intensityConfirmation1;
-        break;
-      case 2:
-        confirmation = l10n.intensityConfirmation2;
-        break;
-      case 3:
-        confirmation = l10n.intensityConfirmation3;
-        break;
-      case 4:
-        confirmation = l10n.intensityConfirmation4;
-        break;
-      case 5:
-        confirmation = l10n.intensityConfirmation5;
-        break;
-      default:
-        confirmation = l10n.intensityDirect;
-    }
-
-    setState(() {
-      _messages.add(ChatMessage(
-        role: 'assistant',
-        content: confirmation,
-        timestamp: DateTime.now(),
-        tier: ChatTier.none,
-      ));
-    });
-    _scrollToBottom();
-  }
 
   /// Regex patterns for voice intensity adjustment commands.
   static final RegExp _intensityUpPattern = RegExp(
@@ -1035,6 +992,11 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       debugPrint('[CoachChat] ${e.toString().substring(0, (e.toString().length > 80) ? 80 : e.toString().length)}');
     }
 
+    // Mounted gate after the await above (use_build_context_synchronously) —
+    // if the widget unmounted during the 2s timeout, abort before any
+    // further `context.read` / `context.go`.
+    if (!mounted) return;
+
     // Wire Spec V2: append entry payload context if present (one-shot).
     if (_entryPayloadContext != null) {
       memoryBlock = '${memoryBlock ?? ''}\n$_entryPayloadContext';
@@ -1052,7 +1014,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         // Minimal profile with no fake data — zeros mean "unknown".
         _profile = CoachProfile.defaults();
       }
-      _hasProfile = provider.hasProfile;
     }
 
     // Try SLM streaming first.
@@ -1595,7 +1556,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     if (answers.isNotEmpty) {
       provider.mergeAnswers(answers);
       _profile = provider.profile;
-      _hasProfile = provider.hasProfile;
     }
   }
 
@@ -1736,43 +1696,6 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       knownValues: knownValues,
       hasDebt: profile.isInDebtCrisis,
     );
-  }
-
-  List<String> _inferSuggestedActions(
-    String userMessage,
-    String coachResponse,
-  ) {
-    final s = S.of(context)!;
-    final combined = '$userMessage $coachResponse'.toLowerCase();
-    final actions = <String>[];
-
-    if (RegExp(r'3a|pilier|troisi[eè]me|versement').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulate3a, s.coachSuggestView3a]);
-    }
-    if (RegExp(r'lpp|rachat|2e\s*pilier|deuxi[eè]me').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestSimulateLpp, s.coachSuggestUnderstandLpp]);
-    }
-    if (RegExp(r'retraite|pension|avs|rente').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestTrajectory, s.coachSuggestScenarios]);
-    }
-    if (RegExp(r'imp[oô]t|fiscal|d[eé]duction').hasMatch(combined)) {
-      actions.addAll([s.coachSuggestDeductions, s.coachSuggestTaxImpact]);
-    }
-    if (RegExp(r'budget|d[eé]pense|train\s*de\s*vie|niveau\s*de\s*vie')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestBudget, s.coachSuggestBudgetGap]);
-    }
-    if (RegExp(r'immobilier|hypoth[eè]que|maison|achat|propri[eé]t[eé]|logement')
-        .hasMatch(combined)) {
-      actions.addAll([s.coachSuggestMortgage, s.coachSuggestMortgageCapacity]);
-    }
-
-    // UX-04: No hardcoded defaults. Chips appear ONLY when the
-    // conversation matches a topic regex — otherwise the list is empty
-    // and no chips are shown. This prevents static/irrelevant chips
-    // from appearing after every response regardless of context.
-    // Deduplicate and cap at 3
-    return actions.toSet().take(3).toList();
   }
 
   /// UX-04: Extract contextual chip labels from route_to_screen tool calls.
@@ -2305,7 +2228,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
                         padding: const EdgeInsets.only(left: 42, top: 4),
                         child: Text(
                           S.of(context)!.coachResponseDegradedHint,
-                          style: TextStyle(
+                          style: const TextStyle(
                             fontSize: 11,
                             color: MintColors.textSecondary,
                             fontStyle: FontStyle.italic,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -350,10 +350,21 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
               _sendMessage(payload.userMessage!);
             });
           } else if (payload.topic == 'onboarding') {
-            // Onboarding topic — send a real intake question instead of
-            // injecting raw context. This replaces the old ?prompt=onboarding.
+            // B1 fix (2026-05-08) : the previous `_sendMessage(...)` call
+            // rendered the seed string as user-authored, producing a
+            // phantom message « Salut, je viens de créer mon compte. Par
+            // où je commence ? » that the user never wrote (CLAUDE.md
+            // NEVER #6 + 0-Trust §9.1 trust killer). Switch to a
+            // coach-initiated opener so the coach speaks first and the
+            // user answers — same pattern as _isNotificationTopic below.
+            // The old ARB key coachOnboardingFirstUserMessage is
+            // deprecated (no callers post-fix); flutter gen-l10n keeps
+            // the binding for backwards compat but it is not referenced
+            // in lib/.
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              _sendMessage(S.of(context)!.coachOnboardingFirstUserMessage);
+              _addCoachOpenerMessage(
+                S.of(context)!.coachOnboardingFirstAssistantGreeting,
+              );
             });
           } else if (_isNotificationTopic(payload.topic)) {
             // Notification topics (monthlyCheckIn, commitmentReminder,

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -1693,9 +1693,40 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       firstName: profile.firstName ?? 'utilisateur',
       age: profile.age,
       canton: profile.canton,
+      // B6 fix (2026-05-08) : pass archetype to the LLM context. Adversarial
+      // QA audit (panel 2026-05-08) flagged that the previous build dropped
+      // the field on the floor → empty default → doctrine_checks fall-through
+      // PASS → FATCA bypass on expat_us etc. ~35-45% of CH residents were
+      // mis-archétypés silently. Backend snake_case format expected.
+      archetype: _archetypeToBackendName(profile.archetype),
       knownValues: knownValues,
       hasDebt: profile.isInDebtCrisis,
     );
+  }
+
+  /// B6 helper — convert Dart camelCase [FinancialArchetype] to the snake_case
+  /// string the backend expects in [CoachContext.archetype]. Used by the
+  /// LLM doctrine_checks (`check_archetype_aware`) to enforce FATCA / PFIC /
+  /// frontalier-specific cues per archetype.
+  String _archetypeToBackendName(FinancialArchetype a) {
+    switch (a) {
+      case FinancialArchetype.swissNative:
+        return 'swiss_native';
+      case FinancialArchetype.expatEu:
+        return 'expat_eu';
+      case FinancialArchetype.expatNonEu:
+        return 'expat_non_eu';
+      case FinancialArchetype.expatUs:
+        return 'expat_us';
+      case FinancialArchetype.independentWithLpp:
+        return 'independent_with_lpp';
+      case FinancialArchetype.independentNoLpp:
+        return 'independent_no_lpp';
+      case FinancialArchetype.crossBorder:
+        return 'cross_border';
+      case FinancialArchetype.returningSwiss:
+        return 'returning_swiss';
+    }
   }
 
   /// UX-04: Extract contextual chip labels from route_to_screen tool calls.

--- a/apps/mobile/lib/services/coach/coach_context_builder.dart
+++ b/apps/mobile/lib/services/coach/coach_context_builder.dart
@@ -68,9 +68,14 @@ class CoachContextBuilder {
   ///   Passed through as simplified dataReliability map for SLM prompting.
   static CoachContext build({
     String firstName = '',
-    int age = 30,
-    String canton = 'ZH',
-    String archetype = 'swiss_native',
+    // B6 fix (2026-05-08) : empty/zero defaults — mirror of B4 (Python).
+    // Don't fabricate « 30 / ZH / swiss_native » when caller didn't pass.
+    // Adversarial QA audit found that retiree (70yo) calling build() w/o
+    // overrides got aged 30 + ZH + swiss_native silently — see
+    // .planning/decisions/2026-05-08-coach-onboarding-redesign-panel/
+    int age = 0,
+    String canton = '',
+    String archetype = '',
     double friTotal = 0,
     double friDelta = 0,
     String primaryFocus = '',

--- a/apps/mobile/lib/services/coach/coach_models.dart
+++ b/apps/mobile/lib/services/coach/coach_models.dart
@@ -93,9 +93,15 @@ class CoachContext {
 
   const CoachContext({
     this.firstName = 'utilisateur',
-    this.archetype = 'swiss_native',
-    this.age = 30,
-    this.canton = 'ZH',
+    // B6 fix (2026-05-08) : empty/zero defaults so callers that don't
+    // populate these fields don't leak fake « known facts » to the LLM
+    // context. Mirror of the Python-side B4 fix in coach_models.py.
+    // Consumers gate prompt lines on truthy values (claude_coach_service
+    // .py:793-798). Empty string here means « unknown — ask user »
+    // rather than the previous "swiss_native"/"ZH"/30 lies.
+    this.archetype = '',
+    this.age = 0,
+    this.canton = '',
     this.friTotal = 0.0,
     this.friDelta = 0.0,
     this.primaryFocus = '',

--- a/apps/mobile/lib/services/coach/prompt_registry.dart
+++ b/apps/mobile/lib/services/coach/prompt_registry.dart
@@ -256,16 +256,19 @@ TÂCHE : Guide l'utilisateur pour compléter le bloc "$blockType".
           'réel et la fortune imposable. Impact sur confiance : +15 pts.',
       'objectifRetraite' => 'DONNÉES CONNUES :\n'
           '- Âge actuel : ${ctx.age} ans\n'
-          '- Âge retraite cible : ${ctx.knownValues['target_retirement_age']?.toInt() ?? 65} ans\n'
+          '- Âge retraite cible : ${ctx.knownValues['target_retirement_age']?.toInt() ?? '?'}\n'
           '\n'
           'OBJECTIF : Définir un âge de retraite souhaité (58-70 ans).\n'
+          'Si l\'âge retraite cible est "?", DEMANDE-le, ne suppose pas 65 par défaut.\n'
           'Avant 63 ans : seule la LPP est disponible (pas d\'AVS).\n'
           'Impact sur confiance : +10 pts.',
       'compositionMenage' => 'DONNÉES CONNUES :\n'
-          '- État civil : ${ctx.knownValues['etat_civil'] ?? 'célibataire'}\n'
-          '- Enfants : ${ctx.knownValues['nombre_enfants']?.toInt() ?? 0}\n'
+          '- État civil : ${ctx.knownValues['etat_civil'] ?? '?'}\n'
+          '- Enfants : ${ctx.knownValues['nombre_enfants']?.toInt() ?? '?'}\n'
           '\n'
           'OBJECTIF : Savoir si en couple (marié/concubin) et les données du conjoint.\n'
+          'Si l\'état civil est "?" ou les enfants sont "?", DEMANDE-les. Ne suppose JAMAIS\n'
+          'célibataire ou 0 enfants par défaut — ne dis pas "tu es célibataire" si tu ne le sais pas.\n'
           'Impact : AVS plafonnée à 150% pour les mariés (LAVS art. 35).\n'
           'Impact sur confiance : +15 pts.',
       _ => 'Score de confiance : ${ctx.confidenceScore.toStringAsFixed(0)}%\n'

--- a/apps/mobile/test/services/coach_context_builder_test.dart
+++ b/apps/mobile/test/services/coach_context_builder_test.dart
@@ -66,12 +66,19 @@ void main() {
     });
 
     test('default values produce a valid CoachContext', () {
+      // B6 fix (2026-05-08): empty/zero defaults — see commit d68a0f14 +
+      // .planning/decisions/2026-05-08-coach-onboarding-redesign-panel/.
+      // Pre-B6, defaults were 30 / ZH / swiss_native — fake « known facts »
+      // injected into the LLM context for empty profiles, producing the
+      // « 3 pièces du puzzle » bug reported in TestFlight v2.12.1+3.
+      // Consumers (claude_coach_service.py:793-798) gate prompt lines on
+      // truthy values so empty defaults correctly drop the line.
       final ctx = CoachContextBuilder.build();
 
       expect(ctx.firstName, '');
-      expect(ctx.age, 30);
-      expect(ctx.canton, 'ZH');
-      expect(ctx.archetype, 'swiss_native');
+      expect(ctx.age, 0);
+      expect(ctx.canton, '');
+      expect(ctx.archetype, '');
       expect(ctx.friTotal, 0);
       expect(ctx.friDelta, 0);
       expect(ctx.knownValues, isEmpty);

--- a/services/backend/app/api/v1/endpoints/budget.py
+++ b/services/backend/app/api/v1/endpoints/budget.py
@@ -177,9 +177,13 @@ def _build_response(
         )
 
     if income == 0:
+        # B2 fix (2026-05-08) : archetype-agnostic prompt — money source
+        # rather than « salaire net mensuel » (covers the 8 MINT archetypes
+        # incl. indépendants / retraités / étudiants / expat_us, per
+        # CLAUDE.md NEVER #4 + NEVER #7).
         eclairage = (
             "On ne peut pas tracer ta marge sans revenu connu. "
-            "Dis-moi ton salaire net mensuel pour démarrer."
+            "Dis-moi d'où vient ton argent (salaire, dividendes, rente, autre)."
         )
     elif free_margin < 0:
         eclairage = (

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -914,7 +914,15 @@ def _compute_suggested_actions(
     if not data.get("canton"):
         actions.append({"label": "Dans quel canton vis-tu ?", "type": "question"})
     if not data.get("incomeNetMonthly") and not data.get("incomeGrossYearly"):
-        actions.append({"label": "Quel est ton salaire net mensuel ?", "type": "question"})
+        # B2 fix (2026-05-08) : archetype-agnostic — salaried_active is only
+        # 4/8 archetypes (independents, retirees, students, expat_us in
+        # transition, etc. don't have « salaire net mensuel »). Asking
+        # about money source covers the 8 archetypes (CLAUDE.md NEVER #4
+        # + #7).
+        actions.append({
+            "label": "D'où vient ton argent ? (salaire, dividendes, rente, autre)",
+            "type": "question",
+        })
 
     if len(actions) >= 3:
         return actions[:3]

--- a/services/backend/app/services/coach/coach_context_builder.py
+++ b/services/backend/app/services/coach/coach_context_builder.py
@@ -20,9 +20,12 @@ from app.services.coach.coach_models import CoachContext
 
 def build_coach_context(
     first_name: str = "utilisateur",
-    age: int = 30,
-    canton: str = "VD",
-    archetype: str = "swiss_native",
+    # B4 fix (2026-05-08) : defaults set to empty/zero so missing fields
+    # don't leak fake « known facts » into the LLM context. Consumers
+    # gate prompt lines on truthy values (claude_coach_service.py:793-798).
+    age: int = 0,
+    canton: str = "",
+    archetype: str = "",
     fri_total: float = 0.0,
     fri_delta: float = 0.0,
     primary_focus: str = "",

--- a/services/backend/app/services/coach/coach_models.py
+++ b/services/backend/app/services/coach/coach_models.py
@@ -53,9 +53,15 @@ class CoachContext:
     to support the Coach Narrative Service.
     """
     first_name: str = "utilisateur"
-    archetype: str = "swiss_native"
-    age: int = 30
-    canton: str = "VD"
+    # B4 fix (2026-05-08) : defaults set to empty/zero so callers that
+    # don't provide these fields don't leak fake « known facts » into the
+    # LLM context. Consumers (claude_coach_service.py:793-798) gate prompt
+    # lines on truthy values, so an empty canton/archetype/age means the
+    # LLM is told « unknown — ask the user », not « VD / swiss_native /
+    # 30 ans » (false confidence reported in TestFlight v2.12.1+3).
+    archetype: str = ""
+    age: int = 0
+    canton: str = ""
     # Financial state (aggregated, never raw)
     fri_total: float = 0.0
     fri_delta: float = 0.0

--- a/services/backend/app/services/coach/coach_tools.py
+++ b/services/backend/app/services/coach/coach_tools.py
@@ -608,7 +608,11 @@ COACH_TOOLS: list[dict[str, Any]] = [
             "JSON list of next actions based on what MINT knows and "
             "doesn't know about the user.\n\n"
             "Examples of returned suggestions:\n"
-            "  - 'Dis-moi ton salaire net mensuel' (profile gap)\n"
+            # B2 fix (2026-05-08) : example must NOT bias the LLM toward a
+            # salaried-active archetype (4/8 archetypes only). Use a
+            # money-source question that covers indépendant, retraité,
+            # étudiant, expat_us in transition, etc. (CLAUDE.md NEVER #4 + #7).
+            "  - 'D'où vient ton argent ? (salaire, dividendes, rente, autre)' (profile gap)\n"
             "  - 'Upload ton certificat LPP' (missing document)\n"
             "  - 'Configure ton budget' (no budget set up)\n"
             "  - 'Simule ton rachat LPP' (has avoirLpp + buybackMax)\n"

--- a/services/backend/app/services/coach/doctrine_checks.py
+++ b/services/backend/app/services/coach/doctrine_checks.py
@@ -487,6 +487,23 @@ def check_archetype_aware(response: str, meta: QuestionMeta) -> CheckResult:
     the response names at least one archetype-specific cue.
     """
     name = "archetype_aware"
+
+    # B6 fix (2026-05-08) — fail-loud on empty/unknown archetype.
+    # Adversarial QA panel found that pre-B6, the front-end never plumbed
+    # CoachProfile.archetype into CoachContext, so meta.archetype defaulted
+    # to "" (post-B4 empty default) and the check fell through to the
+    # « no cues defined → pass » branch below. Net effect: an expat_us user
+    # could receive « Verse 7'258 CHF sur ton 3a » without the FATCA guard
+    # firing. Treat empty/unknown archetype as a guard violation rather than
+    # a silent skip — the response is reviewable but cannot be claimed
+    # archetype-aware.
+    if not meta.archetype or not meta.archetype.strip():
+        return CheckResult(
+            name,
+            False,
+            "archetype empty/unknown — cannot enforce archetype-aware constraint (would silently bypass FATCA/PFIC/frontalier guards)",
+        )
+
     if meta.archetype == "swiss_native":
         return CheckResult(name, True, "swiss_native: no extra constraint")
 

--- a/services/backend/app/services/rag/orchestrator.py
+++ b/services/backend/app/services/rag/orchestrator.py
@@ -134,8 +134,19 @@ class RAGOrchestrator:
         else:
             response_text = raw_response
 
-        # Step 6: Apply post-generation compliance filter
-        filtered = self.guardrails.filter_response(response_text, language)
+        # Step 6: Apply post-generation compliance filter.
+        # Guard: empty response_text combined with tool_calls is a legitimate
+        # intermediate state in the agent loop — the LLM emitted only a
+        # tool_use (e.g. save_insight(salary=8500)) without text narration.
+        # Running filter_response on empty text fires the "Sortie vide"
+        # fallback (_SAFE_FALLBACK_FR) and masks the tool_use with a canned
+        # « Je suis là pour t'aider… » message. This guard mirrors the one
+        # already in _NoRagOrchestrator (coach_chat.py L151-157, fix from
+        # commit 3483f4e3 2026-04-14 that was never ported here).
+        if response_text and response_text.strip():
+            filtered = self.guardrails.filter_response(response_text, language)
+        else:
+            filtered = {"text": "", "warnings": [], "disclaimers_added": []}
 
         # Step 7: Build sources list (vector sources + FAQ sources)
         sources = []

--- a/services/backend/tests/test_coach_chat_b2_b6_coverage.py
+++ b/services/backend/tests/test_coach_chat_b2_b6_coverage.py
@@ -1,0 +1,119 @@
+"""Coverage tests for B2 (archetype-agnostic income chip) and B6
+(doctrine_checks fail-loud on empty archetype).
+
+These tests exist to satisfy the diff-cover gate (--fail-under=80) on the
+PR #529 onboarding hotfix bundle. Without them the new branches at
+coach_chat.py:917-925 and doctrine_checks.py:498-503 would be untested.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.api.v1.endpoints.coach_chat import _compute_suggested_actions
+from app.services.coach.doctrine_checks import (
+    QuestionMeta,
+    check_archetype_aware,
+)
+
+
+# ---------------------------------------------------------------------------
+# B2 — archetype-agnostic « D'où vient ton argent ? » chip
+# ---------------------------------------------------------------------------
+
+
+def test_b2_money_source_chip_appears_when_income_missing():
+    """When neither incomeNetMonthly nor incomeGrossYearly is set in the
+    profile, the suggested-actions chip is the new B2 archetype-agnostic
+    « D'où vient ton argent ? ... » phrasing — NOT the legacy
+    « Quel est ton salaire net mensuel ? ».
+
+    Pre-B2 (2026-05-08), this chip was « Quel est ton salaire net mensuel ? »
+    which assumed salaried_active (4/8 archetypes only) and excluded
+    independents, retirees, students, expat_us in transition, returning_swiss
+    et al. — a CLAUDE.md NEVER #4 + NEVER #7 violation.
+    """
+    fake_profile = MagicMock()
+    fake_profile.data = {
+        # birthYear + canton present so we don't hit those chip branches
+        "birthYear": 1990,
+        "canton": "VD",
+        # incomeNetMonthly + incomeGrossYearly intentionally MISSING — the
+        # branch under test (coach_chat.py:916-925) fires only when both
+        # are falsy.
+    }
+    fake_db = MagicMock()
+    fake_db.query.return_value.filter.return_value.order_by.return_value.first.return_value = (
+        fake_profile
+    )
+
+    actions = _compute_suggested_actions(user_id="user-123", db=fake_db)
+
+    labels = [a["label"] for a in actions]
+    # Must contain the new archetype-agnostic chip
+    money_chip_present = any(
+        "D'où vient ton argent" in label for label in labels
+    )
+    assert money_chip_present, (
+        f"B2 chip missing — actions returned {labels!r}. The chip at "
+        f"coach_chat.py:922 should fire when both incomeNetMonthly and "
+        f"incomeGrossYearly are absent from the profile."
+    )
+
+    # Must NOT contain the legacy salaire-first phrasing
+    salary_first_present = any(
+        "salaire net mensuel" in label.lower() for label in labels
+    )
+    assert not salary_first_present, (
+        f"B2 regression — legacy « salaire net mensuel » chip leaked back "
+        f"into actions: {labels!r}. CLAUDE.md NEVER #4 + #7 violation."
+    )
+
+
+# ---------------------------------------------------------------------------
+# B6 — doctrine_checks fail-loud on empty archetype
+# ---------------------------------------------------------------------------
+
+
+def test_b6_archetype_aware_fails_on_empty_archetype():
+    """check_archetype_aware MUST return passed=False when meta.archetype
+    is empty — closes the silent FATCA bypass.
+
+    Pre-B6 (2026-05-08), if the front-end didn't plumb archetype into the
+    LLM context (which it didn't — see coach_chat_screen.dart:1692-1698
+    pre-fix), meta.archetype defaulted to "" (post-B4 empty default) and
+    the check fell through the « no cues defined → pass » branch at
+    doctrine_checks.py:507. Net effect: an expat_us user could receive
+    « Verse 7'258 CHF sur ton 3a » without the FATCA guard firing.
+
+    The B6 fix at doctrine_checks.py:498-503 makes empty/unknown archetype
+    a guard violation rather than a silent skip.
+    """
+    response = "Verse 7'258 CHF sur ton 3a avant fin décembre."
+    meta = QuestionMeta(archetype="")
+
+    result = check_archetype_aware(response, meta)
+
+    assert not result.passed, (
+        f"B6 regression — empty archetype produced passed=True at "
+        f"doctrine_checks.py. Expected fail-loud per B6 fix to close "
+        f"FATCA bypass. result={result!r}"
+    )
+    assert "empty" in result.reason.lower() or "unknown" in result.reason.lower(), (
+        f"B6 fail message should mention empty/unknown archetype. "
+        f"Got reason={result.reason!r}"
+    )
+
+
+def test_b6_archetype_aware_fails_on_whitespace_archetype():
+    """Whitespace-only archetype is treated the same as empty (B6 strip)."""
+    response = "Plafond 7'258 CHF."
+    meta = QuestionMeta(archetype="   ")
+
+    result = check_archetype_aware(response, meta)
+
+    assert not result.passed, (
+        f"B6 regression — whitespace-only archetype produced passed=True. "
+        f"The .strip() guard at doctrine_checks.py:498 should treat "
+        f"whitespace as empty. result={result!r}"
+    )

--- a/services/backend/tests/test_rag_orchestrator_empty_text_no_fallback.py
+++ b/services/backend/tests/test_rag_orchestrator_empty_text_no_fallback.py
@@ -1,0 +1,138 @@
+"""Regression test for B3 — RAGOrchestrator empty-text canned-fallback bug.
+
+When the LLM emits only a tool_use (e.g. ``save_insight(salary=8500)``) with
+no text narration, ``response_text`` is empty. The previous code called
+``self.guardrails.filter_response("", language)`` unconditionally, which
+triggered the ``"Sortie vide"`` fallback path inside ``ComplianceGuard`` and
+returned the canned ``_SAFE_FALLBACK_FR`` (« Je suis là pour t'aider à
+comprendre ta situation financière. N'hésite pas à reformuler ta question
+ou explorer des simulateurs pour des estimations chiffrées. ») as the
+``answer``. The agent loop in ``coach_chat.py`` then sees a non-empty
+``answer_text``, skips its empty-end-turn re-prompt, and the canned text
+reaches the user — masking the actual ``tool_use``.
+
+The fix in ``orchestrator.py`` mirrors the existing guard in
+``_NoRagOrchestrator`` (commit ``3483f4e3``, 2026-04-14) — skip the filter
+when the text is empty.
+
+This test asserts the symmetric behaviour for ``RAGOrchestrator``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.rag.orchestrator import RAGOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_query_returns_empty_answer_when_llm_returns_tool_only_no_text():
+    """Empty text + tool_calls must NOT trigger the canned fallback.
+
+    Symmetric to the existing ``_NoRagOrchestrator`` coverage. Without the
+    guard at ``orchestrator.py:137-150``, ``answer`` would be the canned
+    ``_SAFE_FALLBACK_FR`` from ``ComplianceGuardrails.filter_response`` —
+    masking the ``tool_use`` and the agent loop's re-prompt opportunity.
+    """
+    # Vector store stub — return one tiny chunk so we don't hit the FAQ branch
+    vector_store = MagicMock()
+
+    orchestrator = RAGOrchestrator(vector_store=vector_store)
+
+    # Stub the retriever to return one chunk (so faq_sources stays empty)
+    orchestrator.retriever = MagicMock()
+    orchestrator.retriever.retrieve = AsyncMock(
+        return_value=[{"text": "context chunk", "source": {}}, {"text": "second", "source": {}}]
+    )
+
+    # Stub the LLMClient to return a tool-only response (text="" + tool_calls)
+    fake_tool_call = {
+        "name": "save_insight",
+        "input": {"key": "salary_monthly_chf", "value": 8500},
+    }
+
+    fake_llm_response = {
+        "text": "",
+        "tool_calls": [fake_tool_call],
+        "usage_tokens": 100,
+    }
+
+    with patch(
+        "app.services.rag.orchestrator.LLMClient",
+        autospec=True,
+    ) as mock_llm_cls:
+        mock_llm = mock_llm_cls.return_value
+        mock_llm.generate = AsyncMock(return_value=fake_llm_response)
+
+        result = await orchestrator.query(
+            question="je gagne 8500 francs par mois",
+            api_key="test-key",
+            provider="claude",
+            language="fr",
+            tools=[{"name": "save_insight"}],
+        )
+
+    # CORE assertion : answer is empty (not the canned fallback)
+    assert result["answer"] == "", (
+        f"Expected empty answer when LLM returns tool-only with no text. "
+        f"Got {result['answer']!r}. The canned _SAFE_FALLBACK_FR fallback "
+        f"is leaking through — guard at orchestrator.py:137-150 is missing "
+        f"or regressed."
+    )
+
+    # Tool call should be preserved so the agent loop can act on it
+    assert result.get("tool_calls") == [fake_tool_call], (
+        "tool_calls must be returned to caller so the agent loop in "
+        "coach_chat.py can execute the save_insight call."
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_still_filters_response_when_text_is_present():
+    """Non-empty text path must still go through compliance filter.
+
+    Negative control — confirms the guard only skips the filter for
+    empty/whitespace text, not for normal coach replies.
+    """
+    vector_store = MagicMock()
+    orchestrator = RAGOrchestrator(vector_store=vector_store)
+    orchestrator.retriever = MagicMock()
+    orchestrator.retriever.retrieve = AsyncMock(
+        return_value=[{"text": "ctx", "source": {}}, {"text": "ctx2", "source": {}}]
+    )
+
+    # Mock guardrails so we can assert filter_response was called
+    orchestrator.guardrails = MagicMock()
+    orchestrator.guardrails.filter_response.return_value = {
+        "text": "Filtered reply",
+        "warnings": [],
+        "disclaimers_added": [],
+    }
+    orchestrator.guardrails.build_system_prompt.return_value = "system"
+
+    fake_llm_response = {
+        "text": "Voici un point sur ta situation.",
+        "tool_calls": None,
+        "usage_tokens": 50,
+    }
+
+    with patch(
+        "app.services.rag.orchestrator.LLMClient",
+        autospec=True,
+    ) as mock_llm_cls:
+        mock_llm = mock_llm_cls.return_value
+        mock_llm.generate = AsyncMock(return_value=fake_llm_response)
+
+        result = await orchestrator.query(
+            question="ok",
+            api_key="test-key",
+            provider="claude",
+            language="fr",
+        )
+
+    orchestrator.guardrails.filter_response.assert_called_once_with(
+        "Voici un point sur ta situation.", "fr"
+    )
+    assert result["answer"] == "Filtered reply"


### PR DESCRIPTION
## Summary

4 P0 bugs reported by Julien on TestFlight v2.12.1+3 G2 device test, all root-cause-investigated by 3 parallel audit subagents post-merge of #525. Coherent thematic bundle: « le coach onboarding ne ment plus, ne ventriloque plus, n'assume plus, ne refuse plus ».

## Bugs fixed (atomic commits, in order of impact)

| Commit | Bug | One-liner |
|---|---|---|
| `7b91be98` | **B3** | RAG orchestrator runs compliance filter on empty LLM text → canned `_SAFE_FALLBACK_FR` (« Je suis là pour t'aider… ») masks legit `tool_use` (e.g. `save_insight(salary=8500)`). Mirror existing `_NoRagOrchestrator` guard from commit 3483f4e3. + 2 regression tests pass locally. |
| `b7cbcee8` | **B4** | Hardcoded defaults `canton="VD"` / `archetype="swiss_native"` / `age=30` injected into LLM context for empty profiles → coach claims « 3 pièces du puzzle » that user never provided. Defaults set to empty/zero so existing truthy-gate at `claude_coach_service.py:793-798` correctly drops the line. Mobile `prompt_registry.dart` `?? 'célibataire'` / `?? 65` / `?? 0` replaced by `?? '?'` + LLM instructed « DEMANDE-le, ne suppose pas ». |
| `51fb4ea6` | **B2** | Salaire-first framing (`coach_chat.py:917` + `coach_tools.py:611` + `budget.py:182`) violates CLAUDE.md NEVER #4 + #7 — assumes salaried-active (4/8 archetypes). Replaced with money-source question covering 8 archetypes. |
| `328b8f65` | **B1** | Phantom user message « Salut, je viens de créer mon compte. Par où je commence ? » rendered as user-authored at `coach_chat_screen.dart:356`. Switch to `_addCoachOpenerMessage` with new ARB key `coachOnboardingFirstAssistantGreeting` (6 langs). Old key deprecated. |

## Out of scope (deferred follow-ups)

- **B5** salary plausibility gate (15_000–500_000 assumes annual, rejects « 8500 francs/mois ») — bonus finding from B3 audit, separate fix
- **B5b** Profile screen — user reports cannot view/upload/change data — investigating in parallel session, separate hotfix
- Backend `CoachContext` Optional refactor (Phase 2 architectural) — minimal-diff approach in this PR fixes user-visible symptom without rewriting dataclass contract
- Archetype-routing of `_compute_suggested_actions` — Phase 2

## Audits

4 parallel subagent audits ran post-#525 merge (TestFlight ship). 3/4 came back with surgical root-cause + fix proposals. Implementation faithful to audit recommendations:
- `a722ed7792f25a259` (code review wire #525 — covered by PR #527)
- `a332fd1d7712ad19a` (B1 phantom message — applied in commit 328b8f65)
- `a0ff6ef6d66497721` (B2 salaire framing — applied in commit 51fb4ea6)
- `ad9ae4497a620a02a` (B3 canned reply — applied in commit 7b91be98)

## Test plan

- [x] `pytest tests/test_rag_orchestrator_empty_text_no_fallback.py tests/test_onboarding_contract.py` → 18/18 pass locally
- [x] `flutter analyze lib/services/coach/prompt_registry.dart` → No issues found
- [x] `flutter analyze lib/screens/coach/coach_chat_screen.dart` on the modified region → clean (3 pre-existing issues remain at L1048/L1741/L2308, unrelated)
- [x] `flutter gen-l10n` → 6 ARB files include `coachOnboardingFirstAssistantGreeting`
- [ ] CI green on this PR
- [ ] Post-merge TestFlight rebuild (next pubspec bump in a separate PR), G2 retest by Julien on iPhone

## Caveats §9.7

- Backend `CoachContext` defaults change might surface other consumers that did `f"Canton: {ctx.canton}"` without truthy gate — I greppped and only `claude_coach_service.py:793-798` is gated explicitly. Other consumers might now display empty strings; that's HONEST behaviour vs the previous lie, but visual review on the rebuild is recommended.
- The deprecated `coachOnboardingFirstUserMessage` ARB key + 6-lang values + generated bindings stay for back-compat. A follow-up can sweep them once we're sure no test asserts on them.
- The mobile `coach_profile_seeds.dart` was left untouched: per its header comment it's gated by `kReleaseMode` + `MINT_E2E_ARCHETYPE` dart-define so it's dead code in production. Confirmed via grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)