### PR TITLE
chore(release): bump pubspec 2.12.2+4 — onboarding crisis hotfix

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.1+3
+version: 2.12.2+4
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary

Patch bump for the post-PR-#529 TestFlight rebuild. App Store Connect rejects duplicate build numbers — staging just shipped 2.12.1+3 (run 25568240358), so dev → staging merge needs a new version.

## What ships in 2.12.2+4

PR #529 onboarding crisis hotfix bundle:
- **B1** phantom user message (« Salut, je viens de créer mon compte ») → coach-initiated greeting
- **B2** salaire-first framing → archetype-agnostic « D'où vient ton argent ? » (3 backend sites)
- **B3** RAG orchestrator empty-text canned-fallback bug — closes 7'258 CHF mis-recommendation to expat_us
- **B4** hardcoded VD/swiss_native/30/celibataire defaults → empty/zero (Python + Mobile)
- **B6** audit-completion : mobile-side B4 finish + doctrine fail-loud on empty archetype (closes silent FATCA bypass per O5 adversarial QA panel)
- 4 pre-existing flutter analyze warnings cleaned (per Julien explicit ask)
- 3 decision docs filed for v2 redesign perimeters

## Test plan

- [x] PR #529 merged at dc987c4c, 18/18 CI SUCCESS at merge time
- [x] pubspec verified: 2.12.2+4
- [ ] CI green on this PR
- [ ] dev → staging merge → fires testflight.yml run
- [ ] TestFlight build available for Julien G2 device retest

🤖 Generated with [Claude Code](https://claude.com/claude-code)