### PR TITLE
docs(decisions): B8 doctrine runtime wire STUB + retractation B6 FATCA claim

### DIFF
--- a/.planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
+++ b/.planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
@@ -230,8 +230,32 @@ Ces 8 règles sont **non-négociables** pour le perimeter d'implémentation.
 
 - `MVP-FONTS-TOKENS-V2-2026-05` — install Supreme + Gambarino + Menthe-vive token + Gambarino italic display style + dark palette (foundation, bloque tous les autres)
 - `MVP-ONBOARDING-V2-AUTH-FIRST-2026-05` — 6 micro-steps OTP-style aligné MINT v2 (post fonts ready)
+- `MVP-B8-DOCTRINE-RUNTIME-WIRE-2026-05` — wire `score_response()` au runtime (audit-found gap : B6 fix function-level OK mais 0 production callers — bypass FATCA reste ouvert au runtime malgré commit message claim)
 - `MVP-COACH-V2-ARTEFACTS-2026-05` (à ouvrir Phase 2 après M1 skills modulaires)
 - `MVP-AUJOURDHUI-V2-HUB-2026-05` (à ouvrir Phase 2-3)
+
+## Addendum 2026-05-08T19:30 — retractation B6 claim (audit-found, post-PR-#529 merge)
+
+PR #529 a été mergé puis 4 audit experts ont audité le bundle (a7d759b1 LSFin / a436c079 i18n / a5fd1174 security / a80125307 code review). 3 PASS, 1 PASS-with-FLAG.
+
+**FLAG (a80125307)** : le commit dc987c4c (B6 backend `doctrine_checks.py`) message dit literal « **closes the silent FATCA bypass** ». Audit + grep verification :
+
+```bash
+$ grep -rn "score_response\|check_archetype_aware" services/backend/app
+# (empty — no production callers outside doctrine_checks.py itself)
+```
+
+**Retractation honnête (CLAUDE.md §9.1)** :
+- ✅ B6 mobile-side : `CoachProfile.archetype` plumbed dans `CoachContext` — LLM prompt context plus accurate (livré, vérifié par security audit a5fd1174)
+- ✅ B6 backend defaults empty : empty/zero plutôt que VD/30/swiss_native — privacy posture améliorée (livré, vérifié)
+- ✅ B6 doctrine_checks `check_archetype_aware` : function fail-loud sur empty archetype — function-level fix OK (couvert par test_coach_chat_b2_b6_coverage.py)
+- ❌ B6 « closes FATCA bypass » : **claim overstated**. La function n'a pas de production caller. Le bypass reste ouvert au runtime.
+
+Net B6 livre **~50 % du claimed value**. Le reste est différé au perimeter `MVP-B8-DOCTRINE-RUNTIME-WIRE-2026-05` qui WIRE `score_response()` dans le production response path (`coach_chat.py` agent loop OR `RAGOrchestrator.query()` post-filter).
+
+**Le bypass FATCA est pré-existant** — pas introduit par PR #529. Donc shipping v2.12.2+4 ne fait ni mieux ni pire sur ce point. Les 4 P0 user-facing fixes (B1+B2+B3+B4 + cosmetics + Dart-side B6 archetype plumbing) restent valides et livrent valeur immédiate.
+
+**Lesson for future commits (0-Trust)** : claim « closes » exige citation du production caller, pas juste l'existence de la function. Un grep production-callers AVANT de write « closes » dans le commit message aurait évité cette retractation.
 - `MVP-DENSITY-V2-HYPOTHEQUE-ETC-2026-05` (à ouvrir Phase 3)
 - `MVP-DARK-MODE-V2-2026-05` (à ouvrir post-onboarding-v2)
 

--- a/.planning/decisions/2026-05-08-perimeter-b8-doctrine-runtime-wire/STUB.md
+++ b/.planning/decisions/2026-05-08-perimeter-b8-doctrine-runtime-wire/STUB.md
@@ -1,0 +1,79 @@
+---
+name: MVP-B8-DOCTRINE-RUNTIME-WIRE — perimeter STUB
+description: Audit-found gap on PR #529 B6. The fail-loud doctrine guard at doctrine_checks.py:498-503 was added but score_response() has 0 production callers. So the « FATCA bypass closure » claimed in B6 commit message is NOT effective at runtime. This STUB plans the actual wiring of score_response into the LLM response path. Effort ~1 j.
+type: decision
+date: 2026-05-08
+status: STUB (à ouvrir post Julien G2 confirm v2.12.2+4)
+related:
+  - .planning/decisions/2026-05-08-coach-onboarding-redesign-panel/SYNTHESIS.md
+  - PR #529 commit dc987c4c (B6 fail-loud function-level fix)
+sources:
+  - 6-agent panel synthesis 2026-05-08
+  - Code audit a80125307 finding (« defensive-only, not wired to runtime »)
+  - Verification grep "score_response\|check_archetype_aware" services/backend/app → 0 production callers
+---
+
+# MVP-B8-DOCTRINE-RUNTIME-WIRE — STUB
+
+## Goal
+
+**Wire `score_response()` into the production LLM response path** to actually catch the FATCA bypass scenarios that B6 only fixed at function-level.
+
+This perimeter exists because PR #529 commit B6 (d68a0f14) message claimed « closes the silent FATCA bypass » but the audit (subagent a80125307) found that `score_response()` and `check_archetype_aware()` have **zero production callers** :
+
+```bash
+$ grep -rn "score_response\|check_archetype_aware" services/backend/app
+# (empty — no hits outside doctrine_checks.py itself)
+```
+
+So the guard exists in code, fails on empty archetype as expected, but is never invoked at runtime. The bypass remains open.
+
+## Truth-in-claim retractation (per CLAUDE.md §9.1)
+
+The B6 commit message at `dc987c4c` says « closes the silent FATCA bypass ». **This claim is overstated.** Actual delivery of B6 :
+
+- ✅ Mobile-side : `CoachProfile.archetype` getter plumbed into `CoachContext` via new `_archetypeToBackendName()` helper at `coach_chat_screen.dart:1711-1730`
+- ✅ Backend `claude_coach_service.py:793-798` consumes the archetype on truthy gate — LLM prompt context now reflects user's real archetype (not « swiss_native » default lie)
+- ❌ Post-LLM `doctrine_checks.score_response()` not wired to runtime — guard exists but never invoked
+
+So **B6 delivers ~50 % of claimed value** : prompt input is more accurate, but post-output safety net is still defensive-only.
+
+## 5 gates mécaniques
+
+| Gate | Description | Évidence |
+|---|---|---|
+| G1 | sim walker — expat_us scenario : assert response with « 3a » imperative without FATCA cue is BLOCKED at runtime (vs current : silently shipped) | promptfoo `fatca_3a_no_recommendation.yaml` from O5 audit recommendation |
+| G2 | device by Julien — confirm archetype-aware responses on his expat_us seed account (manual verify) | TestFlight |
+| G3 | dev CI green — flutter analyze + pytest backend (incl. new doctrine wiring tests) | run green |
+| G4 | regression tests — score_response is invoked once per LLM response in coach_chat.py agent loop | new test asserts the call site is hit |
+| G5 | LSFin/accent/ARB lint — no banned-term regression introduced | banned_terms_arb exit 0 |
+
+## Tâches breakdown
+
+| # | Action | Effort | Dépendance |
+|---|---|---|---|
+| B8.1 | Decide wire location : (a) `coach_chat.py` agent loop final-turn response post-process OR (b) `RAGOrchestrator.query()` post-filter step. (a) is closer to user-visible response, (b) is more centralized | 0.1j | None |
+| B8.2 | Implement the wire — `score_response(response_text, QuestionMeta(archetype=ctx.archetype, …))` after LLM emits final text but before client return | 0.3j | B8.1 |
+| B8.3 | Decide what to do on FAIL — options : (a) log audit signal only (passive), (b) replace response with safe fallback, (c) re-prompt LLM with stricter system prompt + cite the missed cue | 0.2j | B8.2 |
+| B8.4 | Change `QuestionMeta.archetype` default at `doctrine_checks.py:75` from `"swiss_native"` to `""` so bare `QuestionMeta()` triggers fail-loud (closes Risk #2 from a80125307 audit) | 0.05j | None |
+| B8.5 | Add integration test : `tests/test_doctrine_runtime_wire.py` — assert `score_response` is invoked on coach_chat response, mock LLM to return banned 3a-imperative for expat_us, assert response is rejected/replaced/re-prompted per B8.3 decision | 0.3j | B8.2+B8.3 |
+| B8.6 | Add agent-loop assertion : empty answer + no tool_calls + no end-turn → never sent to client (Risk #3 from a80125307 audit) | 0.1j | None |
+| B8.7 | Add `_archetypeToBackendName` round-trip integration test — mobile-side enum → backend snake_case → `QuestionMeta.archetype` matches | 0.1j | None |
+| B8.8 | Update `coach_chat.py` commit message OR add comment retraction at the call site documenting the B6 audit gap closed by this perimeter | 0.05j | B8.2 |
+
+**Total estimé** : ~1 j (sans la phase G2 device verify).
+
+## Counter-arguments and data gaps
+
+- **Risk 1** : Wire at `coach_chat.py` agent loop adds latency (each turn now scores response). Mitigation : score in parallel with the response stream, or post-stream-end. Measure latency delta with first wire commit.
+- **Risk 2** : On FAIL response, what's the right action ? Replacing the response with a canned « FATCA disclaimer + retry » is better than letting it ship, but worse than catching pre-emit. Best practice (per Anthropic constitutional AI patterns) is re-prompt with stricter system prompt cite the missed cue. But re-prompt costs a 2nd LLM round-trip ($$).
+- **Risk 3** : The `_ARCHETYPE_CUES` dict in `doctrine_checks.py:288-321` defines the regex per archetype. If a cue is too restrictive (e.g. requires literal « FATCA »), an LLM that says « tu déclares aux US » would PASS the cue check semantically but fail the regex. Calibrate with real LLM samples post-wire.
+- **Risk 4** : Wire B8.4 (default to `""`) might break test fixtures that called bare `QuestionMeta()` expecting swiss_native. Need to grep + update test fixtures.
+- **Data gap** : No telemetry yet on actual FATCA-relevant turns — without the wire we can't measure how often the bypass would have fired. Only after B8 ships can we observe.
+- **Truth-in-claim** : The B6 commit dc987c4c message is now inaccurate but cannot be amended (already merged + pushed). Mitigation : this STUB is the audit log, retraction is preserved.
+
+## Approval gate
+
+À ouvrir comme PR séparée post-Julien G2 confirm sur TestFlight v2.12.2+4. **Pas avant.**
+
+Reasonably : G2 confirm = the user-facing B1-B4 fixes work. THEN we open B8 to close the runtime gap on the post-LLM safety net.


### PR DESCRIPTION
## Summary

Post-merge audit on PR #529 (4 experts in parallel) found that my B6 commit message at `dc987c4c` claims « closes the silent FATCA bypass » but `score_response()` has **zero production callers**. The function-level fix is correct, but it is NOT wired to runtime — the bypass remains open.

This PR files:

1. **B8 STUB perimeter** — `MVP-B8-DOCTRINE-RUNTIME-WIRE-2026-05` to wire `score_response()` into the production response path. ~1 j effort, opens post Julien G2 confirm of v2.12.2+4.

2. **Retractation B6 claim** in panel SYNTHESIS.md — documents what B6 actually delivers (~50 % of claimed value) per CLAUDE.md §9.1 0-Trust honest-claim policy.

## What B6 actually delivered (verified by audits)

| Aspect | Audit verdict |
|---|---|
| ✅ Mobile-side : archetype plumbed into CoachContext | Verified by a5fd1174 security audit |
| ✅ Backend defaults empty/zero | Verified by a7d759b1 LSFin audit |
| ✅ doctrine_checks function fail-loud on empty archetype | Test-covered by `test_coach_chat_b2_b6_coverage.py` |
| ❌ « closes FATCA bypass » runtime | a80125307 code audit : 0 production callers |

## What this PR does NOT change

- v2.12.2+4 TestFlight build still ships (4 P0 user-facing fixes are real)
- FATCA bypass is pre-existing, NOT introduced by PR #529
- B8 actual runtime wire is deferred to a separate code PR

## Test plan

- [x] `wiki_lint.py` passes (Counter-arguments and data gaps section present in B8 STUB)
- [x] No code change in this PR — docs only
- [ ] CI green on this PR
- [ ] B8 perimeter opens as code PR after Julien G2 confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)