### PR TITLE
fix(coach): gate tier 3.5 anonymous fallback on !isLoggedIn (B13)

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -1178,6 +1178,12 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
       final config = _buildConfig();
       // Capture l10n before await to avoid using BuildContext across async gap.
       final l10n = S.of(context)!;
+      // B13 fix (2026-05-09): pass isLoggedIn so the orchestrator can skip
+      // the tier 3.5 anonymous fallback on logged users. Pre-fix, an
+      // authenticated user whose tier3 server-key call timed out got
+      // silently routed to /anonymous/chat and saw « Limite atteinte. Crée
+      // un compte pour continuer. » — trust-killer.
+      final isLoggedIn = context.read<AuthProvider>().isLoggedIn;
       final response = await CoachLlmService.chat(
         userMessage: text,
         profile: _profile!,
@@ -1185,6 +1191,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
         config: config,
         memoryBlock: memoryBlock,
         cashLevel: _cashLevel,
+        isLoggedIn: isLoggedIn,
       );
 
       final tier = config.hasApiKey ? ChatTier.byok : ChatTier.fallback;

--- a/apps/mobile/lib/services/coach/coach_orchestrator.dart
+++ b/apps/mobile/lib/services/coach/coach_orchestrator.dart
@@ -237,6 +237,12 @@ class CoachOrchestrator {
     String? memoryBlock,
     String language = 'fr',
     int cashLevel = 3,
+    // B13 fix (2026-05-09): tier 3.5 anonymous is gated on auth state.
+    // Pre-fix, an authenticated user whose tier3 (server-key) call timed
+    // out would silently fall through to /anonymous/chat and hit the
+    // 3-message anon quota, returning « Limite atteinte. Crée un compte
+    // pour continuer. » — a trust-killer for users who ARE logged in.
+    bool isLoggedIn = false,
   }) async {
     // Build system prompt with optional memory block injection (S58).
     // Pan5-1: Use PromptRegistry.chatSystemPrompt (enriched, context-aware)
@@ -330,16 +336,34 @@ class CoachOrchestrator {
     // only fired in the chat-screen catch block, which was never reached
     // when the orchestrator degraded gracefully — users saw "Le coach IA
     // n'est pas disponible" even though anonymous would have worked.
-    debugPrint('[CoachChain] tier3.5=Anonymous trying...');
-    final anonymousResponse = await _tryAnonymousChat(
-      userMessage: userMessage,
-      language: language,
-    );
-    if (anonymousResponse != null) {
-      debugPrint('[CoachChain] tier3.5=Anonymous SUCCESS');
-      return anonymousResponse;
+    //
+    // B13 fix (2026-05-09): gated on !isLoggedIn. An authenticated user
+    // whose tier3 (server-key) call failed (timeout, 5xx, rate limit) was
+    // silently routed to /anonymous/chat and hit the 3-message anon quota,
+    // returning « Limite atteinte. Crée un compte pour continuer. » to a
+    // user who was already logged in. Trust-killer reported by Julien on
+    // TestFlight v2.12.2+4 (« j'ai des dettes » flow). For logged users
+    // we now skip tier 3.5 and fall straight to the offline template,
+    // which surfaces a more honest « service indisponible, réessaie »
+    // message instead of an anon-quota one.
+    if (!isLoggedIn) {
+      debugPrint('[CoachChain] tier3.5=Anonymous trying...');
+      final anonymousResponse = await _tryAnonymousChat(
+        userMessage: userMessage,
+        language: language,
+      );
+      if (anonymousResponse != null) {
+        debugPrint('[CoachChain] tier3.5=Anonymous SUCCESS');
+        return anonymousResponse;
+      }
+      debugPrint('[CoachChain] tier3.5=Anonymous returned null');
+    } else {
+      debugPrint(
+        '[CoachChain] tier3.5=Anonymous skipped (user is logged in — '
+        'avoid leaking « Limite atteinte » anon-quota response to '
+        'authenticated users, B13 fix 2026-05-09)',
+      );
     }
-    debugPrint('[CoachChain] tier3.5=Anonymous returned null');
 
     // 4. Fallback — honest "coach unavailable" message.
     debugPrint('[CoachChain] ALL TIERS FAILED — returning fallback');

--- a/apps/mobile/lib/services/coach_llm_service.dart
+++ b/apps/mobile/lib/services/coach_llm_service.dart
@@ -266,6 +266,16 @@ class CoachResponse {
 
 /// Signature for the orchestrator's generateChat, used to break the
 /// circular dependency between coach_llm_service ↔ coach_orchestrator.
+///
+/// B13 fix (2026-05-09): added [isLoggedIn] so the orchestrator can gate
+/// the tier 3.5 anonymous fallback on auth state. Pre-fix, an authenticated
+/// user whose tier3 (server-key) call timed out would silently fall through
+/// to the /anonymous/chat endpoint and hit the 3-message anon quota,
+/// returning « Limite atteinte. Crée un compte pour continuer. » to a user
+/// who was already logged in. Critical UX bug reported on TestFlight
+/// v2.12.2+4 by Julien on 2026-05-09. See
+/// .planning/decisions/2026-05-09-7-panel-comprehensive-audit/SYNTHESIS.md
+/// for full context.
 typedef OrchestratorChatFn = Future<CoachResponse> Function({
   required String userMessage,
   required List<ChatMessage> history,
@@ -274,6 +284,7 @@ typedef OrchestratorChatFn = Future<CoachResponse> Function({
   String? memoryBlock,
   String language,
   int cashLevel,
+  bool isLoggedIn,
 });
 
 /// Service de chat LLM pour le Coach MINT
@@ -305,6 +316,11 @@ class CoachLlmService {
     Map<String, dynamic>? enrichedContext,
     String language = 'fr',
     int cashLevel = 3,
+    // B13 fix (2026-05-09): callers must pass auth state so the
+    // orchestrator can skip tier 3.5 anonymous when the user is logged in.
+    // Default false so any forgotten caller falls through to anon (the
+    // pre-fix behaviour) rather than crashing.
+    bool isLoggedIn = false,
   }) async {
     final coachCtx = _buildCoachContext(profile);
 
@@ -325,6 +341,7 @@ class CoachLlmService {
       memoryBlock: memoryBlock,
       language: language,
       cashLevel: cashLevel,
+      isLoggedIn: isLoggedIn,
     );
 
     // suggestedActions are resolved at the screen layer (CoachChatScreen)


### PR DESCRIPTION
## Summary

Closes the « **Limite atteinte. Crée un compte pour continuer.** » trust-killer reported by Julien on TestFlight v2.12.2+4 (2026-05-09 « j'ai des dettes » flow) — an authenticated user was being silently routed to the `/anonymous/chat` endpoint when the upstream tier 3 (server-key) call failed, then hit the 3-message anon quota.

## Root cause

`coach_orchestrator.dart:333` (Wave 5, 2026-04-18) added a tier 3.5 anonymous fallback to support local-mode users (no login, no BYOK, SLM disabled). The gating was missing — tier 3.5 fired even for logged users when tier 3 failed (timeout, 5xx, rate limit).

## Fix

Thread `bool isLoggedIn = false` through 3 call layers:
- `OrchestratorChatFn` typedef in `coach_llm_service.dart:269`
- `CoachLlmService.chat` signature
- `CoachOrchestrator.generateChat` signature → gate tier 3.5 block on `!isLoggedIn`
- `coach_chat_screen.dart:1181` reads `context.read<AuthProvider>().isLoggedIn` and passes through

## Test plan

- [x] `flutter analyze` on 3 touched files → No issues found! (ran in 2.8s)
- [x] `flutter test test/services/coach_context_builder_test.dart test/providers/financial_plan_provider_test.dart` → 16/16 pass
- [ ] CI green on this PR
- [ ] Julien G2 device retest on next TestFlight cut: « j'ai des dettes » flow no longer surfaces « Limite atteinte » when logged

## Out of scope (deferred to follow-up perimeters)

- Backend `anonymous_chat.py:178` empty-text guard (B3 sibling, EXP-F audit)
- Topic chip classifier « amortissement direct vs indirect » hors-sujet (B14)
- Generic chips ignoring concrete user data (B15)
- Backend tier3 server-key reliability investigation (root cause of WHY tier3 fails — this PR only stops the symptom of leaking anon-quota message to logged users)

## References

- `.planning/decisions/2026-05-09-7-panel-comprehensive-audit/SYNTHESIS.md` — B13 entry in P0 bug tracker
- PR #533 — comprehensive 10-audit synthesis + 5 Maestro flow set
- B13 finding source: Julien device test 2026-05-09 TestFlight v2.12.2+4

🤖 Generated with [Claude Code](https://claude.com/claude-code)