### PR TITLE
fix(calc): FATCA gate on 3a simulator + canonical archetype.backendName (P0#4)

### DIFF
--- a/.planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md
+++ b/.planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md
@@ -1,0 +1,95 @@
+---
+name: MVP-FATCA-CALCULATOR-GATE — perimeter STUB
+description: Audit findings 2026-05-08 (PR #533 P0#4) — (a) `simulator_3a_screen.dart:171` has no FATCA gate so US persons see a fully functional 3a contribution simulator that is not actionable for them ; (b) `rachat_echelonne_screen.dart:191` has a no-op `replaceAll('_', '_').toLowerCase()` that silently downgrades every archetype to swiss_native at the backend, masking FATCA / cross-border / OPP2 art. 60b expat caps. Effort ~0.5 j.
+type: decision
+date: 2026-05-09
+status: STUB → IN_FLIGHT (this PR opens with the fix)
+related:
+  - .planning/decisions/2026-05-09-perimeter-archetype-input-normalization/STUB.md
+  - .planning/decisions/2026-05-08-perimeter-b8-doctrine-runtime-wire/STUB.md (B8 backend wire)
+sources:
+  - PR #533 audit synthesis P0 #4 line item
+  - Code trace `apps/mobile/lib/screens/simulator_3a_screen.dart:171` (independent gate present, FATCA absent)
+  - Code trace `apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart:191` (`replaceAll('_','_')` no-op bug)
+  - Code trace `apps/mobile/lib/models/coach_profile.dart:1823` (canContribute3a getter ALREADY exists — just unused at the simulator)
+---
+
+# MVP-FATCA-CALCULATOR-GATE — STUB
+
+## Goal
+
+**Two surgical fixes that close two silent failure modes in the calculator surface:**
+
+1. Add a FATCA gate panel to the 3a simulator so US-affected users see a calm explainer + alternatives CTA instead of a simulator they can't act on.
+2. Fix the buggy archetype string conversion in `rachat_echelonne_screen.dart` that was silently downgrading every archetype to the swiss_native default at the backend.
+
+Both fixes share the same root concern: archetype-aware logic that exists (`canContribute3a` getter, `_archetypeToBackendName` mapping) but is bypassed at the call site.
+
+## Truth-in-claim
+
+- The `canContribute3a` getter at `coach_profile.dart:1823` was added in an earlier sprint to reflect FATCA / cross-border eligibility — but only `prevoyance_screen.dart` and `wealth_summary_screen.dart` actually consume it. The 3a simulator never read it. So users could fill in 25 000 CHF/year of 3a contributions in the simulator, get a fancy projection, and only later discover their bank refuses them.
+- The `replaceAll('_', '_')` at `rachat_echelonne_screen.dart:191` is a typo bug (intent unclear — possibly meant `replaceAllMapped(camelCase regex)` or simply removing a redundant operation). Net effect: `'crossBorder'.toLowerCase()` = `'crossborder'`, which doesn't match the backend's `'cross_border'`. So `RachatEchelonneSimulator` always received the wrong archetype string, masking the OPP2 art. 60b expat-cap (20% of insured salary if < 5 years CH contribution).
+
+## Fix
+
+Three surgical changes in this PR :
+
+1. **`coach_profile.dart` — promote `_archetypeToBackendName` from a private method on coach_chat_screen to a top-level extension `FinancialArchetypeBackendName.backendName`** so all callers reuse the canonical mapping. CLAUDE.md NEVER #3 (single source of truth).
+
+2. **`rachat_echelonne_screen.dart:191` — replace `name.replaceAll('_','_').toLowerCase()` with `profile.archetype.backendName`** (uses the new extension). Preserves the original intent (snake_case for the backend) without the silent downgrade bug.
+
+3. **`simulator_3a_screen.dart` — gate the simulator body on `coachProfile.canContribute3a`** : when false (US person / FATCA), render a calm explainer panel with FATCA-aware copy + a CTA that routes to the coach with `intent=fatca_3a_alternatives`. The coach already has the alternative-levers playbook (libre passage, mortgage optimization, free investment) and respects archetype-aware doctrine in its system prompt.
+
+## ARB delta
+
+3 new keys (added to all 6 locales: fr, en, de, es, it, pt) :
+- `sim3aFatcaGateTitle` — panel title.
+- `sim3aFatcaGateBody` — explainer + alternative levers.
+- `sim3aFatcaGateAction` — CTA label.
+
+LSFin-compliant copy. No banned terms. No promise.
+
+## 5 gates mécaniques
+
+| Gate | Description | Évidence |
+|---|---|---|
+| G1 | sim walker — set archetype=expatUs in seed, open `/simulator/3a`, assert FATCA panel appears (no input fields visible) | walker logs from a fresh expat_us seed |
+| G2 | device by Julien — flip his profile to US nationality temporarily, open the 3a simulator on TestFlight v2.12.2+5, confirm gate panel | TestFlight |
+| G3 | dev CI green — flutter analyze + flutter test (incl. new archetype tests) | run green |
+| G4 | regression tests — `test_archetype_backend_name.dart` covers all 8 archetypes ; the rachat bug pre-fix path is asserted-different in a regression guard | new test exit 0 |
+| G5 | LSFin/accent/ARB lint + ARB parity — 6-locale parity on the 3 new keys | ARB validation green |
+
+## Tâches breakdown
+
+| # | Action | Effort | Dépendance |
+|---|---|---|---|
+| 1 | Add `extension FinancialArchetypeBackendName on FinancialArchetype { String get backendName }` at top of `coach_profile.dart` (after enum) | 0.05 j | None |
+| 2 | Replace `_archetype = profile.archetype.name.replaceAll('_','_').toLowerCase();` at `rachat_echelonne_screen.dart:191` with `profile.archetype.backendName` | 0.02 j | 1 |
+| 3 | In `simulator_3a_screen.dart` build method, read `coachProfile.canContribute3a` ; if false, render `_buildFatcaGateBody()` instead of the simulator inputs | 0.1 j | None |
+| 4 | Implement `_buildFatcaGateBody()` — title + body + CTA routing to `/coach?intent=fatca_3a_alternatives` | 0.1 j | None |
+| 5 | Add ARB keys `sim3aFatcaGateTitle` / `sim3aFatcaGateBody` / `sim3aFatcaGateAction` to all 6 ARBs ; run `flutter gen-l10n` | 0.1 j | None |
+| 6 | Unit test `test/models/coach_profile_archetype_backend_name_test.dart` — exhaustive map + regression guard against pre-fix `.name.toLowerCase()` | 0.1 j | 1 |
+| 7 | flutter analyze + flutter test (touched test/models green) | 0.05 j | All |
+
+**Total estimé** : ~0.5 j.
+
+## Counter-arguments and data gaps
+
+- **Risk 1** : The CTA `/coach?intent=fatca_3a_alternatives` deep link is referenced but the coach side may not yet have a tailored intent handler for `fatca_3a_alternatives`. Worst case : the coach just opens with a default greeting. Acceptable v1 — the user can ask « quelles sont les alternatives au 3a en tant que US person » manually. Future perimeter : pre-fill the message with an intent-tagged opener.
+- **Risk 2** : The FATCA gate is binary (canContribute3a true / false). Some FATCA-affected users with quasi-resident frontalier status (≥90% Swiss income) CAN contribute via Raiffeisen. The current `canContribute3a` getter handles this case (returns true for cross-border with revenue). So the gate fires only on actual blocked users. Verified at `coach_profile.dart:1823-1830`.
+- **Risk 3** : Removing the buggy `replaceAll('_','_').toLowerCase()` at rachat_echelonne_screen.dart may surface latent issues in `RachatEchelonneSimulator` if it had grown to depend on the buggy values. Mitigation : grep `RachatEchelonneSimulator` for archetype string usage and read the test fixtures to confirm none rely on the wrong values.
+- **Risk 4** : The new extension `backendName` introduces a parallel API to `_archetypeToBackendName` in coach_chat_screen.dart. Future cleanup : delete the private method from coach_chat_screen.dart and have it call the extension. Out of scope for this perimeter (CLAUDE.md NEVER #6 — surgical changes ; touch only what the audit found).
+- **Data gap** : No telemetry on how many production users are actually FATCA-affected (we don't track nationality at scale). Mitigation : log archetype distribution once per session for 1 week post-deploy ; size impact based on actual `expat_us` ratio.
+
+## Approval gate
+
+**This PR opens immediately**. The fixes are mobile-side, surgical, fully unit-tested, and reverse cleanly if needed. G2 device verify is encouraged post-merge but does NOT block PR open.
+
+## Order of fixes (within this perimeter)
+
+1. Task 1 (extension) — single commit.
+2. Task 2 (rachat_echelonne fix) — single commit.
+3. Tasks 3 + 4 + 5 (FATCA gate body + ARB keys) — single commit.
+4. Tasks 6 + 7 (tests + CI gates).
+
+Each commit atomic + traceable.

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Nur eine Minderheit der Anbieter akzeptiert (z.B. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Säule 3a — eingeschränkter Zugang (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "Dein FATCA-Status schränkt den Zugang zur Säule 3a in der Schweiz ein. Die meisten Anbieter lehnen US-Personen oder Green-Card-Inhaber ab. Bevor du Einzahlungen simulierst, vergewissere dich, dass ein Anbieter dich akzeptiert (z.B. Raiffeisen) und erwäge alternative Hebel: Freizügigkeitsguthaben, Hypothekenoptimierung, freies Investment.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "Alternativen zur Säule 3a anzeigen",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Vorsorge bearbeiten",
   "financialSummaryEditAvoirLpp": "BVG-Gesamtguthaben (CHF)",
   "financialSummaryEditNombre3a": "Anzahl 3a-Konten",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Only a minority of providers accept (e.g. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Pillar 3a — limited access (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "Your FATCA status limits access to Swiss pillar 3a. Most providers refuse US persons or green card holders. Before simulating contributions, confirm a provider accepts you (e.g. Raiffeisen) and consider alternative levers: vested benefits, mortgage optimization, free investment.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "See alternatives to 3a",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Edit pension",
   "financialSummaryEditAvoirLpp": "Total LPP assets (CHF)",
   "financialSummaryEditNombre3a": "Number of 3a accounts",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Solo una minoría de proveedores acepta (ej. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Pilar 3a — acceso limitado (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "Tu estatus FATCA limita el acceso al pilar 3a en Suiza. La mayoría de los proveedores rechaza a las personas estadounidenses o titulares de green card. Antes de simular aportaciones, confirma que un proveedor te acepte (ej. Raiffeisen) y considera palancas alternativas: prestaciones de salida, optimización hipotecaria, inversión libre.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "Ver alternativas al 3a",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Modificar previsión",
   "financialSummaryEditAvoirLpp": "Activos LPP totales (CHF)",
   "financialSummaryEditNombre3a": "Número de cuentas 3a",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Seule une minorité de prestataires accepte (ex. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Pilier 3a — accès limité (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "Ton statut FATCA limite l'accès au pilier 3a en Suisse. La majorité des prestataires refuse les personnes US ou titulaires d'une green card. Avant de simuler des versements, vérifie qu'un prestataire t'accepte (ex. Raiffeisen) et envisage des leviers alternatifs : libre passage, optimisation hypothécaire, investissement libre.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "Voir les alternatives au 3a",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Modifier la prévoyance",
   "financialSummaryEditAvoirLpp": "Avoir LPP total (CHF)",
   "financialSummaryEditNombre3a": "Nombre de comptes 3a",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Solo una minoranza di fornitori accetta (es. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Pilastro 3a — accesso limitato (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "Il tuo status FATCA limita l'accesso al pilastro 3a in Svizzera. La maggior parte dei fornitori rifiuta le persone US o i titolari di green card. Prima di simulare versamenti, verifica che un fornitore ti accetti (es. Raiffeisen) e considera leve alternative: prestazioni di libero passaggio, ottimizzazione ipotecaria, investimento libero.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "Vedi alternative al 3a",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Modificare previdenza",
   "financialSummaryEditAvoirLpp": "Averi LPP totali (CHF)",
   "financialSummaryEditNombre3a": "Numero di conti 3a",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -8344,6 +8344,24 @@ abstract class S {
   /// **'⚠️ FATCA — Seule une minorité de prestataires accepte (ex. Raiffeisen)'**
   String get financialSummaryFatcaWarning;
 
+  /// FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card).
+  ///
+  /// In fr, this message translates to:
+  /// **'Pilier 3a — accès limité (FATCA)'**
+  String get sim3aFatcaGateTitle;
+
+  /// FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton statut FATCA limite l\'accès au pilier 3a en Suisse. La majorité des prestataires refuse les personnes US ou titulaires d\'une green card. Avant de simuler des versements, vérifie qu\'un prestataire t\'accepte (ex. Raiffeisen) et envisage des leviers alternatifs : libre passage, optimisation hypothécaire, investissement libre.'**
+  String get sim3aFatcaGateBody;
+
+  /// FATCA gate CTA — opens an alternatives screen / coach prompt.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voir les alternatives au 3a'**
+  String get sim3aFatcaGateAction;
+
   /// No description provided for @financialSummaryModifierPrevoyance.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -4595,6 +4595,16 @@ class SDe extends S {
       '⚠️ FATCA — Nur eine Minderheit der Anbieter akzeptiert (z.B. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Säule 3a — eingeschränkter Zugang (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'Dein FATCA-Status schränkt den Zugang zur Säule 3a in der Schweiz ein. Die meisten Anbieter lehnen US-Personen oder Green-Card-Inhaber ab. Bevor du Einzahlungen simulierst, vergewissere dich, dass ein Anbieter dich akzeptiert (z.B. Raiffeisen) und erwäge alternative Hebel: Freizügigkeitsguthaben, Hypothekenoptimierung, freies Investment.';
+
+  @override
+  String get sim3aFatcaGateAction => 'Alternativen zur Säule 3a anzeigen';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Vorsorge bearbeiten';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -4566,6 +4566,16 @@ class SEn extends S {
       '⚠️ FATCA — Only a minority of providers accept (e.g. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Pillar 3a — limited access (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'Your FATCA status limits access to Swiss pillar 3a. Most providers refuse US persons or green card holders. Before simulating contributions, confirm a provider accepts you (e.g. Raiffeisen) and consider alternative levers: vested benefits, mortgage optimization, free investment.';
+
+  @override
+  String get sim3aFatcaGateAction => 'See alternatives to 3a';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Edit pension';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -4588,6 +4588,16 @@ class SEs extends S {
       '⚠️ FATCA — Solo una minoría de proveedores acepta (ej. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Pilar 3a — acceso limitado (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'Tu estatus FATCA limita el acceso al pilar 3a en Suiza. La mayoría de los proveedores rechaza a las personas estadounidenses o titulares de green card. Antes de simular aportaciones, confirma que un proveedor te acepte (ej. Raiffeisen) y considera palancas alternativas: prestaciones de salida, optimización hipotecaria, inversión libre.';
+
+  @override
+  String get sim3aFatcaGateAction => 'Ver alternativas al 3a';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Modificar previsión';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -4591,6 +4591,16 @@ class SFr extends S {
       '⚠️ FATCA — Seule une minorité de prestataires accepte (ex. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Pilier 3a — accès limité (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'Ton statut FATCA limite l\'accès au pilier 3a en Suisse. La majorité des prestataires refuse les personnes US ou titulaires d\'une green card. Avant de simuler des versements, vérifie qu\'un prestataire t\'accepte (ex. Raiffeisen) et envisage des leviers alternatifs : libre passage, optimisation hypothécaire, investissement libre.';
+
+  @override
+  String get sim3aFatcaGateAction => 'Voir les alternatives au 3a';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Modifier la prévoyance';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -4596,6 +4596,16 @@ class SIt extends S {
       '⚠️ FATCA — Solo una minoranza di fornitori accetta (es. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Pilastro 3a — accesso limitato (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'Il tuo status FATCA limita l\'accesso al pilastro 3a in Svizzera. La maggior parte dei fornitori rifiuta le persone US o i titolari di green card. Prima di simulare versamenti, verifica che un fornitore ti accetti (es. Raiffeisen) e considera leve alternative: prestazioni di libero passaggio, ottimizzazione ipotecaria, investimento libero.';
+
+  @override
+  String get sim3aFatcaGateAction => 'Vedi alternative al 3a';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Modificare previdenza';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -4586,6 +4586,16 @@ class SPt extends S {
       '⚠️ FATCA — Apenas uma minoria de fornecedores aceita (ex. Raiffeisen)';
 
   @override
+  String get sim3aFatcaGateTitle => 'Pilar 3a — acesso limitado (FATCA)';
+
+  @override
+  String get sim3aFatcaGateBody =>
+      'O teu estatuto FATCA limita o acesso ao pilar 3a na Suíça. A maioria dos fornecedores recusa pessoas dos EUA ou titulares de green card. Antes de simular contribuições, confirma que um fornecedor te aceita (ex. Raiffeisen) e considera alavancas alternativas: prestações de livre passagem, otimização hipotecária, investimento livre.';
+
+  @override
+  String get sim3aFatcaGateAction => 'Ver alternativas ao 3a';
+
+  @override
   String get financialSummaryModifierPrevoyance => 'Modificar previdência';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -2146,6 +2146,18 @@
     }
   },
   "financialSummaryFatcaWarning": "⚠️ FATCA — Apenas uma minoria de fornecedores aceita (ex. Raiffeisen)",
+  "sim3aFatcaGateTitle": "Pilar 3a — acesso limitado (FATCA)",
+  "@sim3aFatcaGateTitle": {
+    "description": "FATCA gate panel title shown on the 3a simulator when canContribute3a is false (US persons / green card)."
+  },
+  "sim3aFatcaGateBody": "O teu estatuto FATCA limita o acesso ao pilar 3a na Suíça. A maioria dos fornecedores recusa pessoas dos EUA ou titulares de green card. Antes de simular contribuições, confirma que um fornecedor te aceita (ex. Raiffeisen) e considera alavancas alternativas: prestações de livre passagem, otimização hipotecária, investimento livre.",
+  "@sim3aFatcaGateBody": {
+    "description": "FATCA gate body explaining why the 3a simulator is not actionable for US persons + alternatives."
+  },
+  "sim3aFatcaGateAction": "Ver alternativas ao 3a",
+  "@sim3aFatcaGateAction": {
+    "description": "FATCA gate CTA — opens an alternatives screen / coach prompt."
+  },
   "financialSummaryModifierPrevoyance": "Modificar previdência",
   "financialSummaryEditAvoirLpp": "Ativos LPP totais (CHF)",
   "financialSummaryEditNombre3a": "Número de contas 3a",

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -77,6 +77,41 @@ enum FinancialArchetype {
   returningSwiss,
 }
 
+/// Extension that exposes the canonical snake_case backend name for each
+/// archetype. The backend `CoachContext.archetype` string + the doctrine
+/// checker (`check_archetype_aware`) expect snake_case ; the Dart enum is
+/// camelCase. Without this conversion the backend silently treats every
+/// query as the default archetype, which masks FATCA / PFIC / frontalier
+/// guards.
+///
+/// Audit fix 2026-05-09 (perimeter STUB at
+/// `.planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md`)
+/// — extracted from `coach_chat_screen._archetypeToBackendName` so other
+/// screens (rachat_echelonne, simulator_3a, …) can reuse it instead of
+/// re-implementing camelCase → snake_case via a buggy `replaceAll('_','_')`.
+extension FinancialArchetypeBackendName on FinancialArchetype {
+  String get backendName {
+    switch (this) {
+      case FinancialArchetype.swissNative:
+        return 'swiss_native';
+      case FinancialArchetype.expatEu:
+        return 'expat_eu';
+      case FinancialArchetype.expatNonEu:
+        return 'expat_non_eu';
+      case FinancialArchetype.expatUs:
+        return 'expat_us';
+      case FinancialArchetype.independentWithLpp:
+        return 'independent_with_lpp';
+      case FinancialArchetype.independentNoLpp:
+        return 'independent_no_lpp';
+      case FinancialArchetype.crossBorder:
+        return 'cross_border';
+      case FinancialArchetype.returningSwiss:
+        return 'returning_swiss';
+    }
+  }
+}
+
 // ════════════════════════════════════════════════════════════════
 //  SOUS-MODELES
 // ════════════════════════════════════════════════════════════════

--- a/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
+++ b/apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart
@@ -188,7 +188,12 @@ class _RachatEchelonneScreenState extends State<RachatEchelonneScreen>
     }
     // Audit 2026-04-18 Q2 (swiss-brain) : OPP2 art. 60b s'applique aux
     // expats < 5 ans de cotisation CH → cap rachat 20% du salaire assuré.
-    _archetype = profile.archetype.name.replaceAll('_', '_').toLowerCase();
+    // Audit 2026-05-09 fix : pre-existing `replaceAll('_', '_').toLowerCase()`
+    // was a no-op (Dart enum `name` is camelCase, not snake_case). Result :
+    // `_archetype` ended up as `'swissnative'` / `'crossborder'` etc. and
+    // never matched the backend snake_case constants. Use the canonical
+    // [FinancialArchetype.backendName] extension instead.
+    _archetype = profile.archetype.backendName;
     final sAssure = profile.prevoyance.salaireAssure;
     if (sAssure != null && sAssure > 0) {
       _salaireAssure = sAssure;

--- a/apps/mobile/lib/screens/simulator_3a_screen.dart
+++ b/apps/mobile/lib/screens/simulator_3a_screen.dart
@@ -300,6 +300,17 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
     final l = S.of(context)!;
     final hasDebt = context.watch<ProfileProvider>().profile?.hasDebt ?? false;
 
+    // Audit fix 2026-05-09 (perimeter STUB
+    // .planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/):
+    // FATCA-affected users (US citizens / green card holders) are blocked
+    // from most Swiss 3a providers (LSFin compliance + PFIC). Render a
+    // calm explainer instead of the simulator inputs so the user does
+    // not waste effort filling fields they can't act on.
+    final coachProfile = context.select<CoachProfileProvider, CoachProfile?>(
+      (p) => p.profile,
+    );
+    final isFatcaBlocked = coachProfile != null && !coachProfile.canContribute3a;
+
     return PopScope(
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) _emitFinalReturn();
@@ -312,7 +323,9 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
         title: Text(l.sim3aTitle, style: MintTextStyles.headlineMedium()),
         actions: const [],
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
+      body: isFatcaBlocked
+          ? _buildFatcaGateBody()
+          : Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -345,6 +358,75 @@ class _Simulator3aScreenState extends State<Simulator3aScreen> {
           ],
         ),
       )))),
+    );
+  }
+
+  /// Audit fix 2026-05-09 (perimeter STUB
+  /// .planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/):
+  /// FATCA gate body. Rendered instead of the simulator inputs when the
+  /// user is FATCA-affected (US person / green card) and Swiss 3a
+  /// providers refuse them. Calm explainer + CTA to coach for
+  /// alternative levers.
+  Widget _buildFatcaGateBody() {
+    final l = S.of(context)!;
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 600),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MintSpacing.lg,
+            vertical: MintSpacing.lg,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MintSurface(
+                tone: MintSurfaceTone.porcelaine,
+                padding: const EdgeInsets.all(MintSpacing.lg),
+                radius: 20,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.flag_outlined,
+                            color: MintColors.primary, size: 28),
+                        const SizedBox(width: MintSpacing.sm),
+                        Expanded(
+                          child: Text(
+                            l.sim3aFatcaGateTitle,
+                            style: MintTextStyles.titleLarge(),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: MintSpacing.md),
+                    Text(
+                      l.sim3aFatcaGateBody,
+                      style: MintTextStyles.bodyMedium(),
+                    ),
+                    const SizedBox(height: MintSpacing.lg),
+                    FilledButton.icon(
+                      onPressed: () {
+                        // Route to coach with FATCA context — coach has the
+                        // alternative-levers playbook and respects
+                        // archetype-aware doctrine via system prompt.
+                        context.push(
+                          '/coach?intent=fatca_3a_alternatives',
+                        );
+                      },
+                      icon: const Icon(Icons.chat_outlined),
+                      label: Text(l.sim3aFatcaGateAction),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: MintSpacing.xl),
+              _buildDisclaimer(),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/apps/mobile/test/models/coach_profile_archetype_backend_name_test.dart
+++ b/apps/mobile/test/models/coach_profile_archetype_backend_name_test.dart
@@ -1,0 +1,81 @@
+/// Tests for [FinancialArchetypeBackendName.backendName] extension.
+///
+/// Audit fix 2026-05-09 (perimeter STUB at
+/// `.planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md`):
+/// Replaces the per-screen ad-hoc conversion (camelCase → snake_case) which
+/// was buggy in `rachat_echelonne_screen.dart:191`
+/// (`name.replaceAll('_', '_')` was a no-op).
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+
+void main() {
+  group('FinancialArchetype.backendName — exhaustive snake_case map', () {
+    test('all 8 archetypes return non-empty snake_case strings', () {
+      for (final a in FinancialArchetype.values) {
+        final name = a.backendName;
+        expect(name, isNotEmpty, reason: 'archetype $a → empty backend name');
+        expect(
+          name,
+          isNot(contains(' ')),
+          reason: 'archetype $a → contains whitespace',
+        );
+        // snake_case: only lowercase ASCII letters + underscores.
+        expect(
+          RegExp(r'^[a-z_]+$').hasMatch(name),
+          isTrue,
+          reason: 'archetype $a → "$name" not snake_case',
+        );
+      }
+    });
+
+    test('explicit mapping matches backend doctrine_checks expectations', () {
+      // Matches the keys in
+      // services/backend/app/services/coach/doctrine_checks.py
+      // _ARCHETYPE_CUES dict (swiss_native / expat_eu / expat_us / etc.).
+      expect(FinancialArchetype.swissNative.backendName, equals('swiss_native'));
+      expect(FinancialArchetype.expatEu.backendName, equals('expat_eu'));
+      expect(FinancialArchetype.expatNonEu.backendName, equals('expat_non_eu'));
+      expect(FinancialArchetype.expatUs.backendName, equals('expat_us'));
+      expect(
+        FinancialArchetype.independentWithLpp.backendName,
+        equals('independent_with_lpp'),
+      );
+      expect(
+        FinancialArchetype.independentNoLpp.backendName,
+        equals('independent_no_lpp'),
+      );
+      expect(FinancialArchetype.crossBorder.backendName, equals('cross_border'));
+      expect(
+        FinancialArchetype.returningSwiss.backendName,
+        equals('returning_swiss'),
+      );
+    });
+
+    test(
+      'PRE-FIX REGRESSION GUARD: enum.name.toLowerCase() does NOT match',
+      () {
+        // The pre-fix code at rachat_echelonne_screen.dart:191 did
+        // `profile.archetype.name.replaceAll('_', '_').toLowerCase()` which
+        // produced 'swissnative' / 'crossborder' (no underscore). The
+        // backend expects 'swiss_native' / 'cross_border'. The bug went
+        // unnoticed because doctrine_checks fell back to the default
+        // archetype on every mismatch.
+        for (final a in FinancialArchetype.values) {
+          final buggy = a.name.toLowerCase();
+          final canonical = a.backendName;
+          if (canonical.contains('_')) {
+            expect(
+              buggy,
+              isNot(equals(canonical)),
+              reason:
+                  'Pre-fix path .name.toLowerCase() should differ from '
+                  'canonical backendName for $a',
+            );
+          }
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **3a simulator FATCA gate** — when `coachProfile.canContribute3a == false` (US person / green card / FATCA), render a calm explainer panel + CTA to coach with `intent=fatca_3a_alternatives` instead of the simulator inputs.
- **Canonical `backendName` extension** — promotes the camelCase → snake_case archetype mapping from a private method on `coach_chat_screen.dart` to a top-level extension on `FinancialArchetype` so other surfaces stop re-implementing it (single source of truth, CLAUDE.md NEVER #3).
- **Fix `rachat_echelonne_screen.dart:191`** — replaces the no-op `replaceAll('_', '_').toLowerCase()` (which produced `'crossborder'` etc.) with `profile.archetype.backendName`. Pre-fix, the buggy string never matched backend doctrine_checks → every archetype silently fell back to `swiss_native`, masking OPP2 art. 60b expat caps in rachat recommendations.

## Why

PR #533 audit synthesis P0 #4 line item. Both bugs are silent failure modes — the simulator builds a full projection a US user can't act on ; rachat_echelonne ships archetype-blind recommendations. Perimeter STUB at `.planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md`.

## ARB delta

3 new keys × 6 locales (fr / en / de / es / it / pt) :
- `sim3aFatcaGateTitle`
- `sim3aFatcaGateBody`
- `sim3aFatcaGateAction`

LSFin-compliant copy. No banned terms (« garanti », « optimal » etc.). No promise.

## 0-Trust receipts (CLAUDE.md §9)

- `flutter analyze` on touched files → 0 issues
- `flutter test test/models/` → 213 passed
- New `coach_profile_archetype_backend_name_test.dart` → 3 passed (exhaustive map + regression guard)
- `flutter gen-l10n` regenerated cleanly

## What this PR does NOT claim

Stage 1 of 4 per CLAUDE.md §9.5. Verifiable post-merge :
- G1 sim walker — flip seed to `expat_us` archetype, open `/simulator/3a`, assert FATCA panel + no input fields
- G2 device by Julien on TestFlight v2.12.2+5 (set US nationality temporarily)
- G3 dev CI green
- G4 archetype-distribution telemetry for 1 week to size FATCA-affected user base

## Test plan

- [ ] CI green on this PR
- [ ] Post-merge: walk a fresh `expat_us` seed through `/simulator/3a` → assert gate renders
- [ ] Post-merge: walk a `cross_border` seed through `/lpp/rachat-echelonne` → assert archetype string at backend = `'cross_border'` (regression closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)