### PR TITLE
fix(p1): archetype-aware annual refresh + precision field help (B-EXP-F P1 sweep)

### DIFF
--- a/.planning/decisions/2026-05-09-perimeter-p1-cron-archetype-aware/STUB.md
+++ b/.planning/decisions/2026-05-09-perimeter-p1-cron-archetype-aware/STUB.md
@@ -1,0 +1,89 @@
+---
+name: MVP-P1-CRON-ARCHETYPE-AWARE — perimeter STUB
+description: Audit findings 2026-05-08 (PR #533 P1 sweep) — (a) annual_refresh_service.py:145 yearly cron asks « Ton salaire annuel brut a-t-il change ? » to retirees who have no salary ; (b) precision_service.py:99,109 hardcodes « Fiche de salaire mensuelle » as the canonical source for both salaire_brut and salaire_net, ignoring independents / retirees / cross-border. Both reframed to be archetype-aware. Effort ~0.3 j.
+type: decision
+date: 2026-05-09
+status: STUB → IN_FLIGHT (this PR opens with the fix)
+related:
+  - .planning/decisions/2026-05-09-perimeter-archetype-input-normalization/STUB.md
+  - .planning/decisions/2026-05-09-perimeter-fatca-calculator-gate/STUB.md
+sources:
+  - PR #533 audit synthesis P1 sweep B-EXP-F-1 + B-EXP-F-2 line items
+  - Code trace `services/backend/app/services/scenario/annual_refresh_service.py:145` (salary-only label)
+  - Code trace `services/backend/app/services/precision/precision_service.py:99,109` (Fiche de salaire prescriptive)
+---
+
+# MVP-P1-CRON-ARCHETYPE-AWARE — STUB
+
+## Goal
+
+**Reframe two backend services so they don't assume a salaried-active archetype** :
+
+1. `annual_refresh_service` — accepts `employment_status` and reframes the salary / job-change questions when the user is `'retraite'`. Same pattern as the B2 fix on `suggest_actions` chips (« source de revenus » instead of « salaire »).
+2. `precision_service` — `salaire_brut` / `salaire_net` field-help entries reframed to cover the 8 archetypes (salaried, independent, retiree, FATCA in transition, cross-border, etc.) instead of prescribing « Fiche de salaire mensuelle » as the only source.
+
+## Background (CLAUDE.md NEVER #4 + #7)
+
+MINT positioned itself as 18-99 multi-archetype after the 2026-04-12 pivot. But two backend services kept the salaried-active framing :
+- A retiree opening the app in Jan would get a yearly cron prompt « Ton salaire annuel brut a-t-il change ? » → frustrating, condescending, signals MINT « doesn't know me ».
+- An independent uploading their tax declaration would see « Cherche ta fiche de salaire mensuelle » in field help → wrong document type.
+
+Both cases are silent fail modes (the user-facing copy is misleading but doesn't break the flow). They erode trust over months.
+
+## Fix
+
+### `annual_refresh_service.py`
+
+- New optional `employment_status` parameter on `generate_refresh_questions()`, propagated to `_build_questions()`.
+- When `employment_status == 'retraite'`, the salary question becomes :
+  - `« Tes sources de revenus (rentes, retraits, autres) ont-elles change ? »`
+- And the job-change question becomes :
+  - `« Y a-t-il eu un changement dans ta situation (rente, activite reduite, deces conjoint) ? »`
+- All other archetypes (None, 'salarie', 'independant', etc.) keep the current salary-framed labels (since most data flows still assume them).
+- `risk_profile`, `current_lpp`, `current_3a` questions unchanged — these are universal.
+
+### `precision_service.py`
+
+- `salaire_brut.where_to_find` reframed to enumerate three sources : salaried (fiche de salaire), independent (declaration fiscale), retiree (rentes + autres revenus).
+- `salaire_net.where_to_find` same pattern.
+- `document_name` now lists multiple acceptable documents.
+- `fallback_estimation` made archetype-agnostic.
+
+## 5 gates mécaniques
+
+| Gate | Description | Évidence |
+|---|---|---|
+| G1 | sim walker — set seed.employment_status='retraite' on a stale profile, trigger annual refresh, assert salary question label contains « rentes » or « retraits » | walker logs |
+| G2 | device by Julien — flip his profile to 'retraite' temporarily on TestFlight v2.12.2+5, hit the 12-month cron, confirm reframed questions | TestFlight |
+| G3 | dev CI green — backend pytest (incl. new annual_refresh employment_status branches) | run green |
+| G4 | regression tests — `test_annual_refresh_archetype_aware.py` covers 'salarie' (legacy phrasing) + 'retraite' (new phrasing) + None (legacy phrasing) | new test exit 0 |
+| G5 | LSFin/accent/ARB lint — backend Python only ; no ARB changes ; lint clean | banned_terms exit 0 |
+
+## Tâches breakdown
+
+| # | Action | Effort | Dépendance |
+|---|---|---|---|
+| 1 | annual_refresh_service: add `employment_status` param to `generate_refresh_questions` + `_build_questions` | 0.05 j | None |
+| 2 | annual_refresh_service: branch salary + job labels on `is_retired` | 0.05 j | 1 |
+| 3 | precision_service: reframe `salaire_brut.where_to_find` + `document_name` + `fallback_estimation` | 0.05 j | None |
+| 4 | precision_service: reframe `salaire_net.where_to_find` + `document_name` + `fallback_estimation` | 0.05 j | None |
+| 5 | regression test `test_annual_refresh_archetype_aware.py` — 3 archetypes × salary label assertion | 0.1 j | 1+2 |
+| 6 | full backend pytest pass | 0.05 j | All |
+
+**Total estimé** : ~0.3 j.
+
+## Counter-arguments and data gaps
+
+- **Risk 1** : Other archetypes (independent, student, expat_us in transition) still get the salary-framed labels. This is intentional v1 — independents do have salary-equivalent income (revenue net independant) ; students and transition-state users typically don't trigger the annual refresh cron in the first place. v2 could reframe further.
+- **Risk 2** : The `precision_service` fix changes user-visible copy. If users had memorized the old « Fiche de salaire mensuelle » phrasing they may be confused by the new enumeration. Mitigation : the new copy is a SUPERSET of the old ; old paths still work.
+- **Risk 3** : Backwards compat — existing callers of `generate_refresh_questions()` don't pass `employment_status`. The new param defaults to None ; legacy behavior preserved. Tests cover this.
+- **Risk 4** : Banned-term sweep — new copy uses « rentes », « retraits », « decompte de rente », none of which are banned per LSFin (no « garanti », « optimal », « meilleur »). Verified manually.
+- **Data gap** : No telemetry on actual archetype distribution. We don't know how often the retiree-on-salary-cron mismatch fires today. Mitigation : log archetype × cron-fired event for 1 week post-deploy ; size impact based on actual ratio.
+
+## Approval gate
+
+**This PR opens immediately**. The fixes are backend-only, surgical, fully unit-tested, and reverse cleanly.
+
+## Order of fixes (within this perimeter)
+
+Single commit covering both services + STUB + regression test.

--- a/services/backend/app/services/precision/precision_service.py
+++ b/services/backend/app/services/precision/precision_service.py
@@ -92,28 +92,39 @@ _FIELD_HELP_REGISTRY: Dict[str, FieldHelp] = {
     ),
     "salaire_brut": FieldHelp(
         field_name="salaire_brut",
+        # B-EXP-F-2 audit fix 2026-05-09 : phrasing was salaried-active
+        # only ("Fiche de salaire mensuelle"). Independents, retirees,
+        # students, expat_us in transition, returning_swiss don't have a
+        # salary slip. Reframe via "selon ta source de revenus" so it
+        # covers the 8 archetypes (CLAUDE.md NEVER #4 + #7).
         where_to_find=(
-            "Ton salaire brut annuel figure sur ta fiche de salaire (ligne 'Salaire brut') "
-            "ou sur ton contrat de travail. Inclus le 13e salaire si applicable."
+            "Selon ta source de revenus : pour un emploi salarie, fiche de salaire "
+            "(ligne 'Salaire brut') ou contrat — inclus le 13e si applicable. Pour un "
+            "statut independant, declaration fiscale (revenu net independant). Pour "
+            "un statut retraite / sans emploi, somme des rentes et autres revenus."
         ),
-        document_name="Fiche de salaire mensuelle ou contrat de travail",
-        german_name="Bruttolohn (Lohnabrechnung / Arbeitsvertrag)",
+        document_name="Fiche de salaire / contrat / declaration fiscale / decompte de rente",
+        german_name="Lohnabrechnung / Vertrag / Steuererklaerung / Rentenabrechnung",
         fallback_estimation=(
-            "Tu peux aussi regarder ta declaration fiscale: "
-            "le revenu d'activite lucrative dependante."
+            "A defaut, tu peux estimer a partir de ta declaration fiscale "
+            "ou des decomptes mensuels recents."
         ),
     ),
     "salaire_net": FieldHelp(
         field_name="salaire_net",
+        # B-EXP-F-2 audit fix 2026-05-09 : same archetype-blind phrasing.
         where_to_find=(
-            "Ton salaire net mensuel figure en bas de ta fiche de salaire, "
-            "apres deductions AVS, LPP, AC, impot a la source (si applicable)."
+            "Selon ta source de revenus : pour un emploi salarie, bas de la fiche de "
+            "salaire (apres AVS, LPP, AC, impot a la source si applicable). Pour un "
+            "statut independant, revenu net apres cotisations sociales et charges "
+            "professionnelles. Pour une rente, montant net verse mensuellement."
         ),
-        document_name="Fiche de salaire mensuelle",
-        german_name="Nettolohn (Lohnabrechnung)",
+        document_name="Fiche de salaire / decompte cotisations / decompte de rente",
+        german_name="Lohnabrechnung / Beitragsabrechnung / Rentenabrechnung",
         fallback_estimation=(
-            "En general, le net represente 75-85% du brut selon le canton "
-            "et la situation familiale."
+            "En general, pour un emploi salarie, le net represente 75-85% du brut "
+            "selon le canton et la situation familiale ; pour les autres statuts, "
+            "se referer aux decomptes specifiques."
         ),
     ),
     "taux_marginal": FieldHelp(

--- a/services/backend/app/services/scenario/annual_refresh_service.py
+++ b/services/backend/app/services/scenario/annual_refresh_service.py
@@ -94,6 +94,7 @@ class AnnualRefreshService:
         risk_profile: str = "modere",
         last_major_update: Optional[date] = None,
         today: Optional[date] = None,
+        employment_status: Optional[str] = None,
     ) -> AnnualRefreshResult:
         """Generate the 7 refresh questions with pre-filled values.
 
@@ -104,6 +105,13 @@ class AnnualRefreshService:
             risk_profile: Current risk profile (conservateur/modere/dynamique).
             last_major_update: Date of last update (for months_since calculation).
             today: Override for current date (for testing).
+            employment_status: Optional employment status code
+                ('salarie', 'independant', 'retraite', 'student', ...).
+                When set to 'retraite', the salary question is reframed
+                ("source de revenus" instead of "salaire brut") to avoid
+                hitting retirees with an inapplicable cron prompt
+                (B-EXP-F-1 audit fix 2026-05-09 — perimeter STUB
+                .planning/decisions/2026-05-09-perimeter-p1-cron-archetype-aware/).
 
         Returns:
             AnnualRefreshResult with refresh_needed flag and 7 questions.
@@ -121,6 +129,7 @@ class AnnualRefreshService:
             current_lpp=current_lpp,
             current_3a=current_3a,
             risk_profile=risk_profile,
+            employment_status=employment_status,
         )
 
         return AnnualRefreshResult(
@@ -137,18 +146,36 @@ class AnnualRefreshService:
         current_lpp: float,
         current_3a: float,
         risk_profile: str,
+        employment_status: Optional[str] = None,
     ) -> List[RefreshQuestion]:
-        """Build the 7 standard refresh questions."""
+        """Build the 7 standard refresh questions.
+
+        B-EXP-F-1 audit fix 2026-05-09 : when employment_status == 'retraite',
+        reframe the salary question to "source de revenus" so retirees
+        don't get a yearly cron prompt about a salary they don't have.
+        Same pattern as the B2 fix on suggest_actions chips.
+        """
+        is_retired = employment_status == "retraite"
+        salary_label = (
+            "Tes sources de revenus (rentes, retraits, autres) ont-elles change ?"
+            if is_retired
+            else "Ton salaire annuel brut a-t-il change ?"
+        )
+        job_label = (
+            "Y a-t-il eu un changement dans ta situation (rente, activite reduite, deces conjoint) ?"
+            if is_retired
+            else "As-tu change d'emploi ou de statut professionnel ?"
+        )
         return [
             RefreshQuestion(
                 key="salary_changed",
-                label="Ton salaire annuel brut a-t-il change ?",
+                label=salary_label,
                 question_type="slider",
                 current_value=_format_chf_value(current_salary) if current_salary else None,
             ),
             RefreshQuestion(
                 key="job_changed",
-                label="As-tu change d'emploi ou de statut professionnel ?",
+                label=job_label,
                 question_type="yes_no",
             ),
             RefreshQuestion(

--- a/services/backend/tests/test_annual_refresh_archetype_aware.py
+++ b/services/backend/tests/test_annual_refresh_archetype_aware.py
@@ -1,0 +1,112 @@
+"""B-EXP-F-1 regression tests — archetype-aware annual refresh.
+
+Audit finding 2026-05-08 (PR #533) : the yearly refresh cron asked
+« Ton salaire annuel brut a-t-il change ? » to retirees. Reframed to
+« Tes sources de revenus (rentes, retraits, autres) ont-elles change ? »
+when employment_status == 'retraite'.
+
+Refs:
+- Perimeter STUB
+  .planning/decisions/2026-05-09-perimeter-p1-cron-archetype-aware/STUB.md
+"""
+
+from __future__ import annotations
+
+from app.services.scenario.annual_refresh_service import AnnualRefreshService
+
+
+def test_legacy_no_employment_status_keeps_salary_label():
+    """Backward-compat: callers that don't pass employment_status get the
+    pre-fix salary-framed labels.
+    """
+    service = AnnualRefreshService()
+    result = service.generate_refresh_questions(
+        current_salary=120000,
+        current_lpp=350000,
+        current_3a=22000,
+    )
+    salary_q = next(q for q in result.questions if q.key == "salary_changed")
+    assert "salaire" in salary_q.label.lower()
+    assert "rentes" not in salary_q.label.lower()
+
+
+def test_employment_status_salarie_keeps_salary_label():
+    """Active salaried users get the standard salary-framed labels."""
+    service = AnnualRefreshService()
+    result = service.generate_refresh_questions(
+        current_salary=120000,
+        current_lpp=350000,
+        current_3a=22000,
+        employment_status="salarie",
+    )
+    salary_q = next(q for q in result.questions if q.key == "salary_changed")
+    assert "salaire" in salary_q.label.lower()
+
+
+def test_employment_status_retraite_reframes_salary_to_revenue_sources():
+    """Retirees get reframed labels — « sources de revenus » instead of
+    « salaire annuel brut ».
+
+    This is the device-friendly fix that prevents the yearly cron from
+    asking a retiree about a salary they don't have.
+    """
+    service = AnnualRefreshService()
+    result = service.generate_refresh_questions(
+        current_salary=0,
+        current_lpp=350000,
+        current_3a=22000,
+        employment_status="retraite",
+    )
+    salary_q = next(q for q in result.questions if q.key == "salary_changed")
+    assert "salaire" not in salary_q.label.lower(), (
+        f"Retiree should not see 'salaire' in cron prompt — got "
+        f"{salary_q.label!r}"
+    )
+    assert "rentes" in salary_q.label.lower() or "revenus" in salary_q.label.lower()
+
+
+def test_employment_status_retraite_reframes_job_change_too():
+    """The companion 'job_changed' question is also archetype-aware so
+    a retiree isn't asked « As-tu change d'emploi ».
+    """
+    service = AnnualRefreshService()
+    result = service.generate_refresh_questions(
+        employment_status="retraite",
+    )
+    job_q = next(q for q in result.questions if q.key == "job_changed")
+    label = job_q.label.lower()
+    # Should reference retiree-relevant change events, not job change.
+    assert "emploi" not in label or "rente" in label, (
+        f"Retiree job-change prompt should reference rente / activite "
+        f"reduite, got {job_q.label!r}"
+    )
+
+
+def test_question_count_unchanged_at_seven():
+    """All 7 questions still present regardless of employment_status —
+    only the labels are reframed, not the structure.
+    """
+    service = AnnualRefreshService()
+    for status in (None, "salarie", "retraite", "independant", "student"):
+        result = service.generate_refresh_questions(
+            employment_status=status,
+        )
+        assert len(result.questions) == 7, (
+            f"Expected 7 questions for employment_status={status!r}, "
+            f"got {len(result.questions)}"
+        )
+
+
+def test_lpp_3a_questions_unchanged_across_archetypes():
+    """LPP and 3a questions are universal (don't depend on archetype)."""
+    service = AnnualRefreshService()
+    legacy = service.generate_refresh_questions(employment_status=None)
+    retired = service.generate_refresh_questions(employment_status="retraite")
+
+    legacy_lpp = next(q for q in legacy.questions if q.key == "lpp_balance")
+    retired_lpp = next(q for q in retired.questions if q.key == "lpp_balance")
+    assert legacy_lpp.label == retired_lpp.label
+
+    legacy_3a = next(q for q in legacy.questions if q.key == "three_a_balance")
+    retired_3a = next(q for q in retired.questions if q.key == "three_a_balance")
+    assert legacy_3a.label == retired_3a.label


### PR DESCRIPTION
## Summary

Two backend services reframed to be archetype-aware (same pattern as the B2 fix on `suggest_actions` chips):

- **annual_refresh_service** — yearly cron no longer asks « Ton salaire annuel brut a-t-il change ? » to retirees. New optional `employment_status` parameter ; when `'retraite'`, salary question reframes to « Tes sources de revenus (rentes, retraits, autres) ont-elles change ? » + job-change question reframes to retiree-relevant events (rente, activite reduite, deces conjoint).
- **precision_service** — `salaire_brut` / `salaire_net` field-help entries reframed to enumerate 3 sources (salaried / independent / retiree) instead of prescribing « Fiche de salaire mensuelle » as the only acceptable document.

## Why

PR #533 audit synthesis P1 sweep (B-EXP-F-1 + B-EXP-F-2). Both bugs are silent fail modes — the user-facing copy is misleading but doesn't break the flow ; trust erodes over months. CLAUDE.md NEVER #4 (MINT ≠ retirement-first) + NEVER #7 (don't assume swiss_native).

Perimeter STUB at `.planning/decisions/2026-05-09-perimeter-p1-cron-archetype-aware/STUB.md`.

## 0-Trust receipts (CLAUDE.md §9)

- Backend pytest: 6047 passed, 6 skipped (was 6041, +6 new tests in this PR)
- New `test_annual_refresh_archetype_aware.py` → 6 passed
- Backwards compat verified : legacy callers (no `employment_status` param) get the pre-fix salary-framed labels
- LSFin/banned-term sweep clean

## What this PR does NOT claim

Stage 1 of 4 per CLAUDE.md §9.5. Verifiable post-merge :
- G1 sim walker — flip seed.employment_status to 'retraite', force annual refresh trigger, assert reframed labels
- G2 device by Julien on TestFlight v2.12.2+5
- G3 dev CI green
- G4 archetype × cron-fired telemetry for 1 week to size impact

## Test plan

- [ ] CI green on this PR
- [ ] Post-merge: walk a 'retraite' seed through the 12-month staleness threshold ; confirm cron prompt reframed

🤖 Generated with [Claude Code](https://claude.com/claude-code)