### PR TITLE
fix(auth-gate): GoRouterState.of(context) Sentry fatal 070bdda9 (showModalBottomSheet)

### DIFF
--- a/apps/mobile/lib/widgets/auth/auth_gate.dart
+++ b/apps/mobile/lib/widgets/auth/auth_gate.dart
@@ -72,6 +72,13 @@ class AuthGate extends StatelessWidget {
   }
 
   void _showRegistrationSheet(BuildContext context) {
+    // Capture the current route NOW with the outer (GoRouter-rooted) context.
+    // showModalBottomSheet's builder gets a stripped context that lives below
+    // a Navigator overlay — calling `GoRouterState.of(context)` from inside
+    // the sheet builder throws « The parent route must be a page route to
+    // have a GoRouterState ». Sentry fatal `070bdda9…` 2026-05-04 18:48 UTC
+    // (ch.mint.app@2.9.0+37, /byok). Pass the route down as a parameter.
+    final currentRoute = GoRouterState.of(context).uri.toString();
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: MintColors.transparent,
@@ -79,7 +86,10 @@ class AuthGate extends StatelessWidget {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
-      builder: (_) => _RegistrationBottomSheet(trigger: triggerContext),
+      builder: (_) => _RegistrationBottomSheet(
+        trigger: triggerContext,
+        currentRoute: currentRoute,
+      ),
     );
   }
 }
@@ -157,14 +167,16 @@ String _messageForTrigger(AuthTrigger trigger, S l) {
 
 class _RegistrationBottomSheet extends StatelessWidget {
   final AuthTrigger trigger;
+  final String currentRoute;
 
-  const _RegistrationBottomSheet({required this.trigger});
+  const _RegistrationBottomSheet({
+    required this.trigger,
+    required this.currentRoute,
+  });
 
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
-    final currentRoute =
-        GoRouterState.of(context).uri.toString();
 
     return Container(
       constraints: BoxConstraints(

--- a/tools/checks/baselines/prefer_mint_cta.baseline.txt
+++ b/tools/checks/baselines/prefer_mint_cta.baseline.txt
@@ -89,8 +89,8 @@ lib/services/slm/slm_auto_prompt_service.dart:226: FilledButton(
 lib/services/slm/slm_auto_prompt_service.dart:282: OutlinedButton(
 lib/widgets/analytics_consent_banner.dart:174: OutlinedButton(
 lib/widgets/analytics_consent_banner.dart:196: FilledButton(
-lib/widgets/auth/auth_gate.dart:232: ElevatedButton(
-lib/widgets/auth/auth_gate.dart:259: TextButton(
+lib/widgets/auth/auth_gate.dart:244: ElevatedButton(
+lib/widgets/auth/auth_gate.dart:271: TextButton(
 lib/widgets/auth/auth_gate_bottom_sheet.dart:116: TextButton(
 lib/widgets/auth/auth_gate_bottom_sheet.dart:140: TextButton(
 lib/widgets/auth/auth_gate_bottom_sheet.dart:90: ElevatedButton(


### PR DESCRIPTION
## Summary
- Capture `currentRoute` from outer GoRouter-rooted context BEFORE `showModalBottomSheet`, pass to `_RegistrationBottomSheet` as constructor param
- Fixes Sentry fatal `070bdda9…` 2026-05-04 18:48 UTC, ch.mint.app@2.9.0+37, /byok route

## Background
`GoRouterState.of(context)` inside `showModalBottomSheet`'s builder throws « The parent route must be a page route to have a GoRouterState » because the sheet builder receives a stripped context that lives below a Navigator overlay.

The crash has been latent in local-only branch `fix/sim-walkthrough-crash-loop` since 2026-05-07 without ever being merged. Recovered during 2026-05-10 branch hygiene audit.

## Test plan
- [x] Single call site of `_RegistrationBottomSheet` in `auth_gate.dart:82` ; constructor at L161 — change is contained
- [ ] Manual sim verification on /byok route (existing Sentry trigger path)
- [ ] CI: `flutter analyze` + `flutter test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)