### PR TITLE
chore: cleanup bundle 2026-05-10 (build/lib gitignore + docs/brand + 2 Flutter skills)

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,30 @@
+# `.agents/skills/` — universal-agent skills
+
+Imported skills that work across multiple agent CLIs (Claude Code, Cursor, Copilot, etc.).
+
+Distinct from `.claude/skills/` which holds Claude-Code-specific skills (`mint-flutter-dev`, `mint-backend-dev`, etc.).
+
+## Currently installed
+
+| Skill | Source | Purpose | Why imported |
+|-------|--------|---------|--------------|
+| [flutter-fix-layout-issues](flutter-fix-layout-issues/SKILL.md) | github.com/flutter/skills | RenderFlex / unbounded-constraint debugging | Pure complement to MINT's mint-flutter-dev — used on-demand when layout errors happen |
+| [flutter-add-integration-test](flutter-add-integration-test/SKILL.md) | github.com/flutter/skills | integration_test package setup + Flutter Driver | Maestro complement — in-process integration tests for fast inner loops |
+
+## NOT imported (deliberate)
+
+Per audit `.planning/audit/codebase-audit-2026-05-10/flutter-skills-evaluation.md`, these flutter/skills entries are NOT adopted:
+
+| Skill | Why not |
+|-------|---------|
+| `flutter-apply-architecture-best-practices` | Conflicts with locked MINT decisions: pushes MVVM/`lib/data,domain,ui/` ≠ MINT's `screens/widgets/services` |
+| `flutter-setup-declarative-routing` | go_router already setup at `apps/mobile/lib/router/` (locked) |
+| `flutter-setup-localization` | l10n already setup at `apps/mobile/lib/l10n/` (6 ARBs locked) |
+| 5 others | Off-stack or redundant with MINT's existing skills |
+
+## Update procedure
+
+```bash
+# Refresh from upstream
+gh api repos/flutter/skills/contents/skills/<skill-name>/SKILL.md --jq '.download_url' | xargs curl -fsSL > .agents/skills/<skill-name>/SKILL.md
+```

--- a/.agents/skills/flutter-add-integration-test/SKILL.md
+++ b/.agents/skills/flutter-add-integration-test/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: flutter-add-integration-test
+description: Configures Flutter Driver for app interaction and converts MCP actions into permanent integration tests. Use when adding integration testing to a project, exploring UI components via MCP, or automating user flows with the integration_test package.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 18:29:20 GMT
+---
+# Implementing Flutter Integration Tests
+
+## Contents
+- [Project Setup and Dependencies](#project-setup-and-dependencies)
+- [Interactive Exploration via MCP](#interactive-exploration-via-mcp)
+- [Test Authoring Guidelines](#test-authoring-guidelines)
+- [Execution and Profiling](#execution-and-profiling)
+- [Workflow: End-to-End Integration Testing](#workflow-end-to-end-integration-testing)
+- [Examples](#examples)
+
+## Project Setup and Dependencies
+
+Configure the project to support integration testing and Flutter Driver extensions.
+
+1. Add required development dependencies to `pubspec.yaml`:
+   ```bash
+   flutter pub add 'dev:integration_test:{"sdk":"flutter"}'
+   flutter pub add 'dev:flutter_test:{"sdk":"flutter"}'
+   ```
+2. Enable the Flutter Driver extension in your application entry point (typically `lib/main.dart` or a dedicated `lib/main_test.dart`):
+   - Import `package:flutter_driver/driver_extension.dart`.
+   - Call `enableFlutterDriverExtension();` before `runApp()`.
+3. Add `Key` parameters (e.g., `ValueKey('login_button')`) to critical widgets in the application code to ensure reliable targeting during tests.
+
+## Interactive Exploration via MCP
+
+Use the Dart/Flutter MCP server tools to interactively explore and manipulate the application state before writing static tests.
+
+- **Launch**: Execute `launch_app` with `target: "lib/main_test.dart"` to start the application and acquire the DTD URI.
+- **Inspect**: Execute `get_widget_tree` to discover available `Key`s, `Text` nodes, and widget `Type`s.
+- **Interact**: Execute `tap`, `enter_text`, and `scroll` to simulate user flows.
+- **Wait**: Always execute `waitFor` or verify state with `get_health` when navigating or triggering animations.
+- **Troubleshoot Unmounted Widgets**: If a widget is not found in the tree, it may be lazily loaded in a `SliverList` or `ListView`. Execute `scroll` or `scrollIntoView` to force the widget to mount before interacting with it.
+
+## Test Authoring Guidelines
+
+Structure integration tests using the `flutter_test` API paradigm. 
+
+- Create a dedicated `integration_test/` directory at the project root.
+- Name all test files using the `<name>_test.dart` convention.
+- Initialize the binding by calling `IntegrationTestWidgetsFlutterBinding.ensureInitialized();` at the start of `main()`.
+- Load the application UI using `await tester.pumpWidget(MyApp());`.
+- Trigger frames and wait for animations to complete using `await tester.pumpAndSettle();` after interactions like `tester.tap()`.
+- Assert widget visibility using `expect(find.byKey(ValueKey('foo')), findsOneWidget);` or `findsNothing`.
+- Scroll to specific off-screen widgets using `await tester.scrollUntilVisible(itemFinder, 500.0, scrollable: listFinder);`.
+
+**Conditional Logic for Legacy `flutter_driver`:**
+- If maintaining or migrating legacy `flutter_driver` tests, use `driver.waitFor()`, `driver.waitForAbsent()`, `driver.tap()`, and `driver.scroll()` instead of the `WidgetTester` APIs.
+
+## Execution and Profiling
+
+Execute tests using the `flutter drive` command. Require a host driver script located in `test_driver/integration_test.dart` that calls `integrationDriver()`.
+
+**Conditional Execution Targets:**
+- **If testing on Chrome:** Launch `chromedriver --port=4444` in a separate terminal, then run:
+  `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart -d chrome`
+- **If testing headless web:** Run with `-d web-server`.
+- **If testing on Android (Local):** Run `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart`.
+- **If testing on Firebase Test Lab (Android):** 
+  1. Build debug APK: `flutter build apk --debug`
+  2. Build test APK: `./gradlew app:assembleAndroidTest`
+  3. Upload both APKs to the Firebase Test Lab console.
+
+## Workflow: End-to-End Integration Testing
+
+Copy and follow this checklist to implement and verify integration tests.
+
+- [ ] **Task Progress: Setup**
+  - [ ] Add `integration_test` and `flutter_test` to `pubspec.yaml`.
+  - [ ] Inject `enableFlutterDriverExtension()` into the app entry point.
+  - [ ] Assign `ValueKey`s to target widgets.
+- [ ] **Task Progress: Exploration**
+  - [ ] Run `launch_app` via MCP.
+  - [ ] Map the widget tree using `get_widget_tree`.
+  - [ ] Validate interaction paths using MCP tools (`tap`, `enter_text`).
+- [ ] **Task Progress: Authoring**
+  - [ ] Create `integration_test/app_test.dart`.
+  - [ ] Write test cases using `WidgetTester` APIs.
+  - [ ] Create `test_driver/integration_test.dart` with `integrationDriver()`.
+- [ ] **Task Progress: Execution & Feedback Loop**
+  - [ ] Run `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/app_test.dart`.
+  - [ ] **Feedback Loop**: Review test output -> If `PumpAndSettleTimedOutException` occurs, check for infinite animations -> If widget not found, add `scrollUntilVisible` -> Re-run test until passing.
+
+## Examples
+
+### Standard Integration Test (`integration_test/app_test.dart`)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:my_app/main.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('End-to-end test', () {
+    testWidgets('tap on the floating action button, verify counter', (tester) async {
+      // Load app widget.
+      await tester.pumpWidget(const MyApp());
+
+      // Verify the counter starts at 0.
+      expect(find.text('0'), findsOneWidget);
+
+      // Find the floating action button to tap on.
+      final fab = find.byKey(const ValueKey('increment'));
+
+      // Emulate a tap on the floating action button.
+      await tester.tap(fab);
+
+      // Trigger a frame and wait for animations.
+      await tester.pumpAndSettle();
+
+      // Verify the counter increments by 1.
+      expect(find.text('1'), findsOneWidget);
+    });
+  });
+}
+```
+
+### Host Driver Script (`test_driver/integration_test.dart`)
+
+```dart
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();
+```
+
+### Performance Profiling Driver Script (`test_driver/perf_driver.dart`)
+
+Use this driver script if you wrap your test actions in `binding.traceAction()` to capture performance metrics.
+
+```dart
+import 'package:flutter_driver/flutter_driver.dart' as driver;
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) async {
+      if (data != null) {
+        final timeline = driver.Timeline.fromJson(
+          data['scrolling_timeline'] as Map<String, dynamic>,
+        );
+
+        final summary = driver.TimelineSummary.summarize(timeline);
+
+        await summary.writeTimelineToFile(
+          'scrolling_timeline',
+          pretty: true,
+          includeSummary: true,
+        );
+      }
+    },
+  );
+}
+```

--- a/.agents/skills/flutter-fix-layout-issues/SKILL.md
+++ b/.agents/skills/flutter-fix-layout-issues/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: flutter-fix-layout-issues
+description: Fixes Flutter layout errors (overflows, unbounded constraints) using Dart and Flutter MCP tools. Use when addressing "RenderFlex overflowed", "Vertical viewport was given unbounded height", or similar layout issues.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 19:45:59 GMT
+---
+# Resolving Flutter Layout Errors
+
+## Contents
+- [Constraint Violation Diagnostics](#constraint-violation-diagnostics)
+- [Layout Error Resolution Workflow](#layout-error-resolution-workflow)
+- [Examples](#examples)
+
+## Constraint Violation Diagnostics
+
+Flutter layout operates on a strict rule: **Constraints go down. Sizes go up. Parent sets position.** Layout errors occur when this negotiation fails, typically due to unbounded constraints or unconstrained children. 
+
+Diagnose layout failures using the following error signatures:
+
+*   **"Vertical viewport was given unbounded height"**: Triggered when a scrollable widget (`ListView`, `GridView`) is placed inside an unconstrained vertical parent (`Column`). The parent provides infinite height, and the child attempts to expand infinitely.
+*   **"An InputDecorator...cannot have an unbounded width"**: Triggered when a `TextField` or `TextFormField` is placed inside an unconstrained horizontal parent (`Row`). The text field attempts to determine its width based on infinite available space.
+*   **"RenderFlex overflowed"**: Triggered when a child of a `Row` or `Column` requests a size larger than the parent's allocated constraints. Visually indicated by yellow and black warning stripes.
+*   **"Incorrect use of ParentData widget"**: Triggered when a `ParentDataWidget` is not a direct descendant of its required ancestor. (e.g., `Expanded` outside a `Flex`, `Positioned` outside a `Stack`).
+*   **"RenderBox was not laid out"**: A cascading side-effect error. Ignore this and look further up the stack trace for the primary constraint violation (usually an unbounded height/width error).
+
+## Layout Error Resolution Workflow
+
+Copy and use this checklist to systematically resolve layout constraint violations.
+
+### Task Progress
+- [ ] Run the application in debug mode to capture the exact layout exception in the console.
+- [ ] Identify the primary error message (ignore cascading "RenderBox was not laid out" errors).
+- [ ] Apply the conditional fix based on the specific error type:
+  - **If "Vertical viewport was given unbounded height"**: Wrap the scrollable child (`ListView`, `GridView`) in an `Expanded` widget to consume remaining space, or wrap it in a `SizedBox` to provide an absolute height constraint.
+  - **If "An InputDecorator...cannot have an unbounded width"**: Wrap the `TextField` or `TextFormField` in an `Expanded` or `Flexible` widget.
+  - **If "RenderFlex overflowed"**: Constrain the overflowing child by wrapping it in an `Expanded` widget (to force it to fit) or a `Flexible` widget (to allow it to be smaller than the allocated space).
+  - **If "Incorrect use of ParentData widget"**: Move the `ParentDataWidget` to be a direct child of its required parent. Ensure `Expanded`/`Flexible` are direct children of `Row`/`Column`/`Flex`. Ensure `Positioned` is a direct child of `Stack`.
+- [ ] Execute Flutter hot reload.
+- [ ] Run validator -> review errors -> fix: Inspect the UI to verify the red/grey error screen or yellow/black overflow stripes are resolved. If new layout errors appear, repeat the workflow.
+
+## Examples
+
+### Fixing Unbounded Height (ListView in Column)
+
+**Input (Error State):**
+```dart
+// Throws "Vertical viewport was given unbounded height"
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    ListView(
+      children: const <Widget>[
+        ListTile(title: Text('Item 1')),
+        ListTile(title: Text('Item 2')),
+      ],
+    ),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap ListView in Expanded to constrain its height to the remaining Column space
+Column(
+  children: <Widget>[
+    const Text('Header'),
+    Expanded(
+      child: ListView(
+        children: const <Widget>[
+          ListTile(title: Text('Item 1')),
+          ListTile(title: Text('Item 2')),
+        ],
+      ),
+    ),
+  ],
+)
+```
+
+### Fixing Unbounded Width (TextField in Row)
+
+**Input (Error State):**
+```dart
+// Throws "An InputDecorator...cannot have an unbounded width"
+Row(
+  children: [
+    const Icon(Icons.search),
+    TextField(), 
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap TextField in Expanded to constrain its width to the remaining Row space
+Row(
+  children: [
+    const Icon(Icons.search),
+    Expanded(
+      child: TextField(),
+    ),
+  ],
+)
+```
+
+### Fixing RenderFlex Overflow
+
+**Input (Error State):**
+```dart
+// Throws "A RenderFlex overflowed by X pixels on the right"
+Row(
+  children: [
+    const Icon(Icons.info),
+    const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+  ],
+)
+```
+
+**Output (Resolved State):**
+```dart
+// Wrap the Text widget in Expanded to force it to wrap within the available constraints
+Row(
+  children: [
+    const Icon(Icons.info),
+    Expanded(
+      child: const Text('This is a very long text string that will definitely overflow the available screen width and cause a RenderFlex error.'),
+    ),
+  ],
+)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ tools/simulator/walkthrough/
 
 # Phase 30.7 MCP tools dedicated venv — gitignored per D-01 (reproducible via requirements.txt)
 tools/mcp/mint-tools/.venv/
+
+# Python setup.py build artifacts (regenerable)
+services/backend/build/

--- a/docs/brand/MINT v2 (2).html
+++ b/docs/brand/MINT v2 (2).html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8"/>
+<title>MINT v2 — Refondation identité</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://api.fontshare.com"/>
+<link href="https://api.fontshare.com/v2/css?f[]=supreme@400,500,600&f[]=rosaline@400&f[]=gambarino@400&display=swap" rel="stylesheet"/>
+<style>
+  :root {
+    --ui: 'Supreme', 'Neue Haas Grotesk Display', -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+    --display: 'Gambarino', 'PP Editorial New', 'GT Sectra', Canela, serif;
+  }
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: var(--ui); }
+  * { box-sizing: border-box; }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="mint-v2/tokens.jsx"></script>
+<script type="text/babel" src="mint-v2/primitives.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-landing.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-onboarding.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-aujourdhui.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-lpp.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-coach.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-coach-empty.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-plan.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-hypotheque.jsx"></script>
+<script type="text/babel" src="mint-v2/design-canvas.jsx"></script>
+
+<script type="text/babel">
+const { useState } = React;
+
+// Slogans candidats pour landing — lesquels tiennent la route ?
+const SLOGANS = {
+  ok: ['Ta vie financière.\nEnfin lisible.', 'Tu comprends. Puis tu décides.'],
+  clair: ['L\'argent,\nen clair.', 'Ta Suisse financière, traduite.'],
+  sec:   ['Moins de jargon.\nPlus de thune.', 'Trois piliers. Un plan. Toi.'],
+  eclat: ['MINT t\'éclaire.\nTu décides.', 'Le silence te coûte cher.'],
+  vif:   ['Ton argent\nsait des choses.', 'MINT te les dit.'],
+};
+
+function App() {
+  const TWEAKS = /*EDITMODE-BEGIN*/{
+    "palette": "menthe",
+    "slogan": "clair"
+  }/*EDITMODE-END*/;
+  const [palette, setPalette] = useState(TWEAKS.palette);
+  const [slogan, setSlogan]   = useState(TWEAKS.slogan);
+  const [tweaksOn, setTweaksOn] = useState(false);
+
+  React.useEffect(() => {
+    const handler = (e) => {
+      if (e.data?.type === '__activate_edit_mode')   setTweaksOn(true);
+      if (e.data?.type === '__deactivate_edit_mode') setTweaksOn(false);
+    };
+    window.addEventListener('message', handler);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  const persist = (k, v) => {
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { [k]: v } }, '*');
+  };
+
+  const p = PALETTES[palette];
+  const s = SLOGANS[slogan];
+
+  // Render each screen in each palette
+  const screens = [
+    { id: 'landing',  label: '01 · Landing',    Component: ScreenLanding,    props: { slogan: s } },
+    { id: 'onb',      label: '02 · Onboarding', Component: ScreenOnboarding },
+    { id: 'today',    label: '03 · Aujourd\'hui', Component: ScreenAujourdhui },
+    { id: 'lpp',      label: '04 · Scan LPP',   Component: ScreenLPP },
+    { id: 'coach-empty', label: '05a · Coach (vide)', Component: ScreenCoachEmpty },
+    { id: 'coach',    label: '05b · Coach (artefacts)', Component: ScreenCoach },
+    { id: 'plan',     label: '06 · Trajectoire', Component: ScreenPlan },
+    { id: 'hypo',     label: '07 · Hypothèque', Component: ScreenHypotheque },
+  ];
+
+  const palettesList = ['menthe', 'encre', 'nuit', 'dark'];
+
+  return (
+    <>
+    {tweaksOn && (
+      <div style={{
+        position: 'fixed', bottom: 20, right: 20, zIndex: 9999,
+        background: '#fff', border: '1px solid rgba(0,0,0,0.1)',
+        borderRadius: 16, padding: 16, width: 260,
+        boxShadow: '0 12px 40px rgba(0,0,0,0.15)',
+        fontFamily: 'var(--ui)',
+      }}>
+        <div style={{ fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase', color: 'rgba(0,0,0,0.5)', marginBottom: 12 }}>Tweaks</div>
+        <div style={{ fontSize: 12, color: 'rgba(0,0,0,0.6)', marginBottom: 6 }}>Palette</div>
+        <div style={{ display: 'flex', gap: 6, marginBottom: 14, flexWrap: 'wrap' }}>
+          {palettesList.map(k => (
+            <button key={k} onClick={() => { setPalette(k); persist('palette', k); }} style={{
+              padding: '6px 10px', borderRadius: 100, cursor: 'pointer', fontSize: 12, fontWeight: 500,
+              background: palette === k ? PALETTES[k].ink : 'transparent',
+              color: palette === k ? PALETTES[k].bg : PALETTES[k].ink,
+              border: `1px solid ${PALETTES[k].ink}`,
+              fontFamily: 'var(--ui)',
+            }}>{PALETTES[k].name}</button>
+          ))}
+        </div>
+        <div style={{ fontSize: 12, color: 'rgba(0,0,0,0.6)', marginBottom: 6 }}>Slogan</div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {Object.keys(SLOGANS).map(k => (
+            <button key={k} onClick={() => { setSlogan(k); persist('slogan', k); }} style={{
+              padding: '6px 10px', borderRadius: 100, cursor: 'pointer', fontSize: 12, fontWeight: 500,
+              background: slogan === k ? p.accent : 'transparent',
+              color: '#0f0f10',
+              border: `1px solid ${slogan === k ? p.accent : 'rgba(0,0,0,0.1)'}`,
+              fontFamily: 'var(--ui)',
+            }}>{k}</button>
+          ))}
+        </div>
+      </div>
+    )}
+    <DesignCanvas>
+      {/* Section 0 — identité verrouillée */}
+      <DCSection id="manifest" title="MINT — identité verrouillée"
+                 subtitle={`Palette : ${p.name} · Slogan : ${slogan} · Typo : Supreme + Gambarino · Tweaks pour changer`}>
+        <DCArtboard id="brand" label="Identité" width={740} height={320}>
+          <div style={{
+            height: '100%', padding: 40, background: p.bg, color: p.ink,
+            fontFamily: 'var(--ui)', display: 'flex', flexDirection: 'column', justifyContent: 'space-between',
+            position: 'relative', overflow: 'hidden',
+          }}>
+            {/* Accent plein — un trait vif */}
+            <div style={{
+              position: 'absolute', top: 40, right: 40, width: 52, height: 52, borderRadius: 26,
+              background: p.accent,
+            }}/>
+            <div>
+              <div style={{ ...SCALE.eyebrow, color: p.inkMute, marginBottom: 16 }}>MINT</div>
+              <div style={{ ...SCALE.displayL, color: p.ink, marginBottom: 14 }}>
+                {s[0].split('\n').map((l,i) => <div key={i}>{l}</div>)}
+              </div>
+              <div style={{ ...SCALE.bodyLg, color: p.inkSoft, maxWidth: 420 }}>{s[1]}</div>
+            </div>
+            <div style={{ display: 'flex', gap: 28, ...SCALE.meta, color: p.inkSoft }}>
+              <div><span style={{ color: p.ink, fontWeight: 500 }}>Supreme</span> · UI</div>
+              <div><span style={{ color: p.ink, fontFamily: 'var(--display)', fontStyle: 'italic', fontSize: 14 }}>Gambarino</span> · display</div>
+              <div style={{ marginLeft: 'auto' }}>Active Tweaks pour essayer d'autres palettes</div>
+            </div>
+          </div>
+        </DCArtboard>
+      </DCSection>
+
+      {/* Section 1 — Entrée en matière */}
+      <DCSection id="entry" title="Entrée — la première seconde compte"
+                 subtitle="Landing + onboarding. Une idée par écran.">
+        {screens.slice(0, 2).map(sc => (
+          <DCArtboard key={sc.id} id={sc.id} label={sc.label} width={380} height={800}>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <Phone palette={p}>
+                <sc.Component palette={p} {...(sc.props || {})}/>
+              </Phone>
+            </div>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      {/* Section 2 — Le quotidien + le hook */}
+      <DCSection id="daily" title="Quotidien — un chiffre à retenir"
+                 subtitle="Hub + le moment insolent qui accroche.">
+        {screens.slice(2, 4).map(sc => (
+          <DCArtboard key={sc.id} id={sc.id} label={sc.label} width={380} height={800}>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <Phone palette={p}>
+                <sc.Component palette={p} {...(sc.props || {})}/>
+              </Phone>
+            </div>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      {/* Section 3 — Le coach : 4 artefacts, vide assumé, streaming visible */}
+      <DCSection id="coach" title="Le coach — kit d'artefacts, pas card unique"
+                 subtitle="État vide → 4 types d'artefacts (décision · comparaison · trajectoire · sensibilité). Bouton ▶ devient ■ pour montrer le streaming.">
+        {screens.slice(4, 7).map(sc => (
+          <DCArtboard key={sc.id} id={sc.id} label={sc.label} width={380} height={800}>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <Phone palette={p}>
+                <sc.Component palette={p} {...(sc.props || {})}/>
+              </Phone>
+            </div>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      {/* Section 4 — Parcours dense justifié */}
+      <DCSection id="dense" title="Quand la densité est justifiée"
+                 subtitle="Parcours complet. Chiffres groupés, pas éparpillés.">
+        {screens.slice(7).map(sc => (
+          <DCArtboard key={sc.id} id={sc.id} label={sc.label} width={380} height={800}>
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <Phone palette={p}>
+                <sc.Component palette={p} {...(sc.props || {})}/>
+              </Phone>
+            </div>
+          </DCArtboard>
+        ))}
+      </DCSection>
+
+      {/* Section finale — notes */}
+      <DCSection id="notes" title="Notes de grammaire"
+                 subtitle="Ce qui change vs v1.">
+        <DCArtboard id="notes-grid" label="Règles visuelles" width={740} height={440}>
+          <div style={{ height: '100%', padding: 32, background: p.bg, color: p.ink, fontFamily: 'var(--ui)' }}>
+            <div style={{ ...SCALE.eyebrow, color: p.inkMute, marginBottom: 14 }}>Grammaire MINT v2</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 40, rowGap: 22 }}>
+              {[
+                ['Une idée / écran', 'Pas de mur de cartes. Le chiffre parle, pas l\'UI.'],
+                ['Italique : 2 écrans max', 'Landing + Onboarding. Ailleurs il banalise.'],
+                ['Voix : observer, pas juger', 'Pas "enfin", pas "de justesse", pas "largement mieux".'],
+                ['Chiffre nu = interdit', 'Toujours ConfidenceBand + EnrichmentPrompts à côté.'],
+                ['4 artefacts Coach', 'Décision · comparaison · trajectoire · sensibilité.'],
+                ['Streaming visible', 'Bouton ▶ → ■ + dots animés pendant la génération.'],
+                ['18 events ≠ retraite-app', '"Trajectoire", pas "Plan retraite". Tab neutre.'],
+                ['Dark mode natif', 'Palette dark = 1ʳᵉ classe, pas un afterthought.'],
+              ].map(([k, v]) => (
+                <div key={k}>
+                  <div style={{ ...SCALE.titleS, color: p.ink, marginBottom: 4 }}>{k}</div>
+                  <div style={{ ...SCALE.body, color: p.inkSoft }}>{v}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+</script>
+</body>
+</html>

--- a/docs/brand/MINT v2-print.html
+++ b/docs/brand/MINT v2-print.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8"/>
+<title>MINT v2 — Print</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://api.fontshare.com"/>
+<link href="https://api.fontshare.com/v2/css?f[]=supreme@400,500,600&f[]=rosaline@400&f[]=gambarino@400&display=swap" rel="stylesheet"/>
+<style>
+  :root {
+    --ui: 'Supreme', 'Neue Haas Grotesk Display', -apple-system, BlinkMacSystemFont, 'Inter', sans-serif;
+    --display: 'Gambarino', 'PP Editorial New', 'GT Sectra', Canela, serif;
+  }
+  html, body { margin: 0; padding: 0; background: #f0eee9; font-family: var(--ui); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  * { box-sizing: border-box; }
+
+  /* Screen view: a clean, paged stack so it looks correct even before print */
+  .page {
+    width: 297mm; min-height: 209mm;
+    margin: 12px auto;
+    background: #f0eee9;
+    padding: 16mm 14mm;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    page-break-after: always;
+    break-after: page;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .page:last-child { page-break-after: auto; break-after: auto; }
+  .page-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 14mm;
+  }
+  .eyebrow { font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(0,0,0,0.45); }
+  .page-title { font-family: var(--display); font-style: italic; font-size: 32px; line-height: 1; color: #111; margin: 6px 0 0; letter-spacing: -0.01em; }
+  .page-sub { font-size: 13px; color: rgba(0,0,0,0.55); margin-top: 6px; max-width: 200mm; }
+  .phones-row {
+    display: flex; gap: 24px; align-items: flex-start; justify-content: center;
+    flex-wrap: wrap;
+  }
+  .phone-cell { display: flex; flex-direction: column; align-items: center; gap: 10px; }
+  .phone-label { font-size: 11px; color: rgba(0,0,0,0.55); letter-spacing: 0.04em; }
+  .phone-shrink {
+    /* phones are 380x800 — fit 3 per landscape page comfortably */
+    transform: scale(0.78);
+    transform-origin: top center;
+    width: 380px; height: 800px;
+  }
+  .phone-cell-frame {
+    width: calc(380px * 0.78); height: calc(800px * 0.78);
+    overflow: hidden;
+  }
+  .brand-card {
+    width: 100%; max-width: 740px; margin: 0 auto;
+  }
+  .notes-card { width: 100%; max-width: 740px; margin: 0 auto; }
+  #root { background: transparent; }
+  .footer-meta {
+    margin-top: auto; padding-top: 10mm;
+    display: flex; justify-content: space-between;
+    font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: rgba(0,0,0,0.4);
+  }
+
+  @page { size: A4 landscape; margin: 0; }
+  @media print {
+    html, body { background: #f0eee9; }
+    .page {
+      margin: 0; box-shadow: none; width: 297mm; height: 210mm; min-height: 210mm;
+      page-break-after: always; break-after: page;
+      break-inside: avoid;
+    }
+    .page:last-child { page-break-after: auto; break-after: auto; }
+  }
+</style>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="mint-v2/tokens.jsx"></script>
+<script type="text/babel" src="mint-v2/primitives.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-landing.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-onboarding.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-aujourdhui.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-lpp.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-coach.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-coach-empty.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-plan.jsx"></script>
+<script type="text/babel" src="mint-v2/screen-hypotheque.jsx"></script>
+
+<script type="text/babel">
+const SLOGAN = ['L\'argent,\nen clair.', 'Ta Suisse financière, traduite.'];
+const PALETTE_KEY = 'menthe';
+
+function PhoneCell({ Component, label, palette, props = {} }) {
+  return (
+    <div className="phone-cell">
+      <div className="phone-cell-frame">
+        <div className="phone-shrink">
+          <Phone palette={palette}>
+            <Component palette={palette} {...props}/>
+          </Phone>
+        </div>
+      </div>
+      <div className="phone-label">{label}</div>
+    </div>
+  );
+}
+
+function Page({ section, title, subtitle, children, footer = 'MINT v2' }) {
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">{section}</div>
+          <h1 className="page-title">{title}</h1>
+          {subtitle && <div className="page-sub">{subtitle}</div>}
+        </div>
+        <div className="eyebrow" style={{ alignSelf: 'flex-end' }}>MINT — Refondation v2</div>
+      </div>
+      {children}
+      <div className="footer-meta">
+        <span>{footer}</span>
+        <span>Palette · Menthe vive · Slogan · L'argent, en clair.</span>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const p = PALETTES[PALETTE_KEY];
+
+  return (
+    <>
+      {/* Page 1 — Identité */}
+      <Page section="00 · Identité" title="MINT — identité verrouillée"
+            subtitle="Palette Menthe vive · Supreme (UI) + Gambarino (display)">
+        <div className="brand-card">
+          <div style={{
+            padding: 40, background: p.bg, color: p.ink,
+            fontFamily: 'var(--ui)', position: 'relative', overflow: 'hidden',
+            border: '1px solid rgba(0,0,0,0.08)',
+          }}>
+            <div style={{
+              position: 'absolute', top: 40, right: 40, width: 52, height: 52, borderRadius: 26,
+              background: p.accent,
+            }}/>
+            <div>
+              <div style={{ ...SCALE.eyebrow, color: p.inkMute, marginBottom: 16 }}>MINT</div>
+              <div style={{ ...SCALE.displayL, color: p.ink, marginBottom: 14 }}>
+                {SLOGAN[0].split('\n').map((l,i) => <div key={i}>{l}</div>)}
+              </div>
+              <div style={{ ...SCALE.bodyLg, color: p.inkSoft, maxWidth: 420 }}>{SLOGAN[1]}</div>
+            </div>
+            <div style={{ display: 'flex', gap: 28, ...SCALE.meta, color: p.inkSoft, marginTop: 36 }}>
+              <div><span style={{ color: p.ink, fontWeight: 500 }}>Supreme</span> · UI</div>
+              <div><span style={{ color: p.ink, fontFamily: 'var(--display)', fontStyle: 'italic', fontSize: 14 }}>Gambarino</span> · display</div>
+            </div>
+          </div>
+        </div>
+      </Page>
+
+      {/* Page 2 — Entrée */}
+      <Page section="01 · Entrée" title="La première seconde compte"
+            subtitle="Landing + onboarding. Une idée par écran.">
+        <div className="phones-row">
+          <PhoneCell Component={ScreenLanding}    label="01 · Landing"    palette={p} props={{ slogan: SLOGAN }}/>
+          <PhoneCell Component={ScreenOnboarding} label="02 · Onboarding" palette={p}/>
+        </div>
+      </Page>
+
+      {/* Page 3 — Quotidien */}
+      <Page section="02 · Quotidien" title="Un chiffre à retenir"
+            subtitle="Hub + le moment insolent qui accroche.">
+        <div className="phones-row">
+          <PhoneCell Component={ScreenAujourdhui} label="03 · Aujourd'hui" palette={p}/>
+          <PhoneCell Component={ScreenLPP}        label="04 · Scan LPP"   palette={p}/>
+        </div>
+      </Page>
+
+      {/* Page 4 — Coach */}
+      <Page section="03 · Coach" title="Kit d'artefacts, pas card unique"
+            subtitle="Décision · comparaison · trajectoire · sensibilité. Le coach dessine en parlant.">
+        <div className="phones-row">
+          <PhoneCell Component={ScreenCoachEmpty} label="05a · Coach (vide)"      palette={p}/>
+          <PhoneCell Component={ScreenCoach}      label="05b · Coach (artefacts)" palette={p}/>
+          <PhoneCell Component={ScreenPlan}       label="06 · Trajectoire"        palette={p}/>
+        </div>
+      </Page>
+
+      {/* Page 5 — Densité justifiée */}
+      <Page section="04 · Densité" title="Quand la densité est justifiée"
+            subtitle="Parcours complet. Chiffres groupés, pas éparpillés.">
+        <div className="phones-row">
+          <PhoneCell Component={ScreenHypotheque} label="07 · Hypothèque" palette={p}/>
+        </div>
+      </Page>
+
+      {/* Page 6 — Notes */}
+      <Page section="05 · Grammaire" title="Notes de grammaire"
+            subtitle="Ce qui change vs v1.">
+        <div className="notes-card">
+          <div style={{ padding: 32, background: p.bg, color: p.ink, fontFamily: 'var(--ui)', border: '1px solid rgba(0,0,0,0.08)' }}>
+            <div style={{ ...SCALE.eyebrow, color: p.inkMute, marginBottom: 14 }}>Grammaire MINT v2</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 40, rowGap: 22 }}>
+              {[
+                ['Une idée / écran', 'Pas de mur de cartes. Le chiffre parle, pas l\'UI.'],
+                ['Italique : 2 écrans max', 'Landing + Onboarding. Ailleurs il banalise.'],
+                ['Voix : observer, pas juger', 'Pas "enfin", pas "de justesse", pas "largement mieux".'],
+                ['Chiffre nu = interdit', 'Toujours ConfidenceBand + EnrichmentPrompts à côté.'],
+                ['4 artefacts Coach', 'Décision · comparaison · trajectoire · sensibilité.'],
+                ['Streaming visible', 'Bouton ▶ → ■ + dots animés pendant la génération.'],
+                ['18 events ≠ retraite-app', '"Trajectoire", pas "Plan retraite". Tab neutre.'],
+                ['Dark mode natif', 'Palette dark = 1ʳᵉ classe, pas un afterthought.'],
+              ].map(([k, v]) => (
+                <div key={k}>
+                  <div style={{ ...SCALE.titleS, color: p.ink, marginBottom: 4 }}>{k}</div>
+                  <div style={{ ...SCALE.body, color: p.inkSoft }}>{v}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Page>
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+
+// Auto-print after fonts + Babel JSX scripts have all evaluated
+(async () => {
+  try {
+    if (document.fonts && document.fonts.ready) {
+      await document.fonts.ready;
+    }
+  } catch (e) {}
+  // Wait for all babel scripts to have parsed/run
+  await new Promise(r => setTimeout(r, 1200));
+  window.print();
+})();
+</script>
+</body>
+</html>

--- a/docs/brand/MINT-brand (1).html
+++ b/docs/brand/MINT-brand (1).html
@@ -1,0 +1,596 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8"/>
+<title>MINT — Brand</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=gambarino@400,400i&f[]=supreme@400,500&display=swap"/>
+<style>
+  :root{
+    --bg:#F7F5EE; --paper:#FFFFFF; --ink:#0A0A0A; --inkSoft:rgba(10,10,10,.64); --inkMute:rgba(10,10,10,.42); --inkFaint:rgba(10,10,10,.10); --hairline:rgba(10,10,10,.08);
+    --menthe:#9EE5C5; --mentheDeep:#1C8466;
+    --acide:#E8FF4D; --encre:#0F0F10;
+    --nuit:#0E1B2E; --rose:#F0C9B8;
+    --ui:'Supreme','Neue Haas Grotesk','Inter',-apple-system,system-ui,sans-serif;
+    --display:'Gambarino','GT Sectra','Times New Roman',serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:var(--ui);-webkit-font-smoothing:antialiased;font-feature-settings:'ss01','cv11'}
+  body{padding:80px 64px 200px}
+
+  /* Page rhythm */
+  .sheet{max-width:1280px;margin:0 auto;display:flex;flex-direction:column;gap:140px}
+  .eyebrow{font-size:11px;font-weight:500;letter-spacing:.16em;text-transform:uppercase;color:var(--inkMute)}
+  .h{font-family:var(--display);font-style:italic;font-weight:400;letter-spacing:-.025em;line-height:1;margin:0}
+  .h-xxl{font-size:84px}
+  .h-xl{font-size:64px}
+  .h-l{font-size:44px}
+  .h-m{font-size:28px}
+  .body{font-size:15px;line-height:1.55;color:var(--inkSoft);max-width:60ch}
+  .meta{font-size:11px;letter-spacing:.06em;color:var(--inkMute)}
+
+  .row{display:flex;gap:48px;align-items:flex-start}
+  .grid{display:grid;gap:24px}
+  .hairline{border:none;border-top:1px solid var(--hairline);margin:0}
+
+  /* Section header */
+  .section-head{display:flex;align-items:baseline;justify-content:space-between;gap:32px;padding-bottom:24px;border-bottom:1px solid var(--hairline)}
+  .section-head .num{font-family:var(--display);font-style:italic;font-size:48px;color:var(--inkMute)}
+
+  /* Wordmark master */
+  .master{display:flex;align-items:flex-end;justify-content:space-between;gap:64px;padding:96px 0 32px}
+  .wordmark{font-family:var(--display);font-style:italic;font-weight:400;letter-spacing:-.04em;line-height:.85;color:var(--ink);font-size:280px}
+  .wordmark .dot{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);transform:translateY(-.05em);margin-left:.02em}
+  .master-meta{flex:0 0 240px;padding-bottom:48px;display:flex;flex-direction:column;gap:14px}
+  .master-meta .label{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkMute)}
+  .master-meta .v{font-size:13px;color:var(--ink)}
+
+  /* App icon */
+  .icons-row{display:grid;grid-template-columns:repeat(2,1fr);gap:48px;margin-top:48px;max-width:720px}
+  .icon-cell{display:flex;flex-direction:column;gap:16px}
+  @media print{ .icons-row{max-width:none;gap:32px} }
+  .icon{
+    width:100%;aspect-ratio:1;
+    container-type:inline-size;
+    border-radius:22.37%;
+    display:flex;align-items:center;justify-content:center;
+    position:relative;overflow:hidden;
+    box-shadow:0 1px 0 rgba(0,0,0,.04), 0 30px 60px -20px rgba(0,0,0,.18), 0 8px 24px -8px rgba(0,0,0,.12);
+  }
+  .icon::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,rgba(255,255,255,.04),transparent 30%, transparent 70%, rgba(0,0,0,.04));pointer-events:none}
+  .icon-glyph{font-family:var(--display);font-style:italic;font-weight:400;font-size:64cqw;line-height:1;letter-spacing:-.03em;position:relative;z-index:1;display:flex;align-items:flex-end}
+  .icon-glyph .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;margin-left:.04em;transform:translateY(-.04em)}
+  .ic-menthe{background:var(--menthe);color:var(--encre)} .ic-menthe .pt{background:var(--mentheDeep)}
+  .ic-acide{background:var(--acide);color:var(--encre)} .ic-acide .pt{background:var(--encre)}
+  .ic-encre{background:var(--encre);color:var(--bg)} .ic-encre .pt{background:var(--acide)}
+  .ic-nuit{background:var(--nuit);color:var(--rose)} .ic-nuit .pt{background:var(--rose)}
+  .ic-rose{background:var(--rose);color:var(--nuit)} .ic-rose .pt{background:var(--nuit)}
+  .ic-paper{background:var(--paper);color:var(--ink);border:1px solid var(--hairline)} .ic-paper .pt{background:var(--mentheDeep)}
+  .ic-cream{background:var(--bg);color:var(--ink);border:1px solid var(--hairline)} .ic-cream .pt{background:var(--mentheDeep)}
+
+  /* Mark explorations */
+  .marks{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--hairline);border:1px solid var(--hairline);margin-top:48px}
+  .mark{background:var(--bg);padding:64px 32px 28px;display:flex;flex-direction:column;gap:24px;min-height:280px}
+  .mark-glyph{flex:1;display:flex;align-items:center;justify-content:center;font-family:var(--display);font-style:italic;color:var(--ink)}
+  .mark-glyph svg{display:block}
+  .mark-foot{display:flex;flex-direction:column;gap:4px}
+  .mark-name{font-size:13px;font-weight:500}
+  .mark-desc{font-size:11px;color:var(--inkMute);line-height:1.4}
+
+  /* Construction */
+  .construction{display:grid;grid-template-columns:1.2fr 1fr;gap:64px;align-items:center;margin-top:48px}
+  .construction-grid{
+    aspect-ratio:1;background:var(--paper);border:1px solid var(--hairline);
+    container-type:inline-size;
+    background-image:
+      linear-gradient(var(--hairline) 1px, transparent 1px),
+      linear-gradient(90deg, var(--hairline) 1px, transparent 1px);
+    background-size: 8.33% 8.33%;
+    position:relative;display:flex;align-items:center;justify-content:center;
+  }
+  .construction-grid::before{
+    content:'';position:absolute;inset:8.33% 8.33%;border:1px dashed rgba(28,132,102,.45);border-radius:18%;pointer-events:none;
+  }
+  .construction-grid .glyph{font-family:var(--display);font-style:italic;font-size:50cqw;line-height:1;letter-spacing:-.03em;display:flex;align-items:flex-end;color:var(--ink);position:relative;z-index:2}
+  .construction-grid .glyph .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.04em;transform:translateY(-.04em)}
+  .construction-notes{display:flex;flex-direction:column;gap:24px}
+  .ctn-row{display:flex;gap:16px;padding:14px 0;border-bottom:1px solid var(--hairline)}
+  .ctn-row:last-child{border-bottom:none}
+  .ctn-k{flex:0 0 140px;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--inkMute);padding-top:2px}
+  .ctn-v{font-size:14px;color:var(--ink);line-height:1.5}
+
+  /* Lockups */
+  .lockups{display:grid;grid-template-columns:repeat(2,1fr);gap:32px;margin-top:48px}
+  .lockup{background:var(--paper);border:1px solid var(--hairline);padding:56px 48px;min-height:240px;display:flex;flex-direction:column;gap:8px;justify-content:center}
+  .lockup .lk-mark{font-family:var(--display);font-style:italic;font-size:56px;line-height:1;letter-spacing:-.04em;display:flex;align-items:flex-end;color:var(--ink)}
+  .lockup .lk-mark .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.02em;transform:translateY(-.04em)}
+  .lockup .lk-tag{font-size:13px;color:var(--inkSoft);letter-spacing:-.005em;margin-top:14px}
+  .lockup-h{display:flex;align-items:center;gap:16px}
+  .lockup-h .lk-mark{font-size:42px}
+  .lockup-h .lk-rule{flex:0 0 1px;height:32px;background:var(--hairline)}
+  .lockup-h .lk-tag{margin-top:0;font-size:13px}
+  .lockup.dark{background:var(--encre);color:var(--bg);border-color:transparent}
+  .lockup.dark .lk-mark{color:var(--bg)}
+  .lockup.dark .lk-mark .pt{background:var(--acide)}
+  .lockup.dark .lk-tag{color:rgba(247,245,238,.62)}
+  .lockup.acide{background:var(--acide);color:var(--encre);border-color:transparent}
+  .lockup.acide .lk-mark{color:var(--encre)}
+  .lockup.acide .lk-mark .pt{background:var(--encre)}
+  .lockup.menthe{background:var(--menthe);color:var(--encre);border-color:transparent}
+  .lockup.menthe .lk-mark{color:var(--encre)}
+  .lockup.menthe .lk-mark .pt{background:var(--mentheDeep)}
+
+  /* Home screen mockup */
+  .home-row{display:grid;grid-template-columns:repeat(2,1fr);gap:40px;margin-top:48px}
+  .phone{
+    width:100%;max-width:380px;aspect-ratio:9/19.5;border-radius:48px;
+    background:linear-gradient(160deg,#FBA48E 0%, #E78671 30%, #BC5840 60%, #6E2D24 100%);
+    padding:18px;
+    box-shadow:0 60px 120px -40px rgba(0,0,0,.45), 0 20px 40px -20px rgba(0,0,0,.25);
+    position:relative;overflow:hidden;
+    margin:0 auto;
+  }
+  .phone.dark{background:linear-gradient(160deg,#1a1a1c 0%, #0a0a0c 100%)}
+  .phone-screen{
+    width:100%;height:100%;border-radius:32px;
+    background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='400' viewBox='0 0 200 400'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%23FBA48E'/><stop offset='1' stop-color='%236E2D24'/></linearGradient></defs><rect width='200' height='400' fill='url(%23g)'/></svg>") center/cover;
+    padding:54px 18px 18px;display:flex;flex-direction:column;gap:14px;position:relative;
+  }
+  .phone.dark .phone-screen{background:linear-gradient(180deg,#0a0a0c 0%, #1a1a1c 50%, #0a0a0c 100%)}
+  .status{position:absolute;top:18px;left:32px;right:32px;display:flex;justify-content:space-between;color:#fff;font-size:12px;font-weight:600;font-feature-settings:'tnum';z-index:5}
+  .home-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;padding:8px}
+  .home-app{display:flex;flex-direction:column;align-items:center;gap:5px}
+  .home-app .ic{width:100%;aspect-ratio:1;border-radius:22.37%;container-type:inline-size}
+  .home-app .lb{font-size:10px;color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.3)}
+  /* fake apps */
+  .fa-photos{background:linear-gradient(135deg,#fbcc4d,#fb6f6f 30%,#a347d3 60%,#3697ed)}
+  .fa-msg{background:#34d058;display:flex;align-items:center;justify-content:center;color:#fff;font-size:60cqw}
+  .fa-maps{background:#dceffc;position:relative}
+  .fa-maps::before{content:'';position:absolute;inset:20%;background:radial-gradient(circle at 35% 35%,#ff5252,#cc1010);border-radius:50%;width:30%;height:30%}
+  .fa-cam{background:#1c1c1e;display:flex;align-items:center;justify-content:center;color:#888;font-size:40cqw}
+  .fa-mail{background:#3697ed}
+  .fa-music{background:linear-gradient(135deg,#ff7af0,#ff204a)}
+  .fa-set{background:linear-gradient(135deg,#aaa,#444)}
+  .fa-cal{background:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;font-family:-apple-system}
+  .fa-cal .day{font-size:10px;color:#ff453a;font-weight:600}
+  .fa-cal .num{font-size:32cqw;color:#000;font-weight:300;line-height:1}
+  .fa-clock{background:#1c1c1e;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:40cqw;font-weight:200}
+  .fa-banking{background:#0a3a82;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:48cqw;font-weight:700}
+  .fa-revolut{background:#000;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:38cqw;font-weight:600}
+  .fa-twint{background:#0d0d0d;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:32cqw}
+
+  .home-app.mint .ic{
+    box-shadow:0 4px 14px -4px rgba(0,0,0,.35), 0 0 0 0.5px rgba(255,255,255,.1) inset;
+    transform:scale(1.04);
+    transition:transform .2s;
+  }
+
+  /* Color application table */
+  .palettes{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--hairline);border:1px solid var(--hairline);margin-top:48px}
+  .pal{padding:32px 28px;background:var(--bg);display:flex;flex-direction:column;gap:24px;min-height:300px}
+  .pal-name{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkMute)}
+  .pal-mark{flex:1;display:flex;align-items:center}
+  .pal-swatches{display:flex;gap:0;height:24px}
+  .pal-swatches .sw{flex:1;height:100%}
+
+  /* Notes */
+  .notes-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:48px;margin-top:48px}
+  .note h4{font-family:var(--display);font-style:italic;font-size:24px;font-weight:400;letter-spacing:-.02em;margin:0 0 12px}
+  .note p{font-size:13px;line-height:1.55;color:var(--inkSoft);margin:0}
+
+  /* Footer */
+  .foot{margin-top:80px;padding-top:32px;border-top:1px solid var(--hairline);display:flex;justify-content:space-between;align-items:flex-end;gap:32px}
+  .foot .lk-mark{font-family:var(--display);font-style:italic;font-size:48px;line-height:1;letter-spacing:-.04em;display:flex;align-items:flex-end}
+  .foot .lk-mark .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.02em;transform:translateY(-.04em)}
+
+  /* Tweaks panel */
+  #tw{position:fixed;right:24px;bottom:24px;background:var(--paper);border:1px solid var(--hairline);box-shadow:0 30px 60px -20px rgba(0,0,0,.18);padding:18px 20px;border-radius:14px;display:flex;flex-direction:column;gap:10px;z-index:100;font-size:12px;min-width:240px}
+  #tw .row{display:flex;justify-content:space-between;align-items:center;gap:12px}
+  #tw label{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkMute);margin:0}
+  #tw select{font-family:var(--ui);font-size:12px;border:1px solid var(--hairline);border-radius:8px;padding:6px 10px;background:var(--bg);color:var(--ink)}
+</style>
+</head>
+<body data-screen-label="01 MINT Brand">
+
+<div class="sheet">
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 00. Master wordmark -->
+  <section data-screen-label="01 Wordmark master">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">00 — Marque</div>
+        <h2 class="h h-l" style="margin-top:14px">Le wordmark</h2>
+      </div>
+      <div class="num">01</div>
+    </div>
+    <div class="master">
+      <div class="wordmark">mint<span class="dot"></span></div>
+      <div class="master-meta">
+        <div><div class="label">Type</div><div class="v">Gambarino Italic 400</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Casse</div><div class="v">bas-de-casse, jamais en capitales</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Le point</div><div class="v">menthe deep — la décision posée. Toujours présent.</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Espace</div><div class="v">marge minimum = hauteur du x-height</div></div>
+      </div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Le mark est une <em style="font-family:var(--display);font-style:italic">phrase</em>, pas un logo. Tout en italique, lettres minuscules, et un point — celui qu'on met sur quelque chose, ou celui qu'on coche. C'est éditorial, pas tech ; calme, pas neutre.
+    </p>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 01. App icon -->
+  <section data-screen-label="02 App icons">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">01 — Icône d'application</div>
+        <h2 class="h h-l" style="margin-top:14px">L'icône</h2>
+      </div>
+      <div class="num">02</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Une lettre, un point. <em style="font-family:var(--display);font-style:italic">m.</em> — comme une signature. Lisible à 60×60 px, reconnaissable parmi 50 apps. Le point est l'aimant.
+    </p>
+
+    <div class="icons-row">
+      <div class="icon-cell">
+        <div class="icon ic-menthe"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Menthe — primaire</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-acide"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Acide — variante éditoriale</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-encre"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Encre — variante haut contraste</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-paper"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Papier — print, monochrome</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 02. Construction -->
+  <section data-screen-label="03 Icon construction">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">02 — Construction</div>
+        <h2 class="h h-l" style="margin-top:14px">La grille</h2>
+      </div>
+      <div class="num">03</div>
+    </div>
+    <div class="construction">
+      <div class="construction-grid">
+        <span class="glyph">m<span class="pt"></span></span>
+      </div>
+      <div class="construction-notes">
+        <div class="ctn-row"><div class="ctn-k">Squircle</div><div class="ctn-v">22.37 % corner radius. Apple superellipse, pas un border-radius classique.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Safe area</div><div class="ctn-v">Marge 1/12 = 50 px sur 600 px. Le glyphe reste dans la zone Android adaptive.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Optical</div><div class="ctn-v">Le « m. » s'aligne sur la baseline optique, pas géométrique. Le point est positionné à 4 % du x-height.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Échelle</div><div class="ctn-v">Hauteur du glyphe = 64 % du canvas. À 60 px, le « m » fait 38 px — limite de lisibilité tenue.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Variantes</div><div class="ctn-v">2 variantes uniquement : « m. » carré (app icon, favicon, splash) et « mint. » horizontal (header, navigation, signature).</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 03. Marks exploration -->
+  <section data-screen-label="04 Marks exploration">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">03 — Variantes explorées</div>
+        <h2 class="h h-l" style="margin-top:14px">Ce qui n'a pas été retenu</h2>
+      </div>
+      <div class="num">04</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Quatre directions testées. Le « m. » l'a emporté — éditorial, vivant, aimant. Les autres : trop abstraites, trop tech, ou trop banales.
+    </p>
+
+    <div class="marks">
+      <div class="mark">
+        <div class="mark-glyph" style="font-size:120px">m<span style="display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.04em;transform:translateY(-.04em)"></span></div>
+        <div class="mark-foot">
+          <div class="mark-name">A — m. <span style="color:var(--mentheDeep);font-weight:500">retenu</span></div>
+          <div class="mark-desc">La signature. Une lettre, un point. Éditorial.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph" style="font-size:120px;letter-spacing:-.05em">M.</div>
+        <div class="mark-foot">
+          <div class="mark-name">B — M. capitale</div>
+          <div class="mark-desc">Trop institutionnel. Banque, pas mentor.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph">
+          <svg width="140" height="140" viewBox="0 0 140 140">
+            <circle cx="70" cy="70" r="58" fill="none" stroke="#0A0A0A" stroke-width="6"/>
+            <circle cx="70" cy="70" r="10" fill="#1C8466"/>
+          </svg>
+        </div>
+        <div class="mark-foot">
+          <div class="mark-name">C — Le point + l'orbite</div>
+          <div class="mark-desc">Trop générique. Toute fintech a un cercle.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph">
+          <svg width="140" height="140" viewBox="0 0 140 140">
+            <path d="M 30 110 L 80 30 L 80 110 Z" fill="none" stroke="#0A0A0A" stroke-width="6" stroke-linejoin="round"/>
+            <circle cx="100" cy="100" r="9" fill="#1C8466"/>
+          </svg>
+        </div>
+        <div class="mark-foot">
+          <div class="mark-name">D — La fenêtre</div>
+          <div class="mark-desc">L'idée juste — fenêtre de lucidité — mais visuellement froid.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 04. Lockups -->
+  <section data-screen-label="05 Lockups">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">04 — Verrouillages</div>
+        <h2 class="h h-l" style="margin-top:14px">Le mark + sa voix</h2>
+      </div>
+      <div class="num">05</div>
+    </div>
+
+    <div class="lockups">
+      <div class="lockup">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">L'argent, en clair.</div>
+      </div>
+      <div class="lockup acide">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Ta vie financière, lisible.</div>
+      </div>
+      <div class="lockup menthe">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Un mentor. Pas un guichet.</div>
+      </div>
+      <div class="lockup dark">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Comprendre avant de décider.</div>
+      </div>
+
+      <!-- Horizontal lockup -->
+      <div class="lockup lockup-h" style="grid-column:1 / -1;min-height:auto;padding:32px 48px">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-rule"></div>
+        <div class="lk-tag">Money Intelligence for Next-gen &amp; Transition. Suisse, 18 → 99.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 05. Home screen -->
+  <section data-screen-label="06 Home screen">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">05 — Sur l'écran d'accueil</div>
+        <h2 class="h h-l" style="margin-top:14px">Parmi les autres apps</h2>
+      </div>
+      <div class="num">06</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Test final : est-ce qu'on retrouve MINT en deux secondes parmi UBS, Revolut, TWINT et 47 apps standard ? Le « m. » menthe sur fond crème — instantané.
+    </p>
+
+    <div class="home-row">
+      <!-- iPhone (light) -->
+      <div>
+        <div class="phone">
+          <div class="phone-screen">
+            <div class="status">
+              <span>9:41</span>
+              <span>● ● ●</span>
+            </div>
+            <div class="home-grid">
+              <div class="home-app"><div class="ic fa-msg">💬</div><div class="lb">Messages</div></div>
+              <div class="home-app"><div class="ic fa-photos"></div><div class="lb">Photos</div></div>
+              <div class="home-app"><div class="ic fa-cam">○</div><div class="lb">Camera</div></div>
+              <div class="home-app"><div class="ic fa-cal"><div class="day">SAM</div><div class="num">9</div></div><div class="lb">Calendrier</div></div>
+
+              <div class="home-app"><div class="ic fa-maps"></div><div class="lb">Plans</div></div>
+              <div class="home-app"><div class="ic fa-mail">✉</div><div class="lb">Mail</div></div>
+              <div class="home-app"><div class="ic fa-music"></div><div class="lb">Musique</div></div>
+              <div class="home-app"><div class="ic fa-clock">9:41</div><div class="lb">Horloge</div></div>
+
+              <div class="home-app"><div class="ic fa-banking">UBS</div><div class="lb">UBS</div></div>
+              <div class="home-app"><div class="ic fa-revolut">R</div><div class="lb">Revolut</div></div>
+              <div class="home-app"><div class="ic fa-twint">twint</div><div class="lb">TWINT</div></div>
+              <div class="home-app mint"><div class="ic ic-menthe" style="border-radius:22.37%;display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64cqw">m<span class="pt"></span></span></div><div class="lb"><strong>mint</strong></div></div>
+            </div>
+          </div>
+        </div>
+        <div class="meta" style="text-align:center;margin-top:16px">iPhone 15 — fond clair</div>
+      </div>
+
+      <!-- iPhone (dark) -->
+      <div>
+        <div class="phone dark">
+          <div class="phone-screen">
+            <div class="status">
+              <span>9:41</span>
+              <span>● ● ●</span>
+            </div>
+            <div class="home-grid">
+              <div class="home-app"><div class="ic fa-msg">💬</div><div class="lb">Messages</div></div>
+              <div class="home-app"><div class="ic fa-photos"></div><div class="lb">Photos</div></div>
+              <div class="home-app"><div class="ic fa-cam">○</div><div class="lb">Camera</div></div>
+              <div class="home-app"><div class="ic fa-cal"><div class="day">SAM</div><div class="num">9</div></div><div class="lb">Calendrier</div></div>
+
+              <div class="home-app"><div class="ic fa-maps"></div><div class="lb">Plans</div></div>
+              <div class="home-app"><div class="ic fa-mail">✉</div><div class="lb">Mail</div></div>
+              <div class="home-app"><div class="ic fa-music"></div><div class="lb">Musique</div></div>
+              <div class="home-app"><div class="ic fa-clock">9:41</div><div class="lb">Horloge</div></div>
+
+              <div class="home-app"><div class="ic fa-banking">UBS</div><div class="lb">UBS</div></div>
+              <div class="home-app"><div class="ic fa-revolut">R</div><div class="lb">Revolut</div></div>
+              <div class="home-app"><div class="ic fa-twint">twint</div><div class="lb">TWINT</div></div>
+              <div class="home-app mint"><div class="ic ic-acide" style="border-radius:22.37%;display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64cqw">m<span class="pt"></span></span></div><div class="lb"><strong>mint</strong></div></div>
+            </div>
+          </div>
+        </div>
+        <div class="meta" style="text-align:center;margin-top:16px">iPhone 15 — fond sombre · variante acide</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 06. Palette mapping -->
+  <section data-screen-label="07 Palette mapping">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">06 — Application aux 4 palettes</div>
+        <h2 class="h h-l" style="margin-top:14px">Cohérence inter-mode</h2>
+      </div>
+      <div class="num">07</div>
+    </div>
+
+    <div class="palettes">
+      <div class="pal">
+        <div class="pal-name">Menthe vive — défaut</div>
+        <div class="pal-mark">
+          <div class="icon ic-menthe" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F7F5EE"></div>
+          <div class="sw" style="background:#9EE5C5"></div>
+          <div class="sw" style="background:#1C8466"></div>
+          <div class="sw" style="background:#0A0A0A"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#F3F1EC">
+        <div class="pal-name">Encre + acide</div>
+        <div class="pal-mark">
+          <div class="icon ic-acide" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F3F1EC"></div>
+          <div class="sw" style="background:#E8FF4D"></div>
+          <div class="sw" style="background:#0F0F10"></div>
+          <div class="sw" style="background:#6A7A00"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#F4F4F2">
+        <div class="pal-name">Nuit suisse</div>
+        <div class="pal-mark">
+          <div class="icon ic-nuit" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F4F4F2"></div>
+          <div class="sw" style="background:#F0C9B8"></div>
+          <div class="sw" style="background:#0E1B2E"></div>
+          <div class="sw" style="background:#B8442A"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#0B0B0C;color:#F4F2EC">
+        <div class="pal-name" style="color:rgba(244,242,236,.5)">Dark</div>
+        <div class="pal-mark">
+          <div class="icon" style="background:#151517;color:#9EE5C5;width:140px;aspect-ratio:1;flex:0 0 auto;border:1px solid rgba(244,242,236,.08);display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64cqw;display:flex;align-items:flex-end">m<span style="display:inline-block;width:.18em;height:.18em;border-radius:50%;background:#9EE5C5;margin-left:.04em;transform:translateY(-.04em)"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#0B0B0C"></div>
+          <div class="sw" style="background:#151517"></div>
+          <div class="sw" style="background:#9EE5C5"></div>
+          <div class="sw" style="background:#F4F2EC"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 07. Notes -->
+  <section data-screen-label="08 Notes d'usage">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">07 — Notes d'usage</div>
+        <h2 class="h h-l" style="margin-top:14px">Faire / ne pas faire</h2>
+      </div>
+      <div class="num">08</div>
+    </div>
+
+    <div class="notes-grid">
+      <div class="note">
+        <h4>Le point n'est pas négociable</h4>
+        <p>Pas de wordmark sans point. Il porte la voix. Sans le point, c'est juste une lettre.</p>
+      </div>
+      <div class="note">
+        <h4>Pas de capitales</h4>
+        <p>« MINT » en capitales = banque. Toujours minuscules dans le wordmark — même en début de phrase.</p>
+      </div>
+      <div class="note">
+        <h4>Pas de gradient</h4>
+        <p>Couleurs pleines. Le point est un disque parfait, le « m » est plein. Aucune ombre, aucun dégradé.</p>
+      </div>
+      <div class="note">
+        <h4>Italique seulement</h4>
+        <p>Le mark est <em style="font-family:var(--display);font-style:italic">toujours</em> en Gambarino italic. Le roman est interdit.</p>
+      </div>
+      <div class="note">
+        <h4>Le point change de couleur</h4>
+        <p>Sur menthe, c'est menthe deep. Sur acide, c'est encre. Sur encre, c'est acide. Le point absorbe l'opposé.</p>
+      </div>
+      <div class="note">
+        <h4>Co-branding</h4>
+        <p>Toujours à droite : « partner / mint. » avec une rule verticale entre. Jamais collé.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- Footer -->
+  <div class="foot">
+    <div>
+      <div class="eyebrow">Brand sheet · v1</div>
+      <div class="body" style="margin-top:8px;color:var(--inkSoft);font-size:13px">Construit sur MINT v2 — Gambarino italic + Supreme. Toutes les variantes dérivent du « m. » signature.</div>
+    </div>
+    <div class="lk-mark">mint<span class="pt"></span></div>
+  </div>
+
+</div>
+
+<!-- Tweaks panel — palette switcher -->
+<div id="tw">
+  <label>Palette du wordmark hero</label>
+  <div class="row">
+    <select id="palette">
+      <option value="menthe" selected>Menthe vive</option>
+      <option value="encre">Encre + acide</option>
+      <option value="nuit">Nuit suisse</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
+</div>
+
+<script>
+  const PALS = {
+    menthe: { bg:'#F7F5EE', ink:'#0A0A0A', dot:'#1C8466' },
+    encre:  { bg:'#F3F1EC', ink:'#0F0F10', dot:'#6A7A00' },
+    nuit:   { bg:'#F4F4F2', ink:'#0E1B2E', dot:'#B8442A' },
+    dark:   { bg:'#0B0B0C', ink:'#F4F2EC', dot:'#9EE5C5' },
+  };
+  const sel = document.getElementById('palette');
+  sel.addEventListener('change', e => {
+    const p = PALS[e.target.value];
+    const wm = document.querySelector('.wordmark');
+    wm.style.color = p.ink;
+    wm.querySelector('.dot').style.background = p.dot;
+    document.body.style.background = p.bg;
+  });
+</script>
+
+</body>
+</html>

--- a/docs/brand/MINT-brand-print.html
+++ b/docs/brand/MINT-brand-print.html
@@ -1,0 +1,604 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8"/>
+<title>MINT — Brand</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=gambarino@400,400i&f[]=supreme@400,500&display=swap"/>
+<style>
+  :root{
+    --bg:#F7F5EE; --paper:#FFFFFF; --ink:#0A0A0A; --inkSoft:rgba(10,10,10,.64); --inkMute:rgba(10,10,10,.42); --inkFaint:rgba(10,10,10,.10); --hairline:rgba(10,10,10,.08);
+    --menthe:#9EE5C5; --mentheDeep:#1C8466;
+    --acide:#E8FF4D; --encre:#0F0F10;
+    --nuit:#0E1B2E; --rose:#F0C9B8;
+    --ui:'Supreme','Neue Haas Grotesk','Inter',-apple-system,system-ui,sans-serif;
+    --display:'Gambarino','GT Sectra','Times New Roman',serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:var(--ui);-webkit-font-smoothing:antialiased;font-feature-settings:'ss01','cv11'}
+  body{padding:80px 64px 200px}
+
+  /* Page rhythm */
+  .sheet{max-width:1280px;margin:0 auto;display:flex;flex-direction:column;gap:140px}
+  .eyebrow{font-size:11px;font-weight:500;letter-spacing:.16em;text-transform:uppercase;color:var(--inkMute)}
+  .h{font-family:var(--display);font-style:italic;font-weight:400;letter-spacing:-.025em;line-height:1;margin:0}
+  .h-xxl{font-size:84px}
+  .h-xl{font-size:64px}
+  .h-l{font-size:44px}
+  .h-m{font-size:28px}
+  .body{font-size:15px;line-height:1.55;color:var(--inkSoft);max-width:60ch}
+  .meta{font-size:11px;letter-spacing:.06em;color:var(--inkMute)}
+
+  .row{display:flex;gap:48px;align-items:flex-start}
+  .grid{display:grid;gap:24px}
+  .hairline{border:none;border-top:1px solid var(--hairline);margin:0}
+
+  /* Section header */
+  .section-head{display:flex;align-items:baseline;justify-content:space-between;gap:32px;padding-bottom:24px;border-bottom:1px solid var(--hairline)}
+  .section-head .num{font-family:var(--display);font-style:italic;font-size:48px;color:var(--inkMute)}
+
+  /* Wordmark master */
+  .master{display:flex;align-items:flex-end;justify-content:space-between;gap:64px;padding:96px 0 32px}
+  .wordmark{font-family:var(--display);font-style:italic;font-weight:400;letter-spacing:-.04em;line-height:.85;color:var(--ink);font-size:280px}
+  .wordmark .dot{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);transform:translateY(-.05em);margin-left:.02em}
+  .master-meta{flex:0 0 240px;padding-bottom:48px;display:flex;flex-direction:column;gap:14px}
+  .master-meta .label{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkMute)}
+  .master-meta .v{font-size:13px;color:var(--ink)}
+
+  /* App icon */
+  .icons-row{display:grid;grid-template-columns:repeat(2,1fr);gap:48px;margin-top:48px;max-width:720px}
+  .icon-cell{display:flex;flex-direction:column;gap:16px}
+  @media print{ .icons-row{max-width:none;gap:32px} }
+  .icon{
+    width:100%;aspect-ratio:1;
+    container-type:inline-size;
+    border-radius:22.37%;
+    display:flex;align-items:center;justify-content:center;
+    position:relative;overflow:hidden;
+    box-shadow:0 1px 0 rgba(0,0,0,.04), 0 30px 60px -20px rgba(0,0,0,.18), 0 8px 24px -8px rgba(0,0,0,.12);
+  }
+  .icon::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,rgba(255,255,255,.04),transparent 30%, transparent 70%, rgba(0,0,0,.04));pointer-events:none}
+  .icon-glyph{font-family:var(--display);font-style:italic;font-weight:400;font-size:64cqw;line-height:1;letter-spacing:-.03em;position:relative;z-index:1;display:flex;align-items:flex-end}
+  .icon-glyph .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;margin-left:.04em;transform:translateY(-.04em)}
+  .ic-menthe{background:var(--menthe);color:var(--encre)} .ic-menthe .pt{background:var(--mentheDeep)}
+  .ic-acide{background:var(--acide);color:var(--encre)} .ic-acide .pt{background:var(--encre)}
+  .ic-encre{background:var(--encre);color:var(--bg)} .ic-encre .pt{background:var(--acide)}
+  .ic-nuit{background:var(--nuit);color:var(--rose)} .ic-nuit .pt{background:var(--rose)}
+  .ic-rose{background:var(--rose);color:var(--nuit)} .ic-rose .pt{background:var(--nuit)}
+  .ic-paper{background:var(--paper);color:var(--ink);border:1px solid var(--hairline)} .ic-paper .pt{background:var(--mentheDeep)}
+  .ic-cream{background:var(--bg);color:var(--ink);border:1px solid var(--hairline)} .ic-cream .pt{background:var(--mentheDeep)}
+
+  /* Mark explorations */
+  .marks{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--hairline);border:1px solid var(--hairline);margin-top:48px}
+  .mark{background:var(--bg);padding:64px 32px 28px;display:flex;flex-direction:column;gap:24px;min-height:280px}
+  .mark-glyph{flex:1;display:flex;align-items:center;justify-content:center;font-family:var(--display);font-style:italic;color:var(--ink)}
+  .mark-glyph svg{display:block}
+  .mark-foot{display:flex;flex-direction:column;gap:4px}
+  .mark-name{font-size:13px;font-weight:500}
+  .mark-desc{font-size:11px;color:var(--inkMute);line-height:1.4}
+
+  /* Construction */
+  .construction{display:grid;grid-template-columns:1.2fr 1fr;gap:64px;align-items:center;margin-top:48px}
+  .construction-grid{
+    aspect-ratio:1;background:var(--paper);border:1px solid var(--hairline);
+    background-image:
+      linear-gradient(var(--hairline) 1px, transparent 1px),
+      linear-gradient(90deg, var(--hairline) 1px, transparent 1px);
+    background-size: 8.33% 8.33%;
+    position:relative;display:flex;align-items:center;justify-content:center;
+  }
+  .construction-grid::before{
+    content:'';position:absolute;inset:8.33% 8.33%;border:1px dashed rgba(28,132,102,.45);border-radius:18%;pointer-events:none;
+  }
+  .construction-grid .glyph{font-family:var(--display);font-style:italic;font-size:50%;line-height:1;letter-spacing:-.03em;display:flex;align-items:flex-end;color:var(--ink);position:relative;z-index:2}
+  .construction-grid .glyph .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.04em;transform:translateY(-.04em)}
+  .construction-notes{display:flex;flex-direction:column;gap:24px}
+  .ctn-row{display:flex;gap:16px;padding:14px 0;border-bottom:1px solid var(--hairline)}
+  .ctn-row:last-child{border-bottom:none}
+  .ctn-k{flex:0 0 140px;font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--inkMute);padding-top:2px}
+  .ctn-v{font-size:14px;color:var(--ink);line-height:1.5}
+
+  /* Lockups */
+  .lockups{display:grid;grid-template-columns:repeat(2,1fr);gap:32px;margin-top:48px}
+  .lockup{background:var(--paper);border:1px solid var(--hairline);padding:56px 48px;min-height:240px;display:flex;flex-direction:column;gap:8px;justify-content:center}
+  .lockup .lk-mark{font-family:var(--display);font-style:italic;font-size:56px;line-height:1;letter-spacing:-.04em;display:flex;align-items:flex-end;color:var(--ink)}
+  .lockup .lk-mark .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.02em;transform:translateY(-.04em)}
+  .lockup .lk-tag{font-size:13px;color:var(--inkSoft);letter-spacing:-.005em;margin-top:14px}
+  .lockup-h{display:flex;align-items:center;gap:16px}
+  .lockup-h .lk-mark{font-size:42px}
+  .lockup-h .lk-rule{flex:0 0 1px;height:32px;background:var(--hairline)}
+  .lockup-h .lk-tag{margin-top:0;font-size:13px}
+  .lockup.dark{background:var(--encre);color:var(--bg);border-color:transparent}
+  .lockup.dark .lk-mark{color:var(--bg)}
+  .lockup.dark .lk-mark .pt{background:var(--acide)}
+  .lockup.dark .lk-tag{color:rgba(247,245,238,.62)}
+  .lockup.acide{background:var(--acide);color:var(--encre);border-color:transparent}
+  .lockup.acide .lk-mark{color:var(--encre)}
+  .lockup.acide .lk-mark .pt{background:var(--encre)}
+  .lockup.menthe{background:var(--menthe);color:var(--encre);border-color:transparent}
+  .lockup.menthe .lk-mark{color:var(--encre)}
+  .lockup.menthe .lk-mark .pt{background:var(--mentheDeep)}
+
+  /* Home screen mockup */
+  .home-row{display:grid;grid-template-columns:repeat(2,1fr);gap:40px;margin-top:48px}
+  .phone{
+    width:100%;max-width:380px;aspect-ratio:9/19.5;border-radius:48px;
+    background:linear-gradient(160deg,#FBA48E 0%, #E78671 30%, #BC5840 60%, #6E2D24 100%);
+    padding:18px;
+    box-shadow:0 60px 120px -40px rgba(0,0,0,.45), 0 20px 40px -20px rgba(0,0,0,.25);
+    position:relative;overflow:hidden;
+    margin:0 auto;
+  }
+  .phone.dark{background:linear-gradient(160deg,#1a1a1c 0%, #0a0a0c 100%)}
+  .phone-screen{
+    width:100%;height:100%;border-radius:32px;
+    background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='400' viewBox='0 0 200 400'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%23FBA48E'/><stop offset='1' stop-color='%236E2D24'/></linearGradient></defs><rect width='200' height='400' fill='url(%23g)'/></svg>") center/cover;
+    padding:54px 18px 18px;display:flex;flex-direction:column;gap:14px;position:relative;
+  }
+  .phone.dark .phone-screen{background:linear-gradient(180deg,#0a0a0c 0%, #1a1a1c 50%, #0a0a0c 100%)}
+  .status{position:absolute;top:18px;left:32px;right:32px;display:flex;justify-content:space-between;color:#fff;font-size:12px;font-weight:600;font-feature-settings:'tnum';z-index:5}
+  .home-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;padding:8px}
+  .home-app{display:flex;flex-direction:column;align-items:center;gap:5px}
+  .home-app .ic{width:100%;aspect-ratio:1;border-radius:22.37%}
+  .home-app .lb{font-size:10px;color:#fff;text-shadow:0 1px 2px rgba(0,0,0,.3)}
+  /* fake apps */
+  .fa-photos{background:linear-gradient(135deg,#fbcc4d,#fb6f6f 30%,#a347d3 60%,#3697ed)}
+  .fa-msg{background:#34d058;display:flex;align-items:center;justify-content:center;color:#fff;font-size:60%}
+  .fa-maps{background:#dceffc;position:relative}
+  .fa-maps::before{content:'';position:absolute;inset:20%;background:radial-gradient(circle at 35% 35%,#ff5252,#cc1010);border-radius:50%;width:30%;height:30%}
+  .fa-cam{background:#1c1c1e;display:flex;align-items:center;justify-content:center;color:#888;font-size:40%}
+  .fa-mail{background:#3697ed}
+  .fa-music{background:linear-gradient(135deg,#ff7af0,#ff204a)}
+  .fa-set{background:linear-gradient(135deg,#aaa,#444)}
+  .fa-cal{background:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;font-family:-apple-system}
+  .fa-cal .day{font-size:10px;color:#ff453a;font-weight:600}
+  .fa-cal .num{font-size:32%;color:#000;font-weight:300;line-height:1}
+  .fa-clock{background:#1c1c1e;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:40%;font-weight:200}
+  .fa-banking{background:#0a3a82;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:48%;font-weight:700}
+  .fa-revolut{background:#000;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:38%;font-weight:600}
+  .fa-twint{background:#0d0d0d;display:flex;align-items:center;justify-content:center;color:#fff;font-family:-apple-system;font-size:32%}
+
+  .home-app.mint .ic{
+    box-shadow:0 4px 14px -4px rgba(0,0,0,.35), 0 0 0 0.5px rgba(255,255,255,.1) inset;
+    transform:scale(1.04);
+    transition:transform .2s;
+  }
+
+  /* Color application table */
+  .palettes{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--hairline);border:1px solid var(--hairline);margin-top:48px}
+  .pal{padding:32px 28px;background:var(--bg);display:flex;flex-direction:column;gap:24px;min-height:300px}
+  .pal-name{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkMute)}
+  .pal-mark{flex:1;display:flex;align-items:center}
+  .pal-swatches{display:flex;gap:0;height:24px}
+  .pal-swatches .sw{flex:1;height:100%}
+
+  /* Notes */
+  .notes-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:48px;margin-top:48px}
+  .note h4{font-family:var(--display);font-style:italic;font-size:24px;font-weight:400;letter-spacing:-.02em;margin:0 0 12px}
+  .note p{font-size:13px;line-height:1.55;color:var(--inkSoft);margin:0}
+
+  /* Footer */
+  .foot{margin-top:80px;padding-top:32px;border-top:1px solid var(--hairline);display:flex;justify-content:space-between;align-items:flex-end;gap:32px}
+  .foot .lk-mark{font-family:var(--display);font-style:italic;font-size:48px;line-height:1;letter-spacing:-.04em;display:flex;align-items:flex-end}
+  .foot .lk-mark .pt{display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.02em;transform:translateY(-.04em)}
+
+  /* Tweaks panel */
+  #tw{position:fixed;right:24px;bottom:24px;background:var(--paper);border:1px solid var(--hairline);box-shadow:0 30px 60px -20px rgba(0,0,0,.18);padding:18px 20px;border-radius:14px;display:flex;flex-direction:column;gap:10px;z-index:100;font-size:12px;min-width:240px}
+  #tw .row{display:flex;justify-content:space-between;align-items:center;gap:12px}
+  #tw label{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkMute);margin:0}
+  #tw select{font-family:var(--ui);font-size:12px;border:1px solid var(--hairline);border-radius:8px;padding:6px 10px;background:var(--bg);color:var(--ink)}
+</style>
+</head>
+<body data-screen-label="01 MINT Brand">
+
+<div class="sheet">
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 00. Master wordmark -->
+  <section data-screen-label="01 Wordmark master">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">00 — Marque</div>
+        <h2 class="h h-l" style="margin-top:14px">Le wordmark</h2>
+      </div>
+      <div class="num">01</div>
+    </div>
+    <div class="master">
+      <div class="wordmark">mint<span class="dot"></span></div>
+      <div class="master-meta">
+        <div><div class="label">Type</div><div class="v">Gambarino Italic 400</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Casse</div><div class="v">bas-de-casse, jamais en capitales</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Le point</div><div class="v">menthe deep — la décision posée. Toujours présent.</div></div>
+        <hr class="hairline"/>
+        <div><div class="label">Espace</div><div class="v">marge minimum = hauteur du x-height</div></div>
+      </div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Le mark est une <em style="font-family:var(--display);font-style:italic">phrase</em>, pas un logo. Tout en italique, lettres minuscules, et un point — celui qu'on met sur quelque chose, ou celui qu'on coche. C'est éditorial, pas tech ; calme, pas neutre.
+    </p>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 01. App icon -->
+  <section data-screen-label="02 App icons">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">01 — Icône d'application</div>
+        <h2 class="h h-l" style="margin-top:14px">L'icône</h2>
+      </div>
+      <div class="num">02</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Une lettre, un point. <em style="font-family:var(--display);font-style:italic">m.</em> — comme une signature. Lisible à 60×60 px, reconnaissable parmi 50 apps. Le point est l'aimant.
+    </p>
+
+    <div class="icons-row">
+      <div class="icon-cell">
+        <div class="icon ic-menthe"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Menthe — primaire</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-acide"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Acide — variante éditoriale</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-encre"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Encre — variante haut contraste</div>
+      </div>
+      <div class="icon-cell">
+        <div class="icon ic-paper"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        <div class="meta">Papier — print, monochrome</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 02. Construction -->
+  <section data-screen-label="03 Icon construction">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">02 — Construction</div>
+        <h2 class="h h-l" style="margin-top:14px">La grille</h2>
+      </div>
+      <div class="num">03</div>
+    </div>
+    <div class="construction">
+      <div class="construction-grid">
+        <span class="glyph">m<span class="pt"></span></span>
+      </div>
+      <div class="construction-notes">
+        <div class="ctn-row"><div class="ctn-k">Squircle</div><div class="ctn-v">22.37 % corner radius. Apple superellipse, pas un border-radius classique.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Safe area</div><div class="ctn-v">Marge 1/12 = 50 px sur 600 px. Le glyphe reste dans la zone Android adaptive.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Optical</div><div class="ctn-v">Le « m. » s'aligne sur la baseline optique, pas géométrique. Le point est positionné à 4 % du x-height.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Échelle</div><div class="ctn-v">Hauteur du glyphe = 64 % du canvas. À 60 px, le « m » fait 38 px — limite de lisibilité tenue.</div></div>
+        <div class="ctn-row"><div class="ctn-k">Variantes</div><div class="ctn-v">2 variantes uniquement : « m. » carré (app icon, favicon, splash) et « mint. » horizontal (header, navigation, signature).</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 03. Marks exploration -->
+  <section data-screen-label="04 Marks exploration">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">03 — Variantes explorées</div>
+        <h2 class="h h-l" style="margin-top:14px">Ce qui n'a pas été retenu</h2>
+      </div>
+      <div class="num">04</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Quatre directions testées. Le « m. » l'a emporté — éditorial, vivant, aimant. Les autres : trop abstraites, trop tech, ou trop banales.
+    </p>
+
+    <div class="marks">
+      <div class="mark">
+        <div class="mark-glyph" style="font-size:120px">m<span style="display:inline-block;width:.18em;height:.18em;border-radius:50%;background:var(--mentheDeep);margin-left:.04em;transform:translateY(-.04em)"></span></div>
+        <div class="mark-foot">
+          <div class="mark-name">A — m. <span style="color:var(--mentheDeep);font-weight:500">retenu</span></div>
+          <div class="mark-desc">La signature. Une lettre, un point. Éditorial.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph" style="font-size:120px;letter-spacing:-.05em">M.</div>
+        <div class="mark-foot">
+          <div class="mark-name">B — M. capitale</div>
+          <div class="mark-desc">Trop institutionnel. Banque, pas mentor.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph">
+          <svg width="140" height="140" viewBox="0 0 140 140">
+            <circle cx="70" cy="70" r="58" fill="none" stroke="#0A0A0A" stroke-width="6"/>
+            <circle cx="70" cy="70" r="10" fill="#1C8466"/>
+          </svg>
+        </div>
+        <div class="mark-foot">
+          <div class="mark-name">C — Le point + l'orbite</div>
+          <div class="mark-desc">Trop générique. Toute fintech a un cercle.</div>
+        </div>
+      </div>
+      <div class="mark">
+        <div class="mark-glyph">
+          <svg width="140" height="140" viewBox="0 0 140 140">
+            <path d="M 30 110 L 80 30 L 80 110 Z" fill="none" stroke="#0A0A0A" stroke-width="6" stroke-linejoin="round"/>
+            <circle cx="100" cy="100" r="9" fill="#1C8466"/>
+          </svg>
+        </div>
+        <div class="mark-foot">
+          <div class="mark-name">D — La fenêtre</div>
+          <div class="mark-desc">L'idée juste — fenêtre de lucidité — mais visuellement froid.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 04. Lockups -->
+  <section data-screen-label="05 Lockups">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">04 — Verrouillages</div>
+        <h2 class="h h-l" style="margin-top:14px">Le mark + sa voix</h2>
+      </div>
+      <div class="num">05</div>
+    </div>
+
+    <div class="lockups">
+      <div class="lockup">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">L'argent, en clair.</div>
+      </div>
+      <div class="lockup acide">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Ta vie financière, lisible.</div>
+      </div>
+      <div class="lockup menthe">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Un mentor. Pas un guichet.</div>
+      </div>
+      <div class="lockup dark">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-tag">Comprendre avant de décider.</div>
+      </div>
+
+      <!-- Horizontal lockup -->
+      <div class="lockup lockup-h" style="grid-column:1 / -1;min-height:auto;padding:32px 48px">
+        <div class="lk-mark">mint<span class="pt"></span></div>
+        <div class="lk-rule"></div>
+        <div class="lk-tag">Money Intelligence for Next-gen &amp; Transition. Suisse, 18 → 99.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 05. Home screen -->
+  <section data-screen-label="06 Home screen">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">05 — Sur l'écran d'accueil</div>
+        <h2 class="h h-l" style="margin-top:14px">Parmi les autres apps</h2>
+      </div>
+      <div class="num">06</div>
+    </div>
+    <p class="body" style="margin-top:24px">
+      Test final : est-ce qu'on retrouve MINT en deux secondes parmi UBS, Revolut, TWINT et 47 apps standard ? Le « m. » menthe sur fond crème — instantané.
+    </p>
+
+    <div class="home-row">
+      <!-- iPhone (light) -->
+      <div>
+        <div class="phone">
+          <div class="phone-screen">
+            <div class="status">
+              <span>9:41</span>
+              <span>● ● ●</span>
+            </div>
+            <div class="home-grid">
+              <div class="home-app"><div class="ic fa-msg">💬</div><div class="lb">Messages</div></div>
+              <div class="home-app"><div class="ic fa-photos"></div><div class="lb">Photos</div></div>
+              <div class="home-app"><div class="ic fa-cam">○</div><div class="lb">Camera</div></div>
+              <div class="home-app"><div class="ic fa-cal"><div class="day">SAM</div><div class="num">9</div></div><div class="lb">Calendrier</div></div>
+
+              <div class="home-app"><div class="ic fa-maps"></div><div class="lb">Plans</div></div>
+              <div class="home-app"><div class="ic fa-mail">✉</div><div class="lb">Mail</div></div>
+              <div class="home-app"><div class="ic fa-music"></div><div class="lb">Musique</div></div>
+              <div class="home-app"><div class="ic fa-clock">9:41</div><div class="lb">Horloge</div></div>
+
+              <div class="home-app"><div class="ic fa-banking">UBS</div><div class="lb">UBS</div></div>
+              <div class="home-app"><div class="ic fa-revolut">R</div><div class="lb">Revolut</div></div>
+              <div class="home-app"><div class="ic fa-twint">twint</div><div class="lb">TWINT</div></div>
+              <div class="home-app mint"><div class="ic ic-menthe" style="border-radius:22.37%;display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64%">m<span class="pt"></span></span></div><div class="lb"><strong>mint</strong></div></div>
+            </div>
+          </div>
+        </div>
+        <div class="meta" style="text-align:center;margin-top:16px">iPhone 15 — fond clair</div>
+      </div>
+
+      <!-- iPhone (dark) -->
+      <div>
+        <div class="phone dark">
+          <div class="phone-screen">
+            <div class="status">
+              <span>9:41</span>
+              <span>● ● ●</span>
+            </div>
+            <div class="home-grid">
+              <div class="home-app"><div class="ic fa-msg">💬</div><div class="lb">Messages</div></div>
+              <div class="home-app"><div class="ic fa-photos"></div><div class="lb">Photos</div></div>
+              <div class="home-app"><div class="ic fa-cam">○</div><div class="lb">Camera</div></div>
+              <div class="home-app"><div class="ic fa-cal"><div class="day">SAM</div><div class="num">9</div></div><div class="lb">Calendrier</div></div>
+
+              <div class="home-app"><div class="ic fa-maps"></div><div class="lb">Plans</div></div>
+              <div class="home-app"><div class="ic fa-mail">✉</div><div class="lb">Mail</div></div>
+              <div class="home-app"><div class="ic fa-music"></div><div class="lb">Musique</div></div>
+              <div class="home-app"><div class="ic fa-clock">9:41</div><div class="lb">Horloge</div></div>
+
+              <div class="home-app"><div class="ic fa-banking">UBS</div><div class="lb">UBS</div></div>
+              <div class="home-app"><div class="ic fa-revolut">R</div><div class="lb">Revolut</div></div>
+              <div class="home-app"><div class="ic fa-twint">twint</div><div class="lb">TWINT</div></div>
+              <div class="home-app mint"><div class="ic ic-acide" style="border-radius:22.37%;display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64%">m<span class="pt"></span></span></div><div class="lb"><strong>mint</strong></div></div>
+            </div>
+          </div>
+        </div>
+        <div class="meta" style="text-align:center;margin-top:16px">iPhone 15 — fond sombre · variante acide</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 06. Palette mapping -->
+  <section data-screen-label="07 Palette mapping">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">06 — Application aux 4 palettes</div>
+        <h2 class="h h-l" style="margin-top:14px">Cohérence inter-mode</h2>
+      </div>
+      <div class="num">07</div>
+    </div>
+
+    <div class="palettes">
+      <div class="pal">
+        <div class="pal-name">Menthe vive — défaut</div>
+        <div class="pal-mark">
+          <div class="icon ic-menthe" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F7F5EE"></div>
+          <div class="sw" style="background:#9EE5C5"></div>
+          <div class="sw" style="background:#1C8466"></div>
+          <div class="sw" style="background:#0A0A0A"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#F3F1EC">
+        <div class="pal-name">Encre + acide</div>
+        <div class="pal-mark">
+          <div class="icon ic-acide" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F3F1EC"></div>
+          <div class="sw" style="background:#E8FF4D"></div>
+          <div class="sw" style="background:#0F0F10"></div>
+          <div class="sw" style="background:#6A7A00"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#F4F4F2">
+        <div class="pal-name">Nuit suisse</div>
+        <div class="pal-mark">
+          <div class="icon ic-nuit" style="width:140px;aspect-ratio:1;flex:0 0 auto"><span class="icon-glyph">m<span class="pt"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#F4F4F2"></div>
+          <div class="sw" style="background:#F0C9B8"></div>
+          <div class="sw" style="background:#0E1B2E"></div>
+          <div class="sw" style="background:#B8442A"></div>
+        </div>
+      </div>
+      <div class="pal" style="background:#0B0B0C;color:#F4F2EC">
+        <div class="pal-name" style="color:rgba(244,242,236,.5)">Dark</div>
+        <div class="pal-mark">
+          <div class="icon" style="background:#151517;color:#9EE5C5;width:140px;aspect-ratio:1;flex:0 0 auto;border:1px solid rgba(244,242,236,.08);display:flex;align-items:center;justify-content:center"><span class="icon-glyph" style="font-size:64%;display:flex;align-items:flex-end">m<span style="display:inline-block;width:.18em;height:.18em;border-radius:50%;background:#9EE5C5;margin-left:.04em;transform:translateY(-.04em)"></span></span></div>
+        </div>
+        <div class="pal-swatches">
+          <div class="sw" style="background:#0B0B0C"></div>
+          <div class="sw" style="background:#151517"></div>
+          <div class="sw" style="background:#9EE5C5"></div>
+          <div class="sw" style="background:#F4F2EC"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- 07. Notes -->
+  <section data-screen-label="08 Notes d'usage">
+    <div class="section-head">
+      <div>
+        <div class="eyebrow">07 — Notes d'usage</div>
+        <h2 class="h h-l" style="margin-top:14px">Faire / ne pas faire</h2>
+      </div>
+      <div class="num">08</div>
+    </div>
+
+    <div class="notes-grid">
+      <div class="note">
+        <h4>Le point n'est pas négociable</h4>
+        <p>Pas de wordmark sans point. Il porte la voix. Sans le point, c'est juste une lettre.</p>
+      </div>
+      <div class="note">
+        <h4>Pas de capitales</h4>
+        <p>« MINT » en capitales = banque. Toujours minuscules dans le wordmark — même en début de phrase.</p>
+      </div>
+      <div class="note">
+        <h4>Pas de gradient</h4>
+        <p>Couleurs pleines. Le point est un disque parfait, le « m » est plein. Aucune ombre, aucun dégradé.</p>
+      </div>
+      <div class="note">
+        <h4>Italique seulement</h4>
+        <p>Le mark est <em style="font-family:var(--display);font-style:italic">toujours</em> en Gambarino italic. Le roman est interdit.</p>
+      </div>
+      <div class="note">
+        <h4>Le point change de couleur</h4>
+        <p>Sur menthe, c'est menthe deep. Sur acide, c'est encre. Sur encre, c'est acide. Le point absorbe l'opposé.</p>
+      </div>
+      <div class="note">
+        <h4>Co-branding</h4>
+        <p>Toujours à droite : « partner / mint. » avec une rule verticale entre. Jamais collé.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────────────────────────────────────────────────── -->
+  <!-- Footer -->
+  <div class="foot">
+    <div>
+      <div class="eyebrow">Brand sheet · v1</div>
+      <div class="body" style="margin-top:8px;color:var(--inkSoft);font-size:13px">Construit sur MINT v2 — Gambarino italic + Supreme. Toutes les variantes dérivent du « m. » signature.</div>
+    </div>
+    <div class="lk-mark">mint<span class="pt"></span></div>
+  </div>
+
+</div>
+
+<!-- Tweaks panel — palette switcher -->
+<div id="tw">
+  <label>Palette du wordmark hero</label>
+  <div class="row">
+    <select id="palette">
+      <option value="menthe" selected>Menthe vive</option>
+      <option value="encre">Encre + acide</option>
+      <option value="nuit">Nuit suisse</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
+</div>
+
+<script>
+  const PALS = {
+    menthe: { bg:'#F7F5EE', ink:'#0A0A0A', dot:'#1C8466' },
+    encre:  { bg:'#F3F1EC', ink:'#0F0F10', dot:'#6A7A00' },
+    nuit:   { bg:'#F4F4F2', ink:'#0E1B2E', dot:'#B8442A' },
+    dark:   { bg:'#0B0B0C', ink:'#F4F2EC', dot:'#9EE5C5' },
+  };
+  const sel = document.getElementById('palette');
+  sel.addEventListener('change', e => {
+    const p = PALS[e.target.value];
+    const wm = document.querySelector('.wordmark');
+    wm.style.color = p.ink;
+    wm.querySelector('.dot').style.background = p.dot;
+    document.body.style.background = p.bg;
+  });
+</script>
+
+<script>
+  window.addEventListener('load', () => {
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => setTimeout(() => window.print(), 500));
+    } else {
+      setTimeout(() => window.print(), 800);
+    }
+  });
+</script>
+</body>
+</html>

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -1,0 +1,20 @@
+# MINT Brand — v2 Refondation Source
+
+Design source artifacts for the v2 brand refondation. Consumed by **Phase 92 MVP-FONTS-TOKENS-V2** as design input (Supreme + Gambarino + Menthe-vive palette).
+
+## Files
+
+- `MINT v2 (2).html` — refondation identity (palette + slogan + typography)
+- `MINT v2-print.html` — print-ready version of the above
+- `MINT-brand (1).html` — full brand guidelines (wordmark, icon, grid, retired alternatives)
+- `MINT-brand-print.html` — print-ready version of the above
+
+## Status
+
+- 2026-05-10 — tracked in repo during branch hygiene cleanup ; previously sat untracked at repo root + `docs/brand/`
+- Will be consumed by Phase 92 plans as `read_first` design input ; theme tokens (`apps/mobile/lib/theme/colors.dart`, `apps/mobile/lib/theme/mint_text_styles.dart`) will reflect the locked palette + typography per W2 of Phase 92.
+
+## DO NOT
+
+- Edit these HTMLs directly — they are exports from the design tool. Re-export and replace.
+- Reference at runtime — these are dev-time references only ; assets bundled via Phase 92 plans go to `apps/mobile/assets/`.


### PR DESCRIPTION
## Summary
3 zero-risk wins from `.planning/audit/codebase-audit-2026-05-10/` audit, bundled into one PR.

### 1. Delete `services/backend/build/lib` + .gitignore
260 stale .py from `python setup.py build` (~2.7 MB) — never tracked. Adds `services/backend/build/` to .gitignore so they stop showing up in `git status`.

### 2. Track `docs/brand/` HTMLs as Phase 92 design input
4 HTML brand identity files (Supreme + Gambarino + Menthe-vive palette + wordmark + grid). Tracked under `docs/brand/` with a README that points Phase 92 plans (MVP-FONTS-TOKENS-V2) to consume these as design source.

### 3. Cherry-pick 2 of 10 Flutter skills
Per audit, 8 of 10 are conflict-with-locked-decisions or redundant. Imported to `.agents/skills/` (universal-agent namespace, distinct from `.claude/skills/` Claude-only):
- `flutter-fix-layout-issues` — RenderFlex / unbounded-constraint debug
- `flutter-add-integration-test` — Maestro complement (in-process integration tests)

Non-adoption manifest in `.agents/skills/README.md` — explicit list of NOT-imported skills with reasons.

## Test plan
- [x] Local working tree: build/lib deleted, .gitignore prevents regen
- [x] docs/brand/ tracked + README explains Phase 92 dependency
- [x] .agents/skills/ structure validated (2 SKILL.md files + README)
- [ ] CI: `flutter analyze` + `pytest` green (no code changes, expected pass)

## Bundles defer
- Barrel imports codemod (97 sites) → Phase 92.5 (when schema split forces it)
- Frozen-fixtures plan → Phase 92.5 deliverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)