### PR TITLE
feat(lefthook): Phase 34 GUARD-01 partial — banned_terms_arb + arb_parity (0/50 block rate)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,9 @@
-# lefthook.yml — Skeleton version (Phase 30.5 CTX-01, D-04)
-# Scope: STRICTLY MEMORY retention gate only.
-# Phase 34 GUARD-01 will ADD bare_catch, hardcoded_fr, accent_lint, arb_parity
-# ON TOP of this scaffold. Rails posés, lints NON-ACTIVÉS (D-04).
+# lefthook.yml — Phase 34 GUARD-01 partial (banned_terms_arb + arb_parity active)
+# Phase 30.5 CTX-01 D-04 originally scoped this skeleton to memory_retention only.
+# 2026-05-10: replay on last 50 commits of `dev` measured 0/50 commits blocked by
+# banned_terms_arb and 0/50 by arb_parity → activated as HARD gates.
+# Remaining GUARD-* lints (accent_lint_fr 26/50, no_hardcoded_fr 23/50, no_bare_catch
+# script absent) deferred until --diff/baseline mode lands — see ROADMAP_V2 Phase 34.
 
 min_version: 2.1.5
 
@@ -34,6 +36,27 @@ pre-commit:
       run: python3 tools/checks/wiki_lint.py
       glob: ".planning/**/*.md"
       tags: [wiki, planning]
+    # ── Phase 34 GUARD-01 partial (HARD gates, 0/50 historical block rate) ──
+    banned-terms-arb-gate:
+      # LSFin Rule #1 (CLAUDE.md TOP rule #1) — refuses any ARB containing the
+      # « garanti / guaranteed / garantiert / garantizado / garantito / garantido »
+      # family in a positive (non-negated) context. Replay measure 2026-05-10:
+      # 0/50 commits on `dev` would have been blocked. Bypass via LEFTHOOK_BYPASS=1
+      # is grep-able per CLAUDE.md §5 dev rules.
+      run: python3 tools/checks/banned_terms_arb.py
+      glob: "apps/mobile/lib/l10n/*.arb"
+      tags: [compliance, lsfin, phase-34-guard-01]
+      fail_text: "LSFin banned terms detected in ARB. Rewrite using permitted vocabulary (« vise à fournir », « est conçue pour », …) — CLAUDE.md TOP rule #1."
+    arb-parity-gate:
+      # CLAUDE.md TOP rule #5 — 6 ARB files (fr/en/de/es/it/pt) must share the
+      # same key set. Reference locale = fr. Replay measure 2026-05-10: 0/50
+      # commits on `dev` would have been blocked. MCP shim
+      # (tools/mcp/mint-tools/tools/arb_parity.py) wraps this same script and
+      # returns ArbParityResult to agents.
+      run: python3 tools/checks/arb_parity.py
+      glob: "apps/mobile/lib/l10n/*.arb"
+      tags: [compliance, i18n, phase-34-guard-05]
+      fail_text: "ARB parity drift. Run `flutter gen-l10n` after syncing keys, or update FR reference and propagate to en/de/es/it/pt."
     # ── Phase MVP-DESIGN-LINTS-V1 (chat-as-verb milestone, 2026-05-09) ──
     # 5 design-system lints. SOFT-warn at pre-commit (`fail_text` only
     # printed; exit-0 suffices because each script gracefully no-ops on

--- a/tests/checks/test_arb_parity.py
+++ b/tests/checks/test_arb_parity.py
@@ -1,0 +1,152 @@
+"""Phase 34 GUARD-05 — pytest for ARB parity lint.
+
+Exercises `tools/checks/arb_parity.py` against:
+  1. The live `apps/mobile/lib/l10n/*.arb` (pristine HEAD — must exit 0,
+     6 × 6747 keys parity).
+  2. Synthetic ARBs in tmp_path with intentional drift — must exit 1.
+  3. Single-locale mode (`--locale en`).
+  4. Malformed JSON — must exit 2.
+  5. Missing locale file — must exit 2.
+
+Python 3.9-compatible, stdlib-only (matches the lint's own constraint).
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT = REPO_ROOT / "tools" / "checks" / "arb_parity.py"
+LIVE_ARB_DIR = REPO_ROOT / "apps" / "mobile" / "lib" / "l10n"
+
+
+def _run(args, timeout=30):
+    return subprocess.run(
+        [sys.executable, str(LINT)] + list(args),
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=timeout,
+    )
+
+
+def _write_arbs(arb_dir: Path, keys_by_locale: dict) -> None:
+    arb_dir.mkdir(parents=True, exist_ok=True)
+    for locale, keys in keys_by_locale.items():
+        body = {k: f"value-{locale}-{i}" for i, k in enumerate(sorted(keys))}
+        body["@@locale"] = locale  # metadata key, excluded by the lint
+        (arb_dir / f"app_{locale}.arb").write_text(
+            json.dumps(body, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+
+def test_lint_exists_and_executable():
+    assert LINT.exists(), f"lint script missing: {LINT}"
+    mode = LINT.stat().st_mode
+    assert mode & stat.S_IXUSR, f"lint not executable: {LINT} mode={oct(mode)}"
+
+
+def test_live_arbs_parity_clean():
+    """Pristine HEAD — 6 ARB files must be in parity (6747 keys each as of W1)."""
+    r = _run([])
+    assert r.returncode == 0, (
+        f"live ARB parity failed (expected 0, got {r.returncode}):\n"
+        f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+    assert "OK" in r.stdout
+    assert "parity" in r.stdout
+
+
+def test_drift_detected_exit_1(tmp_path: Path):
+    """Synthetic ARBs with one missing key must exit 1."""
+    full = {"a", "b", "c"}
+    keys = {l: full for l in ("fr", "en", "de", "es", "it", "pt")}
+    keys["en"] = {"a", "b"}  # `c` missing in en
+    _write_arbs(tmp_path, keys)
+    r = _run(["--arb-dir", str(tmp_path)])
+    assert r.returncode == 1, (
+        f"expected exit 1 for drift, got {r.returncode}:\n"
+        f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+    assert "drift" in r.stderr.lower()
+    assert "[en]" in r.stderr
+
+
+def test_extra_key_in_one_locale_is_drift(tmp_path: Path):
+    """If a non-FR locale has a key FR doesn't — that's drift too."""
+    full = {"a", "b"}
+    keys = {l: full for l in ("fr", "en", "de", "es", "it", "pt")}
+    keys["de"] = {"a", "b", "ghost_de_key"}
+    _write_arbs(tmp_path, keys)
+    r = _run(["--arb-dir", str(tmp_path)])
+    assert r.returncode == 1
+    assert "[de]" in r.stderr
+    assert "extra" in r.stderr.lower()
+
+
+def test_locale_filter_single(tmp_path: Path):
+    """`--locale en` checks only EN against FR even if other locales drift."""
+    full = {"a", "b"}
+    keys = {l: full for l in ("fr", "en", "de", "es", "it", "pt")}
+    keys["de"] = {"a"}  # de drifts but we only check en
+    _write_arbs(tmp_path, keys)
+    r = _run(["--arb-dir", str(tmp_path), "--locale", "en"])
+    assert r.returncode == 0, (
+        f"expected 0 (en is clean, de drift ignored), got {r.returncode}:\n"
+        f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+
+def test_metadata_keys_excluded(tmp_path: Path):
+    """`@`-prefixed and `_`-prefixed keys must not count toward parity."""
+    arb_dir = tmp_path
+    arb_dir.mkdir(exist_ok=True)
+    base = {"a": "v", "b": "v", "@@locale": "fr"}
+    fr = {**base, "@a": {"description": "fr only meta"}, "_internal_note": "skip me"}
+    other = {**base, "@@locale": "en"}  # no @a or _internal_note
+    (arb_dir / "app_fr.arb").write_text(json.dumps(fr), encoding="utf-8")
+    for loc in ("en", "de", "es", "it", "pt"):
+        body = dict(other)
+        body["@@locale"] = loc
+        (arb_dir / f"app_{loc}.arb").write_text(json.dumps(body), encoding="utf-8")
+    r = _run(["--arb-dir", str(arb_dir)])
+    assert r.returncode == 0, (
+        f"metadata-only diff should NOT cause drift; got {r.returncode}:\n"
+        f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+
+
+def test_malformed_json_exit_2(tmp_path: Path):
+    arb_dir = tmp_path
+    arb_dir.mkdir(exist_ok=True)
+    full = {"a": "v"}
+    for loc in ("en", "de", "es", "it", "pt"):
+        (arb_dir / f"app_{loc}.arb").write_text(json.dumps(full), encoding="utf-8")
+    (arb_dir / "app_fr.arb").write_text("{not json", encoding="utf-8")
+    r = _run(["--arb-dir", str(arb_dir)])
+    assert r.returncode == 2, f"expected 2 for malformed JSON, got {r.returncode}"
+    assert "malformed" in r.stderr.lower()
+
+
+def test_missing_locale_file_exit_2(tmp_path: Path):
+    arb_dir = tmp_path
+    arb_dir.mkdir(exist_ok=True)
+    full = {"a": "v"}
+    for loc in ("fr", "en", "de", "es", "it"):  # `pt` missing
+        (arb_dir / f"app_{loc}.arb").write_text(json.dumps(full), encoding="utf-8")
+    r = _run(["--arb-dir", str(arb_dir)])
+    assert r.returncode == 2
+    assert "missing" in r.stderr.lower()
+
+
+def test_no_lsfin_banned_terms_in_lint_output():
+    """The lint itself must not emit LSFin-banned vocab in its stderr/stdout."""
+    r = _run([])
+    combined = (r.stdout + r.stderr).lower()
+    for banned in ("garanti", "guaranteed", "garantiert", "garantizado"):
+        assert banned not in combined, f"banned term {banned!r} leaked into lint output"

--- a/tools/checks/arb_parity.py
+++ b/tools/checks/arb_parity.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Phase 34 GUARD-05 — ARB key-set parity lint.
+
+Compares the key sets of the 6 MINT ARB files (fr / en / de / es / it / pt)
+against the FR reference locale (CLAUDE.md TOP rule #5: « i18n required —
+6 ARB files under apps/mobile/lib/l10n/ »).
+
+Parity holds when every non-metadata key present in `app_fr.arb` is also
+present in each of the 5 other locales, and vice versa. Metadata keys
+(those starting with `@` or `_`) are excluded — they describe the
+schema, not user-facing strings.
+
+Exits:
+  0 — parity holds across all 6 locales.
+  1 — drift detected (missing or extra keys vs FR reference).
+  2 — usage / argument / missing-file error.
+
+Python 3.9-compatible (matches project convention). stdlib-only.
+
+Usage:
+    python3 tools/checks/arb_parity.py
+    python3 tools/checks/arb_parity.py --locale en           # check one locale only
+    python3 tools/checks/arb_parity.py --reference fr        # default
+    python3 tools/checks/arb_parity.py --sample 10           # show up to N missing/extra per locale
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Set, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARB_DIR = REPO_ROOT / "apps" / "mobile" / "lib" / "l10n"
+LOCALES = ("fr", "en", "de", "es", "it", "pt")
+DEFAULT_REFERENCE = "fr"
+DEFAULT_SAMPLE = 5
+
+
+def _load_keys(arb_path: Path) -> Set[str]:
+    """Return the set of user-facing keys in an ARB file.
+
+    Excludes metadata keys: those starting with `@` (Flutter ARB convention
+    for placeholder/description metadata) or `_` (project-internal comments).
+    """
+    if not arb_path.is_file():
+        raise FileNotFoundError(f"ARB file missing: {arb_path}")
+    try:
+        data = json.loads(arb_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed ARB {arb_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"ARB root must be a JSON object: {arb_path}")
+    return {k for k in data if not k.startswith(("@", "_"))}
+
+
+def _diff(reference: Set[str], other: Set[str]) -> Tuple[Set[str], Set[str]]:
+    """Return (missing_in_other, extra_in_other) vs the reference."""
+    return reference - other, other - reference
+
+
+def _format_drift(
+    locale: str, missing: Set[str], extra: Set[str], sample: int
+) -> str:
+    out = [f"  [{locale}] missing={len(missing):3d}  extra={len(extra):3d}"]
+    if missing:
+        sample_keys = sorted(missing)[:sample]
+        out.append(f"     missing sample: {sample_keys}")
+    if extra:
+        sample_keys = sorted(extra)[:sample]
+        out.append(f"     extra sample:   {sample_keys}")
+    return "\n".join(out)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--locale",
+        choices=list(LOCALES) + ["all"],
+        default="all",
+        help="check a single locale against reference (default: all 5 non-reference)",
+    )
+    p.add_argument(
+        "--reference",
+        choices=list(LOCALES),
+        default=DEFAULT_REFERENCE,
+        help=f"reference locale (default: {DEFAULT_REFERENCE})",
+    )
+    p.add_argument(
+        "--sample",
+        type=int,
+        default=DEFAULT_SAMPLE,
+        help=f"max missing/extra keys to print per locale (default: {DEFAULT_SAMPLE})",
+    )
+    p.add_argument(
+        "--arb-dir",
+        type=Path,
+        default=ARB_DIR,
+        help="override ARB directory (used by tests)",
+    )
+    return p
+
+
+def main(argv: list | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    arb_dir: Path = args.arb_dir
+
+    keysets: Dict[str, Set[str]] = {}
+    for loc in LOCALES:
+        path = arb_dir / f"app_{loc}.arb"
+        try:
+            keysets[loc] = _load_keys(path)
+        except FileNotFoundError as exc:
+            print(f"FAIL — {exc}", file=sys.stderr)
+            return 2
+        except ValueError as exc:
+            print(f"FAIL — {exc}", file=sys.stderr)
+            return 2
+
+    ref = args.reference
+    targets = (
+        [args.locale] if args.locale != "all" else [l for l in LOCALES if l != ref]
+    )
+    if ref in targets:
+        targets.remove(ref)
+
+    drift_lines = []
+    total_missing = 0
+    total_extra = 0
+    for loc in targets:
+        missing, extra = _diff(keysets[ref], keysets[loc])
+        if missing or extra:
+            drift_lines.append(_format_drift(loc, missing, extra, args.sample))
+            total_missing += len(missing)
+            total_extra += len(extra)
+
+    if not drift_lines:
+        ref_count = len(keysets[ref])
+        n_locales = len(targets) + 1
+        print(
+            f"OK — {n_locales} locale(s) parity (reference={ref}, "
+            f"{ref_count} keys each)."
+        )
+        return 0
+
+    print("ARB parity drift detected:\n", file=sys.stderr)
+    for line in drift_lines:
+        print(line, file=sys.stderr)
+    print(
+        f"\n{total_missing} missing + {total_extra} extra key(s) across "
+        f"{len(drift_lines)} locale(s). Run `flutter gen-l10n` after syncing "
+        f"keys, or update the FR reference and propagate.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Activates the two zero-block-rate HARD gates from Phase 34 GUARD-01, deferred since v2.8 (PROJECT.md:23).

- **`banned_terms_arb-gate`** — refuses any ARB containing the « garanti / guaranteed / garantiert / garantizado / garantito / garantido » family in a positive context (CLAUDE.md TOP rule #1, LSFin compliance).
- **`arb-parity-gate`** — refuses ARBs whose key set drifts from the FR reference across en/de/es/it/pt (CLAUDE.md TOP rule #5, i18n parity).

## Why these two, not the other Phase 34 GUARDs

Replay over the last 50 commits on `dev` (2026-05-10) measured how many would have been blocked retroactively by each candidate gate:

| Gate                | Blocked rate | Decision               |
|---------------------|--------------|------------------------|
| `banned_terms_arb`  | **0/50 (0%)** | **Active in this PR** |
| `arb_parity`        | **0/50 (0%)** | **Active in this PR** |
| `accent_lint_fr`    | 26/50 (52%)  | Deferred (--diff/baseline mode needed) |
| `no_hardcoded_fr`   | 23/50 (46%)  | Deferred (--diff/baseline mode + cleanup needed) |
| `no_bare_catch`     | n/a (script absent) | Deferred (Phase 34 GUARD-02 to write) |

The two zero-block-rate gates ship now; the others wait until `--diff added-lines-only` mode lands and/or a baseline file is established.

## Implementation

- `tools/checks/arb_parity.py` — new stdlib-only Python 3.9-compat lint. Mirrors `route_registry_parity.py` style. Exits 0 (clean) / 1 (drift) / 2 (malformed). Excludes `@`- and `_`-prefixed metadata keys.
- `tests/checks/test_arb_parity.py` — 9 pytest cases (live ARBs, synthetic drift, locale filter, metadata exclusion, malformed JSON, missing-locale, no-LSFin-leak in output).
- `lefthook.yml` — header rewritten to reflect Phase-34-partial state. Both new gates scoped via `glob: "apps/mobile/lib/l10n/*.arb"` so they fire only when ARB files are staged.

The MCP shim at `tools/mcp/mint-tools/tools/arb_parity.py` was already designed (Phase 30.7 TOOL-03) to subprocess-wrap this script; `validate_arb_parity()` now returns `status="ok"` instead of `"lint_not_available"`.

## Test plan

- [x] 9/9 new `tests/checks/test_arb_parity.py` green
- [x] 78/78 MCP shim tests green (`tools/mcp/mint-tools/tests/`)
- [x] 41/41 existing `tools/checks/tests/` green
- [x] 9/9 sister-lint `tests/checks/test_route_registry_parity.py` green
- [x] Smoke test: tampered ARB with banned term → `banned_terms_arb` exits 1 ✓
- [x] Smoke test: tampered ARB with extra key → `arb_parity` exits 1 ✓
- [x] Restored ARB → both lints exit 0 ✓
- [x] Local pre-commit run on this PR's commit: gates correctly skipped (no ARB staged), memory-retention green
- [ ] CI green (awaiting GitHub Actions)

## Honesty / 0-Trust note

PR opened ≠ shipped. After merge to `dev`, the gates become active for everyone — first real test of « gate bloquant + bypass loggé via LEFTHOOK_BYPASS=1 » discipline. Review feedback welcome on the gate text wording and on whether `glob` should also include backend i18n paths (currently scoped to mobile ARB only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)