### PR TITLE
docs(skill): cross-ref cherry-picked flutter/skills in mint-flutter-dev (audit Proposal 2)

### DIFF
--- a/.claude/skills/mint-flutter-dev/SKILL.md
+++ b/.claude/skills/mint-flutter-dev/SKILL.md
@@ -151,3 +151,12 @@ Before ANY commit:
 
 After ANY commit:
 10. **Auto-audit** — list: most likely remaining bug, least proven joint, riskiest fallback
+
+## External skill cross-references (cherry-picked from `flutter/skills` 2026-05-10)
+
+Two generic Flutter skills are available alongside this one for narrow troubleshooting / setup tasks. They live under `.agents/skills/` and do NOT replace anything in this skill — they are supplementary references.
+
+- **[`flutter-fix-layout-issues`](../../../.agents/skills/flutter-fix-layout-issues/SKILL.md)** — debug RenderFlex overflows / unbounded constraints. Use when an exception text mentions « overflowed by N pixels » or « Vertical viewport was given unbounded height ». No MINT equivalent ; this is the only debug reference for these errors.
+- **[`flutter-add-integration-test`](../../../.agents/skills/flutter-add-integration-test/SKILL.md)** — `integration_test` package + Flutter Driver setup. MINT currently uses Maestro for end-to-end ; this skill is reference material for adding a complementary `integration_test/` suite if a regression class needs Dart-level UI verification beyond what Maestro covers.
+
+8 other `flutter/skills` skills are explicitly NOT adopted — see [`.agents/skills/README.md`](../../../.agents/skills/README.md) for the rationale (audit verdict 2026-05-10 : conflicts with locked MINT stack — MVVM vs Provider, GoRouter already wired, 6 ARBs already shipped). Full evaluation : [`.planning/audit/codebase-audit-2026-05-10/flutter-skills-evaluation.md`](../../../.planning/audit/codebase-audit-2026-05-10/flutter-skills-evaluation.md).


### PR DESCRIPTION
## Summary

Tiny documentation PR that closes audit Proposal 2 ([`.planning/audit/codebase-audit-2026-05-10/flutter-skills-evaluation.md`](.planning/audit/codebase-audit-2026-05-10/flutter-skills-evaluation.md) §7.2) : *« add a one-line cross-reference inside mint-flutter-dev/SKILL.md »*.

PR #547 already shipped the imports into `.agents/skills/` (flutter-fix-layout-issues + flutter-add-integration-test) and wrote the non-adoption README. What was missing was the **discoverability link** from `mint-flutter-dev/SKILL.md` (the most-loaded Flutter skill in MINT) back to those imports — without this link, agents loading mint-flutter-dev never know the cherry-picks exist.

## Changes

`.claude/skills/mint-flutter-dev/SKILL.md` — adds a new « External skill cross-references » section at the bottom :
- pointer to `.agents/skills/flutter-fix-layout-issues/SKILL.md` (RenderFlex debugging)
- pointer to `.agents/skills/flutter-add-integration-test/SKILL.md` (integration_test setup)
- pointer to `.agents/skills/README.md` for the 8-skill non-adoption rationale
- pointer to the full audit doc

## What this is NOT

- No new file
- No script change
- No code logic touched
- Doesn't duplicate `.agents/skills/README.md` (which PR #547 created with the same non-adoption list)

## Test plan

- [x] mint-flutter-dev/SKILL.md still parses as valid markdown
- [x] all referenced files exist (`.agents/skills/flutter-fix-layout-issues/SKILL.md`, etc.)
- [x] pre-commit hooks skip (no staged ARB / planning / source files)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)