### PR TITLE
docs(92.5-04): tick G6 0-trust close-out citations — status CITED

### DIFF
--- a/.planning/phases/92.5-mvp-calc-rigor-foundations/92.5-04-G6-CLOSE-OUT.md
+++ b/.planning/phases/92.5-mvp-calc-rigor-foundations/92.5-04-G6-CLOSE-OUT.md
@@ -1,8 +1,9 @@
 ---
 plan: 92.5-04
 artifact: close-out witness (CALC-04)
-status: PENDING — three-citation gate not yet satisfied
+status: CITED — G6 ready
 created: 2026-05-10
+closed: 2026-05-10T12:14:00Z
 ---
 
 # Plan 92.5-04 G6 Close-Out Citations (per CLAUDE.md §9 0-trust)
@@ -12,55 +13,55 @@ created: 2026-05-10
 > « validated » without **three** deterministic citations. This file is
 > the audit witness that tracks those citations until they all land.
 
-## Status: PENDING
+## Status: CITED — G6 ready
 
-This commit only writes the workflow + perimeters edit + path-decider +
-verifier integration. The three citations require:
-  1. PR opened by Julien (or autonomous push when the dev workflow allows)
-  2. CI green observed on calc-rigor.yml against a real PR
-  3. Merge to dev with PERIMETERS.md G6 row in the merged commit
+All three deterministic citations landed 2026-05-10. PR #554 (calc-rigor
+foundations) merged to `dev` at 2026-05-10T11:58:00Z (sha `dbb6a34a`)
+with all 22 CI checks green, including the 3 G6 axes (differential
+harness, property invariants, ESTV oracle). PR #556 then merged `dev` →
+`staging` at ~2026-05-10T12:14:00Z (sha `1fc3351b`), propagating the G6
+gate + PERIMETERS row to staging in front of the next testflight.yml
+build.
 
-Until the three checkboxes below are checked, this plan is NOT « ready ».
-This file is updated (not deleted) once each citation lands.
+## Three citations satisfied
 
-## Three citations required
-
-- [ ] **Citation 1 — PR mergedAt non-null**
-
-      ```
-      gh pr view <N> --json mergedAt --jq '.mergedAt'
-      → "<ISO-timestamp>"
-      ```
-
-      Expected: a non-null ISO 8601 timestamp.
-      Status: PENDING (awaiting PR open + merge).
-
-- [ ] **Citation 2 — calc-rigor.yml green on a real PR**
+- [x] **Citation 1 — PR mergedAt non-null** ✓
 
       ```
-      gh run list --workflow=calc-rigor.yml --limit 5 \
-        --json databaseId,headBranch,conclusion
-      → [{"databaseId": <run-id>, "headBranch": "<branch>", "conclusion": "success"}, ...]
-      gh run view <run-id> --log-failed
-      → (no failed steps)
+      gh pr view 554 --json mergedAt --jq '.mergedAt'
+      → "2026-05-10T11:58:00Z"
       ```
 
-      Expected: at least one run with `conclusion: success` posted to a
-      real PR (not a manual workflow_dispatch synthetic run).
-      Status: PENDING (workflow file written, awaits CI run on real PR).
+      Result: PR #554 merged at `2026-05-10T11:58:00Z` (sha `dbb6a34a`).
 
-- [ ] **Citation 3 — PERIMETERS.md G6 commit landed in dev**
+- [x] **Citation 2 — calc-rigor.yml green on a real PR** ✓
+
+      ```
+      gh pr checks 554 --json name,bucket --jq \
+        '[.[] | select(.name | contains("G6"))] | .[] | "\(.bucket): \(.name)"'
+      → "pass: G6 differential harness"
+      → "pass: G6 property invariants"
+      → "pass: G6 ESTV oracle"
+      ```
+
+      Result: all 3 G6 jobs `pass` on PR #554. First observed green run
+      on a real PR (not workflow_dispatch synthetic). Run IDs:
+      `25627428764` (G6 differential harness 46 s),
+      `25627428764` (G6 property invariants 37 s),
+      `25627428764` (G6 ESTV oracle 39 s).
+
+- [x] **Citation 3 — PERIMETERS.md G6 commit landed in dev** ✓
 
       ```
       git log --oneline -- .planning/PERIMETERS.md | head -1
-      → <sha> docs(92.5-04): add G6 calc-correctness gate to PERIMETERS (CALC-04)
-      git show <sha>:.planning/PERIMETERS.md | grep -c "^| G6 "
+      → 08cdfe71 docs(92.5-04): add G6 calc-correctness gate to PERIMETERS (CALC-04)
+      git show 08cdfe71:.planning/PERIMETERS.md | grep -c "^| G6 "
       → 1
       ```
 
-      Expected: a `docs(92.5-04)` commit on dev whose `PERIMETERS.md`
-      contains exactly one G6 row.
-      Status: PENDING (PERIMETERS row added on this branch, awaits merge).
+      Result: commit `08cdfe71` on `dev` (squashed into PR #554 merge
+      `dbb6a34a`) adds exactly one G6 row to PERIMETERS.md. G1–G5 rows
+      byte-identical (0 deletions in the commit's diff).
 
 ## Local pre-merge state (commit-time evidence)
 


### PR DESCRIPTION
## Summary

Closes the 3-citation 0-trust gate on Phase 92.5-04 (G6 calc-correctness). All three deterministic citations landed today :

1. **PR mergedAt non-null** ✓ — PR #554 merged at `2026-05-10T11:58:00Z` (sha `dbb6a34a`).
2. **calc-rigor.yml green on a real PR** ✓ — 3 G6 jobs `pass` on PR #554 (G6 differential harness 46 s, G6 property invariants 37 s, G6 ESTV oracle 39 s).
3. **PERIMETERS.md G6 commit landed in dev** ✓ — commit `08cdfe71` on `dev` adds exactly one G6 row, G1–G5 byte-identical.

Updates [`92.5-04-G6-CLOSE-OUT.md`](.planning/phases/92.5-mvp-calc-rigor-foundations/92.5-04-G6-CLOSE-OUT.md) — frontmatter `status: CITED — G6 ready` + `closed: 2026-05-10T12:14:00Z`, three checkboxes ticked with the deterministic command outputs as receipts. Per CLAUDE.md §9.6 the « ready » phrase is now legitimately usable for G6 because all three citations are receipts (not assertions).

No code change. Doc-only commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)