### PR TITLE
chore(release): bump pubspec 2.12.3+5 → 2.12.3+44 (TestFlight collision fix)

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.3+5
+version: 2.12.3+44
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Apple TestFlight rejected the previous run (25628454307): « The bundle version must be higher than the previously uploaded version: '43' ». Bumping pubspec build counter from +5 to +44 to step over the collision. Single-line change. testflight.yml fires on merge.

Triggered by failure of run 25628454307 on staging after PR #556 (dev→staging) merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)