### PR TITLE
chore(release): backport pubspec +44 bump to dev (sync with staging)

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.3+5
+version: 2.12.3+44
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Mirrors PR #558 which landed on staging to clear the Apple TestFlight build collision. Backporting to dev so subsequent dev→staging merges don't reintroduce the lower counter.

Single-line pubspec change. No code.