### PR TITLE
chore(release): bump pubspec +44 → +50 (Apple TestFlight collision retry)

### DIFF
--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.3+44
+version: 2.12.3+50
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Apple TestFlight rejected the +44 build with « must be higher than the previously uploaded version: '44' ». Fastlane's increment helper returned 0 from its API call (auth-issue silent fallback), so the submitted value was Flutter's +44 from pubspec, which collided with Apple's stored 44.

Bumping to +50 with margin.