### PR TITLE
fix(testflight): pin build_number from pubspec.yaml + fail-fast on collision

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -84,9 +84,37 @@ platform :ios do
     # system credential store, which works reliably.
     match(match_params)
 
-    # ── 4. Auto-increment build number ──
+    # ── 4. Pin build number from pubspec.yaml (single source of truth) ──
+    # Why: `latest_testflight_build_number(api_key) + 1` returns the latest *processed*
+    # build, but Apple keeps in-flight uploads "reserved" for several minutes after
+    # the binary lands. Three TestFlight runs collided this morning (44/44/46 already
+    # used) because parallel CI re-used the same processed-latest reading.
+    # Pubspec is deterministic — Julien controls the +N suffix when a fresh upload
+    # is needed, and CI accepts whatever value it finds.
+    pubspec_path = File.expand_path("../../pubspec.yaml", __dir__)
+    pubspec_content = File.read(pubspec_path)
+    version_match = pubspec_content.match(/^version:\s*([\d.]+)\+(\d+)/)
+    UI.user_error!("pubspec.yaml: cannot parse 'version: X.Y.Z+N' line") unless version_match
+
+    pubspec_build_number = version_match[2].to_i
+    UI.message("Pubspec build number: #{pubspec_build_number}")
+
+    # Defensive: also fetch latest from TestFlight; if pubspec is ≤ TestFlight's
+    # latest, fail BEFORE the upload so the operator sees a clear "bump pubspec"
+    # message instead of the cryptic Apple `-19232 already been used` error.
+    latest_tf = latest_testflight_build_number(api_key: api_key)
+    UI.message("TestFlight latest processed build number: #{latest_tf}")
+    if pubspec_build_number <= latest_tf
+      UI.user_error!(
+        "pubspec.yaml build number (#{pubspec_build_number}) must be GREATER than the latest " \
+        "TestFlight build (#{latest_tf}). Bump apps/mobile/pubspec.yaml `version: X.Y.Z+N` so " \
+        "N > #{latest_tf} (suggested: #{latest_tf + 5} for safe margin against in-flight uploads) " \
+        "and re-run this lane."
+      )
+    end
+
     increment_build_number(
-      build_number: latest_testflight_build_number(api_key: api_key) + 1,
+      build_number: pubspec_build_number,
       xcodeproj: "Runner.xcodeproj",
     )
 

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: mint_mobile
 description: Mint - Financial mentor mobile app
 publish_to: 'none'
 
-version: 2.12.3+44
+version: 2.12.3+60
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary

Root cause of the 3 TestFlight failures today (`44 / 44 / 46 already used`): the Fastfile was reading `latest_testflight_build_number(api_key) + 1`, which returns Apple's latest **processed** build. In-flight uploads are reserved for several minutes after binary lands, so parallel CI runs collide on the same number even after pubspec bumps.

- Read `build_number` from `apps/mobile/pubspec.yaml` (`version: X.Y.Z+N`) as the single source of truth — Julien controls `N` at PR-time, CI accepts whatever's there.
- Defensive check: if `pubspec N ≤ TestFlight latest`, fail **before** upload with `« bump pubspec to >= latest+5 »` instead of Apple's cryptic `-19232 already been used`.
- Bump pubspec `+44 → +60` to clear the 46-collision band with 14-build margin.

## Test plan

- [ ] PR merges to `dev` ; standard `dev → staging` merge fires TestFlight workflow
- [ ] TestFlight log shows `Pubspec build number: 60` then `TestFlight latest processed build number: <≤46>` then a successful upload of build 60
- [ ] Future bumps require only editing `pubspec.yaml` `version: 2.12.3+N` — no Fastfile change

## Why this is independent of Phase 93.5

Phase 93.5 (`feature/S93.5-skill-bundle-compiler`, MVP-SKILL-BUNDLE-COMPILER, 18 commits, 6251 backend tests passing, awaiting Julien GO/NO-GO on flag flip) is backend Python only — zero touch to iOS / Flutter / pubspec. This PR is the iOS-infrastructure fix that's been blocking TestFlight all day. They merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)