### PR TITLE
fix(97-w7-revert): drop associated-domains entitlement (TestFlight unblock)

### DIFF
--- a/apps/mobile/ios/Runner/Runner.entitlements
+++ b/apps/mobile/ios/Runner/Runner.entitlements
@@ -10,11 +10,6 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:mint.ch</string>
-		<string>applinks:mint-staging.up.railway.app</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)ch.mint.app</string>


### PR DESCRIPTION
## Summary

- TestFlight build_app failed on staging push (run 25696855632) because the App Store provisioning profile in `mint-certificates` doesn't include the `com.apple.developer.associated-domains` capability that I added in W7 iter#6 (commit 009149c7, PR #564).
- Surgical revert: drops the 5-line entitlement block. Keeps the other 3 W7 iter#6 changes (S003 mintapp:// custom URL scheme, F006 FlutterDeepLinkingEnabled, S004 backend AASA endpoint) — none require provisioning updates.
- Re-add when the provisioning profile is updated at Apple Developer + match.

## Error from the failed run

```
Provisioning profile "match AppStore ch.mint.app" doesn't include the
com.apple.developer.associated-domains entitlement. (in target 'Runner'
from project 'Runner')
** ARCHIVE FAILED **
```

## What I should have done

Coordinated the entitlement change with the provisioning profile update BEFORE bundling it in PR #564. Splitting the W7 iter#6 fix into "code" + "infra" perimeters would have caught this in the pre-merge sim.

## Test plan

- [ ] CI green on this PR
- [ ] Squash-merge to dev
- [ ] Open dev → staging follow-up PR
- [ ] TestFlight build_app reaches Upload step (no entitlement mismatch)
- [ ] Build distributes to internal testers

🤖 Generated with [Claude Code](https://claude.com/claude-code)