### PR TITLE
release: dev → staging (revert associated-domains entitlement)

### DIFF
--- a/apps/mobile/ios/Runner/Runner.entitlements
+++ b/apps/mobile/ios/Runner/Runner.entitlements
@@ -10,11 +10,6 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:mint.ch</string>
-		<string>applinks:mint-staging.up.railway.app</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)ch.mint.app</string>


### PR DESCRIPTION
## Summary

- Forward PR #567 (revert of `com.apple.developer.associated-domains` entitlement) from dev to staging.
- Re-fires testflight.yml on staging push. Build_app archive step now succeeds (provisioning profile no longer required for Associated Domains).

## Why

PR #566 (Phase 94+95+96+96.1+97 W7 closure) bundled W7 iter#6's entitlement addition. The App Store provisioning profile in `mint-certificates` doesn't include Associated Domains capability — TestFlight run 25696855632 failed at `xcodebuild archive` with `Provisioning profile "match AppStore ch.mint.app" doesn't include the com.apple.developer.associated-domains entitlement`.

PR #567 surgical revert dropped only the 5-line entitlement block. Preserved the other 3 W7 iter#6 changes (S003 mintapp:// custom URL scheme, F006 FlutterDeepLinkingEnabled, S004 backend AASA endpoint) — none require provisioning updates.

## Re-add path (for when ready)

1. Enable Associated Domains capability on App ID `ch.mint.app` in Apple Developer portal.
2. Run `fastlane match appstore` to regenerate the provisioning profile with the new capability.
3. Push the updated profile to `mint-certificates` repo.
4. Re-PR the entitlement addition as an isolated `[ios-release]` PR per new memory guard.

## Preventative work scheduled

- `tools/checks/ios_release_capability_drift.py` lint to be written next session — fails any PR that adds `com.apple.developer.*` / new `CFBundleURLTypes` / new `NSExtension*` without `[ios-release]` title + provisioning-confirmed description checkbox. Mechanical block to prevent recurrence.

## Test plan

- [ ] testflight.yml fires on merge
- [ ] xcodebuild archive succeeds (no more entitlement mismatch)
- [ ] Build distributes to internal testers

🤖 Generated with [Claude Code](https://claude.com/claude-code)