### PR TITLE
fix(97-w7-f008): MintCardActionBar fits any iPhone width (no overflow)

### DIFF
--- a/.planning/phases/97-mvp-parfait-maestro-full-power-maestro-driven-on-device-grou/97-BUGS-REGISTRY.md
+++ b/.planning/phases/97-mvp-parfait-maestro-full-power-maestro-driven-on-device-grou/97-BUGS-REGISTRY.md
@@ -575,6 +575,24 @@ row enters the 7-step cycle (D-36), it is folded here for state-machine tracking
   found_in: 2026-05-11
   resolved_in: 2026-05-11T17:00:46Z
   notes: « Resolved jointly with F001. Text widget at mint_chat_overlay.dart:198-202 carries Key('chat_turn_counter') + renders '$_turnCount / $kChatMaxTurns'. Local-state UI-only counter ; server-side turn_cap.py is the canonical D-08 enforcement gate. Initial state « 0 / 3 », increments on send, reset on overlay re-mount (test asserts these 3 transitions). »
+
+- id: F008
+  severity: P2
+  surface: mobile
+  archetype: all
+  feature: chat_as_verb
+  title: « MintCardActionBar Row overflows by 35 px on iPhone 17 Pro (393 pt) when the 3 verb chips are laid out without flex distribution »
+  repro: « bash tools/simulator/maestro_env.sh test tools/simulator/flows/regression/bug__S002__maestro_cold_launch_fragment.yaml ; the resulting screenshot /tmp/97_s002_aujourdhui_after_fragment.png shows a yellow-and-black hatch banner « RIGHT OVERFLOWED BY 35 PIXELS » on the action bar row (Rassure-moi chip clipped, third verb partly off-screen). Widget tests at the default 800×600 viewport hide the defect — no width-constrained regression existed pre-fix. »
+  blast_radius: « Every Aujourd'hui card surface using MintCardActionBar. Discoverability of « Rassure-moi » broken on the canonical iPhone 17 Pro screen ; worse on iPhone SE-class widths. »
+  fix_cost: trivial
+  score: 8  # 2 × 4 / 1 (P2 because visual, not functional ; the Rassure-moi InkWell remains tappable via accessibility, just visually clipped)
+  status: RESOLVED
+  started: 2026-05-12T05:48:00Z
+  fix_commit: TBD-F008-row-flex
+  repro_flow: « unit test : apps/mobile/test/widgets/mint_card_action_bar_test.dart group « F008 regression — 3 chips fit within iPhone widths (320pt + 393pt) with no overflow ». Asserts no Flutter overflow exception + width <= viewport at 320 pt AND 393 pt. Pre-fix the assertion `size.width <= widthPt + 0.5` fails on a 393 pt viewport because the chip row natural width is ~428 pt. »
+  found_in: 2026-05-12  # spotted during S002 PASS-step screenshot
+  resolved_in: 2026-05-12T05:55:00Z
+  notes: « Single-perimeter cycle (post-incident discipline). FIX : wrap each `_VerbChip` in `Expanded(flex: 1)` so the 3 chips share the available width equally ; inner `_VerbChip` Row centers its icon+label cluster with `MainAxisAlignment.center` and the Text is wrapped in `Flexible` with `maxLines: 1` + `TextOverflow.ellipsis` as belt-and-suspenders for very narrow viewports (iPhone SE class). LOCK : new widget test « F008 regression » runs at 320 pt + 393 pt viewports, asserts no overflow exception + width ≤ viewport + all 3 verb labels render. SUITE : 14 adjacent widget tests still GREEN (mint_card_action_bar_test 9/9 + mint_card_action_bar_routing_test 4/4 + aujourdhui widget tests 1/1 confirmed via flutter test). Karpathy #3 surgical : 2 files (widget + test), no app-level diff outside this perimeter. »
 ```
 
 ### From sonnet Backend audit (folded 2026-05-11, see audit-backend-api.md for full B001-B025 catalogue)

--- a/apps/mobile/lib/widgets/mint_card_action_bar.dart
+++ b/apps/mobile/lib/widgets/mint_card_action_bar.dart
@@ -72,31 +72,41 @@ class MintCardActionBar extends StatelessWidget {
               padding: const EdgeInsets.symmetric(
                 horizontal: MintSpacing.md,
               ),
+              // F008 (2026-05-12) — 3 chips share the available width via
+              // Expanded(flex: 1) so the row fits any iPhone width
+              // (overflow surfaced at 35px on iPhone 17 Pro pre-fix).
+              // Inner chip row keeps MainAxisSize.min on the icon+label
+              // cluster + centers it within the Expanded slot.
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  _VerbChip(
-                    label: l.verbExplique,
-                    icon: Icons.lightbulb_outline,
-                    semanticsLabel:
-                        'Explique-moi — ouvre le coach sur cette carte',
-                    onTap: onExplain,
+                  Expanded(
+                    child: _VerbChip(
+                      label: l.verbExplique,
+                      icon: Icons.lightbulb_outline,
+                      semanticsLabel:
+                          'Explique-moi — ouvre le coach sur cette carte',
+                      onTap: onExplain,
+                    ),
                   ),
                   const SizedBox(width: MintSpacing.sm),
-                  _VerbChip(
-                    label: l.verbSimule,
-                    icon: Icons.tune_outlined,
-                    semanticsLabel:
-                        'Simule — ouvre le simulateur pour cette carte',
-                    onTap: onSimulate,
+                  Expanded(
+                    child: _VerbChip(
+                      label: l.verbSimule,
+                      icon: Icons.tune_outlined,
+                      semanticsLabel:
+                          'Simule — ouvre le simulateur pour cette carte',
+                      onTap: onSimulate,
+                    ),
                   ),
                   const SizedBox(width: MintSpacing.sm),
-                  _VerbChip(
-                    label: l.verbRassure,
-                    icon: Icons.shield_outlined,
-                    semanticsLabel:
-                        "Rassure-moi — ouvre le coach pour réduire l'inquiétude",
-                    onTap: onReassure,
+                  Expanded(
+                    child: _VerbChip(
+                      label: l.verbRassure,
+                      icon: Icons.shield_outlined,
+                      semanticsLabel:
+                          "Rassure-moi — ouvre le coach pour réduire l'inquiétude",
+                      onTap: onReassure,
+                    ),
                   ),
                 ],
               ),
@@ -148,13 +158,18 @@ class _VerbChip extends StatelessWidget {
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(icon, size: 16, color: MintColors.textMuted),
                 const SizedBox(width: MintSpacing.xs),
-                Text(
-                  label,
-                  style: MintTextStyles.labelLarge(
-                    color: MintColors.textSecondary,
+                Flexible(
+                  child: Text(
+                    label,
+                    style: MintTextStyles.labelLarge(
+                      color: MintColors.textSecondary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],

--- a/apps/mobile/test/widgets/mint_card_action_bar_test.dart
+++ b/apps/mobile/test/widgets/mint_card_action_bar_test.dart
@@ -87,6 +87,74 @@ void main() {
       expect(size.height, greaterThanOrEqualTo(48.0));
     });
 
+    // F008 (2026-05-12) — width-constrained overflow regression guard.
+    //
+    // Pre-fix : 3 chips were laid out via Row(mainAxisAlignment: center)
+    // with no flex distribution, so they overflowed by 35px on iPhone 17
+    // Pro (393pt logical width, sim screenshot
+    // /tmp/97_s002_aujourdhui_after_fragment.png). Default test viewport
+    // is 800×600 which hid the defect.
+    //
+    // Post-fix : each chip wrapped in Expanded(flex: 1), so the row
+    // always fits the parent width. Text uses Flexible + ellipsis as
+    // belt-and-suspenders for narrow viewports.
+    //
+    // This test runs at 320pt (iPhone SE 1st gen lower bound) AND at
+    // 393pt (iPhone 17 Pro) — both must pass with no debug-paint
+    // overflow indicator. Catching it at the unit-test layer means we
+    // never push this class of regression to the sim again.
+    testWidgets(
+      'F008 regression — 3 chips fit within iPhone widths (320pt + 393pt) '
+      'with no overflow',
+      (tester) async {
+        // Test at the tightest realistic width first.
+        for (final widthPt in [320.0, 393.0]) {
+          tester.view.physicalSize = Size(widthPt * 3.0, 200.0 * 3.0);
+          tester.view.devicePixelRatio = 3.0;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+
+          await tester.pumpWidget(_harness(
+            expanded: true,
+            onExplain: () {},
+            onSimulate: () {},
+            onReassure: () {},
+          ));
+          await tester.pumpAndSettle();
+
+          // Flutter renders a RenderFlexOverflow warning to the console
+          // AND adds an OverflowIndicator yellow-banner widget when a Row
+          // overflows. Both surface in tester.takeException() / the error
+          // widget descendants — assert neither is present.
+          expect(
+            tester.takeException(),
+            isNull,
+            reason: 'no overflow exception at $widthPt pt width',
+          );
+
+          // The widget must report a finite, non-negative width matching
+          // the viewport (no overflow into negative space).
+          final size = tester.getSize(find.byType(MintCardActionBar));
+          expect(
+            size.width,
+            lessThanOrEqualTo(widthPt + 0.5),
+            reason:
+                'MintCardActionBar width must fit viewport $widthPt pt '
+                '(got ${size.width})',
+          );
+
+          // The 3 chips must all be visible (none clipped to zero width).
+          for (final verb in ['Explique-moi', 'Simule', 'Rassure-moi']) {
+            expect(
+              find.text(verb),
+              findsOneWidget,
+              reason: '$verb must render at $widthPt pt width',
+            );
+          }
+        }
+      },
+    );
+
     testWidgets('each _VerbChip has minHeight/minWidth >= 44 (Apple HIG)',
         (tester) async {
       await tester.pumpWidget(_harness(


### PR DESCRIPTION
## Summary

- Closes Phase 97 W7 **F008** (P2, score 8, surface=mobile) — MintCardActionBar Row overflowed by 35 px on iPhone 17 Pro (393 pt) because the 3 verb chips had no flex distribution.
- Spotted during S002 PASS-step sim screenshot. The 800×600 default widget-test viewport hid the defect ; no width-constrained regression existed pre-fix.
- Single-perimeter, 2 files, zero diff outside scope.

## What changed

| File | State | Note |
|---|---|---|
| `apps/mobile/lib/widgets/mint_card_action_bar.dart` | PATCH | Wrap each `_VerbChip` in `Expanded(flex: 1)` ; center inner Row ; Flexible+ellipsis Text as belt-and-suspenders for narrow viewports |
| `apps/mobile/test/widgets/mint_card_action_bar_test.dart` | PATCH | New « F008 regression » test : asserts no overflow at 320 pt + 393 pt viewports |
| `.planning/phases/97-…/97-BUGS-REGISTRY.md` | PATCH | F008 row added, status RESOLVED |

## Evidence (deterministic citations per CLAUDE.md §9.6)

### LOCK — width-constrained widget test GREEN
```
$ flutter test test/widgets/mint_card_action_bar_test.dart
00:00 +0: MintCardActionBar expanded=true renders 3 verb chips with FR labels
00:00 +1: expanded=false collapses to zero height
00:00 +2: expanded=true renders height >= 48dp after settle
00:00 +3: F008 regression — 3 chips fit within iPhone widths (320pt + 393pt) with no overflow
00:00 +4: each _VerbChip has minHeight/minWidth >= 44 (Apple HIG)
00:00 +5: tap on Simule invokes onSimulate exactly once
00:00 +6: tap on Explique-moi invokes onExplain exactly once
00:00 +7: tap on Rassure-moi invokes onReassure exactly once
00:00 +8: Semantics labels are present on each verb chip
00:00 +9: All tests passed!
```

### SUITE — adjacent tests no regression
```
$ flutter test test/widgets/mint_card_action_bar_routing_test.dart test/widgets/aujourdhui/
... 14 tests passed (9 + 4 + 1) ...
```

### Sim screenshot — pre-fix RED evidence

`/tmp/97_s002_aujourdhui_after_fragment.png` (captured in S002 PR #570 cycle) shows the overflow banner on the chip row. Post-merge sim re-screenshot will land in the next regression run.

## Why a P2 (not P0)

The `Rassure-moi` InkWell remained tappable via accessibility/keyboard navigation — the defect was visual clipping, not functional unreachability. Still ships discoverability concerns (visible part says « Rass... » which doesn't read as a CTA). Worth fixing immediately because trivial-cost.

## Test plan

- [ ] CI green
- [ ] Squash-merge to dev
- [ ] After merge : confirm sim screenshot no longer shows the overflow banner (manual or via next Maestro G2 run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)