### PR TITLE
fix(hotfix): shorten alembic revision id — Railway staging UNBLOCK

### DIFF
--- a/services/backend/alembic/versions/p97_snapshots_fk_and_server_defaults.py
+++ b/services/backend/alembic/versions/p97_snapshots_fk_and_server_defaults.py
@@ -46,7 +46,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "p97_snapshots_fk_and_server_defaults"
+revision: str = "p97_snapshots_fk_defaults"  # ≤32 chars per Postgres alembic_version.version_num VARCHAR(32) ; long « p97_snapshots_fk_and_server_defaults » (36 ch) blew up Railway staging deploy 2026-05-12T11:14Z with psycopg2.errors.StringDataRightTruncation
 down_revision: Union[str, Sequence[str], None] = "p95_dag_invalidation"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Critical — Railway staging is DOWN

PR #574 deploy 2026-05-12T11:14Z fails with `psycopg2.errors.StringDataRightTruncation` on the alembic_version table — `p97_snapshots_fk_and_server_defaults` (36 chars) overflows Postgres `VARCHAR(32)`. Container failed to start → healthcheck retries exhausted → 502 to every request.

## Fix

Rename revision_id to `p97_snapshots_fk_defaults` (25 chars). Filename unchanged. Local pytest 10/10 GREEN.

## Action sequence post-merge

1. Merge to dev.
2. Emergency dev → staging sync PR (immediately).
3. Railway re-runs alembic upgrade — succeeds at 25 < 32.
4. Verify `/api/v1/health` returns 200.
5. L3 re-curl with Julien's prompt for P003 dim 3 verification.

## Follow-up perimeter filed

Add `tools/checks/alembic_revision_length.py` lint that blocks any revision_id > 32 chars at PR time. Would have caught this 2 hours ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)