### PR TITLE
hotfix: dev → staging (alembic revision_id length) — Railway UNBLOCK

### DIFF
--- a/services/backend/alembic/versions/p97_snapshots_fk_and_server_defaults.py
+++ b/services/backend/alembic/versions/p97_snapshots_fk_and_server_defaults.py
@@ -46,7 +46,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "p97_snapshots_fk_and_server_defaults"
+revision: str = "p97_snapshots_fk_defaults"  # ≤32 chars per Postgres alembic_version.version_num VARCHAR(32) ; long « p97_snapshots_fk_and_server_defaults » (36 ch) blew up Railway staging deploy 2026-05-12T11:14Z with psycopg2.errors.StringDataRightTruncation
 down_revision: Union[str, Sequence[str], None] = "p95_dag_invalidation"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
Merge PR #575 hotfix. Railway staging container has been down since 11:14Z (alembic_version VARCHAR(32) truncation). This sync re-deploys with revision_id shortened to 25 chars. Expected outcome : container starts, healthcheck 200, backend resumes serving.