### PR TITLE
fix(ci): LINT-ALEMBIC-01 — block alembic revision id > 32 chars

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -136,6 +136,26 @@ pre-commit:
       run: python3 tools/checks/banned_terms_python.py --lsfin-annotation {staged_files}
       tags: [compliance, lsfin, phase-95-dag-invalidation]
       fail_text: "LSFin D-12 violation : credible_low/credible_high emitted without verbatim « selon le modèle simplifié actuel » annotation. Add the FR phrase to the module docstring or output template (CLAUDE.md §1)."
+    # ── Incident 2026-05-12 — alembic revision id too long (LINT-ALEMBIC-01) ──
+    alembic_revision_length:
+      # HARD gate. Block any alembic migration whose `revision` identifier
+      # exceeds 32 chars. PostgreSQL `alembic_version.version_num` is
+      # `VARCHAR(32)` — a longer id triggers `psycopg2.errors.
+      # StringDataRightTruncation`, the UPDATE fails, the migration rolls
+      # back, alembic_version stays at the previous revision, the container
+      # fails to start, Railway healthcheck retries exhaust, and prod
+      # serves 502.
+      #
+      # 2026-05-12T11:14Z incident : revision_id
+      # `p97_snapshots_fk_and_server_defaults` (36 chars) overflowed the
+      # column. Staging served 502 for ~35 minutes. SQLite tolerates the
+      # overflow at pytest-time, so this defect only surfaces in production.
+      # Fix : PR #575 shortened to `p97_snapshots_fk_defaults` (25 chars).
+      # This lint is the mechanical guard that prevents recurrence.
+      glob: "services/backend/alembic/versions/*.py"
+      run: python3 tools/checks/alembic_revision_length.py --file {staged_files}
+      tags: [backend, alembic, release, incident-2026-05-12]
+      fail_text: "alembic revision id > 32 chars — PostgreSQL alembic_version.version_num VARCHAR(32) overflow. Shorten the `revision` string in the affected file."
     # ── Incident 2026-05-11 — iOS release capability drift (LINT-IOS-RELEASE-01) ──
     ios_release_capability_drift:
       # HARD gate. Runs when `apps/mobile/ios/Runner/Runner.entitlements`

--- a/tools/checks/alembic_revision_length.py
+++ b/tools/checks/alembic_revision_length.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""LINT-ALEMBIC-01 — alembic_revision_length.
+
+Block any alembic migration whose `revision` identifier exceeds 32 chars.
+
+Why this lint exists
+====================
+2026-05-12T11:14Z — Railway staging container failed to start with :
+
+    sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation)
+        value too long for type character varying(32)
+    [SQL: UPDATE alembic_version
+          SET version_num='p97_snapshots_fk_and_server_defaults'
+          WHERE alembic_version.version_num = 'p95_dag_invalidation']
+
+Alembic's default schema is `alembic_version (version_num VARCHAR(32)
+PRIMARY KEY)`. SQLite (used by local pytest fixtures) tolerates strings
+longer than 32 chars on a `VARCHAR(32)` column, so the local test suite
+passed at PR time. PostgreSQL is strict — the UPDATE failed, the
+migration rolled back, alembic_version stayed at the old revision,
+the container failed startup, Railway healthcheck retries exhausted,
+and staging served 502 to every request including
+`/api/v1/health` for ~35 minutes (incident 2026-05-12T11:14Z → 11:50Z).
+
+This lint runs at pre-commit and CI, scans every
+`services/backend/alembic/versions/*.py` file for the `revision: str =`
+or `revision = ` assignment, and fails on any value > 32 chars.
+
+Behaviour
+=========
+- Scope : `services/backend/alembic/versions/*.py` (overridable via
+  `--scope-root`).
+- Exit codes :
+    0 — clean (all revision ids ≤ 32 chars) OR no migration files found.
+    1 — at least one revision id > 32 chars.
+
+Single source of truth — no baseline / no grandfathering. Postgres
+schema is the authority ; a long revision id can never be safe.
+
+Per memory `feedback_ios_entitlements_block_testflight.md` + today's
+incident : whenever production breaks because of a check we COULD have
+done at PR time, the next perimeter is the mechanical guard. This lint
+is that guard.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+LINT_NAME = "alembic_revision_length"
+MAX_LEN = 32  # PostgreSQL `alembic_version.version_num VARCHAR(32)`.
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_SCOPE = REPO / "services" / "backend" / "alembic" / "versions"
+
+# Matches both `revision: str = "..."` and `revision = "..."` forms.
+# Captures the literal string between the quotes (single or double).
+_REVISION_RE = re.compile(
+    r"""^\s*revision(?:\s*:\s*str)?\s*=\s*(['"])(?P<id>[^'"]+)\1""",
+    re.MULTILINE,
+)
+
+
+def _scan_file(path: Path) -> str | None:
+    """Return the offending revision id if length > MAX_LEN, else None."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    m = _REVISION_RE.search(text)
+    if m is None:
+        return None  # not a revision file (env.py, __init__.py, etc.)
+    rid = m.group("id")
+    if len(rid) > MAX_LEN:
+        return rid
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            f"{LINT_NAME} — block alembic migrations whose revision id "
+            f"exceeds {MAX_LEN} chars (PostgreSQL "
+            f"alembic_version.version_num is VARCHAR({MAX_LEN}))."
+        )
+    )
+    ap.add_argument("--scope-root", type=Path, default=DEFAULT_SCOPE)
+    ap.add_argument(
+        "--file",
+        action="append",
+        type=Path,
+        default=None,
+        help=(
+            "Scan only these specific files (lefthook staged-files mode). "
+            "When omitted, scans every .py file under --scope-root."
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    if not args.scope_root.exists():
+        print(f"INFO {LINT_NAME}: scope-root {args.scope_root} missing")
+        return 0
+
+    if args.file:
+        targets = [
+            f.resolve()
+            for f in args.file
+            if f.exists() and f.suffix == ".py"
+        ]
+    else:
+        targets = sorted(args.scope_root.glob("*.py"))
+
+    violations: list[tuple[str, str, int]] = []
+    for path in targets:
+        rid = _scan_file(path)
+        if rid is not None:
+            try:
+                rel = path.relative_to(REPO).as_posix()
+            except ValueError:
+                rel = path.as_posix()
+            violations.append((rel, rid, len(rid)))
+
+    if violations:
+        print(
+            f"::error::{LINT_NAME}: {len(violations)} revision id(s) "
+            f"longer than {MAX_LEN} chars (PostgreSQL alembic_version "
+            f"VARCHAR({MAX_LEN}) limit) :"
+        )
+        for path, rid, length in violations:
+            print(f"  {path}:")
+            print(f"    revision = '{rid}' ({length} chars > {MAX_LEN})")
+        print()
+        print(
+            "Fix: shorten the `revision` string in the affected file(s) "
+            f"to {MAX_LEN} chars or fewer. Alembic resolves migrations by "
+            "revision id (not filename), so the filename can stay as-is "
+            "if desired."
+        )
+        print()
+        print(
+            "Why this gate : 2026-05-12 Railway staging incident — "
+            "`p97_snapshots_fk_and_server_defaults` (36 chars) overflowed "
+            "the Postgres column, the alembic UPDATE was rejected, the "
+            "container failed to start, and staging served 502 for ~35 "
+            "minutes. SQLite tolerates the overflow at pytest-time, so "
+            "this defect only surfaces in production."
+        )
+        return 1
+
+    print(f"OK {LINT_NAME}: scanned {len(targets)} migration(s), all ≤{MAX_LEN} chars")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Mechanical guard against the failure mode that broke Railway staging at 2026-05-12T11:14Z. Revision_id `p97_snapshots_fk_and_server_defaults` (36 chars) overflowed Postgres `alembic_version.version_num` VARCHAR(32) — UPDATE failed, migration rolled back, container died, ~35min outage.

## What it does

- `tools/checks/alembic_revision_length.py` scans every `services/backend/alembic/versions/*.py` for `revision: str = "..."`.
- Fails if any revision id exceeds 32 chars.
- Wired as pre-commit HARD gate via lefthook (glob-filtered to migration files).

## Why this lint specifically

SQLite (local pytest) tolerates VARCHAR(32) overflows silently — the defect only surfaces on PostgreSQL in production. CI tests passed at PR time on PR #572 ; the bug detonated only on Railway. This lint moves the check upstream to PR time.

## Verification

- Clean run on current dev : 25 migrations scanned, all ≤32 chars.
- Force-test against the offending pre-fix revision_id : exits 1 with full remediation guide.

## Same discipline pattern

Today is the second mechanical guard shipped (PR #569 was the iOS capability drift lint). The pattern : whenever production breaks because of a check we COULD have done at PR time, the next perimeter is the mechanical guard. Both lints live in `tools/checks/` + lefthook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)