### PR TITLE
chore(hygiene): gitignore .hypothesis cache + scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,10 @@ tools/mcp/mint-tools/.venv/
 
 # Codegraph local index (regenerable, 139MB+ SQLite)
 .codegraph/
+
+# Hypothesis property-based testing cache (regenerated per pytest run, never commit)
+.hypothesis/
+**/.hypothesis/
+
+# .gitignore backups produced by failed edits
+.gitignore.bak


### PR DESCRIPTION
## Summary

Drops VSCode source-control untracked-file count from **455 → 3** by ignoring the Hypothesis property-based testing cache and removing 5 orphan scratch files from the repo root.

## Diagnostic

| Source | Count | Action |
|---|---|---|
| `services/backend/.hypothesis/constants/*` | ~430 | Add `**/.hypothesis/` to `.gitignore` |
| `.hypothesis/unicode_data/*` | 1 | Add `.hypothesis/` to `.gitignore` |
| `.gitignore.bak` | 1 | Delete + add `.gitignore.bak` to `.gitignore` |
| `0[1-4]-*.png` (sim screenshots) | 4 | Delete (ad-hoc, not versioned evidence) |
| In-flight cycle artefacts | 3 | Stays untracked (expected) |

## Why

Per memory `feedback_html_evidence_report.md`, real evidence screenshots live under `.planning/phases/<phase>/<bug>-VERIFICATION/screenshots/`. The orphan PNGs at repo root were ad-hoc captures from an earlier session, not versioned evidence — safe to delete.

The Hypothesis cache (`.hypothesis/`) is auto-regenerated on every pytest run. Committing it would create thousands of meaningless diff lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)