### PR TITLE
feat(observability): client/server request-id correlation spine (S97 tier 1)

### DIFF
--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/models/profile.dart';
 import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart' as chf;
 import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// P2-18: Error codes for i18n — UI layer maps these to AppLocalizations.
@@ -96,6 +97,12 @@ class ApiService {
       );
     }
   }
+
+  /// Singleton HTTP client that stamps `X-MINT-Req-Id` on every call and
+  /// emits structured logs to `dart:developer` (category `ch.mint.http`).
+  /// Pair with `tools/debug/mint-trace.sh <req_id>` to fetch matching
+  /// Railway backend logs.
+  static final MintHttpClient _mintHttp = MintHttpClient();
 
   static const String _definedApiBaseUrl =
       String.fromEnvironment('API_BASE_URL');
@@ -263,7 +270,7 @@ class ApiService {
     if (refreshToken == null) return false;
 
     try {
-      final response = await http.post(
+      final response = await _mintHttp.post(
         Uri.parse('$baseUrl/auth/refresh'),
         headers: _publicHeaders(),
         body: jsonEncode({'refresh_token': refreshToken}),
@@ -295,14 +302,14 @@ class ApiService {
   // Méthodes génériques HTTP (now with JWT injection + auto-refresh + P1-7 timeout)
   static Future<Map<String, dynamic>> get(String endpoint) async {
     try {
-      var response = await http.get(
+      var response = await _mintHttp.get(
         Uri.parse('$baseUrl$endpoint'),
         headers: await _authHeaders(),
       ).timeout(_httpTimeout);
 
       // Auto-refresh on 401
       if (response.statusCode == 401 && await _tryRefreshToken()) {
-        response = await http.get(
+        response = await _mintHttp.get(
           Uri.parse('$baseUrl$endpoint'),
           headers: await _authHeaders(),
         ).timeout(_httpTimeout);
@@ -327,13 +334,13 @@ class ApiService {
 
   static Future<String> getText(String endpoint) async {
     try {
-      var response = await http.get(
+      var response = await _mintHttp.get(
         Uri.parse('$baseUrl$endpoint'),
         headers: await _authHeaders(),
       ).timeout(_httpTimeout);
 
       if (response.statusCode == 401 && await _tryRefreshToken()) {
-        response = await http.get(
+        response = await _mintHttp.get(
           Uri.parse('$baseUrl$endpoint'),
           headers: await _authHeaders(),
         ).timeout(_httpTimeout);
@@ -360,14 +367,14 @@ class ApiService {
   static Future<Map<String, dynamic>> post(
       String endpoint, Map<String, dynamic> data) async {
     try {
-      var response = await http.post(
+      var response = await _mintHttp.post(
         Uri.parse('$baseUrl$endpoint'),
         headers: await _authHeaders(),
         body: jsonEncode(data),
       ).timeout(_httpTimeout);
 
       if (response.statusCode == 401 && await _tryRefreshToken()) {
-        response = await http.post(
+        response = await _mintHttp.post(
           Uri.parse('$baseUrl$endpoint'),
           headers: await _authHeaders(),
           body: jsonEncode(data),
@@ -396,14 +403,14 @@ class ApiService {
   static Future<Map<String, dynamic>> put(
       String endpoint, Map<String, dynamic> data) async {
     try {
-      var response = await http.put(
+      var response = await _mintHttp.put(
         Uri.parse('$baseUrl$endpoint'),
         headers: await _authHeaders(),
         body: jsonEncode(data),
       ).timeout(_httpTimeout);
 
       if (response.statusCode == 401 && await _tryRefreshToken()) {
-        response = await http.put(
+        response = await _mintHttp.put(
           Uri.parse('$baseUrl$endpoint'),
           headers: await _authHeaders(),
           body: jsonEncode(data),
@@ -431,13 +438,13 @@ class ApiService {
 
   static Future<void> delete(String endpoint) async {
     try {
-      var response = await http.delete(
+      var response = await _mintHttp.delete(
         Uri.parse('$baseUrl$endpoint'),
         headers: await _authHeaders(),
       ).timeout(_httpTimeout);
 
       if (response.statusCode == 401 && await _tryRefreshToken()) {
-        response = await http.delete(
+        response = await _mintHttp.delete(
           Uri.parse('$baseUrl$endpoint'),
           headers: await _authHeaders(),
         ).timeout(_httpTimeout);
@@ -470,7 +477,7 @@ class ApiService {
     String password, {
     String? displayName,
   }) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/register'),
       headers: _publicHeaders(),
       body: jsonEncode({
@@ -495,7 +502,7 @@ class ApiService {
     String email,
     String password,
   ) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/login'),
       headers: _publicHeaders(),
       body: jsonEncode({
@@ -516,7 +523,7 @@ class ApiService {
   /// Send a magic link to the given email address.
   /// Returns: { message: "..." }
   static Future<Map<String, dynamic>> sendMagicLink(String email) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/magic-link/send'),
       headers: _publicHeaders(),
       body: jsonEncode({'email': email}),
@@ -534,7 +541,7 @@ class ApiService {
   /// Verify a magic link token and return JWT.
   /// Returns: { accessToken: "...", tokenType: "bearer" }
   static Future<Map<String, dynamic>> verifyMagicLink(String token) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/magic-link/verify'),
       headers: _publicHeaders(),
       body: jsonEncode({'token': token}),
@@ -555,7 +562,7 @@ class ApiService {
     required String identityToken,
     required String nonce,
   }) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/apple/verify'),
       headers: _publicHeaders(),
       body: jsonEncode({
@@ -576,7 +583,7 @@ class ApiService {
   /// Get current user info
   /// Returns: { id, email, display_name?, created_at }
   static Future<Map<String, dynamic>> getMe() async {
-    final response = await http.get(
+    final response = await _mintHttp.get(
       Uri.parse('$baseUrl/auth/me'),
       headers: await _authHeaders(),
     );
@@ -592,7 +599,7 @@ class ApiService {
   }
 
   static Future<void> deleteAccount() async {
-    final response = await http.delete(
+    final response = await _mintHttp.delete(
       Uri.parse('$baseUrl/auth/account'),
       headers: await _authHeaders(),
     );
@@ -607,7 +614,7 @@ class ApiService {
   }
 
   static Future<Map<String, dynamic>> requestPasswordReset(String email) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/password-reset/request'),
       headers: _publicHeaders(),
       body: jsonEncode({'email': email}),
@@ -628,7 +635,7 @@ class ApiService {
     String token,
     String newPassword,
   ) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/password-reset/confirm'),
       headers: _publicHeaders(),
       body: jsonEncode({'token': token, 'new_password': newPassword}),
@@ -648,7 +655,7 @@ class ApiService {
   static Future<Map<String, dynamic>> requestEmailVerification(
     String email,
   ) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/email-verification/request'),
       headers: _publicHeaders(),
       body: jsonEncode({'email': email}),
@@ -668,7 +675,7 @@ class ApiService {
   static Future<Map<String, dynamic>> confirmEmailVerification(
     String token,
   ) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/auth/email-verification/confirm'),
       headers: _publicHeaders(),
       body: jsonEncode({'token': token}),
@@ -1200,7 +1207,7 @@ class ApiService {
     List<Map<String, dynamic>> checkins = const [],
   }) async {
     // FIX-W11-1: Send ISO 8601 UTC timestamp for conflict resolution
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/sync/claim-local-data'),
       headers: await _authHeaders(),
       body: jsonEncode({
@@ -1231,7 +1238,7 @@ class ApiService {
     bool isTrial = false,
     String? signedPayload,
   }) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/billing/apple/verify'),
       headers: await _authHeaders(),
       body: jsonEncode({
@@ -1288,7 +1295,7 @@ class ApiService {
     bool hasDebt = false,
     Goal goal = Goal.other,
   }) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/profiles'),
       headers: await _authHeaders(),
       body: jsonEncode({
@@ -1320,7 +1327,7 @@ class ApiService {
     required List<String> selectedFocusKinds,
     String? selectedGoalTemplateId,
   }) async {
-    final response = await http.post(
+    final response = await _mintHttp.post(
       Uri.parse('$baseUrl/sessions'),
       headers: _publicHeaders(),
       body: jsonEncode({

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -98,11 +98,10 @@ class ApiService {
     }
   }
 
-  /// Singleton HTTP client that stamps `X-MINT-Req-Id` on every call and
-  /// emits structured logs to `dart:developer` (category `ch.mint.http`).
-  /// Pair with `tools/debug/mint-trace.sh <req_id>` to fetch matching
-  /// Railway backend logs.
-  static final MintHttpClient _mintHttp = MintHttpClient();
+  /// Process-wide singleton HTTP client (defined in MintHttpClient.shared).
+  /// Aliased here to keep the in-class call sites short. Every other MINT
+  /// service uses `MintHttpClient.shared` directly.
+  static final MintHttpClient _mintHttp = MintHttpClient.shared;
 
   static const String _definedApiBaseUrl =
       String.fromEnvironment('API_BASE_URL');
@@ -168,7 +167,7 @@ class ApiService {
 
     for (final candidate in _baseUrlCandidates) {
       try {
-        final response = await http
+        final response = await MintHttpClient.shared
             .get(Uri.parse('$candidate/health'))
             .timeout(const Duration(milliseconds: 700));
         if (_isUnavailableEndpoint(response)) {

--- a/apps/mobile/lib/services/auth_service.dart
+++ b/apps/mobile/lib/services/auth_service.dart
@@ -3,9 +3,9 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:http/http.dart' as http;
 
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 /// Service for managing JWT authentication tokens and user session.
 /// Uses flutter_secure_storage (Keychain on iOS, Keystore on Android).
@@ -216,7 +216,7 @@ class AuthService {
     if (refresh == null || refresh.isEmpty) return null;
 
     try {
-      final response = await http
+      final response = await MintHttpClient.shared
           .post(
             Uri.parse('${ApiService.baseUrl}/auth/refresh'),
             headers: const {'Content-Type': 'application/json'},

--- a/apps/mobile/lib/services/coach/coach_chat_api_service.dart
+++ b/apps/mobile/lib/services/coach/coach_chat_api_service.dart
@@ -10,6 +10,7 @@ import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/anonymous_session_service.dart';
 import 'package:mint_mobile/services/partner_estimate_service.dart';
 import 'package:mint_mobile/services/rag_service.dart' show RagSource, RagToolCall;
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 /// HTTP client for POST /api/v1/coach/chat — the server-key tier.
 ///
@@ -178,7 +179,7 @@ class CoachChatApiService {
           .post(uri, headers: headers, body: encoded)
           .timeout(const Duration(seconds: 50));
     }
-    return http
+    return MintHttpClient.shared
         .post(uri, headers: headers, body: encoded)
         .timeout(const Duration(seconds: 50));
   }
@@ -221,7 +222,7 @@ class CoachChatApiService {
         body['intent'] = intent;
       }
 
-      final response = await http
+      final response = await MintHttpClient.shared
           .post(
             uri,
             headers: {

--- a/apps/mobile/lib/services/commitment_service.dart
+++ b/apps/mobile/lib/services/commitment_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
 
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/notification_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 // ────────────────────────────────────────────────────────────
 //  COMMITMENT SERVICE — Phase 14 / CMIT-01 + CMIT-02
@@ -55,7 +55,7 @@ class CommitmentService {
       body['reminderAt'] = reminderAt.toUtc().toIso8601String();
     }
 
-    final response = await http
+    final response = await MintHttpClient.shared
         .post(
           uri,
           headers: {
@@ -129,7 +129,7 @@ class CommitmentService {
       uri = uri.replace(queryParameters: {'status': status});
     }
 
-    final response = await http
+    final response = await MintHttpClient.shared
         .get(
           uri,
           headers: {
@@ -163,7 +163,7 @@ class CommitmentService {
     }
 
     final uri = Uri.parse('$baseUrl/coach/commitment/$commitmentId');
-    final response = await http
+    final response = await MintHttpClient.shared
         .patch(
           uri,
           headers: {

--- a/apps/mobile/lib/services/document_service.dart
+++ b/apps/mobile/lib/services/document_service.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/models/document_event.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:uuid/uuid.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 /// v2.7 Task 7 — client-generated UUID v4 for Idempotency-Key header on
 /// all document upload paths. Prevents duplicate processing on network
@@ -1016,7 +1017,7 @@ class DocumentService {
       headers['Authorization'] = 'Bearer $token';
     }
 
-    final response = await http
+    final response = await MintHttpClient.shared
         .get(uri, headers: headers)
         .timeout(const Duration(seconds: 30));
 
@@ -1053,7 +1054,7 @@ class DocumentService {
       headers['Authorization'] = 'Bearer $token';
     }
 
-    final response = await http
+    final response = await MintHttpClient.shared
         .delete(uri, headers: headers)
         .timeout(const Duration(seconds: 30));
 
@@ -1116,7 +1117,7 @@ class DocumentService {
         'timestamp': DateTime.now().toUtc().toIso8601String(),
       });
 
-      var response = await http.post(
+      var response = await MintHttpClient.shared.post(
         Uri.parse('$baseUrl/documents/scan-confirmation'),
         headers: {
           'Authorization': 'Bearer $token',
@@ -1129,7 +1130,7 @@ class DocumentService {
         final fresh = await AuthService.refreshAccessToken();
         if (fresh != null && fresh.isNotEmpty) {
           token = fresh;
-          response = await http.post(
+          response = await MintHttpClient.shared.post(
             Uri.parse('$baseUrl/documents/scan-confirmation'),
             headers: {
               'Authorization': 'Bearer $token',
@@ -1164,7 +1165,7 @@ class DocumentService {
       final token = await AuthService.getToken();
       if (token == null) return null;
 
-      final response = await http.post(
+      final response = await MintHttpClient.shared.post(
         Uri.parse('$baseUrl/documents/extract-vision'),
         headers: {
           'Authorization': 'Bearer $token',
@@ -1211,7 +1212,7 @@ class DocumentService {
       final token = await AuthService.getToken();
       if (token == null) return null;
 
-      final response = await http.post(
+      final response = await MintHttpClient.shared.post(
         Uri.parse('$baseUrl/documents/premier-eclairage'),
         headers: {
           'Authorization': 'Bearer $token',

--- a/apps/mobile/lib/services/fresh_start_service.dart
+++ b/apps/mobile/lib/services/fresh_start_service.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/notification_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 // ────────────────────────────────────────────────────────────
 //  FRESH START SERVICE — Phase 14 / CMIT-03 + CMIT-04
@@ -63,7 +63,7 @@ class FreshStartService {
 
     try {
       final uri = Uri.parse('$baseUrl/coach/fresh-start');
-      final response = await http
+      final response = await MintHttpClient.shared
           .get(
             uri,
             headers: {

--- a/apps/mobile/lib/services/household_service.dart
+++ b/apps/mobile/lib/services/household_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 /// Service for managing Couple+ household.
 ///
@@ -33,7 +33,7 @@ class HouseholdService {
     String token,
     String baseUrl,
   ) async {
-    final response = await http.get(
+    final response = await MintHttpClient.shared.get(
       _uri(baseUrl, ''),
       headers: {'Authorization': 'Bearer $token'},
     );
@@ -47,7 +47,7 @@ class HouseholdService {
     String baseUrl,
     String email,
   ) async {
-    final response = await http.post(
+    final response = await MintHttpClient.shared.post(
       _uri(baseUrl, '/invite'),
       headers: {
         'Authorization': 'Bearer $token',
@@ -73,7 +73,7 @@ class HouseholdService {
     String baseUrl,
     String invitationCode,
   ) async {
-    final response = await http.post(
+    final response = await MintHttpClient.shared.post(
       _uri(baseUrl, '/accept'),
       headers: {
         'Authorization': 'Bearer $token',
@@ -99,7 +99,7 @@ class HouseholdService {
     String baseUrl,
     String userId,
   ) async {
-    final response = await http.delete(
+    final response = await MintHttpClient.shared.delete(
       _uri(baseUrl, '/member/$userId'),
       headers: {'Authorization': 'Bearer $token'},
     );
@@ -121,7 +121,7 @@ class HouseholdService {
     String baseUrl,
     String newOwnerId,
   ) async {
-    final response = await http.put(
+    final response = await MintHttpClient.shared.put(
       _uri(baseUrl, '/transfer'),
       headers: {
         'Authorization': 'Bearer $token',

--- a/apps/mobile/lib/services/memory/coach_memory_service.dart
+++ b/apps/mobile/lib/services/memory/coach_memory_service.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/models/coach_insight.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 // ────────────────────────────────────────────────────────────
 //  COACH MEMORY SERVICE — S58 / AI Memory
@@ -135,7 +135,7 @@ class CoachMemoryService {
       final token = await AuthService.getToken();
       if (token == null) return;
 
-      await http.post(
+      await MintHttpClient.shared.post(
         Uri.parse('$baseUrl/coach/sync-insight'),
         headers: {
           'Authorization': 'Bearer $token',
@@ -171,7 +171,7 @@ class CoachMemoryService {
       final baseUrl = ApiService.baseUrl;
       final token = await AuthService.getToken();
       if (token == null) return;
-      await http.delete(
+      await MintHttpClient.shared.delete(
         Uri.parse('$baseUrl/coach/sync-insight/$insightId'),
         headers: {'Authorization': 'Bearer $token'},
       );

--- a/apps/mobile/lib/services/observability/mint_http_client.dart
+++ b/apps/mobile/lib/services/observability/mint_http_client.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:uuid/uuid.dart';
+
+/// HTTP client that injects a per-call correlation ID and emits structured
+/// logs so an LLM agent can grep the request lifecycle from `simctl log`.
+///
+/// Every outbound call gets `X-MINT-Req-Id: <uuidv4>`. The backend
+/// `LoggingMiddleware` reuses that value as its `trace_id_var`, so a
+/// single ID stitches client stdout to Railway backend logs (see
+/// `tools/debug/mint-trace.sh`).
+///
+/// Surface the logs from a booted iOS simulator with:
+///
+///   xcrun simctl spawn booted log show --last 5m \
+///     --predicate 'category == "ch.mint.http"' --style compact
+///
+/// Debug builds include the response body (capped at [_bodyLogCap] chars)
+/// to surface parsing / serialization mismatches. Release builds log
+/// method, path, status, duration, and IDs only — PII-safe.
+class MintHttpClient extends http.BaseClient {
+  MintHttpClient([http.Client? inner]) : _inner = inner ?? http.Client();
+
+  final http.Client _inner;
+  static const Uuid _uuid = Uuid();
+
+  static const String logCategory = 'ch.mint.http';
+  static const String requestIdHeader = 'X-MINT-Req-Id';
+  static const int _bodyLogCap = 2000;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final requestId = _uuid.v4();
+    request.headers[requestIdHeader] = requestId;
+    final start = DateTime.now();
+
+    _log(
+      'REQ ${request.method} ${request.url.path} '
+      'req_id=$requestId host=${request.url.host}',
+    );
+
+    http.StreamedResponse upstream;
+    try {
+      upstream = await _inner.send(request);
+    } catch (e, s) {
+      _log(
+        'ERR ${request.method} ${request.url.path} '
+        'req_id=$requestId error=$e',
+        error: e,
+        stackTrace: s,
+      );
+      rethrow;
+    }
+
+    final duration = DateTime.now().difference(start).inMilliseconds;
+    final traceId = upstream.headers['x-trace-id'] ?? '-';
+
+    if (!kDebugMode) {
+      _log(
+        'RES ${request.method} ${request.url.path} '
+        'req_id=$requestId trace=$traceId '
+        'status=${upstream.statusCode} ms=$duration',
+      );
+      return upstream;
+    }
+
+    // Buffer the stream so we can both log the body AND hand a fresh
+    // stream back to the caller — `http.BaseClient` consumers expect to
+    // read `.body` themselves.
+    final bytes = await upstream.stream.toBytes();
+    final raw = utf8.decode(bytes, allowMalformed: true);
+    final preview = _truncate(raw, _bodyLogCap);
+    final keys = _extractTopLevelKeys(raw);
+
+    _log(
+      'RES ${request.method} ${request.url.path} '
+      'req_id=$requestId trace=$traceId '
+      'status=${upstream.statusCode} ms=$duration '
+      'bytes=${bytes.length} keys=$keys',
+    );
+    _log('BODY req_id=$requestId body=$preview');
+
+    return http.StreamedResponse(
+      Stream.value(bytes),
+      upstream.statusCode,
+      contentLength: bytes.length,
+      request: upstream.request,
+      headers: upstream.headers,
+      isRedirect: upstream.isRedirect,
+      persistentConnection: upstream.persistentConnection,
+      reasonPhrase: upstream.reasonPhrase,
+    );
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+
+  void _log(String message, {Object? error, StackTrace? stackTrace}) {
+    developer.log(
+      message,
+      name: logCategory,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  String _truncate(String s, int max) =>
+      s.length <= max ? s : '${s.substring(0, max)}…[+${s.length - max}]';
+
+  String _extractTopLevelKeys(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final keys = decoded.keys.toList()..sort();
+        return '[${keys.join(',')}]';
+      }
+      if (decoded is List) return '[<list:${decoded.length}>]';
+    } catch (_) {
+      // Non-JSON body — fine, just skip the keys hint.
+    }
+    return '[]';
+  }
+}

--- a/apps/mobile/lib/services/observability/mint_http_client.dart
+++ b/apps/mobile/lib/services/observability/mint_http_client.dart
@@ -25,6 +25,11 @@ import 'package:uuid/uuid.dart';
 class MintHttpClient extends http.BaseClient {
   MintHttpClient([http.Client? inner]) : _inner = inner ?? http.Client();
 
+  /// Process-wide singleton — every MINT service that performs HTTP
+  /// outbound traffic should call through this so request IDs, body
+  /// inspection, and the connection pool stay unified.
+  static final MintHttpClient shared = MintHttpClient();
+
   final http.Client _inner;
   static const Uuid _uuid = Uuid();
 

--- a/apps/mobile/lib/services/rag_service.dart
+++ b/apps/mobile/lib/services/rag_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 /// A tool call returned by the LLM (e.g. route_to_screen).
 class RagToolCall {
@@ -211,7 +212,7 @@ class RagService {
     // T3-11: Retry with exponential backoff on 429 rate limit.
     const maxRetries = 2;
     for (var attempt = 0; attempt <= maxRetries; attempt++) {
-      final response = await http
+      final response = await MintHttpClient.shared
           .post(
             uri,
             headers: {'Content-Type': 'application/json'},
@@ -305,7 +306,7 @@ class RagService {
     const maxRetries = 2;
     late http.Response response;
     for (var attempt = 0; attempt <= maxRetries; attempt++) {
-      response = await http
+      response = await MintHttpClient.shared
           .post(
             uri,
             headers: {'Content-Type': 'application/json'},
@@ -349,7 +350,7 @@ class RagService {
   Future<RagStatus> getStatus() async {
     final uri = Uri.parse('$baseUrl/rag/status');
 
-    final response = await http
+    final response = await MintHttpClient.shared
         .get(uri, headers: {'Content-Type': 'application/json'})
         .timeout(const Duration(seconds: 10));
 

--- a/apps/mobile/test/services/observability/mint_http_client_test.dart
+++ b/apps/mobile/test/services/observability/mint_http_client_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
+
+void main() {
+  group('MintHttpClient', () {
+    test('stamps X-MINT-Req-Id as a uuid v4 on every request', () async {
+      String? captured;
+      final inner = MockClient((req) async {
+        captured = req.headers[MintHttpClient.requestIdHeader];
+        return http.Response('{"ok":true}', 200,
+            headers: {'X-Trace-Id': 'srv-1'});
+      });
+
+      await MintHttpClient(inner).get(Uri.parse('https://example.test/health'));
+
+      expect(captured, isNotNull);
+      expect(
+        captured,
+        matches(RegExp(
+          r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-'
+          r'[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+        )),
+        reason: 'must be a uuid v4 — verifying version + variant bits',
+      );
+    });
+
+    test('generates a distinct req_id per call', () async {
+      final ids = <String?>[];
+      final inner = MockClient((req) async {
+        ids.add(req.headers[MintHttpClient.requestIdHeader]);
+        return http.Response('{}', 200);
+      });
+      final client = MintHttpClient(inner);
+
+      await client.get(Uri.parse('https://example.test/a'));
+      await client.get(Uri.parse('https://example.test/b'));
+      await client.get(Uri.parse('https://example.test/c'));
+
+      expect(ids.length, 3);
+      expect(ids.toSet().length, 3,
+          reason: 'each call must carry its own correlation id');
+    });
+
+    test('preserves status code and body across the buffer/re-emit', () async {
+      final inner = MockClient((req) async {
+        return http.Response(
+          '{"messagesRemaining":0,"reply":"capped"}',
+          200,
+        );
+      });
+
+      final resp = await MintHttpClient(inner)
+          .post(Uri.parse('https://example.test/chat'), body: '{}');
+
+      expect(resp.statusCode, 200);
+      final body = jsonDecode(resp.body) as Map<String, dynamic>;
+      expect(body['messagesRemaining'], 0);
+      expect(body['reply'], 'capped');
+    });
+
+    test('propagates non-2xx status codes', () async {
+      final inner = MockClient((req) async {
+        return http.Response('{"error":"rate_limited"}', 429);
+      });
+
+      final resp = await MintHttpClient(inner)
+          .post(Uri.parse('https://example.test/chat'), body: '{}');
+
+      expect(resp.statusCode, 429);
+    });
+
+    test('rethrows network errors with no body swallowing', () async {
+      final inner = MockClient((req) async {
+        throw const _NetDown();
+      });
+
+      expect(
+        MintHttpClient(inner).get(Uri.parse('https://example.test/x')),
+        throwsA(isA<_NetDown>()),
+      );
+    });
+  });
+}
+
+class _NetDown implements Exception {
+  const _NetDown();
+  @override
+  String toString() => 'NetDown';
+}

--- a/services/backend/app/core/logging_config.py
+++ b/services/backend/app/core/logging_config.py
@@ -7,13 +7,38 @@ Provides a LoggingMiddleware for FastAPI that logs request method, path, status,
 
 import json
 import logging
+import re
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from uuid import uuid4
+from typing import Optional
+from uuid import UUID, uuid4
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+
+# Mobile clients (MintHttpClient) stamp this header with a uuid4 per call.
+# When present and well-formed we reuse it as the trace_id so client stdout
+# and backend logs share a single key (see tools/debug/mint-trace.sh).
+CLIENT_REQUEST_ID_HEADER = "x-mint-req-id"
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _coerce_client_request_id(raw: Optional[str]) -> Optional[str]:
+    """Return ``raw`` only if it parses as a UUID — defense against log
+    poisoning when the header is attacker-controlled."""
+    if not raw:
+        return None
+    if not _UUID_RE.match(raw):
+        return None
+    try:
+        UUID(raw)
+    except ValueError:
+        return None
+    return raw.lower()
 
 # Context variable for trace ID (correlates all logs within a single request)
 trace_id_var: ContextVar[str] = ContextVar("trace_id", default="-")
@@ -82,7 +107,10 @@ class LoggingMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next):
-        request_trace_id = str(uuid4())
+        incoming = _coerce_client_request_id(
+            request.headers.get(CLIENT_REQUEST_ID_HEADER)
+        )
+        request_trace_id = incoming or str(uuid4())
         trace_id_var.set(request_trace_id)
 
         start = time.perf_counter()

--- a/services/backend/tests/test_logging_middleware_request_id.py
+++ b/services/backend/tests/test_logging_middleware_request_id.py
@@ -1,0 +1,78 @@
+"""Tests that LoggingMiddleware honours a client-supplied X-MINT-Req-Id.
+
+Pairs with apps/mobile/lib/services/observability/mint_http_client.dart —
+the mobile client stamps `X-MINT-Req-Id: <uuidv4>` on every outbound call,
+and the backend reuses that value as its trace_id so that client stdout
+and Railway backend logs share a single key (see tools/debug/mint-trace.sh).
+"""
+import re
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.logging_config import LoggingMiddleware
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(LoggingMiddleware)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_reuses_client_supplied_request_id_as_trace_id() -> None:
+    client = TestClient(_make_app())
+    client_req_id = "abc12345-d6e7-4f89-9123-456789abcdef"
+
+    response = client.get("/ping", headers={"X-MINT-Req-Id": client_req_id})
+
+    assert response.status_code == 200
+    assert response.headers["x-trace-id"] == client_req_id
+
+
+def test_accepts_uppercase_request_id_and_normalizes_to_lower() -> None:
+    client = TestClient(_make_app())
+    client_req_id = "ABC12345-D6E7-4F89-9123-456789ABCDEF"
+
+    response = client.get("/ping", headers={"X-MINT-Req-Id": client_req_id})
+
+    assert response.headers["x-trace-id"] == client_req_id.lower()
+
+
+def test_falls_back_to_generated_uuid_when_header_missing() -> None:
+    client = TestClient(_make_app())
+
+    response = client.get("/ping")
+
+    trace_id = response.headers["x-trace-id"]
+    assert _UUID_RE.match(trace_id)
+    uuid.UUID(trace_id)  # parses
+
+
+def test_rejects_malformed_request_id_to_prevent_log_poisoning() -> None:
+    """A non-UUID value must NOT be reflected back as trace_id."""
+    client = TestClient(_make_app())
+    poisoned = 'not-a-uuid"; level=ERROR; injected'
+
+    response = client.get("/ping", headers={"X-MINT-Req-Id": poisoned})
+
+    trace_id = response.headers["x-trace-id"]
+    assert trace_id != poisoned
+    assert _UUID_RE.match(trace_id)
+
+
+def test_rejects_empty_request_id() -> None:
+    client = TestClient(_make_app())
+
+    response = client.get("/ping", headers={"X-MINT-Req-Id": ""})
+
+    assert _UUID_RE.match(response.headers["x-trace-id"])

--- a/tools/debug/mint-trace.sh
+++ b/tools/debug/mint-trace.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# mint-trace.sh — fetch backend logs for a given client-supplied request ID.
+#
+# Pairs with the X-MINT-Req-Id header that MintHttpClient stamps on every
+# outbound call. The backend LoggingMiddleware reuses that ID as its
+# trace_id_var, so this script can pull the matching server-side lines.
+#
+# Usage:
+#   tools/debug/mint-trace.sh <req_id>
+#   tools/debug/mint-trace.sh <req_id> 30m
+#
+# Defaults: --since=10m.
+#
+# Prerequisites:
+#   - railway CLI:  https://docs.railway.app/develop/cli
+#   - jq:           brew install jq
+#   - Authenticated + linked to the staging service:
+#       railway login
+#       railway link    # pick mint-staging
+#
+# Example end-to-end loop:
+#   1) Run a Maestro flow that exercises the bug.
+#   2) Grep the sim for the client-side request IDs:
+#        xcrun simctl spawn booted log show --last 5m \
+#          --predicate 'category == "ch.mint.http"' --style compact \
+#          | grep req_id=
+#   3) Pull the matching backend lines:
+#        tools/debug/mint-trace.sh <req_id_from_step_2>
+set -euo pipefail
+
+req_id="${1:-}"
+since="${2:-10m}"
+
+if [[ -z "$req_id" ]]; then
+  echo "Usage: $0 <req_id> [since=10m]" >&2
+  exit 1
+fi
+
+if ! command -v railway >/dev/null 2>&1; then
+  echo "ERR: railway CLI not installed." >&2
+  echo "     See https://docs.railway.app/develop/cli" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERR: jq not installed. Run: brew install jq" >&2
+  exit 3
+fi
+
+# `railway logs` streams; we cap output with --since so it terminates.
+# --json yields one NDJSON record per log line.
+railway logs --json --since "$since" \
+  | jq -r --arg id "$req_id" '
+      select(.trace_id == $id) |
+      "\(.timestamp // .ts // "") [\(.level // "INFO")] \(.message // .msg // "")"
+    '


### PR DESCRIPTION
## Summary

Wire `X-MINT-Req-Id` end-to-end so an LLM agent can grep the full lifecycle of a single HTTP call from sim stdout to Railway backend logs **without rebuilding the app**. Tier 1 of the debug-observability spine evaluated by a 4-expert panel (mobile obs / E2E test infra / agent debug surface / SRE correlation) on 2026-05-13 — verdict: agent currently flies blind on client-side state bugs (cassure #4 today required a 15-min `debugPrint + rebuild + Maestro` round-trip per probe).

## What this adds

- **`MintHttpClient`** (`apps/mobile/lib/services/observability/mint_http_client.dart`) — wraps `http.BaseClient`, stamps a uuid v4 on every outbound call, emits structured logs via `dart:developer` under category `ch.mint.http`.
  - Debug builds log method/path/status/duration/req_id/trace_id + response body (capped 2KB) + top-level keys.
  - Release builds log method/path/status/duration/IDs only — PII-safe.
- **`ApiService`** migrated: 26 call sites swap `http.<verb>(` for `_mintHttp.<verb>(`. Public surface unchanged.
- **Backend `LoggingMiddleware`** reuses an incoming `X-MINT-Req-Id` as `trace_id_var` when it parses as a UUID; falls back to `uuid4()` otherwise. Defends against log poisoning by rejecting malformed values.
- **`tools/debug/mint-trace.sh`** wraps `railway logs --json` to filter by req_id.

The existing OBS-04 `sentry-trace` + `baggage` headers continue to flow unchanged; this is additive.

## Operator workflow after deploy

```bash
# Step 1: capture client-side req_ids during a flow
xcrun simctl spawn booted log show --last 5m \
  --predicate 'category == "ch.mint.http"' --style compact \
  | grep req_id=

# Step 2: pull matching backend lines for a specific call
tools/debug/mint-trace.sh <req_id>
```

Resolution time for a client/server state desync: **~5 minutes** vs ~45-90 min today (panel estimate).

## Why now (panel synthesis)

The current `feature/e2e-new-user-full-journey-v0` loop hit 4 cassures, 3 fixed by surface workarounds. Cassure #4 is client-side and required `debugPrint + rebuild + 11-min Maestro re-run` per hypothesis probe. The next 5 client cassures would repeat the same blind-debug pattern (~4-8h waste). 3-4h of Tier 1 wiring vs ~2 days of ping-pong = clear ROI.

## Test plan

- [x] `pytest services/backend/tests/test_logging_middleware_request_id.py -v` — 5/5 passing (incoming UUID reused, uppercase normalized, malformed rejected, empty rejected, missing falls back to uuid4)
- [x] `flutter test test/services/observability/mint_http_client_test.dart` — 5/5 passing (uuid v4 shape, distinct per call, body preservation, non-2xx propagation, error rethrow)
- [x] `flutter test test/services/{api_service_test,api_service_sentry_trace_test,coach_chat_api_service_anon_lockout_test,coach_chat_api_service_safe_mode_payload_test}.dart` — 39/39 passing (zero regression)
- [x] `flutter analyze` clean on `api_service.dart` + `mint_http_client.dart`
- [ ] CI green (waiting on workflow)
- [ ] Post-merge: rebuild staging sim, run `flow_e2e_new_user_full_journey.yaml`, grep `category == "ch.mint.http"` for cassure #4 root cause discrimination (H4a parsing vs H4b coercion vs H4c race vs H4d shape)

## Follow-ups (separate PRs, NOT in this one)

- **Tier 2** — `/debug/state` HTTP route in app debug builds → Maestro `runScript` asserts STATE not just TAP
- **Tier 3** — per-Maestro-run artifact bundle (`tools/simulator/runs/<ts>/` with JUnit XML + step screenshots + applog + summary.md)
- **Tier 4** — `SentryFlutter.init` proper with `tracesSampleRate: 0` breadcrumbs (requires `SENTRY_DSN_MOBILE` from Julien)

🤖 Generated with [Claude Code](https://claude.com/claude-code)