### PR TITLE
feat(vibe-coding): Phase 1 setup engram + mint-review-pr v2.0 (#601)

### DIFF
--- a/.claude/skills/mint-review-pr/SKILL.md
+++ b/.claude/skills/mint-review-pr/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: mint-review-pr
-description: "Staff engineer review of a diff. Checks bugs, compliance, regressions, i18n, archetypes. Fix-First pattern: AUTO-FIX trivial issues, ASK for judgment calls. Use with /review-pr."
-compatibility: Requires Flutter SDK + git
+description: "Staff engineer review of a diff with persistent memory across PRs (engram MCP). Checks bugs, compliance, regressions, i18n, archetypes. Recalls prior findings, accumulates new ones with prior_finding_refs. Fix-First pattern: AUTO-FIX trivial issues, ASK for judgment calls. Use with /review-pr."
+compatibility: Requires Flutter SDK + git + engram MCP (plugin:engram:engram, see docs/AGENTS/VIBE-CODING-INFRA.md)
+memory: local
 metadata:
   author: mint-team
-  version: "1.0"
-  source: "GStack /review (Fix-First + specialist passes) + Superpowers spec-reviewer (Do Not Trust)"
+  version: "2.0"
+  source: "GStack /review (Fix-First + specialist passes) + Superpowers spec-reviewer (Do Not Trust) + vibe-coding infra Phase 1 (engram persistent memory)"
 ---
 
 # Review PR v1 — Staff Engineer Review
@@ -24,6 +25,27 @@ metadata:
 
 **Do NOT approve or say "looks good" without running EVERY verification command yourself.**
 If you haven't run the command in THIS message, you cannot claim it passes.
+
+## Step 0: Recall prior findings (engram MCP, MANDATORY)
+
+Before reading the diff, query your accumulated memory of prior reviews. You DO have memory across sessions via the `plugin:engram:engram` MCP server (see `docs/AGENTS/VIBE-CODING-INFRA.md`).
+
+For each major file/topic touched by the diff, search engram :
+
+```
+mem_search <query> --project mint-ia-mint
+```
+
+Useful queries to run :
+- `mem_search "file:apps/mobile/lib/screens/<filename>"` — past findings on this file
+- `mem_search "topic:flutter:state-management"` — past findings on state management patterns
+- `mem_search "topic:lsfin:banned-terms"` — past banned-term flags + accepted exceptions
+- `mem_search "topic:financial_core:duplicate-calc"` — past calculation duplication flags
+- `mem_search "category:anti-facade"` — past facade-sans-cablage flags
+
+For each hit returned, note the `obs_id` — you'll need it for `prior_finding_refs` in Step 5.5.
+
+**If `mem_search` returns nothing** : either this is the first review of this surface (legitimate), OR engram is disconnected (`claude mcp list` should show `plugin:engram:engram → ✓ Connected`). If disconnected, flag this BEFORE proceeding — do not silently lose memory.
 
 ## Step 1: Read the diff (MANDATORY)
 
@@ -189,7 +211,48 @@ This catches adversarial cases that the grep-based Pass 2 misses.
 - flutter analyze: [result]
 - flutter test: [result]
 - pytest: [result]
+
+### MEMORY (engram findings cited from prior reviews)
+- prior_finding_refs: [list of obs_ids cited in this review, or "none — first review of this surface"]
+- new findings persisted: [count from Step 5.5]
 ```
+
+## Step 5.5: Persist findings to engram (MANDATORY before Step 6)
+
+For each BLOCKER and WARNING in the report, call `mem_save` so the next review of this surface inherits the context.
+
+```
+mem_save "<title>" "<message>" --type review-finding --project mint-ia-mint --scope local
+```
+
+Convention `--title` : `<category>: <file>:<line> — <one-liner>` (e.g. `anti-pattern: onboarding_screen.dart:142 — Provider state outside ChangeNotifier`).
+
+Convention `--message` (structured) :
+
+```
+What:    <one-paragraph description of the finding>
+Why:     <why this is a problem in MINT context — cite CLAUDE.md rule or memory if applicable>
+Where:   file=<path>, line=<int>, pr_number=<N>, pr_sha=<sha>
+Learned: <pattern or principle to remember for future PRs>
+Severity: P0 | P1 | P2 | nit
+Category: anti-pattern | regression | acceptance | warning | anti-facade | banned-term | i18n | financial-duplicate
+Recommendation: <concrete fix or accepted-exception rationale>
+prior_finding_refs: [<obs_id_1>, <obs_id_2>, ...]  // engram obs_ids from Step 0 search that this finding cites
+```
+
+**Topic key convention** : `<area>:<sub-area>:<specific>` — e.g. `flutter:state-management:provider-pattern`, `lsfin:banned-terms:garanti`, `financial_core:avs-calc:duplicate`. Use these in `mem_search` queries for cross-PR retrieval.
+
+**`prior_finding_refs` rule** : if a finding from Step 0 mem_search is **directly relevant** to this finding (same file, same anti-pattern, same banned-term family), include its `obs_id` in `prior_finding_refs`. This is the **compounding observable** metric for Phase 1 gate 2026-05-21 — ≥3 of first 5 PRs must have at least one finding with non-null `prior_finding_refs`.
+
+**Do NOT persist** : trivial AUTO-FIXED items (dead code, missing imports, formatting). Persist only findings that capture a pattern future reviews should re-recognize.
+
+After all findings persisted, sanity check :
+
+```
+mem_search "pr_sha:<sha-of-current-pr>" --project mint-ia-mint
+```
+
+Should return the count of findings just saved.
 
 ## Step 6: Gate for /mint-commit
 

--- a/docs/AGENTS/VIBE-CODING-INFRA.md
+++ b/docs/AGENTS/VIBE-CODING-INFRA.md
@@ -1,0 +1,89 @@
+# AGENTS — Vibe-Coding Infra (MINT)
+
+> Persistent specialist agents with memory for MINT dev workflow.
+> Phase 1 = pilot `@mint-code-reviewer` extension. Full architecture in `~/.gstack/projects/MINT-IA-MINT/julienbattaglia-dev-design-20260514-133000.md`.
+
+## What this is
+
+MINT runs `engram` (Gentleman-Programming, MIT, single Go binary + SQLite) as MCP server providing per-agent persistent memory. Each `mint-*` skill with `memory: local` frontmatter accumulates findings across sessions. Read-side via `mem_search`, write-side via `mem_save`. Cross-agent learning via `@karpathy-curator` (Phase 2).
+
+## Setup (Mac mini, one-time)
+
+```bash
+# Install engram via official Claude marketplace
+claude plugin marketplace add Gentleman-Programming/engram
+claude plugin install engram
+
+# Storage on Fun2 (1.7 TB free, persistent)
+mkdir -p /Volumes/FUN2/engram
+echo 'export ENGRAM_DATA_DIR="/Volumes/FUN2/engram"' >> ~/.zshrc
+
+# Verify
+engram --version       # engram 1.15.11+
+engram doctor          # 4 ok, 0 errors expected
+claude mcp list        # plugin:engram:engram → ✓ Connected
+```
+
+Round-trip smoke test :
+
+```bash
+engram save "test" "round-trip" --type validation --project mint-ia-mint
+engram search "test" --project mint-ia-mint
+```
+
+## Public-repo discipline
+
+Findings can contain sensitive code references. `.gitignore` excludes :
+- `.claude/agent-memory/`
+- `.claude/agent-memory-local/`
+
+Default memory scope for new mint-* skills = `memory: local` (NOT `project`) so memories stay outside version control. `tools/checks/no_legal_admission_in_public_docs.py` scans engram exports if surfaced via `engram export`.
+
+## Skills with persistent memory
+
+| Skill | Memory scope | Role |
+|---|---|---|
+| `mint-review-pr` | `memory: local` | Senior Flutter+Dart reviewer, accumulates patterns across PRs (Phase 1 pilot) |
+
+Phase 2+ extensions (post 2026-05-21 gate) :
+- `mint-swiss-compliance` → `@lsfin-officer` + `@swiss-fintech-expert`
+- `mint-audit-complet` → `@adversarial-tester`
+- NEW `mint-ux-critic-aesop`, `mint-karpathy-curator`
+
+## Multi-machine (future, Phase 4)
+
+Currently engram runs local-stdio on Mac mini. If laptop access needed, expose HTTP API via :
+
+```bash
+engram serve --http :7437 --project mint-ia-mint
+# + Tailscale Mac mini + laptop
+# + .mcp.json HTTP entry on laptop: http://mac-mini.tailscale.net:7437
+```
+
+LaunchAgent auto-start template in `tools/scripts/launchagent-engram.plist.template` (TBD Phase 2 if needed).
+
+## Findings JSON schema (engram entries)
+
+```json
+{
+  "agent": "mint-review-pr",
+  "topic_key": "flutter:state-management:provider-pattern",
+  "file": "apps/mobile/lib/screens/onboarding_screen.dart",
+  "line": 142,
+  "category": "anti-pattern | regression | acceptance | warning",
+  "severity": "P0 | P1 | P2 | nit",
+  "recommendation": "Move state to ChangeNotifier — see PR #XXX where pattern was agreed",
+  "pr_sha": "<sha>",
+  "pr_number": <int>,
+  "prior_finding_refs": ["<obs_id>", "..."]
+}
+```
+
+`prior_finding_refs` non-null in ≥3 of first 5 PRs reviewed = compounding observable (Phase 1 hard gate, 2026-05-21).
+
+## References
+
+- Design doc : `~/.gstack/projects/MINT-IA-MINT/julienbattaglia-dev-design-20260514-133000.md`
+- Backlog : `.planning/sessions/_BACKLOG.md` entry #1
+- Engram upstream : https://github.com/Gentleman-Programming/engram
+- Anthropic subagent memory docs : https://code.claude.com/docs/en/sub-agents


### PR DESCRIPTION
## Summary

Phase 1 of vibe-coding-infra rollout per design doc `~/.gstack/projects/MINT-IA-MINT/julienbattaglia-dev-design-20260514-133000.md` (APPROVED 2026-05-14) and backlog `.planning/sessions/_BACKLOG.md` entry #1.

**2 atomic commits in this PR** :

### Commit 1 : `docs(agents): VIBE-CODING-INFRA setup — engram MCP + Fun2 storage`

- New `docs/AGENTS/VIBE-CODING-INFRA.md` README documenting :
  - engram install via `claude plugin marketplace add Gentleman-Programming/engram`
  - Self-hosted storage `/Volumes/FUN2/engram` on Mac mini (1.7 TB free)
  - Findings JSON schema with `prior_finding_refs` mechanism
  - Compounding observable Phase 1 gate metric

### Commit 2 : `feat(skills): mint-review-pr v2.0 — persistent memory via engram MCP`

- Frontmatter `memory: local` added
- NEW Step 0 : `mem_search` accumulated findings BEFORE reading the diff
- NEW Step 5.5 : `mem_save` each finding with structured What/Why/Where/Learned + `prior_finding_refs`
- Updated Step 5 report with MEMORY section
- Version bump 1.0 → 2.0

## Architecture verified ✓

- ✓ engram 1.15.11 installed on Mac mini, DB on `/Volumes/FUN2/engram/engram.db`
- ✓ `claude mcp list` shows `plugin:engram:engram → ✓ Connected`
- ✓ Round-trip `mem_save` / `mem_search` validated 2026-05-14 13:32
- ✓ ENGRAM_DATA_DIR=`/Volumes/FUN2/engram` in `~/.zshrc`

## Phase 1 hard gate (2026-05-21)

Compounding observable measured deterministically : `prior_finding_refs` non-null in ≥3 of first 5 PRs reviewed by `@mint-code-reviewer`. GO Phase 2 if pass, KILL if not. Decision artifact at `.planning/decisions/2026-05-21-vibe-coding-infra-phase-1-gate.md`.

## Companion PR (separate)

PR #3 sequenced next : `.gitignore` `.claude/agent-memory-local/` + `tools/checks/no_legal_admission_in_public_docs.py` extension for public-repo discipline.

## Test plan

- [ ] Smoke test : after merge, invoke `mint-review-pr` skill on a Wave 1 PR, verify `mem_search` called in Step 0
- [ ] Verify `claude mcp list` shows engram connected
- [ ] Verify engram persistence : `engram search "test" --project mint-ia-mint` returns prior smoke-test
- [ ] CI green (lint frontmatter YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)