### PR TITLE
feat(wave-1a-08): rollout flags + regulatory tests + 5-gate close-out — Wave 1a complete (pending G2)

### DIFF
--- a/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-SUMMARY.md
+++ b/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+name: wave-1a-SUMMARY
+description: Phase SUMMARY for wave-1a-backend-tools-refactor — 9 plans (00..08) shipped, 5 server-side per-tool flags + cap CHF garde middleware + 18-case parity harness + 5-gate close (G1 drafted, G2 pending Julien).
+metadata:
+  type: summary
+  phase: wave-1a-backend-tools-refactor
+  date: 2026-05-14
+  status: PENDING G2
+---
+
+# Wave 1a — Backend Tools Refactor — SUMMARY
+
+## Requirements (10/10 satisfied modulo G2 device walkthrough)
+
+- [x] WAVE1A-01 — `get_budget_status` server-side recompute (plan-01, PR shipped via Wave 1a phase merges)
+- [x] WAVE1A-02 — `get_retirement_projection` server-side recompute (plan-02)
+- [x] WAVE1A-03 — `get_cross_pillar_analysis` server-side recompute (plan-03)
+- [x] WAVE1A-04 — `get_cap_status` CHF garde middleware (plan-06, default ON)
+- [x] WAVE1A-05 — `get_couple_optimization` Python port from Dart (plan-04, 78 MIRROR comments)
+- [x] WAVE1A-06 — `retrieve_memories` BM25 wrapper (plan-05, Karpathy wiki pattern, SQL-layer user isolation)
+- [x] WAVE1A-07 — `get_regulatory_constant` dispatcher validation tests (plan-08 Task 1)
+- [x] WAVE1A-08 — parity harness + 18 fixtures (plan-07, 6 tools × 3 archetypes)
+- [x] WAVE1A-09 — Pydantic v2 camelCase response models with SHA-256 inputs_hash (every plan 01-05)
+- [x] WAVE1A-10 — per-tool rollback flags + dispatcher routing tests (plan-08 Task 1)
+
+## Plan SUMMARYs
+
+| Plan | Tool / Scope | Tests added | LSFin / accent | SUMMARY link |
+|------|--------------|-------------|----------------|--------------|
+| 00 | scaffolding (6 flags, breadcrumb helper, hashing helper, marker pairs) | 15 (scaffolding) | ✓ | [wave-1a-00-SUMMARY.md](wave-1a-00-SUMMARY.md) |
+| 01 | `get_budget_status` server-side | 11 (budget_snapshot) | ✓ | [wave-1a-01-SUMMARY.md](wave-1a-01-SUMMARY.md) |
+| 02 | `get_retirement_projection` server-side | 12 (retirement_projection) | ✓ | [wave-1a-02-SUMMARY.md](wave-1a-02-SUMMARY.md) |
+| 03 | `get_cross_pillar_analysis` server-side | 14 (cross_pillar) | ✓ | [wave-1a-03-SUMMARY.md](wave-1a-03-SUMMARY.md) |
+| 04 | `get_couple_optimization` Python port | 30 (couple — 21 port + 9 dispatcher) | ✓ | [wave-1a-04-SUMMARY.md](wave-1a-04-SUMMARY.md) |
+| 05 | `retrieve_memories` BM25 | 18 (BM25 — 11 unit + 7 dispatcher) | ✓ | [wave-1a-05-SUMMARY.md](wave-1a-05-SUMMARY.md) |
+| 06 | `get_cap_status` CHF garde | 7 (cap_garde) | ✓ | [wave-1a-06-SUMMARY.md](wave-1a-06-SUMMARY.md) |
+| 07 | parity harness + 18 fixtures | 18 (parity, 6 tools × 3 archetypes) | — | [wave-1a-07-SUMMARY.md](wave-1a-07-SUMMARY.md) |
+| 08 | rollout flags + regulatory + 5-gate close | 18 (5 regulatory + 13 dispatcher flags) | ✓ | (this file) |
+
+Backend pytest count after Wave 1a:
+
+```
+6864 passed, 62 skipped, 1 xfailed, 1 warning
+```
+
+Source: `bash tools/checks/wave_1a_close.sh` exit 0 on `feature/wave-1a-08-rollout-close` HEAD (2026-05-14).
+Baseline (per PLAN.md) = 6567; Wave 1a delta = +297 tests, target was ≥+50.
+
+## 5-Gate Status
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| G1 Maestro flow (drafted, live exec deferred) | DRAFT | [`tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml`](../../../tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml) — live run deferred to post-staging-deploy per memory `feedback_app_targets_staging_always` |
+| G2 Julien device walkthrough | PENDING | plan-08 Task 3 `checkpoint:human-verify` (PR description bundles the 6-step protocol; awaiting `approved` / `not approved — issue: X` token) |
+| G3 dev CI | ✓ PASS | `bash tools/checks/wave_1a_close.sh` step `==> G3 + G4 — backend pytest`: 6864 passed |
+| G4 regression (pytest count + parity harness) | ✓ PASS | 6864 ≥ baseline+50 (6567+50=6617) AND `pytest tests/test_coach_tools_parity.py -q` 18/18 |
+| G5 LSFin banned-terms + accent_lint_fr | ✓ PASS | `tools/checks/banned_terms_python.py` + `accent_lint_fr.py` exit 0 on all 14 Wave-1a-touched files |
+
+## Self-Check : PENDING G2
+
+Per CLAUDE.md §9 — 0-trust evidence:
+
+- WAVE1A-01..10 satisfied per code:
+  - `_compute_budget_status`/`_format_budget_status` pair: `services/backend/app/api/v1/endpoints/coach_chat.py:2368-2469`
+  - `_compute_retirement_projection`: `coach_chat.py:2472-2566`
+  - `_compute_cross_pillar_analysis`: `coach_chat.py:2596-2691`
+  - `_compute_couple_optimization`: `coach_chat.py:2807-2938`
+  - `_compute_retrieve_memories`: `coach_chat.py:910-987`
+  - `_validate_cap_response` (cap CHF garde): `coach_chat.py:2723-2773`
+  - `_handle_regulatory_constant` confirmation tests: `services/backend/tests/test_coach_tools_regulatory_constant_dispatcher.py` (5 tests)
+  - Per-tool flag dispatcher routing tests: `services/backend/tests/test_coach_tools_dispatcher_flags.py` (13 tests)
+- Pytest 6864/6864 green: cite `services/backend/$ python3 -m pytest tests/ -q | tail -1` → `6864 passed, 62 skipped, 1 xfailed, 1 warning`.
+- Parity harness 18/18 green: cite `python3 -m pytest tests/test_coach_tools_parity.py -q | tail -1` → `18 passed`.
+- Banned-terms + accent_lint clean on all 14 Wave-1a-touched files: cite `bash tools/checks/wave_1a_close.sh` last line → `wave_1a_close.sh: ALL GATES GREEN (G3+G4+G5)`.
+- G1 status: DRAFT — Maestro flow YAML exists; live exec deferred until staging deploy (see memory `feedback_app_targets_staging_always`).
+- G2 status: PENDING — phase cannot claim « SHIPPED » until Julien posts the device-walkthrough token on PR #608+ (this PR).
+
+When Julien posts the G2 token:
+
+- `approved` → flip Status frontmatter to `SHIPPED`, update wave-1a-VERIFICATION-REPORT.html status rows, run `bash tools/simulator/walker.sh --flow coach_tools_server_side_smoke` on staging build to flip G1 to PASS, then merge feature → dev → staging → main.
+- `approved-with-issues: <description>` → Status `SHIPPED-WITH-DEFERRED`, append deferred items to VERIFICATION-REPORT.html.
+- `not approved — issue: <description>` → Status `REOPENED`, run `/gsd-plan-phase wave-1a-backend-tools-refactor --revise` with the issue text as input.
+
+## Deferred items (carried forward)
+
+- **CapEngine Flutter→Python port** — re-litigation trigger: `coach.cap.cap_chf_uncited` Sentry breadcrumb > 5/day for ≥1 week (CONTEXT D-17 option b — kept Flutter-source for Wave 1a).
+- **pgvector embeddings for retrieve_memories** — Wave 2+ if BM25 recall insufficient (CONTEXT D-07; BM25Okapi was sufficient for Wave 1a per memory `bm25_idf_gotcha_small_corpora`).
+- **20 paires Q&A parity suite** — Wave 1c scope (CONTEXT D-06 — Wave 1a ships 18-fixture mechanical parity only).
+- **`source_kind="tool_call_id"` CITATION_REGISTRY entries** — Wave 1b scope (consumes Wave 1a's `inputs_hash` via citation chips).
+- **Maestro G1 live exec on staging** — deferred until the next Railway staging deploy carries the flag flips (see G1 row above).

--- a/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-SUMMARY.md
+++ b/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-SUMMARY.md
@@ -5,7 +5,7 @@ metadata:
   type: summary
   phase: wave-1a-backend-tools-refactor
   date: 2026-05-14
-  status: PENDING G2
+  status: PENDING G2 (Claude autonomous, post-staging-deploy)
 ---
 
 # Wave 1a — Backend Tools Refactor — SUMMARY
@@ -51,12 +51,12 @@ Baseline (per PLAN.md) = 6567; Wave 1a delta = +297 tests, target was ≥+50.
 | Gate | Status | Evidence |
 |------|--------|----------|
 | G1 Maestro flow (drafted, live exec deferred) | DRAFT | [`tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml`](../../../tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml) — live run deferred to post-staging-deploy per memory `feedback_app_targets_staging_always` |
-| G2 Julien device walkthrough | PENDING | plan-08 Task 3 `checkpoint:human-verify` (PR description bundles the 6-step protocol; awaiting `approved` / `not approved — issue: X` token) |
+| G2 Claude autonomous device walkthrough (Maestro+sim) | PARTIAL — pre-merge cold-launch PASS, full server-side flow deferred to post-staging-deploy | Pre-merge evidence: `bash tools/simulator/flows/maestro-perfect-set/_fragment_cold_launch_to_aujourdhui.yaml` on iPhone-17-Pro sim — all 6 steps COMPLETED (log: `evidence/g2-pre-merge-cold-launch.log`). Full `coach_tools_server_side_smoke.yaml` exec deferred until (a) dev→staging merge carries Wave 1a + (b) Railway env vars flipped to `true` for the 5 server-side flags. **Owner**: Claude (per memory [[g2-claude-autonomous-not-julien-token]] + [[feedback_device_gates]]) — not a human-verify checkpoint. |
 | G3 dev CI | ✓ PASS | `bash tools/checks/wave_1a_close.sh` step `==> G3 + G4 — backend pytest`: 6864 passed |
 | G4 regression (pytest count + parity harness) | ✓ PASS | 6864 ≥ baseline+50 (6567+50=6617) AND `pytest tests/test_coach_tools_parity.py -q` 18/18 |
 | G5 LSFin banned-terms + accent_lint_fr | ✓ PASS | `tools/checks/banned_terms_python.py` + `accent_lint_fr.py` exit 0 on all 14 Wave-1a-touched files |
 
-## Self-Check : PENDING G2
+## Self-Check : PENDING G2 (Claude follow-up, not human gate)
 
 Per CLAUDE.md §9 — 0-trust evidence:
 
@@ -73,13 +73,17 @@ Per CLAUDE.md §9 — 0-trust evidence:
 - Parity harness 18/18 green: cite `python3 -m pytest tests/test_coach_tools_parity.py -q | tail -1` → `18 passed`.
 - Banned-terms + accent_lint clean on all 14 Wave-1a-touched files: cite `bash tools/checks/wave_1a_close.sh` last line → `wave_1a_close.sh: ALL GATES GREEN (G3+G4+G5)`.
 - G1 status: DRAFT — Maestro flow YAML exists; live exec deferred until staging deploy (see memory `feedback_app_targets_staging_always`).
-- G2 status: PENDING — phase cannot claim « SHIPPED » until Julien posts the device-walkthrough token on PR #608+ (this PR).
+- G2 status: PARTIAL pre-merge — Claude ran the cold-launch fragment autonomously on iPhone-17-Pro sim, all 6 steps COMPLETED (Maestro 2.5.1 transcript in `evidence/g2-pre-merge-cold-launch.log`). Full server-side flow exec deferred to post-staging-deploy. **Owner**: Claude, not Julien (per memory [[g2-claude-autonomous-not-julien-token]]).
 
-When Julien posts the G2 token:
+Post-merge Claude follow-up (this is the rest of G2):
 
-- `approved` → flip Status frontmatter to `SHIPPED`, update wave-1a-VERIFICATION-REPORT.html status rows, run `bash tools/simulator/walker.sh --flow coach_tools_server_side_smoke` on staging build to flip G1 to PASS, then merge feature → dev → staging → main.
-- `approved-with-issues: <description>` → Status `SHIPPED-WITH-DEFERRED`, append deferred items to VERIFICATION-REPORT.html.
-- `not approved — issue: <description>` → Status `REOPENED`, run `/gsd-plan-phase wave-1a-backend-tools-refactor --revise` with the issue text as input.
+1. Merge feature/wave-1a-08-rollout-close → dev (G3/G4/G5 + cold-launch G2 = sufficient for dev).
+2. Open dev → staging PR to land Wave 1a on `mint-staging.up.railway.app`.
+3. Flip 5 Railway env vars to `true` (server-side flags).
+4. Build mobile against staging, reinstall on sim.
+5. Claude runs `bash tools/simulator/walker.sh --flow coach_tools_server_side_smoke` and `~/.maestro/bin/maestro --device <UDID> test coach_tools_server_side_smoke.yaml`; captures Maestro transcript + `idb`/hierarchy snapshot proving each of the 6 refactored tools renders.
+6. Claude runs Sentry filter `category:coach.tool.*` and confirms each `*.invoked` breadcrumb fires with `inputs_hash` + `flag_state="on"`.
+7. Status: flips to `SHIPPED` if all 6 tools green; `SHIPPED-WITH-DEFERRED` with appended items in `wave-1a-VERIFICATION-REPORT.html` otherwise.
 
 ## Deferred items (carried forward)
 

--- a/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-VERIFICATION-REPORT.html
+++ b/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-VERIFICATION-REPORT.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Wave 1a — Verification Report</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 920px; margin: 2em auto; padding: 0 1em; line-height: 1.5; color: #1a1a1a; }
+  h1, h2 { color: #003B2F; }
+  h1 { border-bottom: 2px solid #003B2F; padding-bottom: .3em; }
+  table { border-collapse: collapse; width: 100%; margin: .8em 0 1.4em; }
+  td, th { border: 1px solid #ccc; padding: .45em .7em; text-align: left; vertical-align: top; }
+  th { background: #f2f4f3; color: #003B2F; }
+  .ok { color: #0a7d4d; font-weight: 600; }
+  .pending { color: #b85c00; font-weight: 600; }
+  .fail { color: #a32020; font-weight: 600; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, monospace; background: #f5f5f5; padding: .1em .35em; border-radius: 3px; }
+  pre { padding: .8em 1em; overflow: auto; }
+  ul li { margin: .3em 0; }
+  .meta { color: #555; font-size: .9em; }
+</style>
+</head>
+<body>
+
+<h1>Wave 1a — Backend Tools Refactor — Verification Report</h1>
+<p class="meta">
+  Phase : <code>wave-1a-backend-tools-refactor</code>
+  · Branch : <code>feature/wave-1a-08-rollout-close</code>
+  · Generated : 2026-05-14
+  · Source : <code>tools/checks/wave_1a_close.sh</code> exit 0
+</p>
+
+<h2>Requirements coverage (10/10 modulo G2)</h2>
+<table>
+  <tr><th>ID</th><th>Description</th><th>Plan</th><th>Status</th></tr>
+  <tr><td>WAVE1A-01</td><td><code>get_budget_status</code> server-side recompute</td><td>plan-01</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-02</td><td><code>get_retirement_projection</code> server-side recompute</td><td>plan-02</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-03</td><td><code>get_cross_pillar_analysis</code> server-side recompute</td><td>plan-03</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-04</td><td><code>get_cap_status</code> CHF garde middleware (default ON)</td><td>plan-06</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-05</td><td><code>get_couple_optimization</code> 1:1 Dart→Python port (78 MIRROR refs)</td><td>plan-04</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-06</td><td><code>retrieve_memories</code> BM25 wrapper + SQL-layer isolation</td><td>plan-05</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-07</td><td><code>get_regulatory_constant</code> dispatcher validation tests</td><td>plan-08</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-08</td><td>Parity harness (18 cases, 6 tools × 3 archetypes)</td><td>plan-07</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-09</td><td>Pydantic v2 camelCase response models + SHA-256 inputs_hash</td><td>01-05</td><td class="ok">SATISFIED</td></tr>
+  <tr><td>WAVE1A-10</td><td>Per-tool rollback flags + dispatcher routing tests</td><td>plan-08</td><td class="ok">SATISFIED</td></tr>
+</table>
+
+<h2>Shipped PRs / branches (Wave 1a phase)</h2>
+<table>
+  <tr><th>Plan</th><th>PR</th><th>Tests added</th><th>Status</th></tr>
+  <tr><td>00</td><td>scaffolding (squashed into early Wave 1a phase merges)</td><td>15</td><td class="ok">MERGED</td></tr>
+  <tr><td>01</td><td>#605 (Wave 1a backend tools refactor, plans 00-02)</td><td>11</td><td class="ok">MERGED</td></tr>
+  <tr><td>02</td><td>#605</td><td>12</td><td class="ok">MERGED</td></tr>
+  <tr><td>03</td><td>#612</td><td>14</td><td class="ok">MERGED</td></tr>
+  <tr><td>04</td><td>#610</td><td>30</td><td class="ok">MERGED</td></tr>
+  <tr><td>05</td><td>#609</td><td>18</td><td class="ok">MERGED</td></tr>
+  <tr><td>06</td><td>#608</td><td>7</td><td class="ok">MERGED</td></tr>
+  <tr><td>07</td><td>#613</td><td>18</td><td class="ok">MERGED</td></tr>
+  <tr><td>08</td><td>this PR (feature/wave-1a-08-rollout-close)</td><td>18</td><td class="pending">OPEN — PENDING G2</td></tr>
+</table>
+
+<h2>5-Gate close status</h2>
+<table>
+  <tr><th>Gate</th><th>Status</th><th>Evidence</th></tr>
+  <tr><td>G1 Maestro flow</td><td class="pending">DRAFT</td><td><code>tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml</code> — live exec deferred to post-staging-deploy per memory <code>feedback_app_targets_staging_always</code>.</td></tr>
+  <tr><td>G2 Julien device</td><td class="pending">PENDING</td><td>plan-08 Task 3 <code>checkpoint:human-verify</code> — bundled in PR description as 6-step staging walkthrough.</td></tr>
+  <tr><td>G3 dev CI</td><td class="ok">PASS</td><td><code>pytest services/backend/tests/ -q</code> → <code>6864 passed, 62 skipped, 1 xfailed</code>.</td></tr>
+  <tr><td>G4 regression</td><td class="ok">PASS</td><td>Baseline 6567 → 6864 (+297, target was ≥+50). Parity harness: <code>pytest tests/test_coach_tools_parity.py -q</code> → 18/18.</td></tr>
+  <tr><td>G5 LSFin + accent_lint</td><td class="ok">PASS</td><td><code>banned_terms_python.py</code> + <code>accent_lint_fr.py</code> exit 0 on all 14 Wave-1a-touched files.</td></tr>
+</table>
+
+<h2>Panel verdicts (composite review across Wave 1a phase)</h2>
+<table>
+  <tr><th>Plan</th><th>Panel</th><th>Verdict</th></tr>
+  <tr><td>03</td><td>code-reviewer + architect-review + security-auditor + python-pro</td><td class="ok">PASS (FLAG → resolved post-replan, see memory obs 67d0ed986ae0d316)</td></tr>
+  <tr><td>04</td><td>code-reviewer + python-pro + architect-review</td><td class="ok">PASS (30 tests, parity ±0.01 CHF, 78 MIRROR comments)</td></tr>
+  <tr><td>05</td><td>code-reviewer + qa-expert + ai-engineer (Karpathy wiki)</td><td class="ok">PASS (BM25 score floor + SQL-layer user isolation)</td></tr>
+  <tr><td>06</td><td>code-reviewer + security-auditor (cap CHF garde)</td><td class="ok">PASS (FIRST mint-review-pr Phase 1 pilot)</td></tr>
+  <tr><td>07</td><td>qa-expert + code-reviewer + test-automator (parity harness)</td><td class="ok">FLAG (defensive-except blind spot — non-blocking, accepted)</td></tr>
+  <tr><td>08</td><td>this PR — panel review pending pre-merge</td><td class="pending">SCHEDULED</td></tr>
+</table>
+
+<h2>Deferred items (carried forward, not blocking Wave 1a)</h2>
+<ul>
+  <li><strong>CapEngine Flutter→Python port</strong> — re-litigation trigger: <code>coach.cap.cap_chf_uncited</code> Sentry breadcrumb &gt; 5/day for ≥1 week (CONTEXT D-17 option b — kept Flutter-source for Wave 1a).</li>
+  <li><strong>pgvector embeddings for retrieve_memories</strong> — Wave 2+ if BM25 recall insufficient (CONTEXT D-07; BM25Okapi was sufficient for Wave 1a per engram memory <code>bm25_idf_gotcha_small_corpora</code>).</li>
+  <li><strong>20 paires Q&amp;A parity suite</strong> — Wave 1c scope (CONTEXT D-06 — Wave 1a ships 18-fixture mechanical parity only).</li>
+  <li><strong><code>source_kind="tool_call_id"</code> CITATION_REGISTRY entries</strong> — Wave 1b scope (consumes Wave 1a's <code>inputs_hash</code> via citation chips).</li>
+  <li><strong>Maestro G1 live exec on staging</strong> — deferred until the next Railway staging deploy carries the flag flips.</li>
+</ul>
+
+<h2>Plan-08 tiny side-quest fix log (LSFin + accent)</h2>
+<p>
+  The 5-gate close-out ran banned_terms_python.py for the first time across the
+  full Wave-1a-touched-file set (14 files). It surfaced 4 pre-existing hits
+  (introduced before Wave 1a per <code>git blame</code> — dates 2026-02-09 and
+  2026-04-17). They were fixed in plan-08 as surgical Karpathy-#3 edits, in
+  scope for the close-out:
+</p>
+<ul>
+  <li><code>services/backend/app/services/coaching_engine.py:20</code> — module docstring listed banned terms verbatim → reworded to reference <code>tools/checks/banned_terms_python.py</code>.</li>
+  <li><code>services/backend/app/services/coaching_engine.py:100</code> — class docstring same fix.</li>
+  <li><code>services/backend/app/services/coaching_engine.py:760</code> — user-facing FR string <code>"salaire assure"</code> → <code>"salaire assuré"</code> (accent restored, also removes <code>\bassure\b</code> banned-term match).</li>
+  <li><code>services/backend/app/api/v1/endpoints/coach_chat.py:3736</code> — same fix (<code>"Salaire assure LPP"</code> → <code>"Salaire assuré LPP"</code>).</li>
+</ul>
+
+</body>
+</html>

--- a/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-VERIFICATION-REPORT.html
+++ b/.planning/phases/wave-1a-backend-tools-refactor/wave-1a-VERIFICATION-REPORT.html
@@ -55,14 +55,14 @@
   <tr><td>05</td><td>#609</td><td>18</td><td class="ok">MERGED</td></tr>
   <tr><td>06</td><td>#608</td><td>7</td><td class="ok">MERGED</td></tr>
   <tr><td>07</td><td>#613</td><td>18</td><td class="ok">MERGED</td></tr>
-  <tr><td>08</td><td>this PR (feature/wave-1a-08-rollout-close)</td><td>18</td><td class="pending">OPEN — PENDING G2</td></tr>
+  <tr><td>08</td><td>this PR (feature/wave-1a-08-rollout-close)</td><td>18</td><td class="pending">OPEN — G3/G4/G5 PASS + G2 pre-merge cold-launch PASS; G2 full server-side flow deferred to post-staging-deploy (Claude owns).</td></tr>
 </table>
 
 <h2>5-Gate close status</h2>
 <table>
   <tr><th>Gate</th><th>Status</th><th>Evidence</th></tr>
   <tr><td>G1 Maestro flow</td><td class="pending">DRAFT</td><td><code>tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml</code> — live exec deferred to post-staging-deploy per memory <code>feedback_app_targets_staging_always</code>.</td></tr>
-  <tr><td>G2 Julien device</td><td class="pending">PENDING</td><td>plan-08 Task 3 <code>checkpoint:human-verify</code> — bundled in PR description as 6-step staging walkthrough.</td></tr>
+  <tr><td>G2 Claude autonomous device walkthrough</td><td class="pending">PARTIAL</td><td>Pre-merge: <code>~/.maestro/bin/maestro --device B03E429D-… test _fragment_cold_launch_to_aujourdhui.yaml</code> on iPhone-17-Pro sim — all 6 Maestro steps COMPLETED (cold launch → bêta modal → LandingScreen → « Continuer sans compte » → Aujourd'hui visible). Evidence log: <code>evidence/g2-pre-merge-cold-launch.log</code>. Full <code>coach_tools_server_side_smoke.yaml</code> run is owned by Claude, deferred post-staging-deploy. <strong>Not a human-verify checkpoint</strong> — per memory <code>g2-claude-autonomous-not-julien-token</code>.</td></tr>
   <tr><td>G3 dev CI</td><td class="ok">PASS</td><td><code>pytest services/backend/tests/ -q</code> → <code>6864 passed, 62 skipped, 1 xfailed</code>.</td></tr>
   <tr><td>G4 regression</td><td class="ok">PASS</td><td>Baseline 6567 → 6864 (+297, target was ≥+50). Parity harness: <code>pytest tests/test_coach_tools_parity.py -q</code> → 18/18.</td></tr>
   <tr><td>G5 LSFin + accent_lint</td><td class="ok">PASS</td><td><code>banned_terms_python.py</code> + <code>accent_lint_fr.py</code> exit 0 on all 14 Wave-1a-touched files.</td></tr>
@@ -87,6 +87,29 @@
   <li><strong><code>source_kind="tool_call_id"</code> CITATION_REGISTRY entries</strong> — Wave 1b scope (consumes Wave 1a's <code>inputs_hash</code> via citation chips).</li>
   <li><strong>Maestro G1 live exec on staging</strong> — deferred until the next Railway staging deploy carries the flag flips.</li>
 </ul>
+
+<h2>G2 pre-merge evidence — Maestro cold-launch transcript</h2>
+<p>
+  Reproducible via:
+  <code>JAVA_HOME=$(brew --prefix openjdk@21) ~/.maestro/bin/maestro --device &lt;UDID&gt; test tools/simulator/flows/maestro-perfect-set/_fragment_cold_launch_to_aujourdhui.yaml</code>
+  (booted iPhone 17 Pro, iOS 26.2, ch.mint.app installed from the latest dev build).
+</p>
+<pre>Running on iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9
+ > Flow _fragment_cold_launch_to_aujourdhui
+Launch app "ch.mint.app" with clear state... COMPLETED
+Run flow when "Je comprends, on y va" is visible...
+  Tap on "Je comprends, on y va"... COMPLETED
+  Wait for animation to end... COMPLETED
+Run flow when "Je comprends, on y va" is visible... COMPLETED
+Assert that "Parle à Mint" is visible... COMPLETED
+Wait for animation to end... COMPLETED
+Assert that ".*Continuer sans compte.*" is visible... COMPLETED
+Tap on ".*Continuer sans compte.*"... COMPLETED
+Wait for animation to end... COMPLETED
+Assert that ".*Aujourd'hui.*" is visible... COMPLETED</pre>
+<p>
+  This validates the LEGACY user-facing flow (cold launch → bêta modal dismiss → LandingScreen → anonymous CTA → Aujourd'hui surface) is unbroken post-Wave-1a backend refactor. It does NOT exercise the server-side recompute path — that needs the full <code>coach_tools_server_side_smoke.yaml</code> run after staging carries the flag flips.
+</p>
 
 <h2>Plan-08 tiny side-quest fix log (LSFin + accent)</h2>
 <p>

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -3733,7 +3733,7 @@ async def coach_chat(
                 if _d.get("avoirLpp"):
                     _facts.append(f"- Avoir LPP actuel: {int(_d['avoirLpp']):,} CHF".replace(",", "'"))
                 if _d.get("lppInsuredSalary"):
-                    _facts.append(f"- Salaire assure LPP: {int(_d['lppInsuredSalary']):,} CHF".replace(",", "'"))
+                    _facts.append(f"- Salaire assuré LPP: {int(_d['lppInsuredSalary']):,} CHF".replace(",", "'"))
                 if _d.get("lppBuybackMax"):
                     _facts.append(f"- Rachat LPP maximum: {int(_d['lppBuybackMax']):,} CHF".replace(",", "'"))
                 if _d.get("pillar3aBalance"):

--- a/services/backend/app/services/coaching_engine.py
+++ b/services/backend/app/services/coaching_engine.py
@@ -17,7 +17,7 @@ Sources:
 
 Ethical requirements:
     - Gender-neutral language throughout
-    - NEVER use "garanti", "assure", "certain"
+    - NEVER use LSFin banned terms (see tools/checks/banned_terms_python.py)
     - All tips include a source reference
     - Disclaimer on every response
 """
@@ -97,7 +97,7 @@ class CoachingEngine:
     """Generate personalized coaching tips based on user profile.
 
     All tips are in French, include law references, and use gender-neutral
-    language. No banned terms ("garanti", "assure", "certain").
+    language. No LSFin banned terms (see tools/checks/banned_terms_python.py).
     """
 
     @staticmethod
@@ -757,7 +757,7 @@ class CoachingEngine:
                 f"En travaillant a {profile.taux_activite:.0f}%, votre "
                 f"deduction de coordination ({self.COORDINATION_DEDUCTION:,.0f} CHF) "
                 f"n'est pas toujours proratisee par l'employeur. "
-                f"Cela peut reduire significativement votre salaire assure "
+                f"Cela peut reduire significativement votre salaire assuré "
                 f"LPP et donc votre rente future. "
                 f"Verifiez votre certificat de prevoyance."
             ),

--- a/services/backend/tests/test_coach_tools_dispatcher_flags.py
+++ b/services/backend/tests/test_coach_tools_dispatcher_flags.py
@@ -1,0 +1,289 @@
+"""Wave 1a plan-08 Task 1 (WAVE1A-10).
+
+Safety-net suite confirming the 6 rollback flags shipped during Wave 1a
+gate the dispatcher correctly:
+
+  - 5 server-side per-tool flags (default False):
+      COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED              (plan-01)
+      COACH_TOOL_SERVER_SIDE_RETIREMENT_PROJECTION_ENABLED (plan-02)
+      COACH_TOOL_SERVER_SIDE_CROSS_PILLAR_ENABLED        (plan-03)
+      COACH_TOOL_SERVER_SIDE_COUPLE_OPTIMIZATION_ENABLED (plan-04)
+      COACH_TOOL_SERVER_SIDE_RETRIEVE_MEMORIES_ENABLED   (plan-05)
+  - 1 cap CHF garde flag (default True):
+      COACH_CAP_CHF_GARDE_ENABLED                        (plan-06)
+
+Strategy:
+  * Flag OFF: monkeypatch the corresponding legacy formatter / handler to
+    a sentinel; assert the dispatcher returns the sentinel; assert no
+    server-side traversal happened (e.g. db.query not called).
+  * Flag ON: monkeypatch the inner service entry point (db.query for the
+    4 ProfileModel-backed tools; bm25 for retrieve_memories; the cite
+    regex for cap garde) to be observable; assert the server-side path
+    was attempted (.called) regardless of downstream outcome.
+
+This file is intentionally *light* — each tool's dedicated test file
+(test_coach_tools_<tool>.py) already exhaustively exercises the
+success / fallback paths. The contract here is only "flag routing works
+at the dispatcher entry point".
+
+13 tests total: 6 tools × 2 (OFF/ON) + 1 defaults audit.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.core.config import Settings, settings
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Flag default values (production-shipped contract)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_all_six_flags_exist_with_correct_defaults() -> None:
+    fresh = Settings(_env_file=None)
+    assert fresh.COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED is False
+    assert fresh.COACH_TOOL_SERVER_SIDE_RETIREMENT_PROJECTION_ENABLED is False
+    assert fresh.COACH_TOOL_SERVER_SIDE_CROSS_PILLAR_ENABLED is False
+    assert fresh.COACH_TOOL_SERVER_SIDE_COUPLE_OPTIMIZATION_ENABLED is False
+    assert fresh.COACH_TOOL_SERVER_SIDE_RETRIEVE_MEMORIES_ENABLED is False
+    assert fresh.COACH_CAP_CHF_GARDE_ENABLED is True
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# get_budget_status flag routing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_budget_status_flag_off_routes_to_legacy_format(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED", False
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_budget_status",
+        lambda ctx: "LEGACY_BUDGET_OFF",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_budget_status
+
+    mock_db = MagicMock()
+    assert _compute_budget_status(user_id="u", ctx={}, db=mock_db) == "LEGACY_BUDGET_OFF"
+    assert not mock_db.query.called
+
+
+def test_budget_status_flag_on_attempts_server_side(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED", True
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_budget_status",
+        lambda ctx: "LEGACY_BUDGET_ON_FALLBACK",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_budget_status
+
+    mock_db = MagicMock()
+    mock_db.query.side_effect = RuntimeError("forced — server-side reached")
+    _compute_budget_status(user_id="u", ctx={}, db=mock_db)
+    assert mock_db.query.called
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# get_retirement_projection flag routing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_retirement_projection_flag_off_routes_to_legacy_format(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_RETIREMENT_PROJECTION_ENABLED", False
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_retirement_projection",
+        lambda ctx: "LEGACY_RETIREMENT_OFF",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_retirement_projection
+
+    mock_db = MagicMock()
+    assert (
+        _compute_retirement_projection(user_id="u", ctx={}, db=mock_db)
+        == "LEGACY_RETIREMENT_OFF"
+    )
+    assert not mock_db.query.called
+
+
+def test_retirement_projection_flag_on_attempts_server_side(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_RETIREMENT_PROJECTION_ENABLED", True
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_retirement_projection",
+        lambda ctx: "LEGACY_RETIREMENT_ON_FALLBACK",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_retirement_projection
+
+    mock_db = MagicMock()
+    mock_db.query.side_effect = RuntimeError("forced — server-side reached")
+    _compute_retirement_projection(user_id="u", ctx={}, db=mock_db)
+    assert mock_db.query.called
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# get_cross_pillar_analysis flag routing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_cross_pillar_flag_off_routes_to_legacy_format(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_CROSS_PILLAR_ENABLED", False
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_cross_pillar_analysis",
+        lambda ctx: "LEGACY_CROSS_PILLAR_OFF",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_cross_pillar_analysis
+
+    mock_db = MagicMock()
+    assert (
+        _compute_cross_pillar_analysis(user_id="u", ctx={}, db=mock_db)
+        == "LEGACY_CROSS_PILLAR_OFF"
+    )
+    assert not mock_db.query.called
+
+
+def test_cross_pillar_flag_on_attempts_server_side(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_CROSS_PILLAR_ENABLED", True
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_cross_pillar_analysis",
+        lambda ctx: "LEGACY_CROSS_PILLAR_ON_FALLBACK",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_cross_pillar_analysis
+
+    mock_db = MagicMock()
+    mock_db.query.side_effect = RuntimeError("forced — server-side reached")
+    _compute_cross_pillar_analysis(user_id="u", ctx={}, db=mock_db)
+    assert mock_db.query.called
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# get_couple_optimization flag routing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_couple_optimization_flag_off_routes_to_legacy_format(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_COUPLE_OPTIMIZATION_ENABLED", False
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_couple_optimization",
+        lambda ctx: "LEGACY_COUPLE_OFF",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_couple_optimization
+
+    mock_db = MagicMock()
+    assert (
+        _compute_couple_optimization(user_id="u", ctx={}, db=mock_db)
+        == "LEGACY_COUPLE_OFF"
+    )
+    assert not mock_db.query.called
+
+
+def test_couple_optimization_flag_on_attempts_server_side(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_COUPLE_OPTIMIZATION_ENABLED", True
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._format_couple_optimization",
+        lambda ctx: "LEGACY_COUPLE_ON_FALLBACK",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_couple_optimization
+
+    mock_db = MagicMock()
+    mock_db.query.side_effect = RuntimeError("forced — server-side reached")
+    _compute_couple_optimization(user_id="u", ctx={}, db=mock_db)
+    assert mock_db.query.called
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# retrieve_memories flag routing (legacy = _handle_retrieve_memories)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_retrieve_memories_flag_off_routes_to_legacy_handler(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_RETRIEVE_MEMORIES_ENABLED", False
+    )
+    called = {"legacy": False}
+
+    def _legacy_sentinel(topic, memory_block, max_results, user_id, db):
+        called["legacy"] = True
+        return "LEGACY_MEMORIES_OFF"
+
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._handle_retrieve_memories",
+        _legacy_sentinel,
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_retrieve_memories
+
+    result = _compute_retrieve_memories(
+        topic="3a",
+        user_id="u",
+        db=MagicMock(),
+        max_results=3,
+        memory_block=None,
+    )
+    assert result == "LEGACY_MEMORIES_OFF"
+    assert called["legacy"]
+
+
+def test_retrieve_memories_flag_on_invokes_bm25(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "COACH_TOOL_SERVER_SIDE_RETRIEVE_MEMORIES_ENABLED", True
+    )
+    bm25_called = {"yes": False}
+
+    def _bm25_sentinel(topic, user_id, db, k):
+        bm25_called["yes"] = True
+        return []  # empty hits → fallback to legacy handler
+
+    monkeypatch.setattr(
+        "app.services.memory.bm25.retrieve", _bm25_sentinel
+    )
+    monkeypatch.setattr(
+        "app.api.v1.endpoints.coach_chat._handle_retrieve_memories",
+        lambda **_: "LEGACY_MEMORIES_FALLBACK",
+    )
+    from app.api.v1.endpoints.coach_chat import _compute_retrieve_memories
+
+    _compute_retrieve_memories(
+        topic="3a",
+        user_id="u",
+        db=MagicMock(),
+        max_results=3,
+        memory_block=None,
+    )
+    assert bm25_called["yes"]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# get_cap_status CHF garde flag routing (gate = _validate_cap_response)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_cap_garde_flag_off_passes_through(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "COACH_CAP_CHF_GARDE_ENABLED", False)
+    from app.api.v1.endpoints.coach_chat import _validate_cap_response
+
+    raw = "Cap : retire 3'000 CHF du compte courant."
+    assert _validate_cap_response(raw) == raw
+
+
+def test_cap_garde_flag_on_strips_uncited_chf(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "COACH_CAP_CHF_GARDE_ENABLED", True)
+    from app.api.v1.endpoints.coach_chat import _validate_cap_response
+
+    raw = "Cap : retire 3'000 CHF du compte courant."
+    sanitized = _validate_cap_response(raw)
+    assert "[montant indisponible]" in sanitized
+    assert "3'000 CHF" not in sanitized

--- a/services/backend/tests/test_coach_tools_regulatory_constant_dispatcher.py
+++ b/services/backend/tests/test_coach_tools_regulatory_constant_dispatcher.py
@@ -1,0 +1,52 @@
+"""Wave 1a plan-08 Task 1 (WAVE1A-07).
+
+Confirms `_handle_regulatory_constant` routes to
+`RegulatoryRegistry.instance().get(key, jurisdiction)` and formats output
+correctly. Wave 1a only ADDS confirmation tests — the handler itself is
+unchanged (see plan-08 PLAN.md objective §1 and audit §1 line 39).
+
+Five tests:
+  1. Known key (pillar3a.max_with_lpp) returns value + source + effective_from.
+  2. Unknown key returns the canonical "non trouvée" message.
+  3. Canton override path (capital_tax.cantonal + canton=VD) resolves to VD value.
+  4. Missing key returns the canonical FR error string.
+  5. Unknown subkey within a known namespace returns prefix-match suggestions.
+"""
+from __future__ import annotations
+
+from app.api.v1.endpoints.coach_chat import _handle_regulatory_constant
+
+
+def test_pillar3a_max_with_lpp_returns_value_source_effective_from() -> None:
+    result = _handle_regulatory_constant({"key": "pillar3a.max_with_lpp"})
+    assert "pillar3a.max_with_lpp = 7258.0 CHF" in result
+    assert "OPP3 art. 7 al. 1" in result
+    assert "En vigueur depuis : 2025-01-01" in result
+
+
+def test_unknown_key_returns_non_trouvee_message() -> None:
+    result = _handle_regulatory_constant({"key": "unknown.key"})
+    assert result.startswith("Constante 'unknown.key' non trouvée.")
+
+
+def test_capital_tax_cantonal_with_vd_returns_vd_value() -> None:
+    result = _handle_regulatory_constant(
+        {"key": "capital_tax.cantonal", "canton": "VD"}
+    )
+    assert "capital_tax.cantonal.VD = 0.08 ratio" in result
+    assert "Vaud" in result
+
+
+def test_missing_key_returns_explicit_error() -> None:
+    result = _handle_regulatory_constant({})
+    assert result == (
+        "Erreur : clé manquante. Fournis un key comme "
+        "'pillar3a.max_with_lpp'."
+    )
+
+
+def test_unknown_pillar3a_subkey_returns_suggestions() -> None:
+    result = _handle_regulatory_constant({"key": "pillar3a.unknown"})
+    assert "Suggestions :" in result
+    suffix = result.split("Suggestions :", 1)[1]
+    assert "pillar3a." in suffix

--- a/tools/checks/wave_1a_close.sh
+++ b/tools/checks/wave_1a_close.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wave 1a — 5-gate close-out (G3 + G4 + G5).
+#
+# G1 + G2 are SEPARATE and not exercised by this script:
+#   G1 = Maestro flow run on staging build
+#        (tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml)
+#   G2 = Julien device walkthrough on staging build
+#
+# This script handles only the deterministic, in-CI gates:
+#   G3 = dev CI (full backend pytest, baseline ≥ 6617 per plan-08 PLAN.md)
+#   G4 = regression (parity harness alone — fast sub-set re-run)
+#   G5 = LSFin banned-terms lint + accent_lint_fr on every Wave-1a-touched file
+#
+# Exit code: 0 iff every gate passes; non-zero on the first failure.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Wave 1a touched-file set — kept in sync with the 7 prior plans' SUMMARY.md
+# `key-files.modified` blocks (plans 01-06) + plan-00 scaffolding.
+WAVE_1A_BACKEND_FILES=(
+  services/backend/app/services/coaching_engine.py
+  services/backend/app/services/retirement/retirement_projection_service.py
+  services/backend/app/services/arbitrage/cross_pillar_service.py
+  services/backend/app/services/couple_optimizer/couple_optimizer.py
+  services/backend/app/services/memory/bm25.py
+  services/backend/app/api/v1/endpoints/coach_chat.py
+  services/backend/app/core/config.py
+  services/backend/app/observability/coach_breadcrumbs.py
+  services/backend/app/utils/hashing.py
+)
+# coach_tools models package — one file per plan + the package marker.
+WAVE_1A_BACKEND_FILES+=( $(ls services/backend/app/models/coach_tools/*.py) )
+
+echo "==> G3 + G4 — backend pytest (full suite, baseline ≥ 6617)"
+(
+  cd services/backend
+  python3 -m pytest tests/ -q
+)
+
+echo "==> G4 — parity harness alone (fast re-run)"
+(
+  cd services/backend
+  python3 -m pytest tests/test_coach_tools_parity.py -q
+)
+
+echo "==> G5 — banned_terms_python lint on Wave 1a touched files"
+python3 tools/checks/banned_terms_python.py "${WAVE_1A_BACKEND_FILES[@]}"
+
+echo "==> G5 — accent_lint_fr on Wave 1a touched files"
+for f in "${WAVE_1A_BACKEND_FILES[@]}"; do
+  python3 tools/checks/accent_lint_fr.py --file "$f"
+done
+
+echo "==> wave_1a_close.sh: ALL GATES GREEN (G3+G4+G5)"

--- a/tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml
@@ -1,0 +1,133 @@
+# tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml
+#
+# ─── PURPOSE ──────────────────────────────────────────────────────────────
+# Wave 1a G1 smoke — exercise each of the 6 refactored coach tools end-to-end
+# against the Railway STAGING backend, with all 5 server-side flags ON and the
+# cap CHF garde flag ON. The flow taps a coach card per tool, opens the
+# « Explique-moi » verb, and asserts the per-tool top-line FR string appears
+# in the response (no crash, response returned).
+#
+# This is the G1 contract for plan-08's 5-gate close. Live exit-0 is DEFERRED
+# until staging deploy is live with the flag flips — see PRECONDITIONS below.
+#
+# ─── PRECONDITIONS (DEFERRED — see Task 3 of wave-1a-08-PLAN.md) ──────────
+#   (a) Staging Railway has the Wave 1a branch deployed with all 5 server-side
+#       flags ON + cap garde ON (default already True):
+#         COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED=true
+#         COACH_TOOL_SERVER_SIDE_RETIREMENT_PROJECTION_ENABLED=true
+#         COACH_TOOL_SERVER_SIDE_CROSS_PILLAR_ENABLED=true
+#         COACH_TOOL_SERVER_SIDE_COUPLE_OPTIMIZATION_ENABLED=true
+#         COACH_TOOL_SERVER_SIDE_RETRIEVE_MEMORIES_ENABLED=true
+#         COACH_CAP_CHF_GARDE_ENABLED=true
+#   (b) Mobile build on the booted sim targets staging
+#       (`mint-staging.up.railway.app`, release flavor — memory
+#       `feedback_app_targets_staging_always`).
+#   (c) ANTHROPIC_API_KEY present on Railway staging (memory
+#       `feedback_anthropic_key_on_railway`).
+#   (d) Profile fixture seeded with enough data for each tool to traverse
+#       its server-side branch (budget, retirement, cross-pillar, couple,
+#       insights). A populated `julien` or `lauren` archetype profile is
+#       sufficient.
+#
+# ─── SCOPE ────────────────────────────────────────────────────────────────
+# Wave 1a-only smoke = response returned, no crash, top-line FR string
+# present. Wave 1b will assert the `inputs_hash` chip and the citation
+# placeholders surface UI-side; Wave 1c will run the 20 Q&A parity suite.
+# This flow does NOT assert numeric values — that's the harness in
+# tests/test_coach_tools_parity.py.
+#
+# ─── EXPECTED DURATION ────────────────────────────────────────────────────
+# ~120s wall-clock — cold launch + auth + 6 card taps + 6 narrator
+# round-trips on staging Anthropic.
+#
+# ─── MAESTRO 2.5.1 SYNTAX ─────────────────────────────────────────────────
+# Mirrors flow_card_action_intent_bar.yaml conventions: regex locators on
+# FR strings where stable testIDs are absent (cards may not yet carry
+# Keys on the production card list as of Wave 1a).
+appId: ch.mint.app
+---
+- launchApp:
+    clearState: false
+- assertVisible:
+    text: "Mon argent|Aujourd'hui|Mon coach"
+    timeout: 15000
+
+# ─── 1. get_budget_status (WAVE1A-01) ─────────────────────────────────────
+- tapOn:
+    text: "(?i)Mon argent|Budget|Aujourd'hui"
+- tapOn:
+    text: "(?i)Budget|Mes finances"
+- tapOn:
+    text: "(?i)Explique"
+- assertVisible:
+    text: "(?i)Budget actuel|Revenu net|Marge libre"
+    timeout: 20000
+- back
+
+# ─── 2. get_retirement_projection (WAVE1A-02) ─────────────────────────────
+- tapOn:
+    text: "(?i)Retraite|LPP|Projection"
+- tapOn:
+    text: "(?i)Explique"
+- assertVisible:
+    text: "(?i)Projection retraite|Capital LPP|Rente AVS"
+    timeout: 20000
+- back
+
+# ─── 3. get_cross_pillar_analysis (WAVE1A-03) ─────────────────────────────
+- tapOn:
+    text: "(?i)Inter-piliers|Optimisation|Cross.?pillar"
+- tapOn:
+    text: "(?i)Explique"
+- assertVisible:
+    text: "(?i)Analyse inter-piliers|3a|LPP"
+    timeout: 20000
+- back
+
+# ─── 4. get_couple_optimization (WAVE1A-05) ───────────────────────────────
+# Skipped for single-archetype profiles (etatCivil != marie) — the dispatcher
+# falls back to legacy text in that case. For couple-fixture runs the
+# assertion below covers the server-side branch.
+- runFlow:
+    when:
+      visible:
+        text: "(?i)Couple|Conjoint|Mariage"
+    commands:
+      - tapOn:
+          text: "(?i)Couple|Conjoint|Mariage"
+      - tapOn:
+          text: "(?i)Explique"
+      - assertVisible:
+          text: "(?i)Rachat LPP|Pilier 3a|Cap AVS|Pénalité"
+          timeout: 20000
+      - back
+
+# ─── 5. retrieve_memories (WAVE1A-06) ─────────────────────────────────────
+# Triggered by an explicit user question that the coach answers using
+# stored insights — exercises the BM25 path on Railway staging.
+- tapOn:
+    text: "(?i)Mon coach|Coach"
+- tapOn:
+    id: "chat_input_field"
+    optional: true
+- inputText: "qu'est-ce que tu retiens de moi à propos de mon 3a ?"
+- tapOn:
+    id: "chat_send_button"
+    optional: true
+- assertVisible:
+    text: "(?i)3a|Pilier|Retiens|Souviens"
+    timeout: 25000
+
+# ─── 6. get_cap_status with CHF garde (WAVE1A-04) ─────────────────────────
+# The garde middleware (default ON) replaces any un-cited CHF token with the
+# verbatim FR string « [montant indisponible] » before reaching the LLM. The
+# assertion below covers either a cited CHF amount OR the garde redaction —
+# both are valid (cap text comes from the Flutter CapEngine per CONTEXT D-17
+# option b).
+- tapOn:
+    text: "(?i)Cap|Action du jour|Aujourd'hui"
+- tapOn:
+    text: "(?i)Explique"
+- assertVisible:
+    text: "(?i)Cap du jour|Action|\\[montant indisponible\\]"
+    timeout: 20000


### PR DESCRIPTION
## Summary

Wave 1a plan-08 — final plan of the wave-1a-backend-tools-refactor phase. Ships the 5-gate close-out infrastructure and the WAVE1A-07 + WAVE1A-10 validation tests.

- **WAVE1A-07** — `get_regulatory_constant` dispatcher confirmation tests (no handler refactor; the handler was already wired on `RegulatoryRegistry` pre-Wave-1a). 5 tests cover happy path, unknown key, canton override, missing key, prefix-match suggestions.
- **WAVE1A-10** — Per-tool rollback flag dispatcher routing tests. 13 tests covering 6 tools × {OFF→legacy, ON→server-side attempted} + 1 defaults-audit test pinning all 6 production-shipped flag values.
- **5-gate close-out** — `tools/checks/wave_1a_close.sh` mechanically asserts G3 (dev CI), G4 (regression), G5 (LSFin + accent_lint) on the 14 Wave-1a-touched files.
- **G1 Maestro flow** — drafted at `tools/simulator/flows/maestro-perfect-set/coach_tools_server_side_smoke.yaml`. Live exec deferred to post-staging-deploy per memory `feedback_app_targets_staging_always`.
- **Phase SUMMARY.md + VERIFICATION-REPORT.html** — cumulative report per memory `feedback_html_evidence_report`.

### Side-quest LSFin / accent fixes (Karpathy #3 surgical)

The close-out script ran banned_terms_python.py for the first time across the full Wave-1a-touched-file set and surfaced 4 pre-existing hits (git blame: 2026-02-09 and 2026-04-17). Fixed in this PR because the close-out gate could not exit 0 otherwise:

- `coaching_engine.py:20` + `:100` — module/class docstring listed banned terms verbatim → reworded to reference `tools/checks/banned_terms_python.py`.
- `coaching_engine.py:760` — `"salaire assure"` → `"salaire assuré"` (accent restored, removes `\bassure\b` match).
- `coach_chat.py:3736` — same fix (`"Salaire assure LPP"` → `"Salaire assuré LPP"`).

## Mechanical evidence (CLAUDE.md §9 0-trust)

```
$ bash tools/checks/wave_1a_close.sh
...
6864 passed, 62 skipped, 1 xfailed, 1 warning in 113.33s
==> G4 — parity harness alone (fast re-run)
18 passed in 0.28s
==> G5 — banned_terms_python lint on Wave 1a touched files
==> G5 — accent_lint_fr on Wave 1a touched files
==> wave_1a_close.sh: ALL GATES GREEN (G3+G4+G5)
```

Backend pytest delta: 6567 baseline → 6864 (+297 tests; plan-08 alone adds 18). Target was ≥+50.

## G2 = Claude autonomous, not Julien token (corrected mid-PR)

The original Plan-08 PLAN.md framed G2 as a `checkpoint:human-verify` waiting on a Julien token. Julien corrected during PR review: sim + idb + Maestro are wired, so G2 is Claude's job. The PR now reflects that.

**Pre-merge G2 evidence (Claude already ran)**:

```
$ JAVA_HOME=$(brew --prefix openjdk@21) ~/.maestro/bin/maestro \
    --device B03E429D-0422-4357-B754-536637D979F9 test \
    tools/simulator/flows/maestro-perfect-set/_fragment_cold_launch_to_aujourdhui.yaml

Running on iPhone 17 Pro - iOS 26.2
 > Flow _fragment_cold_launch_to_aujourdhui
Launch app "ch.mint.app" with clear state... COMPLETED
Tap on "Je comprends, on y va"... COMPLETED
Assert that "Parle à Mint" is visible... COMPLETED
Assert that ".*Continuer sans compte.*" is visible... COMPLETED
Tap on ".*Continuer sans compte.*"... COMPLETED
Assert that ".*Aujourd'hui.*" is visible... COMPLETED
```

This validates the LEGACY user-facing flow (cold launch → bêta modal dismiss → LandingScreen → anonymous CTA → Aujourd'hui surface) is unbroken post-Wave-1a backend refactor.

**Deferred G2 follow-up (Claude owns, post-merge)**:

1. Merge this PR → `dev` (G3/G4/G5 + pre-merge cold-launch G2 sufficient for `dev`).
2. Open `dev → staging` PR to land Wave 1a on `mint-staging.up.railway.app`.
3. Flip 5 Railway env vars to `true`: `COACH_TOOL_SERVER_SIDE_BUDGET_ENABLED`, `..._RETIREMENT_PROJECTION_ENABLED`, `..._CROSS_PILLAR_ENABLED`, `..._COUPLE_OPTIMIZATION_ENABLED`, `..._RETRIEVE_MEMORIES_ENABLED`.
4. Rebuild mobile against staging, reinstall on sim.
5. Run `~/.maestro/bin/maestro test coach_tools_server_side_smoke.yaml`; capture Maestro transcript + hierarchy snapshot proving each refactored tool renders without crash.
6. Filter Sentry `category:coach.tool.*`; confirm each `*.invoked` breadcrumb fires with `inputs_hash` (64 hex chars) and `flag_state="on"`.

Status flips to `SHIPPED` once steps 1-6 complete with all 6 tools green; `SHIPPED-WITH-DEFERRED` with appended items otherwise.

Per engram memory `g2-claude-autonomous-not-julien-token` + `feedback_device_gates`.

## Test plan

- [x] G3 — `pytest services/backend/tests/ -q` exits 0 (6864 passed)
- [x] G4 — `pytest tests/test_coach_tools_parity.py -q` exits 0 (18/18)
- [x] G5 — `banned_terms_python.py` + `accent_lint_fr.py` exit 0 on all 14 Wave-1a-touched files
- [x] G2 pre-merge — Maestro cold-launch fragment on iPhone-17-Pro sim, 6/6 steps COMPLETED
- [ ] G2 full (Claude follow-up, post-staging-deploy) — `coach_tools_server_side_smoke.yaml` with flags ON + Sentry breadcrumbs verified
- [ ] G1 — Maestro flow live exec on staging build (overlaps with G2 full above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)