### PR TITLE
feat(wave-1c): WAVE1C_PAYLOAD instrumentation + falsification experiment

### DIFF
--- a/.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment.py
+++ b/.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment.py
@@ -1,0 +1,140 @@
+"""
+Wave 1c distinguishing experiment per 3-agent RCA consensus (engram obs id 73).
+
+Replay probe v7 (Wave 1b G2 Run #2) directly against Anthropic API twice with
+identical model + system prompt + tools + message, only `tool_choice` differs.
+
+Reads tools from `tools.json` (dumped from `get_narrator_llm_tools()` to avoid
+pulling psycopg2 + the full MINT backend into the runtime). Uses
+ANTHROPIC_API_KEY from environment (inject via `railway run`).
+
+Decision rule:
+- Variant `tool_choice={"type":"any"}` returns `stop_reason="tool_use"` with
+  >=1 tool_use content block -> fix is single-line at llm_client.py:227 +
+  bundle prompt mandates (small wave-1c PR).
+- Variant still `stop_reason="end_turn"` with text-only response -> doctrine
+  rewrite needed (kill refusal escape hatch + wire forced-tool-invocation
+  gate per memory project_coach_forced_tool_invocation).
+
+Run: railway run --service MINT --environment staging -- python3 \
+       .planning/phases/wave-1c-coach-tool-dispatch-rca/experiment.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from anthropic import Anthropic
+
+HERE = Path(__file__).resolve().parent
+TOOLS_PATH = HERE / "tools.json"
+OUT_PATH = HERE / "experiment_results.json"
+
+USER_MESSAGE = (
+    "Quelle sera ma rente AVS et LPP à 65 ans avec mon 3eme pilier actuel ? "
+    "Donne-moi la projection chiffrée."
+)
+
+# Mirrors the staging "no MANDATE" condition: tools advertised, role + LSFin
+# disclaimer + refusal-escape-hatch wording present, no «invoque OBLIGATOIREMENT»
+# language. This approximates what staging actually sends in the legacy
+# narrator path (when COACH_BUNDLE_COMPILER_ENABLED=False on staging, which
+# per services/backend/app/core/config.py:71,80 is the default).
+SYSTEM_PROMPT = (
+    "Tu es Mint, un coach financier suisse. Tu accompagnes l'utilisateur sur "
+    "ses décisions financières en français. Tu disposes d'outils pour récupérer "
+    "les données du profil de l'utilisateur (get_budget_status, "
+    "get_retirement_projection, get_cross_pillar_analysis, "
+    "get_couple_optimization, get_cap_status, retrieve_memories). "
+    "Respecte la LSFin : information générale uniquement, pas de conseil "
+    "personnalisé garanti. En l'absence de donnée fiable, écris « Je n'ai pas "
+    "cette donnée pour l'instant » plutôt que d'inventer un chiffre."
+)
+
+MODEL = "claude-sonnet-4-5-20250929"
+MAX_TOKENS = 600
+
+if not TOOLS_PATH.exists():
+    sys.exit(
+        f"tools.json missing at {TOOLS_PATH}. Run the tools dump first:\n"
+        "  PYTHONPATH=services/backend python3 -c "
+        "'import json; from app.services.coach.coach_tools import "
+        "get_narrator_llm_tools; "
+        f"json.dump(get_narrator_llm_tools(), open(\"{TOOLS_PATH}\", \"w\"), indent=2)'"
+    )
+
+tools = json.loads(TOOLS_PATH.read_text(encoding="utf-8"))
+print(f"# tools advertised ({len(tools)}): {[t['name'] for t in tools]}\n")
+
+api_key = os.environ.get("ANTHROPIC_API_KEY")
+if not api_key:
+    sys.exit("ANTHROPIC_API_KEY missing. Run via `railway run --service MINT --environment staging --`.")
+
+client = Anthropic(api_key=api_key)
+results = {}
+
+for tag, choice in [("baseline_auto", {"type": "auto"}), ("variant_any", {"type": "any"})]:
+    print(f"\n========== tool_choice = {choice} ({tag}) ==========")
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        tools=tools,
+        tool_choice=choice,
+        messages=[{"role": "user", "content": USER_MESSAGE}],
+    )
+    summary = {
+        "stop_reason": resp.stop_reason,
+        "model": resp.model,
+        "input_tokens": resp.usage.input_tokens,
+        "output_tokens": resp.usage.output_tokens,
+        "block_count": len(resp.content),
+        "block_types": [b.type for b in resp.content],
+        "tool_use_blocks": [
+            {"name": b.name, "input": b.input}
+            for b in resp.content if b.type == "tool_use"
+        ],
+        "text_preview": next(
+            (b.text[:400] for b in resp.content if b.type == "text"), None
+        ),
+    }
+    results[tag] = summary
+    print(f"stop_reason: {summary['stop_reason']}")
+    print(f"block_types: {summary['block_types']}")
+    print(f"input/output tokens: {summary['input_tokens']}/{summary['output_tokens']}")
+    print(f"tool_use_blocks: {len(summary['tool_use_blocks'])}")
+    for b in summary["tool_use_blocks"]:
+        print(f"  TOOL_USE: {b['name']}({json.dumps(b['input'])[:200]})")
+    if summary["text_preview"]:
+        print(f"text: {summary['text_preview']}")
+
+print("\n========== VERDICT ==========")
+baseline_tool_used = len(results["baseline_auto"]["tool_use_blocks"]) > 0
+variant_tool_used = len(results["variant_any"]["tool_use_blocks"]) > 0
+print(f"baseline_auto emitted tool_use: {baseline_tool_used}")
+print(f"variant_any  emitted tool_use: {variant_tool_used}")
+
+if not baseline_tool_used and variant_tool_used:
+    print(
+        "\nVERDICT: hypothesis CONFIRMED. tool_choice=auto suppresses tool_use; "
+        "tool_choice=any forces it. Wave 1c fix path = small PR "
+        "(llm_client.py:227 routing + bundle prompt mandates)."
+    )
+elif not baseline_tool_used and not variant_tool_used:
+    print(
+        "\nVERDICT: hypothesis FALSIFIED. Even tool_choice=any does NOT emit "
+        "tool_use. Doctrine rewrite needed (refusal escape hatch wins). "
+        "Wave 1c fix path = larger PR (kill refusal hatch + wire forced-tool gate)."
+    )
+elif baseline_tool_used:
+    print(
+        "\nVERDICT: hypothesis CONTRADICTED locally. tool_choice=auto DID "
+        "emit tool_use here. Staging-specific suppression — likely bundle "
+        "prompt fragment or system prompt difference. Need to fetch the "
+        "exact staging-side system prompt + RAG context and re-test."
+    )
+
+OUT_PATH.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+print(f"\nResults saved to {OUT_PATH}")

--- a/.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment_results.json
+++ b/.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment_results.json
@@ -1,0 +1,37 @@
+{
+  "baseline_auto": {
+    "stop_reason": "tool_use",
+    "model": "claude-sonnet-4-5-20250929",
+    "input_tokens": 6869,
+    "output_tokens": 89,
+    "block_count": 2,
+    "block_types": [
+      "text",
+      "tool_use"
+    ],
+    "tool_use_blocks": [
+      {
+        "name": "get_retirement_projection",
+        "input": {}
+      }
+    ],
+    "text_preview": "Je vais regarder ta projection de retraite pour te donner les chiffres de tes rentes AVS et LPP à 65 ans, ainsi que l'apport de ton 3e pilier."
+  },
+  "variant_any": {
+    "stop_reason": "tool_use",
+    "model": "claude-sonnet-4-5-20250929",
+    "input_tokens": 6961,
+    "output_tokens": 23,
+    "block_count": 1,
+    "block_types": [
+      "tool_use"
+    ],
+    "tool_use_blocks": [
+      {
+        "name": "get_retirement_projection",
+        "input": {}
+      }
+    ],
+    "text_preview": null
+  }
+}

--- a/.planning/phases/wave-1c-coach-tool-dispatch-rca/tools.json
+++ b/.planning/phases/wave-1c-coach-tool-dispatch-rca/tools.json
@@ -1,0 +1,555 @@
+[
+  {
+    "name": "show_fact_card",
+    "description": "Display an educational fact card inline in the chat. Use for conceptual explanations, key numbers, or legal references. Do NOT use when a dedicated MINT screen exists for the topic.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Short title for the fact (max 60 chars)."
+        },
+        "content": {
+          "type": "string",
+          "description": "Educational content. Must be conditional and non-prescriptive."
+        },
+        "source": {
+          "type": "string",
+          "description": "Legal or official source (e.g. 'LPP art. 14', 'LAVS art. 21')."
+        },
+        "highlight_value": {
+          "type": "string",
+          "description": "Optional key figure to highlight visually (e.g. '6.8%', '30 240 CHF')."
+        }
+      },
+      "required": [
+        "title",
+        "content",
+        "source"
+      ]
+    }
+  },
+  {
+    "name": "show_budget_snapshot",
+    "description": "Display the user's budget snapshot inline in the chat. Use when the user asks about their current financial situation, remaining budget, or monthly overview. Requires netIncome to be present in the user profile.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "focus_category": {
+          "type": "string",
+          "description": "Optional category to highlight in the snapshot (e.g. 'savings', 'fixed_costs', 'discretionary')."
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "show_score_gauge",
+    "description": "Display the user's Financial Readiness Index (FRI) score as an inline gauge widget. Use when the user asks about their score, their financial health, or how they are progressing.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "show_breakdown": {
+          "type": "boolean",
+          "description": "Whether to show the 4-axis breakdown (L/F/R/S). Default false."
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "ask_user_input",
+    "description": "Ask the user for a specific piece of missing data via a structured input chip or form. Use when a readiness gate is blocked due to a missing critical field. Ask only ONE piece of data at a time.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "field_key": {
+          "type": "string",
+          "description": "The CoachProfile field key being requested (e.g. 'salaireBrut', 'age', 'canton', 'avoirLpp')."
+        },
+        "prompt_text": {
+          "type": "string",
+          "description": "The question to ask the user. Must be short, friendly, and non-prescriptive."
+        },
+        "input_type": {
+          "type": "string",
+          "description": "Input type hint for Flutter: 'number', 'text', 'canton_picker', 'date', 'chips'. Default 'text'."
+        }
+      },
+      "required": [
+        "field_key",
+        "prompt_text"
+      ]
+    }
+  },
+  {
+    "name": "retrieve_memories",
+    "description": "Search the user's conversation memory for past insights, goals, and screen visits. Use this when the user references something they discussed before, or when you want to provide continuity from past sessions. This tool is handled internally by the backend — it never reaches the Flutter app. The result is injected back into the conversation so you can use it in your next response.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "The topic to search for in memory (e.g. 'retraite', 'lpp', 'budget', '3a'). Use the user's own words or financial topics."
+        },
+        "max_results": {
+          "type": "integer",
+          "description": "Maximum number of memory entries to return (default 3, max 5).",
+          "default": 3
+        }
+      },
+      "required": [
+        "topic"
+      ]
+    }
+  },
+  {
+    "name": "route_to_screen",
+    "description": "Route the user to a specific MINT screen based on their intent. The Flutter app will verify readiness before opening. Use this when the user's question maps to a specific MINT feature screen (simulator, life event flow, comparison tool). For simple conceptual questions, use show_fact_card instead. For budget or score queries, use show_budget_snapshot or show_score_gauge instead.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "intent": {
+          "type": "string",
+          "description": "The identified user intent tag. Must be one of the registered intent tags: advisor_30_day_plan, advisor_handoff, advisor_wizard, annual_allocation, arbitrage_bilan, ask_mint, avs_cotisations_independant, avs_extract_guide, avs_guide, bank_import, budget_overview, budget_setup, cantonal_comparison, cantonal_fiscal_comparator, compound_interest_simulator, confidence_dashboard, consult_specialist, consumer_credit_simulator, coverage_check, cross_border, debt_help_resources, debt_ratio, debt_repayment, debt_risk_check, decaissement_plan, disability_gap, disability_gap_check, disability_insurance_flow, disability_self_employed, dividende_vs_salaire, document_scan, document_scan_entry, documents_list, early_pension_withdrawal, education_hub, education_theme_detail, epl_combined, explore_hub_famille, explore_hub_fiscalite, explore_hub_logement, explore_hub_patrimoine, explore_hub_retraite, explore_hub_sante, explore_hub_travail, financial_cockpit, financial_report, financial_summary, gender_gap, household_accept_invite, household_couple, household_overview, housing_purchase, ijm_independant, imputed_rental, job_comparison, lamal_franchise, leasing_simulator, libre_passage, life_event_birth, life_event_canton_move, life_event_concubinage, life_event_country_move, life_event_death_of_relative, life_event_divorce, life_event_divorce_v2, life_event_donation, life_event_first_job, life_event_housing_sale, life_event_job_loss, life_event_marriage, life_event_succession, life_timeline, lpp_buyback, lpp_buyback_vs_market, lpp_deep_epl, lpp_deep_libre_passage, lpp_deep_rachat, lpp_volontaire, mortgage_affordability_v2, mortgage_amortization, open_banking, pillar_3a_independant, portfolio_overview, prepare_avs_letter, prepare_lpp_transfer, prepare_tax_form, preretraite_complete, profile_enrichment, provider_comparator_3a, real_return_3a, rent_vs_buy, rente_vs_capital_arbitrage, report_overview, report_v2, retirement_choice, retirement_overview, retirement_projection, retirement_projection_v2, retroactive_3a, saron_vs_fixed, self_employment, simulator_3a, simulator_3a_v2, simulator_disability_gap, simulator_rente_capital, succession_patrimoine, succession_planning, tax_optimization_3a, withdrawal_calendar, withdrawal_sequencing"
+        },
+        "confidence": {
+          "type": "number",
+          "description": "Confidence in the intent identification (0.0 to 1.0). Use 0.8+ for clear intents, 0.5-0.8 for probable intents. Below 0.5: ask a clarifying question instead of routing."
+        },
+        "context_message": {
+          "type": "string",
+          "description": "A brief message from the coach explaining why this screen is relevant. Shown to the user before navigation. Must be educational and non-prescriptive. Use conditional language ('pourrait', 'dans ce scénario'). Never use banned terms (garanti, optimal, tu devrais)."
+        },
+        "prefill": {
+          "type": "object",
+          "description": "Optional key-value map of profile fields to pre-populate the target screen. Keys match CoachProfile field names: avoirLppTotal, salaireBrutMensuel, tauxConversion, ageRetraite, canton, epargneLiquide, rachatMaximum. Only include fields with confirmed values from the user's profile context. Omit entirely if no values are known.",
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "intent",
+        "confidence",
+        "context_message"
+      ]
+    }
+  },
+  {
+    "name": "set_goal",
+    "description": "Set the user's primary financial goal. Use when the user declares a new focus area or explicitly states a financial objective. The goal_intent_tag must match a registered intent tag so that the CapEngine can surface relevant widgets and nudges.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "goal_intent_tag": {
+          "type": "string",
+          "description": "The goal intent tag identifying the focus area (e.g. 'retirement_choice', 'budget_overview', 'housing_purchase', 'tax_optimization_3a')."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Brief reason for the goal change, derived from the user's own words. Used for memory and continuity."
+        }
+      },
+      "required": [
+        "goal_intent_tag"
+      ]
+    }
+  },
+  {
+    "name": "mark_step_completed",
+    "description": "Mark a step in the user's financial plan (CapSequence) as completed or skipped. Use when the user confirms they have taken an action (e.g. 'I opened my 3a account', 'I skipped the LPP buyback for now'). Never mark steps without explicit confirmation.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "step_id": {
+          "type": "string",
+          "description": "The CapSequence step identifier to mark (e.g. 'open_3a', 'lpp_buyback_check', 'avs_voluntary')."
+        },
+        "outcome": {
+          "type": "string",
+          "enum": [
+            "completed",
+            "skipped"
+          ],
+          "description": "'completed' if the user has done the step, 'skipped' if they have decided not to."
+        }
+      },
+      "required": [
+        "step_id",
+        "outcome"
+      ]
+    }
+  },
+  {
+    "name": "suggest_actions",
+    "description": "MANDATORY: call at the END of every response to generate 2-3 personalized suggestion chips for the user. Returns a JSON list of next actions based on what MINT knows and doesn't know about the user.\n\nExamples of returned suggestions:\n  - 'D'où vient ton argent ? (salaire, dividendes, rente, autre)' (profile gap)\n  - 'Upload ton certificat LPP' (missing document)\n  - 'Configure ton budget' (no budget set up)\n  - 'Simule ton rachat LPP' (has avoirLpp + buybackMax)\n  - 'Compare rente vs capital' (has LPP projection)\n\nDo NOT call this tool for goodbye/clarification messages.\nPresent the returned suggestions as follow-up questions or action chips — never hide them.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_budget_status",
+    "description": "Get the user's current budget status including monthly free margin, savings rate, and budget stage. Use when you need to reason about the user's financial situation, remaining budget, or spending capacity. Returns structured data as text. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_retirement_projection",
+    "description": "Get the user's retirement projection including replacement rate, projected gap, and pillar breakdown. Use when the user asks about retirement income, pension, or how much they will receive. Returns structured data as text. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_cross_pillar_analysis",
+    "description": "Get cross-pillar optimization insights: 3a gap, LPP buyback potential, tax optimization, and coordination between pillars. Use when the user asks about optimizing their financial situation across pillars. Returns structured data as text. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_cap_status",
+    "description": "Get the user's current Cap du jour (priority action), sequence progress, and next recommended step. Use when you need to know what the user should focus on next or their progress toward their financial goal. Returns structured data as text. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_couple_optimization",
+    "description": "Get couple-level financial optimization analysis. Compares scenarios for the user and their partner: who should buy back LPP first, who should contribute to 3a first (FATCA-aware), AVS couple cap impact, and marriage penalty analysis. Use when the user is in a couple and asks about joint financial decisions, partner coordination, or marriage impact. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  {
+    "name": "get_regulatory_constant",
+    "description": "Look up a Swiss financial regulatory constant from the official registry (LPP, AVS, 3a, mortgage, capital tax, LAMal, etc.). Use this when you need an exact legal value to answer the user's question — for example pillar 3a limits, LPP conversion rate, AVS pension amounts, or cantonal capital withdrawal tax rates. This tool is handled internally by the backend.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The constant key, e.g. 'pillar3a.max_with_lpp', 'avs.max_monthly_pension', 'lpp.conversion_rate', 'mortgage.theoretical_rate', 'capital_tax.cantonal.VS'. Use dotted notation matching the registry keys."
+        },
+        "canton": {
+          "type": "string",
+          "description": "Canton code for cantonal parameters (e.g. 'VS', 'ZH', 'GE'). Only needed for capital_tax.cantonal.* keys. Optional."
+        }
+      },
+      "required": [
+        "key"
+      ]
+    }
+  },
+  {
+    "name": "record_check_in",
+    "description": "Record the user's monthly check-in contributions. Use ONLY after the user has answered all contribution questions for the current month. Displays a summary card in chat and persists data to the user's profile. Never call this tool preemptively — wait for the user to provide actual amounts.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "month": {
+          "type": "string",
+          "description": "ISO month string YYYY-MM (e.g. '2026-04')"
+        },
+        "versements": {
+          "type": "object",
+          "description": "Map of contribution_id to amount in CHF (e.g. {'3a_julien': 500.0, 'epargne_libre': 200.0})"
+        },
+        "summary_message": {
+          "type": "string",
+          "description": "Coach summary to display to user (e.g. 'Parfait, 500 CHF sur le 3a et 200 CHF en épargne libre. C'est noté !')"
+        }
+      },
+      "required": [
+        "month",
+        "versements",
+        "summary_message"
+      ]
+    }
+  },
+  {
+    "name": "generate_financial_plan",
+    "description": "Generate a personalized financial plan based on the user's goal. The plan is computed by Flutter-side calculators (financial_core), NOT by the LLM. Only the narrative field may come from the coach. Use when the user asks for a plan, a roadmap, or a strategy to reach a financial goal. This tool is forwarded to Flutter for execution — the backend does NOT generate the plan itself.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "goal": {
+          "type": "string",
+          "description": "Human-readable description of the financial goal (e.g. 'Acheter un appartement à Sion', 'Optimiser mon 3e pilier', 'Constituer un fonds d’urgence')."
+        },
+        "monthly_amount": {
+          "type": "number",
+          "description": "Suggested monthly contribution in CHF. This is a coaching suggestion — the actual plan amount is computed by calculators."
+        },
+        "milestones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of milestone descriptions for the plan (e.g. ['Ouvrir un compte 3a', 'Premier versement', 'Atteindre 7258 CHF/an'])."
+        },
+        "projected_outcome": {
+          "type": "string",
+          "description": "Brief projected outcome description using conditional language. Must include a disclaimer that this is educational, not a guarantee."
+        },
+        "narrative": {
+          "type": "string",
+          "description": "Coach narrative explaining the plan in human terms. Must be educational and non-prescriptive. Use conditional language ('pourrait', 'dans ce scénario')."
+        }
+      },
+      "required": [
+        "goal",
+        "narrative"
+      ]
+    }
+  },
+  {
+    "name": "generate_document",
+    "description": "Generate a pre-filled document for the user (fiscal declaration prep, pension fund letter, LPP buyback request). The document is read-only — MINT never submits it. The user reviews and uses it independently. Use when the user asks about preparing a tax declaration, writing to their pension fund, or requesting an LPP buyback. This tool is forwarded to Flutter for execution — the backend does NOT generate the document itself.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "document_type": {
+          "type": "string",
+          "enum": [
+            "fiscal_declaration",
+            "pension_fund_letter",
+            "lpp_buyback_request"
+          ],
+          "description": "Type of document to generate: 'fiscal_declaration' = pre-filled tax declaration fields, 'pension_fund_letter' = formal letter to pension fund, 'lpp_buyback_request' = LPP buyback request form."
+        },
+        "context": {
+          "type": "string",
+          "description": "Brief summary of what the user asked for, used to customize the document generation. Do not include PII."
+        }
+      },
+      "required": [
+        "document_type",
+        "context"
+      ]
+    }
+  },
+  {
+    "name": "record_commitment",
+    "description": "Record an implementation intention (WHEN/WHERE/IF-THEN) after a Layer 4 insight. The backend acknowledges and persists the commitment. This tool is handled internally by the backend.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "when_text": {
+          "type": "string",
+          "description": "WHEN part of the intention (e.g. 'Ce lundi, quand tu recevras ta fiche de paie')."
+        },
+        "where_text": {
+          "type": "string",
+          "description": "WHERE part of the intention (e.g. 'Sur ton app bancaire 3a')."
+        },
+        "if_then_text": {
+          "type": "string",
+          "description": "IF-THEN part of the intention (e.g. 'Si le solde est insuffisant pour 604 CHF, verse au moins 200 CHF')."
+        },
+        "reminder_at": {
+          "type": "string",
+          "description": "Optional ISO 8601 datetime for a reminder (e.g. '2026-04-15T09:00:00Z'). Omit if no reminder needed."
+        }
+      },
+      "required": [
+        "when_text",
+        "where_text",
+        "if_then_text"
+      ]
+    }
+  },
+  {
+    "name": "save_pre_mortem",
+    "description": "Save a pre-mortem risk scenario before an irrevocable financial decision (EPL, capital withdrawal, 3a closure). The backend acknowledges and persists the entry. This tool is handled internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "decision_type": {
+          "type": "string",
+          "enum": [
+            "epl",
+            "capital_withdrawal",
+            "pillar_3a_closure"
+          ],
+          "description": "Type of irrevocable decision: 'epl' = EPL (retrait anticipé 2e pilier pour achat immobilier), 'capital_withdrawal' = retrait en capital du 2e pilier, 'pillar_3a_closure' = clôture du 3e pilier."
+        },
+        "decision_context": {
+          "type": "string",
+          "description": "Optional context about the decision being considered (e.g. 'Achat appartement à Sion, EPL de 50k envisagé')."
+        },
+        "user_response": {
+          "type": "string",
+          "description": "The user's response to the pre-mortem prompt: what could go wrong if this decision turns out badly."
+        }
+      },
+      "required": [
+        "decision_type",
+        "user_response"
+      ]
+    }
+  },
+  {
+    "name": "save_provenance",
+    "description": "Record who recommended a financial product to the user. Call when the user mentions who proposed or sold them a product (3a, LPP, assurance, hypotheque). Internal — handled by backend.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "product_type": {
+          "type": "string",
+          "description": "Type of financial product: '3a', 'lpp', 'assurance_vie', 'hypotheque', 'placement', 'prevoyance', 'autre'."
+        },
+        "recommended_by": {
+          "type": "string",
+          "description": "Who recommended the product (e.g. 'mon banquier', 'un ami', 'Uncle Patrick')."
+        },
+        "institution": {
+          "type": "string",
+          "description": "Optional: financial institution (e.g. 'UBS', 'PostFinance', 'Swiss Life')."
+        }
+      },
+      "required": [
+        "product_type",
+        "recommended_by"
+      ]
+    }
+  },
+  {
+    "name": "save_earmark",
+    "description": "Tag a sum of money with its relational or emotional origin. Call when the user associates money with a person, event, or purpose ('l'argent de mamie', 'le compte pour les enfants', 'mon heritage'). Internal — handled by backend.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The earmark label as the user expressed it (e.g. 'l'argent de mamie')."
+        },
+        "source_description": {
+          "type": "string",
+          "description": "Optional context about the origin (e.g. 'heritage de grand-mere en 2019')."
+        },
+        "amount_hint": {
+          "type": "string",
+          "description": "Optional approximate amount as expressed by user (e.g. 'environ 50k', '~30000')."
+        }
+      },
+      "required": [
+        "label"
+      ]
+    }
+  },
+  {
+    "name": "remove_earmark",
+    "description": "Remove an earmark tag when the user asks to forget it. Call when user says 'oublie le tag sur l'argent de mamie' or similar. Internal — handled by backend.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The earmark label to remove (e.g. 'l'argent de mamie')."
+        }
+      },
+      "required": [
+        "label"
+      ]
+    }
+  },
+  {
+    "name": "save_partner_estimate",
+    "description": "Store an estimate about the user's partner. Backend acknowledges only — actual data persisted by Flutter locally. Fields: estimated_salary (annual CHF), estimated_age (int), estimated_lpp (CHF), estimated_3a (CHF), estimated_canton (2-letter).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "estimated_salary": {
+          "type": "number",
+          "description": "Partner's estimated annual gross salary in CHF"
+        },
+        "estimated_age": {
+          "type": "integer",
+          "description": "Partner's estimated age"
+        },
+        "estimated_lpp": {
+          "type": "number",
+          "description": "Partner's estimated LPP assets in CHF"
+        },
+        "estimated_3a": {
+          "type": "number",
+          "description": "Partner's estimated 3a capital in CHF"
+        },
+        "estimated_canton": {
+          "type": "string",
+          "description": "Partner's canton of residence (2-letter, e.g. VS, ZH)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "update_partner_estimate",
+    "description": "Update a previously stored partner estimate field. Backend acknowledges only — actual data persisted by Flutter locally. Fields: estimated_salary (annual CHF), estimated_age (int), estimated_lpp (CHF), estimated_3a (CHF), estimated_canton (2-letter).",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "estimated_salary": {
+          "type": "number",
+          "description": "Partner's estimated annual gross salary in CHF"
+        },
+        "estimated_age": {
+          "type": "integer",
+          "description": "Partner's estimated age"
+        },
+        "estimated_lpp": {
+          "type": "number",
+          "description": "Partner's estimated LPP assets in CHF"
+        },
+        "estimated_3a": {
+          "type": "number",
+          "description": "Partner's estimated 3a capital in CHF"
+        },
+        "estimated_canton": {
+          "type": "string",
+          "description": "Partner's canton of residence (2-letter, e.g. VS, ZH)"
+        }
+      },
+      "required": []
+    }
+  },
+  {
+    "name": "show_commitment_card",
+    "description": "Display an editable commitment card (WHEN/WHERE/IF-THEN) inline in chat. The user can accept, edit, or dismiss the commitment. This tool is forwarded to Flutter for rendering — the backend does NOT handle it internally.",
+    "input_schema": {
+      "type": "object",
+      "properties": {
+        "when_text": {
+          "type": "string",
+          "description": "WHEN part of the intention."
+        },
+        "where_text": {
+          "type": "string",
+          "description": "WHERE part of the intention."
+        },
+        "if_then_text": {
+          "type": "string",
+          "description": "IF-THEN part of the intention."
+        }
+      },
+      "required": [
+        "when_text",
+        "where_text",
+        "if_then_text"
+      ]
+    }
+  }
+]

--- a/services/backend/app/services/rag/llm_client.py
+++ b/services/backend/app/services/rag/llm_client.py
@@ -229,6 +229,33 @@ class LLMClient:
                     "disable_parallel_tool_use": False,
                 }
 
+            # Wave 1c instrumentation (engram obs id 74, 2026-05-15): when
+            # WAVE1C_INSTRUMENT_ENABLED=true is set on the staging env, log the
+            # full Anthropic API payload (system prompt, tool names + count,
+            # tool_choice, message stack) immediately before the create() call.
+            # Used to bisect which context layer suppresses tool_use disposition
+            # vs the local minimal-prompt experiment which DOES emit tool_use
+            # under tool_choice=auto. Default OFF -> no production log volume.
+            # Drop the env var to disable; this gate is intentionally not in
+            # Pydantic Settings to keep instrumentation hot-loadable.
+            import os as _os  # local import to keep instrumentation isolated
+            if _os.environ.get("WAVE1C_INSTRUMENT_ENABLED", "").lower() == "true":
+                try:
+                    import json as _json
+                    _payload = {
+                        "model": kwargs.get("model"),
+                        "system": kwargs.get("system"),
+                        "tools": [t.get("name") for t in kwargs.get("tools", [])],
+                        "tool_choice": kwargs.get("tool_choice"),
+                        "messages": kwargs.get("messages"),
+                    }
+                    logger.info(
+                        "WAVE1C_PAYLOAD %s",
+                        _json.dumps(_payload, ensure_ascii=False)[:80000],
+                    )
+                except Exception as _e:  # pragma: no cover (instrumentation only)
+                    logger.warning("WAVE1C_PAYLOAD instrumentation failed: %s", _e)
+
             # v2.7 STAB-02: retry transient upstream failures (429/5xx/529 +
             # connection/timeout). Wait: 0.5s, 1s, 2s (max 8s). Final failure
             # is wrapped into CoachUpstreamError so the orchestrator can


### PR DESCRIPTION
## Summary

Hot-loadable env-gated payload logger for the Anthropic API call in the coach narrator path. Activates via `WAVE1C_INSTRUMENT_ENABLED=true` on Railway, default OFF. Used to bisect which context layer on staging suppresses `tool_use` disposition vs the local minimal-prompt replay (which DOES emit `tool_use` under `tool_choice=auto`).

### Why

Wave 1b citation chips ship to dev+staging (PR #625/626) but live G2 never passed. PR #627 v2 documents 3 blockers from the autonomous G2 run; Blocker 3 ("coach narrator emits no `tool_use` blocks") was misattributed to `tool_choice=auto` by the 3-agent RCA panel (engram obs id 73). The deterministic experiment in this PR's `.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment.py` falsifies that hypothesis: both `auto` and `any` emit `tool_use: get_retirement_projection({})` with a minimal staging-like prompt. The suppressor is somewhere in the staging context-assembly delta (~9,700 input tokens larger than my minimal replay). This PR ships the instrument needed to identify which layer.

### What this PR ships

- **`services/backend/app/services/rag/llm_client.py:230-256`** (post-edit) — one structured `logger.info("WAVE1C_PAYLOAD %s", ...)` call after `kwargs` is fully assembled and before the retry loop wrapping `client.messages.create(**kwargs)`. Logs: model, system prompt (full), tool names + count, tool_choice, messages stack. JSON-encoded, capped at 80k chars. Defensive try/except. Only fires when `WAVE1C_INSTRUMENT_ENABLED=true`. The companion claude vision call at line 412 is the OCR path and intentionally NOT instrumented.
- **`.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment.py`** — the falsifying experiment script.
- **`.planning/phases/wave-1c-coach-tool-dispatch-rca/experiment_results.json`** — verbatim 2026-05-15 16:08 outputs (both variants return `stop_reason="tool_use"`).
- **`.planning/phases/wave-1c-coach-tool-dispatch-rca/tools.json`** — dump of `get_narrator_llm_tools()` (26 tools incl. all 6 Wave 1b chip-emitters) used as input to the experiment, so `experiment.py` doesn't have to import the full MINT backend (sidesteps psycopg2 dep).

### Activation runbook (after merge to dev → merge dev→staging)

1. `railway variable set --service MINT --environment staging WAVE1C_INSTRUMENT_ENABLED=true`
2. `railway restart --service MINT --yes`
3. Fire one probe v7 against staging (any authed test account)
4. `railway logs --service mint-staging | grep WAVE1C_PAYLOAD` — capture the full payload
5. Modify `experiment.py` to consume the captured `system` + `messages`, bisect by dropping context layers one at a time (RAG chunks → bundle fragments → `conversation_history` → `profile_context` → legacy doctrine at `claude_coach_service.py:660`). First drop that restores `tool_use` names the culprit.
6. Revert: `railway variable delete --service MINT --environment staging WAVE1C_INSTRUMENT_ENABLED` + `railway restart --service MINT --yes`.

### Phase status

Wave 1b stays `PENDING G2 — RUNTIME GAP`. This PR enables the bisection that will name the culprit; the actual fix lands in a follow-up PR (small if a single context layer is the bug, larger if it's a doctrine rewrite per the falsified ai-engineer hypothesis).

## Test plan

- [ ] Backend pytest targeted to llm_client + narrator + claude_coach: `cd services/backend && python3 -m pytest tests/ -q -k 'llm_client or narrator or claude_coach'` returns 175 passed, 2 skipped, 1 xfailed (~2.0s). Verified locally pre-commit.
- [ ] Full backend pytest CI gate (G3): green.
- [ ] `WAVE1C_INSTRUMENT_ENABLED` unset by default — no production log volume change.
- [ ] When enabled, one log line per coach chat request (single point of insertion, before the retry loop, so no log spam under retries).

## Followups

- After bisection finds the culprit, ship the targeted fix as a separate small PR.
- Tear down `WAVE1C_INSTRUMENT_ENABLED` from Railway after the bisection completes.
- Run the qa-expert regression test floor per PR #627's verification report ("Recommended next phase" section) on the fix PR.

Engram: `obs-bcb0b41d70a52ae4` (id 74) — supersedes the falsified `obs id 73` 3-agent RCA consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)