### PR TITLE
hotfix: dev → staging — runtime_verb_gate parents[5] IndexError on Railway boot

### DIFF
--- a/services/backend/app/services/coach/runtime_verb_gate.py
+++ b/services/backend/app/services/coach/runtime_verb_gate.py
@@ -40,51 +40,60 @@ Threat coverage per Plan-18 STRIDE register :
 """
 from __future__ import annotations
 
-import importlib.util
 import re
 import unicodedata
-from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Pattern established in Plan 04 SUMMARY decisions — load the banned-term
-# vocabulary at runtime via importlib so the backend doesn't depend on
-# `tools/` being on `sys.path` (which it isn't when running from
-# `services/backend/`). This keeps the lint module the canonical single
-# source of truth without forcing a packaging restructure.
+# Stage 0-followup (2026-05-17, post mint-calc-engine-v1) — INLINED banned-
+# term vocabulary. The previous `parents[5] / "tools" / "checks" /
+# "banned_terms_python.py"` importlib path traversal worked on dev-box
+# (5 levels up from `services/backend/app/services/coach/runtime_verb_gate.py`
+# lands at repo root) but CRASHED on Railway container at boot with
+# `IndexError: 5` because (a) Railway `WORKDIR=/app` only has 4 ancestors
+# and (b) `tools/checks/banned_terms_python.py` is NOT shipped to the
+# container — the Dockerfile build context is `services/backend/` so the
+# repo-root `tools/` directory is OUTSIDE the build context.
+#
+# Fix : inline the 3 tuples here verbatim. Drift between runtime gate and
+# the canonical `tools/checks/banned_terms_python.py` is caught by
+# `tests/test_runtime_banned_verb_gate.py::test_runtime_lint_drift_guard`
+# (added in this same commit), which runs locally + in CI where both
+# files are accessible. The runtime gate becomes self-contained — no
+# build-time tooling dependency at HTTP request path.
+#
+# Self-exemption marker below tells `banned_terms_python.py` to skip
+# scanning these 3 tuples when it walks this file ; the strings here are
+# the lint vocabulary, not user-facing narrator output.
 # ---------------------------------------------------------------------------
-_LINT_PATH = (
-    Path(__file__).resolve().parents[5] / "tools" / "checks" / "banned_terms_python.py"
+# llm-doctrine-fragment-banned-list
+"""
+Inlined banned-term vocabulary — kept in sync with
+`tools/checks/banned_terms_python.py` via test_runtime_lint_drift_guard.
+"""
+
+_WORD_BOUNDARY_BANNED: tuple[str, ...] = (
+    "garanti",
+    "optimal",
+    "meilleur",
+    "certain",
+    "assure",
+    "parfait",
 )
 
+_PHRASE_BANNED: tuple[str, ...] = ("sans risque",)
 
-def _load_lint_vocabulary() -> tuple[
-    tuple[str, ...], tuple[str, ...], tuple[str, ...]
-]:
-    """Load (_WORD_BOUNDARY_BANNED, _PHRASE_BANNED, BANNED_PARAPHRASE_VERBS).
-
-    Same import-via-importlib pattern as `tests/test_lucidity_payloads.py`
-    (Plan 04 decision) — avoids the `tools.checks` ImportError when this
-    module is imported from inside `services/backend/`.
-    """
-    spec = importlib.util.spec_from_file_location(
-        "banned_terms_python_runtime", _LINT_PATH
-    )
-    if spec is None or spec.loader is None:  # pragma: no cover — defensive
-        raise ImportError(
-            f"D-CE-16(c) runtime gate cannot load banned-term vocabulary "
-            f"from {_LINT_PATH}"
-        )
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return (
-        tuple(module._WORD_BOUNDARY_BANNED),
-        tuple(module._PHRASE_BANNED),
-        tuple(module.BANNED_PARAPHRASE_VERBS),
-    )
-
-
-_WORD_BOUNDARY_BANNED, _PHRASE_BANNED, BANNED_PARAPHRASE_VERBS = (
-    _load_lint_vocabulary()
+BANNED_PARAPHRASE_VERBS: tuple[str, ...] = (
+    "le choix le plus avisé",
+    "le plus pertinent",
+    "plus avantageux que",
+    "nettement plus",
+    "clairement supérieur",
+    "à mon avis",
+    "je pense que tu",
+    "mon conseil serait",
+    "tu devrais",
+    "il faut",
+    "recommandé",
 )
 
 # Verbatim FR fallback. INTENTIONALLY shorter than Phase 94's

--- a/services/backend/tests/test_compliance_wording.py
+++ b/services/backend/tests/test_compliance_wording.py
@@ -49,6 +49,7 @@ GUARDRAIL_FILES = {
     "coach_tools.py",                  # tool schema with banned terms reminder
     "vision_guard.py",                 # LLM-as-judge prompt: literally lists banned terms
     "anonymous_chat.py",               # anon discovery prompt: « Termes interdits : garanti... »
+    "runtime_verb_gate.py",            # Plan 18 D-CE-16(c) inlined banned-term vocab (2026-05-17)
     # Dart
     "compliance_guard.dart",
     "coach_checkin_screen.dart",

--- a/services/backend/tests/test_runtime_banned_verb_gate.py
+++ b/services/backend/tests/test_runtime_banned_verb_gate.py
@@ -147,3 +147,72 @@ def test_zero_width_chars_constant_present():
     assert "﻿" in _ZERO_WIDTH_CHARS  # ZERO WIDTH NO-BREAK SPACE
     assert "⁠" in _ZERO_WIDTH_CHARS  # WORD JOINER
     assert len(_ZERO_WIDTH_CHARS) >= 5
+
+
+# ---------------------------------------------------------------------------
+# Stage 0-followup (2026-05-17, post mint-calc-engine-v1) — drift guard.
+# Runtime gate inlines its banned-term vocabulary so the Railway container
+# (where `tools/checks/banned_terms_python.py` is NOT shipped) can boot.
+# This test asserts the 3 inlined tuples match the canonical lint exactly.
+# Runs in CI + local — both files are present here. Drift = test fails.
+# ---------------------------------------------------------------------------
+def test_runtime_lint_drift_guard():
+    """Runtime gate's 3 banned-term tuples MUST match the lint canonical.
+
+    Inlined values live in `runtime_verb_gate.py` (so Railway container can
+    boot without `tools/` on Python path). Source-of-truth values live in
+    `tools/checks/banned_terms_python.py`. Any drift between the two would
+    create a Layer-(b) ↔ Layer-(c) defense gap : the lint flags a verb at
+    commit-time but the runtime gate doesn't catch it at narrator output
+    (or vice versa).
+
+    Test uses importlib (not regular import) because `tools/` is not on
+    Python path from `services/backend/tests/`. Test SKIPS cleanly if the
+    canonical lint file cannot be found — that's the expected state on
+    Railway container ; the test is a dev-box / CI gate, not a runtime gate.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    from app.services.coach.runtime_verb_gate import (
+        BANNED_PARAPHRASE_VERBS as runtime_paraphrase,
+        _PHRASE_BANNED as runtime_phrase,
+        _WORD_BOUNDARY_BANNED as runtime_word,
+    )
+
+    # Walk up from `services/backend/tests/test_runtime_banned_verb_gate.py`
+    # to the repo root (parents[3] = repo root) then into `tools/checks/`.
+    lint_path = (
+        Path(__file__).resolve().parents[3]
+        / "tools"
+        / "checks"
+        / "banned_terms_python.py"
+    )
+
+    if not lint_path.is_file():
+        pytest.skip(
+            f"Canonical lint not found at {lint_path} — skipping drift guard. "
+            f"Expected state on Railway container (build context excludes "
+            f"repo-root tools/). On dev-box / CI this should resolve."
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "banned_terms_python_drift_guard", lint_path
+    )
+    assert spec is not None and spec.loader is not None
+    lint_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lint_module)
+
+    assert runtime_word == tuple(lint_module._WORD_BOUNDARY_BANNED), (
+        f"_WORD_BOUNDARY_BANNED drift — runtime={runtime_word!r} vs "
+        f"lint={tuple(lint_module._WORD_BOUNDARY_BANNED)!r}. Sync "
+        f"runtime_verb_gate.py with tools/checks/banned_terms_python.py."
+    )
+    assert runtime_phrase == tuple(lint_module._PHRASE_BANNED), (
+        f"_PHRASE_BANNED drift — runtime={runtime_phrase!r} vs "
+        f"lint={tuple(lint_module._PHRASE_BANNED)!r}"
+    )
+    assert runtime_paraphrase == tuple(lint_module.BANNED_PARAPHRASE_VERBS), (
+        f"BANNED_PARAPHRASE_VERBS drift — runtime={runtime_paraphrase!r} vs "
+        f"lint={tuple(lint_module.BANNED_PARAPHRASE_VERBS)!r}"
+    )


### PR DESCRIPTION
## Summary

Hotfix unblocking the previous PR #644 merge that crashed Railway staging at boot with `IndexError: 5`.

- `runtime_verb_gate.py` was loading the banned-term vocabulary via `Path(__file__).resolve().parents[5] / "tools" / "checks" / "banned_terms_python.py"`. Worked on dev-box (5 levels up = repo root). Crashed on Railway container (`WORKDIR=/app`, only 4 ancestors + `tools/` not in Dockerfile build context).
- **Fix**: inline the 3 banned-term tuples directly into `runtime_verb_gate.py`. Self-contained, no build-time tooling dependency at HTTP request path.
- **Drift guard**: new pytest `test_runtime_lint_drift_guard` compares the inlined tuples against the canonical `tools/checks/banned_terms_python.py` via importlib. Skips cleanly when canonical absent (= Railway state); enforces strictly when present (= dev/CI state).
- **Allow-list**: added `runtime_verb_gate.py` to `tests/test_compliance_wording.py::GUARDRAIL_FILES` (same pattern as `compliance_guard.py`, `claude_coach_service.py`, `coach_tools.py`).

## Verification

- Backend regression: `pytest services/backend/tests/ -q` → **7279 passed, 63 skipped, 3 xfailed in 115.70s** (+1 exact vs Stage 1.1 baseline 7278 = the new drift guard test, zero regression).
- 23/23 `test_runtime_banned_verb_gate.py` tests green including the new drift guard.
- Module boot smoke: `python3 -c "from app.services.coach.runtime_verb_gate import gate"` → import OK (no IndexError).

## Engram learning saved

obs #155: « any service-side module that depends on `tools/` repo-root assets must inline OR vendor the asset into the Dockerfile build context. » + « 7264 tests passing locally is NECESSARY but NOT SUFFICIENT for production confidence — next stage gate for guardrail modules: `docker build` + module import smoke ».

## Test plan

- [x] Backend regression green (7279 passed)
- [x] Local module import works (no IndexError)
- [ ] CI green on this PR
- [ ] dev→staging merge
- [ ] Railway redeploy `SUCCESS`
- [ ] `railway ssh ... GET /metrics` returns 200 with the 4 D-CE-17 counters present
- [ ] Sentry 30 min watch — no new exception types

🤖 Generated with [Claude Code](https://claude.com/claude-code)