### PR TITLE
fix(compliance): nLPD/LSFin hotfix bundle A+B+C (gated on mint-calc-engine-v1 Stage 3)

### DIFF
--- a/services/backend/alembic/versions/p111_projection_audit.py
+++ b/services/backend/alembic/versions/p111_projection_audit.py
@@ -1,0 +1,114 @@
+"""Hotfix B 2026-05-17 — projection_audit_records + snapshots.constants_version_hash.
+
+Closes two gaps surfaced by the data-architecture panel (ADR
+.planning/decisions/2026-05-17-data-architecture-event-log-vs-bitemporal.md):
+
+  (i)  Snapshots had no record of the regulatory snapshot that produced
+       them. Adds `snapshots.constants_version_hash` (nullable for
+       backfill compat; populated on new rows by the writer in
+       app/services/snapshots/snapshot_service.py).
+
+  (ii) No append-only LSFin advice audit trail existed. Creates the
+       `projection_audit_records` table and, on Postgres, runs
+       `REVOKE UPDATE, DELETE` so the table is structurally append-only
+       at the DB level — `DROP TABLE` remains the only way to clear
+       rows (which itself is auditable in Postgres).
+
+Revision ID : p111_projection_audit       (21 chars — within Postgres
+              alembic_version.version_num VARCHAR(32) cap that bit
+              the p97 deploy on 2026-05-12).
+Revises     : p110_scenarios_cache_idx
+Create Date : 2026-05-17
+
+Dialect branch
+==============
+Postgres : REVOKE UPDATE, DELETE on the audit table from PUBLIC and (if
+the role exists) from `app_role`. SQLite test path keeps INSERT-only by
+convention — SQLite has no role-level GRANT, so the test fixtures rely
+on the application never issuing UPDATE / DELETE on this table. The
+behavioural contract is identical; only the enforcement mechanism
+differs.
+
+Downgrade
+=========
+DROP TABLE removes all privileges automatically, so no symmetric GRANT
+is needed on downgrade. The `constants_version_hash` column is dropped
+via `batch_alter_table` for SQLite compatibility.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "p111_projection_audit"  # 21 chars — within Postgres VARCHAR(32) cap
+down_revision: Union[str, Sequence[str], None] = "p110_scenarios_cache_idx"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── Step 1 : add constants_version_hash to snapshots ────────────────
+    # Nullable so existing rows backfill cleanly (they predate the writer
+    # change). New rows get a non-null value from
+    # snapshot_service.create_snapshot.
+    with op.batch_alter_table("snapshots", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("constants_version_hash", sa.String(length=64), nullable=True),
+        )
+
+    # ── Step 2 : create projection_audit_records (append-only) ──────────
+    op.create_table(
+        "projection_audit_records",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id_hash", sa.String(length=64), nullable=False),
+        sa.Column("computed_at", sa.DateTime(), nullable=False),
+        sa.Column("projection_type", sa.String(length=32), nullable=False),
+        sa.Column("projection_id", sa.String(), nullable=False),
+        sa.Column("constants_version_hash", sa.String(length=64), nullable=False),
+        sa.Column("scenario_inputs_hash", sa.String(length=64), nullable=False),
+        sa.Column("output_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "lsfin_disclaimer_shown",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),  # SQLite-safe; Postgres coerces to false
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_projection_audit_user_computed",
+        "projection_audit_records",
+        ["user_id_hash", "computed_at"],
+    )
+
+    # ── Step 3 : Postgres append-only enforcement ───────────────────────
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "REVOKE UPDATE, DELETE ON projection_audit_records FROM PUBLIC"
+        )
+        # Defense in depth: revoke from the named app role if it exists.
+        # The DO block makes this safe in environments where app_role is
+        # not provisioned (CI, dev). Failure to revoke is non-blocking.
+        op.execute(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_role') THEN
+                    REVOKE UPDATE, DELETE ON projection_audit_records FROM app_role;
+                END IF;
+            END
+            $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_projection_audit_user_computed",
+        table_name="projection_audit_records",
+    )
+    op.drop_table("projection_audit_records")
+    with op.batch_alter_table("snapshots", schema=None) as batch_op:
+        batch_op.drop_column("constants_version_hash")

--- a/services/backend/alembic/versions/p112_audit_event_user_hash.py
+++ b/services/backend/alembic/versions/p112_audit_event_user_hash.py
@@ -1,0 +1,86 @@
+"""Hotfix C 2026-05-17 — audit_events.user_id_hash + Postgres backfill.
+
+Closes the PII-residency gap on the audit log surfaced by the data-
+architecture panel: `audit_events.user_id` was stored in plaintext with
+no FK CASCADE and no DEK protection, so audit rows for an erased user
+remained fully re-identifiable.
+
+This migration adds `audit_events.user_id_hash` (sha256, indexed) and
+backfills existing rows on Postgres. The plaintext `user_id` column
+is intentionally NOT dropped here — it stays one deprecation cycle so
+read paths can migrate. A follow-up migration (PR body tracks the gap)
+will NULL it after writers have shipped.
+
+Revision ID : p112_audit_event_user_hash     (26 chars — within Postgres
+              alembic_version.version_num VARCHAR(32) cap).
+Revises     : p111_projection_audit
+Create Date : 2026-05-17
+
+Dialect branch
+==============
+Postgres : backfill via `encode(digest(user_id, 'sha256'), 'hex')`
+(requires the `pgcrypto` extension — see fallback below). Defense in
+depth: a DO block tries pgcrypto first, falls back to a no-op if the
+extension is not installed. New writes (audit_service.log_audit_event)
+populate the column going forward regardless.
+
+SQLite : skip backfill. Test fixtures use fresh DBs; existing rows are
+created within the test session and write through the updated helper.
+
+Downgrade
+=========
+Drop the column + drop the index.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "p112_audit_event_user_hash"  # 26 chars — within Postgres VARCHAR(32) cap
+down_revision: Union[str, Sequence[str], None] = "p111_projection_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── Step 1 : add user_id_hash column (nullable for backfill compat) ──
+    with op.batch_alter_table("audit_events", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("user_id_hash", sa.String(length=64), nullable=True),
+        )
+        batch_op.create_index(
+            "ix_audit_events_user_id_hash",
+            ["user_id_hash"],
+        )
+
+    # ── Step 2 : Postgres backfill (best-effort, no-op if pgcrypto absent) ──
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto'
+                ) THEN
+                    UPDATE audit_events
+                       SET user_id_hash = encode(digest(user_id, 'sha256'), 'hex')
+                     WHERE user_id IS NOT NULL
+                       AND user_id_hash IS NULL;
+                END IF;
+            END
+            $$;
+            """
+        )
+        # Note: rows where pgcrypto is missing OR user_id IS NULL stay
+        # with user_id_hash IS NULL. New writes populate via
+        # audit_service.hash_user_id() in Python; backfill of missing
+        # rows can be re-attempted as a one-off if pgcrypto is later
+        # installed.
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("audit_events", schema=None) as batch_op:
+        batch_op.drop_index("ix_audit_events_user_id_hash")
+        batch_op.drop_column("user_id_hash")

--- a/services/backend/app/api/v1/endpoints/privacy.py
+++ b/services/backend/app/api/v1/endpoints/privacy.py
@@ -194,6 +194,27 @@ def export_user_data(
     profile_data["consents"] = consent_data
     profile_data["coach_memory"] = coach_memory_data
 
+    # P1-nLPD: Coach insights (relational CoachInsightRecord rows — distinct from
+    # pgvector coach_memory above). Surfaces save_insight tool outputs for DSAR
+    # right-of-access (nLPD art. 25).
+    from app.models.coach_insight import CoachInsightRecord
+    coach_insights_data: list = []
+    if request.include_coach_insights:
+        coach_insights_rows = db.query(CoachInsightRecord).filter(
+            CoachInsightRecord.user_id == user_id
+        ).order_by(CoachInsightRecord.created_at.desc()).limit(1000).all()
+        coach_insights_data = [
+            {
+                "id": ci.id,
+                "topic": ci.topic,
+                "summary": ci.summary,
+                "insight_type": ci.insight_type,
+                "created_at": str(ci.created_at),
+                "updated_at": str(ci.updated_at),
+            }
+            for ci in coach_insights_rows
+        ]
+
     result = service.export_user_data(
         profile_id=user_id,
         profile_data=profile_data,
@@ -201,10 +222,12 @@ def export_user_data(
         reports_data=reports_data,
         documents_data=documents_data,
         analytics_data=analytics_data,
+        coach_insights_data=coach_insights_data,
         include_sessions=request.include_sessions,
         include_reports=request.include_reports,
         include_documents=request.include_documents,
         include_analytics=request.include_analytics,
+        include_coach_insights=request.include_coach_insights,
     )
 
     categories_schema = [
@@ -228,6 +251,7 @@ def export_user_data(
         donnees_rapports=result.donnees_rapports,
         donnees_documents=result.donnees_documents,
         donnees_analytics=result.donnees_analytics,
+        donnees_coach_insights=result.donnees_coach_insights,
         politique_conservation=result.politique_conservation,
         responsable_traitement=result.responsable_traitement,
         premier_eclairage=result.premier_eclairage,
@@ -261,6 +285,15 @@ def delete_user_data(
     # V12-1: Use authenticated user ID, never client-supplied profile_id.
     user_id = _user.id
 
+    # Count coach insights (CoachInsightRecord rows) for nLPD art. 32 deletion
+    # manifest. Note: other categories still pass 0 — pre-existing systemic gap
+    # tracked in PR body (this endpoint returns a manifest; the actual row
+    # deletion happens via FK CASCADE when the user row is deleted elsewhere).
+    from app.models.coach_insight import CoachInsightRecord
+    nb_coach_insights = db.query(CoachInsightRecord).filter(
+        CoachInsightRecord.user_id == user_id
+    ).count()
+
     # In production, counts would come from the database
     result = service.delete_user_data(
         profile_id=user_id,
@@ -269,6 +302,7 @@ def delete_user_data(
         nb_reports=0,
         nb_documents=0,
         nb_analytics=0,
+        nb_coach_insights=nb_coach_insights,
         raison=request.raison,
     )
 

--- a/services/backend/app/models/__init__.py
+++ b/services/backend/app/models/__init__.py
@@ -34,6 +34,7 @@ from app.models.magic_link_token import MagicLinkTokenModel
 from app.models.coach_insight import CoachInsightRecord
 from app.models.document_memory import DocumentMemory
 from app.models.dek_vault import DEKVault
+from app.models.projection_audit_record import ProjectionAuditRecord
 
 __all__ = [
     "User",
@@ -62,4 +63,5 @@ __all__ = [
     "CoachInsightRecord",
     "DocumentMemory",
     "DEKVault",
+    "ProjectionAuditRecord",
 ]

--- a/services/backend/app/models/audit_event.py
+++ b/services/backend/app/models/audit_event.py
@@ -15,6 +15,11 @@ class AuditEventModel(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     user_id = Column(String, nullable=True, index=True)
+    # Hotfix C 2026-05-17 — sha256(user_id) so the audit row survives nLPD
+    # erasure on the user record without re-identification risk. Plaintext
+    # user_id kept for one deprecation window; a follow-up migration will
+    # NULL it after writers stop reading it.
+    user_id_hash = Column(String(64), nullable=True, index=True)
     actor_email = Column(String, nullable=True)
     event_type = Column(String, nullable=False, index=True)
     status = Column(String, nullable=False, default="success")

--- a/services/backend/app/models/projection_audit_record.py
+++ b/services/backend/app/models/projection_audit_record.py
@@ -1,0 +1,53 @@
+"""ProjectionAuditRecord — append-only LSFin advice audit log (Hotfix B 2026-05-17).
+
+Stores tamper-evident metadata about every persisted projection shown to a
+user, so that the regulatory snapshot + user-fact inputs that produced the
+output can be reconstructed for advice documentation (LSFin retention
+obligation, ~10y).
+
+Append-only at the DB level: the accompanying alembic migration runs
+`REVOKE UPDATE, DELETE ON projection_audit_records FROM PUBLIC` (and from
+the explicit `app_role` if present) on Postgres. SQLite test path keeps
+INSERT-only by convention (no role-level GRANT in SQLite).
+
+PII boundary: `user_id_hash` is sha256(user_id), never plaintext, so the
+audit row can outlive the user record under nLPD right-of-erasure without
+re-identification risk.
+
+Writers should be added per projection surface (see snapshot_service.py
+for the snapshot pathway). Do NOT instantiate elsewhere without
+recomputing the three hashes — that's the whole point of the table.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, Index, String
+
+from app.core.database import Base
+
+
+class ProjectionAuditRecord(Base):
+    """Append-only audit row per persisted projection output."""
+
+    __tablename__ = "projection_audit_records"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid4()))
+    user_id_hash = Column(String(64), nullable=False)
+    computed_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+    projection_type = Column(String(32), nullable=False)  # "snapshot" | future projection kinds
+    projection_id = Column(String, nullable=False)  # id of the projection row in its own table
+    constants_version_hash = Column(String(64), nullable=False)
+    scenario_inputs_hash = Column(String(64), nullable=False)
+    output_hash = Column(String(64), nullable=False)
+    lsfin_disclaimer_shown = Column(Boolean, default=False, nullable=False)
+
+    __table_args__ = (
+        # Composite index covers the two dominant query patterns: per-user
+        # audit retrieval and time-window scans for compliance reports.
+        Index("ix_projection_audit_user_computed", "user_id_hash", "computed_at"),
+    )

--- a/services/backend/app/models/snapshot.py
+++ b/services/backend/app/models/snapshot.py
@@ -20,6 +20,10 @@ class SnapshotModel(Base):
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
     trigger = Column(String, nullable=False)  # quarterly, life_event, profile_update, check_in
     model_version = Column(String, default="1.0", nullable=False)
+    # Hotfix B 2026-05-17 — sha256 of active RegulatoryRegistry params at compute time.
+    # Enables LSFin reconstruction of the regulatory snapshot that produced this row.
+    # Nullable for backfill compat; populated by snapshot_service writer on new rows.
+    constants_version_hash = Column(String(64), nullable=True)
 
     # Core inputs
     age = Column(Integer, default=0, server_default=text("0"))

--- a/services/backend/app/schemas/privacy.py
+++ b/services/backend/app/schemas/privacy.py
@@ -35,6 +35,7 @@ class ConsentCategory(str, Enum):
     open_banking = "open_banking"
     document_upload = "document_upload"
     rag_queries = "rag_queries"
+    coach_insights = "coach_insights"
 
 
 class ConsentBasis(str, Enum):
@@ -80,6 +81,10 @@ class DataExportRequest(PrivacyBaseModel):
     include_analytics: bool = Field(
         default=True,
         description="Inclure les evenements analytics",
+    )
+    include_coach_insights: bool = Field(
+        default=True,
+        description="Inclure les insights enregistres par le coach IA",
     )
 
 
@@ -140,6 +145,10 @@ class DataExportResponse(PrivacyBaseModel):
     donnees_analytics: List[Dict] = Field(
         default_factory=list,
         description="Evenements analytics",
+    )
+    donnees_coach_insights: List[Dict] = Field(
+        default_factory=list,
+        description="Insights enregistres par le coach IA (memoire conversationnelle)",
     )
     politique_conservation: Dict[str, str] = Field(
         default_factory=dict,

--- a/services/backend/app/services/audit_service.py
+++ b/services/backend/app/services/audit_service.py
@@ -4,11 +4,25 @@ Audit service helpers.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any, Optional
 from sqlalchemy.orm import Session
 
 from app.models.audit_event import AuditEventModel
+
+
+def hash_user_id(user_id: Optional[str]) -> Optional[str]:
+    """Return sha256(user_id) hex digest, or None when user_id is None.
+
+    Hotfix C 2026-05-17 — single source of truth for the audit-row PII
+    hash. Re-used by any code path that writes AuditEventModel directly
+    (e.g. open_banking.consent_manager._log_audit) so the audit table
+    stays PII-clean even after nLPD right-of-erasure on the user row.
+    """
+    if user_id is None:
+        return None
+    return hashlib.sha256(user_id.encode("utf-8")).hexdigest()
 
 
 def log_audit_event(
@@ -29,6 +43,7 @@ def log_audit_event(
     db.add(
         AuditEventModel(
             user_id=user_id,
+            user_id_hash=hash_user_id(user_id),
             actor_email=actor_email,
             event_type=event_type,
             status=status,

--- a/services/backend/app/services/open_banking/consent_manager.py
+++ b/services/backend/app/services/open_banking/consent_manager.py
@@ -118,8 +118,10 @@ class ConsentManager:
         details: dict,
     ) -> None:
         """Persist an audit entry to the audit_events table."""
+        from app.services.audit_service import hash_user_id  # local import: avoid cycle on module load
         db.add(AuditEventModel(
             user_id=user_id,
+            user_id_hash=hash_user_id(user_id),
             event_type=event_type,
             status="success",
             source="open_banking",

--- a/services/backend/app/services/privacy_service.py
+++ b/services/backend/app/services/privacy_service.py
@@ -48,6 +48,7 @@ RETENTION_POLICIES: Dict[str, str] = {
     "open_banking": "Duree du consentement, donnees supprimees a la revocation",
     "document_upload": "Duree du consentement, max 24 mois",
     "rag_queries": "Duree du consentement, donnees supprimees a la revocation (BYOK)",
+    "coach_insights": "Duree du consentement, donnees supprimees a la revocation",
 }
 
 # Categories de consentement avec leurs bases legales et descriptions
@@ -139,6 +140,22 @@ CONSENT_CATEGORIES: Dict[str, Dict] = {
             "Toutes les autres fonctionnalites restent disponibles."
         ),
     },
+    "coach_insights": {
+        "nom_affiche": "Memoire du coach (insights conversationnels)",
+        "description": (
+            "Le coach IA enregistre des faits, decisions et preferences detectes "
+            "dans tes conversations pour personnaliser les sessions futures. "
+            "Tu peux consulter, exporter et supprimer ces enregistrements a tout moment."
+        ),
+        "base_legale": "consent",
+        "est_obligatoire": False,
+        "peut_etre_retire": True,
+        "impact_retrait": (
+            "Les insights enregistres seront supprimes et le coach ne sauvegardera "
+            "plus de nouvelles informations entre les sessions. Il continuera de t'aider "
+            "mais devra te reposer les questions de base a chaque conversation."
+        ),
+    },
 }
 
 # Sources legales
@@ -194,6 +211,7 @@ class ExportResult:
     responsable_traitement: str
     premier_eclairage: str
     disclaimer: str
+    donnees_coach_insights: List[Dict] = field(default_factory=list)
     sources: List[str] = field(default_factory=list)
 
 
@@ -287,10 +305,12 @@ class PrivacyService:
         reports_data: Optional[List[Dict]] = None,
         documents_data: Optional[List[Dict]] = None,
         analytics_data: Optional[List[Dict]] = None,
+        coach_insights_data: Optional[List[Dict]] = None,
         include_sessions: bool = True,
         include_reports: bool = True,
         include_documents: bool = True,
         include_analytics: bool = True,
+        include_coach_insights: bool = True,
     ) -> ExportResult:
         """Exporte toutes les donnees personnelles d'un utilisateur.
 
@@ -322,6 +342,7 @@ class PrivacyService:
         _reports = reports_data if include_reports and reports_data else []
         _documents = documents_data if include_documents and documents_data else []
         _analytics = analytics_data if include_analytics and analytics_data else []
+        _coach_insights = coach_insights_data if include_coach_insights and coach_insights_data else []
 
         # Build category info
         categories: List[DataCategoryInfo] = []
@@ -370,6 +391,15 @@ class PrivacyService:
                 duree_conservation=RETENTION_POLICIES["analytics"],
             ))
 
+        if include_coach_insights:
+            categories.append(DataCategoryInfo(
+                categorie="coach_insights",
+                nombre_enregistrements=len(_coach_insights),
+                description="Insights enregistres par le coach IA (faits, decisions, preferences)",
+                base_legale="Consentement (nLPD art. 6 al. 6)",
+                duree_conservation=RETENTION_POLICIES["coach_insights"],
+            ))
+
         # Count total records
         total_records = sum(c.nombre_enregistrements for c in categories)
 
@@ -394,6 +424,7 @@ class PrivacyService:
             responsable_traitement=RESPONSABLE_TRAITEMENT,
             premier_eclairage=premier_eclairage,
             disclaimer=DISCLAIMER,
+            donnees_coach_insights=_coach_insights,
             sources=SOURCES_EXPORT,
         )
 
@@ -405,6 +436,7 @@ class PrivacyService:
         nb_reports: int = 0,
         nb_documents: int = 0,
         nb_analytics: int = 0,
+        nb_coach_insights: int = 0,
         raison: Optional[str] = None,
     ) -> DeletionResult:
         """Supprime les donnees personnelles d'un utilisateur.
@@ -482,7 +514,14 @@ class PrivacyService:
             statut=statut_donnees,
         ))
 
-        total_supprime = nb_sessions + nb_reports + nb_documents + nb_analytics + 1
+        # Coach insights (memoire conversationnelle)
+        categories_traitees.append(DeletionCategoryInfo(
+            categorie="coach_insights",
+            nombre_supprime=nb_coach_insights,
+            statut=statut_donnees,
+        ))
+
+        total_supprime = nb_sessions + nb_reports + nb_documents + nb_analytics + nb_coach_insights + 1
 
         # Build alertes
         alertes: List[str] = []

--- a/services/backend/app/services/regulatory/registry.py
+++ b/services/backend/app/services/regulatory/registry.py
@@ -1385,3 +1385,41 @@ class RegulatoryRegistry:
     def count(self) -> int:
         """Return total number of parameters (including historical variants)."""
         return sum(len(v) for v in self._params.values())
+
+    def version_hash(self, on_date: Optional[date] = None) -> str:
+        """SHA-256 hex digest of the active parameter set at ``on_date``.
+
+        Hotfix B 2026-05-17 — stamps every persisted projection with a
+        deterministic fingerprint of the regulatory snapshot that produced
+        it. Required by LSFin advice-documentation obligations so a future
+        audit can reconstruct the inputs to a given projection.
+
+        The hash is stable across runs given identical _PARAMETERS and
+        identical ``on_date``. Adding a new parameter with a future
+        ``effective_from`` does NOT change hashes for past dates (the new
+        param is not ``is_active(past_date)``).
+
+        Args:
+            on_date: Date at which to evaluate the active parameter set;
+                None means today.
+
+        Returns:
+            64-character SHA-256 hex digest.
+        """
+        import hashlib
+        import json
+
+        check_date = on_date or date.today()
+        active: list[tuple[str, str, str, str]] = []
+        for params in self._params.values():
+            for p in params:
+                if p.is_active(check_date):
+                    active.append((
+                        p.key,
+                        p.jurisdiction,
+                        p.effective_from.isoformat() if p.effective_from else "",
+                        repr(p.value),  # handles floats, ints, and list values (avs.echelle44)
+                    ))
+        active.sort()
+        canonical = json.dumps(active, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/services/backend/app/services/snapshots/snapshot_service.py
+++ b/services/backend/app/services/snapshots/snapshot_service.py
@@ -102,13 +102,25 @@ def create_snapshot(
     now = datetime.now(timezone.utc)
 
     if db is not None:
+        import hashlib
+        import json
+
         from app.models.snapshot import SnapshotModel
+        from app.models.projection_audit_record import ProjectionAuditRecord
+        from app.services.regulatory.registry import RegulatoryRegistry
+
+        # Hotfix B 2026-05-17 — stamp the snapshot with the regulatory
+        # version hash that was active at compute time. Enables LSFin
+        # reconstruction of the inputs that produced this projection.
+        constants_hash = RegulatoryRegistry.instance().version_hash(on_date=now.date())
+
         row = SnapshotModel(
             id=snapshot_id,
             user_id=user_id,
             created_at=now,
             trigger=trigger,
             model_version="1.0",
+            constants_version_hash=constants_hash,
             age=profile_data.get("age", 0),
             gross_income=profile_data.get("gross_income", 0.0),
             canton=profile_data.get("canton", "VD"),
@@ -126,6 +138,47 @@ def create_snapshot(
             fri_s=profile_data.get("fri_s", 0.0),
         )
         db.add(row)
+
+        # Hotfix B 2026-05-17 — append-only LSFin advice audit trail.
+        # Hashes are computed before the commit so the audit row and the
+        # snapshot land in the same transaction.
+        inputs_canonical = json.dumps(
+            {k: v for k, v in profile_data.items() if not k.startswith("_")},
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        inputs_hash = hashlib.sha256(inputs_canonical.encode("utf-8")).hexdigest()
+        output_canonical = json.dumps(
+            {
+                "replacement_ratio": row.replacement_ratio,
+                "months_liquidity": row.months_liquidity,
+                "tax_saving_potential": row.tax_saving_potential,
+                "confidence_score": row.confidence_score,
+                "fri_total": row.fri_total,
+                "fri_l": row.fri_l,
+                "fri_f": row.fri_f,
+                "fri_r": row.fri_r,
+                "fri_s": row.fri_s,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        output_hash = hashlib.sha256(output_canonical.encode("utf-8")).hexdigest()
+        user_id_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+
+        audit_row = ProjectionAuditRecord(
+            user_id_hash=user_id_hash,
+            computed_at=now,
+            projection_type="snapshot",
+            projection_id=snapshot_id,
+            constants_version_hash=constants_hash,
+            scenario_inputs_hash=inputs_hash,
+            output_hash=output_hash,
+            lsfin_disclaimer_shown=False,  # endpoint owns this signal; conservative default
+        )
+        db.add(audit_row)
+
         db.commit()
         db.refresh(row)
         return _snapshot_to_dataclass(row)

--- a/services/backend/tests/test_audit_user_id_hash.py
+++ b/services/backend/tests/test_audit_user_id_hash.py
@@ -1,0 +1,80 @@
+"""Tests for audit_service.hash_user_id + log_audit_event hash wiring
+(Hotfix C 2026-05-17).
+
+Verifies the PII-clean audit contract:
+    - hash_user_id returns 64-char sha256 hex (or None on None input)
+    - hash_user_id is deterministic
+    - log_audit_event populates both user_id (legacy) and user_id_hash
+    - The hash matches `hash_user_id(user_id)` exactly (no drift)
+"""
+
+import hashlib
+import re
+from typing import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.core.database import Base
+from app.models.audit_event import AuditEventModel
+from app.services.audit_service import hash_user_id, log_audit_event
+
+
+@pytest.fixture
+def db() -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_hash_user_id_returns_64char_hex() -> None:
+    h = hash_user_id("user-abc")
+    assert h is not None
+    assert re.fullmatch(r"[0-9a-f]{64}", h)
+
+
+def test_hash_user_id_is_deterministic() -> None:
+    assert hash_user_id("alice") == hash_user_id("alice")
+
+
+def test_hash_user_id_returns_none_for_none() -> None:
+    assert hash_user_id(None) is None
+
+
+def test_hash_user_id_matches_stdlib_sha256() -> None:
+    user_id = "user-12345"
+    expected = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+    assert hash_user_id(user_id) == expected
+
+
+def test_log_audit_event_writes_user_id_hash(db: Session) -> None:
+    log_audit_event(
+        db,
+        event_type="login",
+        user_id="alice-id",
+    )
+    db.commit()
+    row = db.query(AuditEventModel).first()
+    assert row is not None
+    assert row.user_id == "alice-id"  # legacy plaintext kept one cycle
+    assert row.user_id_hash == hash_user_id("alice-id")
+
+
+def test_log_audit_event_handles_none_user_id(db: Session) -> None:
+    log_audit_event(
+        db,
+        event_type="system_boot",
+        user_id=None,
+    )
+    db.commit()
+    row = db.query(AuditEventModel).first()
+    assert row is not None
+    assert row.user_id is None
+    assert row.user_id_hash is None

--- a/services/backend/tests/test_privacy.py
+++ b/services/backend/tests/test_privacy.py
@@ -111,7 +111,7 @@ class TestDataExport:
         sample_sessions_data, sample_reports_data,
         sample_documents_data, sample_analytics_data,
     ):
-        """Full export should include 5 categories."""
+        """Full export should include 6 categories (incl. coach_insights since Hotfix A 2026-05-17)."""
         result = privacy_service.export_user_data(
             profile_id="u1",
             profile_data=sample_profile_data,
@@ -120,13 +120,14 @@ class TestDataExport:
             documents_data=sample_documents_data,
             analytics_data=sample_analytics_data,
         )
-        assert len(result.categories) == 5
+        assert len(result.categories) == 6
         category_names = [c.categorie for c in result.categories]
         assert "core_profile" in category_names
         assert "sessions" in category_names
         assert "rapports" in category_names
         assert "documents" in category_names
         assert "analytics" in category_names
+        assert "coach_insights" in category_names
 
     def test_export_category_counts(
         self, privacy_service, sample_profile_data,
@@ -237,13 +238,13 @@ class TestDataDeletion:
         diff = (effective_date - request_date).total_seconds()
         assert diff == 0
 
-    def test_deletion_returns_all_5_categories(self, privacy_service):
-        """Deletion should process all 5 data categories."""
+    def test_deletion_returns_all_6_categories(self, privacy_service):
+        """Deletion should process all 6 data categories (coach_insights added Hotfix A 2026-05-17)."""
         result = privacy_service.delete_user_data(
             profile_id="u1", mode="immediate",
             nb_sessions=5, nb_reports=2, nb_documents=3, nb_analytics=10,
         )
-        assert len(result.categories_traitees) == 5
+        assert len(result.categories_traitees) == 6
 
     def test_deletion_core_profile_conserve_obligation_legale(self, privacy_service):
         """Core profile should be marked as conserved for legal obligation."""
@@ -312,17 +313,18 @@ class TestConsentStatus:
             if c.categorie != "core_profile":
                 assert c.est_actif is False, f"{c.categorie} should not be active by default"
 
-    def test_consent_returns_6_categories(self, privacy_service):
-        """Should return exactly 6 consent categories."""
+    def test_consent_returns_7_categories(self, privacy_service):
+        """Should return exactly 7 consent categories (coach_insights added Hotfix A 2026-05-17)."""
         result = privacy_service.get_consent_status(profile_id="u1")
-        assert len(result.consentements) == 6
+        assert len(result.consentements) == 7
 
     def test_consent_categories_complete(self, privacy_service):
         """All expected categories should be present."""
         result = privacy_service.get_consent_status(profile_id="u1")
         categories = {c.categorie for c in result.consentements}
         expected = {"core_profile", "analytics", "coaching_notifications",
-                    "open_banking", "document_upload", "rag_queries"}
+                    "open_banking", "document_upload", "rag_queries",
+                    "coach_insights"}
         assert categories == expected
 
     def test_consent_core_profile_is_obligatory(self, privacy_service):
@@ -356,6 +358,7 @@ class TestConsentStatus:
             "open_banking": False,
             "document_upload": True,
             "rag_queries": False,
+            "coach_insights": True,
         }
         result = privacy_service.get_consent_status(
             profile_id="u1",
@@ -375,13 +378,14 @@ class TestConsentStatus:
             "open_banking": False,
             "document_upload": True,
             "rag_queries": False,
+            "coach_insights": False,
         }
         result = privacy_service.get_consent_status(
             profile_id="u1",
             current_consents=custom,
         )
         assert result.nb_consentements_actifs == 3  # core, analytics, documents
-        assert result.nb_consentements_optionnels == 5  # all except core
+        assert result.nb_consentements_optionnels == 6  # all except core (was 5; Hotfix A added coach_insights)
 
 
 # ===========================================================================
@@ -598,25 +602,26 @@ class TestPrivacyEndpoints:
         assert "profileId" in data
         assert data["profileId"] == "test-user-id"
         assert "consentements" in data
-        assert len(data["consentements"]) == 6
+        assert len(data["consentements"]) == 7
         assert "nbConsentementsActifs" in data
         assert "nbConsentementsOptionnels" in data
         assert "disclaimer" in data
         assert "sources" in data
 
-    def test_consent_status_has_6_categories(self, client):
-        """Consent status should list exactly 6 categories."""
+    def test_consent_status_has_7_categories(self, client):
+        """Consent status should list exactly 7 categories (coach_insights added Hotfix A 2026-05-17)."""
         response = client.get("/api/v1/privacy/consent-status")
         assert response.status_code == 200
         data = response.json()
         categories = [c["categorie"] for c in data["consentements"]]
-        assert len(categories) == 6
+        assert len(categories) == 7
         assert "core_profile" in categories
         assert "analytics" in categories
         assert "coaching_notifications" in categories
         assert "open_banking" in categories
         assert "document_upload" in categories
         assert "rag_queries" in categories
+        assert "coach_insights" in categories
 
     def test_consent_update_activate(self, client):
         """POST /privacy/consent-update should activate a consent.

--- a/services/backend/tests/test_regulatory_version_hash.py
+++ b/services/backend/tests/test_regulatory_version_hash.py
@@ -1,0 +1,58 @@
+"""Tests for RegulatoryRegistry.version_hash (Hotfix B 2026-05-17).
+
+The hash is the load-bearing primitive of the LSFin advice-audit trail:
+every persisted projection stamps it on, and reconstructability depends
+on it being deterministic + sensitive to the parameter set in scope at
+the requested date.
+
+These are pure (no DB) tests of the hash contract:
+    - 64-char SHA-256 hex output shape.
+    - Deterministic across calls for the same date.
+    - Different across dates when the active parameter set differs
+      (uses the AVS 13th-pension flip on 2026-01-01 as the anchor:
+      keys `avs.13th_pension_active` / `_start_year` / `_factor` are
+      `effective_from=date(2026, 1, 1)`, so 2025 ⇒ inactive,
+      2026 ⇒ active).
+"""
+
+import re
+from datetime import date
+
+import pytest
+
+from app.services.regulatory.registry import RegulatoryRegistry
+
+
+@pytest.fixture
+def registry() -> RegulatoryRegistry:
+    return RegulatoryRegistry.instance()
+
+
+def test_version_hash_returns_64char_hex(registry: RegulatoryRegistry) -> None:
+    h = registry.version_hash(on_date=date(2026, 5, 17))
+    assert re.fullmatch(r"[0-9a-f]{64}", h), f"expected 64-char sha256 hex, got {h!r}"
+
+
+def test_version_hash_is_deterministic(registry: RegulatoryRegistry) -> None:
+    target_date = date(2026, 3, 15)
+    h1 = registry.version_hash(on_date=target_date)
+    h2 = registry.version_hash(on_date=target_date)
+    assert h1 == h2, "version_hash must be stable across calls for the same date"
+
+
+def test_version_hash_changes_when_active_set_changes(
+    registry: RegulatoryRegistry,
+) -> None:
+    # The AVS 13th-pension parameters become active 2026-01-01. So the
+    # active set on 2025-12-31 must differ from the active set on
+    # 2026-01-01, and the hashes must differ.
+    h_2025 = registry.version_hash(on_date=date(2025, 12, 31))
+    h_2026 = registry.version_hash(on_date=date(2026, 1, 1))
+    assert h_2025 != h_2026, (
+        "version_hash should differ across the 2026 AVS 13th-pension activation"
+    )
+
+
+def test_version_hash_today_is_64char_hex(registry: RegulatoryRegistry) -> None:
+    h = registry.version_hash()  # on_date=None ⇒ today
+    assert re.fullmatch(r"[0-9a-f]{64}", h)

--- a/services/backend/tests/test_scenarios_cache_index.py
+++ b/services/backend/tests/test_scenarios_cache_index.py
@@ -172,20 +172,26 @@ def test_upgrade_head_creates_index_on_sqlite(tmp_path, monkeypatch):
     )
 
 
-def test_downgrade_one_removes_index(tmp_path, monkeypatch):
-    """`alembic downgrade -1` from p110 head removes the index, leaves p97 intact."""
+def test_downgrade_below_p110_removes_index(tmp_path, monkeypatch):
+    """Downgrading past p110 removes the index, leaves p97 + p95 intact.
+
+    Targets the specific revision boundary (`p97_snapshots_fk_defaults`,
+    the parent of p110) instead of relative `-1` so the test is robust
+    to future migrations stacked above p110 (Hotfix B p111, Hotfix C
+    p112, etc.).
+    """
     cfg = _make_config(tmp_path, monkeypatch)
     command.upgrade(cfg, "head")
-    command.downgrade(cfg, "-1")
+    command.downgrade(cfg, "p97_snapshots_fk_defaults")
     engine = sa.create_engine(f"sqlite:///{tmp_path}/test.db")
     insp = sa.inspect(engine)
     index_names = {idx["name"] for idx in insp.get_indexes("scenarios")}
     assert INDEX_NAME not in index_names, (
-        f"Expected index {INDEX_NAME} dropped after `alembic downgrade -1` ; "
+        f"Expected index {INDEX_NAME} dropped after downgrade past p110 ; "
         f"still found: {index_names}"
     )
     # Sanity : scenarios table itself + Phase 95 columns still present
-    # (we only undid p110, not p95).
+    # (we only undid p110+later, not p95).
     cols = {c["name"] for c in insp.get_columns("scenarios")}
     assert "inputs_hash" in cols, "Downgraded too far — p95 columns gone"
     assert "superseded_by" in cols, "Downgraded too far — p95 columns gone"

--- a/services/backend/tests/test_snapshots_migration_exists.py
+++ b/services/backend/tests/test_snapshots_migration_exists.py
@@ -49,12 +49,15 @@ from alembic.script import ScriptDirectory
 
 
 # Expected columns on the snapshots table (mirrors app/models/snapshot.py).
+# 22 columns since Hotfix B 2026-05-17 added constants_version_hash for the
+# LSFin advice audit trail (see migration p111_projection_audit).
 EXPECTED_COLUMNS = {
     "id",
     "user_id",
     "created_at",
     "trigger",
     "model_version",
+    "constants_version_hash",
     "age",
     "birth_date",
     "gross_income",

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -5347,7 +5347,8 @@
           "coaching_notifications",
           "open_banking",
           "document_upload",
-          "rag_queries"
+          "rag_queries",
+          "coach_insights"
         ],
         "title": "ConsentCategory",
         "type": "string"
@@ -6456,6 +6457,12 @@
             "title": "Includeanalytics",
             "type": "boolean"
           },
+          "includeCoachInsights": {
+            "default": true,
+            "description": "Inclure les insights enregistres par le coach IA",
+            "title": "Includecoachinsights",
+            "type": "boolean"
+          },
           "includeDocuments": {
             "default": true,
             "description": "Inclure les documents uploades",
@@ -6518,6 +6525,15 @@
               "type": "object"
             },
             "title": "Donneesanalytics",
+            "type": "array"
+          },
+          "donneesCoachInsights": {
+            "description": "Insights enregistres par le coach IA (memoire conversationnelle)",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Donneescoachinsights",
             "type": "array"
           },
           "donneesDocuments": {


### PR DESCRIPTION
## Summary

Three atomic compliance hotfixes bundled on a single branch, derived from the [data-architecture panel verdict](.planning/decisions/2026-05-17-data-architecture-event-log-vs-bitemporal.md) shipped today as Draft PR #646. Each hotfix is its own commit for review focus.

| Hotfix | Commit | Scope |
|---|---|---|
| **A — coach_insights** | `843ea662` | `coach_insights` registered as 7th `CONSENT_CATEGORIES` entry + DSAR export + deletion manifest + endpoint wiring + 6 brittle test counts bumped. Closes the gap where `CoachInsightRecord` rows (written by the `save_insight` LLM tool since Phase 21) had no consent declaration and no right-of-access path. |
| **B — projection audit** | `6a40373a` | `SnapshotModel.constants_version_hash` column + new append-only `projection_audit_records` table (`REVOKE UPDATE, DELETE` on Postgres) + `RegulatoryRegistry.version_hash(on_date)` deterministic hash + writer wiring in `snapshot_service.py`. Closes the LSFin advice-documentation gap (no record of which regulatory snapshot produced a given projection). |
| **C — audit_events PII hash** | `c698702a` | `AuditEventModel.user_id_hash` column + `audit_service.hash_user_id()` public helper + `consent_manager._log_audit` wire + Postgres backfill (pgcrypto-conditional). Mirrors the `DocumentAuditLog` pattern so the audit log survives nLPD erasure without re-identification risk. |
| chore — openapi regen | `4e117471` | Auto-regen of `tools/openapi/mint.openapi.canonical.json` to reflect Hotfix A schema additions (`includeCoachInsights`, `donneesCoachInsights`, 7th `ConsentCategory` value). |
| chore — test fix | `e50e6838` | `test_downgrade_one_removes_index` renamed + targets revision `p97_snapshots_fk_defaults` explicitly instead of relative `-1` (broken by Hotfix B/C stacking p111/p112 above p110). Future-proof. |

## Status & gating

- **Draft.** Merge gated on `mint-calc-engine-v1` Stage 3 (Maestro UAT) close. Avoids `SnapshotModel` race during the UAT loop. Convert to Ready For Review when that perimeter closes with G1+G2 evidence.
- Companion ADR: #646 (`docs/adr-data-architecture-2026-05-17` branch, also gated). Both PRs land together once unblocked.

## Scope revisions vs. original security-auditor findings

The audit-verify step found that 1/5 sec-auditor findings was partially stale against current code. Revised scope captured in commit messages:
- **Dropped:** « shred at delete_user_data invocation ». `privacy.py:280` already shreds the DEK on `immediate` deletion. The `grace_period` path intentionally keeps the DEK 30 days so the user can cancel — shredding earlier would break the cancellation feature (by design, not a bug).
- **Refined:** the export gap was partially false-flagged. `coach_memory` (pgvector `document_embeddings` doc_type='memory') is already exported by `privacy.py:165-191`. Only the relational `CoachInsightRecord` table needed surfacing — which Hotfix A does.

## Wider systemic gaps surfaced (NOT in scope of this bundle)

Both observed during audit-verify, both pre-existing, both deserve their own follow-up PR/issue:

1. **`privacy.py` delete endpoint is a manifest, not a real deletion.** The endpoint hardcodes `nb_sessions=0, nb_reports=0, nb_documents=0, nb_analytics=0` and returns a deletion summary. Actual row removal happens elsewhere (likely FK CASCADE on user deletion). This is a wider DSAR completeness gap unrelated to coach_insights specifically.
2. **T+30d grace-period DEK shred job missing.** `privacy.py` comments reference a scheduled job that calls `key_vault.crypto_shred_user(db, user_id)` at T+30d for `grace_period` deletions; that job does not exist. `immediate` deletions are fine. Grace-period DEKs accumulate indefinitely. Needs Celery/cron — out of scope of a hotfix bundle.

## Verification

- Hotfix A: `pytest tests/test_privacy.py` — 51/51 ✓ (6 brittle category-count assertions bumped 5→6 and 6→7)
- Hotfix B: `pytest tests/test_regulatory_version_hash.py tests/test_snapshots_migration_exists.py` — 10/10 ✓
- Hotfix C: `pytest tests/test_audit_user_id_hash.py` — 6/6 ✓
- Wider regression: `pytest tests/ -q -k "audit or auth or consent or open_banking"` — 308/308 ✓
- **Full backend suite**: `pytest tests/ -q` — **7289/7289 pass** (initial run had 1 failure on the test_scenarios_cache_index `-1` downgrade — fixed in commit `e50e6838`). Lefthook clean throughout.

## Re-litigation triggers

- `mint-calc-engine-v1` Stage 3 surfaces a finding that materially changes the data architecture — re-open panel before merging.
- A schema-change in `SnapshotModel` lands between this PR and merge — rebase + re-run `tests/test_snapshots_migration_exists.py`.
- pgcrypto extension state changes on production Postgres — re-run Hotfix C backfill DO block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)