### PR TITLE
fix(coach): block stale 3a/regulatory values via quad-defense (obs #157)

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -74,6 +74,17 @@ from app.services.coach.citation_parser import (
 # Wired UPSTREAM of `_citation_gate` (Q5 = before) so paraphrase verbs are
 # caught BEFORE citation substitution to avoid double-template fallback chains.
 from app.services.coach.runtime_verb_gate import gate as _runtime_verb_gate
+
+# Post-Stage-3-UAT (2026-05-17, obs #157) — runtime freshness gate.
+# Wired AFTER `_runtime_verb_gate` and BEFORE `_citation_gate` : verb
+# gate catches LSFin banned verbs ; freshness gate catches stale
+# regulatory values (e.g. 7'056 hallucinated for 2024 plafond 3a) ;
+# citation gate then validates the placeholder format on the remaining
+# clean output. Defense layer (c) of the obs #157 quad-defense.
+from app.services.coach.runtime_freshness_gate import (
+    gate as _runtime_freshness_gate,
+)
+
 from app.services.coach.coach_tools import (
     INTERNAL_TOOL_NAMES,
     get_llm_tools,
@@ -4737,6 +4748,38 @@ async def coach_chat(
             except Exception:  # pragma: no cover — telemetry is fail-open
                 pass
             loop_result["answer"] = _vg_text
+            return loop_result
+
+        # Post-Stage-3-UAT (obs #157) — runtime freshness gate. Catches
+        # stale regulatory integer values (e.g. 7'056 CHF for 2024 3a
+        # plafond) emitted by an LLM that hallucinated from training-
+        # data instead of invoking `get_regulatory_constant`. Fail-
+        # closed : Sentry breadcrumb + templated FR fallback + short-
+        # circuit (no citation-parser call when the value is stale —
+        # the citation chip would falsely assert authority on the
+        # stale figure).
+        _fg_passed, _fg_text = _runtime_freshness_gate(
+            loop_result["answer"], user_message=body.message
+        )
+        if not _fg_passed:
+            try:
+                import sentry_sdk  # type: ignore
+                sentry_sdk.add_breadcrumb(  # type: ignore[union-attr]
+                    category="coach.freshness_gate.fired",
+                    message="runtime regulatory-value freshness gate fired",
+                    level="info",
+                    data={
+                        "profile_id_hashed": (
+                            __import__("hashlib")
+                            .sha256(str(_user.id).encode("utf-8") if _user else b"")
+                            .hexdigest()[:16]
+                        ),
+                        "fallback_emitted": True,
+                    },
+                )
+            except Exception:  # pragma: no cover — telemetry is fail-open
+                pass
+            loop_result["answer"] = _fg_text
             return loop_result
 
         gated = _citation_gate(

--- a/services/backend/app/services/coach/citation_grammar.py
+++ b/services/backend/app/services/coach/citation_grammar.py
@@ -102,6 +102,27 @@ _TOOL_USE_MANDATE: str = (
     "Le `{{cite:tool_<name>}}` n'est PAS une formule magique — c'est une "
     "référence à un calcul serveur qui doit avoir été déclenché via "
     "`tool_use` plus tôt dans ce même tour.\n"
+    "\n"
+    "## DOCTRINE — VALEURS RÉGLEMENTAIRES DATÉES "
+    "(plafond 3a, coordination LPP, rente AVS, barèmes IFD/IS, taux LAMal)\n"
+    "\n"
+    "Pour TOUTE valeur réglementaire datée (CHF, %, durée) que tu cites "
+    "avec une clé non-`tool_*` (par exemple `r3a_plafond_salarie_2026`, "
+    "`lpp_coordination_2026`, `avs_rente_max_2026`, `ifd_bracket_*`), il "
+    "est OBLIGATOIRE d'invoquer d'abord l'outil `get_regulatory_constant` "
+    "via `tool_use(get_regulatory_constant, key=\"<registry-key>\")`, ET "
+    "d'écrire EXACTEMENT la valeur retournée par `tool_result` — JAMAIS "
+    "de mémoire, d'estimation, ni de valeur tirée d'un exemple "
+    "(les exemples REJETÉS plus bas ne sont pas des sources de "
+    "valeurs).\n"
+    "\n"
+    "Le registre officiel (OFAS, OPP3, LAVS, LIFD) est la SEULE source "
+    "fiable. Toute valeur reproduite « de tête » est par définition "
+    "obsolète — les plafonds OFAS sont révisés chaque année. Ne donne "
+    "JAMAIS un chiffre régulatoire sans `tool_use(get_regulatory_constant)` "
+    "préalable dans ce même tour. À défaut, écris « je n'ai pas cette "
+    "donnée pour l'instant » plutôt que d'émettre une valeur non "
+    "sourcée.\n"
 )
 
 _TOOL_USE_WRONG_RIGHT_EXAMPLE: str = (
@@ -155,6 +176,15 @@ _TOOL_USE_MANDATE_REPEAT: str = (
     "récupère automatiquement le profil et les valeurs côté serveur. "
     "Toute formulation du type « j'ai besoin de récupérer tes "
     "données » indique un manquement à cette doctrine.\n"
+    "\n"
+    "## RAPPEL — VALEURS RÉGLEMENTAIRES (seconde occurrence)\n"
+    "\n"
+    "Pour TOUTE valeur réglementaire datée citée avec une clé "
+    "non-`tool_*` (`r3a_*`, `lpp_*`, `avs_*`, `ifd_*`, etc.) : "
+    "INVOQUE `tool_use(get_regulatory_constant, key=\"<registry-key>\")` "
+    "AVANT d'écrire le chiffre, puis recopie EXACTEMENT la valeur du "
+    "`tool_result`. Une valeur tirée de mémoire est par construction "
+    "obsolète et déclenche le fallback templaté.\n"
 )
 
 

--- a/services/backend/app/services/coach/citation_grammar.py
+++ b/services/backend/app/services/coach/citation_grammar.py
@@ -560,13 +560,20 @@ def build_intent_scoped_citation_grammar(intents: Iterable[str]) -> str:
         "« Je n'ai pas cette donnée pour l'instant. Pour avancer "
         "ensemble, dis-moi un peu plus sur ta situation. »\n"
         "\n"
-        "**REJETÉ — chiffre nu, sans `{{cite:<clé>}}`** :\n"
-        "« Le plafond 3a est de 7'056 CHF cette année. » → la garde "
-        "détecte le chiffre non cité, demande une reformulation, et "
-        "si la deuxième tentative reste non citée, ta réponse bascule "
-        "sur le fallback templaté. Évite ce cas en plaçant la clé "
-        "directement après le chiffre, ou en écrivant « je n'ai pas "
-        "cette donnée pour l'instant » à la place du chiffre.\n"
+        # obs #157 (2026-05-17) — replaced earlier REJETÉ example that
+        # used the literal value « 7'056 CHF cette année » (the 2024
+        # Pilier 3a max). LLMs leak negative few-shot examples as
+        # positive when surface form matches the user query (« cette
+        # année ») — staging coach was emitting 7'056 for 2026 prompts.
+        # Mirror the full fragment's safer fabricated-estimate framing.
+        "**REJETÉ — chiffre fabriqué que tu ne peux pas sourcer** :\n"
+        "« Tu pourrais économiser 1'200 CHF de plus par mois. » → "
+        "le chiffre 1'200 n'est PAS dans le message de l'utilisateur "
+        "et n'a pas de clé `{{cite:<clé>}}` adaptée dans le "
+        "vocabulaire fermé. La garde le rejette. Pour formuler une "
+        "estimation, soit cite la clé qui couvre le calcul, soit "
+        "reformule au conditionnel sans avancer de chiffre précis "
+        "(« une marge mensuelle resterait à dégager »).\n"
     )
 
     rule_section = (

--- a/services/backend/app/services/coach/runtime_freshness_gate.py
+++ b/services/backend/app/services/coach/runtime_freshness_gate.py
@@ -1,0 +1,236 @@
+"""Post-Stage-3-UAT (2026-05-17, obs #157) — runtime regulatory-value freshness gate.
+
+Triple-defense layer (c) for stale-numeric-value LSFin risk. Sister to
+`runtime_verb_gate` (D-CE-16(c) for banned verbs) ; this gate scans the
+narrator's output for any literal CHF / EUR / USD / % / duration value that
+matches a STALE entry in `app.services.regulatory.registry._PARAMETERS`
+(i.e. a value tagged under `<category>.historical_limits.<year>` where the
+SAME value is NOT in the canonical/current key). Fail-closed : if a stale
+value slips through, return the LSFin-safe templated fallback.
+
+Defense layers active in parallel :
+    (a) prompt-doctrine — `citation_grammar._TOOL_USE_MANDATE` mandates
+        `tool_use(get_regulatory_constant)` BEFORE emitting any regulatory
+        non-`tool_*` citation key (Fix B).
+    (b) toxic-example removal — `citation_grammar.py:564` no longer
+        contains a literal stale value in a REJETÉ example (Fix A).
+    (c) THIS MODULE — runtime regex on NFKC-normalised + zero-width-
+        stripped narrator output (Fix C).
+    (d) lefthook lint (planned, Fix D) — scan all
+        `services/backend/app/services/coach/**.py` for any literal that
+        also appears in `historical_limits.<year-not-current>` registry
+        entries.
+
+Why all layers : the citation gate (Phase 94) enforces FORMAT only
+(presence of `{{cite:<key>}}`), not CONTENT freshness. The coach LLM can
+emit `« 7'056 CHF {{cite:r3a_plafond_salarie_2026}} »` — the citation
+gate accepts because the key is valid, but the VALUE is the stale 2024
+figure hallucinated from training data. Without this freshness gate, any
+year-tagged regulatory value the LLM hallucinates from a prior tax year
+ships to the user with a citation chip that falsely asserts the value is
+the official 2026 one.
+
+User-echo exemption :
+    The user may legitimately echo a historical figure (« j'ai versé
+    7'056 l'an dernier ») and the narrator may echo it back ; per the
+    same exemption pattern in `citation_parser.gate` step 5b, we skip
+    matches that are ALSO present (verbatim, normalised) in
+    `user_message`. Caller passes `user_message` explicitly.
+
+Determinism contract :
+    The fallback template is a verbatim string literal — INTENTIONALLY
+    SHORTER than Phase 94's `FALLBACK_TEMPLATED_TEXT` so QA can
+    distinguish a freshness-gate fallback from a citation-gate or
+    verb-gate fallback. Sentry breadcrumb
+    `coach.freshness_gate.fired` is emitted at the call site
+    (coach_chat.py) when this gate returns (False, _FALLBACK_FR).
+
+Threat coverage :
+    - T-3a-stale (LLM emits 7'056 / 6'883 / 6'826 / 6'768 etc. with a
+      2026 regulatory citation key) — value is in STALE_VALUES, gate
+      catches.
+    - T-lpp-stale, T-avs-stale, T-ifd-stale — same mechanism extends to
+      every category with `historical_limits.*` keys in the registry.
+    - T-future-anchor — a future toxic few-shot example in another
+      file (e.g. a bundle fragment) would still be caught at runtime
+      even if Fix A / B / D don't catch it at prompt-build / lint time.
+    - T-paraphrase — values are exact integer-match ; no paraphrase
+      attack surface since values are numbers, not lexemes.
+    - T-NFKC-bypass — NFKC normalisation first.
+    - T-thousand-separator-bypass — Swiss apostrophe `7'056`, no-sep
+      `7056`, space-sep `7 056`, comma-sep `7,056` all normalised to
+      the same int before matching.
+    - T-info-disclosure — gate returns the template, never the
+      offending narrator text.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from functools import lru_cache
+
+from app.services.regulatory.registry import _PARAMETERS
+
+
+# Verbatim FR template — INTENTIONALLY SHORTER + tone consistent with
+# `runtime_verb_gate._FALLBACK_FR` and Phase 94 `FALLBACK_TEMPLATED_TEXT`.
+_FALLBACK_FR: str = "Je n'ai pas cette donnée à jour pour l'instant."
+
+# Zero-width / invisible chars from runtime_verb_gate (kept in sync).
+_ZERO_WIDTH_CHARS: frozenset[str] = frozenset({
+    "​",  # ZERO WIDTH SPACE
+    "‌",  # ZERO WIDTH NON-JOINER
+    "‍",  # ZERO WIDTH JOINER
+    "﻿",  # ZERO WIDTH NO-BREAK SPACE (BOM)
+    "⁠",  # WORD JOINER
+})
+
+
+def _strip_zero_width(s: str) -> str:
+    """Remove all zero-width / invisible chars from `s`."""
+    if not s:
+        return s
+    if not any(c in _ZERO_WIDTH_CHARS for c in s):
+        return s
+    return "".join(c for c in s if c not in _ZERO_WIDTH_CHARS)
+
+
+def _normalise_number_token(raw: str) -> int | None:
+    """Strip Swiss / French / anglo thousand separators ; parse to int.
+
+    Accepts : `7'056`, `7056`, `7 056`, `7 056`, `7,056`,
+    `7.056` (when followed by a non-decimal context — rare ; we
+    conservatively only strip `,` if 3-digit grouping is consistent).
+    Returns None if the token is not parseable as a thousand-grouped
+    integer.
+
+    Pure function ; no I/O ; safe for high-call-frequency use.
+    """
+    s = re.sub(r"[\s']", "", raw)
+    # Anglo-comma thousand separator : « 7,056 » → 7056. Skip if any
+    # comma is followed by 1-2 digits (= decimal, not grouping).
+    if "," in s:
+        parts = s.split(",")
+        if all(len(p) == 3 for p in parts[1:]) and parts[0].isdigit():
+            s = "".join(parts)
+        else:
+            return None
+    if not s.isdigit():
+        return None
+    try:
+        return int(s)
+    except (ValueError, TypeError):
+        return None
+
+
+@lru_cache(maxsize=1)
+def _build_stale_value_set() -> frozenset[int]:
+    """Compute the frozen set of stale-year regulatory integer values.
+
+    Algorithm :
+        1. CURRENT_INTS = {int(p.value) for p in _PARAMETERS where
+           p.key does NOT match `*.historical_limits.<year>` AND
+           p.value is numeric}.
+        2. HISTORICAL_INTS = {int(p.value) for p in _PARAMETERS where
+           p.key matches `*.historical_limits.<year>` AND p.value is
+           numeric}.
+        3. STALE_INTS = HISTORICAL_INTS - CURRENT_INTS.
+
+    A historical value that ALSO appears in a current canonical key
+    (e.g. 7'258 appears in both `pillar3a.max_with_lpp` AND
+    `pillar3a.historical_limits.2025` because OFAS didn't change it
+    for 2026) is NOT stale — it's still the right answer today.
+
+    Cached via lru_cache : built once at first call, reused for the
+    process lifetime. The registry is module-level immutable.
+    """
+    historical_pat = re.compile(r"\.historical_limits\.\d{4}$")
+    current_ints: set[int] = set()
+    historical_ints: set[int] = set()
+    for p in _PARAMETERS:
+        if not isinstance(p.value, (int, float)):
+            continue
+        # Ratios (e.g. 0.20 for 20%) — skip ; freshness gate only
+        # protects nominal monetary / count thresholds, not ratios.
+        if abs(p.value) < 100:
+            continue
+        ivalue = int(p.value)
+        if historical_pat.search(p.key):
+            historical_ints.add(ivalue)
+        else:
+            current_ints.add(ivalue)
+    return frozenset(historical_ints - current_ints)
+
+
+# Number-token regex : matches integer with optional Swiss apostrophe
+# `'`, French space ` `, NBSP ` `, or anglo comma `,` thousand
+# separators. Min length 4 digits (≥ 1000) to avoid false-positives on
+# small numbers (ages, percent, counts).
+_NUMBER_TOKEN_RE: re.Pattern[str] = re.compile(
+    r"\b\d{1,3}(?:['  ,]\d{3})+\b|\b\d{4,}\b",
+)
+
+
+def gate(text: str, user_message: str = "") -> tuple[bool, str]:
+    """Runtime freshness gate — fail-closed on stale regulatory values.
+
+    Args:
+        text: Narrator output (post-LLM, pre-Phase-94 citation gate).
+        user_message: The user's most recent message in this turn —
+            used to exempt legitimate user-echoes (« j'ai versé 7'056
+            l'an dernier ») from triggering the gate. Pass empty string
+            if not available.
+
+    Returns:
+        (passed, output) :
+            - (True, text) — text contains no stale regulatory value
+              (after NFKC + zero-width strip + thousand-separator
+              normalisation) ; original string returned unchanged.
+            - (False, _FALLBACK_FR) — at least one stale integer value
+              detected in `text` that is NOT also present in
+              `user_message`. The verbatim FR template is returned ;
+              the narrator's text is NEVER leaked to the user.
+
+    Empty-string / whitespace-only text is pass-through (True, text) —
+    same convention as `runtime_verb_gate.gate`. Phase 94 citation
+    gate owns the empty-input FALLBACK.
+    """
+    if not text or not text.strip():
+        return (True, text)
+
+    stale_set = _build_stale_value_set()
+    if not stale_set:
+        # Defensive : empty registry → no stale values → nothing to
+        # block. Shouldn't happen in production but keep the gate
+        # robust during tests with monkey-patched registry.
+        return (True, text)
+
+    normalised = unicodedata.normalize("NFKC", text)
+    cleaned = _strip_zero_width(normalised)
+
+    # User-echo exemption — pre-compute the set of stale ints present
+    # in the user message ; matches in narrator output that are also in
+    # the user message are not gate violations (legit echo).
+    user_stale: set[int] = set()
+    if user_message:
+        u_norm = _strip_zero_width(unicodedata.normalize("NFKC", user_message))
+        for m in _NUMBER_TOKEN_RE.finditer(u_norm):
+            n = _normalise_number_token(m.group(0))
+            if n is not None and n in stale_set:
+                user_stale.add(n)
+
+    for m in _NUMBER_TOKEN_RE.finditer(cleaned):
+        n = _normalise_number_token(m.group(0))
+        if n is not None and n in stale_set and n not in user_stale:
+            return (False, _FALLBACK_FR)
+
+    return (True, text)
+
+
+__all__ = [
+    "gate",
+    "_FALLBACK_FR",
+    "_ZERO_WIDTH_CHARS",
+    "_build_stale_value_set",
+    "_normalise_number_token",
+]

--- a/services/backend/app/services/coach/runtime_freshness_gate.py
+++ b/services/backend/app/services/coach/runtime_freshness_gate.py
@@ -1,3 +1,4 @@
+# noqa: stale-regulatory-anchors — module documents the values it catches in its docstring + tests (not LLM-injected). Per Fix D opt-out convention.
 """Post-Stage-3-UAT (2026-05-17, obs #157) — runtime regulatory-value freshness gate.
 
 Triple-defense layer (c) for stale-numeric-value LSFin risk. Sister to

--- a/services/backend/tests/test_runtime_freshness_gate.py
+++ b/services/backend/tests/test_runtime_freshness_gate.py
@@ -1,0 +1,209 @@
+"""Tests for runtime_freshness_gate (Fix C / obs #157).
+
+Covers : stale-value detection across thousand-separator formats, NFKC
+normalisation, zero-width injection, user-echo exemption, current-value
+pass-through, empty input pass-through, and the registry-derived
+stale_set computation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.coach.runtime_freshness_gate import (
+    _FALLBACK_FR,
+    _build_stale_value_set,
+    _normalise_number_token,
+    gate,
+)
+
+
+# ── stale_set derivation ──────────────────────────────────────────────
+
+
+def test_stale_set_contains_known_stale_3a_values():
+    """4 known 3a historical limits (2017-2023) must be in stale set."""
+    stale = _build_stale_value_set()
+    # These four are the 3a historical limits where the value is NOT
+    # also present in any current canonical key (verified by
+    # _build_stale_value_set algorithm at module load).
+    assert 7056 in stale, "2024 plafond 3a salarie-LPP must be stale"
+    assert 6883 in stale, "2023 plafond 3a must be stale"
+    assert 6826 in stale, "2018-2022 plafond 3a must be stale"
+    assert 6768 in stale, "2016-2017 plafond 3a must be stale"
+
+
+def test_stale_set_excludes_current_value():
+    """7'258 = current 2025+2026 plafond 3a + canonical key — NOT stale."""
+    stale = _build_stale_value_set()
+    assert 7258 not in stale, (
+        "7'258 is the current 3a max (canonical key + 2025/2026 historical), "
+        "must NOT be flagged stale"
+    )
+
+
+def test_stale_set_is_frozen():
+    """lru_cache returns a frozenset for immutability."""
+    stale = _build_stale_value_set()
+    assert isinstance(stale, frozenset)
+
+
+# ── number-token normalisation ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("7056", 7056),
+    ("7'056", 7056),
+    ("7 056", 7056),     # regular space
+    ("7 056", 7056),  # narrow no-break space
+    ("7 056", 7056),  # NBSP
+    ("1,234,567", 1234567),  # anglo comma 3-digit groups
+    ("36'288", 36288),
+    # Invalid : decimal-style comma rejected
+    ("7,5", None),
+    ("not a number", None),
+    ("", None),
+])
+def test_normalise_number_token(raw, expected):
+    """Thousand-separator variants normalise to the same int."""
+    assert _normalise_number_token(raw) == expected
+
+
+# ── gate behaviour ────────────────────────────────────────────────────
+
+
+def test_gate_blocks_7056_swiss_apostrophe():
+    """The exact LSFin defect from obs #157."""
+    result, output = gate("Le plafond 3a est de 7'056 CHF cette année.")
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_blocks_7056_no_separator():
+    """LLM may emit `7056` without thousand separator."""
+    result, output = gate("Le plafond 3a est de 7056 CHF.")
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_blocks_7056_french_space():
+    """LLM may emit `7 056` with regular space."""
+    result, output = gate("Le plafond 3a est de 7 056 CHF.")
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_blocks_7056_nbsp():
+    """LLM may emit `7 056` with NBSP (proper FR typography)."""
+    result, output = gate("Le plafond 3a est de 7 056 CHF.")
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_passes_7258_current_value():
+    """7'258 = current 2026 value, MUST NOT be blocked."""
+    text = "Le plafond 3a est de 7'258 CHF en 2026."
+    result, output = gate(text)
+    assert result is True
+    assert output == text
+
+
+def test_gate_passes_empty():
+    """Empty input passes through — Phase 94 owns the empty fallback."""
+    result, output = gate("")
+    assert result is True
+    assert output == ""
+
+
+def test_gate_passes_whitespace_only():
+    """Whitespace-only input passes through."""
+    result, output = gate("   \n\t  ")
+    assert result is True
+
+
+def test_gate_user_echo_exempted():
+    """If user echoes a stale value, narrator may echo it back."""
+    user_msg = "J'ai versé 7'056 CHF l'an dernier dans mon 3a."
+    narrator = "Tu as versé 7'056 CHF l'an dernier — c'était le plafond 2024."
+    result, _ = gate(narrator, user_message=user_msg)
+    assert result is True, (
+        "User-echo exemption must let through stale values present in user msg"
+    )
+
+
+def test_gate_user_echo_partial_does_not_exempt_other_stale_values():
+    """User echoes 7'056 ; narrator emits 7'056 AND 6'883 — 6'883 still blocks."""
+    user_msg = "J'ai versé 7'056 CHF en 2024."
+    narrator = "En 2023 c'était 6'883 CHF, en 2024 c'était 7'056 CHF."
+    result, output = gate(narrator, user_message=user_msg)
+    assert result is False, (
+        "6'883 not in user msg → still stale → still blocks"
+    )
+    assert output == _FALLBACK_FR
+
+
+def test_gate_zero_width_bypass_caught():
+    """Character-injection bypass `7'0​56` is neutralised by NFKC + ZWS strip."""
+    # U+200B = ZERO WIDTH SPACE inserted to evade naive regex
+    sneaky = "Le plafond 3a est de 7'0​56 CHF."
+    result, output = gate(sneaky)
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_NFKC_normalisation():
+    """Decomposed accent does not affect number matching."""
+    # e + combining acute accent = "é" via NFD; NFKC normalises
+    text = "Le plafond 3a cette année est de 7'056 CHF."
+    result, output = gate(text)
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_preserves_text_on_pass():
+    """When passing, the original text is returned unchanged."""
+    text = "Bonjour ! Voici une projection sans chiffre régulatoire."
+    result, output = gate(text)
+    assert result is True
+    assert output == text
+
+
+def test_gate_ignores_small_numbers():
+    """Ages, percent, durations < 100 are not regulatory thresholds."""
+    text = "Tu as 35 ans, ton taux marginal est 25%, durée 10 ans."
+    result, output = gate(text)
+    assert result is True
+
+
+def test_gate_multiple_stale_short_circuits_first():
+    """Multiple stale values still produce a single fallback."""
+    text = "2017 = 6'768, 2018 = 6'826, 2023 = 6'883, 2024 = 7'056."
+    result, output = gate(text)
+    assert result is False
+    assert output == _FALLBACK_FR
+
+
+# ── threat coverage ──────────────────────────────────────────────────
+
+
+def test_gate_threat_t_3a_stale_with_citation():
+    """T-3a-stale : LLM emits stale value + valid citation key.
+
+    The cited key is mechanically valid (citation gate accepts), but
+    the value is stale 2024. Without this freshness gate, the value
+    ships to user under a 2026 citation chip — exactly obs #157.
+    """
+    text = "Le plafond 3a 2026 est 7'056 CHF {{cite:r3a_plafond_salarie_2026}}."
+    result, output = gate(text)
+    assert result is False, (
+        "Freshness gate must catch even citation-decorated stale values"
+    )
+    assert output == _FALLBACK_FR
+
+
+def test_fallback_is_short_and_deterministic():
+    """The fallback string is a verbatim short literal — no f-string surprise."""
+    assert _FALLBACK_FR == "Je n'ai pas cette donnée à jour pour l'instant."
+    # Verify it's distinguishable from Phase 94 citation-gate fallback
+    # (which is much longer) and from runtime_verb_gate (« Je n'ai pas
+    # cette donnée pour l'instant. » — no « à jour »).
+    assert "à jour" in _FALLBACK_FR

--- a/tools/checks/no_stale_regulatory_anchors.py
+++ b/tools/checks/no_stale_regulatory_anchors.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""no_stale_regulatory_anchors.py — Fix D / obs #157.
+
+Lint that prevents future toxic few-shot examples or hardcoded stale
+regulatory values from leaking into LLM-injected prompt text. Scans
+Python string literals (NOT comments) in `services/backend/app/services/
+coach/` for any integer that matches a stale-year entry in the
+regulatory registry (e.g. 2024 plafond 3a = 7'056 CHF — stale since 2025).
+
+Rationale (from obs #157 root-cause analysis 2026-05-17) :
+    A « REJETÉ » example string in `citation_grammar.py:564` contained
+    the literal value `7'056 CHF cette année` — the 2024 OFAS 3a max.
+    Even though the example was negative (« here's what NOT to do »),
+    the LLM leaked it back as positive when surface form matched the
+    user query. This lint blocks the class of bug at commit time.
+
+Algorithm :
+    1. Import `_PARAMETERS` from `app.services.regulatory.registry`.
+    2. Build STALE_VALUES = {int(p.value) for p in _PARAMETERS where
+       key matches `*.historical_limits.<year>` AND the value is NOT
+       also present in any canonical (non-historical) key}.
+    3. For each target .py file, parse to AST.
+    4. Walk all `ast.Constant(value=str)` nodes (string literals — this
+       intentionally excludes Python comments, which are not in the
+       AST tree). Module docstrings ARE included.
+    5. For each string literal, regex-scan for any stale value in any
+       thousand-separator format (Swiss apostrophe, French space,
+       narrow NBSP, anglo comma, no separator).
+    6. Skip files in the allow-list (see ALLOWED_FILES below).
+    7. Exit 1 with a structured report if any violation found ;
+       exit 0 otherwise.
+
+Allow-list rationale :
+    - `registry.py` IS the registry — historical values legitimately
+      live there as data ; that's the canonical store.
+    - `retroactive_3a_service.py` has a per-year dict mapping
+      historical limits ; required for the « rattrapage 3a » feature.
+    - Test files need to assert against stale values to verify the
+      runtime freshness gate works ; can't lint them or they'd block.
+    - Files with a top-level `# noqa: stale-regulatory-anchors`
+      comment as the FIRST non-shebang line are opted out (escape
+      hatch for future legitimate cases — must be justified in PR).
+
+Usage :
+    # default scope = services/backend/app/services/coach/
+    python3 tools/checks/no_stale_regulatory_anchors.py
+
+    # specific files
+    python3 tools/checks/no_stale_regulatory_anchors.py path/to/file.py ...
+
+    # verbose (show STALE_VALUES set)
+    python3 tools/checks/no_stale_regulatory_anchors.py --verbose
+
+Lefthook integration : add a pre-commit step targeting
+`services/backend/app/services/coach/**/*.py`.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+# Files exempted from this lint (legit historical values, or test
+# fixtures that need to assert against stale values).
+ALLOWED_FILES: set[str] = {
+    "services/backend/app/services/regulatory/registry.py",
+    "services/backend/app/services/pillar_3a_deep/retroactive_3a_service.py",
+}
+
+# Per-file opt-out comment (must be first non-shebang line).
+OPT_OUT_MARKER: str = "# noqa: stale-regulatory-anchors"
+
+# Default scope when no file paths are passed on CLI.
+DEFAULT_SCOPE: tuple[str, ...] = (
+    "services/backend/app/services/coach/",
+)
+
+
+def _repo_root() -> Path:
+    """Return repo root assuming this file lives at tools/checks/."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _import_stale_set() -> frozenset[int]:
+    """Reuse runtime_freshness_gate's stale-set derivation.
+
+    Importing the runtime gate keeps a single source of truth for the
+    derivation algorithm. If the gate's logic changes, this lint
+    automatically follows.
+    """
+    sys.path.insert(0, str(_repo_root() / "services" / "backend"))
+    try:
+        from app.services.coach.runtime_freshness_gate import (  # noqa: E402
+            _build_stale_value_set,
+        )
+    finally:
+        sys.path.pop(0)
+    return _build_stale_value_set()
+
+
+def _build_pattern(stale_values: frozenset[int]) -> re.Pattern[str]:
+    """Build a single regex matching any stale value in any format.
+
+    Formats covered :
+        - bare integer : `7056`
+        - Swiss apostrophe : `7'056`
+        - French regular space : `7 056`
+        - French NBSP / narrow NBSP : `7 056` (U+00A0), `7 056` (U+202F)
+        - anglo comma : `7,056`
+
+    Word boundaries on both sides prevent matching `27056` or `70560`.
+    """
+    alternatives: list[str] = []
+    for v in sorted(stale_values):
+        s = str(v)
+        # No separator : exact integer.
+        alternatives.append(re.escape(s))
+        # Thousand-separated variants. For each separator class, insert
+        # the separator before each group of 3 trailing digits.
+        if len(s) > 3:
+            grouped = s[:-3] + s[-3:]  # split tail
+            # Sep class : Swiss apostrophe, regular space, NBSP, narrow NBSP, comma.
+            sep_class = "['   ,]"
+            with_sep = re.escape(s[:-3]) + sep_class + re.escape(s[-3:])
+            alternatives.append(with_sep)
+    pattern_str = r"(?<![\d])(?:" + "|".join(alternatives) + r")(?![\d])"
+    return re.compile(pattern_str)
+
+
+def _is_opted_out(file_path: Path) -> bool:
+    """File opted out via top-line marker comment."""
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#!"):
+                    continue
+                return OPT_OUT_MARKER in stripped
+    except OSError:
+        return False
+    return False
+
+
+def _is_allowed(file_path: Path, repo_root: Path) -> bool:
+    """Check file against allow-list (relative-path match)."""
+    try:
+        rel = file_path.resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+    return str(rel) in ALLOWED_FILES
+
+
+def _scan_file(
+    file_path: Path,
+    pattern: re.Pattern[str],
+    repo_root: Path,
+) -> list[tuple[int, str, str]]:
+    """Return list of (line_no, matched_value, string_literal_snippet)."""
+    if _is_allowed(file_path, repo_root):
+        return []
+    if _is_opted_out(file_path):
+        return []
+
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            source = f.read()
+    except OSError:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return []
+
+    findings: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        s: str = node.value
+        for m in pattern.finditer(s):
+            line_no = getattr(node, "lineno", 0)
+            snippet = s[max(0, m.start() - 30) : m.end() + 30]
+            snippet = snippet.replace("\n", "\\n")
+            findings.append((line_no, m.group(0), snippet))
+    return findings
+
+
+def _resolve_targets(cli_paths: list[str], repo_root: Path) -> list[Path]:
+    """Expand CLI args (or DEFAULT_SCOPE) to a list of .py files.
+
+    Test files are auto-excluded — tests legitimately assert against
+    stale values to verify the runtime gate works. They are NEVER
+    injected into LLM prompts.
+    """
+    if not cli_paths:
+        candidates: list[Path] = []
+        for scope in DEFAULT_SCOPE:
+            base = repo_root / scope
+            if base.is_dir():
+                candidates.extend(base.rglob("*.py"))
+    else:
+        candidates = []
+        for p in cli_paths:
+            path = Path(p)
+            if not path.is_absolute():
+                path = repo_root / path
+            if path.is_dir():
+                candidates.extend(path.rglob("*.py"))
+            elif path.is_file() and path.suffix == ".py":
+                candidates.append(path)
+
+    return [
+        c
+        for c in candidates
+        if "tests" not in c.parts and "test_" not in c.name
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=f"Files or directories to scan (default: {DEFAULT_SCOPE})",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the STALE_VALUES set before scanning",
+    )
+    args = parser.parse_args()
+
+    repo_root = _repo_root()
+    stale_set = _import_stale_set()
+    if args.verbose:
+        print(f"[no_stale_regulatory_anchors] stale set ({len(stale_set)}): "
+              f"{sorted(stale_set)}")
+
+    if not stale_set:
+        print("[no_stale_regulatory_anchors] empty stale set ; skipping.")
+        return 0
+
+    pattern = _build_pattern(stale_set)
+    targets = _resolve_targets(args.paths, repo_root)
+
+    total_violations = 0
+    for file_path in targets:
+        findings = _scan_file(file_path, pattern, repo_root)
+        if not findings:
+            continue
+        try:
+            rel = file_path.resolve().relative_to(repo_root)
+        except ValueError:
+            rel = file_path.resolve()
+        for line_no, matched, snippet in findings:
+            total_violations += 1
+            print(
+                f"{rel}:{line_no}: stale regulatory value `{matched}` "
+                f"in string literal ... « {snippet} » ..."
+            )
+
+    if total_violations:
+        print(
+            f"\n[no_stale_regulatory_anchors] {total_violations} violation(s) "
+            f"across {len(targets)} scanned file(s).\n"
+            "Fix : either replace the literal value with a placeholder "
+            "(e.g. `N CHF`), use a current-year value, OR if legitimate "
+            f"(historical record), add `{OPT_OUT_MARKER}` as the first "
+            "non-shebang line of the file and justify in the PR description."
+        )
+        return 1
+
+    print(
+        f"[no_stale_regulatory_anchors] OK — {len(targets)} file(s) scanned, "
+        f"0 stale regulatory-value leaks found in LLM-injected string "
+        f"literals."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes obs #157 (engram, 2026-05-17) — coach surfacing 2024 Pilier 3a value (7'056 CHF) instead of 2026 (7'258 CHF) on staging. LSFin freshness regression on a regulatory value. Surgical patch + architectural mandate + runtime gate + lint = quad-defense, durable.

## Root cause (confirmed)

Two converging factors :

1. **LLM training-data leak** (Julien-observed mid-Stage-3-UAT 2026-05-17). Anthropic Sonnet/Haiku coach has `7'056 CHF` as the 3a max in its training corpus (correct in 2024). When prompted « combien je peux mettre dans mon 3a », the LLM did NOT invoke `get_regulatory_constant` and fell back to training-data knowledge.
2. **Toxic negative few-shot example** (Claude-found via grep). `services/backend/app/services/coach/citation_grammar.py:564` contained the literal `« Le plafond 3a est de 7'056 CHF cette année. »` as a REJETÉ example — LLMs leak negative few-shot examples as positive when surface form matches the user query (« cette année » → « cette année »).

The two factors reinforce each other. Without the toxic example, the LLM might still hallucinate ; without the LLM training data, the example might be inert ; combined, they produce the freshness regression.

## Quad-defense

| Layer | Commit | Scope | Catches |
|---|---|---|---|
| **A — surgical** | `3ca9e117` | Remove `7'056 CHF cette année` from `citation_grammar.py:564` REJETÉ example. Mirror the safer fabricated-estimate framing already in the full builder. | The specific 7'056 anchor in the intent-scoped fragment. |
| **B — architectural mandate** | `597f0fb8` | Extend `_TOOL_USE_MANDATE` + `_TOOL_USE_MANDATE_REPEAT` with a second doctrine block mandating `tool_use(get_regulatory_constant)` BEFORE emitting any regulatory non-`tool_*` citation key (`r3a_*`, `lpp_*`, `avs_*`, `ifd_*`). Recopies tool_result verbatim. | All future regulatory keys, not just 3a. Closes the « LLM bypasses the tool catalog » trust-collapse hole. |
| **C — runtime gate** | `8bb7ab35` | `services/backend/app/services/coach/runtime_freshness_gate.py` — mirror of `runtime_verb_gate` API. Derives `STALE_VALUES = historical_limits.<year> values - canonical_values` from registry. NFKC + zero-width-strip + 5 thousand-separator format coverage. User-echo exemption. Wired post-verb-gate, pre-citation-gate in `coach_chat._run_narrator_with_gate`. Sentry breadcrumb `coach.freshness_gate.fired`. | Any stale-year regulatory value emitted by any future LLM regression — works for 3a, LPP, AVS, IFD, IS, LAMal, …, every category with `historical_limits.*` registry entries. |
| **D — commit-time lint** | `74cdf488` | `tools/checks/no_stale_regulatory_anchors.py` — scans coach/ Python source for any string literal containing a stale value. Auto-excludes test files + registry + retroactive_3a_service. Opt-out marker for documented exceptions. | Future toxic anchors added by devs or AI agents during prompt edits. CI / lefthook eligible. |

Today's `STALE_VALUES` set (per registry, 2026-05-17) : `{6768, 6826, 6883, 7056}` — the 4 pillar3a historical maxima from 2016-2024 that are NOT also present in any canonical key. `7'258` (current 2025+2026 OFAS value) is correctly NOT in the stale set.

## Verification

- Full backend suite : **`7308 passed, 63 skipped, 3 xfailed in 118.68s`** — delta vs Plan 20 baseline 7264 = **+44**, **zero regression**.
- Fix C tests : 29 new tests in `tests/test_runtime_freshness_gate.py` covering stale-set derivation, number-token normalisation across formats, NFKC + zero-width bypass, user-echo exemption, citation-decorated stale value (the obs #157 exact pattern), current-value pass-through, multi-stale single-fallback, empty/whitespace pass-through.
- Fix D sanity : verified the lint **exits 1 with a clear file:line citation** when a toxic anchor is planted ; **exits 0** on the entire backend (420 files scanned).
- Lints : `banned_terms_python` OK (self-exempt marker honored on `runtime_verb_gate.py`), `accent_lint_fr` OK, `no_stale_regulatory_anchors` OK, `profile_safe_fields_parity` SOFT-WARN baseline (Plan 19 documented drift, unrelated).

## Architecture rationale (Software 3.0)

This bug exposed a structural sub-investment in **defense in depth on the LLM-vs-deterministic-source boundary**. The coach LLM was given authority to GENERATE regulatory values when it should only RETRIEVE them via `get_regulatory_constant`. Per Karpathy Software 3.0 framing, the LLM is a great prose assembler and a terrible calculator. Three patterns enforce the right split mechanically :

1. **Forced tool invocation** (Fix B) — LLM must call the deterministic source before emitting a regulatory value.
2. **Runtime gates** (Fix C, alongside Plan 18 verb gate + Phase 94 citation gate) — defense in depth at narrator emit time, fail-closed.
3. **Lint at commit** (Fix D) — prevent regression introduction at the source-code boundary.

MINT's cohabitation map after this PR : **100% deterministic for regulatory values**, **95-98% deterministic for derived calculations**, **100% LLM for prose / framing / empathy** — measured as « % of user-facing tokens whose value is derived from a deterministic source ».

## LSFin gravity

Outdated 3a max in user-facing coach output → potential breach of LSFin art. 8 (« information appropriée à l'investisseur ») + art. 10 (« adéquation »). Staging is currently public to TestFlight testers (none enrolled yet). Production not yet impacted by the calc-engine spine deploy. This fix lands before any production exposure of the calc-engine path.

## What this PR does NOT do (per CLAUDE.md §9.5 0-trust)

- ❌ NOT merged. Stage 1 of 4 of the shipping pipeline.
- ❌ NOT deployed. Railway staging will pick this up only after merge to `dev`, then `staging`.
- ❌ NOT verified on sim post-deploy. End-to-end re-test with prompt « combien je peux mettre en 3a » must run after Railway staging redeploy — receipt to be posted on this PR after merge.
- ❌ NOT a fix for the two OTHER findings Julien surfaced on 2026-05-17 (markdown `**bold**` leak in chat — engram obs #158 ; `Outil éducatif simplifié` label oversizing). Those are their own perimeters, will be opened separately.

## Test plan

- [x] G4 backend suite green (`pytest tests/ -q`)
- [x] Citation gate suite green (`pytest tests/test_citation_gate/`)
- [x] New freshness gate suite green (`pytest tests/test_runtime_freshness_gate.py`)
- [x] Fix D lint exits 0 on default scope (`python3 tools/checks/no_stale_regulatory_anchors.py`)
- [x] Fix D lint exits 1 on planted toxic anchor (sanity)
- [x] banned_terms_python + accent_lint_fr clean
- [ ] **Post-merge** : Maestro sweep + manual prompt « combien je peux mettre en 3a » on sim, verify coach emits 7'258 (or « je n'ai pas cette donnée à jour » if fallback fires)
- [ ] **Post-merge** : Sentry `coach.freshness_gate.fired` breadcrumb rate over 24h staging — should trend toward 0 as the prompt mandate (Fix B) does its job ; non-zero rate = LLM still occasionally hallucinates, but Fix C catches.

## Engram references

- obs #157 — root cause confirmed (LLM training-data leak + toxic few-shot)
- obs #159 — Stage 3 UAT assertion design gap (Maestro asserts on chip visibility ≠ user-value validated)
- obs #161 — screenshot hygiene method (codified during this debug session)

## Companion perimeters (not in this PR)

- obs #158 — coach markdown `**bold**` leak (Flutter chat renderer doesn't parse markdown) — separate PR
- Maestro flow corpus refresh (9 stale flows post-UI refactor) — separate PR
- coach_tool_search_round_trip.yaml schema drift (Maestro `timeout` property unsupported) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
