### PR TITLE
fix(anonymous_chat): render coach markdown via MarkdownBody + constrain LLM usage (obs #158)

### DIFF
--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback, LengthLimitingTextInputFormatter;
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
@@ -737,12 +738,54 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
             bottomRight: Radius.circular(isUser ? 4 : 18),
           ),
         ),
-        child: Text(
-          message.text,
-          style: MintTextStyles.labelLarge(
-            color: isUser ? MintColors.white : MintColors.inkPrimary,
-          ).copyWith(fontWeight: FontWeight.w400),
-        ),
+        // obs #158 (2026-05-17) — coach LLM emits markdown bold (`**…**`),
+        // italic (`_…_`), etc. The main coach surface
+        // (`widgets/coach/coach_message_bubble.dart:89-118`) already renders
+        // these via MarkdownBody. The anonymous chat surface was the orphan
+        // raw-Text holdout — users were seeing literal asterisks. Mirror the
+        // proven pattern from coach_message_bubble. Guard with `!isUser` so
+        // user-typed bubbles stay plain text (users don't emit markdown ;
+        // their input is echoed back via `Text(message.text)` in the user
+        // branch to avoid markdown-injection via user message into the chat
+        // surface).
+        child: isUser
+            ? Text(
+                message.text,
+                style: MintTextStyles.labelLarge(
+                  color: MintColors.white,
+                ).copyWith(fontWeight: FontWeight.w400),
+              )
+            : MarkdownBody(
+                data: message.text,
+                styleSheet: MarkdownStyleSheet(
+                  p: MintTextStyles.labelLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(fontWeight: FontWeight.w400, height: 1.45),
+                  strong: MintTextStyles.labelLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(fontWeight: FontWeight.w700, height: 1.45),
+                  em: MintTextStyles.labelLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(
+                    fontWeight: FontWeight.w400,
+                    fontStyle: FontStyle.italic,
+                    height: 1.45,
+                  ),
+                  listBullet: MintTextStyles.labelLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(fontWeight: FontWeight.w400, height: 1.45),
+                  h3: MintTextStyles.labelLarge(
+                    color: MintColors.inkPrimary,
+                  ).copyWith(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 15,
+                    height: 1.45,
+                  ),
+                ),
+                shrinkWrap: true,
+                softLineBreak: false,
+                selectable: true,
+              ),
       ),
     );
 

--- a/services/backend/app/services/coach/citation_grammar.py
+++ b/services/backend/app/services/coach/citation_grammar.py
@@ -123,6 +123,19 @@ _TOOL_USE_MANDATE: str = (
     "préalable dans ce même tour. À défaut, écris « je n'ai pas cette "
     "donnée pour l'instant » plutôt que d'émettre une valeur non "
     "sourcée.\n"
+    "\n"
+    "## DOCTRINE — USAGE MESURÉ DU MARKDOWN (obs #158)\n"
+    "\n"
+    "Tu peux utiliser le markdown `**gras**` et `*italique*` UNIQUEMENT "
+    "pour de l'emphase ponctuelle (un mot-clé important, un verdict). "
+    "PAS de titres (`#`, `##`, `###`), PAS de blocs de code (`` ``` ``), "
+    "PAS de listes numérotées, PAS de tableaux, PAS de liens "
+    "(`[texte](url)`). Le rendu mobile du chat n'est pas un éditeur "
+    "Markdown : c'est une conversation. Écris en prose française "
+    "naturelle, fluide, en phrases courtes, avec emphase TYPOGRAPHIQUE "
+    "(gras / italique) seulement quand c'est vraiment justifié — pas "
+    "plus d'UNE emphase par bulle de coach en moyenne. Un texte "
+    "saturé de `**` est aussi mauvais qu'un texte sans aucune emphase.\n"
 )
 
 _TOOL_USE_WRONG_RIGHT_EXAMPLE: str = (


### PR DESCRIPTION
## Summary

Fixes obs #158 (engram, 2026-05-17) — coach LLM emits markdown bold/italic (`**…**`, `_…_`) but the anonymous chat surface renders them as raw asterisks because it used a plain `Text(message.text)` widget. The main coach surface (`coach_message_bubble.dart`) already renders markdown correctly via `MarkdownBody` — the anonymous chat was the orphan.

## Root cause

UI rendering inconsistency between two coach surfaces :
- ✅ Main coach (`widgets/coach/coach_message_bubble.dart:89-118`) : `MarkdownBody` with full `MintTextStyles` wiring. Markdown renders properly.
- ❌ Anonymous chat (`screens/anonymous/anonymous_chat_screen.dart:740-745`) : raw `Text(message.text)`. Markdown shows as literal asterisks.

Coach LLM (Anthropic Sonnet/Haiku) emits markdown by default in conversational responses. The main coach was already wired for it ; the anonymous chat was missed during the original implementation.

## Design decision (3-agent panel synthesis 2026-05-17)

Three options surveyed by parallel `flutter-expert` + `ai-engineer` + `architect-review` specialists :
- **(i) Backend strip filter at narrator emit** — runtime gate analogue to `runtime_freshness_gate`. ❌ Rejected : would kill legitimate emphasis on the main coach surface that ALREADY renders markdown correctly.
- **(ii) Frontend wire `flutter_markdown`** — mirror the proven pattern from `coach_message_bubble`. ✅ Selected as primary fix : consolidates rendering across both surfaces, ~20 LOC single-file diff, zero new dependency (`flutter_markdown: ^0.7.6` already in pubspec).
- **(b) Prompt constraint** in `citation_grammar._TOOL_USE_MANDATE` constraining LLM to sparing emphasis-only markdown (no headers, no code blocks, no tables, no links). ✅ Selected as companion : prevents the LLM from over-emphasizing or emitting structural markdown that doesn't make sense in conversational chat.
- **(c) Full layered defense** (backend strip + prompt) — Rejected : the « N surfaces » / TTS concern is a future bug, not current. Karpathy #2 simplicity wins over speculative future-proofing for an entirely UX-class issue (not LSFin).

## Commits

| sha | Layer | Scope |
|---|---|---|
| `b6f7ce07` | **Frontend (ii)** | `apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart` — replace raw `Text(message.text)` with `MarkdownBody` (mirroring `coach_message_bubble.dart:89-118`). Guard `!isUser` — users don't emit markdown ; their input is echoed as-is via `Text` to avoid markdown-injection from user message. `flutter_markdown: ^0.7.6` already declared, BSD-3, no `rawHtml` extension (no XSS surface). +49 / -6 LOC. |
| `01ed527a` | **Prompt constraint (b)** | `services/backend/app/services/coach/citation_grammar.py` — append `## DOCTRINE — USAGE MESURÉ DU MARKDOWN (obs #158)` block to `_TOOL_USE_MANDATE` constraining markdown usage to ~1 emphasis per coach bubble, banning headers / code blocks / tables / links. Byte-additive : 229/229 citation_gate tests preserved. |

## Verification

- Full G4 backend suite : **`7279 passed, 63 skipped, 3 xfailed in 118.25s`** (delta vs Plan 20 baseline 7264 = +15 ; zero regression).
- Anonymous chat widget tests : **`+13 passed, +1 skipped, All tests passed!`** (`test/screens/anonymous/`).
- Citation gate suite : 229/229 green (byte-additive prompt change verified).
- Flutter analyze on touched file : zero NEW warnings ; 4 pre-existing warnings on the same file (l.16 unused_import, l.100 prefer_final, l.100 unused_field, l.842 dead_code) NOT touched per Karpathy #3 surgical discipline.
- Lints : `banned_terms_python` clean, `accent_lint_fr backend` clean.

## What this PR does NOT do (per CLAUDE.md §9.5 0-trust)

- ❌ NOT merged. Stage 1 of 4.
- ❌ NOT verified visually on sim. Will post a screenshot from the anonymous chat surface after merge + Railway redeploy proving markdown renders bold/italic instead of asterisks.
- ❌ NOT a fix for the OTHER finding from the same 2026-05-17 Julien observation : « `Outil éducatif simplifié` label oversized + appearing too often ». Separate perimeter.
- ❌ Does NOT touch `coach_message_bubble.dart` — it already renders markdown correctly. Karpathy #3 surgical.
- ❌ Does NOT add a runtime markdown strip gate. Intentional design choice — would kill emphasis on the main coach surface.

## Engram references

- obs #158 — coach markdown leak (root cause + decision rationale)
- obs #161 — screenshot hygiene method (no PNG added to session context during this debug)
- obs #162 — quad-defense pattern shipped on PR #648 (reusable but NOT applied here per panel synthesis)

## Companion perimeters (separate PRs)

- #648 — quad-defense for 3a stale regulatory values (obs #157) — pending merge
- obs #159 — Stage 3 UAT assertion design gap (Maestro asserts on chip visibility ≠ user-value validated) — process improvement, not a code fix
- `Outil éducatif simplifié` label sizing — UX polish, separate perimeter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
