### PR TITLE
fix(backend): backport #377 create_all() prod gate to dev

### DIFF
--- a/services/backend/app/main.py
+++ b/services/backend/app/main.py
@@ -69,7 +69,19 @@ async def lifespan(app: FastAPI):
     """Create database tables and auto-ingest RAG knowledge base on startup."""
     # Import models to ensure they're registered with Base
     from app import models as _models  # noqa: F401
-    Base.metadata.create_all(bind=engine)
+
+    # Backport of hotfix #377 (was main-only until 2026-05-17). Alembic is
+    # the source of truth in production — running create_all() after migrate
+    # conflicts with existing tables whose implicit row-type already exists
+    # in pg_type (UniqueViolation on pg_type_typname_nsp_index, observed
+    # 2026-04-21 for magic_link_tokens which lacked a dedicated alembic
+    # revision at the time). Keep create_all() in dev/test where the DB can
+    # start empty and there is no alembic at boot time. Any production-only
+    # table missing a migration must be backfilled via a dedicated alembic
+    # revision, not by this bypass. Incident: Railway prod healthcheck loop
+    # post-#376.
+    if settings.ENVIRONMENT != "production":
+        Base.metadata.create_all(bind=engine)
 
     # FIX-106: Validate DB connectivity at startup — fail fast if misconfigured.
     try:


### PR DESCRIPTION
## Summary

Backports hotfix #377 (2026-04-21, main-only) to dev. Without this, the next dev → staging → main release would re-introduce un-gated `Base.metadata.create_all(bind=engine)` and regress the Railway prod healthcheck fix on main.

## Context

#377 landed directly on main on 2026-04-21 to unblock the Railway healthcheck loop — `create_all()` after alembic migrate hit `pg_type UniqueViolation` on `magic_link_tokens` (table created by `create_all()` initially, no alembic revision yet; the orphan pg row-type stayed across boots). The gate was never backported to dev.

Discovered during cleanup audit 2026-05-17 : `git log origin/staging..origin/main` showed exactly 1 commit on main not on staging (#377), and `git grep` confirmed dev's `app/main.py:72` still has `create_all()` un-gated.

## What this commit does

- 1 file changed (`services/backend/app/main.py`), +13/-1.
- Wraps `Base.metadata.create_all(bind=engine)` in `if settings.ENVIRONMENT != "production":` — same gate as #377.
- Preserves the original incident comment for traceability.

## What this commit does NOT do

- The `29_05_magic_link_tokens.py` migration that #377 also added is already present on dev via PR #546 « recover 29_05_magic_link_tokens migration (prod-debt closure) ». No migration touch needed here.
- No backport to staging — staging will inherit the gate at the next dev → staging promotion, which is the natural release flow.

## Verification

- `python3 -m py_compile services/backend/app/main.py` — clean.
- `settings.ENVIRONMENT` already referenced at `main.py:143` (`_is_production = settings.ENVIRONMENT == "production"`), so the import + setting exist.
- Behaviour in dev/test : unchanged (still runs `create_all()` since `ENVIRONMENT != "production"`).
- Behaviour in production : `create_all()` skipped, alembic remains the sole DDL source. Matches #377 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)