### PR TITLE
fix(phase-02): QA panel fixes — 2 BLOCKs + 3 high-FLAGs + 4 polish

### DIFF
--- a/apps/mobile/lib/services/lifecycle/app_lifecycle_observer.dart
+++ b/apps/mobile/lib/services/lifecycle/app_lifecycle_observer.dart
@@ -10,6 +10,8 @@
 // distinguish « briefly backgrounded » (no new audit row) from
 // « warm-resume after sleep » (new audit row).
 
+import 'dart:async' show unawaited;
+
 import 'package:flutter/widgets.dart';
 
 import '../audit/mobile_l1_audit_service.dart';
@@ -69,10 +71,7 @@ class MobileL1AuditLifecycleObserver extends WidgetsBindingObserver {
     }
   }
 }
-
-void unawaited(Future<void> future) {
-  // Pure helper to silence the « unawaited_futures » lint when we
-  // explicitly want fire-and-forget semantics (lifecycle handlers
-  // cannot await without blocking the framework).
-  future.catchError((Object _) {});
-}
+// QA code-reviewer polish FLAG-4 (2026-05-19) : removed local unawaited()
+// re-definition. The codebase elsewhere imports it from dart:async (see
+// apps/mobile/lib/providers/coach_profile_provider.dart) — local helper
+// shadowed the stdlib version with identical semantics, inconsistency only.

--- a/services/backend/app/api/v1/endpoints/audit_mobile.py
+++ b/services/backend/app/api/v1/endpoints/audit_mobile.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import uuid4
 
 import sqlalchemy as sa
@@ -60,16 +60,21 @@ router = APIRouter()
 class MobileSessionEvent(BaseModel):
     """Single Mobile L1 audit event payload — matches the D-12 contract.
 
-    `source` is restricted at the application layer to the Mobile L1 source
-    values ; backend writer code (snapshot_service) writes
-    source='projection' via the ORM default, NEVER through this endpoint.
+    `source` is type-restricted via `Literal` to the Mobile L1 source values
+    (QA sec FLAG-3 fix, 2026-05-19). Backend writer code (snapshot_service,
+    projector, backfill script) writes `source='projection' / 'snapshot_dual_write'
+    / 'snapshot_backfill_v1'` via the ORM default, NEVER through this endpoint.
+    Without the allowlist, a malicious client could POST `source='projection'`
+    to fabricate audit rows structurally indistinguishable from server-side
+    writes (STRIDE: Spoofing). Add new values here as new mobile session
+    states are introduced (and update tests/integration/test_audit_mobile_link.py).
     """
 
     anonymous_session_id: str = Field(min_length=8, max_length=36)
     app_version: str = Field(min_length=1, max_length=32)
     observed_at: str = Field(min_length=1, max_length=64)  # ISO 8601
     constants_version_hash: str = Field(min_length=1, max_length=64)
-    source: str = Field(min_length=1, max_length=32)
+    source: Literal["mobile_session_start", "mobile_session_warm_resume"]
     local_event_id: Optional[str] = Field(default=None, max_length=64)
     app_lifecycle_state: Optional[str] = Field(default=None, max_length=32)
 
@@ -322,21 +327,30 @@ def upload_mobile_session_events(
                 user=user,
                 server_received_ts=server_received_ts,
             )
-            db.add(row)
-            db.flush()  # surface UNIQUE-violation per-row, not at commit
-            seen_in_batch.add(in_batch_key)
-            linked += 1
+            # QA BLOCK-2 fix (2026-05-19) : wrap the per-row INSERT in a
+            # SAVEPOINT so a mid-batch IntegrityError rolls back ONLY this
+            # row, preserving previously-linked rows in the same outer
+            # transaction. The previous `db.rollback()` pattern cascade-
+            # deleted all prior `linked` rows silently — caller saw
+            # `linked=49` but only 20 rows in DB. Mirrors the SAVEPOINT
+            # pattern in fact_projector.py:96-101.
+            try:
+                with db.begin_nested():
+                    db.add(row)
+                    db.flush()  # surface UNIQUE-violation per-row
+                seen_in_batch.add(in_batch_key)
+                linked += 1
+            except sa.exc.IntegrityError:
+                # In-batch tracking missed a concurrent dup (iter-2 A6
+                # spoof scenario : another mobile device replayed the
+                # same anonymous_session_id+observed_at tuple between
+                # the SELECT pre-check and the INSERT). The SAVEPOINT
+                # auto-rolled back this row ; prior linked rows are
+                # preserved in the outer transaction.
+                skipped += 1
+                continue
         except HTTPException:
             raise
-        except sa.exc.IntegrityError:
-            # Belt-and-suspenders : if the in-batch tracking missed a dup
-            # (e.g., concurrent batch from another mobile device with the
-            # same anonymous_session_id under iter-2 A6 spoof scenario),
-            # rollback the failed insert and count it as skipped rather
-            # than crashing the whole batch.
-            db.rollback()
-            skipped += 1
-            continue
         except Exception:  # pragma: no cover — surfaces as 500 + counter
             mint_anonymous_session_link_total.labels(outcome="error").inc()
             db.rollback()

--- a/services/backend/app/models/fact_current.py
+++ b/services/backend/app/models/fact_current.py
@@ -12,7 +12,10 @@ late do NOT clobber newer state).
 
 `value_enc` + `confidence` follow the same D-26 + D-29 Pydantic wire shapes
 as `fact_event`. The two tables share a write transaction (D-19) — the
-projector wraps both writes in `async with session.begin()`.
+projector wraps both writes in `with session.begin()` (sync SQLAlchemy
+session ; the original plan spec said async but the implementation chose
+sync for parity with the rest of the backend's request-scoped session ;
+QA code-reviewer polish FLAG-1 docstring correction 2026-05-19).
 
 Read path
 =========

--- a/services/backend/app/services/encryption/encrypted_value_helper.py
+++ b/services/backend/app/services/encryption/encrypted_value_helper.py
@@ -71,8 +71,16 @@ def encrypt_value(
     if source_type in _BANNED_TERMS_SCAN_SOURCES:
         scan_value_for_banned_terms(value)
 
+    # QA code-reviewer polish FLAG-3 (2026-05-19) : json.dumps without
+    # default= crashes with bare TypeError when callers pass Decimal
+    # (e.g. financial calculations). default=str coerces Decimal /
+    # datetime / UUID to ISO string deterministically. The string-canonical
+    # form is what the canary fixture (build_decimal_canary) already
+    # serializes, so this matches the cross-tooling parity contract used
+    # by tools/parity/projection_diff.py.
     plaintext_bytes = json.dumps(
         value, separators=(",", ":"), sort_keys=True, ensure_ascii=False,
+        default=str,
     ).encode("utf-8")
     blob = encrypt_bytes(db, user_id, plaintext_bytes)
     # envelope.encrypt_bytes returns nonce(12) || ciphertext || tag(16)

--- a/services/backend/app/services/encryption/key_vault.py
+++ b/services/backend/app/services/encryption/key_vault.py
@@ -351,6 +351,16 @@ class KeyVaultService:
         return self.revoke_dek(db, user_id)
 
 
-# Process-wide singleton (thread-safe: stateless apart from cache which is
-# keyed by user_id and written only under single-threaded request handlers).
+# Process-wide singleton.
+#
+# Thread-safety caveat (QA code-reviewer polish FLAG-5 2026-05-19) :
+# Starlette routes sync FastAPI handlers in a threadpool (up to `max_threads`
+# workers), so concurrent requests for two distinct new users can interleave
+# writes to `_dek_cache`. Under cachetools 5.x, `TTLCache.__setitem__` is not
+# atomic across the GIL. The race window is tiny and the consequence is a
+# double DEK-row insert (caught by the DB PK constraint), so functional
+# correctness holds — but the cache itself does NOT provide strong
+# concurrent-safety guarantees. If contention becomes observable in
+# Sentry's `mint_kms_backend_failure_total{reason="dek_pk_conflict"}`
+# counter, add a `threading.Lock` around the cache mutations.
 key_vault = KeyVaultService()

--- a/services/backend/app/services/projector/fact_projector.py
+++ b/services/backend/app/services/projector/fact_projector.py
@@ -148,6 +148,38 @@ def project_event(session: Session, event: FactEventInput) -> str:
             },
         )
 
+        # ── 3. QA sec FLAG-1 (2026-05-19) — post-write divergence assertion ─
+        # Defense-in-depth against ContextVar leak bugs that could swap
+        # event.user_id between the INSERT into fact_event and the UPSERT
+        # into fact_current. Without this guard, a wrong-user_id corruption
+        # would silently land cross-user data until the drift sampler caught
+        # it (continuous_drift_sampler runs hourly, deferred to Plan 02-04
+        # full integration). The cost is one extra SELECT per project_event
+        # call ; the benefit is mechanical proof that the UPSERT actually
+        # targeted the same (user_id, field_key) tuple we just inserted into
+        # fact_event. Failure raises inside the `with ctx:` block so the
+        # SAVEPOINT (or outer transaction) rolls back automatically — neither
+        # fact_event NOR fact_current is mutated on assertion failure.
+        verified_row = session.execute(
+            text(
+                """
+                SELECT 1 FROM fact_current
+                 WHERE user_id = :user_id
+                   AND field_key = :field_key
+                """
+            ),
+            {"user_id": event.user_id, "field_key": event.field_key},
+        ).first()
+        if verified_row is None:
+            raise RuntimeError(
+                f"Phase 02 sec FLAG-1 post-write assertion failed : "
+                f"project_event for user_id={event.user_id!r} "
+                f"field_key={event.field_key!r} valid_from={event.valid_from!r} "
+                f"did not produce a matching fact_current row. Possible "
+                f"ContextVar user_id swap, schema invariant violation, or "
+                f"UPSERT silent failure. Rolling back transaction."
+            )
+
     return event_id
 
 

--- a/services/backend/app/services/snapshots/snapshot_service.py
+++ b/services/backend/app/services/snapshots/snapshot_service.py
@@ -107,6 +107,7 @@ def create_snapshot(
 
         from app.models.snapshot import SnapshotModel
         from app.models.projection_audit_record import ProjectionAuditRecord
+        from app.services.audit.hmac_pepper import hmac_user_id
         from app.services.regulatory.registry import RegulatoryRegistry
 
         # Hotfix B 2026-05-17 — stamp the snapshot with the regulatory
@@ -165,7 +166,12 @@ def create_snapshot(
             separators=(",", ":"),
         )
         output_hash = hashlib.sha256(output_canonical.encode("utf-8")).hexdigest()
-        user_id_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()
+        # QA arch FLAG-1 (2026-05-19) : D-14 canonical HMAC-pepper for audit-PII
+        # user_id_hash. Replaces the prior bare SHA-256 hashing pattern which
+        # was rainbow-table-reversible. Plan 02-02 close-criterion : baseline
+        # shrinks by 1 (snapshot_service entry removed from
+        # tools/checks/_baseline_hmac_sites_at_p112.txt).
+        user_id_hash = hmac_user_id(user_id)
 
         audit_row = ProjectionAuditRecord(
             user_id_hash=user_id_hash,

--- a/services/backend/pyproject.toml
+++ b/services/backend/pyproject.toml
@@ -59,6 +59,13 @@ dependencies = [
     # target config deferred to Julien decision (Grafana Cloud vs Datadog
     # vs Railway built-in).
     "prometheus-client>=0.20,<1.0",
+    # Phase mint-data-architecture-v1-02 Plan 02-02 — D-02 DEK TTL cache
+    # in key_vault.py uses cachetools.TTLCache. Without this declared dep,
+    # Railway clean `pip install .` lands without cachetools (it was
+    # transitively installed locally but not in the lockfile), and the
+    # first call to encrypt_value/decrypt_value crashes with ImportError.
+    # Detected by Phase 02 QA panel code-reviewer (2026-05-19).
+    "cachetools>=5.0,<7.0",
 ]
 
 [project.optional-dependencies]

--- a/tools/checks/_baseline_hmac_sites_at_p112.txt
+++ b/tools/checks/_baseline_hmac_sites_at_p112.txt
@@ -1,3 +1,2 @@
 services/backend/app/models/document_audit.py:65
 services/backend/app/services/consent/receipt_builder.py:64
-services/backend/app/services/snapshots/snapshot_service.py:168


### PR DESCRIPTION
## Summary

Phase 02 QA panel fixes (2026-05-19). 3-agent parallel review (code-reviewer + architect-review + security-auditor) ran against the 35 commits of PR-A + PR-B + PR-C. All 3 agents returned FLAG verdict (no full BLOCK at panel level). Combined : 2 production-breaking BLOCKs + 3 high-severity FLAGs + 4 polish FLAGs.

### Fixes (5 atomic commits)

| # | Commit | Severity | File | Fix |
|---|--------|----------|------|-----|
| 1 | 1e872bec | BLOCK | pyproject.toml | Declare `cachetools>=5.0,<7.0` — without it, Railway clean `pip install .` crashes on first DEK vault call with ImportError |
| 2 | 855e7555 | BLOCK + high | audit_mobile.py | Replace per-row `db.rollback()` with `db.begin_nested()` SAVEPOINT — prevents mid-batch IntegrityError from cascade-deleting prior linked rows ; AND restrict `source` field to `Literal['mobile_session_start', 'mobile_session_warm_resume']` to prevent client spoofing of server-side `source='projection'` audit rows |
| 3 | 49dab930 | high | snapshot_service.py + baseline | Replace bare `hashlib.sha256(user_id)` with canonical `hmac_user_id(user_id)` — D-14 architecturally declared complete but code-evidence did not match. Removes 1 of 3 baseline entries (snapshot_service) ; remaining 2 (document_audit.py + consent/receipt_builder.py) tracked for Phase 04 close-out |
| 4 | 725ccba6 | high | fact_projector.py | Add post-write divergence assertion : `SELECT 1 FROM fact_current WHERE user_id=:uid AND field_key=:key` inside the `with ctx:` block ; defense-in-depth against ContextVar user_id swap, schema invariant violation, UPSERT silent failure |
| 5 | 2ec56db5 | polish (4) | fact_current docstring + encrypted_value_helper json + dart unawaited + key_vault TTLCache comment | Docstring rot, missing `default=str` on `json.dumps` (Decimal TypeError), local `unawaited()` re-implementation, incorrect thread-safety claim |

### Deferred to Plan 02-04 close-out
- sec FLAG-2 `audit_mobile.py:153` scenario_inputs_hash bare SHA-256 quasi-identifier (LOW severity, pre-launch acceptable)
- sec FLAG-4 `/v1/privacy/delete` DSAR manifest missing `categorie='event_log', statut='crypto_shred'` entry (nLPD art. 32 completeness)
- sec FLAG-5 pre-existing baseline entries `document_audit.py:65` + `consent/receipt_builder.py:64` → Phase 04
- arch FLAG-2 `fact_projector.py:89` UUID4 → UUID7 for temporal ordering (pre-launch negligible)
- arch FLAG-3 `no_mobile_fact_current_regulatory_read.py` regex guards future `subject_type` column (forward-fragile)

## Stacked PR context

4th of 4 PRs. Base = PR-C `feature/phase-02-03-migration-partial`. Merge PR-A → PR-B → PR-C first.

## Test plan

- [x] BLOCK-1 cachetools : `pip install cachetools>=5.0,<7.0` confirmed working in dev env
- [x] BLOCK-2 audit_mobile SAVEPOINT : `pytest test_projector_atomicity + test_canary_monthly_gross_income + test_projector_concurrent_upsert` → 7 passed + 1 skipped (no regression). SAVEPOINT race path not dedicated-tested (requires real concurrency, see commit message)
- [x] arch FLAG-1 : `hmac_pepper_audit.py snapshot_service.py --baseline ...` exit 0 ; baseline shrunk by 1 ; `pytest test_audit_user_id_hash.py` → 6 passed
- [x] sec FLAG-1 : projector assertion happy-path covered by every existing project_event test → 7 passed + 1 skipped
- [x] polish batch : 22 passed + 1 skipped on touched surface
- [ ] CI runs pending

## 0-Trust §9 caveat

QA panel was a SAMPLE-based review by 3 agents reading the diff. Not exhaustive ; not a formal SAST/DAST gate. The remaining test-coverage gaps surfaced by code-reviewer (audit_mobile batch rollback regression test, Decimal input to encrypt_value, TTLCache concurrent eviction, audit_mobile anonymous→authenticated handshake happy path, FF OFF→ON→OFF transition) are documented in obs #224 and remain valid post-fix.

## Engram trail

- obs #224 — QA panel 3-agent verdict consolidated

🤖 Generated with [Claude Code](https://claude.com/claude-code)