### PR TITLE
fix(rag): demote UndefinedTable to warning in hybrid_search — silence Sentry BACKEND-3

### DIFF
--- a/services/backend/app/services/rag/hybrid_search_service.py
+++ b/services/backend/app/services/rag/hybrid_search_service.py
@@ -300,7 +300,29 @@ class HybridSearchService:
             return results
 
         except Exception as exc:
-            logger.error("hybrid_search failed: %s", exc)
+            # Sentry MINT-BACKEND-3 (2026-04-11 → 2026-05-15, 208 events) :
+            # `relation "document_embeddings" does not exist` repeatedly when the
+            # pgvector extension / table aren't provisioned on the target Postgres
+            # (probed 2026-05-20 — Railway-managed `postgres-ssl:17` does NOT
+            # ship pgvector ; `pg_available_extensions` returns 0 rows for
+            # 'vector'). The hybrid search is supposed to degrade gracefully —
+            # the FaqService fallback keyword path picks up downstream — so
+            # demote the UndefinedTable case to a warning (not surfaced to
+            # Sentry via the logging integration's default ERROR threshold).
+            # Other errors still go through logger.error → Sentry.
+            try:
+                import psycopg2  # local import to avoid hard dep on parse
+                is_missing_table = isinstance(exc, psycopg2.errors.UndefinedTable)
+            except Exception:  # pragma: no cover — psycopg2 always imported in prod
+                is_missing_table = "does not exist" in str(exc)
+            if is_missing_table:
+                logger.warning(
+                    "hybrid_search skipped: vector table not provisioned on this env "
+                    "(pgvector unavailable). Coach degrades to keyword-only via "
+                    "FaqService fallback."
+                )
+            else:
+                logger.error("hybrid_search failed: %s", exc)
             return []
         finally:
             if conn is not None and self._pool is not None:  # pragma: no cover


### PR DESCRIPTION
## Summary

Single commit follow-up to PR #661. After PR #661 merged + Railway staging deployed (alembic head advanced to `p122_orm_orphan_safety_net`), the post-deploy probe surfaced that pgvector is **not available** on the current Railway `postgres-ssl:17` Postgres image (`pg_available_extensions` returns 0 rows for `'vector'`). So the p122 migration correctly skipped the `document_embeddings` table creation per its defensive gate.

Result : `hybrid_search.search()` continues to catch `UndefinedTable` and return `[]` (intended graceful degradation — the FaqService keyword fallback downstream handles it), but the bare `logger.error()` on line 303 fires through the Sentry logging integration on every call. That's the 208-event flood on `MINT-BACKEND-3`.

This PR narrows the catch : `psycopg2.errors.UndefinedTable` → `logger.warning` (below Sentry's default capture threshold). All other exceptions still flow through `logger.error` → Sentry, so unexpected failures stay visible.

When pgvector eventually lands on staging (Option A in the session : swap Postgres image to `pgvector/pgvector:pg17`), the migration re-runs idempotently and `document_embeddings` gets created — at which point `hybrid_search` returns real results instead of `[]` and this branch is no longer hit.

## Test plan
- [x] CI green on dev (run 26170190390 — 18 success)
- [x] `python3 -c "import ast; ast.parse(...)"` clean
- [ ] Post-merge: Railway staging redeploys with new code
- [ ] Post-deploy: trigger `/api/v1/coach/chat` via Maestro or curl, confirm no new `MINT-BACKEND-3` event in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)