### PR TITLE
fix(fastlane): remove non-idempotent TestFlight upload retry (false-positive workflow failure)

### DIFF
--- a/apps/mobile/ios/fastlane/Fastfile
+++ b/apps/mobile/ios/fastlane/Fastfile
@@ -150,10 +150,20 @@ platform :ios do
     # That makes our CI flap as failure on what is in fact a successful upload.
     #
     # Strategy: try the full submission first. If the « Another build is in
-    # review » error is raised, fall back to upload-only (skip_submission:
-    # true) so the binary lands in ASC and Julien can manually click
-    # « Submit for Review » in the ASC UI once the previous build clears.
-    # Either way, the binary is already uploaded by step 6's altool path.
+    # review » error is raised, log the manual ASC step and exit clean.
+    # The binary is already in App Store Connect at this point (altool
+    # uploads it BEFORE auto-submit runs) — the operator just needs to
+    # manually submit it to Beta Testeurs from the ASC UI once the
+    # previous build clears Apple's review queue.
+    #
+    # Historical bug (fixed 2026-05-21 by `fix/fastlane-testflight-retry-idempotency`) :
+    # the previous version of this block re-tried with
+    # `upload_to_testflight(skip_submission: true)` on the assumption that
+    # altool would fast-path a duplicate upload. It does NOT — altool
+    # rejects the duplicate with `-19232 ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE`,
+    # making every staging promote a false-positive workflow failure even
+    # though the binary was already in ASC. Removing the retry fixes the
+    # workflow exit code without losing the manual-step message.
     begin
       upload_to_testflight(
         api_key: api_key,
@@ -166,15 +176,11 @@ platform :ios do
       msg = e.message.to_s
       if msg.include?("Another build is in review") ||
          msg.include?("already in beta review")
-        UI.important("Auto-submit for beta review skipped: previous build of this train is still in Apple's review queue.")
-        UI.important("The binary is uploaded to App Store Connect — submit it for review manually once the previous build clears.")
-        # Re-run with submission off so the upload phase reconciles cleanly
-        # (idempotent — if binary already uploaded, fastlane fast-paths).
-        upload_to_testflight(
-          api_key: api_key,
-          skip_submission: true,
-          skip_waiting_for_build_processing: true,
-        )
+        UI.important("✅ Binary uploaded to App Store Connect successfully.")
+        UI.important("⚠️  Auto-submit to « Beta Testeurs » skipped: previous build of this train is still in Apple's review queue.")
+        UI.important("👉  Manual step: once the previous build clears review, open App Store Connect → TestFlight → Beta Testeurs group → submit this build for review.")
+        # Exit clean — the binary IS in ASC, no retry needed. Re-uploading
+        # would trip altool's duplicate-bundle-version guard.
       else
         raise
       end


### PR DESCRIPTION
## Summary

PR #669 dev→staging promote (TestFlight run 26242482987 at 2026-05-21 17:34 UTC) uploaded build 66 to App Store Connect successfully but the workflow exited non-zero, masking the actual success as a failure.

## Root cause

Fastfile rescue block at line 165 catches the expected « Another build is in review » error (previous build of train 2.12.4 still in Apple's review queue) and re-tries `upload_to_testflight(skip_submission: true)` assuming altool would fast-path a duplicate upload.

**altool does NOT fast-path.** It rejects the duplicate with :

```
-19232 ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE
The bundle version must be higher than the previously uploaded version: '66'.
```

This makes the entire fastlane lane exit non-zero on every staging promote where the previous build is still in beta review — a recurring false-positive across PR #660, #661, #667, #669.

## Evidence build 66 IS already in App Store Connect

From the TestFlight workflow log (run 26242482987, step 20) :

```
17:43:20  Successfully uploaded package to App Store Connect. It might take a few minutes until it's visible online.
17:43:20  Successfully uploaded the new binary to App Store Connect
17:43:20  Waiting for processing on... app_id: 6759292583, app_version: 2.12.4, build_version: 66, platform: IOS
17:45:22  Auto-submit for beta review skipped: previous build of this train is still in Apple's review queue.
17:45:25  [altool] -19232 ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE        ← retry double-fire
```

The retry is the failing call. The first call's binary push succeeded.

## Fix

Remove the retry. Replace with operator-facing messaging :

```
✅ Binary uploaded to App Store Connect successfully.
⚠️  Auto-submit to « Beta Testeurs » skipped: previous build of this
   train is still in Apple's review queue.
👉  Manual step: once the previous build clears review, open
   App Store Connect → TestFlight → Beta Testeurs group → submit
   this build for review.
```

The workflow now exits 0 in the "previous-build-in-review" case, matching the real outcome.

## Risk

Low. The rescue regex only matches `« Another build is in review »` or `« already in beta review »` — both Apple-side states that occur AFTER the binary push (`Successfully uploaded the new binary` log line), never before it. If altool itself fails to upload, the rescue does not match and re-raises (unchanged behavior).

## Test plan

- [x] Read the actual TestFlight log for run 26242482987 confirming binary 66 IS in ASC despite workflow exit 1
- [x] Doctrine atomicity gate PASS (0/6 doctrine files touched)
- [ ] Next dev→staging promote (whoever does it next, with pubspec bumped to ≥67) → workflow exits 0 even when previous build is still in beta review
- [ ] Julien verifies build 66 in App Store Connect → TestFlight → submits to Beta Testeurs manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)