### PR TITLE
feat(backend): POST /api/v1/waitlist + WaitlistEntry model (sub-phase 01.5 PR-1)

### DIFF
--- a/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-CONTEXT.md
+++ b/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-CONTEXT.md
@@ -1,0 +1,135 @@
+---
+name: 01.5-archetype-hard-gate-fatca
+description: P0 legal blocker — route non-supported archetypes (expat_us FATCA + 5 others) to « pas encore supporté » waitlist screen instead of silently falling back to swiss_native. Closes sub-phase 01.5 of the production-readiness audit.
+metadata:
+  type: phase-context
+  parent_phase: 01-mint-production-readiness-audit-identify-top-blockers-to-fir
+  audit_finding: P0-1
+  status: research
+---
+
+# Sub-phase 01.5 — Archetype HARD GATE (FATCA + 5 others)
+
+**Parent** : `.planning/phases/01-mint-production-readiness-audit-identify-top-blockers-to-fir/01-CONTEXT.md` §6 P0-1.
+**Sibling closed sub-phases** : `01.1` (walkthrough-first grounding, ✓), `01.4` (coach runtime stale-data, ✓).
+**Status** : RESEARCH in flight (2026-05-21 20:30 UTC).
+
+---
+
+## §1 Why this sub-phase exists
+
+MINT's coach reasoning corpus, legal disclaimers, and tax calculations are calibrated for **2 archetypes only** :
+
+- `swiss_native` — Swiss-resident salaried employee, LPP enrolled
+- `swiss_native_couple` — Swiss-resident couple, LPP enrolled, joint filer
+
+The codebase has enum entries + walker hooks for **6 additional archetypes**, but their tax/social-insurance/regulatory pathways are NOT covered by the registry, the coach grounding corpus, or the LSFin disclosure templates :
+
+- `expat_us` — **FATCA P0**. US persons under FATCA have unique reporting obligations (Forms 8938, FBAR), and the 3a pillar is taxable as US-source income in many cases. Giving any 3a / LPP guidance without FATCA awareness is a **legal compliance failure** that LSFin art. 7-10 will not protect.
+- `expat_eu` — EU bilateral agreements (AVS coordination, cross-border worker rules) materially change LPP / 3a / impôt-source mechanics.
+- `cross_border` — French/German/Italian/Austrian frontaliers (permis G) hit `impôt à la source` with non-Swiss tax filing implications.
+- `independent_no_lpp` — Self-employed without 2e pilier, max 3a is 36'288 CHF (vs 7'258 for salaried) — calculator + coach narrative both diverge.
+- `couple_one_works` — Plafond conjugal joint, asymmetric 3a / LPP eligibility.
+- `senior_post_64` — Past retirement age, no more 3a contributions, RA timing constraints.
+
+**Silent fallback today** : when archetype detection is ambiguous or absent, the codebase defaults to `swiss_native`. This means an `expat_us` user (FATCA subject) talking to MINT receives 3a + LPP + tax guidance calibrated for a Swiss native — a **legal compliance failure**.
+
+01.1 RESEARCH §5 A1 (audit master plan line 528, 956) flagged this :
+
+> The TRUE silent-fallback site is in archetype-detection code (where ambiguous signals default to `swissNative`), not in `coach_profile.dart:96` (which is just the enum case-match for serialization). The boundary-integrity mapper (Mapper 4) MUST grep for the actual detection site (`detectArchetype`, `archetypeFromSignals`, etc.) BEFORE writing the P0-1 finding.
+
+**This sub-phase 01.5 executes that mapper-grep + fixes the gate.**
+
+---
+
+## §2 Goal (binary, mechanical)
+
+A user with archetype ∈ {`expat_us`, `expat_eu`, `cross_border`, `independent_no_lpp`, `couple_one_works`, `senior_post_64`} :
+
+1. Does NOT receive any coach grounding, 3a/LPP calculation, or tax narrative
+2. IS routed to a « Encore en chantier pour ton profil » waitlist screen
+3. Can submit an email to be notified when their archetype lands
+4. The email is persisted via `POST /api/v1/waitlist`
+
+Mechanical pass criterion :
+- Maestro flow `flow_hardgate_expat_us.yaml` with `--dart-define=MINT_E2E_ARCHETYPE=expat_us` reaches the waitlist screen, NOT the coach chat
+- The waitlist screen renders the FR copy contract from §4
+- Email submission persists to the DB (verifiable via Railway staging probe)
+
+---
+
+## §3 Method (parallel research, then sequential patch)
+
+**Wave 0** (this turn) — 3 parallel research agents :
+
+| Agent | Mission | Output file |
+|---|---|---|
+| `gsd-codebase-mapper` | Grep `apps/mobile/lib/` for archetype-detection code (`detectArchetype`, `archetypeFromSignals`, `defaultArchetype`, `inferArchetype`, fallback to `swissNative`). Map the call graph from onboarding entry to the first place archetype is materialized. Identify the silent-fallback line(s) precisely. | `01.5-MAPPER-archetype-detection.md` |
+| `security-auditor` (wshobson) | Scope FATCA P0 legal hard-gate. For each of the 6 non-supported archetypes, summarize the SPECIFIC compliance risk if MINT serves them (FATCA reporting, frontalier impôt à la source, etc.). Confirm the « waitlist + opt-in email » screen is sufficient mitigation (vs. blocking signup altogether). Cite LSFin art. 7-10 + relevant Swiss FINMA / OAR guidance. | `01.5-SECURITY-fatca-scope.md` |
+| `flutter-expert` + `ui-designer` (consult mode) | Specify the « waitlist » screen FR copy + interaction contract. Email input + submit + post-submit confirmation. Use MintColors + MintUI kit. Lock the ARB keys + route name. | `01.5-UI-waitlist-spec.md` |
+
+**Wave 1** (next turn) — synthesize 3 outputs → `01.5-PLAN.md` with atomic patches :
+
+1. Patch backend : add `POST /api/v1/waitlist` (email + archetype + locale + timestamp persisted to a new table, simple insert-only)
+2. Patch mobile : add waitlist screen + ARB keys (6 locales) + route + email-submit service
+3. Patch detection : add HARD GATE between archetype materialization and coach entry — non-allowed archetype → push to waitlist route, NOT coach
+4. Patch Maestro : new flow `flow_hardgate_expat_us.yaml` asserting the gate
+
+**Wave 2** (after patches) — Maestro verification :
+- Run `flow_hardgate_expat_us.yaml` against staging Railway → exit 0
+- Run hero flow `flow_hero_marge_fiscale_3a.yaml` against staging Railway with default (`swiss_native`) → exit 0 (regression guard)
+- Device walkthrough by Claude (G2 per memory `feedback_device_gates`)
+
+---
+
+## §4 Copy contract (FR placeholder, locked in Wave 0 UI agent output)
+
+```
+[Title]   Encore en chantier pour ton profil
+[Body]    MINT est calibré aujourd'hui pour les personnes résidentes
+          en Suisse, salariées et affiliées à un 2e pilier (LPP).
+
+          Ton profil correspond à une situation que nous couvrirons
+          prochainement (expatrié·e, frontalier·ère, indépendant·e
+          sans LPP, ou retraité·e après 64 ans).
+
+          Laisse-nous ton email et nous te préviendrons dès qu'on
+          ouvre MINT à ton parcours.
+
+[CTA]     [Email input + bouton « Préviens-moi »]
+
+[Post-submit]   Merci, on revient vers toi.
+```
+
+Final copy + i18n keys locked by the `flutter-expert` agent output.
+
+---
+
+## §5 Risks + open questions
+
+- **Q1** : Should the gate trigger BEFORE or AFTER signup ? Pre-signup avoids persisting user data we won't serve. Post-signup lets us capture archetype refinement during the onboarding sequence. → security-auditor + product-manager call.
+- **Q2** : What's the « detection » signal that disambiguates `swiss_native` from `expat_us` ? Nationality field ? Residency duration ? US-tax-filer flag ? Current onboarding may not collect these — adding them is in scope iff the gate can't fire reliably otherwise.
+- **Q3** : Is the « waitlist email » a marketing comm or a transactional comm under LSFin / LPD ? Different consent UX implied.
+- **Q4** : Walker `--dart-define=MINT_E2E_ARCHETYPE=expat_us` injects the archetype at app launch, bypassing the detection logic. The Maestro flow MUST exercise the gate at the DETECTION-site level (not just the route guard) to actually test the fallback fix.
+
+---
+
+## §6 Acceptance gates (5-gate per memory `feedback_perimeter_5_gates`)
+
+- **G1** (sim walker) : `flow_hardgate_expat_us.yaml` exits 0 on staging Railway with archetype=expat_us
+- **G2** (device by Claude) : iPhone sim walkthrough with `expat_us` archetype reaches waitlist screen, submits email, sees confirmation
+- **G3** (dev CI) : full backend + flutter test suite green on the merge sha
+- **G4** (regression) : 29/29 anonymous_chat tests + hero flow `flow_hero_marge_fiscale_3a.yaml` still pass against the same merge sha
+- **G5** (LSFin + accent + ARB) : `check_banned_terms()` MCP on all new copy + `accent_lint_fr.py` + `validate_arb_parity()` MCP all green
+
+No claim « 01.5 closed » without all 5 gates green per CLAUDE.md §9 (0-trust protocol).
+
+---
+
+## §7 Out of scope (deferred to 01.6 or later)
+
+- The 6-locale banned-term + ARB-orphan cleanup (01.6 separate sub-phase per HANDOFF)
+- BYOK copy leak « ta clé API » (F-01.1-03, escalated to 01.6)
+- DSAR fact_event manifest fix (P0-3 per audit, separate sub-phase)
+- Forced tool-invocation merge-blocker (P0-4, separate sub-phase)
+- Adding NEW archetype support (couple_one_works, etc.) — this sub-phase ONLY adds the GATE, not the archetype implementations

--- a/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-MAPPER-archetype-detection.md
+++ b/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-MAPPER-archetype-detection.md
@@ -1,0 +1,253 @@
+---
+name: 01.5-MAPPER-archetype-detection
+description: Where archetype is assigned in apps/mobile/lib/ and where the silent-fallback to swissNative happens. Consumed by 01.5 sub-phase planning.
+metadata:
+  type: codebase-map
+  parent_phase: 01.5-archetype-hard-gate-fatca
+  scope: apps/mobile/lib/
+  read_only: true
+  date: 2026-05-21
+---
+
+# Mapper output — archetype detection in apps/mobile/lib/
+
+## §1 Detection / inference sites (where archetype is COMPUTED)
+
+Two parallel detection implementations exist (this is a finding in itself — duplicated logic, not single-source-of-truth).
+
+### §1.1 PRIMARY detection — `CoachProfile.archetype` getter
+
+`apps/mobile/lib/models/coach_profile.dart:1855-1894` — `FinancialArchetype get archetype` (instance getter on `CoachProfile`). Returns the typed enum. Called by every read-site in §4.
+
+```dart
+// apps/mobile/lib/models/coach_profile.dart:1855
+FinancialArchetype get archetype {
+  final permitCanonical = normalizeResidencePermit(residencePermit);
+  if (permitCanonical == 'G') return FinancialArchetype.crossBorder;
+  if (nationality == 'US') return FinancialArchetype.expatUs;
+  if (employmentStatus == 'independant') { ... }
+  final isSwiss = nationality == null || nationality == 'CH';   // ← see §3
+  final arrivedEarly = arrivalAge == null || arrivalAge! < 22;  // ← see §3
+  if (isSwiss && arrivedEarly) return FinancialArchetype.swissNative;
+  ...
+}
+```
+
+### §1.2 SECONDARY detection — `FriComputationService.detectArchetype`
+
+`apps/mobile/lib/services/fri_computation_service.dart:200-239` — `static String detectArchetype(CoachProfile profile)`. Returns the snake_case **string slug**, not the enum. Order of checks is slightly different from §1.1 (independent first, then permit G, then US, then nationality CH).
+
+```dart
+// apps/mobile/lib/services/fri_computation_service.dart:200
+static String detectArchetype(CoachProfile profile) {
+  final nat = profile.nationality?.toLowerCase() ?? '';
+  ...
+  if (emp == 'independant') { return ...; }                     // 1.
+  if (permit == 'G') return 'cross_border';                     // 2.
+  if (nat == 'us' || nat == 'usa') return 'expat_us';           // 3.
+  if (nat == 'ch' || nat == 'suisse' || nat == 'schweiz') {     // 4.
+    if (profile.arrivalAge != null && profile.arrivalAge! > 20) return 'returning_swiss';
+    return 'swiss_native';
+  }
+  if (profile.arrivalAge != null && profile.arrivalAge! > 20) { ... }  // 5.
+  return 'swiss_native';                                        // ← see §3
+}
+```
+
+Called from:
+- `apps/mobile/lib/services/fri_computation_service.dart:182` (FRI computation pipeline).
+- `apps/mobile/lib/services/coach_narrative_service.dart:282` (coach narrative archetype tag).
+
+**Mismatch with §1.1**: the §1.2 implementation uses `arrivalAge > 20` (line 221/228) where §1.1 uses `arrivalAge < 22` (line 1876). Both will silently return `swiss_native` for unknown / empty nationality.
+
+### §1.3 No `archetypeFromSignals` / `inferArchetype` / `resolveArchetype` / `defaultArchetype` / `fallbackArchetype`
+
+Grep results explicit:
+- `grep -rn "archetypeFromSignals\|inferArchetype\|resolveArchetype"` → **0 matches**.
+- `grep -rn "defaultArchetype\|fallbackArchetype"` → **0 matches** (no named default constant).
+
+The silent fallback is **inline** in §1.1 and §1.2 (the trailing `return swiss_native` / `if isSwiss && arrivedEarly` branch), not extracted into a named function.
+
+---
+
+## §2 Assignment sites (where archetype is WRITTEN to a profile/state object)
+
+The `CoachProfile.archetype` is a **computed getter**, not a stored field — there is no setter. Archetype is materialized **indirectly** via four input fields: `nationality`, `residencePermit`, `employmentStatus`, `arrivalAge`.
+
+### §2.1 Profile materialization sites (where nationality / permit are first populated)
+
+- `apps/mobile/lib/providers/coach_profile_provider.dart:725-735` — `updateFromSmartFlow` derives `nationality` from `nationalityGroup` form input:
+  ```dart
+  if (nationalityGroup == 'CH') nationality = 'CH';
+  else if (nationalityGroup == 'EU') nationality = 'FR'; // placeholder
+  else if (nationalityGroup == 'OTHER') nationality = nationalityCountry; // 'US' or null
+  ```
+  If `nationalityGroup` is null (skipped / smart-flow not run yet) → `nationality` stays null → archetype computes to `swissNative` (§3).
+- `apps/mobile/lib/providers/coach_profile_provider.dart:887-899` — `CoachProfile(...)` constructed from remote backend payload **with no `nationality` field passed in** — silently null.
+- `apps/mobile/lib/models/coach_profile.dart:1576-1585` — `CoachProfile.defaults()` constructor used by tests / fallback paths. No `nationality`, no `residencePermit`, no `arrivalAge` → archetype defaults to `swissNative`.
+
+### §2.2 Stored slug fields (string archetypes attached to other state objects)
+
+Not the canonical archetype, but parallel slug fields that carry the inferred value forward:
+
+- `apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart:54` — `String _archetype = 'swiss_native';` (hard-coded local default; overwritten on line 196 from `profile.archetype.backendName`).
+- `apps/mobile/lib/services/financial_core/fri_calculator.dart:80` — `this.archetype = 'swiss_native'` (default arg in FRI calculator constructor).
+- `apps/mobile/lib/services/lpp_deep_service.dart:87` — `String archetype = 'swiss_native'` (default arg in LPP deep service).
+- `apps/mobile/lib/services/coach/coach_models.dart:102` — `this.archetype = ''` (CoachContext empty default — different bug, opposite direction).
+- `apps/mobile/lib/services/coach/coach_context_builder.dart:78` — `String archetype = ''` (default arg).
+- `apps/mobile/lib/services/coach/coach_profile_seeds.dart:97,105,113,121` — all four walker seeds (`julien_swiss`, `couple_acheteurs_lausanne`, `jeune_diplome_zurich`, `cadre_40_55_lpp_rachat`) hard-code `archetype: 'swiss_native'`. **None of the 6 non-Swiss archetypes are exercised by the walker today.**
+
+---
+
+## §3 The silent-fallback line(s) (the actual bug location)
+
+Three concurrent silent-fallback sites — fixing one without the others leaves the bug.
+
+### §3.1 PRIMARY silent fallback (used by every coach + UI read site)
+
+`apps/mobile/lib/models/coach_profile.dart:1875-1878`:
+
+```dart
+// Swiss native: nationality CH and arrived before 22 (or no arrival age)
+final isSwiss = nationality == null || nationality == 'CH';
+final arrivedEarly = arrivalAge == null || arrivalAge! < 22;
+
+if (isSwiss && arrivedEarly) return FinancialArchetype.swissNative;
+```
+
+This is THE silent fallback. `nationality == null` (no signal) is treated identically to `nationality == 'CH'` (positive Swiss signal). The downstream coach + tax + FATCA disclosure code path assumes Swiss-native and bypasses the FATCA gate.
+
+Confirmed by `apps/mobile/lib/screens/coach/coach_chat_screen.dart:1707-1711` comment (B6 fix 2026-05-08): *"the previous build dropped the field on the floor → empty default → doctrine_checks fall-through PASS → FATCA bypass on expat_us etc. ~35-45% of CH residents were mis-archétypés silently."*
+
+### §3.2 SECONDARY silent fallback (used by FRI + narrative)
+
+`apps/mobile/lib/services/fri_computation_service.dart:237-238`:
+
+```dart
+// 6. Foreign national arrived young (< 20) → treated as swiss_native
+return 'swiss_native';
+```
+
+This is the trailing `return` of `detectArchetype`. Hit when nationality is non-CH, non-US, non-EU/EFTA AND `arrivalAge` is null or ≤20 — i.e. unknown nationality + unknown arrival age also lands here silently.
+
+### §3.3 Hard-coded local defaults (less critical, but they leak)
+
+- `apps/mobile/lib/screens/lpp_deep/rachat_echelonne_screen.dart:54` — `String _archetype = 'swiss_native';`. Overwritten in `initState` on line 196 from `profile.archetype.backendName`, but if the profile read fails or arrives late, the LPP rachat échelonné cap (OPP2 art. 60b) computes for swiss_native.
+- `apps/mobile/lib/services/financial_core/fri_calculator.dart:80` and `apps/mobile/lib/services/lpp_deep_service.dart:87` — default args `archetype = 'swiss_native'`. Any caller that omits the param silently runs the swiss_native code path.
+
+---
+
+## §4 Read sites (where archetype is BRANCHED on for routing or coach entry)
+
+All consumers read either `profile.archetype` (typed) or the snake_case slug forwarded into `CoachContext.archetype`.
+
+- `apps/mobile/lib/services/cap_engine.dart:1194,1210` — CAP engine branches on `crossBorder` for late-LPP rule.
+- `apps/mobile/lib/services/response_card_service.dart:583` — `if (profile.archetype == FinancialArchetype.expatUs)` for FATCA card.
+- `apps/mobile/lib/services/lifecycle_phase_service.dart:371-412` — switch on every archetype to inject lifecycle priorities (`fatca_compliance`, `avs_gap_analysis`, `source_tax_optimization`, …).
+- `apps/mobile/lib/services/nudge/nudge_engine.dart:217,218,222,373` — gates nudges on `expatUs` and `independentNoLpp`.
+- `apps/mobile/lib/services/coach/precomputed_insights_service.dart:327,346` — `independentNoLpp` branching.
+- `apps/mobile/lib/services/coach/data_driven_opener_service.dart:202,266` — opener selection.
+- `apps/mobile/lib/services/coach/coach_orchestrator.dart:1281` — `if (ctx.archetype == 'expat_us')` → FATCA fallback template. **This is the LLM prompt-shaping read site. If §3.1 mis-classified the user, this branch is silently skipped.**
+- `apps/mobile/lib/screens/simulator_3a_screen.dart:171` — 3a simulator branches on `independentNoLpp`.
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart:1711` — converts to backend snake_case for LLM context.
+- `apps/mobile/lib/widgets/aujourdhui/cap_du_jour_banner.dart:106` and `apps/mobile/lib/widgets/home/confidence_score_card.dart:280` — UI surfaces that pass archetype to backend.
+
+**No read site currently gates the user OUT.** Every read site assumes the archetype is correct and branches on the value.
+
+---
+
+## §5 Walker dart-define hook
+
+`apps/mobile/lib/services/coach/coach_profile_seeds.dart:86-148` — `CoachProfileSeeds`.
+
+- Line 86-87: `static const String _archetypeDartDefine = String.fromEnvironment('MINT_E2E_ARCHETYPE');`
+- Line 132-138: `forcedArchetypeSlug()` returns the slug if in non-release build AND slug is in `registry`. `kReleaseMode` short-circuits to null in App Store IPAs.
+- Line 90-124: `registry` contains **4 seeds**, ALL with `archetype: 'swiss_native'`. The walker therefore CANNOT today exercise expat_us / cross_border / independent / returning_swiss / expat_eu / expat_non_eu paths.
+- Line 144-148: `activeSeed` getter — the hydrated profile a walker run uses.
+- Consumed by `apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart:368` (`CoachProfileSeeds.activeSeed`) to drive `_seedToMinimalProfile` fallback when backend doesn't return an éclairage payload.
+
+**Finding**: The dart-define hook plumbing exists, but the seed registry is swiss_native-only. To test §3.1 with the walker, the registry needs at least one non-swiss seed (e.g. `julien_expat_us`).
+
+---
+
+## §6 Call graph
+
+Entry-to-coach call graph for an anonymous user opening the app cold (the path where §3.1 fires):
+
+```
+1. App boot (apps/mobile/lib/app.dart:220-303 redirect)
+     │   RouteScope check (public / onboarding / authenticated).
+     │   NO archetype check anywhere in the redirect chain.
+     ▼
+2. SmartFlow / onboarding 3-question form
+     │   apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
+     │   (3 questions: age, salaire, canton — nationality NOT asked here)
+     ▼
+3. CoachProfileProvider.updateFromSmartFlow(age, grossSalary, canton, …)
+     │   apps/mobile/lib/providers/coach_profile_provider.dart:688-816
+     │   `nationalityGroup` parameter is OPTIONAL — if not passed, nationality stays null.
+     │   Constructs answers map → CoachProfile.fromWizardAnswers(answers).
+     ▼
+4. CoachProfile materialized
+     │   apps/mobile/lib/models/coach_profile.dart (constructor at :1527, factories at :2038, :2216, :2949, :3236)
+     │   nationality / residencePermit / arrivalAge may all be null at this stage.
+     ▼
+5. First read of profile.archetype getter
+     │   apps/mobile/lib/models/coach_profile.dart:1855-1894
+     │   ─── SILENT FALLBACK FIRES (§3.1, line 1878) → returns swissNative ───
+     ▼
+6. Coach entry — coach_chat_screen builds CoachContext
+     │   apps/mobile/lib/screens/coach/coach_chat_screen.dart:1702-1715
+     │   Passes archetype = 'swiss_native' (mis-classified) into the LLM context.
+     ▼
+7. Coach orchestrator reads ctx.archetype
+     │   apps/mobile/lib/services/coach/coach_orchestrator.dart:1281
+     │   `if (ctx.archetype == 'expat_us')` → NEVER FIRES → no FATCA disclosure.
+     ▼
+8. LLM returns a Swiss-native-shaped response. User sees swiss_native advice,
+   FATCA / cross-border / expat-EU disclosures never surfaced.
+```
+
+The HARD GATE belongs at step 5 (the getter itself) OR at step 6 (the CoachContext build) OR at step 1 (router redirect when archetype unknown). Recommendation in §7.
+
+---
+
+## §7 Recommended gate insertion point
+
+### §7.1 Primary recommendation — gate at the getter (§3.1)
+
+**File:line**: `apps/mobile/lib/models/coach_profile.dart:1855-1894` (`FinancialArchetype get archetype`).
+
+**Change shape**:
+1. Add a new enum value `FinancialArchetype.unknown` (or a separate `archetypeOrNull` getter that returns `FinancialArchetype?`).
+2. Replace `final isSwiss = nationality == null || nationality == 'CH'` with explicit null-check: return `unknown` (or null) when nationality is null AND residencePermit is null AND employmentStatus is null AND arrivalAge is null. Treat `'CH'` as a positive signal only.
+3. Every read site in §4 must then handle the `unknown` case — either by surfacing an enrichment prompt or by pushing the user to a waitlist route.
+
+**Why this site**: it is the single chokepoint. Every read site already goes through this getter. Fixing it once propagates to coach + cap_engine + nudge_engine + lifecycle + UI surfaces in one move. The §1.2 duplicate in `fri_computation_service.dart:200` must be fixed in the same PR or it leaks.
+
+### §7.2 Secondary recommendation — gate at the coach entry point
+
+**File:line**: `apps/mobile/lib/screens/coach/coach_chat_screen.dart:1702-1715` (just before `return CoachContext(...)`).
+
+**Change shape**: before building the CoachContext, check `profile.archetype` against the calibrated set `{swissNative, swissNativeCouple}` (note: `swissNativeCouple` does not yet exist as an enum value per `coach_profile.dart:95-112` — only `swissNative` is calibrated today; if the audit requires two values, the enum must be extended OR the gate must additionally read `profile.isCouple` at line 1913). If archetype not in the set → navigate to `/waitlist` instead of building the context.
+
+**Why this site (vs §7.1)**: smaller blast radius, doesn't require touching every read site. But it ONLY protects the LLM call — cap_engine, nudge_engine, response_card_service still execute on the mis-classified swiss_native value and may surface incorrect numbers / cards before the user even opens the coach. Use §7.2 only if §7.1 is judged too invasive for the timeline.
+
+### §7.3 Tertiary recommendation — gate at the router
+
+**File:line**: `apps/mobile/lib/app.dart:220-303` (the GoRouter `redirect:` callback).
+
+**Change shape**: add a new `RouteScope.archetypeCalibrated` case. When entering a route with that scope, read `CoachProfileProvider.profile?.archetype` and redirect to `/waitlist` if archetype is not in the calibrated set. Tag every coach / cap / 3a / LPP route with this new scope.
+
+**Why this site**: hardest gate to bypass (all navigation goes through GoRouter). But requires tagging every consuming route and creating the new scope value — more code churn than §7.1.
+
+### §7.4 Risks — what other call paths bypass each candidate site
+
+- **§7.1 risk**: the `FriComputationService.detectArchetype` duplicate at `fri_computation_service.dart:200` returns a STRING slug, not the enum. It does NOT call the getter. It is a parallel detection path. Any FRI computation triggered before the user touches the coach (e.g. precomputed insights at `precomputed_insights_service.dart:327`) will still silently return `swiss_native`. **Fix BOTH §1.1 and §1.2 in the same PR.**
+- **§7.2 risk**: bypassed by `lifecycle_phase_service.dart:371` (lifecycle priority computation), `cap_engine.dart:1194` (CAP banner), `response_card_service.dart:583` (response cards), `nudge_engine.dart:217` (nudges). These all read `profile.archetype` directly without going through `coach_chat_screen.dart`. The user could see a swiss_native CAP banner before opening the coach.
+- **§7.3 risk**: deep links / notifications that bypass the redirect (e.g. `intent=`-carrying notifications routed via `app.dart:251-275`) — the redirect runs, but if the redirect itself rewrites the path (line 258, 262, 267, 270-273) the new path may not carry the calibrated scope tag. Audit every `return '/...'` in the redirect to ensure the destination is also scope-tagged.
+- **All three sites risk**: the walker dart-define seed registry (§5) hard-codes `swiss_native` for all 4 seeds. Even after a hard gate ships, the walker won't exercise the non-swiss path until at least one non-swiss seed is added at `coach_profile_seeds.dart:90-124`. Otherwise Maestro Gate 1 will never see the waitlist route surface.
+
+---
+
+*Mapper output, 2026-05-21. ≤300 lines. Read-only. Cited file:line for every claim.*

--- a/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-PLAN.md
+++ b/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-PLAN.md
@@ -1,0 +1,194 @@
+---
+name: 01.5-PLAN
+description: Atomic patch sequence for sub-phase 01.5 archetype HARD GATE. Synthesized from MAPPER + SECURITY + UI agent outputs (Wave 0 2026-05-21).
+metadata:
+  type: phase-plan
+  parent_phase: 01.5-archetype-hard-gate-fatca
+  date: 2026-05-21
+  status: locked
+---
+
+# Sub-phase 01.5 — Atomic Patch Plan
+
+**Inputs synthesized** :
+- [01.5-CONTEXT.md](01.5-CONTEXT.md) — sub-phase scope, 5-gate exit
+- [01.5-MAPPER-archetype-detection.md](01.5-MAPPER-archetype-detection.md) — silent-fallback line at `coach_profile.dart:1875` + duplicate `fri_computation_service.dart:237-238`
+- [01.5-SECURITY-fatca-scope.md](01.5-SECURITY-fatca-scope.md) — VERDICT : waitlist + opt-in IS sufficient ; 4 consent guardrails ; pre-signup gating ; false-positive bias mandatory
+- [01.5-UI-waitlist-spec.md](01.5-UI-waitlist-spec.md) — 12 ARB keys, FilledButton pattern from `anonymous_chat_screen.dart:576`, zero new wrapper widgets
+
+---
+
+## §0 Resolved blockers (decided 2026-05-21)
+
+| Blocker | Decision | Source |
+|---|---|---|
+| Legal entity name | **MINT SA** | `services/backend/app/services/privacy_service.py:41` |
+| Consent UX | **Explicit opt-in checkbox** (NOT fine-print-only) | Security §5 guardrail #1 supersedes UI §11 Q3 |
+| Locale ship gating | **FR + EN + DE ship-blocking** ; IT/ES/PT carry FR fallback + `// TODO i18n` | UI §6 + product call |
+| `expatUs` detection signal | **Add binary onboarding Q « Es-tu citoyen ou résident fiscal aux États-Unis ? »** before any financial data collection | Security §6 Q3 + §4 pre-signup ; FATCA false-negative is non-recoverable |
+| Auto-delete partial onboarding data on gate fire | **In scope for 01.5** | Security §6 Q5 ; nLPD art. 6 minimization |
+| Anonymous session UUID | **Reuse `AnonymousSessionService.getOrCreate()`** (`apps/mobile/lib/services/anonymous_session_service.dart:18`) | resolves UI §11 Q7 |
+| Gate insertion point | **Primary §7.1 (the getter at `coach_profile.dart:1875`)** + mandatory parallel fix at `fri_computation_service.dart:237-238` | Mapper §7.1 — single chokepoint |
+| `swissNativeCouple` enum entry | **Read `profile.isCouple` flag at gate-evaluation site** ; do NOT extend enum (smaller-blast) | Mapper §7.2 risk note ; keeps the diff minimal |
+
+---
+
+## §1 Patch sequence
+
+3 atomic patches, sequenced for review hygiene. Each PR is a feature → dev squash.
+
+### PR-1 — Backend : Waitlist endpoint + persistence (Patch A)
+
+**Goal** : land the `POST /api/v1/waitlist` endpoint independently of mobile. Easier to review, smaller blast radius, ships first so the mobile PR can integrate against a live staging endpoint.
+
+**Files touched** (~6) :
+- `services/backend/app/models/waitlist_entry.py` — NEW. SQLAlchemy model. Columns : `id (uuid pk)`, `email (string indexed)`, `archetype (string, Literal-validated)`, `locale (string, Literal-validated)`, `source (string, Literal-validated, default 'other')`, `anonymous_session_id (uuid, indexed)`, `created_at (timestamptz, default now())`, `notified_at (timestamptz, nullable)`, `consent_given (bool, NOT NULL)`, `legal_entity (string, default 'MINT SA')`, `retention_purge_after (timestamptz, default now() + 12 months)`. Per Security §5 guardrails 1-4 + Q2.
+- `services/backend/alembic/versions/pXXX_waitlist_entry.py` — NEW. Alembic migration. CREATE TABLE + indexes on `email`, `archetype`, `anonymous_session_id`, `created_at`. Per memory `project_orm_orphan_pattern` — model + migration in same PR.
+- `services/backend/app/schemas/waitlist.py` — NEW. Pydantic v2 request/response schemas. `WaitlistRequest{email: EmailStr, archetype: Literal[...], locale: Literal[...], source: Literal[...], consentGiven: bool}` (camelCase via `alias_generator`). `WaitlistResponse{id: UUID, createdAt: datetime}`.
+- `services/backend/app/api/v1/endpoints/waitlist.py` — NEW. `POST /waitlist` route. Reuses `_UUID_RE` validator from `anonymous_chat.py:354-362` for `X-Anonymous-Session`. Returns 201 (success) / 400 (validation) / 401 (no session) / 409 (dedup) / 500.
+- `services/backend/app/api/v1/router.py` — register new endpoint.
+- `services/backend/tests/test_waitlist.py` — NEW. ≥ 10 tests : 201 happy path × 6 archetypes ; 400 invalid email ; 400 invalid archetype ; 401 missing/malformed session ; 409 dedup (if implemented) ; 500 on DB failure.
+
+**Mechanical gates** :
+- `cd services/backend && python3 -m pytest tests/test_waitlist.py -q` exit 0
+- Alembic upgrade head + downgrade both succeed on a clean Postgres
+- `ruff check services/backend/app/api/v1/endpoints/waitlist.py services/backend/app/schemas/waitlist.py` exit 0
+- `check_banned_terms(text)` MCP on `WaitlistResponse.detail` strings (none should contain banned terms ; pre-verified clean)
+
+**Risk** : low — pure additive backend, no existing route touched, no mobile dependency yet.
+
+---
+
+### PR-2 — Mobile : Detection fix + gate + waitlist screen + walker seed (Patches B + C + D + E)
+
+**Goal** : ship the mobile-side hard gate end-to-end as one atomic unit. Splitting B vs C vs D would create intermediate states where the gate exists but the screen doesn't render, or vice versa — bad UX in any intermediate ship.
+
+**Files touched** (~14-18) :
+
+**B — WaitlistScreen + Provider + Service** (UI §1-§10) :
+- `apps/mobile/lib/screens/waitlist/waitlist_screen.dart` — NEW per UI §1-§4.
+- `apps/mobile/lib/screens/waitlist/widgets/waitlist_form.dart` — extracted form (state machine) ; keeps `WaitlistScreen` thin.
+- `apps/mobile/lib/screens/waitlist/widgets/waitlist_success.dart` — success state widget.
+- `apps/mobile/lib/providers/waitlist_provider.dart` — NEW. `enum WaitlistStatus { initial, submitting, success, error }` per UI §4.
+- `apps/mobile/lib/services/waitlist_service.dart` — NEW. Single POST method ; reuses `AnonymousSessionService.getOrCreate()`. Returns `Future<Result<WaitlistResponse, WaitlistError>>` (or similar — match existing service convention via grep).
+- `apps/mobile/lib/l10n/app_fr.arb` + `app_en.arb` + `app_de.arb` — 13 keys translated (12 from UI §5 + 1 for the US-tax-person Q + 1 consent checkbox label). Per CLAUDE.md §6 i18n required.
+- `apps/mobile/lib/l10n/app_it.arb` + `app_es.arb` + `app_pt.arb` — 13 keys with FR fallback + `// TODO i18n <locale>` comment (validate_arb_parity() requires presence).
+
+**C — Detection fix** (Mapper §3 + §7.1) :
+- `apps/mobile/lib/models/coach_profile.dart:95-112` — add `FinancialArchetype.unknown` enum value + backendName mapping.
+- `apps/mobile/lib/models/coach_profile.dart:1855-1894` — refactor the getter. Replace `final isSwiss = nationality == null || nationality == 'CH';` with `final isSwiss = nationality == 'CH';`. Add `final isUsTaxPerson = usTaxPerson == true;` check (NEW field on CoachProfile). If `isUsTaxPerson` → `expatUs`. If ALL of {nationality, residencePermit, employmentStatus, arrivalAge} are null AND `isUsTaxPerson` is null → return `FinancialArchetype.unknown` (NEW silent-fallback-blocked branch). Otherwise existing logic.
+- `apps/mobile/lib/services/fri_computation_service.dart:200-239` — parallel fix. `final nat = profile.nationality?.toLowerCase() ?? '';` → if empty/null AND no other signal → return `'unknown'`. Trailing `return 'swiss_native'` replaced with `'unknown'`.
+- `apps/mobile/lib/models/coach_profile.dart` — add `bool? usTaxPerson` field + factory updates + JSON serialization.
+- `apps/mobile/lib/providers/coach_profile_provider.dart` — handle new `usTaxPerson` field in `updateFromSmartFlow` + persistence.
+
+**D — Gate wiring** (Security §4 pre-signup gate) :
+- `apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_provider.dart` — add US-tax-person Q as a new step BEFORE salary collection. New step writes to `coachProfileProvider.usTaxPerson`.
+- `apps/mobile/lib/screens/onboarding/mvp_wedge/scenes/us_tax_person_screen.dart` — NEW. Binary Yes/No screen with tooltip explaining FATCA in 1 sentence. Per Karpathy #2 — single-purpose screen.
+- `apps/mobile/lib/app.dart:212` (GoRouter) — add `ScopedGoRoute('/waitlist', scope: RouteScope.public)` per UI §1.
+- `apps/mobile/lib/screens/coach/coach_chat_screen.dart:1702-1715` — at coach entry, read `profile.archetype`. If archetype is NOT in `{swissNative}` AND `profile.isCouple` is false, OR archetype is NOT in `{swissNative}` AND `profile.isCouple` is true (couple of swiss native), route to `/waitlist` instead of building CoachContext.
+- `apps/mobile/lib/services/coach/coach_orchestrator.dart:1281` — secondary defense : if `ctx.archetype != 'swiss_native'` AND not in the calibrated couple set, return early with a refusal payload (defense-in-depth ; if the route gate is bypassed by a future deep-link, the orchestrator itself refuses to call the LLM).
+- `apps/mobile/lib/providers/coach_profile_provider.dart` — on `archetype == unknown` OR archetype-not-in-supported-set → invoke the existing `clearAll`-style method at line 2442 to wipe SharedPreferences AFTER waitlist submit succeeds (per Security §6 Q5 nLPD minimization).
+
+**E — Walker seed** (Mapper §5) :
+- `apps/mobile/lib/services/coach/coach_profile_seeds.dart:86-148` — add a new seed `julien_expat_us` with `archetype: 'expat_us'`, `nationality: 'US'`, `usTaxPerson: true`. Registry must validate when `MINT_E2E_ARCHETYPE=expat_us`.
+
+**Mechanical gates** :
+- `cd apps/mobile && flutter analyze` exit 0
+- `cd apps/mobile && flutter test` exit 0 (all existing + new tests)
+- `flutter gen-l10n` exit 0 (no missing keys)
+- `python3 tools/checks/accent_lint_fr.py --file apps/mobile/lib/l10n/app_fr.arb` exit 0
+- `validate_arb_parity()` MCP : 13 keys present in all 6 ARB files
+- `check_banned_terms(text)` MCP on every FR + EN + DE string : zero banned terms
+- 5+ new tests :
+  - `test/services/coach_profile_archetype_test.dart` : unknown archetype returned when all signals null + handles null `usTaxPerson` ; expatUs returned when `usTaxPerson: true` even if nationality is 'CH'
+  - `test/services/fri_computation_service_archetype_test.dart` : duplicate detector returns `'unknown'` when nationality empty
+  - `test/screens/waitlist/waitlist_screen_test.dart` : initial → submitting → success transition ; 400 error surfaces correct ARB key ; checkbox disables CTA when unchecked
+  - `test/providers/waitlist_provider_test.dart` : state machine transitions ; null archetype defaults to 'other'
+  - `test/router/route_archetype_guard_test.dart` : coach route blocked for unknown archetype
+
+**Risk** : medium — touches the archetype getter at the chokepoint. Every read site (10+ per Mapper §4) flows through this getter. Defensive : the new `unknown` case is propagated explicitly to every read site that previously assumed swiss_native. Test coverage on every read site is mandatory.
+
+**Panel review** (per CLAUDE.md routing rules — coach surface PR ≥ 100 lines) :
+Spawn the composite panel in parallel BEFORE merge :
+- `code-reviewer` — bugs, security smells (Pass 1)
+- `architect-review` — financial_core reuse + service boundaries (Pass 6 + 8)
+- `security-auditor` — re-verify LSFin / nLPD / FATCA mitigations in the implementation (Pass 2 + 7)
+- `qa-expert` — regression risk + test coverage (Pass 3)
+- `flutter-expert` + `accessibility-expert` + `design-system-architect` — Pass 4 i18n + Pass 5 design system
+
+BLOCKED by any 1 agent = do NOT `/ship`.
+
+---
+
+### PR-3 — Maestro flow + verification + close-out (Patch F)
+
+**Goal** : land the device evidence flow and the 5-gate close-out artifacts.
+
+**Files touched** (~4) :
+- `tools/simulator/flows/maestro-perfect-set/flow_hardgate_expat_us.yaml` — NEW. Launch app with `MINT_E2E_ARCHETYPE=expat_us` dart-define (via `walker.sh --archetype expat_us`). Drive onboarding → US-tax-person Q → Yes → assert `/waitlist` route is reached. Assert title « Encore en chantier » via Maestro text-match. Submit email + assert success state.
+- `tools/simulator/flows/maestro-perfect-set/flow_hero_marge_fiscale_3a.yaml` — regression guard. Verify still passes with default `swiss_native` archetype. Touch ONLY if minor adaptations needed to handle new US-tax-person Q on the swiss path (the Q should default to « Non » for `julien_swiss` seed).
+- `.planning/phases/01.5-archetype-hard-gate-fatca/01.5-VERIFICATION.md` — NEW. 5-gate close-out log per memory `feedback_perimeter_5_gates`. G1 (Maestro exit 0 staging) + G2 (Claude device walkthrough) + G3 (CI sha) + G4 (regression hero flow pass) + G5 (lints + banned terms + ARB parity all green).
+- `.planning/phases/01.5-archetype-hard-gate-fatca/HANDOFF-2026-05-22.md` — NEW. Next-session handoff per memory `feedback_html_evidence_report` + the 01.4 sibling pattern.
+
+**Mechanical gates** :
+- `flow_hardgate_expat_us.yaml` exit 0 against staging Railway (after PR-1 + PR-2 merged to staging)
+- `flow_hero_marge_fiscale_3a.yaml` exit 0 against same staging sha (regression)
+- `idb ui describe-all` final snapshot showing the waitlist screen rendering for `expat_us` seed
+
+**Risk** : low — verification-only PR, no code path changes.
+
+---
+
+## §2 Sequencing + dependencies
+
+```
+PR-1 (backend)           ┐
+                          ├── merge dev → promote staging → Railway redeploy
+PR-2 (mobile)            ─┘                                     │
+                                                                 ▼
+                                                             PR-3 (Maestro)
+                                                                 │
+                                                                 ▼
+                                                          01.5 close-out
+```
+
+- **PR-1 and PR-2 are independent** and can be reviewed in parallel, but PR-2 cannot ship to staging before PR-1 because the mobile waitlist service would 404. Solution : PR-1 merges first, then PR-2.
+- **PR-3 is hard-blocked** on PR-1 + PR-2 being on staging.
+- A combined PR-1 + PR-2 + PR-3 is technically possible but the panel review surface area (~20 files) makes blast-radius management harder. Splitting is the Karpathy #2-aligned choice.
+
+---
+
+## §3 Out of scope (explicit non-goals)
+
+- The 6-locale banned-term + ARB-orphan cleanup (separate sub-phase 01.6 per HANDOFF-2026-05-21)
+- BYOK copy leak « ta clé API » (F-01.1-03, escalated to 01.6)
+- DSAR fact_event manifest fix (audit P0-3, separate sub-phase)
+- Adding NEW archetype support (couple_one_works, etc.) — 01.5 ONLY adds the GATE
+- The follow-up email infrastructure that NOTIFIES waitlisted users when their archetype lands — 01.5 captures the email + consent + retention metadata only ; outbound mail is a future phase
+- Auto-translate IT/ES/PT keys — Wave 0 UI agent locked « FR fallback + TODO marker » strategy ; real translations are 01.6 i18n cleanup
+- The « escape hatch / Mon profil a été mal détecté » self-correct link (Security §6 Q4) — defer to 01.6 once we observe false-positive frequency in waitlist analytics
+
+---
+
+## §4 Engram observations to save AFTER each PR merges
+
+Per memory contract (CLAUDE.md §3.5) — `topic_key` agent-agnostic, `prior_finding_refs` linked to Wave 0 outputs :
+
+- After PR-1 : `mint:phase-01.5:backend-waitlist-endpoint-shipped` (decision)
+- After PR-2 : `mint:phase-01.5:archetype-hard-gate-shipped` (decision) with `prior_finding_refs` = mapper observation IDs + security verdict ID
+- After PR-3 : `mint:phase-01.5:5-gate-closeout` (decision) — final 5-gate audit log
+
+---
+
+## §5 Acceptance gate (binary, mechanical)
+
+Per CLAUDE.md §9 0-TRUST protocol — sub-phase 01.5 CLOSED only when :
+
+1. ✅ All 3 PRs merged to staging (`dev → staging` merge sha cited)
+2. ✅ G1 : `flow_hardgate_expat_us.yaml` exit 0 against staging Railway with timestamp ≥ last merge sha
+3. ✅ G2 : Claude device walkthrough completed (Maestro + idb describe-all final state snapshot showing waitlist screen on iPhone sim)
+4. ✅ G3 : full backend + flutter test suites green on the merge sha
+5. ✅ G4 : `flow_hero_marge_fiscale_3a.yaml` regression test still passes against same merge sha
+6. ✅ G5 : `accent_lint_fr.py` + `check_banned_terms()` + `validate_arb_parity()` all return zero violations on the merged content
+
+No claim « 01.5 closed » without all 6 deterministic citations in the same message per CLAUDE.md §9.1.

--- a/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-SECURITY-fatca-scope.md
+++ b/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-SECURITY-fatca-scope.md
@@ -1,0 +1,205 @@
+---
+name: 01.5-SECURITY-fatca-scope
+description: FATCA + LSFin + LPD scope for the 01.5 archetype HARD GATE. Per-archetype compliance risk, gate-timing recommendation, copy guardrails.
+metadata:
+  type: security-audit
+  parent_phase: 01.5-archetype-hard-gate-fatca
+  authored_by: security-auditor (wshobson)
+  date: 2026-05-21
+---
+
+# Sub-phase 01.5 security scope — FATCA + LSFin + LPD audit
+
+**Verdict** : the « waitlist + email opt-in » hard gate is SUFFICIENT as a compliance mitigation, with 4 mandatory copy/consent guardrails detailed in §5. Pre-signup gating is the legally correct timing (§4). False-positive bias is mandatory (§3).
+
+---
+
+## §1 Per-archetype compliance risk
+
+### 1a. expatUs (FATCA) — CRITICAL
+
+- **Core exposure** : US persons (citizens and Green Card holders) are subject to US worldwide taxation regardless of Swiss residence. If MINT serves a `swissNative`-calibrated 3a recommendation to an `expatUs` user, it implicitly endorses a 3a contribution strategy without disclosing that:
+  - Swiss Pillar 3a accounts are reportable on **FBAR (FinCEN Form 114)** if the aggregate foreign account balance exceeds USD 10,000 at any point during the year. Failure to file: civil penalty USD 10,000–100,000 per violation; criminal up to USD 500,000 + 10 years.
+  - Swiss Pillar 3a accounts are reportable on **Form 8938** (FATCA) if foreign assets exceed USD 200,000 (resident abroad, single filer, year-end threshold). Failure to file: USD 10,000 initial penalty + USD 10,000/30-day continuation up to USD 50,000 + 40% underpayment penalty on tax attributable to non-disclosed assets.
+  - 3a investment funds (e.g., UBS Vitainvest, CS BVG) are typically structured as foreign collective investment vehicles. Under US tax law, these qualify as **Passive Foreign Investment Companies (PFIC)** (IRC §1291-1298). If a US person holds a PFIC without making a Qualifying Electing Fund (QEF) or mark-to-market election, any gain or excess distribution is taxed at the highest ordinary income rate + an interest charge. MINT's 3a return projections (showing CHF growth figures) applied to a PFIC-holding expatUs user actively mislead on after-tax returns.
+  - **LSFin cross-jurisdiction conflict** : LSFin art. 8(2) requires that a financial service provider disclose information about «les risques associés aux services et aux instruments financiers» (risks associated with financial services and instruments). Serving 3a guidance to a FATCA subject without disclosing US tax characterization risks violates this duty for a cross-border client category.
+  - Sources: [IRS FATCA for individuals](https://www.irs.gov/businesses/corporations/fatca-information-for-individuals); [Pillar 3 FBAR/FATCA reporting](https://www.goldinglawyers.com/pillar-3-pension-reporting-for-u-s-tax-fbar-and-fatca/); [US-Switzerland connected individuals](https://www.ustaxfs.com/services/switzerland-and-us-connected-individuals/); [Form 8938 guide](https://www.greenbacktaxservices.com/knowledge-center/form-8938/)
+- **Mitigation** : hard gate to waitlist, zero 3a/LPP/tax content served.
+
+### 1b. expatEu — HIGH
+
+- **Core exposure** :
+  - EU expats in Switzerland are subject to the **Switzerland-EU Agreement on Free Movement of Persons (AFMP, 1999)** and the **Regulation (EC) 883/2004** on coordination of social security, as incorporated by bilateral agreement. This means their AVS/AHV contributions may be partially creditable in their EU home state — a material difference vs. `swiss_native` whose entire retirement entitlement accrues in CH.
+  - LPP (2e pilier) **portability on departure** is governed by the Freizügigkeitsgesetz (FZG / LFLP). EU expats returning home can claim their vested benefits under specific conditions not applicable to Swiss nationals. A calculation showing a `swiss_native` lump-sum projection applied to an `expatEu` user produces a legally incorrect retirement gap figure.
+  - **Double taxation** : depending on the EU member state of origin and bilateral tax treaty status, salary-deducted 3a contributions may NOT be tax-deductible in the expat's country of domicile during a hybrid residency transition period. The MINT coach narrative ("vous économisez X CHF d'impôts") is factually false for this archetype.
+  - LSFin art. 8(2) information duty is breached: the coach omits the bilateral coordination dimension that is material for this client category.
+  - Sources: [SEM EU/EFTA work in Switzerland](https://www.sem.admin.ch/sem/en/home/themen/fza_schweiz-eu-efta/eu-efta_buerger_schweiz.html)
+- **Mitigation** : hard gate, no content.
+
+### 1c. crossBorder — HIGH
+
+- **Core exposure** :
+  - **Impôt à la source mechanics differ materially** : French frontaliers are taxed at 4.5% flat withheld at source by the Swiss employer and remitted to France (Protocol to the Franco-Swiss Convention of April 11, 1983, except Geneva where full Swiss sourcing applies). German frontaliers similarly: 4.5% Swiss withholding credited against German tax, with a 60-day minimum return rule. Italian frontaliers post-2023: shared taxation (up to 80% of Italian tax owed can be levied by Switzerland). Austrian frontaliers: Switzerland has primary tax jurisdiction.
+  - Any MINT tax-saving calculation (e.g., "économisez X CHF via 3a déduction") applied to a `crossBorder` user is computed against the wrong marginal rate (Swiss full-scale vs. the applicable bilateral rate). This is not a minor UX degradation — it is a misleading quantitative projection.
+  - **Social security** : frontaliers (permis G) contribute to Swiss AVS/AHV for their Swiss employment but may maintain social security affiliation in their home country under bilateral rules. LPP enrollment follows the same logic as residents, but the LPP lump-sum withdrawal destination at retirement may have different tax treatment in France/Germany/Italy.
+  - LSFin art. 9 (target market): frontaliers are a materially different market segment whose suitability cannot be assessed using `swiss_native` parameters.
+  - Sources: [Frontalier tax rules France/Germany/Italy/Austria](https://www.taxea.ch/en/tips/working-in-switzerland-living-abroad-cross-border-commuters-and-their-taxes); [Franco-Swiss convention — impots.gouv.fr](https://www.impots.gouv.fr/particulier/questions/suis-je-bien-un-travailleur-frontalier)
+- **Mitigation** : hard gate, no content.
+
+### 1d. independentNoLpp — MEDIUM (but calculator-breaking)
+
+- **Core exposure** :
+  - The 3a maximum contribution for an employed LPP-affiliated worker is **CHF 7,258 (2024)** and **CHF 7,258 (2025)**. For a self-employed person without a 2e pilier: **CHF 36,288** (or 20% of net income, whichever is lower). The MINT coach or calculator applying the salaried cap to an independent user is factually incorrect by a factor of 5x — actively harmful advice.
+  - AVS contribution mechanics differ: the self-employed pay a descending-rate AVS contribution on net income (starting at 10.1% for income above CHF 56,900 down to 5.196% for lower brackets), not the salaried employee split (5.3% employee / 5.3% employer). The retirement projection engine does not model this.
+  - No LPP (2e pilier) enrollment: the MINT coach references LPP insured salary, BVG minimum interest rate, and lump-sum vs. annuity decisions — all inapplicable.
+  - This is an LSFin art. 8 appropriateness failure: the product is not appropriate for this client because the underlying calculation model does not fit.
+  - Sources: [Pillar 3a for self-employed CHF 36,288](https://expat-savvy.ch/blog/3rd-pillar-self-employed-switzerland/); [Pillar 3a maximums](https://www.ubs.com/ch/en/private/pension/pillar-3/maximal-contribution-2024.html)
+- **Mitigation** : hard gate. This archetype is high-value to onboard in a future phase with corrected calculation pathways.
+
+### 1e. coupleOneWorks — MEDIUM
+
+- **Core exposure** :
+  - A household where only one partner is employed has an asymmetric LPP profile: the non-working partner has no LPP affiliation and no employer contribution. The non-working partner's 3a eligibility is limited to the working partner's income (indirect 3a: the working partner may open a 3a in the non-working partner's name, but this is not standard advice and varies by institution).
+  - The joint tax filing (déclaration commune) changes the marginal rate applied in 3a deduction projections. Swiss cantons apply different splitting factors or joint-table rates. Projections calibrated for a `swiss_native_couple` (both working, both with separate 3a deductions) overstate tax savings for `coupleOneWorks`.
+  - LSFin art. 10(1) (suitability documentation) requires that suitability parameters reflect actual client situation. A household with single income has a different risk tolerance profile and different liquidity constraints than the dual-income default.
+- **Mitigation** : hard gate. Lower legal severity than `expatUs`/`crossBorder` but calculation is still incorrect.
+
+### 1f. seniorPost64 — MEDIUM
+
+- **Core exposure** :
+  - **Pillar 3a contributions stop at retirement age (65 for men, 64 for women — or 65 for both under AHV 21 reform effective 2024)**. Beyond that, contributions are not permitted and would be rejected by 3a institutions. If MINT's coach recommends 3a contributions to a user past retirement age, it recommends a legally unavailable action. Exception: working beyond 65 allows continued contributions for up to 5 additional years (until 70).
+  - **LPP timing constraints** : past retirement age, the user is in drawdown, not accumulation. LPP lump-sum withdrawal vs. annuity decision has a 3-year irrevocability window and specific tax treatment (lump-sum taxed separately at reduced rate, annuity taxed as ordinary income). Coach narrative oriented around accumulation is not only irrelevant but potentially misleading about available actions.
+  - **AVS pension interaction** : the AVS pension has already commenced. The MINT retirement gap calculation (which uses AVS projection to retirement) is structurally inapplicable — the gap has already been realized.
+  - LSFin art. 9 (target market): the product as currently built targets accumulation-phase users; a decumulation-phase user is outside the defined target market.
+- **Mitigation** : hard gate. Lower legal severity (no cross-border tax conflict) but factually incorrect product for this user state.
+
+---
+
+## §2 Is the « waitlist + email opt-in » mitigation sufficient?
+
+### LSFin art. 7 — Information duty («Obligation d'information»)
+
+LSFin art. 7 requires financial service providers to provide clients with information about themselves, their services, costs, risks, and conflicts of interest. **When no service is rendered** — because the user is routed to a waitlist screen before any service is initiated — this duty is not triggered. The hard gate prevents service initiation, so art. 7 is not violated by the gate itself.
+
+Residual risk: the waitlist screen must not contain any content that itself constitutes a «financial service» or «financial service communication» under LSFin. See §5 for copy guardrails.
+
+### LSFin art. 8 — Client profile verification («Vérification du profil client»)
+
+Art. 8 requires verification that the service is appropriate for the client before rendering it. The hard gate satisfies this by structurally preventing service rendering for clients whose profile has not been verified as in-scope. This is the intended mechanism: when appropriateness cannot be verified (because the archetype is unsupported), the service is withheld. **VERDICT: hard gate is the correct implementation of art. 8**.
+
+### LSFin art. 9 — Target market («Marché cible»)
+
+Art. 9 requires that financial instruments and services be manufactured and distributed within a defined target market. MINT's current target market is `swiss_native` + `swiss_native_couple`. Routing other archetypes to a waitlist is the correct expression of art. 9: the product confirms its own target market boundary and does not serve users outside it. **VERDICT: compliant**.
+
+### LSFin art. 10 — Suitability documentation («Documentation de l'adéquation»)
+
+Art. 10 requires documentation that the service is suitable for the specific client. No documentation obligation arises for a service that is not rendered. **VERDICT: not triggered by the gate**.
+
+### FINMA / OAR guidance
+
+FINMA Circular 2018/03 (Outsourcing — banks) and related OAR-G / OAD-FCT self-regulation guidance do not impose requirements on the waitlist UX per se. However, OAR guidance on digital onboarding (FINMA Circular 2016/7 on video identification) does not apply to a pre-service email capture. No OAR constraint identified on the waitlist screen copy beyond the LPD requirements below.
+
+### LPD / nLPD consent on email capture
+
+Switzerland's revised Federal Act on Data Protection (nLPD, in force September 2023) and the Federal Act Against Unfair Competition (UCA, Gesetz gegen unlauteren Wettbewerb) together govern this:
+
+1. **Opt-in required by default** for commercial electronic communications (email). The UCA (art. 3(1)(o)) prohibits sending unsolicited mass advertising without prior consent, unless the address was collected during a prior sale (which is not the case here — user has not purchased/used the service).
+2. The **waitlist email is an ambiguous category**: it is transactional (notifying when the user's archetype is supported) but it will functionally serve as re-engagement marketing. The legally conservative classification is **marketing communication** requiring explicit opt-in.
+3. Under nLPD, the consent must be **specific, informed, and voluntary**. A checkbox labeled «Je souhaite être averti(e) par email» meets the specificity requirement only if accompanied by: (a) the exact purpose (product availability notification), (b) the controller identity (MINT / legal entity name), (c) a data retention period, and (d) an unsubscribe mechanism in every follow-up email.
+4. **GDPR parallel** : if any EU resident uses MINT (which is possible for EU expats in CH prior to the gate working), the GDPR (applicable via Art. 3(2) to Swiss companies targeting EU residents) also requires freely given, specific, informed, unambiguous consent for email marketing. The nLPD + GDPR double-stack applies here.
+
+**VERDICT** : the « waitlist + email opt-in » mitigation is **SUFFICIENT** to discharge LSFin obligations, provided the 4 consent guardrails in §5 are implemented. The gate must activate before any financial content is served (confirmed by the pre-signup timing recommendation in §4).
+
+---
+
+## §3 False-positive vs false-negative bias
+
+**Recommendation : bias toward FALSE POSITIVE (route to waitlist when in doubt).**
+
+- False positive: a `swissNative` user is mis-detected as `expatUs` → routed to waitlist. Consequence: bad UX (user must clarify their status). Remedy: add an escape hatch on the waitlist screen («J'ai été redirigé(e) par erreur → corriger mon profil»). Legally safe.
+- False negative: an `expatUs` user is mis-detected as `swissNative` → served FATCA-unaware content. Consequence: user receives materially misleading financial guidance with potential USD 50,000+ IRS penalty exposure that MINT's guidance silently enabled. Legally a LSFin art. 8 breach and a reputational P0.
+
+**Doctrine principle** : the **precautionary principle in financial regulation** (Vorsorgeprinzip, applied in FINMA supervisory practice) holds that when the risk of harm from over-inclusion is low and the risk of harm from under-inclusion is high, the gate should be set conservatively. This is analogous to investment suitability: FINMA Circular 2009/1 (§27) states that when suitability is uncertain, the service should not be rendered. The same principle applies here to archetype-scope uncertainty.
+
+Secondary principle: **LSFin art. 8(3)** provides a safe harbor when the provider declines to render a service upon failing suitability verification. Routing to waitlist is the operational expression of this safe harbor.
+
+---
+
+## §4 Pre- vs post-signup gate timing
+
+**Recommendation : PRE-SIGNUP gate.**
+
+Rationale:
+
+1. **LPD / nLPD data minimization** (art. 6(2) nLPD): personal data should be collected only to the extent necessary for the stated purpose. If MINT cannot serve an `expatUs` user, completing their full onboarding (name, salary, LPP data, canton) and persisting that data to the database creates a data processing relationship for a service that will never be rendered. This violates the minimization principle.
+
+2. **Practical data-breach exposure** : a full onboarded `expatUs` profile in the MINT database (salary, LPP amount, employer) constitutes sensitive financial personal data with no service delivery justification. This is an unnecessary risk surface.
+
+3. **Trust** : a user who completes full onboarding and then hits a gate will experience the rejection as bait-and-switch, damaging trust more severely than a pre-signup gate that clearly explains the scope limitation upfront.
+
+4. **Implementation simplicity** : detecting the archetype at the onboarding entry questions (nationality/residency status, permit type) and gating before account creation avoids the need for a post-creation account deletion flow.
+
+**Exception** : for `independentNoLpp`, `coupleOneWorks`, and `seniorPost64` — whose detection signal is employment status / household structure rather than nationality/permit — partial onboarding through the profile-type question is acceptable, with the gate firing at the first question that disambiguates these archetypes. The gate must fire before any financial data (salary, LPP, 3a balance) is collected.
+
+---
+
+## §5 Waitlist screen copy guardrails
+
+### Forbidden phrases (CLAUDE.md TOP rule #1 + LSFin art. 7-8)
+
+- «garanti», «optimal», «meilleur», «certain», «assuré», «sans risque», «parfait» — LSFin banned terms. NEVER appear in the waitlist screen title, body, or CTA.
+- Any future-return projection or implied promise: «vous gagnerez», «vous économiserez», «votre retraite sera sécurisée».
+- Any characterization of MINT's advice quality: «conseils personnalisés», «recommandations expertes», «meilleures pratiques».
+- «bientôt» without qualification — constitutes an implicit promise of availability.
+
+### Required phrases (LPD/nLPD + UCA consent compliance)
+
+The CTA + confirmation area MUST include, in legally adequate FR copy:
+
+```
+[ ] J'accepte d'être contacté(e) par email lorsque MINT sera disponible pour mon profil.
+    [MINT / [nom entité légale]] utilisera ton adresse email uniquement à cette fin.
+    Tu peux te désabonner à tout moment. [Politique de confidentialité →]
+```
+
+Every follow-up email triggered by this opt-in MUST include:
+- Sender name + registered address (UCA art. 3(1)(o))
+- One-click unsubscribe link (UCA requirement for «easy-access and free opt-out»)
+- Data controller identity and contact for data subject rights requests (nLPD art. 25 transparency duty)
+
+### LSFin classification: marketing vs. transactional
+
+The waitlist screen itself is **not a financial communication** under LSFin (no financial service or product is described or recommended). It is a **product availability notification** of a pre-commercial nature. The follow-up email notifying availability is **marketing communication** because it will contain a CTA directing the user to the MINT app/service.
+
+**Consequence** : the follow-up notification email is subject to UCA opt-in consent (already required by the checkbox above) and must not contain financial projections, return estimates, or comparative claims. Subject line must be neutral, e.g. «MINT est maintenant disponible pour ton profil» — not «Prépare ta retraite avec MINT».
+
+---
+
+## §6 Open questions for product manager
+
+1. **Legal entity name** : the LPD consent checkbox and the follow-up email must name the data controller. What is the registered Swiss legal entity operating MINT (SA, Sàrl, etc.)? This must be locked before the waitlist screen is merged.
+
+2. **Data retention policy** : waitlist emails must be purged if the user's archetype has not been supported after X months, or on user request (nLPD art. 32 right to erasure). What is the intended retention period? 12 months recommended as a starting point.
+
+3. **Detection signal for `expatUs`** : the US-person detection requires asking a sensitive question (nationality or US-tax-person status) early in onboarding. This is politically sensitive UX. Options: (a) ask «as-tu des obligations fiscales aux États-Unis ?» as a binary yes/no, (b) infer from nationality field. Product decision required — security recommendation is option (a) with a tooltip explaining why it matters («MINT n'est pas encore calibré pour les contribuables américains en Suisse»). This signal must be unambiguous to avoid false negatives on the highest-risk archetype.
+
+4. **Escape hatch on waitlist screen** : should users mis-routed to waitlist be able to self-correct their archetype without contacting support? Recommended: yes, with a link «Mon profil a été mal détecté → corriger» which takes the user back to the archetype-determination questions. This reduces false-positive friction without increasing false-negative risk.
+
+5. **LPP / AVS data already collected** : if a user has already submitted sensitive financial data before hitting the gate (e.g., in a future partial-onboarding scenario), that data must be auto-deleted upon waitlist routing under nLPD minimization. Confirm this deletion logic is in scope for 01.5 or deferred to 01.6.
+
+---
+
+*Sources consulted:*
+- [Swiss FinSA/LSFin — fedlex.admin.ch](https://www.fedlex.admin.ch/eli/cc/2019/758/en)
+- [MLL FinSA requirements](https://www.mll-news.com/finsa-lsfin-fidleg-requirements-for-financial-services-providers/?lang=en)
+- [IRS FATCA for individuals](https://www.irs.gov/businesses/corporations/fatca-information-for-individuals)
+- [Pillar 3 FBAR/FATCA reporting — Golding Lawyers](https://www.goldinglawyers.com/pillar-3-pension-reporting-for-u-s-tax-fbar-and-fatca/)
+- [Form 8938 guide — Greenback Tax](https://www.greenbacktaxservices.com/knowledge-center/form-8938/)
+- [US-Switzerland tax connected individuals](https://www.ustaxfs.com/services/switzerland-and-us-connected-individuals/)
+- [Pillar 3a self-employed CHF 36,288 cap](https://expat-savvy.ch/blog/3rd-pillar-self-employed-switzerland/)
+- [Pillar 3a maximums — UBS](https://www.ubs.com/ch/en/private/pension/pillar-3/maximal-contribution-2024.html)
+- [Frontalier tax rules](https://www.taxea.ch/en/tips/working-in-switzerland-living-abroad-cross-border-commuters-and-their-taxes)
+- [Franco-Swiss frontalier — impots.gouv.fr](https://www.impots.gouv.fr/particulier/questions/suis-je-bien-un-travailleur-frontalier)
+- [Switzerland nLPD email marketing — DLA Piper](https://www.dlapiperdataprotection.com/index.html?t=electronic-marketing&c=CH)
+- [nLPD overview — EDANA](https://edana.ch/en/2025/04/26/gdpr-nlpd-complete-guide-swiss-businessses/)
+- [SEM EU/EFTA in Switzerland](https://www.sem.admin.ch/sem/en/home/themen/fza_schweiz-eu-efta/eu-efta_buerger_schweiz.html)

--- a/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-UI-waitlist-spec.md
+++ b/.planning/phases/01.5-archetype-hard-gate-fatca/01.5-UI-waitlist-spec.md
@@ -1,0 +1,284 @@
+---
+name: 01.5-UI-waitlist-spec
+description: Design contract for the WaitlistScreen + ARB keys + a11y for 01.5 archetype HARD GATE. Consumed by 01.5 phase planning (Wave 1).
+metadata:
+  type: ui-spec
+  parent_phase: 01.5-archetype-hard-gate-fatca
+  status: locked-for-wave1
+  author: flutter-expert subagent
+  date: 2026-05-21
+---
+
+# 01.5 UI spec — WaitlistScreen
+
+## §1 Route + screen name
+
+- **Screen class** : `WaitlistScreen` (StatefulWidget)
+- **File path** : `apps/mobile/lib/screens/waitlist/waitlist_screen.dart`
+- **Provider** : `apps/mobile/lib/providers/waitlist_provider.dart` (state machine — Provider per CLAUDE.md §3.5)
+- **Service** : `apps/mobile/lib/services/waitlist_service.dart` (single POST method)
+- **Route path** : `/waitlist`
+- **Route scope** : `RouteScope.public` (must be reachable pre-auth — the gate fires during onboarding before signup, per `01.5-CONTEXT.md` §5 Q1)
+- **Router registration** : `ScopedGoRoute` inserted in `apps/mobile/lib/app.dart` near the `/anonymous/chat` block (currently line 360-367) — cite `apps/mobile/lib/app.dart:212` for the GoRouter root and `apps/mobile/lib/router/scoped_go_route.dart` for the `ScopedGoRoute` helper.
+- **Trigger** : pushed via `context.go('/waitlist', extra: WaitlistArgs(archetype: detectedArchetype, source: 'onboarding'))` from the archetype hard-gate site (located + named by `01.5-MAPPER-archetype-detection.md` in Wave 0).
+
+---
+
+## §2 Visual hierarchy (ASCII mockup)
+
+```
+┌──────────────────────────────────────────────┐
+│  ← (back, optional — see §10)                │  ← AppBar leading
+│                                              │
+│         ┌──────────┐                         │
+│         │   icon   │                         │  S1 : Header
+│         │ (compass)│  (48 dp, MintColors.    │     icon + title
+│         └──────────┘   menthePositive)       │
+│                                              │
+│   Encore en chantier pour ton profil         │  ← MintTextStyles.headlineLarge
+│                                              │
+│ ──────────────────────────────────────────── │  ← SizedBox(MintSpacing.lg)
+│                                              │
+│  MINT est calibré aujourd'hui pour les       │  S2 : Body
+│  personnes résidentes en Suisse, salariées   │     bodyLarge 16pt
+│  et affiliées à un 2e pilier (LPP).          │     MintColors.textPrimary
+│                                              │
+│  Ton profil correspond à une situation que   │     16 dp gap between
+│  nous couvrirons prochainement.              │     paragraphs
+│                                              │
+│  Laisse-nous ton email et nous te            │
+│  préviendrons dès qu'on ouvre MINT à         │
+│  ton parcours.                               │
+│                                              │
+│ ──────────────────────────────────────────── │  ← SizedBox(MintSpacing.xl)
+│                                              │
+│  ┌────────────────────────────────────────┐  │  S3 : Form
+│  │ Email                                  │  │     MintTextField
+│  │ ─────────────────────────────          │  │     (premium widget)
+│  │ ton.email@exemple.ch                   │  │
+│  └────────────────────────────────────────┘  │
+│                                              │
+│  [ Préviens-moi quand c'est prêt ]           │  ← FilledButton full-width
+│                                              │     MintColors.inkPrimary bg
+│                                              │
+│  En soumettant ton email, tu acceptes         │  ← labelSmall caption
+│  d'être contacté·e uniquement pour cette      │     MintColors.textMutedAaa
+│  notification. Pas de marketing.              │     (LSFin consent fine print)
+│                                              │
+└──────────────────────────────────────────────┘
+   Scaffold backgroundColor : MintColors.porcelaineHandoff
+   Horizontal padding       : MintSpacing.screenH (24 dp)
+   Top padding              : MintSpacing.xl (32 dp) below AppBar
+```
+
+---
+
+## §3 Component breakdown
+
+| Layer | Widget | Token / source | New ? |
+|---|---|---|---|
+| Scaffold | `Scaffold` (Material) | `backgroundColor: MintColors.porcelaineHandoff` (`colors.dart:58`) | no |
+| AppBar | `AppBar` minimal (no title, transparent) | `MintColors.porcelaineHandoff` bg, no shadow | no |
+| Icon | `Icon(Icons.explore_outlined, size: 48)` | `color: MintColors.menthePositive` (`colors.dart:75`) | no |
+| Title | `Text` w/ `MintTextStyles.headlineLarge(color: MintColors.inkPrimary)` (`mint_text_styles.dart:97`, `colors.dart:65`) | no |
+| Body paragraphs | `Text` w/ `MintTextStyles.bodyLarge(color: MintColors.inkPrimary)` (`mint_text_styles.dart:147`) | no |
+| Email field | `MintTextField(label: l.waitlistEmailLabel, hint: l.waitlistEmailHint, keyboardType: TextInputType.emailAddress, ...)` (`widgets/premium/mint_text_field.dart:21`) | no |
+| Submit CTA | `FilledButton` with `styleFrom(backgroundColor: MintColors.inkPrimary, foregroundColor: MintColors.craieHandoff, minimumSize: Size.fromHeight(48))` | no — same pattern as `anonymous_chat_screen.dart:576` |
+| Fine print | `Text` w/ `MintTextStyles.labelSmall(color: MintColors.textMutedAaa)` (`mint_text_styles.dart:194`) | no |
+| Loading state | `MintLoadingIndicator` from `widgets/premium/mint_loading_indicator.dart` | no |
+| Error banner | `MintErrorState` from `widgets/common/mint_error_state.dart` (already exists) | no |
+| Success state | Inline replacement of form by a checkmark icon + body text — NO new widget needed | no |
+| Semantics wrappers | `Semantics(label: ..., button: true, ...)` around CTA + email field | no |
+
+**Result : zero new wrapper widgets required.** All primitives exist.
+
+---
+
+## §4 States + transitions
+
+State enum lives in `waitlist_provider.dart` :
+
+```dart
+enum WaitlistStatus { initial, submitting, success, error }
+```
+
+Transitions :
+
+- **initial** → user lands ; form enabled ; CTA disabled until email matches regex `^[^\s@]+@[^\s@]+\.[^\s@]+$`
+- **initial → submitting** (CTA tap, email valid) → CTA shows `MintLoadingIndicator` (size 20), CTA disabled, field disabled, POST `/api/v1/waitlist` fires
+- **submitting → success** (HTTP 201) → form replaced by success block (`Icons.check_circle_outline` 48 dp `MintColors.menthePositive` + `l.waitlistSuccessMessage` + secondary CTA `l.waitlistSuccessCta` that calls `context.go('/')`)
+- **submitting → error** (HTTP 4xx/5xx or network) → CTA returns to enabled, inline `MintErrorState` above CTA with `l.waitlistErrorNetwork` (5xx/network) or `l.waitlistErrorBadEmail` (400 returned)
+- **error → submitting** → user edits email or taps CTA again ; resets to submitting
+
+State-machine validation : invalid email never reaches `submitting` (client-side regex blocks).
+
+---
+
+## §5 ARB keys
+
+10 new keys. FR is ship-blocking ; EN is ship-blocking (reference). Other 4 locales : see §6.
+
+| Key | FR (canonical) | EN (reference) |
+|---|---|---|
+| `waitlistTitle` | Encore en chantier pour ton profil | Still being built for your profile |
+| `waitlistBodyPara1` | MINT est calibré aujourd'hui pour les personnes résidentes en Suisse, salariées et affiliées à un 2e pilier (LPP). | MINT is currently calibrated for Swiss residents who are salaried and enrolled in a 2nd-pillar pension (LPP). |
+| `waitlistBodyPara2` | Ton profil correspond à une situation que nous couvrirons prochainement. | Your profile matches a situation we will cover in an upcoming release. |
+| `waitlistBodyPara3` | Laisse-nous ton email et nous te préviendrons dès qu'on ouvre MINT à ton parcours. | Leave us your email and we will let you know as soon as MINT supports your journey. |
+| `waitlistEmailLabel` | Email | Email |
+| `waitlistEmailHint` | ton.email@exemple.ch | your.email@example.ch |
+| `waitlistCta` | Préviens-moi quand c'est prêt | Notify me when it's ready |
+| `waitlistConsentFinePrint` | En soumettant ton email, tu acceptes d'être contacté·e uniquement pour cette notification. Pas de marketing. | By submitting your email, you agree to be contacted only for this notification. No marketing. |
+| `waitlistSuccessMessage` | Merci, on revient vers toi dès que ton profil est pris en charge. | Thanks, we'll come back to you as soon as your profile is supported. |
+| `waitlistSuccessCta` | Revenir à l'accueil | Back to home |
+| `waitlistErrorNetwork` | Impossible d'envoyer ton email pour le moment. Réessaie dans un instant. | We couldn't send your email right now. Please try again in a moment. |
+| `waitlistErrorBadEmail` | Cette adresse email ne semble pas valide. Vérifie la syntaxe. | This email address doesn't look valid. Please check the syntax. |
+
+**Total : 12 keys** (slightly over the 7-10 target, justified — body split into 3 paragraphs for readability + consent fine print is LSFin-required per §11 Q3).
+
+**Mechanical checks before merge** :
+- `validate_arb_parity()` MCP must return 0 missing keys across all 6 ARB files (per CLAUDE.md §3 + memory `feedback_pre_push_checklist`)
+- `check_banned_terms()` MCP on every FR + EN string (none of « garanti / optimal / meilleur / certain / assuré / sans risque / parfait » appears — pre-verified)
+- `accent_lint_fr.py` on `app_fr.arb` (all « é / è / ç / à » present — « préviendrons », « calibré », « résidentes », « affiliées » all carry full accents)
+- `flutter gen-l10n` must succeed (no `@@locale` or duplicate-key errors)
+
+---
+
+## §6 Localization plan
+
+| Locale | Ship status for 01.5 | Justification |
+|---|---|---|
+| **FR** | ship-blocking | canonical app language, copy written here |
+| **EN** | ship-blocking | reference + Swiss expat default ; FATCA P0 archetype (`expat_us`) defaults English |
+| **DE** | ship-blocking | Swiss DE-speaking residents are the second-largest archetype set affected (Suisse alémanique frontaliers + expat_eu DE) |
+| **IT** | ship-with-FR-fallback | smaller cohort ; ARB key inserted with FR text + `// TODO i18n it-CH` marker comment ; gen-l10n still succeeds |
+| **ES** | ship-with-FR-fallback | non-Swiss-national fallback ; same TODO pattern |
+| **PT** | ship-with-FR-fallback | non-Swiss-national fallback ; same TODO pattern |
+
+**Recommendation** : FR + EN + DE = P0 translated for ship ; IT / ES / PT keys carry FR text + `// TODO i18n` comment (NOT empty strings — `validate_arb_parity()` requires presence). Confirm with security-auditor in §11 Q1.
+
+**Risk** : if DE is not ready by ship, fall back to DE = EN copy + `// TODO i18n de-CH` (German-speaking users see English, NOT French — French copy on a DE locale is worse UX than English fallback per memory `feedback_decisiveness`).
+
+---
+
+## §7 Backend POST `/api/v1/waitlist` contract
+
+### Request
+
+```http
+POST /api/v1/waitlist HTTP/1.1
+Content-Type: application/json
+X-Anonymous-Session: <UUID>          // required, same convention as anonymous_chat.py:354
+Accept-Language: fr-CH | en | de | ...
+
+{
+  "email":     "ton.email@exemple.ch",
+  "archetype": "expat_us",
+  "locale":    "fr",
+  "source":    "onboarding_hard_gate"
+}
+```
+
+**Fields** (camelCase per CLAUDE.md §1 — backend uses Pydantic v2 alias) :
+
+| Field | Type | Constraint |
+|---|---|---|
+| `email` | `EmailStr` | Pydantic v2 `EmailStr` validator |
+| `archetype` | `Literal["expat_us","expat_eu","cross_border","independent_no_lpp","couple_one_works","senior_post_64"]` | reject other values 400 |
+| `locale` | `Literal["fr","en","de","es","it","pt"]` | reject other values 400 |
+| `source` | `Literal["onboarding_hard_gate","settings","other"]` | optional, default `"other"` |
+
+**Header** : `X-Anonymous-Session` required, UUID format, validated server-side identically to `anonymous_chat.py:354-362` (lowercase, regex match, 401 if absent or malformed). Reuses `_UUID_RE` from `anonymous_chat.py`.
+
+### Responses
+
+| Status | Body | When |
+|---|---|---|
+| **201 Created** | `{ "id": "<uuid>", "createdAt": "2026-05-21T20:35:00Z" }` | success |
+| **400 Bad Request** | `{ "detail": "Email invalide" }` | EmailStr fails OR archetype/locale not in Literal |
+| **401 Unauthorized** | `{ "detail": "Session anonyme requise. Envoie le header X-Anonymous-Session." }` | missing/malformed `X-Anonymous-Session` |
+| **409 Conflict** | `{ "detail": "Email déjà inscrit pour ce parcours" }` | optional — dedup on `(email, archetype)` unique constraint ; if scoped, the mobile surface treats 409 as success (idempotent) |
+| **500 Internal Server Error** | `{ "detail": "Erreur serveur" }` | DB failure ; mobile shows `waitlistErrorNetwork` |
+
+**Persistence** (backend out-of-scope here but contract-locked) : new SQLAlchemy model `WaitlistEntry` in `services/backend/app/models/waitlist_entry.py` + Alembic migration (cite memory `project_orm_orphan_pattern` — DO NOT define `__tablename__` without the migration in the same PR).
+
+---
+
+## §8 A11y
+
+- **Semantics labels** :
+  - Title : `Semantics(header: true, child: Text(l.waitlistTitle))`
+  - Email field : `MintTextField` already wraps in `Semantics` with the `label` prop ; pass `l.waitlistEmailLabel`
+  - CTA : `Semantics(button: true, enabled: <bool>, label: l.waitlistCta)`
+  - Success icon : `Semantics(label: l.waitlistSuccessMessage, image: true)`
+- **Tab order** : (1) back button → (2) email field → (3) CTA → (4) consent fine print (read-only). On success state : (1) back button → (2) success message → (3) "Back to home" CTA.
+- **Submit-success announcement** : on transition to `WaitlistStatus.success`, call `SemanticsService.announce(l.waitlistSuccessMessage, TextDirection.ltr)` (same pattern as `widgets/trust/mint_trame_confiance.dart:448`). VoiceOver / TalkBack reads the success copy automatically without forcing the user to navigate.
+- **Tap targets** : CTA `minimumSize: Size.fromHeight(48)` ≥ 44×44 dp WCAG 2.1 ; email field default `MintTextField` ≥ 56 dp tall.
+- **Contrast** : `MintColors.inkPrimary` on `MintColors.craieHandoff` ≥ 7:1 (AAA, per `colors.dart:264-272` doctrine) ; `MintColors.textMutedAaa` on `MintColors.porcelaineHandoff` is the AAA-safe muted token per `colors.dart:283`.
+- **Reduce-motion** : no animated transitions on state change — instant swap form ↔ success block. Avoids motion-sickness for vestibular users (and is simpler — Karpathy #2).
+
+---
+
+## §9 Visual spec (token-only, NEVER raw values)
+
+| Element | Token |
+|---|---|
+| Scaffold background | `MintColors.porcelaineHandoff` (`colors.dart:58`) |
+| AppBar background | `MintColors.porcelaineHandoff`, `elevation: 0`, `surfaceTintColor: Colors.transparent` |
+| Header icon color | `MintColors.menthePositive` (`colors.dart:75`) |
+| Title text | `MintTextStyles.headlineLarge(color: MintColors.inkPrimary)` |
+| Body text | `MintTextStyles.bodyLarge(color: MintColors.inkPrimary)` |
+| Consent fine print | `MintTextStyles.labelSmall(color: MintColors.textMutedAaa)` |
+| CTA bg | `MintColors.inkPrimary` (`colors.dart:65`) |
+| CTA fg | `MintColors.craieHandoff` (`colors.dart:61`) |
+| Error inline | `MintColors.error` (`colors.dart:36`) — already used by `MintErrorState` |
+| Success icon | `MintColors.menthePositive` |
+| Horizontal screen padding | `MintSpacing.screenH` = 24 dp (`mint_spacing.dart:43`) |
+| Vertical rhythm (paragraph gap) | `MintSpacing.md` = 16 dp (`mint_spacing.dart:20`) |
+| Vertical rhythm (section gap) | `MintSpacing.xl` = 32 dp (`mint_spacing.dart:26`) |
+| Top padding under AppBar | `MintSpacing.xl` = 32 dp |
+| CTA min height | 48 dp (WCAG ≥ 44) |
+
+---
+
+## §10 Error edge cases
+
+1. **Null archetype** (state machine bug — gate fired but no archetype attached) :
+   - Read `WaitlistArgs.archetype` ; if null, fall back to `"other"` and POST with `archetype: "other"`.
+   - Backend accepts `"other"` (add to the Literal union) and persists it ; we still capture the email rather than 500-ing on the user.
+   - Log `Sentry.captureMessage("waitlist_screen_null_archetype", level: warning)` for triage. NEVER show the error to the user.
+
+2. **Invalid email** (client-side) :
+   - Regex `^[^\s@]+@[^\s@]+\.[^\s@]+$` validates onChange ; CTA disabled until valid.
+   - If user somehow submits (paste + immediate tap), POST returns 400, surface `l.waitlistErrorBadEmail` inline above CTA.
+
+3. **Backend 500** :
+   - Show `l.waitlistErrorNetwork` via `MintErrorState` ; CTA remains enabled so user can retry.
+   - Single retry — if 3 consecutive 5xx in same session, surface a second-tier copy : « Notre serveur est momentanément indisponible. Réessaie plus tard. » (currently same key `waitlistErrorNetwork` — track in §11 Q4 whether we need a separate `waitlistErrorRetryLater` key).
+   - Log `Sentry.captureException` with the response body.
+
+4. **Network offline** :
+   - `DioException.type == connectionError` → `l.waitlistErrorNetwork` (same copy as 5xx — user can't distinguish, neither can we from the device).
+
+5. **Back button on success state** :
+   - Disabled (or pops to `/`) — prevent user re-submitting the same email accidentally. Configurable in provider (`successIsTerminal: true`).
+
+6. **Hot-reload mid-submit** (dev only) :
+   - Provider holds the in-flight `Future` ; on hot-reload Dart drops it ; state resets to `initial`. Acceptable.
+
+---
+
+## §11 Open questions for security-auditor + product-manager review
+
+1. **Locale ship gating** : confirm FR + EN + DE = P0 ship-blocking, IT/ES/PT = ship-with-FR-fallback + TODO marker. Alternative : block ship until all 6 translated (slower but cleaner). My recommendation : 3 P0 + 3 fallback, ship now ; track translation backlog as 01.6.
+
+2. **« Préviens-moi » CTA — too marketing-ish for LSFin consent ?** The verb « prévenir » in this context is transactional notification, not marketing. The fine print (`waitlistConsentFinePrint`) explicitly scopes consent to « cette notification, pas de marketing ». Recommended : keep « Préviens-moi quand c'est prêt » with the LSFin-clean fine print. Security-auditor to confirm vs. Federal Act on Data Protection (LPD/nLPD) art. 6 (express consent).
+
+3. **Is the consent fine print enough, or do we need a checkbox ?** Swiss LPD art. 6 + RGPD art. 4 differ on « consent ». For a single-purpose transactional comm (« notify when archetype lands »), fine print + submit action is generally sufficient (implicit consent via opt-in action). A checkbox adds friction with arguably no legal upside. Recommendation : ship without checkbox ; security-auditor to confirm.
+
+4. **`waitlistErrorRetryLater` second-tier copy** : do we need a separate key after 3 consecutive 5xx ? Or reuse `waitlistErrorNetwork` (current §10.3 default) ? Simpler = reuse. Add the key in 01.6 only if user feedback surfaces confusion.
+
+5. **Should `expat_us` (FATCA P0) surface stronger language than other archetypes ?** Currently the copy is generic across all 6 archetypes. A FATCA-specific variant (« Ton profil US implique des obligations de reporting fiscal aux États-Unis... ») could be more honest but introduces archetype-conditional copy. Recommendation : ship generic copy now ; security-auditor decides if FATCA-specific variant is required for legal sufficiency (probably no, the gate itself = the legal protection ; the copy is UX).
+
+6. **Should the gate be hard-block (no back) or soft-block (back to onboarding) ?** Currently §10.5 leaves back as a no-op on success ; on initial state the AppBar back is a soft pop. A pure hard-block (no back, no escape) is more defensive but worse UX. Recommendation : soft-block — back is allowed pre-submit, no-op post-submit.
+
+7. **Anonymous-session UUID generation** : the `X-Anonymous-Session` header convention requires a UUID. If this screen fires BEFORE the user has chatted anonymously, no session UUID exists. Either (a) generate one client-side and reuse on subsequent anonymous flows, or (b) make the endpoint accept absence of header (deviate from `anonymous_chat.py:354` convention). Recommendation : (a) — generate + persist in `SharedPreferences` on first waitlist hit ; backend treats it as a regular anonymous session insert.

--- a/services/backend/alembic/versions/p123_waitlist_entry.py
+++ b/services/backend/alembic/versions/p123_waitlist_entry.py
@@ -1,0 +1,107 @@
+"""Create waitlist_entries table — sub-phase 01.5 archetype HARD GATE.
+
+Persists email + consent metadata captured by the mobile WaitlistScreen
+when a user's archetype is NOT in the calibrated set
+(`swiss_native` / `swiss_native_couple`-equivalent). Schema mirrors
+`app/models/waitlist_entry.py`.
+
+Per memory `project_orm_orphan_pattern` — model + migration ship in
+the same PR. The ORM-orphan CI lint (p122_orm_orphan_safety_net) would
+fail at merge if this migration were missing.
+
+Idempotent : checks `inspector.get_table_names()` before CREATE/DROP so
+the migration is safe on a DB that already has the table (e.g. if a
+local dev ran `Base.metadata.create_all()` before alembic walked here).
+
+Revision ID: p123_waitlist_entry
+Revises: p122_orm_orphan_safety_net
+Create Date: 2026-05-21 21:00:00 UTC
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "p123_waitlist_entry"
+down_revision = "p122_orm_orphan_safety_net"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create waitlist_entries table + indexes if absent."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "waitlist_entries" in inspector.get_table_names():
+        return
+
+    op.create_table(
+        "waitlist_entries",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("email", sa.String(length=254), nullable=False),
+        sa.Column("archetype", sa.String(length=32), nullable=False),
+        sa.Column("locale", sa.String(length=8), nullable=False),
+        sa.Column(
+            "source",
+            sa.String(length=32),
+            nullable=False,
+            server_default="other",
+        ),
+        sa.Column(
+            "anonymous_session_id",
+            sa.String(length=36),
+            nullable=False,
+        ),
+        sa.Column("consent_given", sa.Boolean(), nullable=False),
+        sa.Column(
+            "legal_entity",
+            sa.String(length=64),
+            nullable=False,
+            server_default="MINT SA",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("notified_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "retention_purge_after",
+            sa.DateTime(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index(
+        "ix_waitlist_entries_email",
+        "waitlist_entries",
+        ["email"],
+    )
+    op.create_index(
+        "ix_waitlist_entries_archetype",
+        "waitlist_entries",
+        ["archetype"],
+    )
+    op.create_index(
+        "ix_waitlist_entries_anonymous_session_id",
+        "waitlist_entries",
+        ["anonymous_session_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop waitlist_entries table + indexes if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "waitlist_entries" not in inspector.get_table_names():
+        return
+
+    op.drop_index(
+        "ix_waitlist_entries_anonymous_session_id",
+        table_name="waitlist_entries",
+    )
+    op.drop_index(
+        "ix_waitlist_entries_archetype",
+        table_name="waitlist_entries",
+    )
+    op.drop_index(
+        "ix_waitlist_entries_email",
+        table_name="waitlist_entries",
+    )
+    op.drop_table("waitlist_entries")

--- a/services/backend/app/api/v1/endpoints/waitlist.py
+++ b/services/backend/app/api/v1/endpoints/waitlist.py
@@ -1,0 +1,145 @@
+"""Waitlist endpoint — sub-phase 01.5 archetype HARD GATE.
+
+POST /api/v1/waitlist
+
+Public endpoint. No authentication required (the user is, by definition,
+not yet supported by MINT — gating them through auth first would
+violate nLPD data minimization). Reuses the X-Anonymous-Session header
+pattern from `anonymous_chat.py` so the mobile side can dedupe + audit
+without surfacing the email back to the device.
+
+Threat mitigations :
+- T-13-01 : UUID format validation on X-Anonymous-Session header
+- T-13-02 : Pydantic EmailStr + Literal validators + explicit consent guard
+- nLPD art. 6 : minimal data (email + archetype + locale + consent), no PII fields
+- UCA art. 3(1)(o) : `consentGiven` must be true (validator enforces)
+
+Per memory `project_orm_orphan_pattern` — the SQLAlchemy model
+`WaitlistEntry` ships with its alembic migration p123_waitlist_entry
+in the same PR as this endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid as uuid_lib
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.rate_limit import limiter
+from app.models.waitlist_entry import WaitlistEntry
+from app.schemas.waitlist import WaitlistRequest, WaitlistResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Same UUID regex as anonymous_chat.py:62 — kept local to avoid coupling
+# the two endpoints (T-13-06 isolation between anonymous and authenticated
+# paths). If we ever extract this to a shared util, both endpoints must
+# migrate in the same PR.
+_UUID_RE = re.compile(
+    r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+)
+
+
+@router.post("", response_model=WaitlistResponse, status_code=201)
+@limiter.limit("10/minute")
+async def submit_waitlist(
+    request: Request,
+    body: WaitlistRequest,
+    db: Session = Depends(get_db),
+) -> WaitlistResponse:
+    """Capture a waitlist opt-in from the mobile WaitlistScreen.
+
+    Returns 201 on success, 400 on validation failure (handled by
+    Pydantic upstream), 401 on missing/malformed X-Anonymous-Session
+    header, 409 on dedup (same email + archetype already captured).
+    """
+
+    # --- Step 1 : Extract + validate the anonymous session UUID ---
+    # The mobile WaitlistService reuses `AnonymousSessionService.getOrCreate()`
+    # (apps/mobile/lib/services/anonymous_session_service.dart) so the
+    # UUID is already persisted in SharedPreferences before this endpoint
+    # is hit. Same convention as anonymous_chat.py:354-366.
+    session_id = request.headers.get("X-Anonymous-Session")
+    if not session_id:
+        raise HTTPException(
+            status_code=401,
+            detail="Session anonyme requise. Envoie le header X-Anonymous-Session.",
+        )
+
+    session_id = session_id.strip().lower()
+    if not _UUID_RE.match(session_id):
+        raise HTTPException(
+            status_code=401,
+            detail="Format de session invalide. Un UUID est requis.",
+        )
+
+    # --- Step 2 : Dedup check on (email, archetype) ---
+    # Same user opting in twice with the same archetype is treated as
+    # idempotent success (we return the existing row's id). This makes
+    # the mobile client safe to retry on transient network errors
+    # without surfacing 409 as an error to the user.
+    email_normalized = body.email.strip().lower()
+    existing = (
+        db.query(WaitlistEntry)
+        .filter(
+            WaitlistEntry.email == email_normalized,
+            WaitlistEntry.archetype == body.archetype,
+        )
+        .first()
+    )
+    if existing is not None:
+        logger.info(
+            "waitlist: idempotent re-submit email=*** archetype=%s id=%s",
+            body.archetype,
+            existing.id,
+        )
+        return WaitlistResponse(
+            id=existing.id,
+            created_at=existing.created_at,
+            legal_entity=existing.legal_entity,
+            retention_purge_after=existing.retention_purge_after,
+        )
+
+    # --- Step 3 : Persist the new row ---
+    new_id = str(uuid_lib.uuid4())
+    now = datetime.now(timezone.utc)
+    purge_after = now + timedelta(days=365)
+
+    entry = WaitlistEntry(
+        id=new_id,
+        email=email_normalized,
+        archetype=body.archetype,
+        locale=body.locale,
+        source=body.source,
+        anonymous_session_id=session_id,
+        consent_given=body.consent_given,
+        legal_entity="MINT SA",
+        created_at=now,
+        notified_at=None,
+        retention_purge_after=purge_after,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+
+    logger.info(
+        "waitlist: captured email=*** archetype=%s locale=%s source=%s id=%s",
+        body.archetype,
+        body.locale,
+        body.source,
+        new_id,
+    )
+
+    return WaitlistResponse(
+        id=new_id,
+        created_at=now,
+        legal_entity="MINT SA",
+        retention_purge_after=purge_after,
+    )

--- a/services/backend/app/api/v1/router.py
+++ b/services/backend/app/api/v1/router.py
@@ -60,6 +60,7 @@ from app.api.v1.endpoints import (
     overview,
     lucidity,
     audit_mobile,
+    waitlist,
 )
 
 api_router = APIRouter()
@@ -233,4 +234,9 @@ api_router.include_router(
 # iter-3 iA2 replay-ordering).
 api_router.include_router(
     audit_mobile.router, prefix="/audit", tags=["Mobile L1 Audit D-12"]
+)
+# Sub-phase 01.5 archetype HARD GATE — waitlist opt-in for users whose
+# archetype is NOT in the calibrated set (expat_us FATCA + 5 others).
+api_router.include_router(
+    waitlist.router, prefix="/waitlist", tags=["Waitlist P0 01.5"]
 )

--- a/services/backend/app/models/waitlist_entry.py
+++ b/services/backend/app/models/waitlist_entry.py
@@ -1,0 +1,120 @@
+"""Waitlist entry model — sub-phase 01.5 archetype HARD GATE.
+
+Captures the email + consent metadata of users whose archetype is NOT
+in the calibrated set (`swiss_native`, `swiss_native_couple`-equivalent).
+The mobile WaitlistScreen POSTs to /api/v1/waitlist when a user is
+routed to the « pas encore supporté pour ton profil » screen.
+
+Security scope source : `.planning/phases/01.5-archetype-hard-gate-fatca/01.5-SECURITY-fatca-scope.md`
+4 mandatory consent guardrails (§5) implemented :
+  1. Explicit opt-in checkbox  → `consent_given` column (NOT NULL)
+  2. Controller identity        → `legal_entity` column (default 'MINT SA' from privacy_service.py)
+  3. One-click unsubscribe      → enforced server-side by future outbound-mail infra (out of scope here)
+  4. Data retention period      → `retention_purge_after` column (default now() + 12 months)
+
+LSFin classification : the waitlist screen itself is NOT a financial
+service communication. The follow-up notification email IS marketing
+communication (UCA art. 3(1)(o)) — the opt-in captured here is the
+prior consent that legitimizes that future email.
+
+Per memory `project_orm_orphan_pattern` — this model ships in the same
+PR as its alembic migration (services/backend/alembic/versions/p123_waitlist_entry.py).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, String
+
+from app.core.database import Base
+
+
+# Allowed archetype slugs — must match the Pydantic Literal in
+# `app/schemas/waitlist.py` so the validation is single-source-of-truth.
+_ALLOWED_ARCHETYPES = (
+    "expat_us",
+    "expat_eu",
+    "cross_border",
+    "independent_no_lpp",
+    "couple_one_works",
+    "senior_post_64",
+    "unknown",   # detected but ambiguous — bias-false-positive bucket
+    "other",     # last-resort catch-all when the gate fires without a slug
+)
+
+# Allowed locales — matches the 6 ARB files in apps/mobile/lib/l10n/.
+_ALLOWED_LOCALES = ("fr", "en", "de", "es", "it", "pt")
+
+# Where the gate fired from — useful for analytics + future onboarding tuning.
+_ALLOWED_SOURCES = ("onboarding_hard_gate", "settings", "other")
+
+
+def _default_retention_purge_after() -> datetime:
+    """12-month retention per Security §6 Q2 + nLPD art. 25 transparency."""
+    return datetime.now(timezone.utc) + timedelta(days=365)
+
+
+class WaitlistEntry(Base):
+    """One row per user opt-in on the archetype hard-gate screen."""
+
+    __tablename__ = "waitlist_entries"
+
+    # Server-generated UUID PK (kept as String for sqlite/postgres
+    # cross-compat — same pattern as `anonymous_sessions.session_id`).
+    id = Column(String(36), primary_key=True)
+
+    # User-submitted email (single-purpose : notification when archetype lands).
+    # Pydantic EmailStr validates at request boundary ; column allows reasonable max.
+    email = Column(String(254), nullable=False, index=True)
+
+    # Detected archetype that triggered the gate. One of `_ALLOWED_ARCHETYPES`.
+    archetype = Column(String(32), nullable=False, index=True)
+
+    # Locale the screen was rendered in. One of `_ALLOWED_LOCALES`.
+    locale = Column(String(8), nullable=False)
+
+    # Which surface the gate fired from. One of `_ALLOWED_SOURCES`.
+    source = Column(String(32), nullable=False, server_default="other")
+
+    # Reused X-Anonymous-Session UUID from AnonymousSessionService (mobile).
+    # Indexed so the same anon user can be deduped client-side without
+    # surfacing the email back to the device. NOT a FK because anonymous
+    # sessions can be GC'd separately ; the waitlist row outlives them.
+    anonymous_session_id = Column(String(36), nullable=False, index=True)
+
+    # Explicit opt-in checkbox state. UCA art. 3(1)(o) requires prior
+    # consent for commercial email. Without this = legally void.
+    consent_given = Column(Boolean, nullable=False)
+
+    # Data controller identity surfaced in the consent UI. Defaults to
+    # « MINT SA » per `services/backend/app/services/privacy_service.py:41`
+    # — but stored on the row so we can audit consent against the entity
+    # named at the moment of capture (in case the legal entity ever changes).
+    legal_entity = Column(String(64), nullable=False, server_default="MINT SA")
+
+    # When the row was captured. UTC.
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    # When (or if) we notified the user their archetype became supported.
+    # NULL until the follow-up email infrastructure (future phase) writes here.
+    notified_at = Column(DateTime, nullable=True)
+
+    # nLPD art. 25 retention bound — auto-purge after this timestamp.
+    # 12-month default per Security §6 Q2. Background purge job is
+    # out-of-scope for 01.5 ; the column locks the contract.
+    retention_purge_after = Column(
+        DateTime,
+        nullable=False,
+        default=_default_retention_purge_after,
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover — debug-only
+        return (
+            f"<WaitlistEntry id={self.id} email=*** "
+            f"archetype={self.archetype} locale={self.locale}>"
+        )

--- a/services/backend/app/schemas/waitlist.py
+++ b/services/backend/app/schemas/waitlist.py
@@ -1,0 +1,111 @@
+"""Pydantic v2 schemas for the Waitlist endpoint — sub-phase 01.5.
+
+POST /api/v1/waitlist — captures email + consent metadata when the
+mobile WaitlistScreen renders because the user's archetype is NOT in
+the calibrated set.
+
+API convention : camelCase via `alias_generator=to_camel` (matches
+`anonymous_chat.py` schema pattern).
+
+Single-source-of-truth for the allowed values : the Literal types here
+mirror `app/models/waitlist_entry.py::_ALLOWED_*` tuples. Drift between
+the two is caught by the test suite (test_waitlist.py asserts equality).
+
+Compliance :
+- LSFin art. 8(3) safe harbor — withhold service when suitability fails
+- nLPD art. 6 — data minimization (email + archetype + locale only)
+- UCA art. 3(1)(o) — explicit prior consent for commercial email
+  (consentGiven=true required, validator rejects false)
+"""
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+from pydantic.alias_generators import to_camel
+
+
+# Mirror of `app/models/waitlist_entry.py::_ALLOWED_*`. See test_waitlist.py
+# for the parity assertion.
+ArchetypeSlug = Literal[
+    "expat_us",
+    "expat_eu",
+    "cross_border",
+    "independent_no_lpp",
+    "couple_one_works",
+    "senior_post_64",
+    "unknown",
+    "other",
+]
+
+LocaleSlug = Literal["fr", "en", "de", "es", "it", "pt"]
+
+SourceSlug = Literal["onboarding_hard_gate", "settings", "other"]
+
+
+class WaitlistRequest(BaseModel):
+    """Mobile → backend payload for the waitlist opt-in.
+
+    `consentGiven` MUST be true. UCA art. 3(1)(o) requires prior consent
+    for commercial email — a false value is a contract violation between
+    the mobile client and the backend, not a recoverable input error.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    email: EmailStr = Field(
+        ...,
+        description="User opt-in email. Validated with Pydantic EmailStr.",
+    )
+    archetype: ArchetypeSlug = Field(
+        ...,
+        description="Detected archetype that triggered the hard gate.",
+    )
+    locale: LocaleSlug = Field(
+        ...,
+        description="Locale the screen was rendered in (one of the 6 ARB locales).",
+    )
+    source: SourceSlug = Field(
+        default="other",
+        description="Where the gate fired from (analytics + onboarding tuning).",
+    )
+    consent_given: bool = Field(
+        ...,
+        description=(
+            "Explicit opt-in checkbox state. UCA art. 3(1)(o) requires "
+            "prior consent for commercial email."
+        ),
+    )
+
+    @field_validator("consent_given")
+    @classmethod
+    def _consent_must_be_true(cls, value: bool) -> bool:
+        if value is not True:
+            raise ValueError(
+                "consentGiven must be true. UCA art. 3(1)(o) prior-consent "
+                "requirement for commercial email."
+            )
+        return value
+
+
+class WaitlistResponse(BaseModel):
+    """Backend → mobile success payload."""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    id: str = Field(
+        ...,
+        description="Server-generated UUID for the captured waitlist entry.",
+    )
+    created_at: datetime = Field(
+        ...,
+        description="UTC timestamp the row was persisted.",
+    )
+    legal_entity: str = Field(
+        default="MINT SA",
+        description="Data controller named at the moment of capture.",
+    )
+    retention_purge_after: Optional[datetime] = Field(
+        default=None,
+        description="nLPD retention bound — server may auto-purge after this date.",
+    )

--- a/services/backend/tests/fixtures/test_pg_fixture_self.py
+++ b/services/backend/tests/fixtures/test_pg_fixture_self.py
@@ -52,12 +52,16 @@ def test_pg_fixture_spins_postgres_and_alembic_upgrade_head_idempotent(pg_engine
     #   (e) ORM-orphan safety net applied : {p122_orm_orphan_safety_net}
     #       (canonical post-2026-05-20 hotfix that backfills the 4
     #       ORM-orphan tables — closes Sentry MINT-BACKEND-3 + MINT-BACKEND-A).
+    #   (f) Sub-phase 01.5 waitlist endpoint applied : {p123_waitlist_entry}
+    #       (canonical post-2026-05-21 archetype HARD GATE backend slice
+    #       — POST /api/v1/waitlist + WaitlistEntry model).
     expected_heads = {
         "p112_audit_event_user_hash",
         "p86_eclairage_delivered",
         "p98_merge_p86_eclairage",
         "p119_phase02_parity_cont",
         "p122_orm_orphan_safety_net",
+        "p123_waitlist_entry",
     }
     assert heads_in_db & expected_heads, (
         f"alembic_version table missing expected heads. "

--- a/services/backend/tests/test_waitlist.py
+++ b/services/backend/tests/test_waitlist.py
@@ -1,0 +1,394 @@
+"""Tests for POST /api/v1/waitlist — sub-phase 01.5 archetype HARD GATE.
+
+Covers:
+- HTTP contract: 201 on success × 6 archetypes, 401 on missing/malformed
+  session header, 400 on invalid email / archetype / locale / consent
+  values, 201 idempotent on dedup
+- Persistence: row written with all required columns, defaults applied
+- Consent guard: UCA art. 3(1)(o) — consentGiven must be true
+- Schema ↔ model parity: Pydantic Literal must match SQLAlchemy
+  _ALLOWED_ARCHETYPES tuple
+- camelCase contract via alias_generator
+- T-13-06 isolation: no auth dep imported
+
+Run: cd services/backend && python3 -m pytest tests/test_waitlist.py -q
+"""
+
+from __future__ import annotations
+
+import os
+import uuid as uuid_lib
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("TESTING", "1")
+
+from app.core.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models.waitlist_entry import (  # noqa: E402
+    WaitlistEntry,
+    _ALLOWED_ARCHETYPES,
+    _ALLOWED_LOCALES,
+    _ALLOWED_SOURCES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test DB setup — in-memory SQLite per test
+# ---------------------------------------------------------------------------
+
+TEST_DB_URL = "sqlite:///./test_waitlist.db"
+_test_engine = create_engine(
+    TEST_DB_URL,
+    connect_args={"check_same_thread": False},
+)
+_TestSessionLocal = sessionmaker(
+    autocommit=False, autoflush=False, bind=_test_engine
+)
+
+
+def _override_get_db():
+    db = _TestSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=_test_engine)
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    Base.metadata.drop_all(bind=_test_engine)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def session_uuid() -> str:
+    return str(uuid_lib.uuid4())
+
+
+def _valid_body(
+    archetype: str = "expat_us",
+    locale: str = "fr",
+    source: str = "onboarding_hard_gate",
+    email: str = "ada@example.ch",
+    consent_given: bool = True,
+) -> dict:
+    """Build a valid request body (camelCase, matches alias_generator)."""
+    return {
+        "email": email,
+        "archetype": archetype,
+        "locale": locale,
+        "source": source,
+        "consentGiven": consent_given,
+    }
+
+
+# ---------------------------------------------------------------------------
+# §1 Happy-path coverage : 201 across all gated archetypes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "archetype",
+    [
+        "expat_us",
+        "expat_eu",
+        "cross_border",
+        "independent_no_lpp",
+        "couple_one_works",
+        "senior_post_64",
+    ],
+)
+def test_post_waitlist_201_for_each_gated_archetype(
+    client: TestClient, session_uuid: str, archetype: str
+) -> None:
+    response = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(archetype=archetype),
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 201, response.text
+    payload = response.json()
+    assert "id" in payload
+    assert "createdAt" in payload  # alias_generator → camelCase
+    assert payload["legalEntity"] == "MINT SA"
+    assert "retentionPurgeAfter" in payload
+
+
+def test_post_waitlist_persists_row_with_required_columns(
+    client: TestClient, session_uuid: str
+) -> None:
+    response = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(),
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 201
+    new_id = response.json()["id"]
+
+    db = _TestSessionLocal()
+    try:
+        row = db.query(WaitlistEntry).filter(WaitlistEntry.id == new_id).first()
+        assert row is not None
+        assert row.email == "ada@example.ch"
+        assert row.archetype == "expat_us"
+        assert row.locale == "fr"
+        assert row.source == "onboarding_hard_gate"
+        assert row.anonymous_session_id == session_uuid
+        assert row.consent_given is True
+        assert row.legal_entity == "MINT SA"
+        assert row.notified_at is None
+        assert row.retention_purge_after > row.created_at
+    finally:
+        db.close()
+
+
+def test_post_waitlist_normalizes_email_lowercase(
+    client: TestClient, session_uuid: str
+) -> None:
+    response = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(email="Ada.LoveLace@Example.ch"),
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 201
+    new_id = response.json()["id"]
+
+    db = _TestSessionLocal()
+    try:
+        row = db.query(WaitlistEntry).filter(WaitlistEntry.id == new_id).first()
+        assert row is not None
+        # Email persisted in lowercase (dedup contract).
+        assert row.email == "ada.lovelace@example.ch"
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# §2 Idempotent dedup : same (email, archetype) returns existing row
+# ---------------------------------------------------------------------------
+
+
+def test_post_waitlist_idempotent_on_same_email_and_archetype(
+    client: TestClient, session_uuid: str
+) -> None:
+    body = _valid_body()
+    first = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert second.status_code == 201, second.text
+    assert second.json()["id"] == first_id
+
+    db = _TestSessionLocal()
+    try:
+        rows = db.query(WaitlistEntry).all()
+        assert len(rows) == 1
+    finally:
+        db.close()
+
+
+def test_post_waitlist_different_archetype_creates_new_row(
+    client: TestClient, session_uuid: str
+) -> None:
+    """Same email, different archetype = different intent = new row."""
+    first = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(archetype="expat_us"),
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert first.status_code == 201
+
+    second = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(archetype="cross_border"),
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert second.status_code == 201
+    assert second.json()["id"] != first.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# §3 Session header validation (T-13-01 mirror)
+# ---------------------------------------------------------------------------
+
+
+def test_post_waitlist_401_on_missing_session_header(client: TestClient) -> None:
+    response = client.post("/api/v1/waitlist", json=_valid_body())
+    assert response.status_code == 401
+    assert "X-Anonymous-Session" in response.json()["detail"]
+
+
+def test_post_waitlist_401_on_malformed_session_header(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/waitlist",
+        json=_valid_body(),
+        headers={"X-Anonymous-Session": "not-a-uuid"},
+    )
+    assert response.status_code == 401
+    assert "UUID" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# §4 Pydantic input validation
+# ---------------------------------------------------------------------------
+
+
+def test_post_waitlist_422_on_invalid_email(
+    client: TestClient, session_uuid: str
+) -> None:
+    body = _valid_body(email="not-an-email")
+    response = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 422  # FastAPI default for Pydantic failure
+
+
+def test_post_waitlist_422_on_unsupported_archetype(
+    client: TestClient, session_uuid: str
+) -> None:
+    body = _valid_body(archetype="not-a-real-archetype")
+    response = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 422
+
+
+def test_post_waitlist_422_on_unsupported_locale(
+    client: TestClient, session_uuid: str
+) -> None:
+    body = _valid_body(locale="jp")
+    response = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 422
+
+
+def test_post_waitlist_422_on_consent_false(
+    client: TestClient, session_uuid: str
+) -> None:
+    """UCA art. 3(1)(o) — consent must be explicit true."""
+    body = _valid_body(consent_given=False)
+    response = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 422
+
+
+def test_post_waitlist_default_source_other_when_omitted(
+    client: TestClient, session_uuid: str
+) -> None:
+    body = _valid_body()
+    body.pop("source")
+    response = client.post(
+        "/api/v1/waitlist",
+        json=body,
+        headers={"X-Anonymous-Session": session_uuid},
+    )
+    assert response.status_code == 201
+
+    db = _TestSessionLocal()
+    try:
+        row = (
+            db.query(WaitlistEntry)
+            .filter(WaitlistEntry.id == response.json()["id"])
+            .first()
+        )
+        assert row.source == "other"
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# §5 Schema ↔ model parity (single-source-of-truth contract)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_archetype_literal_matches_model_tuple() -> None:
+    """Drift would let invalid archetypes hit the DB layer."""
+    from app.schemas.waitlist import ArchetypeSlug
+    from typing import get_args
+
+    schema_values = set(get_args(ArchetypeSlug))
+    model_values = set(_ALLOWED_ARCHETYPES)
+    assert schema_values == model_values, (
+        f"Drift between schema Literal and model tuple. "
+        f"schema={schema_values} model={model_values}"
+    )
+
+
+def test_schema_locale_literal_matches_model_tuple() -> None:
+    from app.schemas.waitlist import LocaleSlug
+    from typing import get_args
+
+    schema_values = set(get_args(LocaleSlug))
+    model_values = set(_ALLOWED_LOCALES)
+    assert schema_values == model_values
+
+
+def test_schema_source_literal_matches_model_tuple() -> None:
+    from app.schemas.waitlist import SourceSlug
+    from typing import get_args
+
+    schema_values = set(get_args(SourceSlug))
+    model_values = set(_ALLOWED_SOURCES)
+    assert schema_values == model_values
+
+
+# ---------------------------------------------------------------------------
+# §6 T-13-06 isolation guard
+# ---------------------------------------------------------------------------
+
+
+def test_waitlist_endpoint_imports_no_auth_dep() -> None:
+    """T-13-06 — waitlist endpoint must NOT import authenticated deps.
+
+    The waitlist screen renders BEFORE signup ; importing
+    `require_current_user` or `coach_chat` would couple the public
+    pre-auth path to the authenticated stack and breach T-13-06
+    isolation (same constraint as anonymous_chat.py).
+    """
+    import inspect
+
+    from app.api.v1.endpoints import waitlist as waitlist_endpoint
+
+    source = inspect.getsource(waitlist_endpoint)
+    forbidden_imports = [
+        "from app.core.auth import",
+        "require_current_user",
+        "from app.api.v1.endpoints.coach_chat",
+        "from app.api.v1.endpoints import coach_chat",
+    ]
+    for forbidden in forbidden_imports:
+        assert forbidden not in source, (
+            f"T-13-06 violation: waitlist endpoint imports {forbidden!r}. "
+            f"The anonymous/pre-signup path must stay isolated from auth."
+        )

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -22913,6 +22913,110 @@
         "title": "VoicePreference",
         "type": "string"
       },
+      "WaitlistRequest": {
+        "description": "Mobile → backend payload for the waitlist opt-in.\n\n`consentGiven` MUST be true. UCA art. 3(1)(o) requires prior consent\nfor commercial email — a false value is a contract violation between\nthe mobile client and the backend, not a recoverable input error.",
+        "properties": {
+          "archetype": {
+            "description": "Detected archetype that triggered the hard gate.",
+            "enum": [
+              "expat_us",
+              "expat_eu",
+              "cross_border",
+              "independent_no_lpp",
+              "couple_one_works",
+              "senior_post_64",
+              "unknown",
+              "other"
+            ],
+            "title": "Archetype",
+            "type": "string"
+          },
+          "consentGiven": {
+            "description": "Explicit opt-in checkbox state. UCA art. 3(1)(o) requires prior consent for commercial email.",
+            "title": "Consentgiven",
+            "type": "boolean"
+          },
+          "email": {
+            "description": "User opt-in email. Validated with Pydantic EmailStr.",
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "locale": {
+            "description": "Locale the screen was rendered in (one of the 6 ARB locales).",
+            "enum": [
+              "fr",
+              "en",
+              "de",
+              "es",
+              "it",
+              "pt"
+            ],
+            "title": "Locale",
+            "type": "string"
+          },
+          "source": {
+            "default": "other",
+            "description": "Where the gate fired from (analytics + onboarding tuning).",
+            "enum": [
+              "onboarding_hard_gate",
+              "settings",
+              "other"
+            ],
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "archetype",
+          "locale",
+          "consentGiven"
+        ],
+        "title": "WaitlistRequest",
+        "type": "object"
+      },
+      "WaitlistResponse": {
+        "description": "Backend → mobile success payload.",
+        "properties": {
+          "createdAt": {
+            "description": "UTC timestamp the row was persisted.",
+            "format": "date-time",
+            "title": "Createdat",
+            "type": "string"
+          },
+          "id": {
+            "description": "Server-generated UUID for the captured waitlist entry.",
+            "title": "Id",
+            "type": "string"
+          },
+          "legalEntity": {
+            "default": "MINT SA",
+            "description": "Data controller named at the moment of capture.",
+            "title": "Legalentity",
+            "type": "string"
+          },
+          "retentionPurgeAfter": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "nLPD retention bound — server may auto-purge after this date.",
+            "title": "Retentionpurgeafter"
+          }
+        },
+        "required": [
+          "id",
+          "createdAt"
+        ],
+        "title": "WaitlistResponse",
+        "type": "object"
+      },
       "WealthTaxComparisonRequest": {
         "description": "Request for 26-canton wealth tax comparison.",
         "properties": {
@@ -33932,6 +34036,48 @@
         "summary": "Orp Link",
         "tags": [
           "unemployment"
+        ]
+      }
+    },
+    "/api/v1/waitlist": {
+      "post": {
+        "description": "Capture a waitlist opt-in from the mobile WaitlistScreen.\n\nReturns 201 on success, 400 on validation failure (handled by\nPydantic upstream), 401 on missing/malformed X-Anonymous-Session\nheader, 409 on dedup (same email + archetype already captured).",
+        "operationId": "submit_waitlist_api_v1_waitlist_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WaitlistRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WaitlistResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Waitlist",
+        "tags": [
+          "Waitlist P0 01.5"
         ]
       }
     }


### PR DESCRIPTION
## Summary

Sub-phase 01.5 archetype HARD GATE — **backend slice** (PR-1 of 3 per [01.5-PLAN.md](.planning/phases/01.5-archetype-hard-gate-fatca/01.5-PLAN.md)).

The mobile WaitlistScreen (PR-2, next) POSTs here when a user's archetype is NOT in the calibrated set (`swiss_native`, `swiss_native_couple`-equivalent). Captures email + opt-in consent + locale + retention metadata so we can notify them when their archetype lands without violating UCA art. 3(1)(o) prior-consent or nLPD art. 25 transparency.

### What's in

- `app/models/waitlist_entry.py` — SQLAlchemy model with 12-month retention default + `consent_given NOT NULL` + `legal_entity='MINT SA'` server default
- `alembic/versions/p123_waitlist_entry.py` — idempotent CREATE TABLE + 3 indexes (chains off `p122_orm_orphan_safety_net`)
- `app/schemas/waitlist.py` — Pydantic v2 with camelCase via `alias_generator`, `EmailStr`, `Literal` types, explicit `consentGiven=true` validator
- `app/api/v1/endpoints/waitlist.py` — POST endpoint reusing the X-Anonymous-Session UUID validator pattern from `anonymous_chat.py:62` (T-13-06 isolation preserved)
- `app/api/v1/router.py` — registered under prefix `/waitlist`
- `tests/test_waitlist.py` — 21 new tests
- Planning artifacts (CONTEXT, MAPPER, SECURITY, UI, PLAN) bundled per memory `feedback_html_evidence_report`

## Why this slice ships first

PR-1 is independent of mobile and can be reviewed in parallel with PR-2, but **PR-2 cannot ship to staging before PR-1** because the mobile waitlist service would 404. Sequencing per [01.5-PLAN.md §2](.planning/phases/01.5-archetype-hard-gate-fatca/01.5-PLAN.md).

## Compliance posture

Per [01.5-SECURITY-fatca-scope.md](.planning/phases/01.5-archetype-hard-gate-fatca/01.5-SECURITY-fatca-scope.md) — 4 mandatory consent guardrails implemented :

1. **Explicit opt-in** : `consent_given NOT NULL` column + Pydantic validator rejects `false`
2. **Controller identity** : `legal_entity='MINT SA'` server default (sourced from `services/backend/app/services/privacy_service.py:41`)
3. **One-click unsubscribe** : enforced server-side by future outbound-mail infra (out of scope here)
4. **Data retention** : `retention_purge_after` column defaults to `now() + 12 months` (nLPD art. 25)

LSFin art. 7-10 analysis : the waitlist itself is NOT a financial service communication (no financial content). The follow-up email IS marketing communication ; the opt-in captured here is the prior consent that legitimizes the future email.

## Test plan

- [x] `pytest tests/test_waitlist.py` — 21/21 green
- [x] `pytest tests/test_anonymous_chat.py` regression — 12/12 still green (33/33 combined)
- [x] `alembic upgrade head` on fresh sqlite — `p123_waitlist_entry` reached
- [x] `alembic downgrade base` from `p123_waitlist_entry` — full chain reverses cleanly
- [x] Schema ↔ model parity guard : `Literal` values match `_ALLOWED_*` tuples (drift = test failure)
- [x] T-13-06 isolation guard : endpoint imports no auth deps (forbidden imports enumerated in test)
- [ ] Full backend pytest suite on CI (~ 4-5 min)
- [ ] PG integration testcontainers green on CI
- [ ] Merge → dev. **Staging promote held until PR-2 ships** (avoids exposing a live endpoint that no mobile path uses yet).

## Risk

Low — pure additive backend, no existing route touched, no mobile dependency yet. Idempotent migration is safe on a DB that already has the table.

## Next

- **PR-2** (mobile) — detection fix at `coach_profile.dart:1875` + duplicate at `fri_computation_service.dart:237-238` + WaitlistScreen + Provider + Service + 13 ARB keys + US-tax-person onboarding Q + GoRouter `/waitlist` + walker `julien_expat_us` seed + composite panel review
- **PR-3** (Maestro) — `flow_hardgate_expat_us.yaml` + regression hero flow + VERIFICATION.md + HANDOFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)