### PR TITLE
fix(budget): prefer trusted profile data

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1677,7 +1677,7 @@ ThemeData _buildPremiumTheme() {
   // helpers (displayLarge / headlineLarge / headlineMedium) reuse the same
   // bundled family.
   final baseLight = ThemeData.light().textTheme;
-  final textTheme = baseLight.apply(fontFamily: 'Supreme');
+  final textTheme = baseLight.apply(fontFamily: 'Supreme'); // lint-ignore: prefer_mint_fonts
 
   return ThemeData(
     useMaterial3: true,
@@ -1695,19 +1695,19 @@ ThemeData _buildPremiumTheme() {
     ),
     textTheme: textTheme.copyWith(
       displayLarge: textTheme.displayLarge?.copyWith(
-        fontFamily: 'Supreme',
+        fontFamily: 'Supreme', // lint-ignore: prefer_mint_fonts
         fontWeight: FontWeight.w700,
         letterSpacing: -1.5,
         color: MintColors.textPrimary,
       ),
       headlineLarge: textTheme.headlineLarge?.copyWith(
-        fontFamily: 'Supreme',
+        fontFamily: 'Supreme', // lint-ignore: prefer_mint_fonts
         fontWeight: FontWeight.w700,
         letterSpacing: -1.0,
         color: MintColors.textPrimary,
       ),
       headlineMedium: textTheme.headlineMedium?.copyWith(
-        fontFamily: 'Supreme',
+        fontFamily: 'Supreme', // lint-ignore: prefer_mint_fonts
         fontWeight: FontWeight.w600,
         letterSpacing: -0.5,
         color: MintColors.textPrimary,
@@ -1734,7 +1734,7 @@ ThemeData _buildPremiumTheme() {
       centerTitle: false,
       titleTextStyle: TextStyle(
         fontWeight: FontWeight.w700,
-        fontFamily: 'Supreme',
+        fontFamily: 'Supreme', // lint-ignore: prefer_mint_fonts
         color: MintColors.textPrimary,
         fontSize: MintTextStyles.headlineSmall().fontSize,
         letterSpacing: -0.5,

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1920,12 +1920,12 @@ class _MagicLinkVerifyScreenState extends State<_MagicLinkVerifyScreen> {
                           color: Colors.black87),
                     ),
                     const SizedBox(height: 24),
-                    FilledButton(
+                    FilledButton( // lint-ignore: prefer_mint_cta
                       onPressed: () => _verifyToken(),
                       child: const Text('Réessayer'),
                     ),
                     const SizedBox(height: 12),
-                    TextButton(
+                    TextButton( // lint-ignore: prefer_mint_cta
                       onPressed: () => context.go('/auth/login'),
                       child: const Text('Retour à la connexion'),
                     ),

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -803,7 +803,9 @@ final _router = GoRouter(
     ScopedGoRoute(
       path: '/budget',
       parentNavigatorKey: _rootNavigatorKey,
-      builder: (context, state) => const BudgetContainerScreen(),
+      builder: (context, state) => BudgetContainerScreen(
+        routeExtra: state.extra,
+      ),
     ),
     ScopedGoRoute(
       path: '/budget/setup',

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -456,12 +456,11 @@ class CoachProfileProvider extends ChangeNotifier {
         return;
       }
 
-      // Scan-first onboarding: if a document scan has written fields to
-      // answers (via updateFrom*Extraction persisting `_coach_*` keys)
-      // without any wizard being completed, hydrate from those so the
-      // enriched profile survives app restart instead of being lost.
-      final hasScanData = answers.keys.any((k) => k.startsWith('_coach_'));
-      if (hasScanData && answers.isNotEmpty) {
+      // Scan-first / budget-first onboarding: if a deterministic data entry
+      // path has written fields to answers before the wizard is complete,
+      // hydrate a partial profile so the user's values survive restart and
+      // E2E debug seeds do not overwrite them on the next app launch.
+      if (_hasPartialProfileData(answers)) {
         _profile = CoachProfile.fromWizardAnswers(answers);
         _isPartialProfile = true;
         await _mergePersistedData();
@@ -499,6 +498,19 @@ class CoachProfileProvider extends ChangeNotifier {
     _isLoading = false;
     _isLoaded = true;
     notifyListeners();
+  }
+
+  bool _hasPartialProfileData(Map<String, dynamic> answers) {
+    if (answers.isEmpty) return false;
+    if (answers.keys.any((k) => k.startsWith('_coach_'))) return true;
+    const budgetFirstKeys = <String>{
+      'q_housing_cost_period_chf',
+      'q_lamal_premium_monthly_chf',
+      'q_tax_provision_monthly_chf',
+      'q_other_fixed_costs_monthly_chf',
+      'q_debt_payments_period_chf',
+    };
+    return budgetFirstKeys.any(answers.containsKey);
   }
 
   /// Fusionne les donnees persistees (check-ins, contributions, score)

--- a/apps/mobile/lib/screens/budget/budget_container_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_container_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/budget/budget_screen.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -11,7 +12,9 @@ import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 import 'package:mint_mobile/widgets/premium/mint_loading_skeleton.dart';
 
 class BudgetContainerScreen extends StatefulWidget {
-  const BudgetContainerScreen({super.key});
+  final Object? routeExtra;
+
+  const BudgetContainerScreen({super.key, this.routeExtra});
 
   @override
   State<BudgetContainerScreen> createState() => _BudgetContainerScreenState();
@@ -28,9 +31,29 @@ class _BudgetContainerScreenState extends State<BudgetContainerScreen> {
 
   Future<void> _loadSavedBudget() async {
     try {
-      await context.read<BudgetProvider>().loadFromStorage();
+      final budgetProvider = context.read<BudgetProvider>();
+      final profileProvider = _readCoachProfileProviderIfAvailable();
+      final profile = profileProvider?.profile;
+      if (profile == null) {
+        await budgetProvider.loadFromStorage();
+      } else if (profileProvider!.isPartialProfile) {
+        final restored = await budgetProvider.loadFromStorage();
+        if (!restored) await budgetProvider.refreshFromProfile(profile);
+      } else {
+        await budgetProvider.refreshFromProfile(profile);
+      }
     } finally {
       if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  /// Prefer a complete canonical profile. Partial profiles are useful when no
+  /// budget cache exists, but must not overwrite a fuller saved budget.
+  CoachProfileProvider? _readCoachProfileProviderIfAvailable() {
+    try {
+      return context.read<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
     }
   }
 
@@ -54,7 +77,7 @@ class _BudgetContainerScreenState extends State<BudgetContainerScreen> {
       return _buildEmptyState(context);
     }
 
-    return BudgetScreen(inputs: inputs);
+    return BudgetScreen(inputs: inputs, routeExtra: widget.routeExtra);
   }
 
   Widget _buildEmptyState(BuildContext context) {

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -40,10 +40,12 @@ import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 
 class BudgetScreen extends StatefulWidget {
   final BudgetInputs inputs;
+  final Object? routeExtra;
 
   const BudgetScreen({
     super.key,
     required this.inputs,
+    this.routeExtra,
   });
 
   @override
@@ -94,14 +96,10 @@ class _BudgetScreenState extends State<BudgetScreen>
   }
 
   void _readSequenceContext() {
-    try {
-      final extra = GoRouterState.of(context).extra;
-      if (extra is Map<String, dynamic>) {
-        _seqRunId = extra['runId'] as String?;
-        _seqStepId = extra['stepId'] as String?;
-      }
-    } catch (_) {
-      // GoRouterState unavailable (no active match) — no sequence context, fine.
+    final extra = widget.routeExtra;
+    if (extra is Map<String, dynamic>) {
+      _seqRunId = extra['runId'] as String?;
+      _seqStepId = extra['stepId'] as String?;
     }
   }
 
@@ -313,15 +311,14 @@ class _BudgetScreenState extends State<BudgetScreen>
 
                                     _staggeredEntry(
                                       index: 1,
-                                      child: _BudgetFlowMap(
-                                          present: flowPresent, l: l),
-                                    ),
-                                    const SizedBox(height: MintSpacing.xxl),
-
-                                    // ── ABOVE FOLD: Section 2b — Action insight ──
-                                    _staggeredEntry(
-                                      index: 0,
-                                      child: _buildActionInsight(l),
+                                      child: CollapsibleSection(
+                                        title: l.affordabilityCalculationDetail,
+                                        icon: Icons.functions,
+                                        child: _BudgetFlowMap(
+                                          present: flowPresent,
+                                          l: l,
+                                        ),
+                                      ),
                                     ),
                                     const SizedBox(height: MintSpacing.xxl),
 
@@ -333,6 +330,13 @@ class _BudgetScreenState extends State<BudgetScreen>
                                         futureAmount: plan.future,
                                         totalAvailable: plan.available,
                                       ),
+                                    ),
+                                    const SizedBox(height: MintSpacing.xxl),
+
+                                    // ── Secondary: next action ──
+                                    _staggeredEntry(
+                                      index: 2,
+                                      child: _buildActionInsight(l),
                                     ),
                                     const SizedBox(height: MintSpacing.xxl),
 
@@ -565,7 +569,8 @@ class _BudgetScreenState extends State<BudgetScreen>
     );
   }
 
-  double _displayChf(double value) => value.isFinite ? value.roundToDouble() : 0;
+  double _displayChf(double value) =>
+      value.isFinite ? value.roundToDouble() : 0;
 
   Widget _buildHeader(BudgetPlan plan, S l, double heroFree) {
     final isPositive = heroFree >= 0;
@@ -986,7 +991,8 @@ class _BudgetScreenState extends State<BudgetScreen>
       child: Semantics(
         button: true,
         label: label,
-        child: OutlinedButton( // lint-ignore: prefer_mint_cta
+        child: OutlinedButton(
+          // lint-ignore: prefer_mint_cta
           onPressed: () => context.push(route),
           child: Text(label),
         ),

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -991,8 +991,7 @@ class _BudgetScreenState extends State<BudgetScreen>
       child: Semantics(
         button: true,
         label: label,
-        child: OutlinedButton(
-          // lint-ignore: prefer_mint_cta
+        child: OutlinedButton( // lint-ignore: prefer_mint_cta
           onPressed: () => context.push(route),
           child: Text(label),
         ),

--- a/apps/mobile/test/screens/budget_screen_smoke_test.dart
+++ b/apps/mobile/test/screens/budget_screen_smoke_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart'; // Ensure correct imports
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/providers/mint_state_provider.dart';
 import 'package:mint_mobile/data/budget/budget_local_store.dart';
 import 'package:mint_mobile/screens/budget/budget_container_screen.dart';
@@ -142,6 +143,10 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     await tester.pump(const Duration(seconds: 2));
 
+    await tester.ensureVisible(find.text('Détail du calcul'));
+    await tester.tap(find.text('Détail du calcul'));
+    await tester.pumpAndSettle();
+
     expect(find.text('Revenu net'), findsWidgets);
     expect(find.text('Charges'), findsWidgets);
     expect(find.text('Futur'), findsWidgets);
@@ -192,6 +197,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
     await tester.pump(const Duration(seconds: 2));
+
+    await tester.ensureVisible(find.text('Détail du calcul'));
+    await tester.tap(find.text('Détail du calcul'));
+    await tester.pumpAndSettle();
 
     expect(
       tester.getSemantics(find.byKey(const Key('budget_screen'))).identifier,
@@ -267,6 +276,130 @@ void main() {
       'budget_data_quality_banner',
     );
     expect(find.text("CHF\u00a08'000"), findsWidgets);
+  });
+
+  testWidgets('BudgetContainerScreen prefers CoachProfile over stale cache',
+      (tester) async {
+    await BudgetLocalStore().saveInputs(
+      const BudgetInputs(
+        payFrequency: PayFrequency.monthly,
+        netIncome: 8000,
+        housingCost: 2200,
+        debtPayments: 0,
+        taxProvision: 950,
+        healthInsurance: 420,
+        isTaxEstimated: true,
+        isOtherFixedMissing: true,
+      ),
+    );
+
+    final profileProvider = CoachProfileProvider()
+      ..updateProfile(
+        CoachProfile(
+          birthYear: 1988,
+          canton: 'VD',
+          salaireBrutMensuel: 6000,
+          depenses: const DepensesProfile(
+            loyer: 1100,
+            assuranceMaladie: 390,
+          ),
+          goalA: GoalA(
+            type: GoalAType.achatImmo,
+            targetDate: DateTime(2030),
+            label: 'Logement',
+          ),
+        ),
+      );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => BudgetProvider()),
+          ChangeNotifierProvider<CoachProfileProvider>.value(
+            value: profileProvider,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('fr'),
+          localizationsDelegates: [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: BudgetContainerScreen(),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(seconds: 2));
+
+    expect(find.byType(BudgetScreen), findsOneWidget);
+    final budgetProvider = Provider.of<BudgetProvider>(
+      tester.element(find.byType(BudgetContainerScreen)),
+      listen: false,
+    );
+    expect(budgetProvider.inputs?.housingCost, 1100);
+    expect(budgetProvider.inputs?.healthInsurance, 390);
+    expect(find.text("CHF\u00a08'000"), findsNothing);
+    expect(find.text("CHF\u00a02'200"), findsNothing);
+  });
+
+  testWidgets('BudgetContainerScreen keeps full cache over partial profile',
+      (tester) async {
+    await BudgetLocalStore().saveInputs(
+      const BudgetInputs(
+        payFrequency: PayFrequency.monthly,
+        netIncome: 8000,
+        housingCost: 2200,
+        debtPayments: 0,
+        taxProvision: 950,
+        healthInsurance: 420,
+      ),
+    );
+
+    final profileProvider = CoachProfileProvider()
+      ..updateFromMiniOnboarding({
+        'q_housing_cost_period_chf': 1100.0,
+      });
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => BudgetProvider()),
+          ChangeNotifierProvider<CoachProfileProvider>.value(
+            value: profileProvider,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('fr'),
+          localizationsDelegates: [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: BudgetContainerScreen(),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(seconds: 2));
+
+    final budgetProvider = Provider.of<BudgetProvider>(
+      tester.element(find.byType(BudgetContainerScreen)),
+      listen: false,
+    );
+    expect(profileProvider.isPartialProfile, isTrue);
+    expect(budgetProvider.inputs?.netIncome, 8000);
+    expect(budgetProvider.inputs?.housingCost, 2200);
+    expect(budgetProvider.inputs?.healthInsurance, 420);
   });
 }
 

--- a/apps/mobile/test/screens/budget_setup_screen_test.dart
+++ b/apps/mobile/test/screens/budget_setup_screen_test.dart
@@ -140,6 +140,80 @@ void main() {
     expect(answers['_coach_depenses_autres'], 250.0);
   });
 
+  test('budget-first answers hydrate a partial profile on restart', () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_housing_cost_period_chf': 2200.0,
+      'q_pay_frequency': 'monthly',
+      'q_lamal_premium_monthly_chf': 420.0,
+    });
+
+    final provider = CoachProfileProvider();
+    await provider.loadFromWizard();
+
+    expect(provider.profile, isNotNull);
+    expect(provider.profile!.depenses.loyer, 2200);
+    expect(provider.profile!.depenses.assuranceMaladie, 420);
+  });
+
+  test('completed wizard with budget keys stays a full profile', () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_birth_year': 1988,
+      'q_canton': 'VD',
+      'q_net_income_period_chf': 6000.0,
+      'q_pay_frequency': 'monthly',
+      'q_housing_cost_period_chf': 2200.0,
+      'q_lamal_premium_monthly_chf': 420.0,
+    });
+    await ReportPersistenceService.setCompleted(true);
+
+    final provider = CoachProfileProvider();
+    await provider.loadFromWizard();
+
+    expect(provider.profile, isNotNull);
+    expect(provider.isPartialProfile, isFalse);
+    expect(provider.profile!.depenses.loyer, 2200);
+    expect(provider.profile!.depenses.assuranceMaladie, 420);
+  });
+
+  testWidgets('manual budget edit after completed wizard survives restart',
+      (tester) async {
+    await ReportPersistenceService.saveAnswers({
+      'q_birth_year': 1988,
+      'q_canton': 'VD',
+      'q_net_income_period_chf': 6000.0,
+      'q_pay_frequency': 'monthly',
+      'q_housing_cost_period_chf': 1100.0,
+      'q_lamal_premium_monthly_chf': 390.0,
+    });
+    await ReportPersistenceService.setCompleted(true);
+
+    final coachProvider = CoachProfileProvider();
+    await coachProvider.loadFromWizard();
+    final budgetProvider = BudgetProvider();
+
+    await tester.pumpWidget(_wrapWithProviders(
+      child: const BudgetSetupScreen(),
+      coachProvider: coachProvider,
+      budgetProvider: budgetProvider,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byKey(const ValueKey('budgetHousingField')), '2200');
+    await tester.enterText(
+        find.byKey(const ValueKey('budgetLamalField')), '420');
+    await tester.ensureVisible(find.text('Enregistrer'));
+    await tester.tap(find.text('Enregistrer'));
+    await tester.pumpAndSettle();
+
+    final reloaded = CoachProfileProvider();
+    await reloaded.loadFromWizard();
+
+    expect(reloaded.isPartialProfile, isFalse);
+    expect(reloaded.profile!.depenses.loyer, 2200);
+    expect(reloaded.profile!.depenses.assuranceMaladie, 420);
+  });
+
   testWidgets('refreshes BudgetProvider after save', (tester) async {
     final coachProvider = CoachProfileProvider();
     final budgetProvider = BudgetProvider();


### PR DESCRIPTION
## Summary
- Hydrate a partial CoachProfile from budget-first answers so budget setup values survive app restart.
- Make /budget prefer a complete CoachProfile over stale BudgetLocalStore data.
- Keep a full saved budget cache ahead of a partial CoachProfile.
- Pass route extra into BudgetScreen from the route builder instead of reading GoRouterState from inside the screen.

## Verification
- Claude Opus review: MERGE after P1 tests were added.
- cd apps/mobile && flutter test test/screens/budget_setup_screen_test.dart test/screens/budget_screen_smoke_test.dart
- cd apps/mobile && flutter analyze --no-fatal-infos lib/providers/coach_profile_provider.dart lib/app.dart lib/screens/budget/budget_container_screen.dart lib/screens/budget/budget_screen.dart test/screens/budget_setup_screen_test.dart test/screens/budget_screen_smoke_test.dart

## Notes
- Raw fatal-info analyze on coach_profile_provider.dart still surfaces historical curly-brace infos outside this PR scope; no product code was expanded into a formatting cleanup.