### PR TITLE
fix(mon-argent): expose data trust chips

### DIFF
--- a/.planning/phases/money-trust-contract-v1-01-spine-trust-chip/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-01-spine-trust-chip/PLAN.md
@@ -1,0 +1,25 @@
+description: Plan to surface existing data-spine confidence metadata in Mon Argent.
+
+# Money Trust Contract v1-01 — Spine Trust Chip
+
+## Goal
+
+Show a compact trust chip on the first eligible `Mon argent` data-spine rows
+without adding a new money model.
+
+## Implementation
+
+1. Reuse `SpineValue.meta.confidence` and `PillarFact.state`.
+2. Keep chips private, read-only, and local to `MonArgentScreen`.
+3. Add stable semantics identifiers for known, estimated, and missing states.
+4. Add focused widget tests.
+
+## Verification
+
+`dart format`; targeted `flutter analyze`; targeted `flutter test`;
+`validate_arb_parity`; iOS simulator + relevant Maestro flow if gates pass.
+
+## Non-Goals
+
+No global `MoneyFigure`, new ARB strings, Coach edits, Budget edits, or
+financial formula changes.

--- a/apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart
+++ b/apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart
@@ -667,6 +667,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.grossAnnualIncome),
               statusLabel: _fieldStatusLabel(situation.grossAnnualIncome),
               statusColor: _fieldStatusColor(situation.grossAnnualIncome),
+              trustId: 'gross_income',
             ),
             const SizedBox(height: MintSpacing.sm),
             _SituationValueRow(
@@ -674,6 +675,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.monthlyHousingCost),
               statusLabel: _fieldStatusLabel(situation.monthlyHousingCost),
               statusColor: _fieldStatusColor(situation.monthlyHousingCost),
+              trustId: 'housing_cost',
             ),
             const SizedBox(height: MintSpacing.sm),
             _SituationValueRow(
@@ -681,6 +683,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.lamalPremiumMonthly),
               statusLabel: _fieldStatusLabel(situation.lamalPremiumMonthly),
               statusColor: _fieldStatusColor(situation.lamalPremiumMonthly),
+              trustId: 'lamal_premium',
             ),
             const SizedBox(height: MintSpacing.sm),
             _SituationValueRow(
@@ -688,6 +691,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.liquidSavings),
               statusLabel: _fieldStatusLabel(situation.liquidSavings),
               statusColor: _fieldStatusColor(situation.liquidSavings),
+              trustId: 'liquid_savings',
             ),
             const SizedBox(height: MintSpacing.sm),
             _SituationValueRow(
@@ -695,6 +699,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.investments),
               statusLabel: _fieldStatusLabel(situation.investments),
               statusColor: _fieldStatusColor(situation.investments),
+              trustId: 'investments',
             ),
             const SizedBox(height: MintSpacing.sm),
             _SituationValueRow(
@@ -702,6 +707,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _valueOrMissing(situation.totalDebt),
               statusLabel: _fieldStatusLabel(situation.totalDebt),
               statusColor: _fieldStatusColor(situation.totalDebt),
+              trustId: 'total_debt',
             ),
             const Padding(
               padding: EdgeInsets.symmetric(vertical: MintSpacing.md),
@@ -714,6 +720,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               ),
               state: pillars.avs.estimatedMonthlyPension.state,
               color: MintColors.info,
+              trustId: 'avs_estimated_pension',
               l10n: l10n,
             ),
             const SizedBox(height: MintSpacing.sm),
@@ -722,6 +729,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _pillarMoneyOrMissing(pillars.lpp.totalBalance),
               state: pillars.lpp.totalBalance.state,
               color: MintColors.pillarLpp,
+              trustId: 'lpp_total_balance',
               l10n: l10n,
             ),
             const SizedBox(height: MintSpacing.sm),
@@ -730,6 +738,7 @@ class _MonArgentSituationMap extends StatelessWidget {
               value: _pillarMoneyOrMissing(pillars.pillar3a.totalBalance),
               state: pillars.pillar3a.totalBalance.state,
               color: MintColors.success,
+              trustId: 'pillar3a_total_balance',
               l10n: l10n,
             ),
           ],
@@ -807,6 +816,7 @@ class _MonArgentPensionMap extends StatelessWidget {
               ),
               state: pillars.avs.estimatedMonthlyPension.state,
               color: MintColors.info,
+              trustId: 'avs_estimated_pension_pension',
               l10n: l10n,
             ),
             const SizedBox(height: MintSpacing.sm),
@@ -815,6 +825,7 @@ class _MonArgentPensionMap extends StatelessWidget {
               value: _pillarMoneyOrMissing(pillars.lpp.totalBalance),
               state: pillars.lpp.totalBalance.state,
               color: MintColors.pillarLpp,
+              trustId: 'lpp_total_balance_pension',
               l10n: l10n,
             ),
             const SizedBox(height: MintSpacing.sm),
@@ -823,6 +834,7 @@ class _MonArgentPensionMap extends StatelessWidget {
               value: _pillarMoneyOrMissing(pillars.pillar3a.totalBalance),
               state: pillars.pillar3a.totalBalance.state,
               color: MintColors.success,
+              trustId: 'pillar3a_total_balance_pension',
               l10n: l10n,
             ),
           ],
@@ -842,71 +854,92 @@ class _SituationValueRow extends StatelessWidget {
   final String value;
   final String? statusLabel;
   final Color? statusColor;
+  final String? trustId;
 
   const _SituationValueRow({
     required this.label,
     required this.value,
     this.statusLabel,
     this.statusColor,
+    this.trustId,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: Wrap(
-            spacing: 6,
-            runSpacing: 3,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            children: [
-              Text(
-                label,
-                style: MintTextStyles.bodySmall(
-                  color: MintColors.textSecondary,
+    final semanticLabel =
+        statusLabel == null ? '$label, $value' : '$label, $value, $statusLabel';
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label: semanticLabel,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 3,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Text(
+                  label,
+                  style: MintTextStyles.bodySmall(
+                    color: MintColors.textSecondary,
+                  ),
                 ),
-              ),
-              if (statusLabel != null)
-                _FieldStatusChip(
-                  label: statusLabel!,
-                  color: statusColor ?? MintColors.textMuted,
-                ),
-            ],
+                if (statusLabel != null)
+                  _FigureTrustChip(
+                    label: statusLabel!,
+                    color: statusColor ?? MintColors.textMuted,
+                    trustId: trustId,
+                  ),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(width: MintSpacing.sm),
-        Text(
-          value,
-          style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
-              .copyWith(fontWeight: FontWeight.w700),
-        ),
-      ],
+          const SizedBox(width: MintSpacing.sm),
+          Text(
+            value,
+            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
     );
   }
 }
 
-class _FieldStatusChip extends StatelessWidget {
+class _FigureTrustChip extends StatelessWidget {
   final String label;
   final Color color;
+  final String? trustId;
 
-  const _FieldStatusChip({
+  const _FigureTrustChip({
     required this.label,
     required this.color,
+    this.trustId,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        label,
-        style: MintTextStyles.labelSmall(color: color)
-            .copyWith(fontWeight: FontWeight.w700),
+    final identifier = trustId == null ? null : 'figure_trust_chip_$trustId';
+    return Semantics(
+      key: identifier == null ? null : Key(identifier),
+      container: true,
+      identifier: identifier,
+      label: label,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: ExcludeSemantics(
+          child: Text(
+            label,
+            style: MintTextStyles.labelSmall(color: color)
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+        ),
       ),
     );
   }
@@ -917,6 +950,7 @@ class _PillarValueRow extends StatelessWidget {
   final String value;
   final PillarFactState state;
   final Color color;
+  final String trustId;
   final S l10n;
 
   const _PillarValueRow({
@@ -924,54 +958,70 @@ class _PillarValueRow extends StatelessWidget {
     required this.value,
     required this.state,
     required this.color,
+    required this.trustId,
     required this.l10n,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Container(
-          width: 8,
-          height: 32,
-          decoration: BoxDecoration(
-            color: color,
-            borderRadius: BorderRadius.circular(999),
+    final stateLabel = _stateLabel(state);
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label: '$label, $value, $stateLabel',
+      child: Row(
+        children: [
+          Container(
+            width: 8,
+            height: 32,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(999),
+            ),
           ),
-        ),
-        const SizedBox(width: MintSpacing.sm),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                label,
-                style: MintTextStyles.bodyMedium(
-                  color: MintColors.textPrimary,
-                ).copyWith(fontWeight: FontWeight.w700),
-              ),
-              const SizedBox(height: MintSpacing.xs),
-              Text(
-                _stateLabel(state),
-                style: MintTextStyles.micro(color: MintColors.textMuted),
-              ),
-            ],
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: MintTextStyles.bodyMedium(
+                    color: MintColors.textPrimary,
+                  ).copyWith(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: MintSpacing.xs),
+                _FigureTrustChip(
+                  label: stateLabel,
+                  color: _stateColor(state),
+                  trustId: trustId,
+                ),
+              ],
+            ),
           ),
-        ),
-        Text(
-          value,
-          style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
-              .copyWith(fontWeight: FontWeight.w700),
-        ),
-      ],
+          Text(
+            value,
+            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
     );
   }
 
   String _stateLabel(PillarFactState state) {
     return switch (state) {
-      PillarFactState.known => l10n.dataBlockStatusComplete,
-      PillarFactState.estimated => l10n.dataBlockStatusPartial,
-      PillarFactState.missing => l10n.dataBlockStatusMissing,
+      PillarFactState.known => l10n.budgetQualityProvided,
+      PillarFactState.estimated => l10n.budgetQualityEstimated,
+      PillarFactState.missing => l10n.budgetQualityMissing,
+    };
+  }
+
+  Color _stateColor(PillarFactState state) {
+    return switch (state) {
+      PillarFactState.known => MintColors.success,
+      PillarFactState.estimated => MintColors.warning,
+      PillarFactState.missing => MintColors.textMuted,
     };
   }
 }

--- a/apps/mobile/test/screens/mon_argent_screen_test.dart
+++ b/apps/mobile/test/screens/mon_argent_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/data/budget/budget_local_store.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart';
@@ -72,6 +73,27 @@ void main() {
     expect(find.text("12'000\u00a0CHF"), findsOneWidget);
     expect(find.text('saisi'), findsWidgets);
     expect(find.text('estimé'), findsOneWidget);
+    expect(
+      tester
+          .getSemantics(
+            find.byKey(const Key('figure_trust_chip_gross_income')),
+          )
+          .identifier,
+      'figure_trust_chip_gross_income',
+    );
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('figure_trust_chip_investments')))
+          .label,
+      'estimé',
+    );
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('figure_trust_chip_investments')))
+          .getSemanticsData()
+          .hasAction(SemanticsAction.tap),
+      isFalse,
+    );
 
     await tester.tap(find.text('Mois'));
     await tester.pumpAndSettle();
@@ -91,7 +113,28 @@ void main() {
     expect(find.text('3e pilier (3a)'), findsOneWidget);
     expect(find.text("120'000\u00a0CHF"), findsOneWidget);
     expect(find.text("32'000\u00a0CHF"), findsOneWidget);
-    expect(find.text('Manquant'), findsWidgets);
+    expect(find.text('manquant'), findsWidgets);
+    expect(find.text("0\u00a0CHF"), findsNothing);
+    expect(
+      tester
+          .getSemantics(
+            find.byKey(
+              const Key('figure_trust_chip_avs_estimated_pension_pension'),
+            ),
+          )
+          .label,
+      'manquant',
+    );
+    expect(
+      tester
+          .getSemantics(
+            find.byKey(
+              const Key('figure_trust_chip_lpp_total_balance_pension'),
+            ),
+          )
+          .label,
+      'saisi',
+    );
 
     await tester.ensureVisible(find.text('Futur'));
     await tester.tap(find.text('Futur'));
@@ -254,6 +297,49 @@ void main() {
       'mon_argent_section_future',
     );
     expect(find.text('Ta trajectoire'), findsOneWidget);
+  });
+
+  testWidgets('pillar trust chip exposes estimated state without tap action',
+      (tester) async {
+    final mintState = MintStateProvider()
+      ..injectStateForTest(_stateWithDataSpine(spine: _dataSpineEstimated3a()));
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<BudgetProvider>(
+            create: (_) => BudgetProvider(),
+          ),
+          ChangeNotifierProvider<CoachProfileProvider>(
+            create: (_) => CoachProfileProvider(),
+          ),
+          ChangeNotifierProvider<MintStateProvider>.value(value: mintState),
+        ],
+        child: const MaterialApp(
+          locale: Locale('fr'),
+          localizationsDelegates: [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: MonArgentScreen(),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tap(find.text('Prévoyance'));
+    await tester.pumpAndSettle();
+
+    final chip = tester.getSemantics(
+      find.byKey(const Key('figure_trust_chip_pillar3a_total_balance_pension')),
+    );
+    expect(chip.identifier, 'figure_trust_chip_pillar3a_total_balance_pension');
+    expect(chip.label, 'estimé');
+    expect(chip.getSemanticsData().hasAction(SemanticsAction.tap), isFalse);
   });
 
   testWidgets('prefers CoachProfile budget over stale budget cache',
@@ -462,7 +548,7 @@ void main() {
   });
 }
 
-MintUserState _stateWithDataSpine() {
+MintUserState _stateWithDataSpine({DataSpineSnapshot? spine}) {
   final profile = CoachProfile(
     birthYear: 1988,
     canton: 'VD',
@@ -473,7 +559,7 @@ MintUserState _stateWithDataSpine() {
       label: 'Logement',
     ),
   );
-  final spine = _dataSpine();
+  spine ??= _dataSpine();
   return MintUserState(
     profile: profile,
     lifecyclePhase: LifecyclePhase.construction,
@@ -483,6 +569,55 @@ MintUserState _stateWithDataSpine() {
     confidenceScore: 64,
     capMemory: const CapMemory(),
     computedAt: DateTime.utc(2026, 5, 24),
+  );
+}
+
+DataSpineSnapshot _dataSpineEstimated3a() {
+  const meta = SpineFieldMeta(
+    source: ProfileDataSource.userInput,
+    confidence: FieldConfidence.known,
+    freshness: FieldFreshness.fresh,
+  );
+  const estimatedMeta = SpineFieldMeta(
+    source: ProfileDataSource.estimated,
+    confidence: FieldConfidence.estimated,
+    freshness: FieldFreshness.fresh,
+  );
+  final base = _dataSpine();
+  return DataSpineSnapshot(
+    situation: base.situation,
+    budget: base.budget,
+    pillars: const PillarPosition(
+      avs: AvsPosition(
+        contributionYears: PillarFact.missing(),
+        gaps: PillarFact.missing(),
+        estimatedMonthlyPension: PillarFact.missing(),
+        ramd: PillarFact.missing(),
+      ),
+      lpp: LppPosition(
+        totalBalance: PillarFact(
+          value: 120000,
+          state: PillarFactState.known,
+          meta: meta,
+        ),
+        mandatoryBalance: PillarFact.missing(),
+        supplementaryBalance: PillarFact.missing(),
+        insuredSalary: PillarFact.missing(),
+        buybackMax: PillarFact.missing(),
+      ),
+      pillar3a: Pillar3aPosition(
+        totalBalance: PillarFact(
+          value: 32000,
+          state: PillarFactState.estimated,
+          meta: estimatedMeta,
+        ),
+        accountsCount: PillarFact.missing(),
+        annualContribution: PillarFact.missing(),
+        canContribute: true,
+      ),
+    ),
+    trajectory: base.trajectory,
+    computedAt: base.computedAt,
   );
 }
 


### PR DESCRIPTION
## Summary\n- add a local FigureTrustChip display contract in Mon Argent\n- wire situation and pillar rows to existing data-spine confidence/state metadata\n- add semantics IDs and widget coverage for known, estimated, and missing states\n\n## Validation\n- dart format\n- cd apps/mobile && flutter analyze --no-fatal-infos lib/screens/mon_argent/mon_argent_screen.dart test/screens/mon_argent_screen_test.dart\n- cd apps/mobile && flutter test test/screens/mon_argent_screen_test.dart\n- validate_arb_parity: OK, 6 locales / 6817 keys\n- python3 tools/checks/wiki_lint.py lint: OK, historical warnings only\n- git diff --check\n- cd apps/mobile && CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --no-codesign --debug --dart-define=MINT_E2E_ARCHETYPE=julien_swiss --dart-define=MINT_DISABLE_BETA_MODAL=true\n- xcrun simctl install booted apps/mobile/build/ios/iphonesimulator/Runner.app\n- MINT_WALKER_ARTIFACTS=.planning/_walker/money-trust-contract-v1-01-spine-trust-chip bash tools/simulator/maestro_with_watchdog.sh test tools/simulator/flows/maestro-perfect-set/flow_mon_argent_budget_setup_spine.yaml --output .planning/walker/maestro-flows/money-trust-contract-v1-01-spine-trust-chip/result.xml --format junit: PASS 43s\n\n## Reviews\n- flutter-expert, accessibility-expert, architect-review: converged on local non-interactive chip, no new money model, no Coach/Budget expansion\n- code-reviewer: no blocking findings