### PR TITLE
fix(coach): gate heuristic 3a tax figures

### DIFF
--- a/.planning/phases/money-trust-contract-v1-02-coach-number-gate/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-02-coach-number-gate/PLAN.md
@@ -1,0 +1,32 @@
+description: Plan to gate heuristic Coach CHF amounts behind structured producers.
+
+# Money Trust Contract v1-02 — Coach Number Gate
+
+## Goal
+
+Stop Coach static copy from presenting 3a tax CHF amounts as loose heuristics.
+
+## Scope
+
+1. Replace local `margin * 0.30` tax-saving estimates with
+   `RetirementTaxCalculator.estimate3aTaxImpact`.
+2. Make the Q4 3a deadline alert state the visible assumption when the rate is
+   estimated.
+3. Add focused tests for the static alert copy.
+4. Suppress Coach tax-saving CHF copy when canton or salary assumptions are
+   missing or invalid.
+
+## Non-Goals
+
+No backend prompt rewrite, no Coach UI redesign, no Budget changes, and no new
+tax formula.
+
+## Verification
+
+- `flutter analyze --no-fatal-infos lib/services/coach_narrative_service.dart lib/services/coach/fallback_templates.dart test/services/coach_narrative_number_gate_test.dart test/services/fallback_templates_test.dart test/services/coach_narrative_service_test.dart`
+- `flutter test test/services/coach_narrative_number_gate_test.dart test/services/fallback_templates_test.dart test/services/coach_narrative_service_test.dart`
+- `python3 tools/checks/wiki_lint.py lint`
+- `git diff --check`
+- MCP `check_accent_patterns`, `check_banned_terms`, and `validate_arb_parity`
+- Read-only reviews: internal code/product agents and Claude Opus; P1 findings
+  addressed before PR.

--- a/apps/mobile/lib/services/coach/fallback_templates.dart
+++ b/apps/mobile/lib/services/coach/fallback_templates.dart
@@ -8,6 +8,7 @@
 /// References: LSFin, LAVS, LPP, OPP3, LIFD.
 library;
 
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
 
 import 'coach_models.dart';
@@ -95,9 +96,11 @@ class FallbackTemplates {
     final replacement = ctx.knownValues['replacement_ratio'] ?? 60;
 
     // Tax optimization lever (> CHF 1000 potential)
-    if (taxSaving > 1000) {
+    final resolvedCanton = resolveCanton(ctx.canton);
+    if (taxSaving > 1000 && resolvedCanton.isResolved) {
       return '${ctx.firstName}, un versement 3a pourrait réduire ton impôt '
           'd\'environ ${formatChfWithPrefix(taxSaving)} cette année. '
+          'Estimation basée sur un taux marginal estimé, canton ${resolvedCanton.code}. '
           'Simule l\'impact sur ton profil.';
     }
 

--- a/apps/mobile/lib/services/coach_narrative_service.dart
+++ b/apps/mobile/lib/services/coach_narrative_service.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/financial_core/avs_calculator.dart';
 import 'package:mint_mobile/services/fri_computation_service.dart';
 import 'package:mint_mobile/services/financial_core/confidence_scorer.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
 import 'package:mint_mobile/services/financial_core/lpp_calculator.dart';
 import 'package:mint_mobile/services/financial_fitness_service.dart';
@@ -208,13 +209,8 @@ class CoachNarrativeService {
     final liquide = profile.patrimoine.epargneLiquide;
     final monthsLiquidity = depenses > 0 ? liquide / depenses : 0.0;
 
-    // Tax saving potential (3a margin × estimated marginal rate)
-    final plafond3a = profile.employmentStatus == 'independant'
-        ? reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp)
-        : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
-    final verse3a = profile.total3aMensuel * 12;
-    final marge3a = (plafond3a - verse3a).clamp(0, plafond3a);
-    final taxSaving = marge3a * 0.30; // ~30% marginal estimate
+    final taxImpact = _estimateRemaining3aTaxImpact(profile);
+    final taxSaving = taxImpact.estimatedTaxSaving;
 
     // Confidence score
     double confidence = 0;
@@ -506,23 +502,7 @@ class CoachNarrativeService {
     // Oct-Dec: deadline 3a avant le 31 decembre (OPP3 art. 7)
     // Enhanced with personalized tax savings estimate (M6C)
     if (now.month >= 10 && now.month <= 12) {
-      final plafond = profile.employmentStatus == 'independant'
-          ? reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp)
-          : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
-      final verseAnnuel = profile.total3aMensuel * 12;
-      final marge = plafond - verseAnnuel;
-      if (marge > 0) {
-        final deadline = DateTime(now.year, 12, 31);
-        final joursRestants = deadline.difference(now).inDays;
-        // Estimate tax savings from the remaining 3a margin
-        final tauxEstime = profile.canton.isNotEmpty ? 0.30 : 0.28;
-        final economie = marge * tauxEstime;
-        urgentAlert = 'Il te reste $joursRestants jours pour verser '
-            '${formatChfWithPrefix(marge)} en 3a et economiser '
-            '~${formatChfWithPrefix(economie)} d\'impots '
-            '(canton ${profile.canton.isNotEmpty ? profile.canton : "CH"}). '
-            '\u2014 OPP3 art. 7';
-      }
+      urgentAlert = _build3aDeadlineAlert(profile: profile, now: now);
     }
 
     // Feb-Mar: declaration fiscale avant le 31 mars (LIFD / LHID).
@@ -1402,6 +1382,76 @@ class CoachNarrativeService {
       if (RegExp(pattern, caseSensitive: false).hasMatch(text)) return true;
     }
     return false;
+  }
+
+  @visibleForTesting
+  static String? build3aDeadlineAlertForTest({
+    required CoachProfile profile,
+    required DateTime now,
+  }) =>
+      _build3aDeadlineAlert(profile: profile, now: now);
+
+  static String? _build3aDeadlineAlert({
+    required CoachProfile profile,
+    required DateTime now,
+  }) {
+    final estimate = _estimateRemaining3aTaxImpact(profile);
+    if (estimate.confidence == Pillar3aTaxImpactConfidence.unavailable ||
+        estimate.estimatedTaxSaving <= 0) {
+      return null;
+    }
+
+    final deadline = DateTime(now.year, 12, 31);
+    final joursRestants = deadline.difference(now).inDays;
+    final cantonCode = resolveCanton(profile.canton).code;
+    final rateLabel =
+        estimate.confidence == Pillar3aTaxImpactConfidence.actualRate
+            ? 'taux marginal saisi'
+            : 'taux marginal estimé';
+
+    return 'Il te reste $joursRestants jours pour verser '
+        '${formatChfWithPrefix(estimate.deductibleContribution)} en 3a. '
+        'Impact fiscal estimé: '
+        '~${formatChfWithPrefix(estimate.estimatedTaxSaving)} '
+        '($rateLabel, canton $cantonCode). '
+        '\u2014 OPP3 art. 7';
+  }
+
+  static Pillar3aTaxImpactEstimate _estimateRemaining3aTaxImpact(
+    CoachProfile profile,
+  ) {
+    final resolvedCanton = resolveCanton(profile.canton);
+    if (resolvedCanton.isFallback || profile.revenuBrutAnnuel <= 0) {
+      return Pillar3aTaxImpactEstimate.unavailable;
+    }
+    final maxImpact = RetirementTaxCalculator.estimate3aTaxImpact(
+      grossAnnualSalary: profile.revenuBrutAnnuel,
+      canton: resolvedCanton.code,
+      isMarried: profile.etatCivil == CoachCivilStatus.marie,
+      children: profile.nombreEnfants,
+      hasLpp: profile.employmentStatus != 'independant',
+    );
+    if (maxImpact.confidence == Pillar3aTaxImpactConfidence.unavailable ||
+        maxImpact.deductibleContribution <= 0) {
+      return Pillar3aTaxImpactEstimate.unavailable;
+    }
+
+    final alreadyPaid = profile.total3aMensuel * 12;
+    final remainingDeductible = (maxImpact.deductibleContribution - alreadyPaid)
+        .clamp(0.0, maxImpact.deductibleContribution)
+        .toDouble();
+    if (remainingDeductible <= 0) {
+      return Pillar3aTaxImpactEstimate.unavailable;
+    }
+
+    return RetirementTaxCalculator.estimate3aTaxImpact(
+      grossAnnualSalary: profile.revenuBrutAnnuel,
+      canton: resolvedCanton.code,
+      isMarried: profile.etatCivil == CoachCivilStatus.marie,
+      children: profile.nombreEnfants,
+      hasLpp: profile.employmentStatus != 'independant',
+      contribution: remainingDeductible,
+    );
   }
 
   // ════════════════════════════════════════════════════════════════

--- a/apps/mobile/test/services/coach_narrative_number_gate_test.dart
+++ b/apps/mobile/test/services/coach_narrative_number_gate_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/coach/fallback_templates.dart';
+import 'package:mint_mobile/services/coach/coach_models.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+import 'package:mint_mobile/services/coach_narrative_service.dart';
+import 'package:mint_mobile/utils/chf_formatter.dart';
+
+CoachProfile _profileWithOpen3aMargin({
+  String canton = 'VD',
+  double salaireBrutMensuel = 7000,
+  String employmentStatus = 'salarie',
+  double monthly3a = 300,
+}) {
+  return CoachProfile(
+    firstName: 'Julien',
+    birthYear: 1990,
+    canton: canton,
+    salaireBrutMensuel: salaireBrutMensuel,
+    employmentStatus: employmentStatus,
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(2055, 12, 31),
+      label: 'Retraite a 65 ans',
+    ),
+    prevoyance: const PrevoyanceProfile(
+      nombre3a: 1,
+      totalEpargne3a: 15000,
+      avoirLppTotal: 80000,
+    ),
+    depenses: const DepensesProfile(
+      loyer: 1500,
+      assuranceMaladie: 400,
+    ),
+    plannedContributions: [
+      PlannedMonthlyContribution(
+        id: '3a_user',
+        label: '3a Julien',
+        amount: monthly3a,
+        category: '3a',
+      ),
+    ],
+  );
+}
+
+void main() {
+  group('CoachNarrativeService number gate', () {
+    test('3a deadline alert exposes structured tax-impact assumptions', () {
+      final profile = _profileWithOpen3aMargin();
+      final remaining = RetirementTaxCalculator.estimate3aTaxImpact(
+            grossAnnualSalary: profile.revenuBrutAnnuel,
+            canton: profile.canton,
+            contribution: null,
+          ).deductibleContribution -
+          profile.total3aMensuel * 12;
+      final expectedImpact = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: profile.revenuBrutAnnuel,
+        canton: profile.canton,
+        contribution: remaining,
+      );
+
+      final alert = CoachNarrativeService.build3aDeadlineAlertForTest(
+        profile: profile,
+        now: DateTime(2026, 12),
+      );
+
+      expect(alert, isNotNull);
+      expect(alert, contains('3a'));
+      expect(alert, contains('Impact fiscal estimé'));
+      expect(
+        alert,
+        contains(formatChfWithPrefix(expectedImpact.deductibleContribution)),
+      );
+      expect(
+        alert,
+        contains(formatChfWithPrefix(expectedImpact.estimatedTaxSaving)),
+      );
+      expect(alert, contains('taux marginal estimé'));
+      expect(alert, contains('canton VD'));
+      expect(alert, contains('OPP3'));
+      expect(alert, isNot(contains('economiser')));
+      expect(alert, isNot(contains("d'impots")));
+    });
+
+    test('3a deadline alert is suppressed when assumptions are incomplete', () {
+      for (final canton in ['', 'CH', 'ZZ']) {
+        expect(
+          CoachNarrativeService.build3aDeadlineAlertForTest(
+            profile: _profileWithOpen3aMargin(canton: canton),
+            now: DateTime(2026, 12),
+          ),
+          isNull,
+        );
+      }
+      expect(
+        CoachNarrativeService.build3aDeadlineAlertForTest(
+          profile: _profileWithOpen3aMargin(salaireBrutMensuel: 0),
+          now: DateTime(2026, 12),
+        ),
+        isNull,
+      );
+    });
+
+    test('no-LPP remaining 3a margin subtracts already-paid contributions', () {
+      final profile = _profileWithOpen3aMargin(
+        salaireBrutMensuel: 50000 / 12,
+        employmentStatus: 'independant',
+        monthly3a: 8000 / 12,
+      );
+
+      final alert = CoachNarrativeService.build3aDeadlineAlertForTest(
+        profile: profile,
+        now: DateTime(2026, 12),
+      );
+
+      expect(alert, isNotNull);
+      expect(alert, contains(formatChfWithPrefix(2000)));
+      expect(alert, isNot(contains(formatChfWithPrefix(10000))));
+    });
+
+    test('fallback tax tip states canton and estimated-rate assumption', () {
+      final text = FallbackTemplates.tipNarrative(
+        const CoachContext(
+          firstName: 'Julien',
+          canton: 'VD',
+          knownValues: {'tax_saving': 2500},
+        ),
+      );
+
+      expect(text, contains('3a'));
+      expect(text, contains("2'500"));
+      expect(text, contains('taux marginal estimé'));
+      expect(text, contains('canton VD'));
+    });
+
+    test('fallback tax tip is not used without a valid canton assumption', () {
+      for (final canton in ['', 'CH', 'ZZ']) {
+        final text = FallbackTemplates.tipNarrative(
+          CoachContext(
+            firstName: 'Julien',
+            canton: canton,
+            knownValues: const {'tax_saving': 2500},
+          ),
+        );
+
+        expect(text, isNot(contains("2'500")));
+        expect(text, isNot(contains('réduire ton impôt')));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- replace Coach static 3a tax-saving heuristic with RetirementTaxCalculator.estimate3aTaxImpact
- suppress CHF tax-saving copy when canton/salary assumptions are missing or invalid
- expose estimated marginal-rate and canton assumptions in Q4 alert and fallback tip
- add number-gate tests for salaried, no-LPP independent, missing/invalid canton, and fallback tip paths

## Verification
- flutter analyze --no-fatal-infos lib/services/coach_narrative_service.dart lib/services/coach/fallback_templates.dart test/services/coach_narrative_number_gate_test.dart test/services/fallback_templates_test.dart test/services/coach_narrative_service_test.dart
- flutter test test/services/coach_narrative_number_gate_test.dart test/services/fallback_templates_test.dart test/services/coach_narrative_service_test.dart
- python3 tools/checks/wiki_lint.py lint
- git diff --check
- MCP check_accent_patterns / check_banned_terms / validate_arb_parity
- internal code/product review + Claude Opus re-review