### PR TITLE
Gate onboarding 3a tax estimates

### DIFF
--- a/.planning/phases/money-trust-contract-v1-03-onboarding-3a-number-gate/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-03-onboarding-3a-number-gate/PLAN.md
@@ -1,0 +1,27 @@
+description: Plan to align onboarding 3a tax-saving numbers with trust contract.
+
+# Money Trust Contract v1-03 — Onboarding 3a Number Gate
+
+## Goal
+
+Stop the onboarding first-light 3a CHF figure from relying on local marginal
+rate × ceiling shortcuts when assumptions are incomplete or invalid.
+
+## Scope
+
+1. Route mobile `MinimalProfileService.taxSaving3a` through
+   `RetirementTaxCalculator.estimate3aTaxImpact`.
+2. Suppress the tax-saving number when canton or salary cannot support a
+   trustworthy estimate.
+3. Make the `PremierEclairageSelector` tax-saving copy expose the estimated
+   marginal-rate and canton assumptions.
+4. Keep the tax-saving insight in pedagogical confidence mode because the
+   marginal rate is estimated.
+5. Align the backend onboarding service/selector with the same trust gate so
+   `/onboarding/premier-eclairage` cannot bypass the mobile fix.
+6. Add focused tests for valid, invalid-canton, zero-salary, selector-coherence,
+   integration, and no-LPP cases.
+
+## Non-Goals
+
+No onboarding redesign, no new tax formula, and no notification copy rewrite.

--- a/apps/mobile/lib/services/minimal_profile_service.dart
+++ b/apps/mobile/lib/services/minimal_profile_service.dart
@@ -130,14 +130,27 @@ class MinimalProfileService {
         grossMonthlySalary > 0 ? totalMonthlyRetirement / grossMonthlySalary : 0.0;
     final retirementGapMonthly = max(0.0, grossMonthlySalary - totalMonthlyRetirement);
 
-    // --- Tax saving 3a (financial_core via FiscalService for marginal rate) ---
-    // Indépendant sans LPP: plafond 3a = 20% du revenu net, max 36'288 CHF (OPP3 art. 7)
-    // Salarié avec LPP: plafond 3a = 7'258 CHF
-    final marginalRate = RetirementTaxCalculator.estimateMarginalRate(grossSalary, canton);
-    final plafond3a = isIndependantNoLpp
-        ? min(grossSalary * 0.20, reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp))
-        : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
-    final taxSaving3a = marginalRate * plafond3a;
+    // --- Tax saving 3a (financial_core) ---
+    final resolvedCanton = resolveCanton(canton);
+    final taxImpact = resolvedCanton.isResolved && grossSalary > 0
+        ? RetirementTaxCalculator.estimate3aTaxImpact(
+            grossAnnualSalary: grossSalary,
+            canton: resolvedCanton.code,
+            hasLpp: !isIndependantNoLpp,
+          )
+        : Pillar3aTaxImpactEstimate.unavailable;
+    final marginalRate =
+        taxImpact.confidence == Pillar3aTaxImpactConfidence.unavailable
+            ? 0.0
+            : taxImpact.marginalRate;
+    final plafond3a =
+        taxImpact.confidence == Pillar3aTaxImpactConfidence.unavailable
+            ? (isIndependantNoLpp
+                ? min(grossSalary * 0.20,
+                    reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp))
+                : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp))
+            : taxImpact.annualCeiling;
+    final taxSaving3a = taxImpact.estimatedTaxSaving;
 
     // --- Liquidity analysis ---
     final estimatedMonthlyExpenses = _estimateMonthlyExpenses(
@@ -162,7 +175,7 @@ class MinimalProfileService {
       estimatedMonthlyExpenses: estimatedMonthlyExpenses,
       monthlyDebtImpact: effectiveDebtService,
       liquidityMonths: liquidityMonths,
-      canton: canton,
+      canton: resolvedCanton.isResolved ? resolvedCanton.code : canton,
       age: age,
       grossAnnualSalary: grossSalary,
       householdType: effectiveHousehold,
@@ -181,7 +194,9 @@ class MinimalProfileService {
   /// Applies LPP art. 16 age-dependent bonification rates since age 25.
   /// Returns 0 if below LPP seuil d'entree (LPP art. 7).
   static double _estimateLppBalance(int age, double grossAnnualSalary) {
-    if (grossAnnualSalary < reg('lpp.entry_threshold', lppSeuilEntree)) return 0.0;
+    if (grossAnnualSalary < reg('lpp.entry_threshold', lppSeuilEntree)) {
+      return 0.0;
+    }
 
     final salaireCoord = (grossAnnualSalary - reg('lpp.coordination_deduction', lppDeductionCoordination))
         .clamp(reg('lpp.min_coordinated_salary', lppSalaireCoordMin), reg('lpp.max_coordinated_salary', lppSalaireCoordMax));

--- a/apps/mobile/lib/services/premier_eclairage_selector.dart
+++ b/apps/mobile/lib/services/premier_eclairage_selector.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart' as chf;
 
 /// Selects the most impactful "premier éclairage" to show the user.
@@ -59,7 +61,7 @@ class PremierEclairageSelector {
     }
 
     // Tax saving 3a: always relevant if applicable
-    if (profile.existing3a <= 0 && profile.taxSaving3a > 1500) {
+    if (_hasTrustworthy3aTaxSaving(profile, threshold: 1500)) {
       return _withConfidence(_buildTaxSaving3aChoc(profile), profile);
     }
 
@@ -88,7 +90,7 @@ class PremierEclairageSelector {
 
       case 'stress_impots':
         // Tax: show 3a tax saving if applicable
-        if (profile.taxSaving3a > 500) {
+        if (_hasTrustworthy3aTaxSaving(profile, threshold: 500)) {
           return _buildTaxSaving3aChoc(profile);
         }
         return null;
@@ -114,7 +116,7 @@ class PremierEclairageSelector {
 
       case 'stress_prevoyance':
         // First job / prevoyance: show 3a tax saving or compound growth
-        if (profile.taxSaving3a > 500) {
+        if (_hasTrustworthy3aTaxSaving(profile, threshold: 500)) {
           return _buildTaxSaving3aChoc(profile);
         }
         if (profile.age < 35) {
@@ -146,7 +148,7 @@ class PremierEclairageSelector {
     }
     if (profile.age < 38) {
       // Construction: tax saving 3a is the most actionable lever
-      if (profile.existing3a <= 0 && profile.taxSaving3a > 1500) {
+      if (_hasTrustworthy3aTaxSaving(profile, threshold: 1500)) {
         return _buildTaxSaving3aChoc(profile);
       }
       // Else: compound growth still meaningful
@@ -169,10 +171,10 @@ class PremierEclairageSelector {
     if (profile.employmentStatus == 'independant' &&
         profile.lppMonthlyRente <= 0 &&
         profile.grossMonthlySalary > 0) {
-      final gapFormatted = chf.formatChfWithPrefix(profile.retirementGapMonthly);
-      final plafondStr = profile.plafond3a != null
-          ? chf.formatChf(profile.plafond3a!)
-          : '?';
+      final gapFormatted =
+          chf.formatChfWithPrefix(profile.retirementGapMonthly);
+      final plafondStr =
+          profile.plafond3a != null ? chf.formatChf(profile.plafond3a!) : '?';
       return PremierEclairage(
         type: PremierEclairageType.retirementGap,
         value: '$gapFormatted/mois',
@@ -214,6 +216,32 @@ class PremierEclairageSelector {
     return null;
   }
 
+  static bool _hasTrustworthy3aTaxSaving(
+    MinimalProfileResult profile, {
+    required double threshold,
+  }) {
+    final canton = resolveCanton(profile.canton);
+    final hasLpp = profile.employmentStatus != 'independant';
+    final expected = canton.isResolved && profile.grossAnnualSalary > 0
+        ? RetirementTaxCalculator.estimate3aTaxImpact(
+            grossAnnualSalary: profile.grossAnnualSalary,
+            canton: canton.code,
+            hasLpp: hasLpp,
+          )
+        : Pillar3aTaxImpactEstimate.unavailable;
+    final isCoherentTaxSaving =
+        expected.confidence != Pillar3aTaxImpactConfidence.unavailable &&
+            (profile.taxSaving3a - expected.estimatedTaxSaving).abs() <=
+                (expected.estimatedTaxSaving * 0.02).clamp(5, 80);
+
+    return profile.existing3a <= 0 &&
+        profile.taxSaving3a > threshold &&
+        profile.marginalTaxRate > 0 &&
+        isCoherentTaxSaving &&
+        profile.grossAnnualSalary > 0 &&
+        canton.isResolved;
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Chiffre choc builders
   // ═══════════════════════════════════════════════════════════════════════════
@@ -234,7 +262,8 @@ class PremierEclairageSelector {
     );
   }
 
-  static PremierEclairage _buildRetirementGapChoc(MinimalProfileResult profile) {
+  static PremierEclairage _buildRetirementGapChoc(
+      MinimalProfileResult profile) {
     final gapFormatted = chf.formatChfWithPrefix(profile.retirementGapMonthly);
     final pct = (profile.replacementRate * 100).round();
     final isIndep = profile.employmentStatus == 'independant';
@@ -259,24 +288,30 @@ class PremierEclairageSelector {
 
   static PremierEclairage _buildTaxSaving3aChoc(MinimalProfileResult profile) {
     final savingFormatted = chf.formatChfWithPrefix(profile.taxSaving3a);
-    final plafondText = profile.plafond3a != null
-        ? chf.formatChf(profile.plafond3a!)
-        : '?';
+    final marginalRatePct = (profile.marginalTaxRate * 100).round();
+    final plafondText =
+        profile.plafond3a != null ? chf.formatChf(profile.plafond3a!) : '?';
+    final cantonCode = resolveCanton(profile.canton).code;
     return PremierEclairage(
       type: PremierEclairageType.taxSaving3a,
       value: '$savingFormatted/an',
       rawValue: profile.taxSaving3a,
-      title: 'Ton economie d\'impot potentielle',
-      subtitle: 'En cotisant au 3e pilier (max CHF\u00A0$plafondText/an), '
-          'tu pourrais economiser environ $savingFormatted d\'impots chaque annee. '
-          'Et tu prepares ta retraite en meme temps.',
+      title: 'Ton économie d\'impôt potentielle',
+      subtitle: 'Si ton revenu imposable ressemble au salaire déclaré, '
+          'un versement 3e pilier jusqu\'à CHF\u00A0$plafondText/an pourrait '
+          'réduire l\'impôt d\'environ $savingFormatted/an '
+          '(taux marginal estimé $marginalRatePct%, canton $cantonCode). '
+          'Et tu prépares ta retraite en même temps.',
       iconName: 'savings',
       colorKey: 'success',
+      confidenceMode: PremierEclairageConfidence.pedagogical,
     );
   }
 
-  static PremierEclairage _buildRetirementIncomeChoc(MinimalProfileResult profile) {
-    final retirementFormatted = chf.formatChfWithPrefix(profile.totalMonthlyRetirement);
+  static PremierEclairage _buildRetirementIncomeChoc(
+      MinimalProfileResult profile) {
+    final retirementFormatted =
+        chf.formatChfWithPrefix(profile.totalMonthlyRetirement);
     final pct = (profile.replacementRate * 100).round();
     return PremierEclairage(
       type: PremierEclairageType.retirementIncome,
@@ -294,7 +329,8 @@ class PremierEclairageSelector {
   ///
   /// Pure math: compares starting now vs starting at 35.
   /// Always [PremierEclairageConfidence.factual] — no estimation involved.
-  static PremierEclairage _buildCompoundGrowthChoc(MinimalProfileResult profile) {
+  static PremierEclairage _buildCompoundGrowthChoc(
+      MinimalProfileResult profile) {
     final years = 65 - profile.age;
     const monthlyContrib = 200.0;
     const annualRate = 0.03;
@@ -309,8 +345,8 @@ class PremierEclairageSelector {
     const referenceAge = 35;
     const yearsAt35 = 65 - referenceAge;
     const monthsAt35 = yearsAt35 * 12;
-    final futureAt35 = monthlyContrib *
-        ((pow(1 + monthlyRate, monthsAt35) - 1) / monthlyRate);
+    final futureAt35 =
+        monthlyContrib * ((pow(1 + monthlyRate, monthsAt35) - 1) / monthlyRate);
 
     final advantage = futureValue - futureAt35;
     final advantageFormatted = chf.formatChfWithPrefix(advantage);
@@ -358,7 +394,8 @@ class PremierEclairageSelector {
           'Ton loyer te coute ~$rentHours heures de travail par mois.',
       iconName: 'schedule',
       colorKey: 'info',
-      confidenceMode: PremierEclairageConfidence.factual, // Derived from provided salary
+      confidenceMode:
+          PremierEclairageConfidence.factual, // Derived from provided salary
     );
   }
 
@@ -372,7 +409,7 @@ class PremierEclairageSelector {
   /// - [compoundGrowth] and [hourlyRate] are always factual (pure math)
   /// - [liquidityAlert] is pedagogical if currentSavings is estimated
   /// - [retirementGap] / [retirementIncome] are pedagogical if LPP is estimated
-  /// - [taxSaving3a] is factual (derived from salary + canton, both provided)
+  /// - [taxSaving3a] is pedagogical because marginal tax is estimated
   static PremierEclairage _withConfidence(
     PremierEclairage choc,
     MinimalProfileResult profile,
@@ -386,8 +423,9 @@ class PremierEclairageSelector {
     switch (choc.type) {
       case PremierEclairageType.compoundGrowth:
       case PremierEclairageType.hourlyRate:
-      case PremierEclairageType.taxSaving3a:
         mode = PremierEclairageConfidence.factual;
+      case PremierEclairageType.taxSaving3a:
+        mode = PremierEclairageConfidence.pedagogical;
       case PremierEclairageType.liquidityAlert:
         mode = estimated.contains('currentSavings')
             ? PremierEclairageConfidence.pedagogical

--- a/apps/mobile/test/services/minimal_profile_service_test.dart
+++ b/apps/mobile/test/services/minimal_profile_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/services/minimal_profile_service.dart';
 
 /// Tests for MinimalProfileService (Sprint S31 — Onboarding Redesign).
@@ -153,6 +154,62 @@ void main() {
         employmentStatus: 'salarie',
       );
       expect(result.plafond3a, equals(pilier3aPlafondAvecLpp));
+    });
+
+    test('taxSaving3a uses canonical 3a tax-impact estimate', () {
+      final result = MinimalProfileService.compute(
+        age: 40,
+        grossSalary: 80000,
+        canton: 'VD',
+        employmentStatus: 'salarie',
+      );
+      final expected = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: 80000,
+        canton: 'VD',
+      );
+
+      expect(result.taxSaving3a, closeTo(expected.estimatedTaxSaving, 0.01));
+      expect(result.marginalTaxRate, closeTo(expected.marginalRate, 0.0001));
+    });
+
+    test('taxSaving3a is suppressed when canton or salary is invalid', () {
+      for (final canton in ['', 'CH', 'ZZ']) {
+        final result = MinimalProfileService.compute(
+          age: 40,
+          grossSalary: 80000,
+          canton: canton,
+          employmentStatus: 'salarie',
+        );
+
+        expect(result.taxSaving3a, 0);
+        expect(result.marginalTaxRate, 0);
+      }
+
+      final noSalary = MinimalProfileService.compute(
+        age: 40,
+        grossSalary: 0,
+        canton: 'VD',
+        employmentStatus: 'salarie',
+      );
+      expect(noSalary.taxSaving3a, 0);
+      expect(noSalary.marginalTaxRate, 0);
+    });
+
+    test('independent no-LPP taxSaving3a uses 20% income ceiling', () {
+      final result = MinimalProfileService.compute(
+        age: 45,
+        grossSalary: 50000,
+        canton: 'VD',
+        employmentStatus: 'independant',
+      );
+      final expected = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: 50000,
+        canton: 'VD',
+        hasLpp: false,
+      );
+
+      expect(result.plafond3a, closeTo(10000, 0.01));
+      expect(result.taxSaving3a, closeTo(expected.estimatedTaxSaving, 0.01));
     });
 
     test('sans_emploi: reduced AVS, no LPP contributions', () {

--- a/apps/mobile/test/services/premier_eclairage_selector_test.dart
+++ b/apps/mobile/test/services/premier_eclairage_selector_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/models/minimal_profile_models.dart';
+import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+import 'package:mint_mobile/services/minimal_profile_service.dart';
 import 'package:mint_mobile/services/premier_eclairage_selector.dart';
 
 /// Tests for PremierEclairageSelector (Sprint S31).
@@ -177,9 +179,15 @@ void main() {
     // ── Priority 3: Tax saving 3a ────────────────────────────
 
     test('no existing 3a and saving > 1500 triggers tax saving', () {
+      final taxImpact = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: 150000,
+        canton: 'VD',
+      );
       final profile = profile0(
         existing3a: 0,
-        taxSaving3a: 2000,
+        taxSaving3a: taxImpact.estimatedTaxSaving,
+        marginalTaxRate: taxImpact.marginalRate,
+        grossAnnualSalary: 150000,
         replacementRate: 0.60, // No retirement gap
         liquidityMonths: 6,
         nationalityGroup: 'CH',
@@ -190,6 +198,46 @@ void main() {
       expect(result.type, PremierEclairageType.taxSaving3a);
       expect(result.colorKey, 'success');
       expect(result.value, contains('/an'));
+      expect(result.subtitle, contains('taux marginal estimé'));
+      expect(
+        result.subtitle,
+        contains('${(taxImpact.marginalRate * 100).round()}%'),
+      );
+      expect(result.subtitle, contains('canton VD'));
+      expect(result.confidenceMode, PremierEclairageConfidence.pedagogical);
+    });
+
+    test('incoherent raw tax saving is not shown as 3a opportunity', () {
+      final profile = profile0(
+        existing3a: 0,
+        taxSaving3a: 2000,
+        marginalTaxRate: 0.10,
+        plafond3a: 7258,
+        replacementRate: 0.60,
+        liquidityMonths: 6,
+        nationalityGroup: 'CH',
+      );
+
+      final result = PremierEclairageSelector.select(profile);
+
+      expect(result.type, isNot(PremierEclairageType.taxSaving3a));
+    });
+
+    test('compute to selector keeps canonical 3a tax opportunity coherent', () {
+      final profile = MinimalProfileService.compute(
+        age: 25,
+        grossSalary: 150000,
+        canton: 'VD',
+        employmentStatus: 'salarie',
+        currentSavings: 100000,
+        existing3a: 0,
+      );
+
+      final result = PremierEclairageSelector.select(profile);
+
+      expect(result.type, PremierEclairageType.taxSaving3a);
+      expect(result.confidenceMode, PremierEclairageConfidence.pedagogical);
+      expect(result.subtitle, contains('canton VD'));
     });
 
     test('existing 3a > 0 skips tax saving, falls to retirement income', () {
@@ -204,6 +252,22 @@ void main() {
       final result = PremierEclairageSelector.select(profile);
 
       expect(result.type, PremierEclairageType.retirementIncome);
+    });
+
+    test('invalid canton skips tax saving even when raw saving is high', () {
+      final profile = profile0(
+        existing3a: 0,
+        taxSaving3a: 2000,
+        canton: 'ZZ',
+        replacementRate: 0.60,
+        liquidityMonths: 6,
+        nationalityGroup: 'CH',
+      );
+
+      final result = PremierEclairageSelector.select(profile);
+
+      expect(result.type, isNot(PremierEclairageType.taxSaving3a));
+      expect(result.subtitle, isNot(contains('canton ZZ')));
     });
 
     // ── Fallback: Retirement income ──────────────────────────
@@ -289,21 +353,29 @@ void main() {
         liquidityMonths: 6,
         nationalityGroup: 'CH',
       );
-      final result = PremierEclairageSelector.select(profile, stressType: 'stress_budget');
+      final result =
+          PremierEclairageSelector.select(profile, stressType: 'stress_budget');
       expect(result.type, PremierEclairageType.hourlyRate);
       expect(result.confidenceMode, PremierEclairageConfidence.factual);
     });
 
     test('stress_impots produces taxSaving3a', () {
+      final taxImpact = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: 100000,
+        canton: 'VD',
+      );
       final profile = profile0(
         age: 30,
-        taxSaving3a: 2000,
+        taxSaving3a: taxImpact.estimatedTaxSaving,
+        marginalTaxRate: taxImpact.marginalRate,
         replacementRate: 0.65,
         liquidityMonths: 6,
         nationalityGroup: 'CH',
       );
-      final result = PremierEclairageSelector.select(profile, stressType: 'stress_impots');
+      final result =
+          PremierEclairageSelector.select(profile, stressType: 'stress_impots');
       expect(result.type, PremierEclairageType.taxSaving3a);
+      expect(result.confidenceMode, PremierEclairageConfidence.pedagogical);
     });
 
     test('stress_retraite produces retirementGap when ratio low', () {
@@ -313,7 +385,8 @@ void main() {
         liquidityMonths: 6,
         nationalityGroup: 'CH',
       );
-      final result = PremierEclairageSelector.select(profile, stressType: 'stress_retraite');
+      final result = PremierEclairageSelector.select(profile,
+          stressType: 'stress_retraite');
       expect(result.type, PremierEclairageType.retirementGap);
     });
   });
@@ -336,19 +409,27 @@ void main() {
     });
 
     test('age 32 with no 3a gets taxSaving3a', () {
+      final taxImpact = RetirementTaxCalculator.estimate3aTaxImpact(
+        grossAnnualSalary: 150000,
+        canton: 'VD',
+      );
       final profile = profile0(
         age: 32,
         existing3a: 0,
-        taxSaving3a: 2000,
+        taxSaving3a: taxImpact.estimatedTaxSaving,
+        marginalTaxRate: taxImpact.marginalRate,
+        grossAnnualSalary: 150000,
         replacementRate: 0.65,
         liquidityMonths: 6,
         nationalityGroup: 'CH',
       );
       final result = PremierEclairageSelector.select(profile);
       expect(result.type, PremierEclairageType.taxSaving3a);
+      expect(result.confidenceMode, PremierEclairageConfidence.pedagogical);
     });
 
-    test('age < 30 with low ratio still gets lifecycle (no retirement gap)', () {
+    test('age < 30 with low ratio still gets lifecycle (no retirement gap)',
+        () {
       final profile = profile0(
         age: 25,
         replacementRate: 0.40,

--- a/services/backend/app/services/onboarding/minimal_profile_service.py
+++ b/services/backend/app/services/onboarding/minimal_profile_service.py
@@ -44,6 +44,7 @@ from app.constants.social_insurance import (
     LPP_TAUX_CONVERSION_MIN,
     LPP_TAUX_INTERET_MIN,
     PILIER_3A_PLAFOND_AVEC_LPP,
+    PILIER_3A_PLAFOND_SANS_LPP,
     TAUX_IMPOT_RETRAIT_CAPITAL,
     LPP_CONVERSION_RATE_COMPLEMENTAIRE,
     get_lpp_bonification_rate,
@@ -326,52 +327,116 @@ def _estimate_lpp_from_age_25(
 
 
 def _compute_marginal_tax_rate(gross_salary: float, canton: str) -> float:
-    """Approximate marginal income tax rate using cantonal rate table + income brackets.
+    """Approximate marginal income tax rate using the mobile canonical curve.
 
-    Uses a lookup table of approximate marginal income tax rates per canton
-    (federal + cantonal + communal combined, for a single person in the capital).
-    Source: AFC 2024 data, rounded to nearest 0.5%.
+    Mirrors apps/mobile/lib/services/financial_core/tax_calculator.dart:
+    effective AFC 2024 cantonal rates at 100k, income interpolation, then
+    ×1.3 to approximate a marginal deduction rate.
+    """
+    effective_rates_100k = {
+        "ZG": 0.0823, "NW": 0.0891, "OW": 0.0934, "AI": 0.0956,
+        "AR": 0.1012, "SZ": 0.1034, "UR": 0.1067, "LU": 0.1089,
+        "GL": 0.1102, "TG": 0.1145, "SH": 0.1167, "AG": 0.1189,
+        "GR": 0.1203, "BL": 0.1256, "SG": 0.1278, "ZH": 0.1290,
+        "FR": 0.1312, "SO": 0.1334, "TI": 0.1356, "BE": 0.1389,
+        "NE": 0.1423, "VS": 0.1456, "VD": 0.1489, "JU": 0.1512,
+        "GE": 0.1545, "BS": 0.1578,
+    }
+    income_adjustment = {
+        50_000: 0.75,
+        80_000: 0.90,
+        100_000: 1.00,
+        150_000: 1.10,
+        200_000: 1.18,
+        300_000: 1.25,
+        500_000: 1.32,
+    }
 
-    Accuracy: +/-3% for CHF 50k-200k salaries (educational use).
-    For final displays, the mobile RetirementTaxCalculator.estimateMarginalRate()
-    uses full AFC 2024 progressive brackets.
+    base_rate = effective_rates_100k.get(canton.upper(), 0.13)
+    brackets = sorted(income_adjustment)
+    if gross_salary <= brackets[0]:
+        income_adj = income_adjustment[brackets[0]]
+    elif gross_salary >= brackets[-1]:
+        income_adj = income_adjustment[brackets[-1]]
+    else:
+        income_adj = 1.0
+        for lower, upper in zip(brackets, brackets[1:]):
+            if lower <= gross_salary <= upper:
+                ratio = (gross_salary - lower) / (upper - lower)
+                lower_adj = income_adjustment[lower]
+                upper_adj = income_adjustment[upper]
+                income_adj = lower_adj + (upper_adj - lower_adj) * ratio
+                break
 
-    Args:
-        gross_salary: Annual gross salary.
-        canton: Canton code (2 letters).
+    marginal_rate = base_rate * income_adj * 1.3
+    return min(max(marginal_rate, 0.05), 0.45)
+
+
+def _estimate_tax_saving(
+    *,
+    income: float,
+    deduction: float,
+    canton: str,
+    steps: int = 10,
+) -> float:
+    """Estimate deduction value via the same 10-step integration as mobile."""
+    if deduction <= 0 or steps <= 0:
+        return 0.0
+
+    step_size = deduction / steps
+    current_income = income
+    total_saved = 0.0
+    for _ in range(steps):
+        midpoint = current_income - step_size / 2
+        rate = _compute_marginal_tax_rate(midpoint, canton)
+        total_saved += step_size * rate
+        current_income -= step_size
+    return total_saved
+
+
+def _estimate_3a_tax_impact(
+    gross_salary: float,
+    canton: str,
+    *,
+    has_lpp: bool,
+) -> tuple[float, float, float]:
+    """Estimate 3a tax impact for onboarding.
+
+    Source: OPP3 art. 7 (deductible 3a ceiling).
+    Hypotheses: educational marginal-rate estimate from canton + gross salary.
 
     Returns:
-        Estimated marginal tax rate (0.10 - 0.45).
+        (tax_saving_3a, marginal_tax_rate, annual_ceiling).
     """
-    # Approximate combined marginal income tax rates by canton (federal + cantonal + communal)
-    # at ~CHF 100k gross salary, single, chief-lieu. Source: AFC 2024.
-    # Brackets: <50k → ×0.70, 50-80k → ×0.85, 80-120k → ×1.00, 120-200k → ×1.15, 200k+ → ×1.30
-    _CANTONAL_MARGINAL_RATES = {
-        "ZH": 0.265, "BE": 0.305, "LU": 0.235, "UR": 0.225, "SZ": 0.195,
-        "OW": 0.210, "NW": 0.195, "GL": 0.250, "ZG": 0.175, "FR": 0.285,
-        "SO": 0.280, "BS": 0.290, "BL": 0.275, "SH": 0.260, "AR": 0.260,
-        "AI": 0.225, "SG": 0.265, "GR": 0.255, "AG": 0.255, "TG": 0.250,
-        "TI": 0.275, "VD": 0.305, "VS": 0.260, "NE": 0.310, "GE": 0.300,
-        "JU": 0.310,
-    }
-    _DEFAULT_MARGINAL = 0.270  # Swiss average fallback
+    if gross_salary <= 0 or canton.upper() not in TAUX_IMPOT_RETRAIT_CAPITAL:
+        ceiling = (
+            PILIER_3A_PLAFOND_AVEC_LPP
+            if has_lpp
+            else min(gross_salary * 0.20, PILIER_3A_PLAFOND_SANS_LPP)
+        )
+        return 0.0, 0.0, round(max(0.0, ceiling), 2)
 
-    base_rate = _CANTONAL_MARGINAL_RATES.get(canton.upper(), _DEFAULT_MARGINAL)
-
-    # Adjust for income level (bracket scaling)
-    if gross_salary < 50_000:
-        income_factor = base_rate * 0.70
-    elif gross_salary < 80_000:
-        income_factor = base_rate * 0.85
-    elif gross_salary < 120_000:
-        income_factor = base_rate * 1.00
-    elif gross_salary < 200_000:
-        income_factor = base_rate * 1.15
-    else:
-        income_factor = base_rate * 1.30
-
-    # Clamp to reasonable range
-    return round(min(max(income_factor, 0.10), 0.45), 4)
+    annual_ceiling = (
+        PILIER_3A_PLAFOND_AVEC_LPP
+        if has_lpp
+        else min(gross_salary * 0.20, PILIER_3A_PLAFOND_SANS_LPP)
+    )
+    marginal_tax_rate = _compute_marginal_tax_rate(
+        gross_salary - annual_ceiling / 2,
+        canton,
+    )
+    return (
+        round(
+            _estimate_tax_saving(
+                income=gross_salary,
+                deduction=annual_ceiling,
+                canton=canton,
+            ),
+            2,
+        ),
+        marginal_tax_rate,
+        round(annual_ceiling, 2),
+    )
 
 
 def _compute_confidence_score(estimated_fields: List[str]) -> float:
@@ -620,8 +685,13 @@ def compute_minimal_profile(input: MinimalProfileInput) -> MinimalProfileResult:
     )
 
     # ── Tax saving 3a ───────────────────────────────────────────────────────
-    marginal_tax_rate = _compute_marginal_tax_rate(input.gross_salary, canton)
-    tax_saving_3a = round(marginal_tax_rate * PILIER_3A_PLAFOND_AVEC_LPP, 2)
+    archetype = _detect_archetype(input)
+    has_lpp_for_3a = archetype != "independent_no_lpp"
+    tax_saving_3a, marginal_tax_rate, _ = _estimate_3a_tax_impact(
+        input.gross_salary,
+        canton,
+        has_lpp=has_lpp_for_3a,
+    )
 
     # ── Liquidity ───────────────────────────────────────────────────────────
     if estimated_monthly_expenses > 0:
@@ -649,10 +719,11 @@ def compute_minimal_profile(input: MinimalProfileInput) -> MinimalProfileResult:
         monthly_debt_impact=monthly_debt_impact,
         confidence_score=confidence_score,
         estimated_fields=estimated_fields,
-        archetype=_detect_archetype(input),
+        archetype=archetype,
         disclaimer=_DISCLAIMER,
         sources=list(_SOURCES),
         enrichment_prompts=enrichment_prompts,
         age=input.age,
         gross_annual_salary=input.gross_salary,
+        canton=canton,
     )

--- a/services/backend/app/services/onboarding/onboarding_models.py
+++ b/services/backend/app/services/onboarding/onboarding_models.py
@@ -81,6 +81,7 @@ class MinimalProfileResult:
     enrichment_prompts: List[str]
     age: int = 30  # user's age — used by lifecycle-aware premier éclairage selector
     gross_annual_salary: float = 0.0  # gross salary — used by hourly rate choc + archetype alerts
+    canton: str = ""  # canton used for tax-estimate trust gating
 
 
 @dataclass

--- a/services/backend/app/services/onboarding/premier_eclairage_selector.py
+++ b/services/backend/app/services/onboarding/premier_eclairage_selector.py
@@ -214,15 +214,18 @@ def _build_retirement_gap_choc(profile: MinimalProfileResult) -> PremierEclairag
 def _build_tax_saving_choc(profile: MinimalProfileResult) -> PremierEclairage:
     """Build premier éclairage for tax saving opportunity via 3a."""
     tax_saving = profile.tax_saving_3a
+    marginal_rate_pct = round(profile.marginal_tax_rate * 100)
+    canton = profile.canton.upper()
 
     display_text = (
-        f"En ouvrant un 3e pilier, tu pourrais économiser environ "
-        f"CHF {tax_saving:,.0f} d'impôts chaque année."
+        f"Un versement 3e pilier pourrait réduire l'impôt d'environ "
+        f"CHF {tax_saving:,.0f} par an."
     )
     explanation_text = (
-        "Le versement au 3e pilier est déductible du revenu imposable. "
-        "Avec un plafond de CHF 7'258 par an (salarié·e affilié·e LPP), "
-        "l'économie fiscale dépend de ton taux marginal d'imposition."
+        "Estimation basée sur ton salaire déclaré, "
+        f"un taux marginal estimé de {marginal_rate_pct}% "
+        f"et le canton {canton}. Le versement 3e pilier est déductible "
+        "du revenu imposable jusqu'au plafond OPP3."
     )
     action_text = "Explore les options 3a et leur impact fiscal \u2192"
 
@@ -235,7 +238,26 @@ def _build_tax_saving_choc(profile: MinimalProfileResult) -> PremierEclairage:
         disclaimer=_DISCLAIMER,
         sources=list(_SOURCES_TAX),
         confidence_score=profile.confidence_score,
-        confidence_mode="factual",  # Derived from salary + canton, both provided
+        confidence_mode="pedagogical",
+    )
+
+
+def _has_trustworthy_3a_tax_saving(
+    profile: MinimalProfileResult,
+    *,
+    threshold: float,
+) -> bool:
+    """Gate 3a tax displays on the inputs needed for an auditable estimate."""
+    return (
+        profile.existing_3a <= 0.0
+        and profile.tax_saving_3a > threshold
+        and profile.gross_annual_salary > 0
+        and profile.marginal_tax_rate > 0
+        and profile.canton.upper() in {
+            "AG", "AI", "AR", "BE", "BL", "BS", "FR", "GE", "GL", "GR",
+            "JU", "LU", "NE", "NW", "OW", "SG", "SH", "SO", "SZ", "TG",
+            "TI", "UR", "VD", "VS", "ZG", "ZH",
+        }
     )
 
 
@@ -368,7 +390,7 @@ def _select_by_stress(
         return None
 
     if stress_type == "stress_impots":
-        if profile.tax_saving_3a > 500:
+        if _has_trustworthy_3a_tax_saving(profile, threshold=500):
             return _build_tax_saving_choc(profile)
         return None
 
@@ -396,7 +418,7 @@ def _select_by_lifecycle(profile: MinimalProfileResult) -> PremierEclairage:
         return _build_compound_growth_choc(profile)
 
     if age < 38:
-        if profile.existing_3a <= 0 and profile.tax_saving_3a > 1500:
+        if _has_trustworthy_3a_tax_saving(profile, threshold=1500):
             return _build_tax_saving_choc(profile)
         return _build_compound_growth_choc(profile)
 
@@ -452,8 +474,7 @@ def select_premier_eclairage(
         return _build_retirement_gap_choc(profile)
 
     # Tax saving 3a
-    has_no_3a = profile.existing_3a <= 0.0
-    if has_no_3a and profile.tax_saving_3a > 1500:
+    if _has_trustworthy_3a_tax_saving(profile, threshold=1500):
         return _build_tax_saving_choc(profile)
 
     # Phase 4: Lifecycle-aware fallback

--- a/services/backend/tests/test_minimal_profile.py
+++ b/services/backend/tests/test_minimal_profile.py
@@ -26,12 +26,10 @@ from app.services.onboarding.minimal_profile_service import (
     _project_lpp_capital,
     _estimate_lpp_from_age_25,
     _compute_confidence_score,
+    _estimate_3a_tax_impact,
 )
 from app.services.onboarding.onboarding_models import MinimalProfileInput
-from app.constants.social_insurance import (
-    AVS_RENTE_MAX_MENSUELLE,
-    AVS_RENTE_MIN_MENSUELLE,
-)
+from app.constants.social_insurance import AVS_RENTE_MAX_MENSUELLE, AVS_RENTE_MIN_MENSUELLE
 
 
 # Banned terms that must NEVER appear in user-facing text
@@ -100,6 +98,26 @@ class TestMinimalInputs:
         assert r.tax_saving_3a > 0
         assert r.marginal_tax_rate > 0
         assert r.months_liquidity >= 0
+
+    def test_tax_saving_3a_uses_marginal_rate_and_ceiling(self):
+        """3a tax saving follows the onboarding tax-impact gate."""
+        inp = MinimalProfileInput(age=40, gross_salary=80_000.0, canton="VD")
+        r = compute_minimal_profile(inp)
+        expected, marginal_rate, _ = _estimate_3a_tax_impact(
+            80_000.0,
+            "VD",
+            has_lpp=True,
+        )
+        assert r.tax_saving_3a == expected
+        assert r.marginal_tax_rate == marginal_rate
+        assert r.canton == "VD"
+
+    def test_zero_salary_suppresses_tax_saving_3a(self):
+        """No salary means no trustworthy 3a fiscal impact."""
+        inp = MinimalProfileInput(age=40, gross_salary=0.0, canton="VD")
+        r = compute_minimal_profile(inp)
+        assert r.tax_saving_3a == 0.0
+        assert r.marginal_tax_rate == 0.0
 
     def test_low_salary_20k(self):
         """Low salary (20k): below LPP threshold, minimal AVS."""

--- a/services/backend/tests/test_premier_eclairage.py
+++ b/services/backend/tests/test_premier_eclairage.py
@@ -64,6 +64,7 @@ def _make_profile(**overrides) -> MinimalProfileResult:
         enrichment_prompts=[],
         age=45,  # Default age where retirement gap is relevant
         gross_annual_salary=100_000.0,  # Required for hourly_rate and stress guards
+        canton="VD",
     )
     defaults.update(overrides)
     return MinimalProfileResult(**defaults)
@@ -297,19 +298,36 @@ class TestConfidenceGating:
         assert choc.category == "compound_growth"
         assert choc.confidence_mode == "factual"
 
-    def test_tax_saving_always_factual(self):
-        """Tax saving derived from salary + canton (both provided) → factual."""
+    def test_tax_saving_is_pedagogical(self):
+        """Tax saving uses an estimated marginal rate → pedagogical."""
         profile = _make_profile(
             age=32,
             existing_3a=0.0,
             tax_saving_3a=2_000.0,
+            marginal_tax_rate=2_000.0 / 7_258.0,
             estimated_replacement_ratio=0.65,
             months_liquidity=6.0,
             estimated_fields=["existing_lpp", "current_savings"],
         )
         choc = select_premier_eclairage(profile)
         assert choc.category == "tax_saving"
-        assert choc.confidence_mode == "factual"
+        assert choc.confidence_mode == "pedagogical"
+        assert "taux marginal estimé" in choc.explanation_text
+        assert "canton VD" in choc.explanation_text
+
+    def test_invalid_canton_skips_tax_saving(self):
+        """Tax saving is not displayed if the canton cannot support the estimate."""
+        profile = _make_profile(
+            age=32,
+            existing_3a=0.0,
+            tax_saving_3a=2_000.0,
+            marginal_tax_rate=2_000.0 / 7_258.0,
+            canton="ZZ",
+            estimated_replacement_ratio=0.65,
+            months_liquidity=6.0,
+        )
+        choc = select_premier_eclairage(profile)
+        assert choc.category != "tax_saving"
 
 
 # ===========================================================================

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -16718,6 +16718,19 @@
             "description": "Civil status (single, married, etc.)",
             "title": "Civil Status"
           },
+          "coach_context_packet": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Privacy-scoped Data Spine packet from mobile: facts, missing fields, trajectory, and next questions. Never raw wizard answers.",
+            "title": "Coach Context Packet"
+          },
           "employment_status": {
             "anyOf": [
               {


### PR DESCRIPTION
## Summary
- route mobile onboarding 3a tax impact through the canonical RetirementTaxCalculator and require coherent selector inputs before showing the tax insight
- align backend onboarding with the same AFC-style marginal curve and 10-step deduction integration
- mark 3a tax insight as pedagogical and expose canton + estimated marginal-rate assumptions
- add mobile/backend tests for invalid canton, zero salary, incoherent raw values, and compute-to-selector flow

## Validation
- flutter analyze --no-fatal-infos lib/services/minimal_profile_service.dart lib/services/premier_eclairage_selector.dart test/services/minimal_profile_service_test.dart test/services/premier_eclairage_selector_test.dart
- flutter test test/services/minimal_profile_service_test.dart test/services/premier_eclairage_selector_test.dart
- ruff check app/services/onboarding/minimal_profile_service.py app/services/onboarding/premier_eclairage_selector.py app/services/onboarding/onboarding_models.py tests/test_minimal_profile.py tests/test_premier_eclairage.py
- pytest -q tests/test_minimal_profile.py tests/test_premier_eclairage.py
- git diff --check
- python3 tools/checks/wiki_lint.py lint
- MCP validate_arb_parity
- MCP banned/accent checks on new copy

## Reviews
- Product/code agents found blocking issues around factual confidence, backend bypass, and backend/mobile formula divergence; fixed before PR.
