### PR TITLE
fix(budget): keep monthly source coherent

### DIFF
--- a/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/PLAN.md
@@ -1,0 +1,14 @@
+# Money Trust Contract v1 — 04 Budget Source Coherence
+
+## Goal
+Make Budget and Mon Argent display the same trusted monthly numbers after direct budget setup/relaunch, without allowing stale DataSpine/BudgetSnapshot values to override fresh BudgetInputs.
+
+## Scope
+- BudgetSummaryCard source precedence.
+- BudgetScreen present budget deficit preservation.
+- Focused widget/screen tests.
+
+## Acceptance
+- Mon Argent month card prefers fresh BudgetInputs/BudgetPlan over stale BudgetSnapshot when both are present.
+- BudgetScreen detailed flow keeps negative monthlyFree for deficit mode.
+- Existing budget/mon_argent focused tests pass.

--- a/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/SUMMARY.md
+++ b/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/SUMMARY.md
@@ -1,0 +1,38 @@
+# Money Trust Contract v1 — 04 Budget Source Coherence Summary
+
+This phase removes one trust-breaking Budget and Mon Argent divergence while
+keeping the diff small and testable.
+
+## What Changed
+
+- `BudgetSummaryCard` now renders fresh `BudgetInputs` plus `BudgetPlan` before
+  falling back to `BudgetSnapshot`.
+- `BudgetScreen` no longer clamps signed present-budget cashflow to zero.
+- Added widget regression coverage for stale snapshot override.
+- Added screen regression coverage for a monthly deficit.
+
+## Why
+
+The app could show old or sanitized monthly numbers after direct budget setup or
+relaunch. For a financial lucidity app, a false zero or a stale remaining amount
+is worse than an explicit incomplete state.
+
+## Agent Review Synthesis
+
+- Product review: the user journey must answer one question first: how much is
+  left this month, why, and how reliable that number is.
+- QA review: the next blocking Maestro proof should be
+  `flow_mon_argent_budget_setup_spine.yaml`, then coach data-spine visibility.
+- Architecture review: a bigger follow-up must converge Budget, Mon Argent,
+  coach packet, and financial report around one read model.
+
+## Next Phase
+
+Recommended next phase:
+`money-trust-contract-v1-05-budget-read-model-convergence`.
+
+Target:
+- stop stale `budget_inputs_v1` from overriding newer profile/spine data;
+- make Budget, Mon Argent, coach packet, and financial report consume the same
+  canonical present-budget read model;
+- add Maestro proof from setup to relaunch to Mon Argent to Budget to coach.

--- a/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/VERIFICATION.md
+++ b/.planning/phases/money-trust-contract-v1-04-budget-source-coherence/VERIFICATION.md
@@ -1,0 +1,40 @@
+# Money Trust Contract v1 — 04 Budget Source Coherence Verification
+
+This verification record covers the narrow trust fix for Budget and Mon Argent
+monthly-number coherence.
+
+## Result
+
+PASS — focused Flutter checks pass locally.
+
+## Commands
+
+- `cd apps/mobile && flutter test test/widgets/mon_argent_budget_summary_card_test.dart`
+  - Result: `All tests passed`
+- `cd apps/mobile && flutter test test/screens/budget_screen_smoke_test.dart`
+  - Result: `All tests passed`
+- `cd apps/mobile && flutter analyze --no-fatal-infos lib/widgets/mon_argent/budget_summary_card.dart lib/screens/budget/budget_screen.dart test/widgets/mon_argent_budget_summary_card_test.dart test/screens/budget_screen_smoke_test.dart`
+  - Result: `No issues found`
+- `cd apps/mobile && flutter test test/domain/budget_service_test.dart test/domain/budget/budget_service_test.dart test/services/budget_living_engine_test.dart`
+  - Result: `105 passed`
+- `git diff --check`
+  - Result: pass
+- `python3 tools/checks/wiki_lint.py lint`
+  - Result: no FAIL-level violations; existing warnings only
+
+## Reviewed Risks
+
+- `BudgetService.computePlan` still clamps `available` to zero. This is kept
+  intentionally because `BudgetPlan.available` is the amount available to
+  allocate, not the signed cashflow truth.
+- `BudgetScreen` now keeps the signed `PresentBudget.monthlyFree`, so the
+  detailed flow can show a deficit.
+- `BudgetSummaryCard` now prefers fresh `BudgetInputs` plus `BudgetPlan` over a
+  stale `BudgetSnapshot` when both are present.
+
+## Still Open
+
+- Device-level proof still needs Maestro:
+  `tools/simulator/flows/maestro-perfect-set/flow_mon_argent_budget_setup_spine.yaml`.
+- A larger convergence phase is still needed to remove or hash-guard stale
+  `budget_inputs_v1` restore behavior.

--- a/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/PLAN.md
@@ -1,0 +1,19 @@
+# Money Trust Contract v1 — 05 Budget Whisper Deficit
+
+Fix the Mon Argent coach whisper so it detects signed monthly cashflow deficits
+from BudgetInputs, instead of reading the non-negative allocation amount.
+
+## Goal
+
+Make the Mon Argent coach whisper use the same signed cashflow logic as Budget
+and PresentBudget when deciding whether the month is tight.
+
+## Scope
+
+- `CoachWhisperService` deficit rule.
+- Focused unit test for a deficit month.
+
+## Acceptance
+
+- A month where charges exceed income triggers the deficit whisper.
+- The rule does not depend on `BudgetPlan.available` being negative.

--- a/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/SUMMARY.md
+++ b/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/SUMMARY.md
@@ -1,0 +1,21 @@
+# Money Trust Contract v1 — 05 Budget Whisper Deficit Summary
+
+This phase fixes a deterministic Mon Argent guidance bug: the coach whisper
+could not detect a deficit because it checked a non-negative allocation value.
+
+## What Changed
+
+- Added a regression test for a deficit month.
+- Changed `CoachWhisperService` to derive signed monthly free cashflow from
+  budget inputs.
+
+## Why
+
+`BudgetPlan.available` is intentionally clamped to zero because it represents
+money available to allocate. A deficit warning must instead use the signed
+cashflow equation: income minus fixed charges minus planned future allocation.
+
+## Next Phase
+
+The next larger phase remains read-model convergence: make Mon Argent, Budget,
+coach packet, and report surfaces consume one canonical present-budget view.

--- a/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/VERIFICATION.md
+++ b/.planning/phases/money-trust-contract-v1-05-budget-whisper-deficit/VERIFICATION.md
@@ -1,0 +1,22 @@
+# Money Trust Contract v1 — 05 Budget Whisper Deficit Verification
+
+This verification record covers the Mon Argent coach whisper deficit rule.
+
+## Result
+
+PASS — focused service test and analyzer pass locally.
+
+## Commands
+
+- `cd apps/mobile && flutter test test/services/mon_argent_coach_whisper_service_test.dart`
+  - First run before code change: failed as expected, deficit whisper returned null.
+  - Final result: `All tests passed`
+- `cd apps/mobile && flutter analyze --no-fatal-infos lib/services/mon_argent/coach_whisper_service.dart test/services/mon_argent_coach_whisper_service_test.dart`
+  - Result: `No issues found`
+
+## Reviewed Risks
+
+- `BudgetPlan.available` remains non-negative by design.
+- The whisper now computes signed monthly free cashflow from `BudgetInputs`
+  plus optional planned future allocation.
+- No LLM path is involved; this remains deterministic UI guidance.

--- a/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/PLAN.md
+++ b/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/PLAN.md
@@ -1,0 +1,20 @@
+# Money Trust Contract v1 — 06 Budget Proof Maestro
+
+Stabilize the Budget calculation proof so the device flow can verify the
+trusted monthly numbers after setup and relaunch.
+
+## Goal
+
+Make the Budget formula proof visible and addressable in Maestro, then pass the
+Mon Argent/Budget setup flow on the iPhone simulator.
+
+## Scope
+
+- Budget calculation detail visibility.
+- Stable semantic anchor for the calculation detail toggle.
+- Maestro flow selector update.
+
+## Acceptance
+
+- `flow_mon_argent_budget_setup_spine.yaml` passes on the booted iOS simulator.
+- The flow verifies `3'140`, `2'239`, and absence of `19'272'200` / `420'420`.

--- a/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/SUMMARY.md
+++ b/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/SUMMARY.md
@@ -1,0 +1,23 @@
+# Money Trust Contract v1 — 06 Budget Proof Maestro Summary
+
+This phase turns the Budget formula proof into a stable, visible trust surface
+and validates it on the simulator.
+
+## What Changed
+
+- Budget wraps its calculation detail in the
+  `budget_calculation_detail_toggle` semantic anchor.
+- Budget opens the calculation detail by default.
+- Maestro taps/asserts stable ids instead of fragile localized text for this
+  part of the flow.
+
+## Why
+
+The user must immediately see why the monthly free amount is what it is. Hiding
+the formula behind a fragile accordion creates both UX friction and test drift.
+
+## Device Result
+
+`flow_mon_argent_budget_setup_spine.yaml` passed on iPhone 17 Pro simulator in
+39 seconds, with screenshots and JUnit under:
+`.planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z/`.

--- a/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/VERIFICATION.md
+++ b/.planning/phases/money-trust-contract-v1-06-budget-proof-maestro/VERIFICATION.md
@@ -1,0 +1,35 @@
+# Money Trust Contract v1 — 06 Budget Proof Maestro Verification
+
+This verification record covers the device-level Budget and Mon Argent flow.
+
+## Result
+
+PASS — Maestro flow passed on iPhone 17 Pro simulator.
+
+## Commands
+
+- `cd apps/mobile && flutter test test/screens/budget_screen_smoke_test.dart test/services/mon_argent_coach_whisper_service_test.dart test/widgets/mon_argent_budget_summary_card_test.dart`
+  - Result: `12 passed`
+- `cd apps/mobile && flutter analyze --no-fatal-infos lib/screens/budget/budget_screen.dart lib/widgets/collapsible_section.dart test/screens/budget_screen_smoke_test.dart lib/services/mon_argent/coach_whisper_service.dart test/services/mon_argent_coach_whisper_service_test.dart`
+  - Result: `No issues found`
+- `cd apps/mobile && xattr -cr .dart_tool build ios/build && flutter build ios --simulator --debug --dart-define=MINT_E2E_ARCHETYPE=julien_swiss --dart-define=MINT_DISABLE_BETA_MODAL=true`
+  - Result: built `build/ios/iphonesimulator/Runner.app`
+- Installed and launched `ch.mint.app` on simulator `B03E429D-0422-4357-B754-536637D979F9`.
+- `maestro test --device B03E429D-0422-4357-B754-536637D979F9 --format JUNIT --output .planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z/result.xml --test-output-dir .planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z --debug-output .planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z/debug tools/simulator/flows/maestro-perfect-set/flow_mon_argent_budget_setup_spine.yaml`
+  - Result: `1/1 Flow Passed in 39s`
+
+## Evidence
+
+- JUnit: `.planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z/result.xml`
+- Screenshots:
+  - `mon-argent-01-data-spine.png`
+  - `mon-argent-02-budget-setup.png`
+  - `mon-argent-03-budget-direct-relaunch.png`
+  - `mon-argent-04-coach-return.png`
+
+## Notes
+
+- Initial Maestro failures were selector and expansion-state issues, not number
+  calculation failures.
+- The detail section is now initially expanded because the formula proof is a
+  trust surface, not secondary decoration.

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -311,12 +311,20 @@ class _BudgetScreenState extends State<BudgetScreen>
 
                                     _staggeredEntry(
                                       index: 1,
-                                      child: CollapsibleSection(
-                                        title: l.affordabilityCalculationDetail,
-                                        icon: Icons.functions,
-                                        child: _BudgetFlowMap(
-                                          present: flowPresent,
-                                          l: l,
+                                      child: Semantics(
+                                        key: const Key(
+                                            'budget_calculation_detail_toggle'),
+                                        identifier:
+                                            'budget_calculation_detail_toggle',
+                                        child: CollapsibleSection(
+                                          title:
+                                              l.affordabilityCalculationDetail,
+                                          icon: Icons.functions,
+                                          initiallyExpanded: true,
+                                          child: _BudgetFlowMap(
+                                            present: flowPresent,
+                                            l: l,
+                                          ),
                                         ),
                                       ),
                                     ),

--- a/apps/mobile/lib/screens/budget/budget_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_screen.dart
@@ -565,7 +565,7 @@ class _BudgetScreenState extends State<BudgetScreen>
       monthlyNet: monthlyNet,
       monthlyCharges: monthlyCharges,
       monthlySavings: monthlySavings,
-      monthlyFree: monthlyFree > 0 ? monthlyFree : 0,
+      monthlyFree: monthlyFree,
     );
   }
 

--- a/apps/mobile/lib/services/mon_argent/coach_whisper_service.dart
+++ b/apps/mobile/lib/services/mon_argent/coach_whisper_service.dart
@@ -18,8 +18,9 @@ class CoachWhisperService {
     required PatrimoineSummary patrimoine,
     required CoachProfile? profile,
   }) {
-    // Rule 1: Budget deficit — urgent
-    if (budgetPlan != null && budgetPlan.available < 0) {
+    // Rule 1: Budget deficit — urgent. BudgetPlan.available is an allocation
+    // amount and is intentionally non-negative, so use signed cashflow here.
+    if (_signedMonthlyFree(budgetInputs, budgetPlan) < 0) {
       return 'Mois serré. Regarde tes dépenses fixes.';
     }
 
@@ -81,5 +82,15 @@ class CoachWhisperService {
         inputs.debtPayments +
         inputs.otherFixedCosts;
     return fixed > 0 ? fixed : inputs.netIncome;
+  }
+
+  static double _signedMonthlyFree(BudgetInputs? inputs, BudgetPlan? plan) {
+    if (inputs == null) return 0;
+    final fixed = inputs.housingCost +
+        inputs.healthInsurance +
+        inputs.taxProvision +
+        inputs.debtPayments +
+        inputs.otherFixedCosts;
+    return inputs.netIncome - fixed - (plan?.future ?? 0);
   }
 }

--- a/apps/mobile/lib/widgets/mon_argent/budget_summary_card.dart
+++ b/apps/mobile/lib/widgets/mon_argent/budget_summary_card.dart
@@ -44,6 +44,7 @@ class BudgetSummaryCard extends StatelessWidget {
 
     if (isLoading) return _buildLoading();
     if (hasError) return _buildError(l10n);
+    if (inputs != null && plan != null) return _buildData(l10n);
     if (snapshot != null) return _buildSnapshotData(l10n, snapshot!);
     if (inputs == null) return _buildEmpty(l10n);
     return _buildData(l10n);

--- a/apps/mobile/test/screens/budget_screen_smoke_test.dart
+++ b/apps/mobile/test/screens/budget_screen_smoke_test.dart
@@ -143,9 +143,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     await tester.pump(const Duration(seconds: 2));
 
-    await tester.ensureVisible(find.text('Détail du calcul'));
-    await tester.tap(find.text('Détail du calcul'));
-    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('budget_formula_proof')));
 
     expect(find.text('Revenu net'), findsWidgets);
     expect(find.text('Charges'), findsWidgets);
@@ -197,9 +195,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     await tester.pump(const Duration(seconds: 2));
 
-    await tester.ensureVisible(find.text('Détail du calcul'));
-    await tester.tap(find.text('Détail du calcul'));
-    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('budget_formula_proof')));
 
     expect(find.text('Disponible'), findsWidgets);
     expect(find.text("CHF\u00a0-1'120"), findsWidgets);
@@ -241,9 +237,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     await tester.pump(const Duration(seconds: 2));
 
-    await tester.ensureVisible(find.text('Détail du calcul'));
-    await tester.tap(find.text('Détail du calcul'));
-    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const Key('budget_formula_proof')));
 
     expect(
       tester.getSemantics(find.byKey(const Key('budget_screen'))).identifier,
@@ -264,6 +258,14 @@ void main() {
     expect(
       tester.getSemantics(find.byKey(const Key('budget_flow_map'))).identifier,
       'budget_flow_map',
+    );
+    expect(
+      tester
+          .getSemantics(
+            find.byKey(const Key('budget_calculation_detail_toggle')),
+          )
+          .identifier,
+      'budget_calculation_detail_toggle',
     );
     expect(
       tester

--- a/apps/mobile/test/screens/budget_screen_smoke_test.dart
+++ b/apps/mobile/test/screens/budget_screen_smoke_test.dart
@@ -162,6 +162,49 @@ void main() {
     expect(find.text('42%'), findsOneWidget);
   });
 
+  testWidgets('BudgetScreen monthly flow preserves deficit instead of clamping',
+      (tester) async {
+    const inputs = BudgetInputs(
+      payFrequency: PayFrequency.monthly,
+      netIncome: 5000,
+      housingCost: 5200,
+      debtPayments: 0,
+      taxProvision: 500,
+      healthInsurance: 420,
+      style: BudgetStyle.envelopes3,
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => BudgetProvider()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('fr'),
+          localizationsDelegates: [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: BudgetScreen(inputs: inputs),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(seconds: 2));
+
+    await tester.ensureVisible(find.text('Détail du calcul'));
+    await tester.tap(find.text('Détail du calcul'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Disponible'), findsWidgets);
+    expect(find.text("CHF\u00a0-1'120"), findsWidgets);
+  });
+
   testWidgets('BudgetScreen exposes Maestro semantics anchors', (tester) async {
     const inputs = BudgetInputs(
       payFrequency: PayFrequency.monthly,

--- a/apps/mobile/test/services/mon_argent_coach_whisper_service_test.dart
+++ b/apps/mobile/test/services/mon_argent_coach_whisper_service_test.dart
@@ -1,11 +1,36 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart';
+import 'package:mint_mobile/domain/budget/budget_plan.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/mon_argent/coach_whisper_service.dart';
 import 'package:mint_mobile/services/mon_argent/patrimoine_aggregator.dart';
 
 void main() {
   group('CoachWhisperService', () {
+    test('detects deficit from signed monthly cashflow', () {
+      final whisper = CoachWhisperService.evaluate(
+        budgetInputs: const BudgetInputs(
+          payFrequency: PayFrequency.monthly,
+          netIncome: 5000,
+          housingCost: 5200,
+          taxProvision: 500,
+          healthInsurance: 420,
+          debtPayments: 0,
+        ),
+        budgetPlan: const BudgetPlan(
+          available: 0,
+          variables: 0,
+          future: 0,
+          stopRuleTriggered: true,
+          emergencyFundMonths: 0,
+        ),
+        patrimoine: const PatrimoineSummary(),
+        profile: null,
+      );
+
+      expect(whisper, 'Mois serré. Regarde tes dépenses fixes.');
+    });
+
     test('uses fixed charges instead of net income for emergency months', () {
       final whisper = CoachWhisperService.evaluate(
         budgetInputs: const BudgetInputs(

--- a/apps/mobile/test/widgets/mon_argent_budget_summary_card_test.dart
+++ b/apps/mobile/test/widgets/mon_argent_budget_summary_card_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/domain/budget/budget_inputs.dart';
+import 'package:mint_mobile/domain/budget/budget_plan.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/budget_snapshot.dart';
 import 'package:mint_mobile/widgets/mon_argent/budget_summary_card.dart';
@@ -47,5 +49,51 @@ void main() {
           .identifier,
       'mon_argent_budget_flow_bar',
     );
+  });
+
+  testWidgets('prefers fresh budget inputs over stale snapshot',
+      (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const BudgetSummaryCard(
+          snapshot: BudgetSnapshot(
+            present: PresentBudget(
+              monthlyNet: 8000,
+              monthlyCharges: 5200,
+              monthlySavings: 700,
+              monthlyFree: 2100,
+            ),
+            capImpacts: [],
+            stage: BudgetStage.presentOnly,
+            confidenceScore: 64,
+          ),
+          inputs: BudgetInputs(
+            payFrequency: PayFrequency.monthly,
+            netIncome: 5379,
+            housingCost: 2200,
+            debtPayments: 0,
+            taxProvision: 520,
+            healthInsurance: 420,
+            style: BudgetStyle.envelopes3,
+          ),
+          plan: BudgetPlan(
+            available: 2239,
+            variables: 2239,
+            future: 0,
+            stopRuleTriggered: false,
+            emergencyFundMonths: 0,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text("5'379\u00a0CHF"), findsOneWidget);
+    expect(find.text("3'140\u00a0CHF"), findsOneWidget);
+    expect(find.text("2'239\u00a0CHF"), findsOneWidget);
+    expect(find.text("8'000\u00a0CHF"), findsNothing);
+    expect(find.text("5'900\u00a0CHF"), findsNothing);
+    expect(find.text("2'100\u00a0CHF"), findsNothing);
   });
 }

--- a/tools/simulator/flows/maestro-perfect-set/flow_mon_argent_budget_setup_spine.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_mon_argent_budget_setup_spine.yaml
@@ -140,11 +140,7 @@ tags:
 - assertVisible:
     id: "budget_data_quality_banner"
 - assertVisible:
-    text: "Détail du calcul"
-- tapOn:
-    text: "Détail du calcul"
-- waitForAnimationToEnd:
-    timeout: 3000
+    id: "budget_calculation_detail_toggle"
 - assertVisible:
     id: "budget_formula_proof"
 - assertVisible:


### PR DESCRIPTION
## Summary
- make Mon Argent prefer fresh budget inputs over stale budget snapshots
- preserve signed monthly deficits in Budget present cashflow and coach whisper
- expose Budget formula proof by default and stabilize the Maestro budget flow

## Verification
- flutter test test/widgets/mon_argent_budget_summary_card_test.dart test/screens/budget_screen_smoke_test.dart
- flutter test test/domain/budget_service_test.dart test/domain/budget/budget_service_test.dart test/services/budget_living_engine_test.dart
- flutter test test/services/mon_argent_coach_whisper_service_test.dart test/widgets/mon_argent_budget_summary_card_test.dart test/screens/budget_screen_smoke_test.dart
- flutter analyze --no-fatal-infos targeted files
- python3 tools/checks/wiki_lint.py lint
- git diff --check
- Maestro: flow_mon_argent_budget_setup_spine passed on iPhone 17 Pro simulator, JUnit at .planning/walker/maestro-flows/mon-argent-budget-source-coherence/20260525T220249Z/result.xml

## Notes
Initial simulator build failed due macOS xattrs on Flutter artifacts; cleaning .dart_tool, build, and ios/build fixed simulator codesign.