### PR TITLE
fix(SALVAGE-00 SC-4): coach leads with monthly_free (Disponible) + strengthened device gate

### DIFF
--- a/apps/mobile/lib/services/data_spine/coach_packet_insight_presenter.dart
+++ b/apps/mobile/lib/services/data_spine/coach_packet_insight_presenter.dart
@@ -15,9 +15,14 @@ class CoachPacketInsight {
 }
 
 abstract final class CoachPacketInsightPresenter {
+  // SALVAGE-00 SC-4: lead with monthly_free (the converged "Disponible/mois"
+  // shown on Budget + Mon Argent) so the coach surface shows the SAME number
+  // the user sees everywhere — not monthly_capacity (pre-3a), which diverges
+  // and breaks the money-trust-chain. Mirrors coach_context_packet_service's
+  // ordering (monthly_free first).
   static const _factPriority = <String>[
-    'budget.monthly_capacity',
     'budget.monthly_free',
+    'budget.monthly_capacity',
     'budget.monthly_net',
     'pillar.lpp.total_balance',
     'pillar.3a.total_balance',

--- a/apps/mobile/test/services/coach_packet_insight_presenter_test.dart
+++ b/apps/mobile/test/services/coach_packet_insight_presenter_test.dart
@@ -34,6 +34,46 @@ void main() {
       expect(insight.nextText, 'Objectif à atteindre');
     });
 
+    test(
+        'SALVAGE-00 SC-4: leads with monthly_free (Disponible) over '
+        'monthly_capacity when both are present', () {
+      final insight = CoachPacketInsightPresenter.fromSafeMap({
+        'facts': [
+          {
+            'id': 'budget.monthly_capacity',
+            'domain': 'budget',
+            'field_path': 'trajectory.currentMonthlyCapacity',
+            'value': 3740.0,
+          },
+          {
+            'id': 'budget.monthly_free',
+            'domain': 'budget',
+            'field_path': 'budget.present.monthlyFree',
+            'value': 3152.0,
+          },
+        ],
+        'missing_fields': [
+          {
+            'field_path': 'trajectory.targetAmount',
+            'domain': 'trajectory',
+            'reason': 'missing_target_amount',
+          },
+        ],
+        'next_questions': [
+          {
+            'id': 'define_target_amount',
+            'domain': 'trajectory',
+            'field_path': 'trajectory.targetAmount',
+          },
+        ],
+      });
+
+      expect(insight, isNotNull);
+      // Must show the SAME Disponible/mois the user sees on Budget + Mon Argent
+      // (monthlyFree 3'152), NOT monthly_capacity (3'740) — money-trust-chain.
+      expect(insight!.knownText, 'Marge libre: CHF 3\'152');
+    });
+
     test('falls back to the first missing field when no next question exists',
         () {
       final insight = CoachPacketInsightPresenter.fromSafeMap({

--- a/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_3a_contributing.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_3a_contributing.yaml
@@ -112,13 +112,16 @@ tags:
 - assertNotVisible: "NaN"
 - assertNotVisible: "Infinity"
 # The leading budget fact rendered in the chat-open "Point de départ" packet.
-# NOTE (SC-4 finding): the packet prioritises budget.monthly_capacity over
-# budget.monthly_free (CoachPacketInsightPresenter._factPriority), so the
-# coach text reads "Capacité mensuelle: CHF <capacity>". The comparator will
-# therefore FAIL if capacity != monthlyFree — that divergence IS the honest
-# SC-4 verdict for the coach surface, not a flow bug.
+# POST-FIX (SALVAGE-00 SC-4): CoachPacketInsightPresenter._factPriority now
+# lists budget.monthly_free BEFORE budget.monthly_capacity, so the leading
+# coach fact reads "Marge libre: CHF <monthlyFree>" (the converged Disponible),
+# not "Capacité mensuelle: CHF <capacity>". The comparator extracts the CHF
+# token after "CHF" regardless of the label, so a true convergence => PASS and
+# any residual divergence => FAIL (honest verdict, not a flow bug).
+- assertVisible:
+    text: "Marge libre.*"
 - copyTextFrom:
-    text: "Capacité mensuelle.*"
+    text: "Marge libre.*"
 - evalScript: ${output.sc4_coach = maestro.copiedText}
 - takeScreenshot: "sc4-coach-surface"
 

--- a/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_3a_contributing.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_3a_contributing.yaml
@@ -1,23 +1,126 @@
-appId: com.mint.app
-# Device-flow proof for the 3a-contributing money-trust chain (SC-4).
-# Walks: onboarding -> budget -> 3a contribution -> monthlyFree ("Argent libre").
-# NOTE: the seed slug `cadre_3a_contributing` is created in Plan 02 (02-T*).
-#       Until then this flow references it by name and will only resolve once the
-#       seed lands. Keeps SC-4 staged without blocking Wave 1.
+appId: ch.mint.app
+# SALVAGE-00 SC-4 — Device-flow proof for the 3a-contributing money-trust chain.
+#
+# GOAL (the heart of SC-4)
+# Prove that the SAME "Disponible/mois" (argent libre / present.monthlyFree)
+# value renders IDENTICALLY across the THREE money surfaces for the
+# `cadre_3a_contributing` persona (swiss_native seed, gross 9000, hasLpp =>
+# q_3a_annual_contribution > 0 => total3aMensuel > 0 => Futur > 0):
+#   1. Mon Argent  — mon_argent_data_spine_summary  (Text _formatChf:  "<n> CHF")
+#   2. /budget     — budget_hero_formula            (formula: "... = CHF <n>")
+#   3. Coach       — chat-open insight surface       (whisper carrying monthlyFree)
+#
+# The #681/#682 trust-chain fix converges the builder path onto the engine
+# path (monthlyFree subtracts the 3a savings, not the builder path that omits
+# it — SC-2/SC-4). This device gate proves the convergence reaches the user.
+#
+# STRENGTHENED (was: visibility-only assertVisible "Argent libre"/"Coach").
+# Now CAPTURES the actual CHF VALUE on each surface (copyTextFrom) and asserts
+# all three numeric tokens are byte-identical via sc4_assert_value_convergence.js.
+# A divergence => the JS throws => this flow FAILS (the truthful SC-4 result).
+#
+# PRE-CONDITION
+# - App ch.mint.app built --debug --simulator with:
+#     --dart-define=MINT_E2E_ARCHETYPE=cadre_3a_contributing
+#     --dart-define=MINT_DISABLE_BETA_MODAL=true
+#     --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1
+#   installed on a booted iPhone simulator. Staging only (never local backend).
+# - kReleaseMode-guarded seed: forcedArchetypeSlug() returns null in release.
+#
+# LOCATOR STRATEGY
+# Flutter Semantics.identifier anchors for structural surfaces; CHF-number
+# regex for the value tokens. Deep-links bypass the anonymous onboarding so
+# the seeded profile drives all three surfaces directly.
 env:
   MINT_E2E_ARCHETYPE: cadre_3a_contributing
+tags:
+  - money-trust-chain
+  - salvage-00-sc4
+  - budget
+  - mon-argent
+  - coach
+  - maestro-proof
 ---
+
 - launchApp:
     clearState: true
     arguments:
       MINT_E2E_ARCHETYPE: ${MINT_E2E_ARCHETYPE}
-# Onboarding lands the seeded 3a-contributing profile.
-- assertVisible: "Budget"
-- tapOn: "Budget"
-# Budget surface shows the 3a contribution and the resulting free cash.
-- assertVisible: "Argent libre"
-# Trust chain: the free-cash figure must reflect the 3a contribution
-# (engine path), not the builder path that omits it (SC-2 / SC-4).
-- assertVisible: "Coach"
-- tapOn: "Coach"
-- assertVisible: "Coach"
+- waitForAnimationToEnd:
+    timeout: 6000
+
+# Dismiss the anonymous landing's deep-link confirmation if it appears.
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
+
+# ─── Surface 1: /budget — monthlyFree via the hero formula ────────────
+- openLink: "mintapp:///budget"
+- extendedWaitUntil:
+    visible:
+      id: "budget_screen"
+    timeout: 12000
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertVisible:
+    id: "budget_hero_formula"
+# Guard against the absurd-value leaks the trust-chain fix removed.
+- assertNotVisible: "NaN"
+- assertNotVisible: "Infinity"
+- copyTextFrom:
+    id: "budget_hero_formula"
+- evalScript: ${output.sc4_budget = maestro.copiedText}
+
+# ─── Surface 2: Mon Argent — monthlyFree via the data-spine summary ───
+- openLink: "mintapp:///mon-argent?section=month"
+- extendedWaitUntil:
+    visible:
+      id: "mon_argent_screen"
+    timeout: 12000
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertVisible:
+    id: "mon_argent_budget_summary"
+- assertNotVisible: "NaN"
+- assertNotVisible: "Infinity"
+# "Ton budget ce mois. Revenus <net> CHF. Dépenses <chg> CHF. Reste <free> CHF."
+# The convergence comparator extracts the CHF token adjacent to "Reste".
+- copyTextFrom:
+    id: "mon_argent_budget_summary"
+- evalScript: ${output.sc4_mon_argent = maestro.copiedText}
+
+# ─── Surface 3: Coach — the money figure the user sees on chat-open ───
+# The coach chat-open surface carries the budget money figure. We copy the
+# coach-context "Point de départ" packet (coach-context-point-de-depart),
+# which renders the leading budget fact. SC-4 asserts this equals monthlyFree.
+- openLink: "mintapp:///coach/chat"
+- extendedWaitUntil:
+    visible:
+      id: "coach_chat_screen"
+    timeout: 12000
+- waitForAnimationToEnd:
+    timeout: 4000
+- assertNotVisible: "NaN"
+- assertNotVisible: "Infinity"
+# The leading budget fact rendered in the chat-open "Point de départ" packet.
+# NOTE (SC-4 finding): the packet prioritises budget.monthly_capacity over
+# budget.monthly_free (CoachPacketInsightPresenter._factPriority), so the
+# coach text reads "Capacité mensuelle: CHF <capacity>". The comparator will
+# therefore FAIL if capacity != monthlyFree — that divergence IS the honest
+# SC-4 verdict for the coach surface, not a flow bug.
+- copyTextFrom:
+    text: "Capacité mensuelle.*"
+- evalScript: ${output.sc4_coach = maestro.copiedText}
+- takeScreenshot: "sc4-coach-surface"
+
+# ─── THE SC-4 ASSERTION: all three numeric tokens must be identical ───
+- runScript: "sc4_assert_value_convergence.js"

--- a/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
+++ b/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
@@ -83,6 +83,17 @@ var summary =
   'coach="' + coach + '" => ' + output.sc4_converged;
 output.sc4_summary = summary;
 
+// Surface the captured tokens + raw strings deterministically into the log so
+// the rerun evidence shows the exact CHF value seen on each surface, not just
+// a pass/fail bit. (json output below makes the values greppable from disk.)
+output.sc4_evidence_json = JSON.stringify({
+  budget_token: budget, mon_argent_token: monArgent, coach_token: coach,
+  verdict: output.sc4_converged,
+  budget_raw: budgetRaw, mon_argent_raw: monArgentRaw, coach_raw: coachRaw,
+});
+console.log('SC4_EVIDENCE ' + output.sc4_evidence_json);
+console.log(summary);
+
 if (!allEqual) {
   throw new Error(
     'SC-4 FAIL — Disponible/mois (monthlyFree) DIVERGES across surfaces. ' + summary +

--- a/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
+++ b/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
@@ -1,0 +1,92 @@
+// sc4_assert_value_convergence.js — SC-4 value-convergence assertion.
+//
+// The heart of SALVAGE-00 SC-4: prove the SAME "Disponible/mois"
+// (argent libre / present.monthlyFree) value renders IDENTICALLY across the
+// three money surfaces — Mon Argent, /budget, and the coach chat-open surface
+// — for the `cadre_3a_contributing` persona.
+//
+// Each surface formats the figure differently in layout/wording, so we extract
+// the relevant CHF numeric token (Swiss apostrophe thousands sep, e.g. 3'152):
+//   - /budget    captured node "budget_hero_formula":
+//                "Disponible ce mois: CHF 3'152. CHF 7'020 − CHF 3'280 − CHF 588 = CHF 3'152"
+//                => take the token AFTER the final "=" (the monthlyFree result).
+//   - Mon Argent captured node "mon_argent_budget_summary":
+//                "Ton budget ce mois. Revenus 7'020 CHF. Dépenses 3'868 CHF. Reste 3'152 CHF."
+//                => take the token immediately before "CHF" that follows "Reste".
+//   - Coach      captured node text "Capacité mensuelle: CHF 3'740"
+//                => take the token after "CHF".
+//
+// If the trust-chain (#681/#682) converges the builder path onto the engine
+// path, all three tokens are byte-identical. Any divergence => throw => the
+// flow FAILS. (Per the SC-4 device probe, the coach surface renders
+// budget.monthly_capacity, NOT monthly_free, so this assertion surfaces that
+// divergence truthfully rather than masking it.)
+
+function norm(raw) {
+  if (raw == null) {
+    throw new Error('SC-4 capture was null/undefined — copyTextFrom matched no element');
+  }
+  // Strip NBSP ( ) so " CHF" matches uniformly; normalise the two
+  // apostrophe glyphs the app uses (' U+0027 and ’ U+2019) to a single one.
+  return String(raw).replace(/ /g, ' ').replace(/’/g, "'");
+}
+
+function tokenAfterEquals(s) {
+  // "... = CHF 3'152"
+  var m = s.match(/=\s*CHF\s*(-?\d[\d']*)/);
+  return m ? m[1] : null;
+}
+
+function tokenAfterReste(s) {
+  // "... Reste 3'152 CHF."
+  var m = s.match(/Reste\s*(-?\d[\d']*)\s*CHF/i);
+  return m ? m[1] : null;
+}
+
+function tokenAfterCHF(s) {
+  // "Capacité mensuelle: CHF 3'740"
+  var m = s.match(/CHF\s*(-?\d[\d']*)/);
+  if (m) return m[1];
+  // fallback: "<n> CHF"
+  m = s.match(/(-?\d[\d']*)\s*CHF/);
+  return m ? m[1] : null;
+}
+
+function firstNumber(s) {
+  var m = s.match(/-?\d[\d']*/);
+  return m ? m[0] : null;
+}
+
+var budgetRaw = norm(output.sc4_budget);
+var monArgentRaw = norm(output.sc4_mon_argent);
+var coachRaw = norm(output.sc4_coach);
+
+var budget = tokenAfterEquals(budgetRaw) || tokenAfterCHF(budgetRaw) || firstNumber(budgetRaw);
+var monArgent = tokenAfterReste(monArgentRaw) || tokenAfterCHF(monArgentRaw) || firstNumber(monArgentRaw);
+var coach = tokenAfterCHF(coachRaw) || firstNumber(coachRaw);
+
+if (budget == null)    throw new Error('SC-4: no monthlyFree token in /budget capture: "' + budgetRaw + '"');
+if (monArgent == null) throw new Error('SC-4: no monthlyFree token in Mon Argent capture: "' + monArgentRaw + '"');
+if (coach == null)     throw new Error('SC-4: no CHF token in coach capture: "' + coachRaw + '"');
+
+output.sc4_budget_token = budget;
+output.sc4_mon_argent_token = monArgent;
+output.sc4_coach_token = coach;
+
+var allEqual = (budget === monArgent) && (monArgent === coach);
+output.sc4_converged = allEqual ? 'PASS' : 'FAIL';
+
+var summary =
+  'SC-4 value convergence: ' +
+  'budget="' + budget + '" ' +
+  'mon_argent="' + monArgent + '" ' +
+  'coach="' + coach + '" => ' + output.sc4_converged;
+output.sc4_summary = summary;
+
+if (!allEqual) {
+  throw new Error(
+    'SC-4 FAIL — Disponible/mois (monthlyFree) DIVERGES across surfaces. ' + summary +
+    ' (raw: budget="' + budgetRaw + '", mon_argent="' + monArgentRaw +
+    '", coach="' + coachRaw + '")'
+  );
+}


### PR DESCRIPTION
Closes the SALVAGE-00 SC-4 money-trust-chain divergence the device gate caught.

## Problem (device gate, cadre_3a_contributing)
Budget + Mon Argent render the converged Disponible/mois (monthlyFree **3'152**), but the coach chat-open packet led with `budget.monthly_capacity` (**3'740** = monthlyFree + 3a savings) — a different number on the third surface, breaking single-Disponible trust.

## Fix
- `coach_packet_insight_presenter.dart` `_factPriority`: `budget.monthly_free` now ranks above `budget.monthly_capacity` → coach shows the SAME "Marge libre: CHF 3'152". Mirrors `coach_context_packet_service`'s ordering; lead-fact only (follow-ups unchanged).
- Strengthened SC-4 Maestro flow: captures monthlyFree on all 3 surfaces + asserts byte-identical (was visibility-only); fixed `appId: ch.mint.app`; added `sc4_assert_value_convergence.js` comparator.
- Regression test: presenter leads with monthlyFree when both facts present (5/5 green, analyze clean).

## Evidence
Budget `3'152` ✓ · Mon Argent `3'152` ✓ · Coach (post-fix) `Marge libre: CHF 3'152`. Device re-run pending on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)