### PR TITLE
fix(SALVAGE-01-03): net↔gross single-source (onb-02) + job-comparison profile wiring (def-04)

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart';
 import 'package:mint_mobile/services/coaching_service.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+import 'package:mint_mobile/services/income_converter.dart';
 import 'package:mint_mobile/services/voice/voice_cursor_contract.dart'
     show VoicePreference;
 
@@ -2635,21 +2636,25 @@ class CoachProfile {
     } else {
       monthlyNetIncome = netIncome;
     }
+    // Employment status mapping (parsed before the net→gross fallback so the
+    // salaried vs independant IncomeConverter factor can be selected).
+    final employmentRaw = answers['q_employment_status'] as String?;
+    final employmentStatus = _parseEmploymentStatus(employmentRaw);
+
     // Prefer direct gross salary when stored by updateFromSmartFlow
     // (avoids net→gross roundtrip rounding: 120'000 → net → 113'793 brut).
-    // Fallback: net → brut via Swiss social charges ≈ 13%.
-    // (AVS 5.3% + LPP ~5% + AC ~1.1% + AANP ~1% ≈ 12.5%, arrondi 13%)
-    // Source: OFAS barème cotisations 2025. Ceci est une estimation;
-    // le taux réel dépend du plan LPP et du canton.
-    const double socialChargesRate = 0.13;
+    // Fallback: net → brut via the canonical IncomeConverter factor
+    // (single source — onb-02). The onboarding hero figure and this persisted
+    // estimator MUST agree, so we consume IncomeConverter.factorFor instead of
+    // a divergent hardcoded charges rate. Salaried → 1.17, independant → 1.10
+    // (see income_converter.dart for the LAVS/LPP rationale).
     final grossSalaryDirect = _parseDouble(answers['q_gross_salary_annual']);
     final salaireBrutMensuel = grossSalaryDirect != null
         ? grossSalaryDirect / 12
-        : monthlyNetIncome / (1 - socialChargesRate);
-
-    // Employment status mapping
-    final employmentRaw = answers['q_employment_status'] as String?;
-    final employmentStatus = _parseEmploymentStatus(employmentRaw);
+        : monthlyNetIncome *
+            IncomeConverter.factorFor(
+              isSalaried: employmentStatus != 'independant',
+            );
 
     // ── Depenses ────────────────────────────────────────────
     final housingCost = _parseMonthlyAmount(
@@ -3008,10 +3013,14 @@ class CoachProfile {
     ConjointProfile? conjoint;
     final partnerIncome = _parseDouble(answers['q_partner_net_income_chf']);
     if (partnerIncome != null && partnerIncome > 0) {
-      // Net -> Brut estimation: same social charges rate as main user
-      final partnerBrut = partnerIncome / (1 - socialChargesRate);
       final partnerBirthYear = _parseInt(answers['q_partner_birth_year']);
       final conjEmployment = answers['q_partner_employment_status'] as String?;
+      // Net -> Brut estimation via the SAME canonical IncomeConverter factor
+      // as the main user (single source — onb-02). No divergent charges rate.
+      final partnerBrut = partnerIncome *
+          IncomeConverter.factorFor(
+            isSalaried: conjEmployment != 'independant',
+          );
 
       // === Conjoint arrivalAge ===
       // First check for spouse-specific AVS arrival data, then fall back

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -11,6 +11,7 @@ import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
+import 'package:mint_mobile/services/income_converter.dart';
 import 'package:mint_mobile/services/minimal_profile_service.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
 import 'package:mint_mobile/services/coach/coach_cache_service.dart';
@@ -759,14 +760,18 @@ class CoachProfileProvider extends ChangeNotifier {
     // P0-9: Clamp salary to valid bounds before any computation.
     final clampedGrossSalary = grossSalary.clamp(0, 10000000).toDouble();
 
-    // Convert gross annual → net monthly
-    // Net monthly = (grossSalary / 12) × (1 - 0.13) (charges sociales ~13%)
-    // fromWizardAnswers() reconvertit net → brut via / (1 - 0.13),
-    // ce qui préserve le salaire brut original.
-    const double socialChargesRate = 0.13;
-    final netMonthly = (clampedGrossSalary / 12) * (1 - socialChargesRate);
     final birthYear = DateTime.now().year - age;
     final effectiveEmployment = employmentStatus ?? 'salarie';
+
+    // Convert gross annual → net monthly via the canonical IncomeConverter
+    // factor (single source — onb-02). fromWizardAnswers() reconvertit
+    // net → brut via × factorFor(...), donc l'inverse ici DOIT être
+    // / factorFor(...) avec le même prédicat salarié/indépendant, sinon le
+    // round-trip diverge et le chiffre héros ne correspond plus à l'estimateur.
+    final netMonthly = (clampedGrossSalary / 12) /
+        IncomeConverter.factorFor(
+          isSalaried: effectiveEmployment != 'independant',
+        );
 
     // Derive q_nationality for archetype detection (CLAUDE.md archetype table).
     // 'CH' → swissNative/returningSwiss; 'EU' → expatEu (use 'FR' placeholder);
@@ -1151,10 +1156,14 @@ class CoachProfileProvider extends ChangeNotifier {
     if (profile.conjoint != null) {
       final c = profile.conjoint!;
       if (c.salaireBrutMensuel != null) {
-        // Store as net (reverse the brut→net from fromWizardAnswers)
-        const socialChargesRate = 0.133; // AVS+AI+APG+AC standard rate
-        answers['q_partner_net_income_chf'] =
-            c.salaireBrutMensuel! * (1 - socialChargesRate);
+        // Store as net — inverse of the net→brut conversion fromWizardAnswers()
+        // applies to the partner (× IncomeConverter.factorFor). Use / factorFor
+        // with the SAME isSalaried predicate (single source — onb-02) so the
+        // persist/restore round-trip preserves salaireBrutMensuel exactly.
+        answers['q_partner_net_income_chf'] = c.salaireBrutMensuel! /
+            IncomeConverter.factorFor(
+              isSalaried: c.employmentStatus != 'independant',
+            );
       }
       if (c.birthYear != null) {
         answers['q_partner_birth_year'] = c.birthYear;

--- a/apps/mobile/lib/screens/job_comparison_screen.dart
+++ b/apps/mobile/lib/screens/job_comparison_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/job_comparison_service.dart';
+import 'package:provider/provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -84,6 +87,62 @@ class _JobComparisonScreenState extends State<JobComparisonScreen> {
 
   // Checklist state (local only)
   List<bool> _checklistState = [];
+
+  // SALVAGE-01-03 (def-04): seed the "current job" side once from the real
+  // CoachProfile so it reflects the user's actual situation, not the
+  // 35/85000/5.2/120000 fixtures. Guarded so it runs at most once.
+  bool _didSeedFromProfile = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_didSeedFromProfile) {
+      _didSeedFromProfile = true;
+      _seedCurrentJobFromProfile();
+    }
+  }
+
+  /// Seeds the current-job inputs from the persisted CoachProfile when the
+  /// corresponding field is present. Each field falls back to its static
+  /// default when the profile (or that field) is absent — never fabricated.
+  void _seedCurrentJobFromProfile() {
+    CoachProfile? profile;
+    try {
+      profile = context.read<CoachProfileProvider>().profile;
+    } catch (_) {
+      // Provider not in the tree (e.g. some tests) — keep all defaults.
+      return;
+    }
+    if (profile == null) return;
+
+    // Age: use the null-safe getter — NEVER fabricate from raw birthYear
+    // (def-03 anti-pattern). Null age keeps the existing default.
+    final age = profile.ageOrNull;
+    // Annual gross: revenuBrutAnnuel returns 0 when salaireBrutMensuel is null.
+    final annualGross = profile.revenuBrutAnnuel;
+    // Prevoyance fields are optional; seed only when present.
+    final prevoyance = profile.prevoyance;
+    final avoir = prevoyance.avoirLppTotal;
+    final tauxSuroblig = prevoyance.tauxConversionSuroblig;
+
+    setState(() {
+      if (age != null) _age = age;
+      if (annualGross > 0) _currentSalaireBrut = annualGross;
+      if (avoir != null && avoir > 0) _currentAvoirVieillesse = avoir;
+      // tauxConversionSuroblig is a decimal (e.g. 0.058); the field is a
+      // percent (5.8). Only seed when the rate was actually captured.
+      if (tauxSuroblig != null) _currentTauxConversion = tauxSuroblig * 100;
+    });
+  }
+
+  @visibleForTesting
+  int get debugAge => _age;
+  @visibleForTesting
+  double get debugCurrentSalaireBrut => _currentSalaireBrut;
+  @visibleForTesting
+  double get debugCurrentAvoirVieillesse => _currentAvoirVieillesse;
+  @visibleForTesting
+  double get debugCurrentTauxConversion => _currentTauxConversion;
 
   @override
   void dispose() {

--- a/apps/mobile/lib/services/job_comparison_service.dart
+++ b/apps/mobile/lib/services/job_comparison_service.dart
@@ -80,6 +80,13 @@ class LPPPlanInput {
 
   /// Estimated net monthly salary (gross - social charges - LPP employee).
   double get salaireNetMensuel {
+    // NOTE (onb-02): this rate is DISTINCT from IncomeConverter's bundled
+    // net↔gross factor and must NOT be routed through it. IncomeConverter
+    // folds AVS+AC+LAA+LPP into a single ~15% factor for the hero/estimator
+    // round-trip. Here we itemise: this 6.4% covers ONLY the AVS/AI/APG (5.3%)
+    // + AC (1.1%) employee shares, and the LPP employee contribution is
+    // subtracted separately below via cotisationEmployeAnnuelle. Folding in
+    // IncomeConverter's factor would double-count LPP.
     // AVS/AI/APG: 5.3% employee share
     // AC: 1.1% employee share (up to 148'200)
     // AANP: ~0% for employee (paid by employer for occupational)

--- a/apps/mobile/test/screens/job_comparison_profile_seed_test.dart
+++ b/apps/mobile/test/screens/job_comparison_profile_seed_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/screens/job_comparison_screen.dart';
+import 'package:provider/provider.dart';
+
+/// SALVAGE-01-03 (def-04): job_comparison_screen must seed its "current job"
+/// side from the real CoachProfile (age via ageOrNull, annual gross, prevoyance
+/// avoir/conversion-rate) instead of the static fixtures
+/// 35 / 85000 / 5.2 / 120000. When a field is absent it must keep its default;
+/// when no profile / null age it must not crash.
+
+/// Test double: lets the test inject an arbitrary profile (or null) without
+/// touching SharedPreferences-backed persistence in `updateProfile`.
+class _FakeCoachProfileProvider extends CoachProfileProvider {
+  _FakeCoachProfileProvider(this._injected);
+  final CoachProfile? _injected;
+  @override
+  CoachProfile? get profile => _injected;
+}
+
+CoachProfile _profileWith({
+  required int birthYear,
+  required double salaireBrutMensuel,
+  double? avoirLppTotal,
+  double? tauxConversionSuroblig,
+}) {
+  return CoachProfile(
+    birthYear: birthYear,
+    canton: 'VD',
+    salaireBrutMensuel: salaireBrutMensuel,
+    prevoyance: PrevoyanceProfile(
+      avoirLppTotal: avoirLppTotal,
+      tauxConversionSuroblig: tauxConversionSuroblig,
+    ),
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(birthYear + 65),
+      label: 'Retraite',
+    ),
+  );
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  CoachProfileProvider provider,
+) async {
+  await tester.pumpWidget(
+    ChangeNotifierProvider<CoachProfileProvider>.value(
+      value: provider,
+      child: const MaterialApp(
+        locale: Locale('fr'),
+        localizationsDelegates: [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: JobComparisonScreen(),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Reads back the seeded current-job inputs via the @visibleForTesting getters.
+({int age, double salaireBrut, double avoir, double taux}) _read(
+  WidgetTester tester,
+) {
+  final state = tester.state(find.byType(JobComparisonScreen)) as dynamic;
+  return (
+    age: state.debugAge as int,
+    salaireBrut: state.debugCurrentSalaireBrut as double,
+    avoir: state.debugCurrentAvoirVieillesse as double,
+    taux: state.debugCurrentTauxConversion as double,
+  );
+}
+
+void main() {
+  final currentYear = DateTime.now().year;
+
+  testWidgets(
+    'seeds age / annual gross / avoir / taux from a profile with prevoyance',
+    (tester) async {
+      final profile = _profileWith(
+        birthYear: currentYear - 42, // ageOrNull → 42
+        salaireBrutMensuel: 9000, // → annual 108000 (×12, no bonus)
+        avoirLppTotal: 250000,
+        tauxConversionSuroblig: 0.058, // → 5.8%
+      );
+      await _pumpScreen(tester, _FakeCoachProfileProvider(profile));
+
+      final s = _read(tester);
+      expect(s.age, 42, reason: 'age seeded from ageOrNull, not 35');
+      expect(s.salaireBrut, closeTo(108000, 0.01),
+          reason: 'annual gross seeded from profile, not 85000');
+      expect(s.avoir, closeTo(250000, 0.01),
+          reason: 'avoir seeded from prevoyance.avoirLppTotal, not 120000');
+      expect(s.taux, closeTo(5.8, 0.001),
+          reason: 'taux seeded from tauxConversionSuroblig*100, not 5.2');
+    },
+  );
+
+  testWidgets(
+    'keeps avoir 120000 and taux 5.2 defaults when prevoyance fields absent',
+    (tester) async {
+      final profile = _profileWith(
+        birthYear: currentYear - 30,
+        salaireBrutMensuel: 7000, // → annual 84000
+        // avoirLppTotal: null, tauxConversionSuroblig: null
+      );
+      await _pumpScreen(tester, _FakeCoachProfileProvider(profile));
+
+      final s = _read(tester);
+      expect(s.age, 30);
+      expect(s.salaireBrut, closeTo(84000, 0.01));
+      expect(s.avoir, closeTo(120000, 0.01),
+          reason: 'avoir keeps static default when prevoyance avoir absent');
+      expect(s.taux, closeTo(5.2, 0.001),
+          reason: 'taux keeps static default when conversion rate absent');
+    },
+  );
+
+  testWidgets('keeps ALL defaults and does not crash when no profile',
+      (tester) async {
+    await _pumpScreen(tester, _FakeCoachProfileProvider(null));
+
+    final s = _read(tester);
+    expect(s.age, 35);
+    expect(s.salaireBrut, closeTo(85000, 0.01));
+    expect(s.avoir, closeTo(120000, 0.01));
+    expect(s.taux, closeTo(5.2, 0.001));
+  });
+
+  testWidgets('keeps default age when profile age is null (no fabrication)',
+      (tester) async {
+    // birthYear 0 → ageOrNull returns null (sentinel); must NOT fabricate.
+    final profile = _profileWith(
+      birthYear: 0,
+      salaireBrutMensuel: 8000, // annual 96000 still seeds salary
+    );
+    await _pumpScreen(tester, _FakeCoachProfileProvider(profile));
+
+    final s = _read(tester);
+    expect(s.age, 35, reason: 'null age keeps default, never fabricated');
+    expect(s.salaireBrut, closeTo(96000, 0.01));
+  });
+}

--- a/apps/mobile/test/services/income_converter_test.dart
+++ b/apps/mobile/test/services/income_converter_test.dart
@@ -126,4 +126,74 @@ void main() {
       expect(profile.salaireBrutMensuel, closeTo(10000, 0.01));
     });
   });
+
+  // SALVAGE-01 (onb-02): the gross→net INVERSE in the providers must be the
+  // exact inverse of fromWizardAnswers' net→gross (× factorFor). Previously
+  // coach_profile_provider.dart:766 used × (1 - 0.13) = × 0.87 and :1155 used
+  // × (1 - 0.133) = × 0.867 — neither equals / 1.17 ≈ × 0.855, so the
+  // persist/restore round-trip silently shifted the salary (trust break).
+  group('gross→net inverse parity (onb-02)', () {
+    test('inverse / factorFor exactly round-trips net→gross (salaried)', () {
+      const grossMonthly = 9000.0;
+      // Provider direction (gross→net): / factorFor.
+      final net = grossMonthly / IncomeConverter.factorFor(isSalaried: true);
+      // fromWizardAnswers direction (net→gross): × factorFor.
+      final backToGross = net * IncomeConverter.factorFor(isSalaried: true);
+      expect(backToGross, closeTo(grossMonthly, 0.0001),
+          reason: 'round-trip must preserve gross exactly');
+    });
+
+    test('inverse / factorFor exactly round-trips net→gross (independant)', () {
+      const grossMonthly = 9000.0;
+      final net = grossMonthly / IncomeConverter.factorFor(isSalaried: false);
+      final backToGross = net * IncomeConverter.factorFor(isSalaried: false);
+      expect(backToGross, closeTo(grossMonthly, 0.0001));
+    });
+
+    test('canonical inverse net differs from the legacy 0.13/0.133 rates', () {
+      const grossMonthly = 9000.0;
+      final canonicalNet =
+          grossMonthly / IncomeConverter.factorFor(isSalaried: true);
+      // Legacy site :766 (main user) used × 0.87.
+      const legacyMainNet = grossMonthly * (1 - 0.13);
+      // Legacy site :1155 (partner) used × 0.867.
+      const legacyPartnerNet = grossMonthly * (1 - 0.133);
+      expect((canonicalNet - legacyMainNet).abs(), greaterThan(1.0),
+          reason: 'main-user provider path must no longer use 0.13');
+      expect((canonicalNet - legacyPartnerNet).abs(), greaterThan(1.0),
+          reason: 'partner provider path must no longer use 0.133');
+    });
+
+    test('partner persist→restore round-trip preserves brut via fromWizardAnswers',
+        () {
+      // fromWizardAnswers stores partner brut = net × factorFor. The provider
+      // persistence path (coach_profile_provider.dart:1155) reverses it via
+      // / factorFor before re-storing q_partner_net_income_chf. Simulate that
+      // full cycle and assert the recovered brut is unchanged.
+      const partnerNetInput = 4000.0;
+      final profile = CoachProfile.fromWizardAnswers(const {
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'salarie',
+        'q_partner_net_income_chf': partnerNetInput,
+        'q_partner_employment_status': 'salarie',
+      });
+      final brut1 = profile.conjoint!.salaireBrutMensuel!;
+      // Provider :1155 reverse: brut → net via / factorFor (same predicate).
+      final reStoredNet =
+          brut1 / IncomeConverter.factorFor(isSalaried: true);
+      // It must equal the original net the user entered (round-trip identity).
+      expect(reStoredNet, closeTo(partnerNetInput, 0.01),
+          reason: 'persist/restore must recover the original partner net');
+      // And re-deriving brut from that net recovers brut1 unchanged.
+      final profile2 = CoachProfile.fromWizardAnswers({
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'salarie',
+        'q_partner_net_income_chf': reStoredNet,
+        'q_partner_employment_status': 'salarie',
+      });
+      expect(profile2.conjoint!.salaireBrutMensuel!, closeTo(brut1, 0.01));
+    });
+  });
 }

--- a/apps/mobile/test/services/income_converter_test.dart
+++ b/apps/mobile/test/services/income_converter_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/income_converter.dart';
 
 void main() {
@@ -47,6 +48,82 @@ void main() {
     test('exposes salaried factor 1.17 and self-employed 1.10', () {
       expect(IncomeConverter.factorFor(isSalaried: true), closeTo(1.17, 0.001));
       expect(IncomeConverter.factorFor(isSalaried: false), closeTo(1.10, 0.001));
+    });
+  });
+
+  // SALVAGE-01-03 (onb-02): single-source the net→gross factor.
+  // The persisted-profile estimator (CoachProfile.fromWizardAnswers) must
+  // derive its net→gross fallback from THIS converter, not a divergent
+  // hardcoded socialChargesRate=0.13 (which yielded ~1.149, contradicting
+  // the onboarding hero figure of 1.17).
+  group('IncomeConverter single-source parity (onb-02)', () {
+    test('main-user persisted estimator uses the SAME salaried factor as the '
+        'onboarding hero (1.17), not the legacy 0.13/1.149 divergence', () {
+      // Main-user fallback (no q_gross_salary_annual): a salaried profile with
+      // 5000 net monthly → gross monthly via the canonical factor.
+      final profile = CoachProfile.fromWizardAnswers(const {
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'salarie',
+      });
+      // Persisted estimator must equal net * IncomeConverter.factorFor.
+      final expectedGrossMonthly =
+          5000 * IncomeConverter.factorFor(isSalaried: true);
+      expect(profile.salaireBrutMensuel, closeTo(expectedGrossMonthly, 0.01));
+      // And it must NOT equal the legacy 0.13-derived value (5000/0.87≈5747).
+      final legacyGrossMonthly = 5000 / (1 - 0.13);
+      expect(
+        (profile.salaireBrutMensuel - legacyGrossMonthly).abs(),
+        greaterThan(1.0),
+        reason: 'estimator must no longer use the 0.13 socialChargesRate',
+      );
+    });
+
+    test('self-employed main-user fallback uses the independant factor (1.10)',
+        () {
+      final profile = CoachProfile.fromWizardAnswers(const {
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'independant',
+      });
+      final expectedGrossMonthly =
+          5000 * IncomeConverter.factorFor(isSalaried: false);
+      expect(profile.salaireBrutMensuel, closeTo(expectedGrossMonthly, 0.01));
+    });
+
+    test('partner (conjoint) net→gross derives via IncomeConverter, not 0.13',
+        () {
+      final profile = CoachProfile.fromWizardAnswers(const {
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'salarie',
+        'q_partner_net_income_chf': 4000,
+        'q_partner_employment_status': 'salarie',
+      });
+      final conjoint = profile.conjoint;
+      expect(conjoint, isNotNull);
+      final partnerGross = conjoint!.salaireBrutMensuel;
+      expect(partnerGross, isNotNull);
+      final expectedPartnerGrossMonthly =
+          4000 * IncomeConverter.factorFor(isSalaried: true);
+      expect(partnerGross, closeTo(expectedPartnerGrossMonthly, 0.01));
+      final legacyPartnerGross = 4000 / (1 - 0.13);
+      expect(
+        (partnerGross! - legacyPartnerGross).abs(),
+        greaterThan(1.0),
+        reason: 'partner path must no longer use the 0.13 socialChargesRate',
+      );
+    });
+
+    test('direct gross (q_gross_salary_annual) short-circuit is preserved', () {
+      final profile = CoachProfile.fromWizardAnswers(const {
+        'q_net_income_period_chf': 5000,
+        'q_pay_frequency': 'monthly',
+        'q_employment_status': 'salarie',
+        'q_gross_salary_annual': 120000,
+      });
+      // Direct gross stored → no net→gross roundtrip; 120000/12 = 10000.
+      expect(profile.salaireBrutMensuel, closeTo(10000, 0.01));
     });
   });
 }

--- a/apps/mobile/test/services/income_converter_test.dart
+++ b/apps/mobile/test/services/income_converter_test.dart
@@ -71,7 +71,7 @@ void main() {
           5000 * IncomeConverter.factorFor(isSalaried: true);
       expect(profile.salaireBrutMensuel, closeTo(expectedGrossMonthly, 0.01));
       // And it must NOT equal the legacy 0.13-derived value (5000/0.87≈5747).
-      final legacyGrossMonthly = 5000 / (1 - 0.13);
+      const legacyGrossMonthly = 5000 / (1 - 0.13);
       expect(
         (profile.salaireBrutMensuel - legacyGrossMonthly).abs(),
         greaterThan(1.0),
@@ -107,7 +107,7 @@ void main() {
       final expectedPartnerGrossMonthly =
           4000 * IncomeConverter.factorFor(isSalaried: true);
       expect(partnerGross, closeTo(expectedPartnerGrossMonthly, 0.01));
-      final legacyPartnerGross = 4000 / (1 - 0.13);
+      const legacyPartnerGross = 4000 / (1 - 0.13);
       expect(
         (partnerGross! - legacyPartnerGross).abs(),
         greaterThan(1.0),


### PR DESCRIPTION
SALVAGE-01 Plan 03 + full onb-02 SSOT closure.

## onb-02 — one net↔gross source (IncomeConverter)
The onboarding hero figure and the persisted-profile estimator diverged (1.17 factor vs hardcoded 0.13). Now single-sourced through `IncomeConverter.factorFor(isSalaried:)` everywhere:
- coach_profile.dart `fromWizardAnswers` (main + partner) — net→gross via factorFor (deleted 0.13).
- coach_profile_provider.dart `:766` (0.13) + `:1155` (0.133) — gross→net via the inverse `/factorFor` (found by 0-TRUST grep after the initial fix; closed so they agree with the hero).
- job_comparison_service.dart `0.064` — **left distinct** (itemised AVS/AI/APG+AC employee share; LPP subtracted separately — folding through IncomeConverter would double-count LPP), now documented.
- `git grep socialChargesRate` → only the distinct 0.064 remains.

## def-04 — job-comparison "current job" from real profile
Seeds age (null-safe `ageOrNull`, keeps default if unknown), gross salary, LPP avoir, conversion rate from the real CoachProfile instead of static fixtures (35/85000/5.2%/120000).

## Verify (0-TRUST)
- `flutter analyze` 0 errors (touched files clean).
- net→gross parity tests (RED→GREEN: 5500 expected vs legacy 5747) + gross→net inverse round-trip parity + job-comparison seed test → all green (14 + 67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)