### PR TITLE
fix(SALVAGE-01-04): seal-write sim-keychain guard + finalize SC-4 Maestro device-gate flow

### DIFF
--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -32,9 +32,26 @@ class SecureWizardStore {
   static bool isSensitive(String key) => _sensitiveKeys.contains(key);
 
   /// Write a sensitive value to encrypted storage.
+  ///
+  /// On iOS simulator without a valid keychain-access-groups entitlement
+  /// (the usual case during dev sim builds — PlatformException `-34018`),
+  /// swallowing the failure keeps the wizard seal (`saveAnswers` →
+  /// `secureSensitiveKeys`) from hard-failing at the flush. Without this
+  /// guard a fresh onboarding run on the sim throws at the seal, shows
+  /// « Impossible de sceller ton dossier », and never reaches the coach —
+  /// even though the same flow succeeds on a provisioned device (where the
+  /// keychain write does not throw). Symmetric with [read]'s guard.
+  ///
+  /// SEC-10 is preserved: a swallowed write means the value is simply not
+  /// sealed (a later [read] returns null, the already-accepted degraded
+  /// path) — the PII is NEVER demoted to plain SharedPreferences.
   static Future<void> write(String key, String value) async {
-    if (_sensitiveKeys.contains(key)) {
+    if (!_sensitiveKeys.contains(key)) return;
+    try {
       await _storage.write(key: key, value: value);
+    } on Exception {
+      // Secure storage unavailable (sim entitlement / locked keychain):
+      // degrade gracefully rather than aborting the seal.
     }
   }
 

--- a/apps/mobile/test/services/secure_wizard_store_test.dart
+++ b/apps/mobile/test/services/secure_wizard_store_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/services/secure_wizard_store.dart';
+
+/// SALVAGE-01-04: regression for the sim-keychain seal-write asymmetry.
+///
+/// `read()` already swallowed the iOS-simulator `-34018`
+/// (errSecMissingEntitlement) PlatformException; `write()` did not, so a
+/// fresh onboarding flush on the simulator threw at the seal
+/// (`secureSensitiveKeys`) and the user never reached the coach. These
+/// tests pin the symmetric guard and the SEC-10 invariant (no PII demoted
+/// to plain storage).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel =
+      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('SecureWizardStore.write — sim keychain (-34018) guard', () {
+    test('secureSensitiveKeys does NOT throw when the keychain write fails',
+        () async {
+      // Simulate the iOS-sim missing-entitlement failure on every write.
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'write') {
+          throw PlatformException(
+            code: '-34018',
+            message: 'errSecMissingEntitlement',
+          );
+        }
+        return null;
+      });
+
+      final cleaned = await SecureWizardStore.secureSensitiveKeys({
+        'q_net_income_period_chf': '7000',
+        'q_canton': 'VD', // non-sensitive — must pass through untouched
+      });
+
+      // The seal degrades gracefully instead of aborting the flush.
+      expect(cleaned['q_canton'], 'VD');
+      // SEC-10: the sensitive value is sealed-or-dropped, NEVER left as raw
+      // PII in the (plain-SharedPreferences-bound) answer map.
+      expect(cleaned['q_net_income_period_chf'], isNot('7000'));
+      expect(cleaned['q_net_income_period_chf'], '__secure__');
+    });
+  });
+
+  group('SecureWizardStore — happy path (provisioned keychain)', () {
+    test('seals a sensitive value and round-trips it back', () async {
+      FlutterSecureStorage.setMockInitialValues({});
+
+      final cleaned = await SecureWizardStore.secureSensitiveKeys({
+        'q_net_income_period_chf': '7000',
+        'q_canton': 'VD',
+      });
+      expect(cleaned['q_net_income_period_chf'], '__secure__');
+      expect(cleaned['q_canton'], 'VD');
+
+      final restored = await SecureWizardStore.restoreSensitiveKeys(cleaned);
+      expect(restored['q_net_income_period_chf'], 7000);
+      expect(restored['q_canton'], 'VD');
+    });
+  });
+}

--- a/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
+++ b/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
@@ -87,14 +87,26 @@ appId: ch.mint.app
 - tapOn:
     text: "Continuer"
 
-# ─── T6 insight → T7 scene → T8 bifurcation:Creuser ─────────────────────
+# ─── T6 insight ─────────────────────────────────────────────────────────
 - assertVisible:
     text: "Avant de te montrer…"
     timeout: 5000
 - tapOn:
     text: "Voir"
+
+# ─── T7 scene (MintSceneRenteTrouee — renders the user's REAL currentAge) ─
+# The scene receives provider.ageYears, which is derived from q_birth_year
+# (the SALVAGE-01 flush fix). It must show a real age, not the sentinel.
+- assertVisible:
+    text: "Continuer"
+    timeout: 8000
 - tapOn:
     text: "Continuer"
+
+# ─── T8 bifurcation:Creuser → /coach/chat ───────────────────────────────
+- assertVisible:
+    text: "Creuser"
+    timeout: 5000
 - tapOn:
     text: "Creuser"
 
@@ -102,8 +114,14 @@ appId: ch.mint.app
 - assertVisible:
     text: "Dis-moi."          # coachInputHint — input bar present == /coach/chat
     timeout: 15000
+# Waitlist guard: the waitlist screen title is `waitlistTitle` ==
+# "Encore en chantier pour ton profil" (app_fr.arb:12570). The prior stub
+# asserted against "liste d’attente" (curly apostrophe) which is a SUBSTRING
+# of waitlistAnnounceRedirect using a STRAIGHT apostrophe — the mismatch made
+# the guard trivially pass (false-green). The title is apostrophe-free and is
+# the screen's own header, so it is the robust not-waitlist signal.
 - assertNotVisible:
-    text: "liste d’attente"
+    text: "Encore en chantier pour ton profil"
 - takeScreenshot: "01-coach-reachable-not-waitlist"
 
 # Coach answers a real message (substantive engagement, not waitlist).
@@ -112,20 +130,37 @@ appId: ch.mint.app
     timeout: 30000
 
 # ─── SC-4: navigate /pilier-3a, assert a REAL age (never sentinel) ──────
-- openLink: "mint://pilier-3a"
+# Deeplink form proven by the passing maestro-perfect-set flows:
+#   scheme = `mintapp` (Info.plist CFBundleURLSchemes), then `:///<GoRouter path>`.
+#   The GoRouter route is `/pilier-3a` (app.dart:900). `mint://pilier-3a`
+#   (the prior stub) does NOT resolve — wrong scheme + no host→path map.
+- openLink: "mintapp:///pilier-3a"
+# AppBar title `sim3aTitle` == "Ton 3e pilier" (app_fr.arb:4827) — stable
+# semantic locator. The prior stub asserted id:"simulator-3a-root", a key
+# that does not exist in simulator_3a_screen.dart.
 - assertVisible:
-    id: "simulator-3a-root"
+    text: "Ton 3e pilier"
     timeout: 10000
-# The sentinel-age bug rendered "Ton âge: 2026" or a fabricated "65 ans".
-# A correctly-flushed birth_year yields a real years-to-retirement value.
+# Sentinel-age guard. age = currentYear - profile.birthYear
+# (rente_vs_capital_screen.dart:195). An UNFLUSHED birthYear (0) yields
+# age == 2026 (this calendar year) — the sentinel. A correctly-flushed
+# q_birth_year yields a real age. We assert the raw sentinel value 2026
+# does not surface as an age. (Label "Ton âge" is legitimate i18n and is
+# expected to be present — we never assert against the label itself.)
 - assertNotVisible:
     text: "Ton âge: 2026"
 - assertNotVisible:
     text: "Ton âge : 2026"
 - takeScreenshot: "02-pilier3a-real-age"
 
-# ─── SC-4: navigate rente_vs_capital (arbitrage scene), assert a real age ─
-- openLink: "mint://rente_vs_capital"
+# ─── SC-4: navigate rente-vs-capital (arbitrage scene), assert a real age ─
+# GoRouter route is `/rente-vs-capital` (app.dart:766, hyphen). The prior
+# stub used the underscore intentTag `rente_vs_capital`, which is NOT a
+# route and would not resolve.
+- openLink: "mintapp:///rente-vs-capital"
+- assertVisible:
+    text: "Ton âge"
+    timeout: 10000
 - assertNotVisible:
     text: "Ton âge: 2026"
 - assertNotVisible:

--- a/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
+++ b/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
@@ -41,8 +41,15 @@ appId: ch.mint.app
 # `assertVisible` / `assertNotVisible` use Maestro's default assertion window.
 
 # ─── T1 entry → T2 intents ──────────────────────────────────────────────
+# Cold launch lands on the chat-first LANDING screen (app.dart:326 — /start
+# redirects to /anonymous/chat; idb describe-all at gate time confirmed
+# "MINT / Voir clair, décider seul. / Parle à Mint / …"). The MVP wedge
+# storyboard is a DECOUPLED public route at `/onb` (app.dart:331-334,
+# "decoupled from /start"). The SALVAGE-01 contract is the WEDGE
+# onboarding→coach path, so we deeplink straight into it.
 - launchApp:
     clearState: true
+- openLink: "mintapp:///onb"
 - extendedWaitUntil:
     visible:
       text: "Il est temps que tu comprennes."
@@ -51,28 +58,47 @@ appId: ch.mint.app
     text: "Ouvrir"
 
 # ─── T2 intents:RETRAITE ────────────────────────────────────────────────
+# The RETRAITE _IntentCard is a bare InkWell wrapping two Text widgets
+# (eyebrow "RETRAITE" + phrase "Ce que je toucherai, vraiment."). Unlike the
+# FilledButton CTAs elsewhere, this InkWell does NOT expose a single tappable
+# Semantics node carrying the label, so `tapOn: text:` (on either the eyebrow
+# or the phrase) cannot resolve a tappable element. We tap by relative point:
+# the RETRAITE card is the first of four, top of the list. The text assertion
+# below confirms we are on the right screen before the positional tap, so the
+# point is well-defined. (A Semantics(button,label) on _IntentCard would let
+# us go back to a pure text locator, but that is product code outside this
+# device-gate plan's scope.)
 - extendedWaitUntil:
     visible:
       text: "Qu’est-ce qui t’amène ?"
     timeout: 5000
 - tapOn:
-    text: "Ce que je toucherai, vraiment."
+    point: "50%,24%"
 
 # ─── T2.5 usTaxPerson:NO ────────────────────────────────────────────────
+# The NO button is a labelled FilledButton ("Non" = waitlistUsTaxPersonNo).
+# Maestro's `id:` matcher does not resolve Flutter's ValueKey('us-tax-person-no')
+# to an iOS accessibility identifier here, so we tap the button label, which
+# (being a FilledButton, unlike the bare-InkWell cards) exposes a tappable
+# Semantics node. "Non" is unambiguous on this 2-button screen.
 - extendedWaitUntil:
     visible:
       text: "Es-tu citoyen ou résident fiscal aux États-Unis ?"
     timeout: 5000
 - tapOn:
-    id: "us-tax-person-no"
+    text: "Non"
 
 # ─── T2.6 nationality:Suisse (NEW SALVAGE-01 step) ──────────────────────
+# The CH option is a FilledButton.tonal with child Text("Suisse" =
+# nationalitySuisse) and a ValueKey('onboarding-nationality-ch'). As with the
+# usTax button, the ValueKey is not resolved by Maestro's `id:` matcher on
+# iOS; tap the button label instead (exposed as a tappable Semantics node).
 - extendedWaitUntil:
     visible:
       text: "Quelle est ta nationalité ?"
     timeout: 5000
 - tapOn:
-    id: "onboarding-nationality-ch"
+    text: "Suisse"
 
 # ─── T3 age:30 ──────────────────────────────────────────────────────────
 - extendedWaitUntil:
@@ -86,28 +112,45 @@ appId: ch.mint.app
     text: "Continuer"
 
 # ─── T4 canton:VD ───────────────────────────────────────────────────────
+# Canton chips are bare InkWell + Text(code) in a 3-col GridView (same
+# not-tappable-Semantics issue as the intent cards). VD is index 0 →
+# top-left cell of the grid, just under the "Où tu vis ?" prompt. Tap by
+# relative point; assert the prompt first to anchor the screen.
 - extendedWaitUntil:
     visible:
       text: "Où tu vis ?"
     timeout: 5000
 - tapOn:
-    text: "VD"
+    point: "17%,20%"
 
 # ─── T5 revenue (default fourchette) ────────────────────────────────────
+# The revenue step has TWO _PrimaryButton("Continuer") in the widget tree —
+# one for fourchette mode, one for exact mode (only one is visually rendered,
+# but both surface in the a11y hierarchy: the trace shows 3 "Continuer"
+# matches). `tapOn: text:"Continuer"` resolves to the first match, which can
+# be the offstage exact-mode button (disabled when _exactValue == null), so
+# the tap is a no-op and the screen never advances. Tap the visible bottom
+# CTA by relative point instead (fixed-position button above the dossier
+# strip). Keep default fourchette (7'000–7'500 CHF); no slider interaction.
 - extendedWaitUntil:
     visible:
       text: "Combien te tombe net par mois ?"
     timeout: 5000
 - tapOn:
-    text: "Continuer"
+    point: "50%,74%"
 
 # ─── T6 insight ─────────────────────────────────────────────────────────
+# Give the revenue→insight transition a generous window: the revenue
+# "Continuer" tap triggers a provider.advance() + rebuild, and the insight
+# scene computes its copy from the dossier, so first paint can lag a beat.
 - extendedWaitUntil:
     visible:
       text: "Avant de te montrer…"
-    timeout: 5000
+    timeout: 12000
+# "Voir" is the fixed bottom CTA. Tap by relative point (consistent with the
+# revenue CTA) — text-tap proved unreliable here in Maestro 2.5.1.
 - tapOn:
-    text: "Voir"
+    point: "50%,71%"
 
 # ─── T7 scene (MintSceneRenteTrouee — renders the user's REAL currentAge) ─
 # The scene receives provider.ageYears, which is derived from q_birth_year
@@ -120,12 +163,18 @@ appId: ch.mint.app
     text: "Continuer"
 
 # ─── T8 bifurcation:Creuser → /coach/chat ───────────────────────────────
+# "Creuser" is the bottom primary CTA (with "Plus tard" below it). Tap by
+# relative point — text-tap on these full-width MVP-wedge CTAs is unreliable
+# in Maestro 2.5.1 (the FilledButton label node intermittently fails to
+# resolve as the tappable). This is the terminal step: Creuser flushes the
+# dossier to CoachProfile and routes to /coach/chat (onboarding_shell_screen
+# .dart:1049).
 - extendedWaitUntil:
     visible:
       text: "Creuser"
     timeout: 5000
 - tapOn:
-    text: "Creuser"
+    point: "50%,63%"
 
 # ─── SC-3: lands on /coach/chat, NOT /waitlist ──────────────────────────
 - extendedWaitUntil:

--- a/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
+++ b/tools/simulator/flows/salvage01_retraite_onboarding_coach.yaml
@@ -33,39 +33,51 @@
 appId: ch.mint.app
 ---
 
+# NOTE (Maestro 2.5.1): `timeout` is NOT a valid property on `assertVisible`
+# in this CLI version (it raises « Unknown Property: timeout » — verified
+# against the formerly-passing coach_tools_server_side_smoke.yaml too). The
+# wait-with-timeout primitive is `extendedWaitUntil: { visible: {…}, timeout }`
+# (proven by the passing flow_data_spine_visible_coach_packet.yaml). Bare
+# `assertVisible` / `assertNotVisible` use Maestro's default assertion window.
+
 # ─── T1 entry → T2 intents ──────────────────────────────────────────────
 - launchApp:
     clearState: true
-- assertVisible:
-    text: "Il est temps que tu comprennes."
+- extendedWaitUntil:
+    visible:
+      text: "Il est temps que tu comprennes."
     timeout: 10000
 - tapOn:
     text: "Ouvrir"
 
 # ─── T2 intents:RETRAITE ────────────────────────────────────────────────
-- assertVisible:
-    text: "Qu’est-ce qui t’amène ?"
+- extendedWaitUntil:
+    visible:
+      text: "Qu’est-ce qui t’amène ?"
     timeout: 5000
 - tapOn:
     text: "Ce que je toucherai, vraiment."
 
 # ─── T2.5 usTaxPerson:NO ────────────────────────────────────────────────
-- assertVisible:
-    text: "Es-tu citoyen ou résident fiscal aux États-Unis ?"
+- extendedWaitUntil:
+    visible:
+      text: "Es-tu citoyen ou résident fiscal aux États-Unis ?"
     timeout: 5000
 - tapOn:
     id: "us-tax-person-no"
 
 # ─── T2.6 nationality:Suisse (NEW SALVAGE-01 step) ──────────────────────
-- assertVisible:
-    text: "Quelle est ta nationalité ?"
+- extendedWaitUntil:
+    visible:
+      text: "Quelle est ta nationalité ?"
     timeout: 5000
 - tapOn:
     id: "onboarding-nationality-ch"
 
 # ─── T3 age:30 ──────────────────────────────────────────────────────────
-- assertVisible:
-    text: "Quel âge tu as ?"
+- extendedWaitUntil:
+    visible:
+      text: "Quel âge tu as ?"
     timeout: 5000
 # Default picker handle is 34; the device walker may scroll to 30. The
 # storyboard unit test pins the exact birth-year math — here we only assert
@@ -74,22 +86,25 @@ appId: ch.mint.app
     text: "Continuer"
 
 # ─── T4 canton:VD ───────────────────────────────────────────────────────
-- assertVisible:
-    text: "Où tu vis ?"
+- extendedWaitUntil:
+    visible:
+      text: "Où tu vis ?"
     timeout: 5000
 - tapOn:
     text: "VD"
 
 # ─── T5 revenue (default fourchette) ────────────────────────────────────
-- assertVisible:
-    text: "Combien te tombe net par mois ?"
+- extendedWaitUntil:
+    visible:
+      text: "Combien te tombe net par mois ?"
     timeout: 5000
 - tapOn:
     text: "Continuer"
 
 # ─── T6 insight ─────────────────────────────────────────────────────────
-- assertVisible:
-    text: "Avant de te montrer…"
+- extendedWaitUntil:
+    visible:
+      text: "Avant de te montrer…"
     timeout: 5000
 - tapOn:
     text: "Voir"
@@ -97,22 +112,25 @@ appId: ch.mint.app
 # ─── T7 scene (MintSceneRenteTrouee — renders the user's REAL currentAge) ─
 # The scene receives provider.ageYears, which is derived from q_birth_year
 # (the SALVAGE-01 flush fix). It must show a real age, not the sentinel.
-- assertVisible:
-    text: "Continuer"
+- extendedWaitUntil:
+    visible:
+      text: "Continuer"
     timeout: 8000
 - tapOn:
     text: "Continuer"
 
 # ─── T8 bifurcation:Creuser → /coach/chat ───────────────────────────────
-- assertVisible:
-    text: "Creuser"
+- extendedWaitUntil:
+    visible:
+      text: "Creuser"
     timeout: 5000
 - tapOn:
     text: "Creuser"
 
 # ─── SC-3: lands on /coach/chat, NOT /waitlist ──────────────────────────
-- assertVisible:
-    text: "Dis-moi."          # coachInputHint — input bar present == /coach/chat
+- extendedWaitUntil:
+    visible:
+      text: "Dis-moi."          # coachInputHint — input bar present == /coach/chat
     timeout: 15000
 # Waitlist guard: the waitlist screen title is `waitlistTitle` ==
 # "Encore en chantier pour ton profil" (app_fr.arb:12570). The prior stub
@@ -125,8 +143,12 @@ appId: ch.mint.app
 - takeScreenshot: "01-coach-reachable-not-waitlist"
 
 # Coach answers a real message (substantive engagement, not waitlist).
-- assertVisible:
-    text: "Réponse du coach"
+# Staging coach LLM verified live (POST /api/v1/anonymous/chat -> 200, ~7s,
+# real reply) at gate time, so a miss here is a routing/product failure, not
+# infra. 30s window covers LLM latency.
+- extendedWaitUntil:
+    visible:
+      text: "Réponse du coach"
     timeout: 30000
 
 # ─── SC-4: navigate /pilier-3a, assert a REAL age (never sentinel) ──────
@@ -138,8 +160,9 @@ appId: ch.mint.app
 # AppBar title `sim3aTitle` == "Ton 3e pilier" (app_fr.arb:4827) — stable
 # semantic locator. The prior stub asserted id:"simulator-3a-root", a key
 # that does not exist in simulator_3a_screen.dart.
-- assertVisible:
-    text: "Ton 3e pilier"
+- extendedWaitUntil:
+    visible:
+      text: "Ton 3e pilier"
     timeout: 10000
 # Sentinel-age guard. age = currentYear - profile.birthYear
 # (rente_vs_capital_screen.dart:195). An UNFLUSHED birthYear (0) yields
@@ -158,8 +181,9 @@ appId: ch.mint.app
 # stub used the underscore intentTag `rente_vs_capital`, which is NOT a
 # route and would not resolve.
 - openLink: "mintapp:///rente-vs-capital"
-- assertVisible:
-    text: "Ton âge"
+- extendedWaitUntil:
+    visible:
+      text: "Ton âge"
     timeout: 10000
 - assertNotVisible:
     text: "Ton âge: 2026"


### PR DESCRIPTION
## SALVAGE-01 Plan 04 — device-gate enablement

Running the SC-4 Maestro RETRAITE onboarding→coach gate (seed bridge OFF, staging build) surfaced a **simulator-only** latent bug that blocked the gate: the wizard *seal* hard-failed because `SecureWizardStore.write()` — unlike `read()` — did not swallow the missing-keychain-entitlement `PlatformException(-34018)` thrown on dev sim builds. A fresh onboarding flush threw at the seal ("Impossible de sceller ton dossier") and never reached the coach.

### Fix
- `SecureWizardStore.write()` now mirrors `read()`'s existing `-34018` guard. On a provisioned device `write()` succeeds (catch never fires); on the sim the value is simply not sealed (`read()` returns null — the already-accepted degraded path).
- **SEC-10 preserved**: PII is never demoted to plain SharedPreferences — `secureSensitiveKeys` sets the `'__secure__'` placeholder unconditionally at the caller; the swallow only means "not sealed", never "stored in clear".
- Regression test (`secure_wizard_store_test.dart`): channel-mock throws `-34018` on write → `secureSensitiveKeys` no longer propagates, and asserts the no-plain-PII invariant. Plus a happy-path seal/restore round-trip.
- Finalized the SC-4 Maestro flow selectors (deeplink entry, Maestro 2.5.1 extendedWaitUntil, semantic locators for the new nationality step).

### Review
- security-auditor (SEC-10/PII/nLPD): **PASS** (0 critical/high/medium; 1 Low deferred: log swallowed write failures; 1 pre-existing debt noted: `clearDiagnostic` ↛ `deleteAll`).

### Verification
- `flutter test test/services/secure_wizard_store_test.dart` → 2/2 passed
- `flutter analyze` (touched files) → no errors

### Next
- The device gate is re-run after this lands to close SC-4 with cited Maestro JUnit + idb evidence.

### Deferred (non-blocking, tracked)
- `dev.log` on swallowed secure-storage failures (both read + write, to keep symmetry).
- `clearDiagnostic()` should call `SecureWizardStore.deleteAll()` (pre-existing; secure keys not purged on reset).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>