### PR TITLE
Hotfix CJT-021 anonymous temporal gate

### DIFF
--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -165,6 +165,10 @@ class _NoRagOrchestrator:
         # regulatory registry tool instead of citing training-data plafonds.
         # Authentication path already wires this via coach_chat.py:88+186.
         # Defense-in-depth couches A+B+C+D per .planning/phases/01.4-coach-runtime-stale-data/01.4-AUDIT.md
+        from app.services.coach.runtime_temporal_gate import (
+            fallback_for_language as _temporal_fallback_for_language,
+            gate as _runtime_temporal_gate,
+        )
         from app.services.rag.guardrails import ComplianceGuardrails
         from app.services.coach.coach_tools import get_llm_tools
 
@@ -312,6 +316,31 @@ class _NoRagOrchestrator:
             )
             if second_text.strip():
                 final_text = second_text
+
+        # CJT-021 — anonymous path must share the authenticated path's
+        # temporal fail-closed invariant: a current-year question must never
+        # return stale timing anchors from a past tax year.
+        _tg_passed, _tg_text = _runtime_temporal_gate(
+            final_text,
+            user_message=question,
+            fallback_text=_temporal_fallback_for_language(language),
+        )
+        if not _tg_passed:
+            try:  # pragma: no cover — telemetry-only
+                import sentry_sdk
+
+                sentry_sdk.add_breadcrumb(
+                    category="coach.temporal_gate.fired",
+                    message="runtime temporal-anchor gate fired",
+                    level="info",
+                    data={
+                        "profile_id_hashed": "anonymous",
+                        "fallback_emitted": True,
+                    },
+                )
+            except Exception:
+                pass
+            final_text = _tg_text
 
         # Compliance filter (banned-term sanitization, accent normalization,
         # disclaimer injection). Same gate as before but applied to the

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -89,6 +89,12 @@ from app.services.coach.runtime_freshness_gate import (
     gate as _runtime_freshness_gate,
 )
 
+# CJT-021 — runtime temporal-anchor gate.
+# Wired AFTER `_runtime_freshness_gate` and BEFORE `_citation_gate`: numeric
+# freshness catches stale regulatory values; temporal freshness catches past
+# month/year examples in current-year answers.
+from app.services.coach.runtime_temporal_gate import gate as _runtime_temporal_gate
+
 from app.services.coach.coach_tools import (
     INTERNAL_TOOL_NAMES,
     get_llm_tools,
@@ -4857,6 +4863,12 @@ async def coach_chat(
                             ",", "'"
                         )
                     )
+                if _d.get("pillar3aAnnual") is not None:
+                    _facts.append(
+                        f"- 3a verse cette annee: {int(_d['pillar3aAnnual']):,} CHF".replace(
+                            ",", "'"
+                        )
+                    )
                 if _d.get("avsContributionYears"):
                     _facts.append(
                         f"- Annees cotisation AVS: {_d['avsContributionYears']}"
@@ -5274,6 +5286,35 @@ async def coach_chat(
             except Exception:  # pragma: no cover — telemetry is fail-open
                 pass
             loop_result["answer"] = _fg_text
+            return loop_result
+
+        # CJT-021 — runtime temporal-anchor gate. Catches outputs such as
+        # "janvier 2025 / décembre 2025" when the user asked a current-year
+        # question ("cette année"). This is distinct from numeric freshness:
+        # the 7'258 ceiling can be correct while the timing example is stale.
+        _tg_passed, _tg_text = _runtime_temporal_gate(
+            loop_result["answer"], user_message=body.message
+        )
+        if not _tg_passed:
+            try:
+                import sentry_sdk  # type: ignore
+
+                sentry_sdk.add_breadcrumb(  # type: ignore[union-attr]
+                    category="coach.temporal_gate.fired",
+                    message="runtime temporal-anchor gate fired",
+                    level="info",
+                    data={
+                        "profile_id_hashed": (
+                            __import__("hashlib")
+                            .sha256(str(_user.id).encode("utf-8") if _user else b"")
+                            .hexdigest()[:16]
+                        ),
+                        "fallback_emitted": True,
+                    },
+                )
+            except Exception:  # pragma: no cover — telemetry is fail-open
+                pass
+            loop_result["answer"] = _tg_text
             return loop_result
 
         gated = _citation_gate(

--- a/services/backend/app/services/coach/runtime_temporal_gate.py
+++ b/services/backend/app/services/coach/runtime_temporal_gate.py
@@ -15,6 +15,15 @@ from typing import Optional
 
 _FALLBACK_FR: str = "Je n'ai pas cette donnée à jour pour l'instant."
 
+_FALLBACK_BY_LANGUAGE: dict[str, str] = {
+    "fr": _FALLBACK_FR,
+    "de": "Ich habe diese Information im Moment nicht aktuell genug.",
+    "en": "I do not have up-to-date data for this right now.",
+    "it": "Non ho questa informazione aggiornata per il momento.",
+    "es": "No tengo este dato actualizado por el momento.",
+    "pt": "Não tenho este dado atualizado neste momento.",
+}
+
 _ZERO_WIDTH_CHARS: frozenset[str] = frozenset({
     "​",  # ZERO WIDTH SPACE
     "‌",  # ZERO WIDTH NON-JOINER
@@ -25,14 +34,19 @@ _ZERO_WIDTH_CHARS: frozenset[str] = frozenset({
 
 _CURRENT_YEAR_ANCHOR_RE: re.Pattern[str] = re.compile(
     r"\b(?:cette\s+ann[ée]e|this\s+year|ann[ée]e\s+en\s+cours|"
-    r"ann[ée]e\s+fiscale\s+courante)\b",
+    r"ann[ée]e\s+fiscale\s+courante|dieses\s+jahr|quest['’]?anno|"
+    r"este\s+a[nñ]o|este\s+ano)\b",
     re.IGNORECASE,
 )
 
 _THREE_A_CEILING_QUESTION_RE: re.Pattern[str] = re.compile(
     r"\b(?:3a|troisi[eè]me\s+pilier|pilier\s+3a)\b.*"
-    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible)\b|"
-    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible)\b.*"
+    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible|"
+    r"wie\s+viel|einzahlen|s[äa]ule|quanto|versare|pilastro|"
+    r"cu[aá]nto|aportar|pilar|depositar)\b|"
+    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible|"
+    r"wie\s+viel|einzahlen|s[äa]ule|quanto|versare|pilastro|"
+    r"cu[aá]nto|aportar|pilar|depositar)\b.*"
     r"\b(?:3a|troisi[eè]me\s+pilier|pilier\s+3a)\b",
     re.IGNORECASE,
 )
@@ -70,6 +84,11 @@ def _clean(s: str) -> str:
     return _strip_zero_width(unicodedata.normalize("NFKC", s or ""))
 
 
+def fallback_for_language(language: str | None) -> str:
+    code = (language or "fr").strip().lower().split("-", maxsplit=1)[0]
+    return _FALLBACK_BY_LANGUAGE.get(code, _FALLBACK_FR)
+
+
 def _is_current_year_question(user_message: str, current_year: int) -> bool:
     cleaned = _clean(user_message)
     return bool(_CURRENT_YEAR_ANCHOR_RE.search(cleaned)) or str(current_year) in {
@@ -79,6 +98,12 @@ def _is_current_year_question(user_message: str, current_year: int) -> bool:
 
 def _years_mentioned(text: str) -> set[int]:
     return {int(m.group(0)) for m in _YEAR_RE.finditer(_clean(text))}
+
+
+def _is_allowed_historical_year_anchor(text: str, match: re.Match[str]) -> bool:
+    """Allow historical rule context, not stale current-year anchoring."""
+    before = text[max(0, match.start() - 24):match.start()]
+    return bool(re.search(r"(?:\bdepuis\s+|\b[aà]\s+partir\s+de\s+)$", before, re.IGNORECASE))
 
 
 def _is_current_3a_ceiling_question(user_message: str, current_year: int) -> bool:
@@ -95,6 +120,7 @@ def gate(
     *,
     user_message: str = "",
     current_year: Optional[int] = None,
+    fallback_text: str = _FALLBACK_FR,
 ) -> tuple[bool, str]:
     """Fail closed on past month/year examples in current-year answers."""
     if not text or not text.strip():
@@ -110,14 +136,27 @@ def gate(
         _is_current_3a_ceiling_question(user_message, effective_year)
         and _MARKET_TIMING_RE.search(cleaned)
     ):
-        return (False, _FALLBACK_FR)
+        return (False, fallback_text)
+
+    is_current_3a_ceiling_question = _is_current_3a_ceiling_question(
+        user_message, effective_year
+    )
+    if is_current_3a_ceiling_question:
+        for match in _YEAR_RE.finditer(cleaned):
+            year = int(match.group(0))
+            if (
+                year < effective_year
+                and year not in user_years
+                and not _is_allowed_historical_year_anchor(cleaned, match)
+            ):
+                return (False, fallback_text)
 
     for match in _MONTH_YEAR_RE.finditer(cleaned):
         year = int(match.group("year"))
         if year < effective_year and year not in user_years:
-            return (False, _FALLBACK_FR)
+            return (False, fallback_text)
 
     return (True, text)
 
 
-__all__ = ["gate", "_FALLBACK_FR"]
+__all__ = ["gate", "fallback_for_language", "_FALLBACK_FR"]

--- a/services/backend/app/services/coach/runtime_temporal_gate.py
+++ b/services/backend/app/services/coach/runtime_temporal_gate.py
@@ -1,0 +1,123 @@
+"""Runtime temporal-anchor gate for current-year coach questions.
+
+CJT-021: a response can cite the correct 2026 3a ceiling while still using
+past-year timing examples ("janvier 2025") for a user asking "cette annee".
+This gate is deliberately narrower than the numeric freshness gate: it only
+blocks past month/year anchors when the user question is current-year scoped.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+import unicodedata
+from typing import Optional
+
+
+_FALLBACK_FR: str = "Je n'ai pas cette donnée à jour pour l'instant."
+
+_ZERO_WIDTH_CHARS: frozenset[str] = frozenset({
+    "​",  # ZERO WIDTH SPACE
+    "‌",  # ZERO WIDTH NON-JOINER
+    "‍",  # ZERO WIDTH JOINER
+    "﻿",  # ZERO WIDTH NO-BREAK SPACE (BOM)
+    "⁠",  # WORD JOINER
+})
+
+_CURRENT_YEAR_ANCHOR_RE: re.Pattern[str] = re.compile(
+    r"\b(?:cette\s+ann[ée]e|this\s+year|ann[ée]e\s+en\s+cours|"
+    r"ann[ée]e\s+fiscale\s+courante)\b",
+    re.IGNORECASE,
+)
+
+_THREE_A_CEILING_QUESTION_RE: re.Pattern[str] = re.compile(
+    r"\b(?:3a|troisi[eè]me\s+pilier|pilier\s+3a)\b.*"
+    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible)\b|"
+    r"\b(?:combien|mettre|verser|plafond|encore|reste|d[ée]ductible)\b.*"
+    r"\b(?:3a|troisi[eè]me\s+pilier|pilier\s+3a)\b",
+    re.IGNORECASE,
+)
+
+_MARKET_REQUEST_RE: re.Pattern[str] = re.compile(
+    r"\b(?:rendement|march[ée]|titres?|etf|fonds?|risque|placement|produit|cash)\b",
+    re.IGNORECASE,
+)
+
+_MARKET_TIMING_RE: re.Pattern[str] = re.compile(
+    r"\b(?:rendement\s+potentiel|march[ée]\s+en\s+plus|"
+    r"rapport(?:er|era|e|ent)?\s+un\s+an\s+de\s+march[ée])\b",
+    re.IGNORECASE,
+)
+
+_MONTH_YEAR_RE: re.Pattern[str] = re.compile(
+    r"\b(?:janvier|fevrier|février|mars|avril|mai|juin|juillet|aout|août|"
+    r"septembre|octobre|novembre|decembre|décembre)\s+"
+    r"(?P<year>19\d{2}|20\d{2})\b",
+    re.IGNORECASE,
+)
+
+_YEAR_RE: re.Pattern[str] = re.compile(r"\b(19\d{2}|20\d{2})\b")
+
+
+def _strip_zero_width(s: str) -> str:
+    if not s:
+        return s
+    if not any(c in _ZERO_WIDTH_CHARS for c in s):
+        return s
+    return "".join(c for c in s if c not in _ZERO_WIDTH_CHARS)
+
+
+def _clean(s: str) -> str:
+    return _strip_zero_width(unicodedata.normalize("NFKC", s or ""))
+
+
+def _is_current_year_question(user_message: str, current_year: int) -> bool:
+    cleaned = _clean(user_message)
+    return bool(_CURRENT_YEAR_ANCHOR_RE.search(cleaned)) or str(current_year) in {
+        m.group(0) for m in _YEAR_RE.finditer(cleaned)
+    }
+
+
+def _years_mentioned(text: str) -> set[int]:
+    return {int(m.group(0)) for m in _YEAR_RE.finditer(_clean(text))}
+
+
+def _is_current_3a_ceiling_question(user_message: str, current_year: int) -> bool:
+    cleaned = _clean(user_message)
+    if _MARKET_REQUEST_RE.search(cleaned):
+        return False
+    return _is_current_year_question(cleaned, current_year) and bool(
+        _THREE_A_CEILING_QUESTION_RE.search(cleaned)
+    )
+
+
+def gate(
+    text: str,
+    *,
+    user_message: str = "",
+    current_year: Optional[int] = None,
+) -> tuple[bool, str]:
+    """Fail closed on past month/year examples in current-year answers."""
+    if not text or not text.strip():
+        return (True, text)
+
+    effective_year = current_year or _dt.date.today().year
+    if not _is_current_year_question(user_message, effective_year):
+        return (True, text)
+
+    user_years = _years_mentioned(user_message)
+    cleaned = _clean(text)
+    if (
+        _is_current_3a_ceiling_question(user_message, effective_year)
+        and _MARKET_TIMING_RE.search(cleaned)
+    ):
+        return (False, _FALLBACK_FR)
+
+    for match in _MONTH_YEAR_RE.finditer(cleaned):
+        year = int(match.group("year"))
+        if year < effective_year and year not in user_years:
+            return (False, _FALLBACK_FR)
+
+    return (True, text)
+
+
+__all__ = ["gate", "_FALLBACK_FR"]

--- a/services/backend/app/services/coach/structured_reasoning.py
+++ b/services/backend/app/services/coach/structured_reasoning.py
@@ -456,13 +456,14 @@ def _detect_3a_not_maxed(profile: dict, today: Optional[datetime.date] = None) -
 
     remaining = ceiling - annual_3a_contribution
     confidence = 0.60
+    fiscal_year = today.year
 
     return ReasoningOutput(
         fact_tag="3a_not_maxed",
             domain="fiscalite",
         fact_label=(
             f"Pilier 3a non maximisé : {annual_3a_contribution:,.0f} CHF versés "
-            f"sur {ceiling:,.0f} CHF (plafond 2025/2026)"
+            f"sur {ceiling:,.0f} CHF (plafond {fiscal_year})"
         ),
         confidence=confidence,
         suggested_action=(
@@ -480,6 +481,7 @@ def _detect_3a_not_maxed(profile: dict, today: Optional[datetime.date] = None) -
             "deja_verse_CHF": round(annual_3a_contribution, 0),
             "restant_CHF": round(remaining, 0),
             "economie_fiscale_potentielle_CHF": round(tax_saving_potential, 0),
+            "annee_fiscale": fiscal_year,
         },
         sources=[
             "OPP3 art. 7 (plafond 3a : 7'258 CHF/an pour les salariés affiliés LPP)",

--- a/services/backend/tests/test_anonymous_chat_tool_use.py
+++ b/services/backend/tests/test_anonymous_chat_tool_use.py
@@ -208,3 +208,104 @@ async def test_tools_list_is_filtered_to_regulatory_only():
         assert tool_names == ["get_regulatory_constant"], (
             f"anonymous path must expose ONLY get_regulatory_constant ; got {tool_names}"
         )
+
+
+@pytest.mark.asyncio
+async def test_tool_grounded_answer_runs_temporal_gate_before_returning():
+    """Anonymous path must fail closed on stale temporal anchors after tool use."""
+    from app.api.v1.endpoints.anonymous_chat import _NoRagOrchestrator
+    from app.services.coach.runtime_temporal_gate import _FALLBACK_FR
+
+    orchestrator = _NoRagOrchestrator()
+    responses = [
+        _fake_anthropic_tool_use_response(
+            tool_name="get_regulatory_constant",
+            tool_input={"key": "pillar3a.max_with_lpp"},
+            tool_use_id="tu_2026",
+        ),
+        _fake_anthropic_text_response(
+            "Si tu es salarie, tu peux verser 7'258 CHF en 2025 "
+            "(OPP3 art. 7). Verser en janvier ou decembre 2025 reste possible.",
+            input_tokens=15,
+            output_tokens=30,
+        ),
+    ]
+
+    with patch("anthropic.AsyncAnthropic") as MockClient:
+        instance = MockClient.return_value
+        instance.messages.create = AsyncMock(side_effect=responses)
+
+        with patch(
+            "app.services.regulatory.tool_handler.handle_regulatory_constant",
+            return_value="pillar3a.max_with_lpp = 7258 CHF\nSource : OPP3 art. 7",
+        ):
+            result = await orchestrator.query(
+                question="Combien je peux mettre sur mon 3a cette annee ?",
+                system_prompt="System",
+                api_key="sk-test",
+                provider="claude",
+                model="claude-sonnet-4-5-20250929",
+            )
+
+    assert result["answer"] == _FALLBACK_FR
+    assert "2025" not in result["answer"]
+    assert result.get("tool_calls") == [{"name": "get_regulatory_constant"}]
+
+
+@pytest.mark.asyncio
+async def test_text_only_answer_runs_temporal_gate_before_returning():
+    """Temporal gate also protects the first-pass text-only path."""
+    from app.api.v1.endpoints.anonymous_chat import _NoRagOrchestrator
+    from app.services.coach.runtime_temporal_gate import _FALLBACK_FR
+
+    orchestrator = _NoRagOrchestrator()
+
+    with patch("anthropic.AsyncAnthropic") as MockClient:
+        instance = MockClient.return_value
+        instance.messages.create = AsyncMock(
+            return_value=_fake_anthropic_text_response(
+                "Tu peux verser jusqu'a 7'258 CHF en 2025 selon l'OPP3 art. 7."
+            )
+        )
+
+        result = await orchestrator.query(
+            question="Combien je peux mettre sur mon 3a cette annee ?",
+            system_prompt="System",
+            api_key="sk-test",
+            provider="claude",
+            model="claude-sonnet-4-5-20250929",
+            language="fr",
+        )
+
+    assert result["answer"] == _FALLBACK_FR
+    assert "2025" not in result["answer"]
+
+
+@pytest.mark.asyncio
+async def test_german_answer_runs_temporal_gate_with_localized_fallback():
+    """Anonymous temporal gate must not be French-only."""
+    from app.api.v1.endpoints.anonymous_chat import _NoRagOrchestrator
+    from app.services.coach.runtime_temporal_gate import fallback_for_language
+
+    orchestrator = _NoRagOrchestrator()
+    fallback = fallback_for_language("de")
+
+    with patch("anthropic.AsyncAnthropic") as MockClient:
+        instance = MockClient.return_value
+        instance.messages.create = AsyncMock(
+            return_value=_fake_anthropic_text_response(
+                "Du kannst 7'258 CHF im Jahr 2025 in die Säule 3a einzahlen."
+            )
+        )
+
+        result = await orchestrator.query(
+            question="Wie viel kann ich dieses Jahr in die Säule 3a einzahlen?",
+            system_prompt="System",
+            api_key="sk-test",
+            provider="claude",
+            model="claude-sonnet-4-5-20250929",
+            language="de",
+        )
+
+    assert result["answer"] == fallback
+    assert "2025" not in result["answer"]

--- a/services/backend/tests/test_coach_chat_profile_block_contract.py
+++ b/services/backend/tests/test_coach_chat_profile_block_contract.py
@@ -1,0 +1,23 @@
+"""Source contract for the final Coach profile block.
+
+The endpoint currently builds the final `PROFIL UTILISATEUR` block inline.
+This contract pins that DB `pillar3aAnnual` is surfaced there, not only in
+the intermediate sanitized context.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def test_final_profile_block_includes_annual_3a_contribution():
+    source = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "app" / "api" / "v1" / "endpoints" / "coach_chat.py"
+    ).read_text(encoding="utf-8")
+
+    profile_block_start = source.index('if _d.get("pillar3aBalance")')
+    session_block_start = source.index("## PROFIL UTILISATEUR (faits saisis cette session")
+    profile_block_source = source[profile_block_start:session_block_start]
+
+    assert 'if _d.get("pillar3aAnnual")' in profile_block_source
+    assert "3a verse cette annee" in profile_block_source

--- a/services/backend/tests/test_coach_chat_temporal_gate_wire.py
+++ b/services/backend/tests/test_coach_chat_temporal_gate_wire.py
@@ -1,0 +1,43 @@
+"""CJT-021 runtime temporal gate wire-up tests."""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+_COACH_CHAT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "app" / "api" / "v1" / "endpoints" / "coach_chat.py"
+)
+
+
+@pytest.fixture(scope="module")
+def coach_chat_source() -> str:
+    return _COACH_CHAT_PATH.read_text(encoding="utf-8")
+
+
+def test_runtime_temporal_gate_imported(coach_chat_source: str):
+    assert "runtime_temporal_gate" in coach_chat_source
+
+
+def test_temporal_gate_call_precedes_citation_gate_call(coach_chat_source: str):
+    func_re = re.compile(
+        r"async def _run_narrator_with_gate\b[\s\S]*?"
+        r"(?=async def _run_narrator_with_gate_and_cap)",
+        re.MULTILINE,
+    )
+    match = func_re.search(coach_chat_source)
+    assert match, "_run_narrator_with_gate not found in expected position"
+    body = match.group(0)
+
+    temporal_match = re.search(r"_runtime_temporal_gate\s*\(", body)
+    citation_match = re.search(r"_citation_gate\s*\(", body)
+
+    assert temporal_match, "temporal-gate call missing in _run_narrator_with_gate"
+    assert citation_match, "citation-gate call missing in _run_narrator_with_gate"
+    assert temporal_match.start() < citation_match.start()
+
+
+def test_temporal_gate_breadcrumb_category_present(coach_chat_source: str):
+    assert "coach.temporal_gate.fired" in coach_chat_source

--- a/services/backend/tests/test_runtime_temporal_gate.py
+++ b/services/backend/tests/test_runtime_temporal_gate.py
@@ -7,7 +7,11 @@ wrong temporal anchor for "cette annee".
 """
 from __future__ import annotations
 
-from app.services.coach.runtime_temporal_gate import _FALLBACK_FR, gate
+from app.services.coach.runtime_temporal_gate import (
+    _FALLBACK_FR,
+    fallback_for_language,
+    gate,
+)
 
 
 def test_gate_blocks_past_month_year_for_current_year_question():
@@ -51,6 +55,32 @@ def test_gate_does_not_block_historical_rule_without_month_anchor():
 
     assert passed is True
     assert output == narrator
+
+
+def test_gate_blocks_past_year_ceiling_anchor_for_current_year_question():
+    user_msg = "Combien je peux mettre sur mon 3a cette annee ?"
+    narrator = "Tu peux verser jusqu'a 7'258 CHF en 2025 selon l'OPP3 art. 7."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_blocks_german_current_year_3a_question_with_localized_fallback():
+    user_msg = "Wie viel kann ich dieses Jahr in die Säule 3a einzahlen?"
+    narrator = "Du kannst 7'258 CHF im Jahr 2025 in die Säule 3a einzahlen."
+    fallback = fallback_for_language("de")
+
+    passed, output = gate(
+        narrator,
+        user_message=user_msg,
+        current_year=2026,
+        fallback_text=fallback,
+    )
+
+    assert passed is False
+    assert output == fallback
 
 
 def test_gate_blocks_market_timing_for_current_3a_ceiling_question():

--- a/services/backend/tests/test_runtime_temporal_gate.py
+++ b/services/backend/tests/test_runtime_temporal_gate.py
@@ -1,0 +1,73 @@
+"""Tests for runtime_temporal_gate (CJT-021).
+
+Catches narrator answers that answer a current-year question with a past
+month/year timing example. This is separate from runtime_freshness_gate:
+7'258 can be the correct 2026 ceiling while "janvier 2025" is still the
+wrong temporal anchor for "cette annee".
+"""
+from __future__ import annotations
+
+from app.services.coach.runtime_temporal_gate import _FALLBACK_FR, gate
+
+
+def test_gate_blocks_past_month_year_for_current_year_question():
+    user_msg = "Combien je peux mettre sur mon 3a cette annee ?"
+    narrator = (
+        "Verser en janvier 2025 plutot qu'en decembre 2025 pourrait te "
+        "rapporter un an de marche en plus."
+    )
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_passes_current_year_months_for_current_year_question():
+    user_msg = "Combien je peux mettre sur mon 3a cette annee ?"
+    narrator = "Pour 2026, janvier 2026 et decembre 2026 restent dans la meme annee fiscale."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is True
+    assert output == narrator
+
+
+def test_gate_passes_past_year_when_user_explicitly_asked_for_it():
+    user_msg = "En janvier 2025, est-ce que mon versement 3a comptait pour 2025 ?"
+    narrator = "Oui, janvier 2025 et decembre 2025 sont deux mois de l'annee fiscale 2025."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is True
+    assert output == narrator
+
+
+def test_gate_does_not_block_historical_rule_without_month_anchor():
+    user_msg = "Combien je peux mettre sur mon 3a cette annee ?"
+    narrator = "Depuis 2025, le plafond salarie est reste a 7'258 CHF."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is True
+    assert output == narrator
+
+
+def test_gate_blocks_market_timing_for_current_3a_ceiling_question():
+    user_msg = "Combien je peux mettre sur mon 3a cette annee ?"
+    narrator = "Verser en janvier pourrait te rapporter un an de marche en plus."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is False
+    assert output == _FALLBACK_FR
+
+
+def test_gate_allows_market_wording_when_user_asks_return_comparison():
+    user_msg = "Quel rendement attendre avec un 3a titres par rapport au cash ?"
+    narrator = "Le rendement depend du risque, des frais et de l'horizon."
+
+    passed, output = gate(narrator, user_message=user_msg, current_year=2026)
+
+    assert passed is True
+    assert output == narrator

--- a/services/backend/tests/test_structured_reasoning.py
+++ b/services/backend/tests/test_structured_reasoning.py
@@ -172,6 +172,31 @@ class TestDecember3aDeadline:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Group 3b: Non-December 3a fiscal-year wording
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class Test3aNotMaxed:
+    """3a not-maxed prompt block must not prime stale year anchors."""
+
+    @patch("app.services.coach.structured_reasoning.datetime")
+    def test_3a_not_maxed_uses_current_fiscal_year_2026(self, mock_dt):
+        today_2026 = datetime.date(2026, 6, 2)
+        mock_dt.date.today.return_value = today_2026
+        mock_dt.date.side_effect = lambda *a, **kw: datetime.date(*a, **kw)
+
+        output = _reason({
+            "annual_3a_contribution": 1000,
+            "tax_saving_potential": 1800,
+        })
+
+        assert output.fact_tag == "3a_not_maxed"
+        assert "plafond 2026" in output.fact_label
+        assert "2025/2026" not in output.fact_label
+        assert output.supporting_data["annee_fiscale"] == 2026
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Group 4: Gap warning (replacement rate)
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Scope
Backend-only hotfix for CJT-021 on staging. This deliberately avoids the broader salvage QA bundle in PR #689, which is currently blocked by design-lint debt.

## What changes
- Adds runtime temporal-anchor gate for current-year 3a ceiling questions.
- Wires authenticated coach after freshness gate and before citation gate.
- Wires anonymous coach after text-only and tool-use LLM turns.
- Blocks stale anchors like `7'258 CHF en 2025` / `janvier 2025` for current-year questions.
- Adds localized anonymous fallback for supported languages.

## Local proof
- `cd services/backend && pytest -q tests/test_runtime_temporal_gate.py tests/test_anonymous_chat_tool_use.py tests/test_coach_chat_temporal_gate_wire.py tests/test_coach_chat_profile_block_contract.py tests/test_structured_reasoning.py tests/test_anonymous_chat_prompt_parity.py` -> 65 passed
- `cd services/backend && pytest tests/ -q --tb=short -x` -> 7612 passed, 66 skipped, 4 xfailed, 1 warning
- `git diff --check staging..HEAD` -> passed

## Notes
- Full `ruff check .` on raw staging reports existing lint debt unrelated to this hotfix; deploy-backend and CI backend gates are pytest-based.
- PR #689 remains the larger salvage staging promotion and is not abandoned.

## Post-merge proof required
After staging deploy: rerun anonymous 3a staging probe and Maestro `flow_hero_marge_fiscale_3a.yaml`; CJT-021 is not release-closed until those are green without stale 2025 temporal copy.
