### PR TITLE
planning: allow active context on dev

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -8,10 +8,12 @@
   "next_product_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/mint-2-0-first-experience-rente-capital-CONTEXT.md",
   "worktree_root": "/Users/julienbattaglia/Desktop/MINT.foundation-clean.nosync",
   "allowed_branches": [
+    "dev",
+    "codex/mint-dev-active-context-20260614",
     "codex/mint-foundation-cleanup-20260614",
     "codex/mint-karpathy-rules-infra-20260614"
   ],
-  "base_ref": "origin/codex/mint-foundation-cleanup-20260614",
+  "base_ref": "origin/dev",
   "required_phase_files": [
     "CONTEXT.md",
     "SPEC.md",

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -8,6 +8,7 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Active milestone: `mint-karpathy-rules-infra-20260614`
 - Active context: `.planning/phases/mint-karpathy-rules-infra-20260614/CONTEXT.md`
 - Active spec: `.planning/phases/mint-karpathy-rules-infra-20260614/SPEC.md`
+- Active integration branch: `dev`
 - Next product phase: `.planning/phases/mint-2-0-first-experience-rente-capital/mint-2-0-first-experience-rente-capital-CONTEXT.md`
 
 ## Required Session Start

--- a/tools/checks/tests/test_active_context_guard.py
+++ b/tools/checks/tests/test_active_context_guard.py
@@ -36,7 +36,7 @@ def _write_valid_fixture(root: Path) -> None:
         "active_phase_context": ".planning/phases/mint-foundation-cleanup-20260614/CONTEXT.md",
         "active_spec": ".planning/phases/mint-foundation-cleanup-20260614/SPEC.md",
         "next_product_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/mint-2-0-first-experience-rente-capital-CONTEXT.md",
-        "allowed_branches": ["codex/mint-foundation-cleanup-20260614"],
+        "allowed_branches": ["dev", "codex/mint-foundation-cleanup-20260614"],
         "base_ref": "origin/dev",
         "required_phase_files": [
             "CONTEXT.md",


### PR DESCRIPTION
## Summary
- allow the active context guard to pass on dev after #694/#695 landed
- update the active context base ref to origin/dev
- keep the cleanup branch allowlisted for this small follow-up PR

## Verification
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/agent_reference_guard.py
- python3 tools/checks/claude_hooks_guard.py
- python3 -m pytest tools/checks/tests/test_active_context_guard.py tools/checks/tests/test_agent_reference_guard.py tools/checks/tests/test_claude_hooks_guard.py tools/checks/tests/test_mint_rules_guard.py tools/checks/tests/test_phase_contract_guard.py tools/checks/tests/test_verify_phase_acceptance.py -q
- python3 tools/checks/verify_phase_acceptance.py