### PR TITLE
Propose Mint 2.0 first experience contract

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -11,7 +11,8 @@
     "dev",
     "codex/mint-dev-active-context-20260614",
     "codex/mint-foundation-cleanup-20260614",
-    "codex/mint-karpathy-rules-infra-20260614"
+    "codex/mint-karpathy-rules-infra-20260614",
+    "codex/mint-2-first-experience-contract-20260614"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
@@ -61,4 +61,6 @@ Scenario/dossier/UI layers gate and render; they do not calculate.
 
 Promotion requires explicit GO from Julien and one coherent update to
 `.planning/ACTIVE_CONTEXT.md`, `.planning/ACTIVE_CONTEXT.json`,
-`.planning/STATE.md`, and `.planning/ROADMAP.md`.
+`.planning/STATE.md`, and `.planning/ROADMAP.md`. That promotion must repoint
+the router to these canonical files, including `CONTEXT.md`, not to the
+prefixed source receipts.

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
@@ -1,0 +1,64 @@
+# Mint 2.0 First Experience Rente/Capital — Proposed Context
+
+Status: Proposed. This phase stays `next_product_phase_context` until Julien
+gives explicit GO and the router files are promoted together.
+
+## Authority
+
+Canonical files for future promotion: `CONTEXT.md`, `SPEC.md`, `PLAN.md`,
+`VERIFICATION.md`. Earlier prefixed files in this directory are source receipts,
+not future guard targets.
+
+Consolidated source receipts:
+`mint-2-0-first-experience-rente-capital-CONTEXT.md`, `PLANS.md`,
+`STATE-TABLE.md`, `golden-onboarding-archetypes.md`,
+`mint-2-0-first-experience-rente-capital-VERIFICATION.md`, `CLAUDE-REVIEW.md`.
+
+## Product Frame
+
+Mint is a Swiss financial dossier and navigation system. The coach explains and
+routes; it does not replace the dossier.
+
+Mint 2.0 first experience shows three axes and makes one live:
+
+| Axis | Status | Allowed now | Refused now |
+|---|---|---|---|
+| `2e pilier : rente ou capital` | Live | readiness, missing fields, canonical calculation receipt, dossier entry | naked number, product ranking, copied UI calculation |
+| `Logement : 2e / 3e pilier` | Signalétique | education, saved interest, notify/follow, required-data preview | amount, simulation, detailed unused collection |
+| `3a et rachats : impact fiscal` | Signalétique | education, saved interest, missing-data preview | tax amount, tax promise, calculation without active fiscal engine and sources |
+
+This is not a retirement app: 18-99, dossiers by life events, rente/capital as
+one live door rather than the whole product.
+
+## Dossier Minimum
+
+Every answer must be retrievable outside chat:
+
+- Questions: selected axis and user wording.
+- Facts: age/birth date, canton, employment or retirement context, and financial
+  range only when the next answer needs them.
+- Readiness: known fields, missing required fields, optional fields.
+- Answers: explanation tied to facts, assumptions, and calculator version.
+- Calculations: value or range only with unit, sources, assumptions, readiness,
+  missing fields, and version.
+- Next actions: continue, save account after value, start over, exit, follow a
+  signalétique axis.
+
+## Calculation Boundary
+
+Scenario/dossier/UI layers gate and render; they do not calculate.
+
+- L1 single-number calculations: `apps/mobile/lib/services/financial_core/`.
+- L2-L4 compare/explain/invariant calculations: `services/backend/app/services/`.
+- Slice 2 must audit and reuse `/rente-vs-capital` instead of creating a second
+  screen or calculator:
+  `apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart`,
+  `apps/mobile/lib/domain/rente_vs_capital_calculator.dart`,
+  `apps/mobile/lib/services/financial_core/arbitrage_engine.dart`,
+  `apps/mobile/lib/app.dart`, `apps/mobile/lib/routes/route_metadata.dart`.
+
+## Promotion Rule
+
+Promotion requires explicit GO from Julien and one coherent update to
+`.planning/ACTIVE_CONTEXT.md`, `.planning/ACTIVE_CONTEXT.json`,
+`.planning/STATE.md`, and `.planning/ROADMAP.md`.

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/PLAN.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/PLAN.md
@@ -1,0 +1,52 @@
+# Mint 2.0 First Experience Rente/Capital — Proposed Plan
+
+Status: Proposed. Planning-only until explicit GO from Julien.
+
+## Scope
+
+Allowed before GO:
+`.planning/phases/mint-2-0-first-experience-rente-capital/`.
+
+Forbidden before GO:
+`apps/`, `services/`, `tools/`, `docs/`, `.planning/ACTIVE_CONTEXT.md`,
+`.planning/ACTIVE_CONTEXT.json`, `.planning/STATE.md`,
+`.planning/ROADMAP.md`, `.planning/INDEX.md`.
+
+## Slice Order
+
+1. Contract before code.
+2. Entry and three axes.
+3. Rente/capital data readiness.
+4. Rente/capital result provenance.
+5. Dossier navigation and account handoff.
+6. Simulator, iPhone 13 mini, and closeout evidence.
+
+Only Slice 1 is planned here. Later slices require their own code-mapped plan
+before implementation.
+
+## Slice 1 Tasks
+
+1. Consolidate canonical `CONTEXT.md`, `SPEC.md`, `PLAN.md`, `VERIFICATION.md`.
+2. Preserve prefixed files as receipts, not guard targets.
+3. Keep Mint 2.0 as `next_product_phase_context`.
+4. Define eight synthetic archetypes and eight negative cases.
+5. Define receipt requirements for future numbers.
+6. Define signalétique-axis refusal rules.
+7. End with GO request before router promotion or product code.
+
+Exit criteria: no product code, no router file, no public-doc lint finding in
+this directory, `git diff --check` passes, final report names open blockers.
+
+## Slice 2 Preconditions
+
+Before mobile code, write a new plan with exact files, reuse of
+`/rente-vs-capital`, grep proof for route/calculator symbols, calculator-boundary
+decision between `rente_vs_capital_calculator.dart` and
+`financial_core/arbitrage_engine.dart`, feature flag or kill switch, widget
+tests for three axes, negative tests for signalétique axes, dossier persistence
+test, Maestro entry flow from clear state, and iPhone 13 mini proof.
+
+## Proposed Decision
+
+Remain `next_product_phase_context` after Slice 1. Ask Julien for GO before
+promotion. After GO, update the four router files in one coherent commit.

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
@@ -76,6 +76,11 @@ audit names canonical source; Maestro starts from clear state; iPhone 13 mini
 snapshot shows no clipping; dossier revisit is separate from chat; account
 handoff appears after value.
 
+The device-tier criterion below references a Slice 2 Maestro flow that does not
+exist in this planning contract. Until that artifact lands, the deterministic
+tier is the executable planning gate; device-tier output is runtime evidence
+for the implementation slice.
+
 ```verify
 # tier: deterministic
 active-context: python3 tools/checks/active_context_guard.py

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
@@ -1,0 +1,94 @@
+# Mint 2.0 First Experience Rente/Capital — Proposed Spec
+
+Status: Proposed. Not active until router promotion after explicit GO.
+
+## User Promise
+
+The user opens Mint, sees three Swiss life-event axes, enters
+`2e pilier : rente ou capital`, understands what is missing before any amount,
+and can find the answer later in a dossier entry with provenance.
+
+## Required Behavior
+
+1. No account gate before value.
+2. First surface frames Mint as dossier/navigation, not generic chat.
+3. Three axes visible: `2e pilier : rente ou capital`,
+   `Logement : 2e / 3e pilier`, `3a et rachats : impact fiscal`.
+4. Only rente/capital is live in this phase.
+5. Signalétique axes educate, save interest, and offer follow-up; they do not
+   calculate, simulate, or collect detailed unused data.
+6. Each requested field has a visible reason tied to the next answer.
+7. Any visible financial value includes value/range, unit, assumptions, sources,
+   readiness/confidence, missing fields, and calculation or constant version.
+8. Missing required inputs produce education plus missing fields, not a guessed
+   amount.
+9. Coach can navigate and explain the dossier; dossier remains independently
+   visible and revisitable.
+10. Future user-facing strings go through ARB/i18n.
+
+## Forbidden Outputs
+
+Naked financial number; imperative financial instruction; product ranking; tax
+promise; fiscal amount from a signalétique axis; housing simulation in this
+phase; default LPP amount; rare compliance branch before the event requires it;
+account creation as first value moment; silent fallback masking drift; route,
+helper, widget, or service without caller; new calculator outside canonical L1
+or L2-L4 boundary.
+
+## Synthetic Golden Inputs
+
+Synthetic only, never real user data.
+
+| ID | Situation | Expected axis | Amount? | Expected first answer |
+|---|---|---|---|---|
+| A01 | 29, first stable job, pension basics | education | No | dossier orientation, follow-up, no calculation |
+| A02 | 36, first home in VD, 2e/3e question | logement signalétique | No | tracked housing door, save interest, no simulation |
+| A03 | 47, job change, LPP transfer | education or live if explicit | only after live inputs | transfer vs decision clarification, no irrelevant compliance |
+| A04 | 58, early-retirement, rente/capital | rente/capital live | yes with required inputs | readiness first, receipt if value/range appears |
+| A05 | 63, capital or pension, no figures | rente/capital live | No | tradeoff plus missing fields, no invented LPP |
+| A06 | 41, separation, pension question | family/pension education | No | documents and next dossier steps, no formal conclusion |
+| A07 | 52, inheritance, tax impact | fiscal signalétique | No | tracked fiscal door, follow option, no tax amount |
+| A08 | 39, cross-border/new tax residence | residence facts first | no until facts and engine allow | residence facts before fiscal personalization |
+
+## Negative Cases
+
+| ID | State | Forbidden behavior |
+|---|---|---|
+| N01 | age/birth date skipped in live door | personalized amount |
+| N02 | logement selected | detailed values for unused simulation |
+| N03 | fiscal signalétique selected | tax amount |
+| N04 | no LPP amount/range | default LPP amount |
+| N05 | fresh install with Keychain residue | resurrect old conversation |
+| N06 | CHF or percent visible | missing readiness, sources, assumptions, missing fields, or version |
+| N07 | coach follow-up after result | answer stored only in chat |
+| N08 | iPhone 13 mini viewport | clipped CTA, counter, chip, sheet, or receipt text |
+
+## Acceptance Criteria
+
+Planning: canonical four files exist; no product code or router change; eight
+fixtures and eight negative cases exist; receipt requirements are explicit;
+signalétique axes have negative coverage; Slice 2 must plan feature flag or
+kill switch and iPhone 13 mini proof.
+
+Implementation after promotion: widget/provider tests prove three axes and one
+live door; negative tests block signalétique calculations; calculator-boundary
+audit names canonical source; Maestro starts from clear state; iPhone 13 mini
+snapshot shows no clipping; dossier revisit is separate from chat; account
+handoff appears after value.
+
+```verify
+# tier: deterministic
+active-context: python3 tools/checks/active_context_guard.py
+phase-contract: python3 tools/checks/phase_contract_guard.py
+no-legal-admission: python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/phases/mint-2-0-first-experience-rente-capital
+contract-diff-check: git diff --check -- .planning/phases/mint-2-0-first-experience-rente-capital
+guard-tests: python3 -m pytest tools/checks/tests/test_phase_contract_guard.py tools/checks/tests/test_verify_phase_acceptance.py -q
+# tier: device
+iphone-13-mini-runtime: bash tools/simulator/maestro_with_watchdog.sh test tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml
+```
+
+## Caveat
+
+`verify_phase_acceptance.py` reads the active spec from
+`.planning/ACTIVE_CONTEXT.json`. Before router promotion, it proves the active
+infra phase only, not this proposed Mint 2.0 contract.

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/VERIFICATION.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/VERIFICATION.md
@@ -1,0 +1,48 @@
+# Mint 2.0 First Experience Rente/Capital — Proposed Verification
+
+Status: Proposed. These checks describe the contract before promotion.
+
+## Planning Checks
+
+```bash
+git diff --check -- .planning/phases/mint-2-0-first-experience-rente-capital
+python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/phases/mint-2-0-first-experience-rente-capital
+git diff --name-only -- apps services
+python3 tools/checks/active_context_guard.py
+python3 tools/checks/phase_contract_guard.py
+python3 tools/checks/mint_rules_guard.py
+python3 tools/checks/agent_reference_guard.py
+python3 tools/checks/claude_hooks_guard.py
+python3 tools/checks/verify_phase_acceptance.py
+```
+
+`verify_phase_acceptance.py` executes the active infra `SPEC.md` until the
+router points here. Do not cite it as Mint 2.0 proof before promotion.
+
+## Future Gates
+
+G1 automated mobile: `flutter analyze`, focused Flutter tests,
+`./tools/mint-routes check` if routes change, `flutter gen-l10n` and ARB parity
+if user-facing text changes, Maestro first-entry flow, negative signalétique
+tests.
+
+G2 runtime and viewport: iPhone 13 mini simulator screenshot or UI snapshot;
+real device remains required for Keychain/iCloud restore claims.
+
+G3 calculation boundary: canonical L1 or L2-L4 source named; no UI calculation
+copy; result receipt includes assumptions, sources, readiness, missing fields,
+and version.
+
+G4 dossier continuity: answer visible outside chat; reset/new discussion clears
+local draft and conversation state; account handoff preserves or discards local
+dossier only after explicit user choice.
+
+G5 language: no banned LSFin terms, no financial number without receipt, no tax
+promise, future user-facing strings through ARB/i18n, French accents checked for
+future FR copy.
+
+## Open Blockers
+
+No Mint 2.0 runtime flow exists yet; no router promotion GO has been given;
+Keychain/iCloud restore cannot be closed by simulator alone; Slice 2 still needs
+a code-mapped plan before implementation.


### PR DESCRIPTION
## Summary

- add canonical proposed Mint 2.0 contract files: `CONTEXT.md`, `SPEC.md`, `PLAN.md`, `VERIFICATION.md`
- keep Mint 2.0 as `next_product_phase_context`; no active phase promotion
- add this contract branch to `allowed_branches` so active-context guards can run on the PR branch

## Evidence

- `python3 tools/checks/active_context_guard.py` -> exit 0
- `python3 tools/checks/phase_contract_guard.py` -> exit 0
- `python3 tools/checks/mint_rules_guard.py` -> exit 0
- `python3 tools/checks/agent_reference_guard.py` -> exit 0
- `python3 tools/checks/claude_hooks_guard.py` -> exit 0
- `python3 tools/checks/verify_phase_acceptance.py` -> exit 0 for the active infra SPEC
- `python3 -m pytest tools/checks/tests/test_active_context_guard.py tools/checks/tests/test_phase_contract_guard.py tools/checks/tests/test_mint_rules_guard.py tools/checks/tests/test_agent_reference_guard.py tools/checks/tests/test_claude_hooks_guard.py tools/checks/tests/test_verify_phase_acceptance.py -q` -> `23 passed in 0.86s`
- `git diff --check -- .planning/ACTIVE_CONTEXT.json .planning/phases/mint-2-0-first-experience-rente-capital` -> exit 0
- `python3 tools/checks/no_legal_admission_in_public_docs.py --paths .../CONTEXT.md .../SPEC.md .../PLAN.md .../VERIFICATION.md` -> `scanned 4 doc(s), 0 hits`
- `git diff --name-only -- apps services tools docs` -> empty

## Caveat

`verify_phase_acceptance.py` still executes the active infra `SPEC.md`, not the proposed Mint 2.0 `SPEC.md`, until Julien gives GO for coherent router promotion. This PR is contract-only and contains no product code.
