### PR TITLE
Mint 2.0 Slice 2A: RvC calculation receipts

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -14,7 +14,8 @@
     "codex/mint-karpathy-rules-infra-20260614",
     "codex/mint-2-first-experience-contract-20260614",
     "codex/mint-2-router-promotion-20260614",
-    "codex/mint-2-slice-2-code-map-plan-20260614"
+    "codex/mint-2-slice-2-code-map-plan-20260614",
+    "codex/mint-2-slice-2a-calculator-boundary-20260614"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
+++ b/apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart
@@ -558,7 +558,11 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
       setState(() => _result = result);
       _emitScreenReturn(result);
       return;
-    } catch (_) {
+    } catch (error) {
+      final fallbackNotice = error is ApiException &&
+              error.message.contains('receipt missing calculation version')
+          ? 'Réponse backend sans reçu : calcul local affiché'
+          : 'API backend indisponible : calcul local affiché';
       try {
         final fallback = ArbitrageEngine.compareRenteVsCapital(
           capitalLppTotal: capitalTotal,
@@ -576,6 +580,7 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
           isMarried: _isMarried,
           dataSources: _dataSources,
           canonicalConfidence: _canonicalConfidence,
+          fallbackNotice: fallbackNotice,
           currentAge: currentAge,
           grossAnnualSalary: salary,
         );
@@ -2204,13 +2209,14 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
     if (_result == null) return const SizedBox.shrink();
     final sources =
         S.of(context)!.renteVsCapitalSources(_result!.sources.join(' | '));
+    final receipt = _result!.receiptLines.join('. ');
     return Semantics(
       key: const Key('rente_vs_capital_disclaimer_card'),
       identifier: 'rente_vs_capital_disclaimer_card',
       container: true,
       focusable: true,
       label:
-          '${S.of(context)!.renteVsCapitalWarning}. ${_result!.disclaimer}. $sources',
+          '${S.of(context)!.renteVsCapitalWarning}. ${_result!.disclaimer}. $sources. $receipt',
       child: MintSurface(
         tone: MintSurfaceTone.blanc,
         padding: const EdgeInsets.all(MintSpacing.md),
@@ -2245,6 +2251,14 @@ class _RenteVsCapitalScreenState extends State<RenteVsCapitalScreen> {
               sources,
               style: MintTextStyles.micro(),
             ),
+            if (_result!.receiptLines.isNotEmpty) ...[
+              const SizedBox(height: MintSpacing.xs),
+              for (final line in _result!.receiptLines)
+                Text(
+                  line,
+                  style: MintTextStyles.micro(),
+                ),
+            ],
           ],
         ),
       ),

--- a/apps/mobile/lib/services/api_service.dart
+++ b/apps/mobile/lib/services/api_service.dart
@@ -1166,6 +1166,26 @@ class ApiService {
       response,
       const ['breakevenYear', 'breakeven_year'],
     );
+    final calculationVersion = _readString(
+      response,
+      const ['calculationVersion', 'calculation_version'],
+    );
+    if (calculationVersion.isEmpty) {
+      throw const ApiException(
+        'Backend rente/capital receipt missing calculation version',
+      );
+    }
+    final missingFields = _readStringList(
+      response,
+      const ['missingFields', 'missing_fields'],
+    );
+    final readiness = missingFields.isEmpty
+        ? ArbitrageReadiness.complete
+        : ArbitrageReadiness.blocked;
+    final receiptLines = _readStringList(
+      response,
+      const ['receiptLines', 'receipt_lines'],
+    );
 
     // ── Derive hero fields from trajectory data ──
     // full_rente (option A) year-1 cashflow = annual net rente
@@ -1241,6 +1261,18 @@ class ApiService {
       impotCumulRente: impotCumulRente,
       impotRetraitCapital: impotRetraitCapital,
       renteReelleAn20: renteReelleAn20,
+      calculationOrigin: ArbitrageCalculationOrigin.backendL2,
+      calculationVersion: calculationVersion,
+      readiness: readiness,
+      missingFields: missingFields,
+      receiptLines: receiptLines.isNotEmpty
+          ? receiptLines
+          : buildArbitrageReceiptLines(
+              origin: ArbitrageCalculationOrigin.backendL2,
+              version: calculationVersion,
+              readiness: readiness,
+              missingFields: missingFields,
+            ),
     );
   }
 

--- a/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_engine.dart
@@ -23,6 +23,9 @@ import 'package:mint_mobile/utils/chf_formatter.dart' as chf;
 class ArbitrageEngine {
   ArbitrageEngine._();
 
+  static const String renteVsCapitalCalculationVersion =
+      'mobile-l1-rente-vs-capital-v1';
+
   /// LPP art. 79b al. 3 / LIFD art. 33 al. 1 let. g : 3-year blockage
   /// between a rachat and any capital withdrawal (EPL, retraite anticipée,
   /// départ CH, retrait 3e pilier). Tribunal fédéral ATF 142 II 399
@@ -106,6 +109,7 @@ class ArbitrageEngine {
     /// par l'appelant sur le MEME profil. Quand fournie, elle devient LE score
     /// affiche par RvC — un profil = un score sur toutes les surfaces (D12).
     double? canonicalConfidence,
+    String? fallbackNotice,
     // ── Projection params (estimate mode) ──
     int? currentAge,
     double? grossAnnualSalary,
@@ -449,6 +453,15 @@ class ArbitrageEngine {
             'Apres, le capital retire peut constituer un patrimoine plus important.'
         : 'Sur l\'horizon de $horizon ans, les trajectoires ne se croisent pas. '
             'L\'ecart de valeur totale est de ${chf.formatChfWithPrefix(delta)}.';
+    const missingFields = <String>[];
+    const readiness = ArbitrageReadiness.complete;
+    final receiptLines = buildArbitrageReceiptLines(
+      origin: ArbitrageCalculationOrigin.mobileL1,
+      version: renteVsCapitalCalculationVersion,
+      readiness: readiness,
+      missingFields: missingFields,
+      fallbackNotice: fallbackNotice,
+    );
 
     return ArbitrageResult(
       options: options,
@@ -493,6 +506,11 @@ class ArbitrageEngine {
       renteSurvivant: renteSurvivant,
       capitalProjecte: effectiveCapitalTotal,
       isProjected: isProjected,
+      calculationOrigin: ArbitrageCalculationOrigin.mobileL1,
+      calculationVersion: renteVsCapitalCalculationVersion,
+      readiness: readiness,
+      missingFields: missingFields,
+      receiptLines: receiptLines,
     );
   }
 

--- a/apps/mobile/lib/services/financial_core/arbitrage_models.dart
+++ b/apps/mobile/lib/services/financial_core/arbitrage_models.dart
@@ -71,6 +71,41 @@ class RetirementAsset {
   });
 }
 
+/// Calculation origin for a rendered arbitrage result.
+enum ArbitrageCalculationOrigin {
+  mobileL1,
+  backendL2,
+}
+
+/// Whether the result can render financial figures.
+enum ArbitrageReadiness {
+  complete,
+  blocked,
+}
+
+String arbitrageOriginLabel(ArbitrageCalculationOrigin origin) {
+  return switch (origin) {
+    ArbitrageCalculationOrigin.mobileL1 => 'moteur mobile L1',
+    ArbitrageCalculationOrigin.backendL2 => 'comparaison backend L2',
+  };
+}
+
+List<String> buildArbitrageReceiptLines({
+  required ArbitrageCalculationOrigin origin,
+  required String version,
+  required ArbitrageReadiness readiness,
+  required List<String> missingFields,
+  String? fallbackNotice,
+}) {
+  return [
+    'Origine du calcul : ${arbitrageOriginLabel(origin)}',
+    'Version du calcul : $version',
+    'Statut du calcul : ${readiness == ArbitrageReadiness.complete ? 'complet' : 'bloqué'}',
+    'Champs manquants : ${missingFields.isEmpty ? 'aucun' : missingFields.join(', ')}',
+    if (fallbackNotice != null) fallbackNotice,
+  ];
+}
+
 /// Full result of an arbitrage comparison.
 class ArbitrageResult {
   /// Available options (2-4 trajectories).
@@ -135,6 +170,21 @@ class ArbitrageResult {
   /// populated, UI MUST render before any projection figure.
   final List<String> alertes;
 
+  /// Canonical calculation origin for provenance.
+  final ArbitrageCalculationOrigin calculationOrigin;
+
+  /// Version of the calculation contract used to produce the figures.
+  final String calculationVersion;
+
+  /// Whether all required fields were present for the displayed figures.
+  final ArbitrageReadiness readiness;
+
+  /// Missing required fields. Empty means the result can render figures.
+  final List<String> missingFields;
+
+  /// User-visible receipt lines shown with the result provenance.
+  final List<String> receiptLines;
+
   const ArbitrageResult({
     required this.options,
     required this.breakevenYear,
@@ -155,6 +205,11 @@ class ArbitrageResult {
     this.capitalProjecte = 0,
     this.isProjected = false,
     this.alertes = const [],
+    this.calculationOrigin = ArbitrageCalculationOrigin.mobileL1,
+    this.calculationVersion = 'legacy-unversioned',
+    this.readiness = ArbitrageReadiness.complete,
+    this.missingFields = const [],
+    this.receiptLines = const [],
   });
 }
 

--- a/apps/mobile/test/screens/arbitrage_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/arbitrage_screens_smoke_test.dart
@@ -233,6 +233,9 @@ void main() {
       expect(semantics.label, contains('LSFin'));
       expect(semantics.label, contains('LPP art. 14'));
       expect(semantics.label, contains('LIFD art. 38'));
+      expect(semantics.label, contains('Origine du calcul : moteur mobile L1'));
+      expect(semantics.label,
+          contains('Version du calcul : mobile-l1-rente-vs-capital-v1'));
     });
 
     test('warning label is localized in the 6 supported locales', () async {

--- a/apps/mobile/test/screens/rente_vs_capital_defaults_test.dart
+++ b/apps/mobile/test/screens/rente_vs_capital_defaults_test.dart
@@ -35,7 +35,6 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/arbitrage/rente_vs_capital_screen.dart';
-import 'package:mint_mobile/services/financial_core/arbitrage_engine.dart';
 
 GoalA _testGoalA() => GoalA(
       type: GoalAType.retraite,
@@ -146,8 +145,6 @@ void main() {
       expect(find.text(emptyCopy), findsOneWidget,
           reason: 'explicit empty-state invitation must render when no '
               'usable profile data exists');
-      expect(find.byKey(const Key('rente_vs_capital_disclaimer_card')),
-          findsNothing);
     },
   );
 
@@ -195,37 +192,6 @@ void main() {
           reason: 'real profile LPP must prefill the field');
       expect(fieldTexts, isNot(contains('350000')),
           reason: 'fiction default must never coexist with a real value');
-    },
-  );
-
-  testWidgets(
-    'local fallback result exposes origin and version in the receipt',
-    (tester) async {
-      tester.view.physicalSize = const Size(800, 1600);
-      addTearDown(tester.view.resetPhysicalSize);
-
-      final provider = CoachProfileProvider()
-        ..updateProfile(_profileWithEstimatedLpp());
-      await tester.pumpWidget(_wrap(provider));
-      await tester.pump(const Duration(milliseconds: 350));
-      await tester
-          .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
-      await tester.pumpAndSettle();
-
-      final card = find.byKey(const Key('rente_vs_capital_disclaimer_card'));
-      await tester.scrollUntilVisible(card, 500,
-          scrollable: find.byType(Scrollable).first);
-      await tester.pump();
-
-      final label = tester.getSemantics(card).label;
-      for (final expected in [
-        'Origine du calcul : moteur mobile L1',
-        'Version du calcul : ${ArbitrageEngine.renteVsCapitalCalculationVersion}',
-        'Champs manquants : aucun',
-        'API backend indisponible : calcul local affiché',
-      ]) {
-        expect(label, contains(expected));
-      }
     },
   );
 }

--- a/apps/mobile/test/screens/rente_vs_capital_defaults_test.dart
+++ b/apps/mobile/test/screens/rente_vs_capital_defaults_test.dart
@@ -35,6 +35,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/arbitrage/rente_vs_capital_screen.dart';
+import 'package:mint_mobile/services/financial_core/arbitrage_engine.dart';
 
 GoalA _testGoalA() => GoalA(
       type: GoalAType.retraite,
@@ -145,6 +146,8 @@ void main() {
       expect(find.text(emptyCopy), findsOneWidget,
           reason: 'explicit empty-state invitation must render when no '
               'usable profile data exists');
+      expect(find.byKey(const Key('rente_vs_capital_disclaimer_card')),
+          findsNothing);
     },
   );
 
@@ -192,6 +195,37 @@ void main() {
           reason: 'real profile LPP must prefill the field');
       expect(fieldTexts, isNot(contains('350000')),
           reason: 'fiction default must never coexist with a real value');
+    },
+  );
+
+  testWidgets(
+    'local fallback result exposes origin and version in the receipt',
+    (tester) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final provider = CoachProfileProvider()
+        ..updateProfile(_profileWithEstimatedLpp());
+      await tester.pumpWidget(_wrap(provider));
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester
+          .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 100)));
+      await tester.pumpAndSettle();
+
+      final card = find.byKey(const Key('rente_vs_capital_disclaimer_card'));
+      await tester.scrollUntilVisible(card, 500,
+          scrollable: find.byType(Scrollable).first);
+      await tester.pump();
+
+      final label = tester.getSemantics(card).label;
+      for (final expected in [
+        'Origine du calcul : moteur mobile L1',
+        'Version du calcul : ${ArbitrageEngine.renteVsCapitalCalculationVersion}',
+        'Champs manquants : aucun',
+        'API backend indisponible : calcul local affiché',
+      ]) {
+        expect(label, contains(expected));
+      }
     },
   );
 }

--- a/apps/mobile/test/services/api_service_test.dart
+++ b/apps/mobile/test/services/api_service_test.dart
@@ -10,29 +10,12 @@ import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
 import 'package:mint_mobile/services/observability/mint_http_client.dart';
 
 Map<String, dynamic> _rvcResponse({bool versioned = true}) => {
-      'options': [
-        {'id': 'full_rente', 'label': 'Rente', 'trajectory': [{'year': 65, 'netPatrimony': 0, 'annualCashflow': 24000, 'cumulativeTaxDelta': 1200}], 'terminalValue': 0, 'cumulativeTaxImpact': 1200},
-        {'id': 'full_capital', 'label': 'Capital', 'trajectory': [{'year': 65, 'netPatrimony': 500000, 'annualCashflow': 20000, 'cumulativeTaxDelta': 18000}], 'terminalValue': 500000, 'cumulativeTaxImpact': 18000},
-      ],
-      'breakevenYear': -1,
-      'premierEclairage': 'Comparaison backend.',
-      'displaySummary': 'Synthese backend.',
-      'hypotheses': ['Canton ZH'],
-      'disclaimer': 'Outil educatif.',
-      'sources': ['LPP art. 37', 'LIFD art. 38'],
-      'confidenceScore': 80,
-      'sensitivity': {},
+      'options': <Map<String, dynamic>>[],
       if (versioned) 'calculationVersion': 'backend-l2-rente-vs-capital-v1',
-      'missingFields': [],
-      'receiptLines': [
-        'Origine du calcul : comparaison backend L2',
-        'Version du calcul : backend-l2-rente-vs-capital-v1',
-        'Statut du calcul : complet',
-        'Champs manquants : aucun',
-      ],
+      'receiptLines': ['Origine du calcul : comparaison backend L2'],
     };
 
-Future<void> _mockRvcResponse(bool versioned) async {
+void _mockRvcResponse(bool versioned) {
   ApiService.setHttpClientForTesting(MintHttpClient(MockClient((request) async {
     expect(request.url.path, '/api/v1/arbitrage/rente-vs-capital');
     return http.Response(jsonEncode(_rvcResponse(versioned: versioned)), 200,
@@ -214,18 +197,19 @@ void main() {
 
   group('ApiService — rente vs capital receipt', () {
     test('parses backend receipt version and origin', () async {
-      await _mockRvcResponse(true);
+      _mockRvcResponse(true);
       final result = await _callRvc();
 
       expect(result.calculationOrigin, ArbitrageCalculationOrigin.backendL2);
       expect(result.calculationVersion, 'backend-l2-rente-vs-capital-v1');
       expect(result.readiness, ArbitrageReadiness.complete);
       expect(result.missingFields, isEmpty);
-      expect(result.receiptLines, contains('Origine du calcul : comparaison backend L2'));
+      expect(result.receiptLines,
+          contains('Origine du calcul : comparaison backend L2'));
     });
 
     test('rejects backend receipt without calculation version', () async {
-      await _mockRvcResponse(false);
+      _mockRvcResponse(false);
       expect(
         _callRvc,
         throwsA(isA<ApiException>().having(

--- a/apps/mobile/test/services/api_service_test.dart
+++ b/apps/mobile/test/services/api_service_test.dart
@@ -1,9 +1,52 @@
+import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/financial_core/arbitrage_models.dart';
 import 'package:mint_mobile/services/observability/mint_http_client.dart';
+
+Map<String, dynamic> _rvcResponse({bool versioned = true}) => {
+      'options': [
+        {'id': 'full_rente', 'label': 'Rente', 'trajectory': [{'year': 65, 'netPatrimony': 0, 'annualCashflow': 24000, 'cumulativeTaxDelta': 1200}], 'terminalValue': 0, 'cumulativeTaxImpact': 1200},
+        {'id': 'full_capital', 'label': 'Capital', 'trajectory': [{'year': 65, 'netPatrimony': 500000, 'annualCashflow': 20000, 'cumulativeTaxDelta': 18000}], 'terminalValue': 500000, 'cumulativeTaxImpact': 18000},
+      ],
+      'breakevenYear': -1,
+      'premierEclairage': 'Comparaison backend.',
+      'displaySummary': 'Synthese backend.',
+      'hypotheses': ['Canton ZH'],
+      'disclaimer': 'Outil educatif.',
+      'sources': ['LPP art. 37', 'LIFD art. 38'],
+      'confidenceScore': 80,
+      'sensitivity': {},
+      if (versioned) 'calculationVersion': 'backend-l2-rente-vs-capital-v1',
+      'missingFields': [],
+      'receiptLines': [
+        'Origine du calcul : comparaison backend L2',
+        'Version du calcul : backend-l2-rente-vs-capital-v1',
+        'Statut du calcul : complet',
+        'Champs manquants : aucun',
+      ],
+    };
+
+Future<void> _mockRvcResponse(bool versioned) async {
+  ApiService.setHttpClientForTesting(MintHttpClient(MockClient((request) async {
+    expect(request.url.path, '/api/v1/arbitrage/rente-vs-capital');
+    return http.Response(jsonEncode(_rvcResponse(versioned: versioned)), 200,
+        headers: {'content-type': 'application/json'});
+  })));
+}
+
+Future<ArbitrageResult> _callRvc() => ApiService.compareRenteVsCapital(
+      capitalLppTotal: 500000,
+      capitalObligatoire: 300000,
+      capitalSurobligatoire: 200000,
+      renteAnnuelleProposee: 30000,
+      canton: 'ZH',
+    );
 
 /// Unit tests for ApiService
 ///
@@ -15,8 +58,16 @@ import 'package:mint_mobile/services/observability/mint_http_client.dart';
 /// - Class structure and method signatures
 /// - Endpoint path conventions
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    AuthService.resetMemoryCacheForTest();
+    FlutterSecureStorage.setMockInitialValues({'jwt_token': 'test-token'});
+  });
+
   tearDown(() {
     ApiService.setHttpClientForTesting(null);
+    AuthService.resetMemoryCacheForTest();
   });
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -158,6 +209,31 @@ void main() {
       expect(response['id'], 'user-42');
       expect(captured?.url.path, '/api/v1/auth/me');
       expect(captured?.headers['Authorization'], 'Bearer fresh-token');
+    });
+  });
+
+  group('ApiService — rente vs capital receipt', () {
+    test('parses backend receipt version and origin', () async {
+      await _mockRvcResponse(true);
+      final result = await _callRvc();
+
+      expect(result.calculationOrigin, ArbitrageCalculationOrigin.backendL2);
+      expect(result.calculationVersion, 'backend-l2-rente-vs-capital-v1');
+      expect(result.readiness, ArbitrageReadiness.complete);
+      expect(result.missingFields, isEmpty);
+      expect(result.receiptLines, contains('Origine du calcul : comparaison backend L2'));
+    });
+
+    test('rejects backend receipt without calculation version', () async {
+      await _mockRvcResponse(false);
+      expect(
+        _callRvc,
+        throwsA(isA<ApiException>().having(
+          (error) => error.message,
+          'message',
+          contains('receipt missing calculation version'),
+        )),
+      );
     });
   });
 

--- a/apps/mobile/test/services/financial_core/arbitrage_engine_hero_fields_test.dart
+++ b/apps/mobile/test/services/financial_core/arbitrage_engine_hero_fields_test.dart
@@ -223,5 +223,23 @@ void main() {
       final ids = certResult.options.map((o) => o.id).toSet();
       expect(ids, containsAll(['full_rente', 'full_capital', 'mixed']));
     });
+
+    test('calculation receipt exposes origin, version, and missing fields', () {
+      expect(certResult.calculationOrigin, ArbitrageCalculationOrigin.mobileL1);
+      expect(
+        certResult.calculationVersion,
+        ArbitrageEngine.renteVsCapitalCalculationVersion,
+      );
+      expect(certResult.readiness, ArbitrageReadiness.complete);
+      expect(certResult.missingFields, isEmpty);
+      final receipt = certResult.receiptLines.join('\n');
+      expect(receipt, contains('Origine du calcul : moteur mobile L1'));
+      expect(
+        receipt,
+        contains('Version du calcul : '
+            '${ArbitrageEngine.renteVsCapitalCalculationVersion}'),
+      );
+      expect(receipt, contains('Champs manquants : aucun'));
+    });
   });
 }

--- a/services/backend/app/api/v1/endpoints/arbitrage.py
+++ b/services/backend/app/api/v1/endpoints/arbitrage.py
@@ -57,6 +57,8 @@ from app.services.arbitrage import (
 
 router = APIRouter()
 
+RENTE_VS_CAPITAL_CALCULATION_VERSION = "backend-l2-rente-vs-capital-v1"
+
 
 def _option_to_schema(option) -> TrajectoireOptionSchema:
     """Convert service TrajectoireOption dataclass to Pydantic schema."""
@@ -90,6 +92,15 @@ def _result_to_response(result, response_class):
         confidence_score=result.confidence_score,
         sensitivity=result.sensitivity,
     )
+
+
+def _rente_vs_capital_receipt_lines() -> list[str]:
+    return [
+        "Origine du calcul : comparaison backend L2",
+        f"Version du calcul : {RENTE_VS_CAPITAL_CALCULATION_VERSION}",
+        "Statut du calcul : complet",
+        "Champs manquants : aucun",
+    ]
 
 
 @router.post("/rente-vs-capital", response_model=RenteVsCapitalResponse)
@@ -182,7 +193,11 @@ def arbitrage_rente_vs_capital(
             ),
         )
 
-        return _result_to_response(result, RenteVsCapitalResponse)
+        response = _result_to_response(result, RenteVsCapitalResponse)
+        response.calculation_version = RENTE_VS_CAPITAL_CALCULATION_VERSION
+        response.missing_fields = []
+        response.receipt_lines = _rente_vs_capital_receipt_lines()
+        return response
 
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid request parameters")

--- a/services/backend/app/schemas/arbitrage.py
+++ b/services/backend/app/schemas/arbitrage.py
@@ -170,7 +170,18 @@ class RenteVsCapitalRequest(ArbitrageBaseModel):
 
 class RenteVsCapitalResponse(ArbitrageResultSchema):
     """Resultat de la comparaison rente vs capital LPP."""
-    pass
+    calculation_version: str = Field(
+        default="",
+        description="Version du contrat de calcul utilise pour les chiffres",
+    )
+    missing_fields: List[str] = Field(
+        default_factory=list,
+        description="Champs requis manquants; vide quand le calcul peut s'afficher",
+    )
+    receipt_lines: List[str] = Field(
+        default_factory=list,
+        description="Recu utilisateur: origine, version, statut et champs manquants",
+    )
 
 
 # ===========================================================================

--- a/services/backend/tests/test_arbitrage_rente_vs_capital_receipt.py
+++ b/services/backend/tests/test_arbitrage_rente_vs_capital_receipt.py
@@ -1,0 +1,13 @@
+def test_rente_vs_capital_success_includes_receipt(client):
+    resp = client.post(
+        "/api/v1/arbitrage/rente-vs-capital",
+        json={"capital_lpp_total": 500000, "capital_obligatoire": 300000,
+              "capital_surobligatoire": 200000,
+              "rente_annuelle_proposee": 30000, "canton": "ZH"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["calculationVersion"] == "backend-l2-rente-vs-capital-v1"
+    assert body["missingFields"] == []
+    assert "Origine du calcul : comparaison backend L2" in body["receiptLines"]
+    assert "Champs manquants : aucun" in body["receiptLines"]

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -19702,6 +19702,12 @@
             "title": "Breakevenyear",
             "type": "integer"
           },
+          "calculationVersion": {
+            "default": "",
+            "description": "Version du contrat de calcul utilise pour les chiffres",
+            "title": "Calculationversion",
+            "type": "string"
+          },
           "confidenceScore": {
             "description": "Score de confiance (0-100%)",
             "title": "Confidencescore",
@@ -19725,6 +19731,14 @@
             "title": "Hypotheses",
             "type": "array"
           },
+          "missingFields": {
+            "description": "Champs requis manquants; vide quand le calcul peut s'afficher",
+            "items": {
+              "type": "string"
+            },
+            "title": "Missingfields",
+            "type": "array"
+          },
           "options": {
             "description": "Liste des options comparees",
             "items": {
@@ -19737,6 +19751,14 @@
             "description": "Chiffre choc: delta le plus marquant",
             "title": "Premiereclairage",
             "type": "string"
+          },
+          "receiptLines": {
+            "description": "Recu utilisateur: origine, version, statut et champs manquants",
+            "items": {
+              "type": "string"
+            },
+            "title": "Receiptlines",
+            "type": "array"
           },
           "sensitivity": {
             "additionalProperties": {
@@ -25819,7 +25841,7 @@
     },
     "/api/v1/auth/apple/verify": {
       "post": {
-        "description": "Verify an Apple identity token and return a JWT access token.\n\nMVP verification: decode JWT payload and check issuer + audience.\nProduction: validate signature against Apple's public keys\n(https://appleid.apple.com/auth/keys).\n\nRate limited to 5 requests/minute per IP (T-01-11).",
+        "description": "Verify an Apple identity token and return a JWT access token.\n\nVerifies the token signature against Apple's JWKS, then enforces issuer,\naudience, expiry, and SHA-256 nonce binding.\n\nRate limited to 5 requests/minute per IP (T-01-11).",
         "operationId": "apple_verify_api_v1_auth_apple_verify_post",
         "requestBody": {
           "content": {


### PR DESCRIPTION
## Scope
- Add mobile/backend receipt fields for rente-vs-capital calculation origin, version, readiness, and missing fields.
- Require backend RvC responses to carry calculationVersion before mobile accepts them.
- Surface local fallback reasons in the RvC disclaimer receipt.
- Update the canonical OpenAPI contract for the backend response schema.
- Keep this PR under 300 changed lines; legacy domain adapter follow-up is split out.

## Evidence
- flutter test test/services/api_service_test.dart test/services/financial_core/arbitrage_engine_hero_fields_test.dart test/services/financial_core/arbitrage_engine_fields_test.dart test/services/confidence/confidence_source_unification_test.dart test/screens/rente_vs_capital_defaults_test.dart test/screens/rente_vs_capital_prefill_test.dart test/screens/rente_vs_capital_semantics_test.dart test/screens/arbitrage_screens_smoke_test.dart — exit 0, 118 tests
- flutter analyze — exit 0
- python3 -m pytest services/backend/tests/test_arbitrage_rente_vs_capital_receipt.py services/backend/tests/test_rente_vs_capital.py -q — exit 0, 23 tests
- ruff check services/backend/app/api/v1/endpoints/arbitrage.py services/backend/app/schemas/arbitrage.py services/backend/tests/test_arbitrage_rente_vs_capital_receipt.py — exit 0
- Guards: active_context_guard, phase_contract_guard, mint_rules_guard, agent_reference_guard, claude_hooks_guard, verify_phase_acceptance — exit 0
- git diff --check — exit 0
- Branch diff versus origin/dev: 12 files changed, 268 insertions(+), 6 deletions(-)
- Claude CLI re-review: no P0/P1 finding after backend receipt emission was added

## Caveats
- No iPhone 13 mini simulator runtime evidence in this PR.
- Receipt text follows existing backend/engine French-string precedent; ARB/i18n extraction remains future work.
- OpenAPI regeneration also includes the generated Apple auth description drift already produced by the backend app schema.
- Legacy domain adapter conversion is preserved separately in stash `slice2a-domain-adapter-follow-up`.
