### PR TITLE
feat: route Mint 2 live axis to RvC

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -16,7 +16,8 @@
     "codex/mint-2-router-promotion-20260614",
     "codex/mint-2-slice-2-code-map-plan-20260614",
     "feature/mint2-slice-2a-calculator-boundary",
-    "feature/mint2-variable-contract-drift"
+    "feature/mint2-variable-contract-drift",
+    "feature/mint2-live-axis-bridge"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
@@ -594,7 +594,7 @@ class _Mint2AxesStep extends StatelessWidget {
                   onTap: () {
                     provider.setAxisV2(item.axis, item.label);
                     if (item.axis == OnboardingAxisV2.lppRenteCapital) {
-                      provider.advance();
+                      context.go('/rente-vs-capital');
                     }
                   },
                 );
@@ -612,7 +612,7 @@ class _Mint2AxesStep extends StatelessWidget {
                   OnboardingAxisV2.lppRenteCapital,
                   l10n.mint2FirstExperienceLppLabel,
                 );
-                provider.advance();
+                context.go('/rente-vs-capital');
               },
             ),
           ],

--- a/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
+
+Widget _wrap(GoRouter router) {
+  return MaterialApp.router(
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    routerConfig: router,
+  );
+}
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: '/onb',
+    routes: [
+      GoRoute(
+        path: '/onb',
+        builder: (context, state) => const OnboardingShellScreen(),
+      ),
+      GoRoute(
+        path: '/rente-vs-capital',
+        builder: (context, state) => const Scaffold(
+          body: Center(
+            child: Text('RvC route sentinel', key: ValueKey('rvc-sentinel')),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+Future<void> _openAxes(WidgetTester tester, GoRouter router) async {
+  await tester.pumpWidget(_wrap(router));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const ValueKey('onboarding-entry-open')));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+    FeatureFlags.enableMint2FirstExperienceEntry = true;
+  });
+
+  tearDown(() {
+    FeatureFlags.enableMint2FirstExperienceEntry = false;
+  });
+
+  testWidgets('live Mint 2 axis routes directly to the RvC gate',
+      (tester) async {
+    final router = _router();
+
+    await _openAxes(tester, router);
+    await tester
+        .tap(find.byKey(const ValueKey('mint2-axis-lpp_rente_capital')));
+    await tester.pumpAndSettle();
+
+    expect(router.routerDelegate.currentConfiguration.uri.path,
+        '/rente-vs-capital');
+    expect(find.byKey(const ValueKey('rvc-sentinel')), findsOneWidget);
+    expect(find.byType(OnboardingShellScreen), findsNothing);
+  });
+}

--- a/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_signal_axes_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_signal_axes_test.dart
@@ -3,15 +3,15 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 
-Widget _wrap() {
-  return MaterialApp(
-    key: UniqueKey(),
+Widget _wrap(GoRouter router) {
+  return MaterialApp.router(
     locale: const Locale('fr'),
     localizationsDelegates: const [
       S.delegate,
@@ -20,15 +20,37 @@ Widget _wrap() {
       GlobalCupertinoLocalizations.delegate,
     ],
     supportedLocales: S.supportedLocales,
-    home: const OnboardingShellScreen(),
+    routerConfig: router,
   );
 }
 
-Future<void> _openAxes(WidgetTester tester) async {
-  await tester.pumpWidget(_wrap());
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: '/onb',
+    routes: [
+      GoRoute(
+        path: '/onb',
+        builder: (context, state) => const OnboardingShellScreen(),
+      ),
+      GoRoute(
+        path: '/rente-vs-capital',
+        builder: (context, state) => const Scaffold(
+          body: Center(
+            child: Text('RvC route sentinel', key: ValueKey('rvc-sentinel')),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+Future<GoRouter> _openAxes(WidgetTester tester) async {
+  final router = _router();
+  await tester.pumpWidget(_wrap(router));
   await tester.pumpAndSettle();
   await tester.tap(find.byKey(const ValueKey('onboarding-entry-open')));
   await tester.pumpAndSettle();
+  return router;
 }
 
 void main() {
@@ -104,7 +126,7 @@ void main() {
 
   testWidgets('signal axis exposes a forward path to the live RvC gate',
       (tester) async {
-    await _openAxes(tester);
+    final router = await _openAxes(tester);
 
     await tester.tap(find.text('Logement : 2e / 3e pilier').first);
     await tester.pumpAndSettle();
@@ -116,6 +138,9 @@ void main() {
     await tester.tap(continueLive);
     await tester.pumpAndSettle();
 
+    expect(router.routerDelegate.currentConfiguration.uri.path,
+        '/rente-vs-capital');
+    expect(find.byKey(const ValueKey('rvc-sentinel')), findsOneWidget);
     expect(
       find.text('Choisis le sujet que tu veux éclairer d\'abord.'),
       findsNothing,


### PR DESCRIPTION
## Summary
- Route the live Mint 2 LPP/rente-capital axis directly to the RvC gate.
- Route the signal-axis continue-live path to the same RvC gate.
- Add router-backed widget coverage proving the live route leaves the onboarding shell.

## Test Plan
- python3 tools/checks/mint_variable_contract_extract.py --check
- python3 tools/checks/mint_variable_dictionary_lint.py --check
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/agent_reference_guard.py
- python3 tools/checks/claude_hooks_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- python3 tools/checks/prefer_mint_cta.py
- python3 tools/checks/prefer_mint_color_token.py
- python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/ACTIVE_CONTEXT.json apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_signal_axes_test.dart apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart
- git diff --check
- git diff --cached --check
- flutter analyze
- flutter test test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart test/screens/onboarding/mvp_wedge/mint2_first_experience_axes_test.dart test/screens/onboarding/mvp_wedge/mint2_first_experience_signal_axes_test.dart test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart test/screens/onboarding/mvp_wedge/mint2_first_experience_intent_migration_test.dart

## Scope
- No ARB or generated l10n changes.
- No financial calculation or receipt logic changes.
- No backend changes.