### PR TITLE
docs: authorize autonomous skill access

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-06-17",
+  "updated": "2026-06-18",
   "active_milestone": "mint-2-0-first-experience-rente-capital",
   "active_phase_dir": ".planning/phases/mint-2-0-first-experience-rente-capital",
   "active_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md",
@@ -19,7 +19,8 @@
     "feature/mint2-variable-contract-drift",
     "feature/mint2-live-axis-bridge",
     "feature/mint2-fix-cryptography-audit",
-    "feature/mint2-rvc-proof-blockers"
+    "feature/mint2-rvc-proof-blockers",
+    "docs/agent-skill-authority"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,24 @@ rampart. After ship:
 - **Phase 30.7 MCP tools** → Swiss constants / banned-terms /
   ARB-parity as on-demand tools (stop bloating agent context with rules)
 
+## Skill repository authority
+
+Agents are explicitly authorized to read and use every skill repository needed
+for the current task when the path is present and readable: repo-local
+`.agents/skills`, `.claude/skills`, `.codex/skills`, user-level
+`~/.codex/skills`, `~/.agents/skills`, and installed plugin skill caches
+exposed by the session.
+
+This authorization is autonomous. Do not ask for per-skill permission, and do
+not claim a skill repository is inaccessible before checking the concrete path.
+If a skill path is unreadable, report the exact path and continue with the
+closest local fallback.
+
+Skill repositories are method/tooling authority only. They do not override
+MINT product truth: the approved worktree, checked-in governance, current code,
+local tests, and deterministic runtime evidence remain authoritative for
+product behavior.
+
 ## 🤝 Session handshake — run these in order, every time
 
 1. Read curator memory from `$HOME/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/MEMORY.md`; if missing, stop instead of continuing blind.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -38,6 +38,18 @@ Ordre d'autorité pour l'intention produit, la doctrine et les contraintes :
 Engram évite de redécouvrir. Il ne surpasse jamais le repo.
 Si doc et code divergent, ne pas choisir par intuition : citer les deux chemins, ouvrir un finding, puis corriger la source fautive.
 
+Accès skills : les agents ont l'autorisation explicite et autonome de lire et
+d'utiliser tous les skills nécessaires lorsque les chemins existent et sont
+lisibles : `.agents/skills`, `.claude/skills`, `.codex/skills`,
+`~/.codex/skills`, `~/.agents/skills`, et les caches de plugins exposés par la
+session. Ne pas redemander une permission par skill. Ne pas déclarer un repo de
+skills inaccessible sans avoir testé le chemin concret. Si un chemin est
+illisible, citer le chemin exact et utiliser le meilleur fallback local.
+
+Cette autorisation ne change pas l'autorité produit : un skill est méthode et
+outillage, jamais source produit supérieure au worktree approuvé, aux règles
+checked-in, au code courant, aux tests locaux et aux preuves runtime.
+
 Current phase pointer lives in `.planning/ACTIVE_CONTEXT.md`,
 `.planning/ACTIVE_CONTEXT.json`, and `.planning/STATE.md`. As of 2026-06-14,
 product code is frozen until `.planning/phases/mint-karpathy-rules-infra-20260614/`


### PR DESCRIPTION
## Summary
- Authorize agents to read and use required local/user/plugin skill repositories without per-skill permission prompts.
- Preserve product authority boundaries: skills are method/tooling only, not product truth.
- Allow this docs branch in the active context so guards pass.

## Test Plan
- [x] git diff --check
- [x] python3 tools/checks/active_context_guard.py
- [x] python3 tools/checks/phase_contract_guard.py
- [x] python3 tools/checks/mint_rules_guard.py
- [x] python3 tools/checks/doctrine_atomicity_gate.py --base origin/dev --head HEAD
- [x] python3 tools/checks/doctrine_consistency_check.py
- [x] lefthook pre-commit guards