### PR TITLE
Clarify agent tooling autonomy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,26 @@ MINT product truth: the approved worktree, checked-in governance, current code,
 local tests, and deterministic runtime evidence remain authoritative for
 product behavior.
 
+## Tooling autonomy of good sense
+
+When the current objective is already authorized, agents may autonomously use
+the tools needed to finish it: Engram MCP memory, local skills, repo checks,
+GitHub read/PR commands, feature-branch pushes, specialist panels, Maestro,
+`simctl`, `idb`, and xcodebuildmcp / Build iOS Apps when available.
+
+This is not permission to bypass product gates. Ask first for protected-branch
+pushes, merges, destructive Git operations, real user data, legal/compliance
+claims, new regulated financial sources, or anything listed in `rules.md`
+`ASK FIRST`.
+
+Claude Max is advisory. Use it when the local CLI/session or a fresh artifact
+is actually available and the task benefits from it; otherwise continue with
+the local expert panel and say that Claude Max was not available. Never present
+a local panel as Claude Max.
+
 ## 🤝 Session handshake — run these in order, every time
 
-1. Read curator memory from `$HOME/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/MEMORY.md`; if missing, stop instead of continuing blind.
+1. Read curator memory from `$HOME/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/MEMORY.md` when present. If missing, report it, recover with Engram MCP (`mem_context` / `mem_search`) plus checked-in docs, and continue unless the task explicitly depends on that private memory.
 2. Read [`CLAUDE.md`](CLAUDE.md) (auto-loaded).
 3. Read this file.
 4. Read [`docs/MINT_AGENT_WORKFLOW.md`](docs/MINT_AGENT_WORKFLOW.md) for the Claude/Codex/GSD/Engram workflow.

--- a/docs/AGENTS/ENGRAM.md
+++ b/docs/AGENTS/ENGRAM.md
@@ -8,6 +8,9 @@
 - **Don't save** : code patterns derivable from `git blame`, ephemeral state, content already in `CLAUDE.md`/`docs/`.
 - **Tag** : `topic_key: <phase-or-area>:<sub-area>:<specific>` (e.g. `wave-1a:00:backend-architect:review`).
 - **Link** : every save cites `prior_finding_refs: [obs_id, ...]` when building on past work — this is the **compounding observable** gated 2026-05-21 for vibe-coding Phase 1.
+- **Use MCP first** : `mem_*` tools are the normal path. Do not stop because a
+  private `MEMORY.md` file is missing; recover with `mem_context` /
+  `mem_search`, then report the gap.
 
 ## 1. What goes IN
 
@@ -138,6 +141,10 @@ Each `wshobson` agent (36 specialists in `.claude/agents/`) has `memory: local` 
 2. **Per task** : agent calls `mem_search` to load prior context, references obs_ids in its work.
 3. **Per finding** : agent calls `mem_save` with the right type + topic_key + prior_finding_refs. Conflicts are auto-judged silently when low-stakes.
 4. **Session end** : `mem_session_summary` records goal + discoveries + accomplished + next steps + relevant files.
+
+If private curator memory is missing or stale, that is a recoverable context
+gap, not a default STOP. Current repo files and deterministic evidence remain
+authoritative; Engram MCP supplies the durable memory fallback.
 
 ## 8. Where the data lives
 

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -38,13 +38,27 @@ Ordre d'autorité pour l'intention produit, la doctrine et les contraintes :
 Engram évite de redécouvrir. Il ne surpasse jamais le repo.
 Si doc et code divergent, ne pas choisir par intuition : citer les deux chemins, ouvrir un finding, puis corriger la source fautive.
 
+Autorisation d'outillage : quand l'objectif courant est autorisé, les agents
+peuvent utiliser sans redemande les outils nécessaires à la preuve et à la
+livraison : Engram MCP, skills locales, checks repo, commandes GitHub de lecture
+ou de PR, pushes de branches feature, panels de spécialistes, Maestro, `simctl`,
+`idb`, xcodebuildmcp / Build iOS Apps si exposés. Les exceptions restent celles
+de `rules.md` : branches protégées, merge, opérations Git destructrices,
+données réelles, claims juridiques/compliance, nouvelles sources financières
+réglementées.
+
+Claude Max est advisory. L'utiliser si un CLI/session local ou un artefact
+d'audit frais est disponible et utile au risque du travail. Son absence ne
+bloque pas sauf gate explicite de Julien; dans ce cas, dire clairement
+`Claude Max indisponible` au lieu de substituer un panel local.
+
 Accès skills : les agents ont l'autorisation explicite et autonome de lire et
 d'utiliser tous les skills nécessaires lorsque les chemins existent et sont
 lisibles : `.agents/skills`, `.claude/skills`, `.codex/skills`,
 `~/.codex/skills`, `~/.agents/skills`, et les caches de plugins exposés par la
 session. Ne pas redemander une permission par skill. Ne pas déclarer un repo de
 skills inaccessible sans avoir testé le chemin concret. Si un chemin est
-illisible, citer le chemin exact et utiliser le meilleur fallback local.
+illisible, citer le chemin exact et utiliser le fallback local le plus adapté.
 
 Cette autorisation ne change pas l'autorité produit : un skill est méthode et
 outillage, jamais source produit supérieure au worktree approuvé, aux règles
@@ -94,7 +108,7 @@ Périmètres : Flutter reste dans `apps/mobile/`; backend reste dans `services/b
 ```bash
 git status --short --branch
 MEM="$HOME/.claude/projects/-Users-julienbattaglia-Desktop-MINT-nosync/memory/MEMORY.md"
-sed -n '1,220p' "$MEM" || { echo "MEMORY.md introuvable: STOP"; exit 1; }
+test -f "$MEM" && sed -n '1,220p' "$MEM" || echo "MEMORY.md introuvable: fallback Engram MCP + repo docs"
 sed -n '1,220p' CLAUDE.md
 sed -n '1,260p' AGENTS.md
 sed -n '1,220p' .planning/ACTIVE_CONTEXT.md
@@ -106,6 +120,8 @@ python3 tools/checks/mint_rules_guard.py
 Puis `mem_context(project="mint")` et
 `mem_search(query="<zone touchée>", project="mint")`. `mem_current_project`
 peut aider au diagnostic, mais le protocole de reprise ne dépend pas de lui.
+Si la mémoire curateur est absente, ne pas stopper automatiquement : continuer
+avec Engram MCP et les règles checked-in, puis noter le trou dans le rapport.
 
 2. Lire le doc de domaine avant code : coach -> `docs/coach-tool-routing.md`; profil/scan/budget -> `docs/data-flow.md`; calcul -> `docs/calculator-graph.md`; route -> `apps/mobile/lib/routes/route_metadata.dart`; i18n -> `apps/mobile/lib/l10n/app_*.arb`.
 
@@ -285,7 +301,7 @@ Décision produit courante : trois axes visibles, une seule porte live.
 | `Logement : 2e / 3e pilier` | Signalétique | explication, notification, suivi | chiffres, simulation, collecte non utilisée, promesse de décision |
 | `3a et rachats : impact fiscal` | Signalétique | explication prudente, données manquantes, notification | avantage fiscal promis, langage de promesse fiscale, montant fiscal sans moteur et sources |
 
-Slug recommandé : `/gsd:plan-phase mint-2-0-first-experience-rente-capital`.
+Slug de référence : `/gsd:plan-phase mint-2-0-first-experience-rente-capital`.
 
 Contrat utilisateur : l'utilisateur ouvre l'app, voit trois axes, entre par `2e pilier : rente ou capital`, fournit le minimum requis ou voit ce qui manque, reçoit un résultat chiffré seulement si le calcul est défendable, voit sources/hypothèses/readiness/version, puis revient aux deux autres axes comme signalétiques sans faux chiffre.
 

--- a/rules.md
+++ b/rules.md
@@ -19,6 +19,35 @@ explicit confirmation, and what must be refused.
 If sources disagree, stop product work, cite both paths, and fix the stale
 source instead of guessing.
 
+## Autonomous Tooling Authority
+
+Agents may use the normal Mint toolchain without asking for per-tool
+permission when it materially advances the current authorized objective:
+
+- read repo-local, user-level, and plugin skill repositories when paths are
+  present and readable;
+- use Engram MCP tools (`mem_context`, `mem_search`, `mem_save`,
+  `mem_session_summary`) for memory recovery and durable observations;
+- run local checks, tests, lints, route guards, banned-term/accent/i18n guards,
+  and read-only Git/GitHub inspection commands;
+- use Maestro, `simctl`, `idb`, xcodebuildmcp / Build iOS Apps, screenshots,
+  and runtime logs to produce simulator evidence;
+- spawn available specialist subagents or review panels when the user asks for
+  review, premerge, audit, or a task whose checked-in workflow requires a panel;
+- create feature branches, commits, pushes to feature branches, and PR updates
+  for the current authorized objective after diff review and required checks.
+
+Do not stop merely because a tool was not mentioned in the latest prompt. If a
+tool or skill is unavailable, cite the exact missing command/path/capability and
+use the closest deterministic fallback.
+
+Claude Max and external expert audits are advisory unless Julien explicitly
+makes them a gate for the current task. Use them when a local CLI/session or
+fresh audit artifact is available and the work is high-stakes; otherwise report
+that they were unavailable and rely on the local panel, tests, and runtime
+evidence. Never claim Claude Max, Maestro, Engram, or a panel was used unless
+there is an actual tool call, command output, or artifact path.
+
 ## ALWAYS DO
 
 - Read `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json` before


### PR DESCRIPTION
## Summary
- Clarifies that agents may use Engram MCP, local/user/plugin skills, checks, panels, Maestro/sim tooling, and feature-branch PR workflows without per-tool permission when the objective is already authorized.
- Keeps hard gates for protected branches, merges, destructive Git, real data, compliance/legal claims, and new regulated financial sources.
- Replaces the hard STOP on missing private curator MEMORY.md with an Engram MCP + checked-in docs fallback.

## Verification
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/agent_reference_guard.py
- python3 tools/checks/claude_hooks_guard.py
- python3 tools/checks/banned_terms_python.py rules.md AGENTS.md docs/MINT_AGENT_WORKFLOW.md docs/AGENTS/ENGRAM.md
- python3 tools/checks/doctrine_atomicity_gate.py --base origin/dev --head HEAD
- python3 tools/checks/doctrine_consistency_check.py
- git diff --check