### PR TITLE
feat(mint2): show axis handoff in dossier

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -22,6 +22,8 @@
     "feature/mint2-rvc-proof-blockers",
     "feature/mint2-axis-dossier-persist",
     "feature/mint2-claim-axis-handoff",
+    "feature/S06-mint2-dossier-axis-continuity",
+    "feature/S06-mint2-dossier-axis-surface",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -12,6 +12,8 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/services/smart_onboarding_draft_service.dart';
 import 'package:mint_mobile/services/financial_core/lpp_calculator.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
@@ -49,10 +51,7 @@ class FinancialSummaryScreen extends StatelessWidget {
               child: CustomScrollView(
                 slivers: [
                   _buildAppBar(context),
-                  if (profile == null || !profile.hasMaterialData)
-                    _buildEmptyState(context)
-                  else
-                    _buildContent(context, profile),
+                  _buildBodySliver(context, profile),
                 ],
               ))),
     );
@@ -93,6 +92,30 @@ class FinancialSummaryScreen extends StatelessWidget {
         subtitle: '', // No subtitle in original
         ctaLabel: S.of(context)!.financialSummaryStartDiagnostic,
         onCta: () => context.go('/coach/chat'),
+      ),
+    );
+  }
+
+  Widget _buildBodySliver(BuildContext context, CoachProfile? profile) {
+    return FutureBuilder<Map<String, dynamic>>(
+      future: ReportPersistenceService.loadMint2AxisHandoff(),
+      builder: (context, snapshot) {
+        final mint2AxisHandoff = snapshot.data ?? const <String, dynamic>{};
+        final hasMint2AxisHandoff = _hasMint2LiveAxis(mint2AxisHandoff);
+        if (profile == null || !profile.hasMaterialData) {
+          if (!hasMint2AxisHandoff) return _buildEmptyState(context);
+          return _buildHandoffOnlyContent(context);
+        }
+        return _buildContent(context, profile);
+      },
+    );
+  }
+
+  Widget _buildHandoffOnlyContent(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.all(MintSpacing.lg),
+        child: _buildMint2HandoffDossierSummary(context),
       ),
     );
   }
@@ -586,6 +609,200 @@ class FinancialSummaryScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildMint2HandoffDossierSummary(BuildContext context) {
+    final s = S.of(context)!;
+    return MintEntrance(
+      child: MintSurface(
+        tone: MintSurfaceTone.blanc,
+        padding: const EdgeInsets.all(MintSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Semantics(
+              identifier: 'profile_dossier_facts_summary',
+              container: true,
+              child: Container(
+                key: const ValueKey('profile_dossier_facts_summary'),
+                width: double.infinity,
+                color: MintColors.transparent,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      Icons.folder_shared_outlined,
+                      color: MintColors.textPrimary,
+                      size: 22,
+                    ),
+                    const SizedBox(width: MintSpacing.sm),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            s.financialSummaryDossierTitle,
+                            style: MintTextStyles.titleMedium(
+                              color: MintColors.textPrimary,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            s.financialSummaryDossierSubtitle,
+                            style: MintTextStyles.bodySmall(
+                              color: MintColors.textSecondary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: MintColors.appleSurface,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Text(
+                        '1 ${s.financialSummaryDossierFactCountLabel}',
+                        style: MintTextStyles.labelMedium(
+                          color: MintColors.textPrimary,
+                        ).copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: MintSpacing.md),
+            Semantics(
+              identifier: 'profile_dossier_provenance_summary',
+              container: true,
+              child: Container(
+                key: const ValueKey('profile_dossier_provenance_summary'),
+                width: double.infinity,
+                padding: const EdgeInsets.all(10),
+                decoration: BoxDecoration(
+                  color: MintColors.appleSurface,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    Text(
+                      s.financialSummaryDossierSourcesTitle,
+                      style: MintTextStyles.labelMedium(
+                        color: MintColors.textSecondary,
+                      ).copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    _sourcePill(
+                      label: s.sourceBadgeDeclared,
+                      count: 0,
+                      color: MintColors.success,
+                    ),
+                    _sourcePill(
+                      label: s.sourceBadgeEstimated,
+                      count: 0,
+                      color: MintColors.warning,
+                    ),
+                    _sourcePill(
+                      label: s.sourceBadgeCertified,
+                      count: 0,
+                      color: MintColors.info,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: MintSpacing.md),
+            _buildMint2AxisHandoffCard(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _hasMint2LiveAxis(Map<String, dynamic> handoff) {
+    return FeatureFlags.enableMint2FirstExperienceEntry &&
+        handoff['onb_axis_v2'] == 'lpp_rente_capital' &&
+        handoff['onb_axis_schema_version'] == 2;
+  }
+
+  Widget _buildMint2AxisHandoffCard(BuildContext context) {
+    final s = S.of(context)!;
+    return Semantics(
+      identifier: 'profile_dossier_axis_handoff',
+      container: true,
+      child: Container(
+        key: const ValueKey('profile_dossier_axis_handoff'),
+        width: double.infinity,
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: MintColors.appleSurface,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(
+              Icons.account_tree_outlined,
+              color: MintColors.textPrimary,
+              size: 20,
+            ),
+            const SizedBox(width: MintSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    s.mint2FirstExperienceLppLabel,
+                    style: MintTextStyles.titleMedium(
+                      color: MintColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: MintSpacing.xs),
+                  Wrap(
+                    spacing: MintSpacing.xs,
+                    runSpacing: MintSpacing.xs,
+                    children: [
+                      _axisStatePill(
+                        label: s
+                            .renteVsCapitalReceiptReadinessMissingRequiredInputs,
+                        color: MintColors.warning,
+                      ),
+                      _axisStatePill(
+                        label: s.renteVsCapitalReceiptReadinessMissing,
+                        color: MintColors.textSecondary,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _axisStatePill({
+    required String label,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.10),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: MintTextStyles.labelSmall(color: color)
+            .copyWith(fontWeight: FontWeight.w700),
       ),
     );
   }

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -540,6 +540,11 @@ void main() {
         expect(prefs.getBool('local_data_migrated_axis-user'), isTrue);
         expect(prefs.getBool('local_data_sync_pending_axis-user'), isNull);
         expect(await ReportPersistenceService.loadAnswers(), isEmpty);
+        expect(
+          (await ReportPersistenceService.loadMint2AxisHandoff())[
+              'onb_axis_v2'],
+          'lpp_rente_capital',
+        );
       } finally {
         FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
         ConversationStore.setCurrentUserId(null);

--- a/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
+++ b/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
@@ -7,7 +8,10 @@ import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/profile/financial_summary_screen.dart';
 import 'package:mint_mobile/services/coach/coach_profile_seeds.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _FakeCoachProfileProvider extends CoachProfileProvider {
   _FakeCoachProfileProvider(this._profile);
@@ -55,6 +59,12 @@ Widget _pumpable(
 }
 
 void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    FeatureFlags.enableMint2FirstExperienceEntry = false;
+  });
+
   testWidgets('empty material profile shows diagnostic state, not covered gap',
       (tester) async {
     await tester.pumpWidget(_pumpable(CoachProfile.fromWizardAnswers({})));
@@ -63,6 +73,55 @@ void main() {
     expect(find.text('Aucun profil renseigné'), findsOneWidget);
     expect(find.text('Commencer le diagnostic'), findsOneWidget);
     expect(find.text('Tu es bien couvert·e'), findsNothing);
+  });
+
+  testWidgets(
+      'Mint 2 live axis handoff appears in dossier before profile facts',
+      (tester) async {
+    FeatureFlags.enableMint2FirstExperienceEntry = true;
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+      'legacy_onb_intent': 'retraite',
+    });
+
+    await tester.pumpWidget(_pumpable(null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2e pilier : rente ou capital'), findsOneWidget);
+    expect(find.text('Champs requis manquants'), findsOneWidget);
+    expect(find.text('Preuve absente'), findsOneWidget);
+    expect(find.text('Aucun profil renseigné'), findsNothing);
+  });
+
+  testWidgets('Mint 2 axis handoff stays hidden while entry flag is off',
+      (tester) async {
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+    });
+
+    await tester.pumpWidget(_pumpable(null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2e pilier : rente ou capital'), findsNothing);
+    expect(find.text('Aucun profil renseigné'), findsOneWidget);
+  });
+
+  testWidgets('reset removes Mint 2 axis handoff from dossier surface',
+      (tester) async {
+    FeatureFlags.enableMint2FirstExperienceEntry = true;
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+    });
+    await ReportPersistenceService.clearDiagnostic();
+
+    await tester.pumpWidget(_pumpable(null));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2e pilier : rente ou capital'), findsNothing);
+    expect(find.text('Aucun profil renseigné'), findsOneWidget);
   });
 
   testWidgets('material profile leads with dossier facts before projection',

--- a/apps/mobile/test/services/account_handoff_service_test.dart
+++ b/apps/mobile/test/services/account_handoff_service_test.dart
@@ -77,6 +77,10 @@ void main() {
       () async {
     await AccountHandoffService.saveChoice(AccountHandoffChoice.restartClean);
     await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+    });
     await ConversationStore().saveConversation('anonymous_restart', [
       ChatMessage(
         role: 'assistant',
@@ -94,6 +98,7 @@ void main() {
 
     expect(shouldMigrate, isFalse);
     expect(await ReportPersistenceService.loadAnswers(), isEmpty);
+    expect(await ReportPersistenceService.loadMint2AxisHandoff(), isEmpty);
     expect(
       await ConversationStore().loadConversation('anonymous_restart'),
       isEmpty,


### PR DESCRIPTION
## Scope
Tranche 1 for Mint 2.0 LPP/RvC dossier continuity after PR #710.

- Shows the saved `mint2AxisHandoff` for `2e pilier : rente ou capital` in the existing `/profile/bilan` dossier surface when no material profile facts exist yet.
- Keeps the display behind `FeatureFlags.enableMint2FirstExperienceEntry`.
- Extends contract tests proving the axis handoff survives account claim and stays out of `wizardAnswers`.
- Extends reset coverage so start-over/restart-clean clears the anonymous Mint2 axis handoff.

## Split Note
This PR is intentionally below the 300-line gate: `5 files changed, 292 insertions(+), 4 deletions(-)`.

The deterministic iPhone 13 mini runtime harness and evidence are already proven locally on `feature/S06-mint2-dossier-axis-continuity`, but are not included here because that branch is `898 insertions` and must be split or explicitly waived.

## Verification
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/agent_reference_guard.py`
- `python3 tools/checks/claude_hooks_guard.py`
- `python3 tools/checks/verify_phase_acceptance.py`
- `python3 tools/checks/route_registry_parity.py`
- `./tools/mint-routes check`
- `git diff --check && git diff --cached --check`
- `python3 tools/checks/prefer_mint_color_token.py --file apps/mobile/lib/screens/profile/financial_summary_screen.dart`
- `python3 tools/checks/prefer_mint_text_style.py --file apps/mobile/lib/screens/profile/financial_summary_screen.dart`
- `python3 tools/checks/prefer_mint_fonts.py --file apps/mobile/lib/screens/profile/financial_summary_screen.dart`
- `python3 tools/checks/prefer_mint_radius.py --file apps/mobile/lib/screens/profile/financial_summary_screen.dart`
- `python3 tools/checks/prefer_mint_cta.py --file apps/mobile/lib/screens/profile/financial_summary_screen.dart`
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test test/services/account_handoff_service_test.dart test/providers/auth_provider_test.dart test/providers/coach_profile_provider_secure_failure_test.dart test/screens/profile/financial_summary_screen_test.dart test/screens/onboarding/mvp_wedge/ test/screens/arbitrage/`
- `cd apps/mobile && flutter test`

## Runtime Evidence
Local full-branch evidence, not this PR diff: `.planning/runtime-evidence/mint2-lpp-account-claim-20260618T194016/EVIDENCE-SUMMARY.txt`.

Caveat: simulator/debug harness proof only; real-device Keychain/iCloud remains unproven.