### PR TITLE
test(mint2): prove account claim runtime handoff

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -24,6 +24,8 @@
     "feature/mint2-claim-axis-handoff",
     "feature/S06-mint2-dossier-axis-continuity",
     "feature/S06-mint2-dossier-axis-surface",
+    "feature/S06-mint2-dossier-axis-runtime",
+    "feature/S06-mint2-account-runtime",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -17,6 +17,7 @@ import 'package:mint_mobile/screens/landing_screen.dart';
 import 'package:mint_mobile/screens/anonymous/anonymous_chat_screen.dart';
 import 'package:mint_mobile/screens/coach/chat_as_verb_demo_screen.dart';
 import 'package:mint_mobile/screens/debug/debug_budget_bootstrap_screen.dart';
+import 'package:mint_mobile/screens/debug/debug_mint2_account_claim_screen.dart';
 import 'package:mint_mobile/screens/debug/debug_profile_bootstrap_screen.dart';
 import 'package:mint_mobile/screens/auth/login_screen.dart';
 import 'package:mint_mobile/services/debug_profile_bootstrap_service.dart';
@@ -439,6 +440,12 @@ final _router = GoRouter(
         scope: RouteScope.public,
         builder: (context, state) {
           final query = state.uri.queryParameters;
+          if (query['scenario'] == 'mint2-axis-account-claim') {
+            return DebugMint2AccountClaimScreen(
+              key: ValueKey(state.uri.toString()),
+              mode: query['claim'] ?? 'keep',
+            );
+          }
           final mode = query['mode'] == 'update-income'
               ? DebugProfileBootstrapMode.updateIncome
               : DebugProfileBootstrapMode.establish;

--- a/apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart
+++ b/apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart
@@ -1,0 +1,207 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/services/account_handoff_service.dart';
+import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DebugMint2AccountClaimScreen extends StatefulWidget {
+  final String mode;
+
+  const DebugMint2AccountClaimScreen({
+    super.key,
+    required this.mode,
+  });
+
+  @override
+  State<DebugMint2AccountClaimScreen> createState() =>
+      _DebugMint2AccountClaimScreenState();
+}
+
+class _DebugMint2AccountClaimScreenState
+    extends State<DebugMint2AccountClaimScreen> {
+  static const _proofKey = 'e2e_mint2_axis_claim_proof_v1';
+  static const _userId = 'e2e-mint2-axis-user';
+
+  late final Future<Map<String, Object?>> _result = _run();
+
+  Future<Map<String, Object?>> _run() async {
+    if (kReleaseMode) {
+      return _status('unavailable', mode: widget.mode, ok: false);
+    }
+    final mode = widget.mode;
+    if (mode == 'status') return _status('status', mode: mode);
+    if (mode == 'restart') {
+      await AccountHandoffService.saveChoice(AccountHandoffChoice.restartClean);
+      await AccountHandoffService.prepareLocalDataForAccount(
+        _userId,
+        handoffEnabled: true,
+      );
+      await _saveProof('restart_clean', 'absent', false, 0);
+      return _status('restart_clean', mode: mode);
+    }
+
+    final handoff = await ReportPersistenceService.loadMint2AxisHandoff();
+    final axis = handoff['onb_axis_v2'];
+    final answers = await ReportPersistenceService.loadAnswers();
+    final polluted = _polluted(answers);
+    if (axis != 'lpp_rente_capital' ||
+        handoff['onb_axis_schema_version'] != 2 ||
+        polluted) {
+      return _status(
+        polluted ? 'wizard_polluted' : 'missing_axis',
+        mode: mode,
+        ok: false,
+        axis: axis?.toString() ?? 'absent',
+      );
+    }
+
+    await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
+    final shouldClaim = await AccountHandoffService.prepareLocalDataForAccount(
+      _userId,
+      handoffEnabled: true,
+    );
+    if (!shouldClaim) return _status('not_claimable', mode: mode, ok: false);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('local_data_owner', _userId);
+    await prefs.setBool('local_data_migrated_$_userId', true);
+    await _restoreSession();
+    await _saveProof('claimed', axis.toString(), false, answers.length);
+    return _status('claimed', mode: mode);
+  }
+
+  Future<Map<String, Object?>> _status(
+    String fallbackClaim, {
+    required String mode,
+    bool ok = true,
+    String? axis,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final proof = _proof(prefs);
+    if ((proof['claim_status'] ?? fallbackClaim) == 'claimed' &&
+        !(await AuthService.isLoggedIn())) {
+      await _restoreSession();
+    }
+    final handoff = await ReportPersistenceService.loadMint2AxisHandoff();
+    final answers = await ReportPersistenceService.loadAnswers();
+    final claim = (proof['claim_status'] ?? fallbackClaim).toString();
+    final resolvedAxis = axis ??
+        (proof['axis'] ?? handoff['onb_axis_v2'] ?? 'absent').toString();
+    final owner = prefs.getString('local_data_owner') == _userId &&
+        (prefs.getBool('local_data_migrated_$_userId') ?? false);
+    final auth = await AuthService.isLoggedIn();
+    if (auth && mounted) await context.read<AuthProvider>().checkAuth();
+    return {
+      'ok': ok && (claim == 'claimed' || claim == 'restart_clean'),
+      'mode': mode,
+      'claim': claim,
+      'axis': resolvedAxis,
+      'wizardAnswers': answers.length,
+      'axisInWizardAnswers': _polluted(answers),
+      'owner': owner ? 'claimed' : 'absent',
+      'auth': auth ? 'present' : 'absent',
+    };
+  }
+
+  static bool _polluted(Map<String, dynamic> answers) {
+    return answers.containsKey('mint2AxisHandoff') ||
+        answers.containsKey('mint2_axis_handoff') ||
+        answers.containsKey('onb_axis_v2') ||
+        answers.containsKey('onb_axis_schema_version');
+  }
+
+  static Future<void> _restoreSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('auth_local_mode', false);
+    ConversationStore.setCurrentUserId(_userId);
+    await AuthService.saveToken(
+      'e2e-local-claim-access',
+      _userId,
+      'e2e-mint2-axis-account',
+      displayName: 'E2E Mint2',
+      refreshToken: 'e2e-local-claim-refresh',
+    );
+  }
+
+  static Future<void> _saveProof(
+    String claim,
+    String axis,
+    bool polluted,
+    int answersCount,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _proofKey,
+      json.encode({
+        'claim_status': claim,
+        'axis': axis,
+        'axis_in_wizard_answers': polluted,
+        'wizard_answers_count': answersCount,
+        'generated_at': DateTime.now().toUtc().toIso8601String(),
+      }),
+    );
+  }
+
+  static Map<String, dynamic> _proof(SharedPreferences prefs) {
+    final raw = prefs.getString(_proofKey);
+    if (raw == null) return const {};
+    final decoded = json.decode(raw);
+    return decoded is Map ? Map<String, dynamic>.from(decoded) : const {};
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: FutureBuilder<Map<String, Object?>>(
+          future: _result,
+          builder: (context, snapshot) {
+            final result = snapshot.data;
+            if (result == null) {
+              return const Center(
+                child: CircularProgressIndicator(
+                  key: ValueKey('debug_mint2_axis_claim_loading'),
+                ),
+              );
+            }
+            final label = result.entries
+                .map((entry) => '${entry.key}=${entry.value}')
+                .join(' ');
+            return Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Semantics(
+                    key: const ValueKey('e2e_mint2_axis_claim_applied'),
+                    identifier: 'e2e_mint2_axis_claim_applied',
+                    label: label,
+                    container: true,
+                    child: const SizedBox.shrink(),
+                  ),
+                  for (final entry in result.entries)
+                    Semantics(
+                      identifier:
+                          'e2e_mint2_axis_claim_${entry.key}_${entry.value}',
+                      label: '${entry.key}: ${entry.value}',
+                      container: true,
+                      child: Text(
+                        '${entry.key}: ${entry.value}',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/tools/simulator/flows/maestro-perfect-set/flow_mint2_lpp_dossier_account_claim.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_mint2_lpp_dossier_account_claim.yaml
@@ -1,0 +1,83 @@
+appId: ch.mint.app
+tags:
+  - mint2
+  - account-claim
+  - dossier
+  - iphone13mini
+---
+
+- runFlow: flow_mint2_first_experience_rente_capital_entry.yaml
+
+- openLink: "mintapp:///profile/bilan"
+- extendedWaitUntil:
+    visible:
+      text: "MON PROFIL"
+    timeout: 12000
+- takeScreenshot: "01-profile-axis-before-claim"
+
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?scenario=mint2-axis-account-claim&claim=keep"
+- extendedWaitUntil:
+    visible:
+      id: "e2e_mint2_axis_claim_claim_claimed"
+    timeout: 12000
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axis_lpp_rente_capital"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_wizardAnswers_0"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axisInWizardAnswers_false"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_owner_claimed"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_auth_present"
+- takeScreenshot: "02-axis-claim-keep"
+
+- stopApp
+- launchApp:
+    clearState: false
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?scenario=mint2-axis-account-claim&claim=status"
+- extendedWaitUntil:
+    visible:
+      id: "e2e_mint2_axis_claim_claim_claimed"
+    timeout: 12000
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axis_lpp_rente_capital"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axisInWizardAnswers_false"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_owner_claimed"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_auth_present"
+- takeScreenshot: "03-axis-claim-status-after-relaunch"
+
+- openLink: "mintapp:///profile/bilan"
+- extendedWaitUntil:
+    visible:
+      text: "MON PROFIL"
+    timeout: 12000
+- takeScreenshot: "04-profile-axis-after-claim"
+
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?scenario=mint2-axis-account-claim&claim=restart"
+- extendedWaitUntil:
+    visible:
+      id: "e2e_mint2_axis_claim_claim_restart_clean"
+    timeout: 12000
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axis_absent"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axisInWizardAnswers_false"
+- takeScreenshot: "05-axis-restart-clean"
+
+- stopApp
+- launchApp:
+    clearState: false
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?scenario=mint2-axis-account-claim&claim=status"
+- extendedWaitUntil:
+    visible:
+      id: "e2e_mint2_axis_claim_claim_restart_clean"
+    timeout: 12000
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axis_absent"
+- assertVisible:
+    id: "e2e_mint2_axis_claim_axisInWizardAnswers_false"
+- takeScreenshot: "06-axis-status-after-restart-clean"


### PR DESCRIPTION
## Summary
- Adds a non-release E2E route that proves Mint 2 LPP/RvC axis claim/status/restart behavior at runtime.
- Keeps `mint2AxisHandoff` separate from `wizardAnswers` and exposes value-bearing Semantics IDs for Maestro assertions.
- Adds a Maestro flow for fresh Mint 2 entry, dossier before/after claim, relaunch persistence, and restart-clean negative proof.

## Test Plan
- `git diff --check && git diff --cached --check`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/agent_reference_guard.py && python3 tools/checks/claude_hooks_guard.py && python3 tools/checks/verify_phase_acceptance.py && python3 tools/checks/route_registry_parity.py && ./tools/mint-routes check`
- `python3 tools/checks/prefer_mint_color_token.py --file apps/mobile/lib/app.dart --file apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart`
- `python3 tools/checks/prefer_mint_text_style.py --file apps/mobile/lib/app.dart --file apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart`
- `python3 tools/checks/prefer_mint_fonts.py --file apps/mobile/lib/app.dart --file apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart`
- `python3 tools/checks/prefer_mint_radius.py --file apps/mobile/lib/app.dart --file apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart`
- `python3 tools/checks/prefer_mint_cta.py --file apps/mobile/lib/app.dart --file apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart`
- `python3 tools/checks/banned_terms_python.py apps/mobile/lib/app.dart apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart tools/simulator/flows/maestro-perfect-set/flow_mint2_lpp_dossier_account_claim.yaml`
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test test/architecture/route_guard_snapshot_test.dart test/services/account_handoff_service_test.dart test/providers/auth_provider_test.dart test/providers/coach_profile_provider_secure_failure_test.dart test/screens/profile/financial_summary_screen_test.dart test/screens/onboarding/mvp_wedge/ test/screens/arbitrage/`
- `cd apps/mobile && flutter test`
- `cd apps/mobile && CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_MINT2_FIRST_EXPERIENCE=true --dart-define=MINT_E2E_PROOF_ANCHORS=true`
- `MINT_WALKER_ARTIFACTS=.planning/runtime-evidence/mint2-lpp-account-claim-current-20260618T211648 bash tools/simulator/maestro_with_watchdog.sh test --device 3D0534A9-8C3A-4663-9348-106D0599E9D6 tools/simulator/flows/maestro-perfect-set/flow_mint2_lpp_dossier_account_claim.yaml`

## Evidence
- `.planning/runtime-evidence/mint2-lpp-account-claim-current-20260618T211648/`
- SHA: `2a4c5d524eac8d573226c6656cc42c5d70e7a72c`
- UDID: `3D0534A9-8C3A-4663-9348-106D0599E9D6`
- Screenshots include dossier before claim, claim keep, status after relaunch, dossier after claim, restart clean, and status after restart clean.
- `idb-ui-describe-all-final.txt` captures final restart-clean state.

## Caveat
- This is simulator/debug-harness proof, not real-device Keychain/iCloud proof.