### PR TITLE
Guard Mint2 account handoff before auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,10 @@ jobs:
 
       - name: Install PDF text extraction tools
         if: matrix.shard == 'services'
-        run: (sudo apt-get update || sudo apt-get update) && sudo apt-get install -y poppler-utils
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
+          sudo apt-get install -y --no-install-recommends poppler-utils
 
       - name: Install dependencies
         run: flutter pub get

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ tools/agent-drift/spikes/A7_headless_result.txt
 
 # Phase 31 walker.sh runtime output (timestamped screenshots, logs, sentry-event JSON dumps)
 .planning/walker/
+.planning/runtime-evidence/
 .cache/
 
 # Phase 83 walker_premier_eclairage.sh runtime output (SIMH-04, v2.11) —

--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -26,6 +26,7 @@
     "feature/S06-mint2-dossier-axis-surface",
     "feature/S06-mint2-dossier-axis-runtime",
     "feature/S06-mint2-account-runtime",
+    "feature/S07-mint2-account-claim-product",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -24,6 +24,7 @@ import 'package:mint_mobile/services/debug_profile_bootstrap_service.dart';
 import 'package:mint_mobile/screens/auth/register_screen.dart';
 import 'package:mint_mobile/screens/auth/forgot_password_screen.dart';
 import 'package:mint_mobile/screens/auth/verify_email_screen.dart';
+import 'package:mint_mobile/services/account_handoff_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -2181,6 +2182,24 @@ class _MagicLinkVerifyScreenState extends State<_MagicLinkVerifyScreen> {
     }
 
     final authProvider = context.read<AuthProvider>();
+
+    if (FeatureFlags.enableMvpWedgeOnboarding) {
+      final hasSessionProfile = context.read<CoachProfileProvider>().hasProfile;
+      final requiresChoice = await AccountHandoffService.requiresExplicitChoice(
+        handoffEnabled: true,
+        hasSessionProfile: hasSessionProfile,
+      );
+      if (requiresChoice) {
+        if (!mounted) return;
+        setState(() {
+          _isVerifying = false;
+          _errorMessage =
+              'Sélectionne d’abord conserver ou repartir avant d’ouvrir ce lien.';
+        });
+        return;
+      }
+    }
+
     final success = await authProvider.verifyMagicLink(widget.token!);
 
     if (!mounted) return;
@@ -2239,12 +2258,14 @@ class _MagicLinkVerifyScreenState extends State<_MagicLinkVerifyScreen> {
                           color: Colors.black87),
                     ),
                     const SizedBox(height: 24),
-                    FilledButton( // lint-ignore: prefer_mint_cta
+                    FilledButton(
+                      // lint-ignore: prefer_mint_cta
                       onPressed: () => _verifyToken(),
                       child: const Text('Réessayer'),
                     ),
                     const SizedBox(height: 12),
-                    TextButton( // lint-ignore: prefer_mint_cta
+                    TextButton(
+                      // lint-ignore: prefer_mint_cta
                       onPressed: () => context.go('/auth/login'),
                       child: const Text('Retour à la connexion'),
                     ),

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -705,6 +705,16 @@ class AuthProvider extends ChangeNotifier {
 
   /// Verify a magic link token and complete authentication.
   Future<bool> verifyMagicLink(String token) async {
+    if (FeatureFlags.enableMvpWedgeOnboarding &&
+        await AccountHandoffService.requiresExplicitChoice(
+          handoffEnabled: true,
+        )) {
+      _error = AuthError.invalidInput;
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
+
     _isLoading = true;
     _error = null;
     notifyListeners();

--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -7,8 +7,10 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/auth/auth_platform.dart';
 import 'package:mint_mobile/screens/auth/auth_redirect.dart';
+import 'package:mint_mobile/services/account_handoff_service.dart';
 import 'package:mint_mobile/services/apple_sign_in_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
@@ -36,6 +38,7 @@ class _LoginScreenState extends State<LoginScreen> {
   String? _appleSignInError;
   int _countdownSeconds = 0;
   Timer? _countdownTimer;
+  bool _handoffChoiceRequired = false;
 
   @override
   void initState() {
@@ -45,6 +48,7 @@ class _LoginScreenState extends State<LoginScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<AuthProvider>().clearError();
+      _refreshHandoffChoiceRequired();
     });
   }
 
@@ -83,6 +87,8 @@ class _LoginScreenState extends State<LoginScreen> {
         !_emailController.text.contains('@')) {
       return;
     }
+    if (!await _canStartAccountAction()) return;
+    if (!mounted) return;
 
     final authProvider = context.read<AuthProvider>();
     final success =
@@ -113,7 +119,46 @@ class _LoginScreenState extends State<LoginScreen> {
     });
   }
 
+  Future<bool> _refreshHandoffChoiceRequired() async {
+    if (!FeatureFlags.enableMvpWedgeOnboarding) {
+      if (mounted && _handoffChoiceRequired) {
+        setState(() => _handoffChoiceRequired = false);
+      }
+      return false;
+    }
+    final hasSessionProfile = context.read<CoachProfileProvider>().hasProfile;
+    final required = await AccountHandoffService.requiresExplicitChoice(
+      handoffEnabled: true,
+      hasSessionProfile: hasSessionProfile,
+    );
+    if (!mounted) return required;
+    if (_handoffChoiceRequired != required) {
+      setState(() => _handoffChoiceRequired = required);
+    }
+    return required;
+  }
+
+  Future<bool> _canStartAccountAction() async {
+    final required = await _refreshHandoffChoiceRequired();
+    return mounted && !required;
+  }
+
+  Widget _buildAppleSignInButton(S l10n, bool handoffBlocksAuth) {
+    final button = SignInWithAppleButton(
+      onPressed: _handleAppleSignIn,
+      text: l10n.authAppleSignIn,
+      style: SignInWithAppleButtonStyle.black,
+    );
+    if (!handoffBlocksAuth) return button;
+    return Semantics(
+      enabled: false,
+      child: IgnorePointer(child: button),
+    );
+  }
+
   Future<void> _handleAppleSignIn() async {
+    if (!await _canStartAccountAction()) return;
+    if (!mounted) return;
     setState(() => _appleSignInLoading = true);
     try {
       final response = await AppleSignInService.signIn();
@@ -150,6 +195,8 @@ class _LoginScreenState extends State<LoginScreen> {
 
   Future<void> _handlePasswordLogin() async {
     if (!_formKey.currentState!.validate()) return;
+    if (!await _canStartAccountAction()) return;
+    if (!mounted) return;
 
     final authProvider = context.read<AuthProvider>();
     final success = await authProvider.login(
@@ -166,6 +213,8 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final authProvider = context.watch<AuthProvider>();
     final l10n = S.of(context)!;
+    final handoffBlocksAuth =
+        FeatureFlags.enableMvpWedgeOnboarding && _handoffChoiceRequired;
 
     return Scaffold(
       backgroundColor: MintColors.white,
@@ -216,7 +265,9 @@ class _LoginScreenState extends State<LoginScreen> {
                             )),
                         if (FeatureFlags.enableMvpWedgeOnboarding) ...[
                           const SizedBox(height: MintSpacing.lg),
-                          const AccountHandoffChoicePanel(),
+                          AccountHandoffChoicePanel(
+                            onChoiceChanged: _refreshHandoffChoiceRequired,
+                          ),
                         ],
                         const SizedBox(height: MintSpacing.xxl),
 
@@ -264,12 +315,13 @@ class _LoginScreenState extends State<LoginScreen> {
                               height: 56,
                               child: FilledButton(
                                 // lint-ignore: prefer_mint_cta
-                                onPressed: authProvider.isLoading
-                                    ? null
-                                    : () {
-                                        HapticFeedback.lightImpact();
-                                        _handleSendMagicLink();
-                                      },
+                                onPressed:
+                                    authProvider.isLoading || handoffBlocksAuth
+                                        ? null
+                                        : () {
+                                            HapticFeedback.lightImpact();
+                                            _handleSendMagicLink();
+                                          },
                                 child: authProvider.isLoading &&
                                         !_showPasswordFallback
                                     ? const SizedBox(
@@ -332,11 +384,12 @@ class _LoginScreenState extends State<LoginScreen> {
                             Center(
                               child: TextButton(
                                 // lint-ignore: prefer_mint_cta
-                                onPressed: authProvider.isLoading
-                                    ? null
-                                    : () {
-                                        _handleSendMagicLink();
-                                      },
+                                onPressed:
+                                    authProvider.isLoading || handoffBlocksAuth
+                                        ? null
+                                        : () {
+                                            _handleSendMagicLink();
+                                          },
                                 child: Text(
                                   l10n.authResend,
                                   style: MintTextStyles.bodyMedium(
@@ -371,10 +424,9 @@ class _LoginScreenState extends State<LoginScreen> {
                                           strokeWidth: 2),
                                     ),
                                   )
-                                : SignInWithAppleButton(
-                                    onPressed: _handleAppleSignIn,
-                                    text: l10n.authAppleSignIn,
-                                    style: SignInWithAppleButtonStyle.black,
+                                : _buildAppleSignInButton(
+                                    l10n,
+                                    handoffBlocksAuth,
                                   ),
                           ),
                         ],
@@ -493,12 +545,13 @@ class _LoginScreenState extends State<LoginScreen> {
                             button: true,
                             child: FilledButton(
                               // lint-ignore: prefer_mint_cta
-                              onPressed: authProvider.isLoading
-                                  ? null
-                                  : () {
-                                      HapticFeedback.lightImpact();
-                                      _handlePasswordLogin();
-                                    },
+                              onPressed:
+                                  authProvider.isLoading || handoffBlocksAuth
+                                      ? null
+                                      : () {
+                                          HapticFeedback.lightImpact();
+                                          _handlePasswordLogin();
+                                        },
                               child: authProvider.isLoading &&
                                       _showPasswordFallback
                                   ? const SizedBox(

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -7,8 +7,10 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/auth/auth_platform.dart';
 import 'package:mint_mobile/screens/auth/auth_redirect.dart';
+import 'package:mint_mobile/services/account_handoff_service.dart';
 import 'package:mint_mobile/services/apple_sign_in_service.dart';
 import 'package:mint_mobile/services/dob_age_calculator.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
@@ -43,6 +45,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
   bool _showEmailForm = true;
   bool _appleSignInLoading = false;
   String? _appleSignInError;
+  bool _handoffChoiceRequired = false;
 
   /// P2-17: Guard to prevent concurrent SharedPreferences writes.
   bool _isWriting = false;
@@ -59,6 +62,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<AuthProvider>().clearError();
+      _refreshHandoffChoiceRequired();
     });
   }
 
@@ -73,6 +77,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   Future<void> _handleRegister() async {
     if (!_formKey.currentState!.validate()) return;
+    if (!await _canStartAccountAction()) return;
+    if (!mounted) return;
     // P2-17: Prevent concurrent writes
     if (_isWriting) return;
     _isWriting = true;
@@ -130,6 +136,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
       });
       return;
     }
+    if (!await _canStartAccountAction()) return;
+    if (!mounted) return;
 
     _isWriting = true;
     setState(() {
@@ -184,6 +192,43 @@ class _RegisterScreenState extends State<RegisterScreen> {
       currentUri: GoRouterState.of(context).uri,
       hasDossierIdentity: hasDossierIdentity,
     ));
+  }
+
+  Future<bool> _refreshHandoffChoiceRequired() async {
+    if (!FeatureFlags.enableMvpWedgeOnboarding) {
+      if (mounted && _handoffChoiceRequired) {
+        setState(() => _handoffChoiceRequired = false);
+      }
+      return false;
+    }
+    final hasSessionProfile = context.read<CoachProfileProvider>().hasProfile;
+    final required = await AccountHandoffService.requiresExplicitChoice(
+      handoffEnabled: true,
+      hasSessionProfile: hasSessionProfile,
+    );
+    if (!mounted) return required;
+    if (_handoffChoiceRequired != required) {
+      setState(() => _handoffChoiceRequired = required);
+    }
+    return required;
+  }
+
+  Future<bool> _canStartAccountAction() async {
+    final required = await _refreshHandoffChoiceRequired();
+    return mounted && !required;
+  }
+
+  Widget _buildAppleSignInButton(S l10n, bool handoffBlocksAuth) {
+    final button = SignInWithAppleButton(
+      onPressed: _handleAppleSignIn,
+      text: l10n.authAppleSignIn,
+      style: SignInWithAppleButtonStyle.black,
+    );
+    if (!handoffBlocksAuth) return button;
+    return Semantics(
+      enabled: false,
+      child: IgnorePointer(child: button),
+    );
   }
 
   Widget _buildRequiredConsents(S l10n) {
@@ -259,6 +304,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
     final authProvider = context.watch<AuthProvider>();
     final l10n = S.of(context)!;
     final accountActionBusy = authProvider.isLoading || _appleSignInLoading;
+    final handoffBlocksAuth =
+        FeatureFlags.enableMvpWedgeOnboarding && _handoffChoiceRequired;
 
     return Scaffold(
       backgroundColor: MintColors.white,
@@ -344,7 +391,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             )),
                         if (FeatureFlags.enableMvpWedgeOnboarding) ...[
                           const SizedBox(height: MintSpacing.lg),
-                          const AccountHandoffChoicePanel(),
+                          AccountHandoffChoicePanel(
+                            onChoiceChanged: _refreshHandoffChoiceRequired,
+                          ),
                         ],
                         if (_showEmailForm || !canShowAppleSignIn) ...[
                           const SizedBox(height: MintSpacing.md),
@@ -399,10 +448,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                           strokeWidth: 2),
                                     ),
                                   )
-                                : SignInWithAppleButton(
-                                    onPressed: _handleAppleSignIn,
-                                    text: l10n.authAppleSignIn,
-                                    style: SignInWithAppleButtonStyle.black,
+                                : _buildAppleSignInButton(
+                                    l10n,
+                                    handoffBlocksAuth,
                                   ),
                           ),
                           if (_appleSignInError != null) ...[
@@ -779,7 +827,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
                               // lint-ignore: prefer_mint_cta
                               onPressed: (_acceptedCgu &&
                                       _confirmed18Plus &&
-                                      !accountActionBusy)
+                                      !accountActionBusy &&
+                                      !handoffBlocksAuth)
                                   ? () {
                                       HapticFeedback.lightImpact();
                                       _handleRegister();

--- a/apps/mobile/lib/services/account_handoff_service.dart
+++ b/apps/mobile/lib/services/account_handoff_service.dart
@@ -91,6 +91,17 @@ class AccountHandoffService {
     return await AnonymousSessionService.getMessageCount() > 0;
   }
 
+  static Future<bool> requiresExplicitChoice({
+    required bool handoffEnabled,
+    bool hasSessionProfile = false,
+    DateTime? now,
+  }) async {
+    if (!handoffEnabled) return false;
+    if (await loadChoice(now: now) != null) return false;
+    if (hasSessionProfile) return true;
+    return hasLocalData();
+  }
+
   /// Returns whether anonymous/local data should be migrated to [userId].
   ///
   /// `restartClean` means the user chose to open the account with a clean

--- a/apps/mobile/lib/widgets/auth/account_handoff_choice_panel.dart
+++ b/apps/mobile/lib/widgets/auth/account_handoff_choice_panel.dart
@@ -9,7 +9,12 @@ import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:provider/provider.dart';
 
 class AccountHandoffChoicePanel extends StatefulWidget {
-  const AccountHandoffChoicePanel({super.key});
+  const AccountHandoffChoicePanel({
+    super.key,
+    this.onChoiceChanged,
+  });
+
+  final VoidCallback? onChoiceChanged;
 
   @override
   State<AccountHandoffChoicePanel> createState() =>
@@ -39,6 +44,8 @@ class _AccountHandoffChoicePanelState extends State<AccountHandoffChoicePanel> {
   Future<void> _setChoice(AccountHandoffChoice choice) async {
     setState(() => _choice = choice);
     await AccountHandoffService.saveChoice(choice);
+    if (!mounted) return;
+    widget.onChoiceChanged?.call();
   }
 
   @override

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -175,6 +175,44 @@ void main() {
     });
 
     test(
+        'magic-link verification waits for explicit handoff choice when Mint2 axis exists',
+        () async {
+      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+      FeatureFlags.enableMvpWedgeOnboarding = true;
+      final seenPaths = <String>[];
+      ApiService.setHttpClientForTesting(MintHttpClient(
+        MockClient((request) async {
+          seenPaths.add(request.url.path);
+          return http.Response(
+            '{"accessToken":"magic-token","tokenType":"bearer"}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }),
+      ));
+      await ReportPersistenceService.saveMint2AxisHandoff({
+        'onb_axis_v2': 'lpp_rente_capital',
+        'onb_axis_schema_version': 2,
+      });
+
+      try {
+        final provider = AuthProvider();
+        final success = await provider.verifyMagicLink('magic-code');
+
+        expect(success, isFalse);
+        expect(seenPaths, isEmpty);
+        expect(provider.isLoggedIn, isFalse);
+        expect(
+          (await ReportPersistenceService.loadMint2AxisHandoff())[
+              'onb_axis_v2'],
+          'lpp_rente_capital',
+        );
+      } finally {
+        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+      }
+    });
+
+    test(
         'existing account login keeps local dossier separate without explicit handoff choice',
         () async {
       final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;

--- a/apps/mobile/test/services/account_handoff_service_test.dart
+++ b/apps/mobile/test/services/account_handoff_service_test.dart
@@ -175,4 +175,39 @@ void main() {
 
     expect(await AccountHandoffService.hasLocalData(), isTrue);
   });
+
+  test('requires explicit choice when local dossier exists and no choice saved',
+      () async {
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+    });
+
+    expect(
+      await AccountHandoffService.requiresExplicitChoice(
+        handoffEnabled: true,
+      ),
+      isTrue,
+    );
+
+    await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
+
+    expect(
+      await AccountHandoffService.requiresExplicitChoice(
+        handoffEnabled: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('does not require handoff choice when handoff UI is disabled', () async {
+    await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
+
+    expect(
+      await AccountHandoffService.requiresExplicitChoice(
+        handoffEnabled: false,
+      ),
+      isFalse,
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- Require an explicit keep/restart handoff choice before login, register, password auth, Apple auth, and magic-link verification when Mint2 local axis/session dossier exists.
- Keep `mint2AxisHandoff` / `onb_axis_v2` outside `wizardAnswers`; provider-level magic-link guard proves no HTTP call before consent.
- Ignore `.planning/runtime-evidence/` so runtime artifacts cannot be swept into commits.

## Evidence
- Diff size gate: `10 files changed, 257 insertions(+), 31 deletions(-)`.
- Runtime iPhone 13 mini: `MINT iPhone 13 mini RvC`, UDID `3D0534A9-8C3A-4663-9348-106D0599E9D6`, `flow_mint2_lpp_dossier_account_claim.yaml`, Maestro exit 0.
- Runtime assertions included `e2e_mint2_axis_claim_axis_lpp_rente_capital`, `e2e_mint2_axis_claim_wizardAnswers_0`, `e2e_mint2_axis_claim_axisInWizardAnswers_false`, post-relaunch keep/status, and restart-clean `axis_absent`.
- Local artifacts kept out of git under `.planning/runtime-evidence/mint2-lpp-account-20260618T222338/`.

## Test Plan
- [x] `cd apps/mobile && flutter analyze`
- [x] `cd apps/mobile && flutter test test/services/account_handoff_service_test.dart test/providers/auth_provider_test.dart`
- [x] `cd apps/mobile && flutter test` (`24 skipped tests. All other tests passed!`)
- [x] repo guards: active context, phase contract, mint rules, agent refs, Claude hooks, route parity, `./tools/mint-routes check`
- [x] design lints: `prefer_mint_color_token`, `prefer_mint_text_style`, `prefer_mint_fonts`, `prefer_mint_radius`, `prefer_mint_cta`
- [x] compliance copy: banned terms ARB/Python and diff grep for advice/ranking terms

## Notes
- The optional widget-level auth gate regression test was intentionally split out to keep this product PR under the 300-line review gate.
- Do not merge without explicit separate post-CI authorization.