### PR TITLE
Fix Mint2 magic-link handoff choice

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -27,6 +27,7 @@
     "feature/S06-mint2-dossier-axis-runtime",
     "feature/S06-mint2-account-runtime",
     "feature/S07-mint2-account-claim-product",
+    "feature/S08-mint2-magic-link-handoff",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/widgets/auth/migration_notice_listener.dart';
+import 'package:mint_mobile/widgets/auth/account_handoff_choice_panel.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/router/archetype_route_gate.dart';
@@ -1740,6 +1741,10 @@ final _router = GoRouter(
 @visibleForTesting
 GoRouter get testOnlyRootRouter => _router;
 
+@visibleForTesting
+Widget testOnlyMagicLinkVerifyScreen({String? token}) =>
+    _MagicLinkVerifyScreen(token: token);
+
 /// Test-only accessor for the root GoRouter observers list. Used by
 /// `test/app_router_observers_test.dart` (Phase 31-01 OBS-05).
 @visibleForTesting
@@ -2164,113 +2169,168 @@ class _MagicLinkVerifyScreen extends StatefulWidget {
 
 class _MagicLinkVerifyScreenState extends State<_MagicLinkVerifyScreen> {
   bool _isVerifying = true;
+  bool _requiresHandoffChoice = false;
+  bool _didStartVerification = false;
+  bool _verificationInFlight = false;
   String? _errorMessage;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didStartVerification) return;
+    _didStartVerification = true;
     _verifyToken();
   }
 
   Future<void> _verifyToken() async {
-    if (widget.token == null || widget.token!.isEmpty) {
-      setState(() {
-        _isVerifying = false;
-        _errorMessage = 'Lien invalide';
-      });
-      return;
-    }
+    if (_verificationInFlight) return;
+    _verificationInFlight = true;
+    try {
+      final l10n = S.of(context)!;
+      if (!_isVerifying || _errorMessage != null || _requiresHandoffChoice) {
+        setState(() {
+          _isVerifying = true;
+          _requiresHandoffChoice = false;
+          _errorMessage = null;
+        });
+      }
 
-    final authProvider = context.read<AuthProvider>();
-
-    if (FeatureFlags.enableMvpWedgeOnboarding) {
-      final hasSessionProfile = context.read<CoachProfileProvider>().hasProfile;
-      final requiresChoice = await AccountHandoffService.requiresExplicitChoice(
-        handoffEnabled: true,
-        hasSessionProfile: hasSessionProfile,
-      );
-      if (requiresChoice) {
-        if (!mounted) return;
+      if (widget.token == null || widget.token!.isEmpty) {
         setState(() {
           _isVerifying = false;
-          _errorMessage =
-              'Sélectionne d’abord conserver ou repartir avant d’ouvrir ce lien.';
+          _requiresHandoffChoice = false;
+          _errorMessage = l10n.authMagicLinkExpired;
         });
         return;
       }
-    }
 
-    final success = await authProvider.verifyMagicLink(widget.token!);
+      final authProvider = context.read<AuthProvider>();
 
-    if (!mounted) return;
-
-    if (success) {
-      // Post-auth routing: check onboarding status
-      final completed =
-          await ReportPersistenceService.isMiniOnboardingCompleted();
-      if (!mounted) return;
-      if (completed) {
-        context.go('/coach/chat');
-      } else {
-        // NAV-AUDIT: welcome prompt triggers onboarding flow in coach
-        context.go('/coach/chat?topic=onboarding');
+      if (FeatureFlags.enableMvpWedgeOnboarding) {
+        final hasSessionProfile =
+            context.read<CoachProfileProvider>().hasProfile;
+        final requiresChoice =
+            await AccountHandoffService.requiresExplicitChoice(
+          handoffEnabled: true,
+          hasSessionProfile: hasSessionProfile,
+        );
+        if (requiresChoice) {
+          if (!mounted) return;
+          setState(() {
+            _isVerifying = false;
+            _requiresHandoffChoice = true;
+            _errorMessage = l10n.authMagicLinkHandoffChoiceRequired;
+          });
+          return;
+        }
       }
-    } else {
-      setState(() {
-        _isVerifying = false;
-        _errorMessage = 'Ce lien est invalide ou a expiré';
-      });
+
+      final success = await authProvider.verifyMagicLink(widget.token!);
+
+      if (!mounted) return;
+
+      if (success) {
+        // Post-auth routing: check onboarding status
+        final completed =
+            await ReportPersistenceService.isMiniOnboardingCompleted();
+        if (!mounted) return;
+        if (completed) {
+          context.go('/coach/chat');
+        } else {
+          // NAV-AUDIT: welcome prompt triggers onboarding flow in coach
+          context.go('/coach/chat?topic=onboarding');
+        }
+      } else {
+        setState(() {
+          _isVerifying = false;
+          _requiresHandoffChoice = false;
+          _errorMessage = l10n.authMagicLinkExpired;
+        });
+      }
+    } finally {
+      _verificationInFlight = false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = S.of(context)!;
+    final body = _isVerifying
+        ? Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(height: 24),
+              Text(
+                'Vérification en cours...',
+                style: MintTextStyles.bodyLarge(color: MintColors.textPrimary),
+              ),
+            ],
+          )
+        : _requiresHandoffChoice
+            ? Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.storage_outlined,
+                    size: 64,
+                    color: MintColors.primary,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    _errorMessage ?? l10n.authMagicLinkHandoffChoiceRequired,
+                    textAlign: TextAlign.center,
+                    style:
+                        MintTextStyles.bodyLarge(color: MintColors.textPrimary),
+                  ),
+                  const SizedBox(height: 24),
+                  AccountHandoffChoicePanel(
+                    lockAfterChoice: true,
+                    onChoiceChanged: _verifyToken,
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    // lint-ignore: prefer_mint_cta
+                    onPressed: () => context.go('/auth/login'),
+                    child: Text(l10n.authBack),
+                  ),
+                ],
+              )
+            : Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.error_outline,
+                    size: 64,
+                    color: MintColors.error,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    _errorMessage ?? l10n.authMagicLinkExpired,
+                    textAlign: TextAlign.center,
+                    style:
+                        MintTextStyles.bodyLarge(color: MintColors.textPrimary),
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    // lint-ignore: prefer_mint_cta
+                    onPressed: () => _verifyToken(),
+                    child: Text(l10n.commonRetry),
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    // lint-ignore: prefer_mint_cta
+                    onPressed: () => context.go('/auth/login'),
+                    child: Text(l10n.authBack),
+                  ),
+                ],
+              );
     return Scaffold(
       backgroundColor: MintColors.background,
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
-          child: _isVerifying
-              ? Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const CircularProgressIndicator(),
-                    const SizedBox(height: 24),
-                    Text(
-                      'Vérification en cours...',
-                      style: TextStyle(
-                          fontSize: MintTextStyles.bodyLarge().fontSize,
-                          color: Colors.black87),
-                    ),
-                  ],
-                )
-              : Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.error_outline,
-                        size: 64, color: MintColors.error),
-                    const SizedBox(height: 24),
-                    Text(
-                      _errorMessage ?? 'Erreur de vérification',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                          fontSize: MintTextStyles.bodyLarge().fontSize,
-                          color: Colors.black87),
-                    ),
-                    const SizedBox(height: 24),
-                    FilledButton(
-                      // lint-ignore: prefer_mint_cta
-                      onPressed: () => _verifyToken(),
-                      child: const Text('Réessayer'),
-                    ),
-                    const SizedBox(height: 12),
-                    TextButton(
-                      // lint-ignore: prefer_mint_cta
-                      onPressed: () => context.go('/auth/login'),
-                      child: const Text('Retour à la connexion'),
-                    ),
-                  ],
-                ),
+          child: body,
         ),
       ),
     );

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -3609,6 +3609,8 @@
   "authHandoffKeepHint": "Mint behält Diagnose und Chat auf diesem Gerät; Cloud-Sync bleibt standardmässig aus.",
   "authHandoffRestartHint": "Mint öffnet das Konto, ohne lokale Diagnose oder anonymen Chat zu übernehmen.",
   "authHandoffChooseHint": "Wähle vor der Anmeldung, damit du kontrollierst, was deinem Konto folgt.",
+  "authMagicLinkHandoffChoiceRequired": "Lege vor dem Öffnen dieses Links fest, ob Mint lokale Daten behält oder ohne sie neu startet.",
+  "authMagicLinkExpired": "Dieser Link ist ungültig oder abgelaufen.",
   "authRequiredConsents": "Bestätige die Bedingungen und die Altersprüfung, bevor du dein Konto erstellst.",
   "authBack": "Zurück",
   "budgetTaxProvisionNotProvided": "Steuerrückstellung (nicht angegeben)",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -3609,6 +3609,8 @@
   "authHandoffKeepHint": "Mint keeps the diagnostic and chat on this device; cloud sync stays off by default.",
   "authHandoffRestartHint": "Mint opens the account without taking over the local diagnostic or anonymous chat.",
   "authHandoffChooseHint": "Choose before signing in so you control what follows your account.",
+  "authMagicLinkHandoffChoiceRequired": "Before opening this link, choose whether Mint keeps local data or starts without it.",
+  "authMagicLinkExpired": "This link is invalid or has expired.",
   "authRequiredConsents": "Confirm the terms and age check before creating your account.",
   "authBack": "Back",
   "budgetTaxProvisionNotProvided": "Tax provision (not provided)",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -3609,6 +3609,8 @@
   "authHandoffKeepHint": "Mint conserva el diagnóstico y el chat en este dispositivo; la sincronización cloud sigue desactivada por defecto.",
   "authHandoffRestartHint": "Mint abre la cuenta sin retomar el diagnóstico local ni el chat anónimo.",
   "authHandoffChooseHint": "Elige antes de iniciar sesión para controlar qué acompaña a tu cuenta.",
+  "authMagicLinkHandoffChoiceRequired": "Antes de abrir este enlace, indica si Mint conserva los datos locales o empieza sin ellos.",
+  "authMagicLinkExpired": "Este enlace no es válido o ha caducado.",
   "authRequiredConsents": "Confirma las condiciones y la verificación de edad antes de crear tu cuenta.",
   "authBack": "Volver",
   "budgetTaxProvisionNotProvided": "Provisión impuestos (no indicado)",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -4000,6 +4000,8 @@
   "authHandoffKeepHint": "Mint garde le diagnostic et la discussion sur cet appareil; la synchro cloud reste désactivée par défaut.",
   "authHandoffRestartHint": "Mint ouvre le compte sans reprendre le diagnostic local ni la discussion anonyme.",
   "authHandoffChooseHint": "Choisis avant de te connecter pour garder le contrôle sur ce qui suit ton compte.",
+  "authMagicLinkHandoffChoiceRequired": "Avant d’ouvrir ce lien, indique si Mint conserve les données locales ou repart sans elles.",
+  "authMagicLinkExpired": "Ce lien est invalide ou a expiré.",
   "authRequiredConsents": "Confirme les conditions et l'âge avant de créer ton compte.",
   "authBack": "Retour",
   "coachComplianceError": "Je préfère ne pas répondre à ça. Reformule ta question, ou utilise un simulateur pour un chiffre direct.",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -3609,6 +3609,8 @@
   "authHandoffKeepHint": "Mint conserva diagnosi e chat su questo dispositivo; la sincronizzazione cloud resta disattivata di default.",
   "authHandoffRestartHint": "Mint apre l'account senza riprendere diagnosi locale o chat anonima.",
   "authHandoffChooseHint": "Scegli prima di accedere per controllare cosa segue il tuo account.",
+  "authMagicLinkHandoffChoiceRequired": "Prima di aprire questo link, indica se Mint conserva i dati locali o riparte senza di essi.",
+  "authMagicLinkExpired": "Questo link non è valido o è scaduto.",
   "authRequiredConsents": "Conferma le condizioni e la verifica dell'età prima di creare il conto.",
   "authBack": "Indietro",
   "budgetTaxProvisionNotProvided": "Accantonamento imposte (non indicato)",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -14310,6 +14310,18 @@ abstract class S {
   /// **'Choisis avant de te connecter pour garder le contrôle sur ce qui suit ton compte.'**
   String get authHandoffChooseHint;
 
+  /// No description provided for @authMagicLinkHandoffChoiceRequired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Avant d’ouvrir ce lien, indique si Mint conserve les données locales ou repart sans elles.'**
+  String get authMagicLinkHandoffChoiceRequired;
+
+  /// No description provided for @authMagicLinkExpired.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ce lien est invalide ou a expiré.'**
+  String get authMagicLinkExpired;
+
   /// No description provided for @authRequiredConsents.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -8085,6 +8085,14 @@ class SDe extends S {
       'Wähle vor der Anmeldung, damit du kontrollierst, was deinem Konto folgt.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Lege vor dem Öffnen dieses Links fest, ob Mint lokale Daten behält oder ohne sie neu startet.';
+
+  @override
+  String get authMagicLinkExpired =>
+      'Dieser Link ist ungültig oder abgelaufen.';
+
+  @override
   String get authRequiredConsents =>
       'Bestätige die Bedingungen und die Altersprüfung, bevor du dein Konto erstellst.';
 

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -8012,6 +8012,13 @@ class SEn extends S {
       'Choose before signing in so you control what follows your account.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Before opening this link, choose whether Mint keeps local data or starts without it.';
+
+  @override
+  String get authMagicLinkExpired => 'This link is invalid or has expired.';
+
+  @override
   String get authRequiredConsents =>
       'Confirm the terms and age check before creating your account.';
 

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -8064,6 +8064,13 @@ class SEs extends S {
       'Elige antes de iniciar sesión para controlar qué acompaña a tu cuenta.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Antes de abrir este enlace, indica si Mint conserva los datos locales o empieza sin ellos.';
+
+  @override
+  String get authMagicLinkExpired => 'Este enlace no es válido o ha caducado.';
+
+  @override
   String get authRequiredConsents =>
       'Confirma las condiciones y la verificación de edad antes de crear tu cuenta.';
 

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -8061,6 +8061,13 @@ class SFr extends S {
       'Choisis avant de te connecter pour garder le contrôle sur ce qui suit ton compte.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Avant d’ouvrir ce lien, indique si Mint conserve les données locales ou repart sans elles.';
+
+  @override
+  String get authMagicLinkExpired => 'Ce lien est invalide ou a expiré.';
+
+  @override
   String get authRequiredConsents =>
       'Confirme les conditions et l\'âge avant de créer ton compte.';
 

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -8079,6 +8079,13 @@ class SIt extends S {
       'Scegli prima di accedere per controllare cosa segue il tuo account.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Prima di aprire questo link, indica se Mint conserva i dati locali o riparte senza di essi.';
+
+  @override
+  String get authMagicLinkExpired => 'Questo link non è valido o è scaduto.';
+
+  @override
   String get authRequiredConsents =>
       'Conferma le condizioni e la verifica dell\'età prima di creare il conto.';
 

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -8058,6 +8058,13 @@ class SPt extends S {
       'Escolhe antes de iniciar sessão para controlar o que acompanha a tua conta.';
 
   @override
+  String get authMagicLinkHandoffChoiceRequired =>
+      'Antes de abrir este link, indica se o Mint mantém os dados locais ou recomeça sem eles.';
+
+  @override
+  String get authMagicLinkExpired => 'Este link é inválido ou expirou.';
+
+  @override
   String get authRequiredConsents =>
       'Confirma os termos e a verificação de idade antes de criar a tua conta.';
 

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -3609,6 +3609,8 @@
   "authHandoffKeepHint": "Mint mantém o diagnóstico e o chat neste dispositivo; a sincronização cloud fica desativada por defeito.",
   "authHandoffRestartHint": "Mint abre a conta sem retomar o diagnóstico local nem o chat anónimo.",
   "authHandoffChooseHint": "Escolhe antes de iniciar sessão para controlar o que acompanha a tua conta.",
+  "authMagicLinkHandoffChoiceRequired": "Antes de abrir este link, indica se o Mint mantém os dados locais ou recomeça sem eles.",
+  "authMagicLinkExpired": "Este link é inválido ou expirou.",
   "authRequiredConsents": "Confirma os termos e a verificação de idade antes de criar a tua conta.",
   "authBack": "Voltar",
   "budgetTaxProvisionNotProvided": "Provisão impostos (não indicado)",

--- a/apps/mobile/lib/widgets/auth/account_handoff_choice_panel.dart
+++ b/apps/mobile/lib/widgets/auth/account_handoff_choice_panel.dart
@@ -12,9 +12,11 @@ class AccountHandoffChoicePanel extends StatefulWidget {
   const AccountHandoffChoicePanel({
     super.key,
     this.onChoiceChanged,
+    this.lockAfterChoice = false,
   });
 
   final VoidCallback? onChoiceChanged;
+  final bool lockAfterChoice;
 
   @override
   State<AccountHandoffChoicePanel> createState() =>
@@ -24,6 +26,7 @@ class AccountHandoffChoicePanel extends StatefulWidget {
 class _AccountHandoffChoicePanelState extends State<AccountHandoffChoicePanel> {
   AccountHandoffChoice? _choice;
   bool _hasLocalData = false;
+  bool _choiceLocked = false;
 
   @override
   void initState() {
@@ -42,7 +45,13 @@ class _AccountHandoffChoicePanelState extends State<AccountHandoffChoicePanel> {
   }
 
   Future<void> _setChoice(AccountHandoffChoice choice) async {
-    setState(() => _choice = choice);
+    if (_choiceLocked) return;
+    setState(() {
+      _choice = choice;
+      if (widget.lockAfterChoice) {
+        _choiceLocked = true;
+      }
+    });
     await AccountHandoffService.saveChoice(choice);
     if (!mounted) return;
     widget.onChoiceChanged?.call();
@@ -104,10 +113,12 @@ class _AccountHandoffChoicePanelState extends State<AccountHandoffChoicePanel> {
             emptySelectionAllowed: true,
             showSelectedIcon: false,
             selected: _choice == null ? {} : {_choice!},
-            onSelectionChanged: (values) {
-              if (values.isEmpty) return;
-              _setChoice(values.first);
-            },
+            onSelectionChanged: _choiceLocked
+                ? null
+                : (values) {
+                    if (values.isEmpty) return;
+                    _setChoice(values.first);
+                  },
             segments: [
               ButtonSegment(
                 value: AccountHandoffChoice.keepLocal,

--- a/apps/mobile/test/screens/auth_magic_link_verify_handoff_test.dart
+++ b/apps/mobile/test/screens/auth_magic_link_verify_handoff_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mint_mobile/app.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/feature_flags.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _verifyPath = '/api/v1/auth/magic-link/verify';
+const _mePath = '/api/v1/auth/me';
+const _claimPath = '/api/v1/sync/claim-local-data';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late bool previousWedgeFlag;
+
+  setUp(() {
+    previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    ApiService.setHttpClientForTesting(null);
+  });
+
+  tearDown(() {
+    FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+    ApiService.setHttpClientForTesting(null);
+  });
+
+  Widget buildVerifyScreen() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => CoachProfileProvider()),
+      ],
+      child: MaterialApp.router(
+        locale: const Locale('en'),
+        localizationsDelegates: const [S.delegate],
+        routerConfig: GoRouter(
+          initialLocation: '/verify',
+          routes: [
+            GoRoute(
+              path: '/verify',
+              builder: (_, __) =>
+                  testOnlyMagicLinkVerifyScreen(token: 'magic-code'),
+            ),
+            GoRoute(
+              path: '/coach/chat',
+              builder: (_, __) =>
+                  const Scaffold(body: Text('coach-chat-target')),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void installMagicLinkMock(List<String> paths) {
+    ApiService.setHttpClientForTesting(MintHttpClient(
+      MockClient((request) async {
+        paths.add(request.url.path);
+        final body = switch (request.url.path) {
+          _verifyPath => '{"accessToken":"magic-token","tokenType":"bearer"}',
+          _mePath => '{"id":"magic-user","email":"magic@example.ch"}',
+          '/api/v1/profiles/me' => '{}',
+          _ => '{"detail":"not found"}',
+        };
+        return http.Response(
+          body,
+          body.contains('not found') ? 404 : 200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+    ));
+  }
+
+  Future<List<String>> pumpHandoffGate(WidgetTester tester) async {
+    FeatureFlags.enableMvpWedgeOnboarding = true;
+    final paths = <String>[];
+    installMagicLinkMock(paths);
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+    });
+
+    await tester.pumpWidget(buildVerifyScreen());
+    await tester.pumpAndSettle();
+
+    expect(paths, isEmpty);
+    expect(find.text('Local data'), findsOneWidget);
+    return paths;
+  }
+
+  testWidgets(
+      'magic-link verifier offers handoff choice and waits before network call',
+      (tester) async {
+    final paths = await pumpHandoffGate(tester);
+
+    await tester.tap(find.text('Keep'));
+    await tester.pumpAndSettle();
+
+    expect(paths, containsAll([_verifyPath, _mePath]));
+    expect(paths, isNot(contains(_claimPath)));
+    expect(find.text('coach-chat-target'), findsOneWidget);
+  });
+
+  testWidgets('magic-link verifier honors start-over choice before auth',
+      (tester) async {
+    final paths = await pumpHandoffGate(tester);
+    expect(await ReportPersistenceService.loadMint2AxisHandoff(), isNotEmpty);
+
+    await tester.tap(find.text('Start over'));
+    await tester.pumpAndSettle();
+
+    expect(paths, containsAll([_verifyPath, _mePath]));
+    expect(paths, isNot(contains(_claimPath)));
+    expect(await ReportPersistenceService.loadMint2AxisHandoff(), isEmpty);
+    expect(find.text('coach-chat-target'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Gate magic-link verification behind explicit local-data handoff choice when Mint2 anonymous handoff data exists.
- Lock the handoff segmented choice after selection so auth proceeds once with the chosen path.
- Add widget coverage for keep/start-over paths, including no auth network call before choice and no claim call in local-mode flow.

## Tests
- flutter analyze
- flutter test test/screens/auth_magic_link_verify_handoff_test.dart test/services/account_handoff_service_test.dart test/providers/auth_provider_test.dart
- flutter test
- python3 tools/checks/arb_parity.py
- python3 tools/checks/accent_lint_fr.py --file apps/mobile/lib/l10n/app_fr.arb
- python3 tools/checks/banned_terms_arb.py --locale all
- design lints: prefer_mint_color_token/text_style/fonts/radius/cta on touched Dart files