### PR TITLE
feat(mint2): add admin claim readback summary

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -28,6 +28,7 @@
     "feature/S06-mint2-account-runtime",
     "feature/S07-mint2-account-claim-product",
     "feature/S08-mint2-magic-link-handoff",
+    "feature/S06-mint2-admin-claim-readback",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/services/backend/app/api/v1/endpoints/admin.py
+++ b/services/backend/app/api/v1/endpoints/admin.py
@@ -6,7 +6,7 @@ Gated by feature flag: enable_admin_screens.
 """
 
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
@@ -15,11 +15,27 @@ from app.core.auth import require_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.audit_event import AuditEventModel
+from app.models.profile_model import ProfileModel
 from app.models.user import User
 from app.schemas.audit import AuditEventResponse, PaginatedAuditResponse
+from app.schemas.sync import (
+    AdminLocalDataClaimSummaryResponse,
+    LocalDataClaimMetaSummary,
+)
 from app.services.feature_flags import FeatureFlags
 
 router = APIRouter()
+
+_ALLOWED_MINT2_AXIS_IDS = {"lpp_rente_capital"}
+
+_WIZARD_AXIS_KEYS = {
+    "mint2AxisHandoff",
+    "mint2_axis_handoff",
+    "onb_axis_v2",
+    "onb_axis_schema_version",
+    "legacy_onb_intent",
+    "onb_signal_axes_v2",
+}
 
 
 def _require_admin(current_user: User) -> None:
@@ -42,6 +58,19 @@ def _require_admin(current_user: User) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Role support_admin requis",
         )
+
+
+def _safe_mint2_axis_id(value: Any) -> Optional[str]:
+    if not isinstance(value, dict):
+        return None
+    axis_id = value.get("onb_axis_v2")
+    return axis_id if axis_id in _ALLOWED_MINT2_AXIS_IDS else None
+
+
+def _wizard_answers_contains_axis(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return any(key in value for key in _WIZARD_AXIS_KEYS)
 
 
 @router.get("/audit", response_model=PaginatedAuditResponse)
@@ -85,6 +114,85 @@ def list_audit_events(
         total=total,
         limit=limit,
         offset=offset,
+    )
+
+
+@router.get(
+    "/local-data-claim-summary/{profile_id}",
+    response_model=AdminLocalDataClaimSummaryResponse,
+)
+def get_local_data_claim_summary(
+    profile_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
+) -> AdminLocalDataClaimSummaryResponse:
+    """Return a PII-free summary of local-data claim state for admin proof."""
+    FeatureFlags.require_flag("enable_admin_screens")
+    _require_admin(current_user)
+
+    profile = db.query(ProfileModel).filter(ProfileModel.id == profile_id).first()
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found",
+        )
+
+    data = profile.data if isinstance(profile.data, dict) else {}
+    claim = data.get("localDataClaim")
+    if not isinstance(claim, dict):
+        return AdminLocalDataClaimSummaryResponse(
+            profile_id=profile_id,
+            has_local_data_claim=False,
+            wizard_answers_count=0,
+            wizard_answers_contains_axis=False,
+            mint2_axis_handoff_present=False,
+            mint2_axis_id=None,
+            schema_version=None,
+            legacy_intent_present=False,
+            source_engine_present=False,
+            receipt_hash_present=False,
+            receipt_ref_present=False,
+            generated_at_present=False,
+            calculation_version_present=False,
+            regulatory_constants_version_hash_present=False,
+            meta=LocalDataClaimMetaSummary(
+                claimed_at_present=False,
+                updated_at_present=False,
+                device_id_present=False,
+                local_data_version=None,
+            ),
+        )
+
+    wizard_answers = claim.get("wizardAnswers")
+    handoff = claim.get("mint2AxisHandoff")
+    handoff_dict = handoff if isinstance(handoff, dict) else {}
+    meta = claim.get("meta") if isinstance(claim.get("meta"), dict) else {}
+    version = meta.get("localDataVersion")
+    schema_version = handoff_dict.get("onb_axis_schema_version")
+
+    return AdminLocalDataClaimSummaryResponse(
+        profile_id=profile_id,
+        has_local_data_claim=True,
+        wizard_answers_count=len(wizard_answers) if isinstance(wizard_answers, dict) else 0,
+        wizard_answers_contains_axis=_wizard_answers_contains_axis(wizard_answers),
+        mint2_axis_handoff_present=bool(handoff_dict),
+        mint2_axis_id=_safe_mint2_axis_id(handoff_dict),
+        schema_version=schema_version if isinstance(schema_version, int) else None,
+        legacy_intent_present=bool(handoff_dict.get("legacy_onb_intent")),
+        source_engine_present=bool(handoff_dict.get("source_engine")),
+        receipt_hash_present=bool(handoff_dict.get("receipt_hash")),
+        receipt_ref_present=bool(handoff_dict.get("receipt_ref")),
+        generated_at_present=bool(handoff_dict.get("generated_at")),
+        calculation_version_present=bool(handoff_dict.get("calculation_version")),
+        regulatory_constants_version_hash_present=bool(
+            handoff_dict.get("regulatory_constants_version_hash")
+        ),
+        meta=LocalDataClaimMetaSummary(
+            claimed_at_present=bool(meta.get("claimedAt")),
+            updated_at_present=bool(meta.get("updatedAt")),
+            device_id_present=bool(meta.get("deviceId")),
+            local_data_version=version if isinstance(version, int) else None,
+        ),
     )
 
 

--- a/services/backend/app/schemas/sync.py
+++ b/services/backend/app/schemas/sync.py
@@ -30,3 +30,32 @@ class ClaimLocalDataResponse(BaseModel):
     profile_id: str
     created_profile: bool
     merged_fields_count: int
+
+
+class LocalDataClaimMetaSummary(BaseModel):
+    """PII-free metadata summary for admin runtime proof."""
+
+    claimed_at_present: bool
+    updated_at_present: bool
+    device_id_present: bool
+    local_data_version: Optional[int] = None
+
+
+class AdminLocalDataClaimSummaryResponse(BaseModel):
+    """PII-free local-data claim summary for restricted admin observability."""
+
+    profile_id: str
+    has_local_data_claim: bool
+    wizard_answers_count: int
+    wizard_answers_contains_axis: bool
+    mint2_axis_handoff_present: bool
+    mint2_axis_id: Optional[str] = None
+    schema_version: Optional[int] = None
+    legacy_intent_present: bool
+    source_engine_present: bool
+    receipt_hash_present: bool
+    receipt_ref_present: bool
+    generated_at_present: bool
+    calculation_version_present: bool
+    regulatory_constants_version_hash_present: bool
+    meta: LocalDataClaimMetaSummary

--- a/services/backend/tests/test_admin_local_data_claim_summary.py
+++ b/services/backend/tests/test_admin_local_data_claim_summary.py
@@ -1,0 +1,160 @@
+"""
+Tests for admin local-data claim summary readback.
+
+The endpoint exists for staging/runtime proof only: it must not expose the raw
+localDataClaim payload, wizard answers, device id, or user PII.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.auth import get_current_user, require_current_user
+from app.main import app
+from tests.conftest import TestingSessionLocal
+
+
+@pytest.fixture
+def auth_client(client: TestClient):
+    app.dependency_overrides.pop(require_current_user, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    yield client
+
+
+def _register(client: TestClient, email: str) -> dict:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={"email": email, "password": "pass12345"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _promote_admin(email: str) -> None:
+    from app.models.user import User
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).one()
+        user.role = "support_admin"
+        user.email_verified = True
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_admin_local_data_claim_summary_is_whitelisted(
+    auth_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    owner = _register(auth_client, "claim-owner@example.com")
+    owner_token = owner["access_token"]
+
+    claim_response = auth_client.post(
+        "/api/v1/sync/claim-local-data",
+        headers={"Authorization": f"Bearer {owner_token}"},
+        json={
+            "local_data_version": 1,
+            "device_id": "ios-device-claim-readback",
+            "updated_at": "2026-06-19T08:00:00Z",
+            "wizard_answers": {
+                "q_income_monthly": 9200,
+                "q_canton": "VS",
+            },
+            "mint2_axis_handoff": {
+                "onb_axis_v2": "lpp_rente_capital",
+                "onb_axis_schema_version": 2,
+                "legacy_onb_intent": "claim-owner@example.com",
+                "source_engine": "9200 CHF must-not-leak",
+                "receipt_hash": "claim-owner@example.com",
+                "receipt_ref": "ios-device-claim-readback",
+                "generated_at": "9200",
+                "calculation_version": "must-not-leak",
+                "regulatory_constants_version_hash": "claim-owner@example.com",
+                "raw_note": "must-not-leak",
+            },
+        },
+    )
+    assert claim_response.status_code == 200
+    profile_id = claim_response.json()["profile_id"]
+
+    admin_email = "claim-admin@example.com"
+    admin = _register(auth_client, admin_email)
+    _promote_admin(admin_email)
+
+    monkeypatch.setenv("FF_ENABLE_ADMIN_SCREENS", "true")
+    monkeypatch.setenv("AUTH_ADMIN_EMAIL_ALLOWLIST", admin_email)
+    response = auth_client.get(
+        f"/api/v1/admin/local-data-claim-summary/{profile_id}",
+        headers={"Authorization": f"Bearer {admin['access_token']}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "profile_id": profile_id,
+        "has_local_data_claim": True,
+        "wizard_answers_count": 2,
+        "wizard_answers_contains_axis": False,
+        "mint2_axis_handoff_present": True,
+        "mint2_axis_id": "lpp_rente_capital",
+        "schema_version": 2,
+        "legacy_intent_present": True,
+        "source_engine_present": True,
+        "receipt_hash_present": True,
+        "receipt_ref_present": True,
+        "generated_at_present": True,
+        "calculation_version_present": True,
+        "regulatory_constants_version_hash_present": True,
+        "meta": {
+            "claimed_at_present": True,
+            "updated_at_present": True,
+            "device_id_present": True,
+            "local_data_version": 1,
+        },
+    }
+    serialized = json.dumps(body)
+    assert "q_income_monthly" not in serialized
+    assert "9200" not in serialized
+    assert "CHF" not in serialized
+    assert "ios-device-claim-readback" not in serialized
+    assert "claim-owner@example.com" not in serialized
+    assert "must-not-leak" not in serialized
+
+
+def test_admin_local_data_claim_summary_requires_flag(
+    auth_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    admin_email = "claim-admin-flag@example.com"
+    admin = _register(auth_client, admin_email)
+    _promote_admin(admin_email)
+
+    monkeypatch.setenv("FF_ENABLE_ADMIN_SCREENS", "false")
+    monkeypatch.setenv("AUTH_ADMIN_EMAIL_ALLOWLIST", admin_email)
+    response = auth_client.get(
+        "/api/v1/admin/local-data-claim-summary/missing-profile",
+        headers={"Authorization": f"Bearer {admin['access_token']}"},
+    )
+
+    assert response.status_code == 403
+    assert "enable_admin_screens" in response.json()["detail"]
+
+
+def test_admin_local_data_claim_summary_requires_support_admin_role(
+    auth_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user_email = "claim-non-admin@example.com"
+    user = _register(auth_client, user_email)
+
+    monkeypatch.setenv("FF_ENABLE_ADMIN_SCREENS", "true")
+    monkeypatch.setenv("AUTH_ADMIN_EMAIL_ALLOWLIST", user_email)
+    response = auth_client.get(
+        "/api/v1/admin/local-data-claim-summary/missing-profile",
+        headers={"Authorization": f"Bearer {user['access_token']}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Role support_admin requis"

--- a/tools/openapi/mint.openapi.canonical.json
+++ b/tools/openapi/mint.openapi.canonical.json
@@ -190,6 +190,101 @@
         "title": "ActionItemResponse",
         "type": "object"
       },
+      "AdminLocalDataClaimSummaryResponse": {
+        "description": "PII-free local-data claim summary for restricted admin observability.",
+        "properties": {
+          "calculation_version_present": {
+            "title": "Calculation Version Present",
+            "type": "boolean"
+          },
+          "generated_at_present": {
+            "title": "Generated At Present",
+            "type": "boolean"
+          },
+          "has_local_data_claim": {
+            "title": "Has Local Data Claim",
+            "type": "boolean"
+          },
+          "legacy_intent_present": {
+            "title": "Legacy Intent Present",
+            "type": "boolean"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/LocalDataClaimMetaSummary"
+          },
+          "mint2_axis_handoff_present": {
+            "title": "Mint2 Axis Handoff Present",
+            "type": "boolean"
+          },
+          "mint2_axis_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mint2 Axis Id"
+          },
+          "profile_id": {
+            "title": "Profile Id",
+            "type": "string"
+          },
+          "receipt_hash_present": {
+            "title": "Receipt Hash Present",
+            "type": "boolean"
+          },
+          "receipt_ref_present": {
+            "title": "Receipt Ref Present",
+            "type": "boolean"
+          },
+          "regulatory_constants_version_hash_present": {
+            "title": "Regulatory Constants Version Hash Present",
+            "type": "boolean"
+          },
+          "schema_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schema Version"
+          },
+          "source_engine_present": {
+            "title": "Source Engine Present",
+            "type": "boolean"
+          },
+          "wizard_answers_contains_axis": {
+            "title": "Wizard Answers Contains Axis",
+            "type": "boolean"
+          },
+          "wizard_answers_count": {
+            "title": "Wizard Answers Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "profile_id",
+          "has_local_data_claim",
+          "wizard_answers_count",
+          "wizard_answers_contains_axis",
+          "mint2_axis_handoff_present",
+          "legacy_intent_present",
+          "source_engine_present",
+          "receipt_hash_present",
+          "receipt_ref_present",
+          "generated_at_present",
+          "calculation_version_present",
+          "regulatory_constants_version_hash_present",
+          "meta"
+        ],
+        "title": "AdminLocalDataClaimSummaryResponse",
+        "type": "object"
+      },
       "AdminOverrideCooldownRequest": {
         "properties": {
           "reason": {
@@ -13373,6 +13468,41 @@
         "title": "LifeEventChecklistResponse",
         "type": "object"
       },
+      "LocalDataClaimMetaSummary": {
+        "description": "PII-free metadata summary for admin runtime proof.",
+        "properties": {
+          "claimed_at_present": {
+            "title": "Claimed At Present",
+            "type": "boolean"
+          },
+          "device_id_present": {
+            "title": "Device Id Present",
+            "type": "boolean"
+          },
+          "local_data_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Local Data Version"
+          },
+          "updated_at_present": {
+            "title": "Updated At Present",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "claimed_at_present",
+          "updated_at_present",
+          "device_id_present"
+        ],
+        "title": "LocalDataClaimMetaSummary",
+        "type": "object"
+      },
       "LocationVsProprieteRequest": {
         "description": "Requete pour la comparaison location vs achat immobilier.\n\nPer D-CE-06 + D-CE-07 (Plan mint-calc-engine-v1-03), `canton` carries the\n`from_profile` marker so `_resolve_defaults` fills it from\n`_user.profile.canton` before the missing-check fires. W0 audit row 3\nsev-2 : the legacy `canton=\"VD\"` fallback produced wrong rent vs property\neconomic comparison for non-VD users.",
         "properties": {
@@ -24928,6 +25058,54 @@
           }
         },
         "summary": "Set Feature Flag",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/local-data-claim-summary/{profile_id}": {
+      "get": {
+        "description": "Return a PII-free summary of local-data claim state for admin proof.",
+        "operationId": "get_local_data_claim_summary_api_v1_admin_local_data_claim_summary__profile_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "profile_id",
+            "required": true,
+            "schema": {
+              "title": "Profile Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminLocalDataClaimSummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Local Data Claim Summary",
         "tags": [
           "Admin"
         ]


### PR DESCRIPTION
## Summary
- add restricted admin readback for localDataClaim/Mint2 axis persistence proof
- expose only structural, PII-free fields: validated Mint2 axis id, counts, booleans, integer versions
- cover flag/RBAC gates and canary sensitive values under handoff keys

## Verification
- cd services/backend && python3 -m pytest tests/test_admin_local_data_claim_summary.py -q
- cd services/backend && python3 -m pytest tests/test_admin_local_data_claim_summary.py tests/test_admin_audit.py -q
- cd services/backend && python3 -m pytest tests/test_auth.py -q
- cd services/backend && ruff check app tests
- cd services/backend && python3 -m pytest tests/ -q
- python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/agent_reference_guard.py && python3 tools/checks/claude_hooks_guard.py && python3 tools/checks/verify_phase_acceptance.py && python3 tools/checks/route_registry_parity.py && ./tools/mint-routes check && git diff --check && git diff --cached --check

## Reviews
- Expert subagent initial blocker fixed: no raw handoff value echo
- Expert subagent second pass: BLOCKERS: none
- Claude Max: long run exceeded 10 minutes but hung without output; bounded follow-up returned BLOCKERS: none

## Caveat
- Real-device Keychain/iCloud proof remains blocked until a paired physical iPhone is reachable.
- Staging proof requires this PR to deploy with FF_ENABLE_ADMIN_SCREENS and admin allowlist configured.