### PR TITLE
fix(mint2): preserve register dossier redirect

### DIFF
--- a/apps/mobile/lib/screens/auth/auth_redirect.dart
+++ b/apps/mobile/lib/screens/auth/auth_redirect.dart
@@ -1,3 +1,5 @@
+import 'package:mint_mobile/services/report_persistence_service.dart';
+
 String? resolvePostAuthRedirect(Uri uri) {
   final redirect = uri.queryParameters['redirect'];
   if (redirect == null || redirect.isEmpty) return null;
@@ -33,6 +35,14 @@ bool hasDossierIdentityAnswers(Map<String, dynamic> answers) {
   if (birthYear is String && int.tryParse(birthYear) != null) return true;
 
   return false;
+}
+
+Future<bool> hasPostAuthDossierIdentity({
+  required DateTime? localDateOfBirth,
+}) async {
+  if (localDateOfBirth != null) return true;
+  final answers = await ReportPersistenceService.loadAnswers();
+  return hasDossierIdentityAnswers(answers);
 }
 
 String resolvePostAuthDestination({

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -120,7 +120,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
             GoRouterState.of(context).uri,
           ));
         } else {
-          _goAfterAccountCreated();
+          await _goAfterAccountCreated();
         }
       }
     } finally {
@@ -163,7 +163,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
       await _persistConsentPreferences();
       if (!mounted) return;
-      _goAfterAccountCreated();
+      await _goAfterAccountCreated();
     } catch (_) {
       if (mounted) {
         setState(() {
@@ -186,8 +186,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
     await prefs.setString('cgu_accepted_at', DateTime.now().toIso8601String());
   }
 
-  void _goAfterAccountCreated() {
-    final hasDossierIdentity = _dateOfBirth != null;
+  Future<void> _goAfterAccountCreated() async {
+    final hasDossierIdentity = await hasPostAuthDossierIdentity(
+      localDateOfBirth: _dateOfBirth,
+    );
+    if (!mounted) return;
     context.go(resolvePostAuthDestination(
       currentUri: GoRouterState.of(context).uri,
       hasDossierIdentity: hasDossierIdentity,

--- a/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
@@ -375,7 +375,7 @@ class _PrimaryButton extends StatelessWidget {
     final button = SizedBox(
       key: identifier == null ? buttonKey : null,
       width: double.infinity,
-      height: 52,
+      height: 56,
       child: FilledButton(
         // lint-ignore: prefer_mint_cta
         onPressed: onPressed,
@@ -907,32 +907,32 @@ class _AgeStepState extends State<_AgeStep> {
 // ────────────────────────────────────────────────────────────────────
 
 const _cantons = <(String, String)>[
-  ('VD', 'Vaud'),
-  ('GE', 'Genève'),
-  ('VS', 'Valais'),
-  ('FR', 'Fribourg'),
-  ('NE', 'Neuchâtel'),
-  ('JU', 'Jura'),
-  ('BE', 'Berne'),
-  ('ZH', 'Zurich'),
-  ('BS', 'Bâle-Ville'),
-  ('BL', 'Bâle-Campagne'),
-  ('SO', 'Soleure'),
   ('AG', 'Argovie'),
-  ('LU', 'Lucerne'),
-  ('ZG', 'Zoug'),
-  ('SZ', 'Schwytz'),
-  ('OW', 'Obwald'),
-  ('NW', 'Nidwald'),
-  ('UR', 'Uri'),
-  ('GL', 'Glaris'),
-  ('SH', 'Schaffhouse'),
-  ('AR', 'Appenzell RE'),
   ('AI', 'Appenzell RI'),
-  ('SG', 'Saint-Gall'),
+  ('AR', 'Appenzell RE'),
+  ('BE', 'Berne'),
+  ('BL', 'Bâle-Campagne'),
+  ('BS', 'Bâle-Ville'),
+  ('FR', 'Fribourg'),
+  ('GE', 'Genève'),
+  ('GL', 'Glaris'),
   ('GR', 'Grisons'),
+  ('JU', 'Jura'),
+  ('LU', 'Lucerne'),
+  ('NE', 'Neuchâtel'),
+  ('NW', 'Nidwald'),
+  ('OW', 'Obwald'),
+  ('SG', 'Saint-Gall'),
+  ('SH', 'Schaffhouse'),
+  ('SO', 'Soleure'),
+  ('SZ', 'Schwytz'),
   ('TG', 'Thurgovie'),
   ('TI', 'Tessin'),
+  ('UR', 'Uri'),
+  ('VD', 'Vaud'),
+  ('VS', 'Valais'),
+  ('ZG', 'Zoug'),
+  ('ZH', 'Zurich'),
 ];
 
 class _CantonStep extends StatelessWidget {
@@ -944,11 +944,12 @@ class _CantonStep extends StatelessWidget {
     return _StepScaffold(
       prompt: 'Où tu vis ?',
       child: GridView.builder(
+        padding: const EdgeInsets.only(bottom: 12),
         gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: 3,
           crossAxisSpacing: 10,
           mainAxisSpacing: 10,
-          childAspectRatio: 2.2,
+          childAspectRatio: 1.9,
         ),
         itemCount: _cantons.length,
         itemBuilder: (context, i) {
@@ -1573,7 +1574,7 @@ class _BifurcationStepState extends State<_BifurcationStep> {
         child: ExcludeSemantics(
           child: SizedBox(
             width: double.infinity,
-            height: 48,
+            height: 56,
             child: OutlinedButton(
               // lint-ignore: prefer_mint_cta
               onPressed: onPressed,
@@ -1605,7 +1606,7 @@ class _BifurcationStepState extends State<_BifurcationStep> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const Expanded(child: _TerminalDossierSummary()),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           _PrimaryButton(
             key: const ValueKey('onboarding-bifurcation-continue'),
             semanticsIdentifier: 'onboarding-bifurcation-continue',

--- a/apps/mobile/lib/screens/onboarding/mvp_wedge/scenes/mint_scene_statut_emploi.dart
+++ b/apps/mobile/lib/screens/onboarding/mvp_wedge/scenes/mint_scene_statut_emploi.dart
@@ -27,6 +27,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
+import 'package:mint_mobile/theme/mint_spacing.dart';
 
 /// Internal employment values matching `_parseEmploymentStatus` EXACTLY.
 /// `sans_activite` is parsed by the W2 extension to coach_profile.dart so
@@ -93,46 +94,53 @@ class MintSceneStatutEmploi extends StatelessWidget {
               ),
             ),
           ),
-          const Spacer(),
-          Semantics(
-            container: true,
-            label: l.onboardingEmploymentPrompt,
-            child: Column(
-              children: [
-                for (final (value, label, key, hint) in options) ...[
-                  SizedBox(
-                    width: double.infinity,
-                    height: 48,
-                    child: Semantics(
-                      inMutuallyExclusiveGroup: true,
-                      button: true,
-                      label: label,
-                      hint: hint,
-                      child: FilledButton.tonal(
-                        key: ValueKey(key),
-                        onPressed: () => _answer(context, value),
-                        style: FilledButton.styleFrom(
-                          backgroundColor: MintColors.craie,
-                          foregroundColor: MintColors.textPrimary,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(14),
+          const SizedBox(height: MintSpacing.xl),
+          Expanded(
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: SingleChildScrollView(
+                child: Semantics(
+                  container: true,
+                  label: l.onboardingEmploymentPrompt,
+                  child: Column(
+                    children: [
+                      for (final (value, label, key, hint) in options) ...[
+                        SizedBox(
+                          width: double.infinity,
+                          height: 56,
+                          child: Semantics(
+                            inMutuallyExclusiveGroup: true,
+                            button: true,
+                            label: label,
+                            hint: hint,
+                            child: FilledButton.tonal(
+                              key: ValueKey(key),
+                              onPressed: () => _answer(context, value),
+                              style: FilledButton.styleFrom(
+                                backgroundColor: MintColors.craie,
+                                foregroundColor: MintColors.textPrimary,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(14),
+                                ),
+                              ),
+                              child: Text(
+                                label,
+                                textAlign: TextAlign.center,
+                                style: MintTextStyles.labelLarge(
+                                  color: MintColors.textPrimary,
+                                ).copyWith(fontWeight: FontWeight.w600),
+                              ),
+                            ),
                           ),
                         ),
-                        child: Text(
-                          label,
-                          style: MintTextStyles.labelLarge(
-                            color: MintColors.textPrimary,
-                          ).copyWith(fontWeight: FontWeight.w600),
-                        ),
-                      ),
-                    ),
+                        const SizedBox(height: 12),
+                      ],
+                    ],
                   ),
-                  const SizedBox(height: 12),
-                ],
-              ],
+                ),
+              ),
             ),
           ),
-          const SizedBox(height: 12),
         ],
       ),
     );

--- a/apps/mobile/test/screens/login_redirect_resolver_test.dart
+++ b/apps/mobile/test/screens/login_redirect_resolver_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:mint_mobile/screens/auth/auth_redirect.dart';
 
 void main() {
+  setUp(() => SharedPreferences.setMockInitialValues(const <String, Object>{}));
+
   test('resolvePostAuthRedirect prefers safe redirect query param', () {
     expect(
       resolvePostAuthRedirect(Uri.parse(
@@ -91,5 +94,13 @@ void main() {
     );
     expect(hasDossierIdentityAnswers({'q_birth_year': 1992}), isTrue);
     expect(hasDossierIdentityAnswers({'q_birth_year': '1992'}), isTrue);
+  });
+
+  test('post-auth identity falls back to the anonymous dossier', () async {
+    SharedPreferences.setMockInitialValues({
+      'wizard_answers_v2': '{"q_date_of_birth":"1977-07-12"}',
+    });
+
+    expect(await hasPostAuthDossierIdentity(localDateOfBirth: null), isTrue);
   });
 }

--- a/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart
@@ -1,29 +1,75 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 
-Widget _wrap() {
-  return const MaterialApp(
-    locale: Locale('fr'),
-    localizationsDelegates: [
+Widget _wrap({TextScaler textScaler = TextScaler.noScaling}) {
+  return MaterialApp(
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
       S.delegate,
       GlobalMaterialLocalizations.delegate,
       GlobalWidgetsLocalizations.delegate,
       GlobalCupertinoLocalizations.delegate,
     ],
     supportedLocales: S.supportedLocales,
-    home: OnboardingShellScreen(),
+    home: MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AuthProvider>(create: (_) => AuthProvider()),
+        ChangeNotifierProvider<CoachProfileProvider>(
+            create: (_) => CoachProfileProvider()),
+      ],
+      child: MediaQuery(
+        data: MediaQueryData(
+          size: const Size(375, 812),
+          textScaler: textScaler,
+        ),
+        child: const OnboardingShellScreen(),
+      ),
+    ),
   );
+}
+
+void _pinIPhone13Mini(WidgetTester tester) {
+  tester.view.physicalSize = const Size(375, 812);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Future<void> _tapKey(WidgetTester tester, String key) async {
+  final finder = find.byKey(ValueKey(key));
+  await tester.ensureVisible(finder);
+  await tester.pumpAndSettle();
+  await tester.tap(finder);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _reachEmploymentStep(WidgetTester tester) async {
+  await _tapKey(tester, 'onboarding-entry-open');
+  await _tapKey(tester, 'onboarding-intent-impots');
+  await _tapKey(tester, 'us-tax-person-no');
+  final nationality = find.byKey(const ValueKey('onboarding-nationality-ch'));
+  if (nationality.evaluate().isNotEmpty) {
+    await tester.ensureVisible(nationality);
+    await tester.pumpAndSettle();
+    await tester.tap(nationality);
+    await tester.pumpAndSettle();
+  }
 }
 
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(const <String, Object>{});
+    FlutterSecureStorage.setMockInitialValues({});
     FeatureFlags.enableMint2FirstExperienceEntry = true;
   });
 
@@ -33,19 +79,56 @@ void main() {
 
   testWidgets('Mint 2 axes fit the iPhone 13 mini width without overflow',
       (tester) async {
-    tester.view.physicalSize = const Size(375, 812);
-    tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+    _pinIPhone13Mini(tester);
 
     await tester.pumpWidget(_wrap());
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('onboarding-entry-open')));
-    await tester.pumpAndSettle();
+    await _tapKey(tester, 'onboarding-entry-open');
 
     expect(find.text('2e pilier : rente ou capital'), findsOneWidget);
     expect(find.text('Logement : 2e / 3e pilier'), findsWidgets);
     expect(find.text('3a et rachats : impact fiscal'), findsOneWidget);
-    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('employment labels and canton order fit iPhone 13 mini',
+      (tester) async {
+    _pinIPhone13Mini(tester);
+    FeatureFlags.enableMint2FirstExperienceEntry = false;
+
+    await tester.pumpWidget(
+      _wrap(textScaler: const TextScaler.linear(1.3)),
+    );
+    await tester.pumpAndSettle();
+    await _reachEmploymentStep(tester);
+
+    for (final label in const ['Salarié', 'Indépendant', 'Sans activité']) {
+      final textRect = tester.getRect(find.text(label));
+      final buttonRect = tester.getRect(
+        find.ancestor(
+          of: find.text(label),
+          matching: find.byType(FilledButton),
+        ),
+      );
+      expect(textRect.top, greaterThanOrEqualTo(buttonRect.top + 4));
+      expect(textRect.bottom, lessThanOrEqualTo(buttonRect.bottom - 4));
+    }
+
+    await _tapKey(tester, 'onboarding-employment-salarie');
+    await _tapKey(tester, 'onboarding-civil-marie');
+    await _tapKey(tester, 'onboarding-avs-no-gaps');
+    await tester.tap(find.text('Choisir ma date'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('15').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('OK').last);
+    await tester.pumpAndSettle();
+    await _tapKey(tester, 'onboarding-dob-continue');
+    final agTop = tester.getTopLeft(find.text('AG')).dy;
+    final aiTop = tester.getTopLeft(find.text('AI')).dy;
+    final arTop = tester.getTopLeft(find.text('AR')).dy;
+    final beTop = tester.getTopLeft(find.text('BE')).dy;
+
+    expect((agTop - aiTop).abs() + (agTop - arTop).abs(), lessThan(2));
+    expect(agTop, lessThan(beTop));
   });
 }

--- a/apps/mobile/test/screens/onboarding/mvp_wedge_storyboard_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge_storyboard_test.dart
@@ -227,6 +227,14 @@ Future<void> _selectExplicitDateOfBirth(WidgetTester tester) async {
   await tester.pumpAndSettle();
 }
 
+Future<void> _tapCanton(WidgetTester tester, String code) async {
+  final cantonFinder = find.byKey(
+    ValueKey('onboarding-canton-${code.toLowerCase()}'),
+  );
+  await tester.tap(cantonFinder);
+  await tester.pumpAndSettle();
+}
+
 Future<void> _commonData(WidgetTester tester) async {
   // T3 date de naissance → T4 : choisir explicitement une date.
   await _selectExplicitDateOfBirth(tester);
@@ -234,10 +242,7 @@ Future<void> _commonData(WidgetTester tester) async {
   await tester.pumpAndSettle();
   expect(find.text('Où tu vis ?'), findsOneWidget);
 
-  // T4 canton → T5 : tap VD
-  expect(find.byKey(const ValueKey('onboarding-canton-vd')), findsOneWidget);
-  await tester.tap(find.text('VD'));
-  await tester.pumpAndSettle();
+  await _tapCanton(tester, 'AG');
   expect(find.text('Combien te tombe net par mois ?'), findsOneWidget);
 
   // T5 revenue fourchette par défaut (7000–7500) → T6
@@ -288,8 +293,7 @@ void main() {
       await tester.tap(find.text('Continuer'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('VD'));
-      await tester.pumpAndSettle();
+      await _tapCanton(tester, 'AG');
       _expectSemanticsIdentifier(tester, 'onboarding-revenue-range-continue');
       await tester.tap(find.text('Continuer'));
       await tester.pumpAndSettle();
@@ -344,8 +348,7 @@ void main() {
     await _selectExplicitDateOfBirth(tester);
     await tester.tap(find.text('Continuer'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('VD'));
-    await tester.pumpAndSettle();
+    await _tapCanton(tester, 'AG');
 
     expect(find.text('Combien te tombe net par mois ?'), findsOneWidget);
     expect(find.byType(Slider), findsNothing);
@@ -457,7 +460,7 @@ void main() {
 
     expect(find.text('Ce que Mint peut déjà situer'), findsOneWidget);
     expect(find.text('Repères captés'), findsOneWidget);
-    expect(find.text('Vaud · environ 7’250 CHF/mois net'), findsOneWidget);
+    expect(find.text('Argovie · environ 7’250 CHF/mois net'), findsOneWidget);
     expect(find.text('À préciser ensuite'), findsOneWidget);
     expect(find.text('SCENE · TA RETRAITE PROJETEE'), findsNothing);
   });
@@ -539,7 +542,7 @@ void main() {
     expect(merged['q_birth_year'], DateTime.now().year - 34);
     expect(merged['q_date_of_birth'],
         contains('${DateTime.now().year - 34}-07-15'));
-    expect(merged['q_canton'], 'VD');
+    expect(merged['q_canton'], 'AG');
     expect(merged.containsKey('q_email'), isFalse,
         reason: 'email-demain scene killed 2026-04-24, no email captured');
     expect(merged['q_net_income_confidence'], 'medium');
@@ -568,7 +571,7 @@ void main() {
     expect(find.text('Anonyme · conservé sur cet appareil'), findsOneWidget);
     expect(find.text('Ce que Mint a compris'), findsOneWidget);
     expect(find.text('Mes impôts'), findsWidgets);
-    expect(find.text('Vaud'), findsWidgets);
+    expect(find.text('Argovie'), findsWidgets);
     expect(find.text("7'000 – 7'500 CHF"), findsWidgets);
     expect(find.text('Ce qui manque'), findsOneWidget);
     expect(find.text('Certificat LPP'), findsOneWidget);
@@ -683,8 +686,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // T4 canton
-    await tester.tap(find.text('VD'));
-    await tester.pumpAndSettle();
+    await _tapCanton(tester, 'AG');
 
     // T5 bascule mode exact
     await tester.tap(find.text('Je sais le chiffre exact'));
@@ -804,7 +806,8 @@ void main() {
     expect(fake.mergedCalls, hasLength(1));
   });
 
-  testWidgets('T8 Continuer: flushes wantsDeeper=true + navigates to /coach/chat',
+  testWidgets(
+      'T8 Continuer: flushes wantsDeeper=true + navigates to /coach/chat',
       (tester) async {
     final fake = _FakeCoachProfileProvider();
     await _pumpShell(tester, fake);
@@ -858,7 +861,8 @@ void main() {
     expect(fake.mergedCalls.single['q_wants_deeper'], isFalse);
   });
 
-  testWidgets('T8 Repartir de zéro resets local diagnostic without profile flush',
+  testWidgets(
+      'T8 Repartir de zéro resets local diagnostic without profile flush',
       (tester) async {
     final fake = _FakeCoachProfileProvider();
     await _pumpShell(tester, fake);


### PR DESCRIPTION
## Summary
- Preserve anonymous dossier identity after Apple/email registration by falling back to persisted local answers before post-auth routing.
- Fix Mint 2 onboarding label clipping by giving choice buttons stable height and bottom-aligned scrollable choice area.
- Sort canton choices alphabetically and update iPhone 13 mini/layout/storyboard tests.

## Verification
- cd apps/mobile && flutter analyze
- cd apps/mobile && flutter test test/services/account_handoff_service_test.dart test/providers/auth_provider_test.dart test/providers/coach_profile_provider_secure_failure_test.dart test/screens/onboarding/mvp_wedge/ test/screens/arbitrage/
- cd apps/mobile && flutter test
- iPhone 13 mini runtime: .planning/runtime-evidence/mint2-ui-auth-fix-final-exact-20260619T131536 (Maestro exit 0)
- Claude Max review held 10min: BLOCKERS none
