### PR TITLE
Fix fresh anonymous financial residue

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -24,6 +24,7 @@
     "feature/mint2-claim-axis-handoff",
     "feature/S06-mint2-dossier-axis-continuity",
     "feature/S06-mint2-dossier-axis-surface",
+    "feature/S06-mint2-fresh-anon-financial-residue",
     "feature/S06-mint2-dossier-axis-runtime",
     "feature/S06-mint2-account-runtime",
     "feature/S07-mint2-account-claim-product",

--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -460,6 +460,7 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
 
   Future<void> _hydrateBudgetForSilentOpener() async {
     if (!mounted) return;
+    if (_profile == null || !_profile!.hasMaterialData) return;
     final budgetProvider = _readBudgetProviderIfAvailable();
     if (budgetProvider == null || budgetProvider.hasFreshInputs) return;
     final restored = await budgetProvider.loadFromStorage();
@@ -841,11 +842,8 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
     final s = S.of(context)!;
     final budgetProvider = _watchBudgetProviderIfAvailable();
     final budgetPlan = budgetProvider?.plan;
-    final canUseStoredBudget =
-        budgetProvider?.source == BudgetDataSource.storage &&
-            (_profile == null || !_profile!.hasMaterialData);
     if (budgetProvider != null &&
-        (budgetProvider.hasFreshInputs || canUseStoredBudget) &&
+        budgetProvider.hasFreshInputs &&
         budgetPlan != null &&
         budgetPlan.available.isFinite) {
       return (

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -102,13 +102,27 @@ class FinancialSummaryScreen extends StatelessWidget {
       builder: (context, snapshot) {
         final mint2AxisHandoff = snapshot.data ?? const <String, dynamic>{};
         final hasMint2AxisHandoff = _hasMint2LiveAxis(mint2AxisHandoff);
-        if (profile == null || !profile.hasMaterialData) {
+        if (profile == null ||
+            !profile.hasMaterialData ||
+            !_hasDefensibleDossierForFinancialSummary(profile)) {
           if (!hasMint2AxisHandoff) return _buildEmptyState(context);
           return _buildHandoffOnlyContent(context);
         }
         return _buildContent(context, profile);
       },
     );
+  }
+
+  bool _hasDefensibleDossierForFinancialSummary(CoachProfile profile) {
+    final sourceCounts = _dossierSourceCounts(profile);
+    if ((sourceCounts[ProfileDataSource.estimated] ?? 0) > 0) {
+      return false;
+    }
+    return (sourceCounts[ProfileDataSource.userInput] ?? 0) +
+            (sourceCounts[ProfileDataSource.crossValidated] ?? 0) +
+            (sourceCounts[ProfileDataSource.certificate] ?? 0) +
+            (sourceCounts[ProfileDataSource.openBanking] ?? 0) >
+        0;
   }
 
   Widget _buildHandoffOnlyContent(BuildContext context) {
@@ -828,6 +842,14 @@ class FinancialSummaryScreen extends StatelessWidget {
 
   Map<ProfileDataSource, int> _dossierSourceCounts(CoachProfile profile) {
     ProfileDataSource sourceFor(String key) {
+      if (key == 'salaireBrutMensuel') {
+        final salarySource = profile.dataSources['salaireBrutMensuel'] ??
+            profile.dataSources['revenuBrutAnnuel'];
+        if (salarySource != null) return salarySource;
+        if (profile.userProvidedFields.contains('salary')) {
+          return ProfileDataSource.userInput;
+        }
+      }
       return profile.dataSources[key] ??
           (profile.userProvidedFields.contains(key)
               ? ProfileDataSource.userInput

--- a/apps/mobile/test/screens/coach/coach_chat_test.dart
+++ b/apps/mobile/test/screens/coach/coach_chat_test.dart
@@ -343,18 +343,18 @@ void main() {
     });
 
     testWidgets(
-        'silent opener hydrates stored direct budget inputs when provider starts empty',
+        'fresh anonymous silent opener ignores stored direct budget residue',
         (tester) async {
       usePhoneViewport(tester);
       await BudgetLocalStore().saveInputs(const BudgetInputs(
         payFrequency: PayFrequency.monthly,
-        netIncome: 7250,
-        housingCost: 2200,
+        netIncome: 8000,
+        housingCost: 1000,
         debtPayments: 0,
-        taxProvision: 1086.13625,
-        healthInsurance: 420,
+        taxProvision: 0,
+        healthInsurance: 360,
         otherFixedCosts: 0,
-        isTaxEstimated: true,
+        isTaxEstimated: false,
         isHealthEstimated: false,
         isHousingMissing: false,
         isHealthMissing: false,
@@ -369,8 +369,9 @@ void main() {
       );
       await pumpUntilGreeting(tester);
 
-      expect(budgetProvider.source, BudgetDataSource.storage);
-      expect(find.text("3'544"), findsOneWidget);
+      expect(budgetProvider.source, BudgetDataSource.none);
+      expect(find.text("6'640"), findsNothing);
+      expect(find.textContaining('Marge libre'), findsNothing);
     });
 
     testWidgets('first-contact opener does not show question label',

--- a/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
+++ b/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
@@ -58,6 +58,33 @@ Widget _pumpable(
   );
 }
 
+CoachProfile _defensibleJulienProfile() {
+  final profile = CoachProfile.fromWizardAnswers(
+    CoachProfileSeeds.registry['julien_swiss']!.toWizardAnswers(
+      now: DateTime(2026, 6, 4),
+    ),
+  );
+  return profile.copyWith(
+    dataSources: {
+      ...profile.dataSources,
+      'revenuBrutAnnuel': ProfileDataSource.userInput,
+      'salaireBrutMensuel': ProfileDataSource.userInput,
+      'depenses.loyer': ProfileDataSource.userInput,
+      'depenses.assuranceMaladie': ProfileDataSource.userInput,
+      'patrimoine.epargneLiquide': ProfileDataSource.userInput,
+      'patrimoine.investissements': ProfileDataSource.userInput,
+      'prevoyance.avoirLppTotal': ProfileDataSource.certificate,
+      'prevoyance.totalEpargne3a': ProfileDataSource.userInput,
+      'dettes.totalDettes': ProfileDataSource.userInput,
+      'dettes.hypotheque': ProfileDataSource.userInput,
+      'dettes.creditConsommation': ProfileDataSource.userInput,
+      'dettes.leasing': ProfileDataSource.userInput,
+      'dettes.autresDettes': ProfileDataSource.userInput,
+    },
+    userProvidedFields: {...profile.userProvidedFields, 'salary'},
+  );
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -124,6 +151,35 @@ void main() {
     expect(find.text('Aucun profil renseigné'), findsOneWidget);
   });
 
+  testWidgets(
+      'estimated LPP profile stays in incomplete dossier state, not projection',
+      (tester) async {
+    FeatureFlags.enableMint2FirstExperienceEntry = true;
+    await ReportPersistenceService.saveMint2AxisHandoff({
+      'onb_axis_v2': 'lpp_rente_capital',
+      'onb_axis_schema_version': 2,
+      'legacy_onb_intent': 'retraite',
+    });
+    final profile = CoachProfile.defaults().copyWith(
+      birthYear: 1988,
+      canton: 'VS',
+      salaireBrutMensuel: 7000,
+      prevoyance: const PrevoyanceProfile(avoirLppTotal: 37600),
+      dataSources: const {
+        'prevoyance.avoirLppTotal': ProfileDataSource.estimated,
+      },
+    );
+
+    await tester.pumpWidget(_pumpable(profile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2e pilier : rente ou capital'), findsOneWidget);
+    expect(find.text('Champs requis manquants'), findsOneWidget);
+    expect(find.text('Preuve absente'), findsOneWidget);
+    expect(find.textContaining("37'600"), findsNothing);
+    expect(find.text('À la retraite, il te manquera'), findsNothing);
+  });
+
   testWidgets('material profile leads with dossier facts before projection',
       (tester) async {
     tester.view.physicalSize = const Size(368, 800);
@@ -133,11 +189,7 @@ void main() {
       tester.view.resetDevicePixelRatio();
     });
 
-    final profile = CoachProfile.fromWizardAnswers(
-      CoachProfileSeeds.registry['julien_swiss']!.toWizardAnswers(
-        now: DateTime(2026, 6, 4),
-      ),
-    );
+    final profile = _defensibleJulienProfile();
 
     await tester.pumpWidget(_pumpable(profile));
     await tester.pumpAndSettle();
@@ -173,11 +225,7 @@ void main() {
 
   testWidgets('dossier correction sheet covers income housing LAMal and debts',
       (tester) async {
-    final profile = CoachProfile.fromWizardAnswers(
-      CoachProfileSeeds.registry['julien_swiss']!.toWizardAnswers(
-        now: DateTime(2026, 6, 4),
-      ),
-    );
+    final profile = _defensibleJulienProfile();
 
     await tester.pumpWidget(_pumpable(profile));
     await tester.pumpAndSettle();
@@ -204,11 +252,7 @@ void main() {
 
   testWidgets('sync row uses account data state instead of raw cloud bool',
       (tester) async {
-    final profile = CoachProfile.fromWizardAnswers(
-      CoachProfileSeeds.registry['julien_swiss']!.toWizardAnswers(
-        now: DateTime(2026, 6, 4),
-      ),
-    );
+    final profile = _defensibleJulienProfile();
 
     await tester.pumpWidget(
       _pumpable(


### PR DESCRIPTION
## Summary
- block fresh anonymous/incomplete coach opener from hydrating stored budget residue as a defensible key number
- keep /profile/bilan in incomplete dossier state when visible financial facts are estimated or lack a defensible user/certificate/open-banking source
- add regressions for the 6'640 CHF/Marge libre storage path and the 37'600 CHF estimated LPP path

## Root cause
- 6'640 / Marge libre: local budget_inputs_v1 storage was restored as BudgetDataSource.storage and accepted by CoachChatScreen._computeKeyNumber() for absent/non-material profiles. Cause A/D.
- 37'600 / Avoir LPP: CoachProfile correctly marked LPP as ProfileDataSource.estimated, but FinancialSummaryScreen readiness allowed estimated facts into the full financial summary/projection surface. Cause C/D.

## Evidence
- VALUE_LINEAGE: .planning/runtime-evidence/fresh-anon-financial-residue-20260620T071416Z/VALUE_LINEAGE.md
- Red: .planning/runtime-evidence/fresh-anon-financial-residue-20260620T071416Z/red/result.xml and flutter-red.log
- Green runtime: .planning/runtime-evidence/fresh-anon-financial-residue-20260620T071416Z/green/result.xml, maestro.log, simctl.png, ax.json, network-spy.redacted.log, store-dump.redacted.txt
- Final fresh-keychain network-spy verdict: no forbidden fresh-anon /sync/claim-local-data, claimLocalData, _syncToBackend, /api/v1/profiles/me, profile writes, or coach sync endpoint found.

## Verification
- active_context_guard: PASS
- phase_contract_guard: PASS
- mint_rules_guard: PASS
- route_registry_parity: PASS
- ./tools/mint-routes check: PASS
- git diff --check + git diff --cached --check: PASS
- Mint UI lints color/text/font/radius/CTA: PASS
- targeted coach/profile/onboarding/auth-present tests: PASS (+166 ~5)
- flutter analyze: PASS
- full flutter test: PASS (+9573 ~24)
- Maestro watchdog green and local mint2_quality_gate were run on the original validated work branch that contained the local quality-gate infra; this product-only PR branch intentionally excludes that infra to stay under the line cap.

## Gaps
- Red runtime Maestro was not captured; red proof is widget/JUnit. Green Maestro runtime and quality gate were captured.
- Fake staging account cleanup was not performed.
- No TestFlight/App Store archive in this PR.