### PR TITLE
test(mint2): add runtime quality gate runner

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -30,6 +30,7 @@
     "feature/S07-mint2-account-claim-product",
     "feature/S08-mint2-magic-link-handoff",
     "feature/S06-mint2-admin-claim-readback",
+    "feature/S09-mint2-runtime-quality-gate",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/tools/simulator/flows/maestro-perfect-set/flow_mint2_content_quality_surfaces.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_mint2_content_quality_surfaces.yaml
@@ -1,0 +1,79 @@
+# tools/simulator/flows/maestro-perfect-set/flow_mint2_content_quality_surfaces.yaml
+#
+# PURPOSE
+# Mint 2.0 content-quality proof for the current first-activation path.
+# Guards against stale unauthenticated financial residue after the Mint2 entry.
+
+appId: ch.mint.app
+tags:
+  - mint2
+  - content-quality
+  - financial-residue
+  - iphone13mini
+---
+
+- runFlow: flow_mint2_first_experience_rente_capital_entry.yaml
+
+- assertNotVisible:
+    text: "37'600"
+- assertNotVisible:
+    text: "6'640"
+- assertNotVisible:
+    text: "Avoir LPP"
+- assertNotVisible:
+    text: "Marge libre"
+- assertNotVisible:
+    text: "NaN"
+- assertNotVisible:
+    text: "Infinity"
+- assertNotVisible:
+    text: "A RenderFlex overflowed"
+- assertNotVisible:
+    text: "CHF/mois"
+- takeScreenshot: "01-rvc-no-stale-financial-residue"
+
+- openLink: "mintapp:///coach/chat"
+- extendedWaitUntil:
+    visible:
+      id: "coach_chat_screen"
+    timeout: 12000
+- assertNotVisible:
+    text: "37'600"
+- assertNotVisible:
+    text: "6'640"
+- assertNotVisible:
+    text: "Avoir LPP"
+- assertNotVisible:
+    text: "Marge libre"
+- assertNotVisible:
+    text: "NaN"
+- assertNotVisible:
+    text: "Infinity"
+- assertNotVisible:
+    text: "A RenderFlex overflowed"
+- assertNotVisible:
+    text: "NoSuchMethodError"
+- takeScreenshot: "02-coach-no-stale-financial-residue"
+
+- openLink: "mintapp:///profile/bilan"
+- extendedWaitUntil:
+    visible:
+      text: "MON PROFIL"
+    timeout: 12000
+- assertNotVisible:
+    text: "37'600"
+- assertNotVisible:
+    text: "6'640"
+- assertNotVisible:
+    text: "Avoir LPP"
+- assertNotVisible:
+    text: "Marge libre"
+- assertNotVisible:
+    text: "NaN"
+- assertNotVisible:
+    text: "Infinity"
+- assertNotVisible:
+    text: "A RenderFlex overflowed"
+- assertNotVisible:
+    text: "NoSuchMethodError"
+- takeScreenshot: "03-profile-no-stale-financial-residue"

--- a/tools/simulator/mint2_quality_gate.sh
+++ b/tools/simulator/mint2_quality_gate.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Local Mint 2.0 quality gate for the current first-activation path.
+#
+# This gate composes committed proof flows instead of creating another product
+# scenario. It targets the exact iPhone 13 mini simulator used for Mint2 RvC
+# evidence and writes all runtime artifacts under .planning/runtime-evidence/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DEVICE_NAME="MINT iPhone 13 mini RvC"
+BUNDLE_ID="ch.mint.app"
+API_BASE_URL="${MINT_API_BASE_URL:-https://mint-staging.up.railway.app/api/v1}"
+
+LAYOUT_TEST="test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart"
+FIRST_FLOW="tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml"
+CLAIM_FLOW="tools/simulator/flows/maestro-perfect-set/flow_mint2_lpp_dossier_account_claim.yaml"
+CONTENT_FLOW="tools/simulator/flows/maestro-perfect-set/flow_mint2_content_quality_surfaces.yaml"
+WATCHDOG="tools/simulator/maestro_with_watchdog.sh"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_ROOT="${MINT2_QUALITY_ARTIFACTS:-$REPO_ROOT/.planning/runtime-evidence/mint2-quality-gate-$RUN_ID}"
+DRY_RUN=0
+
+usage() {
+  cat <<EOF
+Usage: bash tools/simulator/mint2_quality_gate.sh [--dry-run]
+
+Runs the local Mint 2.0 quality gate:
+  simulator: $DEVICE_NAME
+  staging:   $API_BASE_URL
+  evidence:  .planning/runtime-evidence/mint2-quality-gate-<timestamp>/
+
+Checks:
+  - flutter test $LAYOUT_TEST
+  - $FIRST_FLOW
+  - $CLAIM_FLOW
+  - $CONTENT_FLOW
+EOF
+}
+
+if [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+
+cd "$REPO_ROOT"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  usage
+  cat <<EOF
+
+Build:
+  CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --no-codesign \\
+    --dart-define=API_BASE_URL=$API_BASE_URL \\
+    --dart-define=MINT_DISABLE_BETA_MODAL=true \\
+    --dart-define=MINT_E2E_MINT2_FIRST_EXPERIENCE=true \\
+    --dart-define=MINT_E2E_PROOF_ANCHORS=true
+
+Fresh-state:
+  xcrun simctl shutdown all
+  xcrun simctl boot <UDID for "$DEVICE_NAME">
+  xcrun simctl keychain <UDID> reset
+  xcrun simctl uninstall <UDID> $BUNDLE_ID
+EOF
+  exit 0
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+exec > >(tee "$ARTIFACT_ROOT/run.log") 2>&1
+
+log() {
+  printf '\n[quality-gate] %s\n' "$*"
+}
+
+fail() {
+  printf '\n[quality-gate] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [ -e "$path" ] || fail "missing required path: $path"
+}
+
+resolve_device_udid() {
+  xcrun simctl list devices available -j | python3 -c '
+import json
+import sys
+
+target = sys.argv[1]
+data = json.load(sys.stdin)
+matches = []
+for devices in data.get("devices", {}).values():
+    for device in devices:
+        if device.get("isAvailable") and device.get("name") == target:
+            matches.append(device.get("udid"))
+
+if len(matches) != 1:
+    print(
+        f"expected exactly one available simulator named {target!r}, "
+        f"found {len(matches)}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+print(matches[0])
+' "$DEVICE_NAME"
+}
+
+run_maestro_flow() {
+  local label="$1"
+  local flow="$2"
+  local out_dir="$ARTIFACT_ROOT/$label"
+  mkdir -p "$out_dir"
+
+  log "maestro $label: $flow"
+  MINT_WALKER_ARTIFACTS="$out_dir" \
+    MAESTRO_HARD_LIMIT="${MAESTRO_HARD_LIMIT:-1200}" \
+    bash "$WATCHDOG" test "$flow"
+}
+
+write_summary() {
+  {
+    echo "run_id: $RUN_ID"
+    echo "timestamp_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "repo: $REPO_ROOT"
+    echo "branch: $(git branch --show-current)"
+    echo "head: $(git rev-parse HEAD)"
+    echo "status:"
+    git status --short --branch | sed 's/^/  /'
+    echo "simulator: $DEVICE_NAME"
+    echo "device_udid: ${DEVICE_UDID:-unresolved}"
+    echo "api_base_url: $API_BASE_URL"
+    echo "fresh_state:"
+    echo "  keychain_reset: simulator"
+    echo "  app_uninstall: $BUNDLE_ID"
+    echo "flows:"
+    echo "  - $FIRST_FLOW"
+    echo "  - $CLAIM_FLOW"
+    echo "  - $CONTENT_FLOW"
+  } > "$ARTIFACT_ROOT/run-summary.txt"
+}
+
+trap 'write_summary' EXIT
+
+require_file "$WATCHDOG"
+require_file "$FIRST_FLOW"
+require_file "$CLAIM_FLOW"
+require_file "$CONTENT_FLOW"
+
+log "evidence: $ARTIFACT_ROOT"
+log "checking staging reachability"
+curl -fsS --max-time 10 "$API_BASE_URL/health" >/dev/null || \
+  curl -fsS --max-time 10 "$API_BASE_URL/docs" >/dev/null || \
+  fail "staging API did not answer health/docs at $API_BASE_URL"
+
+log "running Flutter iPhone 13 mini layout anti-clipping test"
+(
+  cd apps/mobile
+  flutter test "$LAYOUT_TEST"
+)
+
+log "resolving exact simulator"
+DEVICE_UDID="$(resolve_device_udid)"
+log "booting only $DEVICE_NAME ($DEVICE_UDID)"
+xcrun simctl shutdown all >/dev/null 2>&1 || true
+xcrun simctl boot "$DEVICE_UDID"
+open -a Simulator
+xcrun simctl bootstatus "$DEVICE_UDID" -b
+
+log "resetting simulator keychain"
+xcrun simctl keychain "$DEVICE_UDID" reset
+
+log "building staging simulator app"
+(
+  cd apps/mobile
+  CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --no-codesign \
+    --dart-define=API_BASE_URL="$API_BASE_URL" \
+    --dart-define=MINT_DISABLE_BETA_MODAL=true \
+    --dart-define=MINT_E2E_MINT2_FIRST_EXPERIENCE=true \
+    --dart-define=MINT_E2E_PROOF_ANCHORS=true
+)
+
+APP_PATH="$REPO_ROOT/apps/mobile/build/ios/iphonesimulator/Runner.app"
+[ -d "$APP_PATH" ] || fail "Runner.app not found at $APP_PATH"
+
+log "installing fresh app on exact simulator"
+xcrun simctl uninstall "$DEVICE_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl install "$DEVICE_UDID" "$APP_PATH"
+
+write_summary
+
+run_maestro_flow "01-first-entry-layout-and-route" "$FIRST_FLOW"
+run_maestro_flow "02-dossier-claim-relaunch-reset" "$CLAIM_FLOW"
+run_maestro_flow "03-content-quality-no-financial-residue" "$CONTENT_FLOW"
+
+log "PASS: Mint 2.0 local quality gate completed"

--- a/tools/simulator/test_mint2_quality_gate.py
+++ b/tools/simulator/test_mint2_quality_gate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GATE = ROOT / "tools" / "simulator" / "mint2_quality_gate.sh"
+CONTENT_FLOW = (
+    ROOT
+    / "tools"
+    / "simulator"
+    / "flows"
+    / "maestro-perfect-set"
+    / "flow_mint2_content_quality_surfaces.yaml"
+)
+
+
+def _read_gate() -> str:
+    return GATE.read_text(encoding="utf-8")
+
+
+def test_mint2_quality_gate_script_exists():
+    assert GATE.is_file(), "Mint2 quality gate runner is missing"
+
+
+def test_mint2_quality_gate_targets_exact_iphone13mini_staging():
+    src = _read_gate()
+
+    assert 'DEVICE_NAME="MINT iPhone 13 mini RvC"' in src
+    assert "https://mint-staging.up.railway.app/api/v1" in src
+    assert "shutdown all" in src
+    assert 'boot "$DEVICE_UDID"' in src
+    assert "keychain \"$DEVICE_UDID\" reset" in src
+    assert "API_BASE_URL=http://127.0.0.1" not in src
+    assert "API_BASE_URL=http://localhost" not in src
+
+
+def test_mint2_quality_gate_combines_layout_and_committed_maestro_flows():
+    src = _read_gate()
+
+    required_fragments = [
+        "mint2_first_experience_iphone13mini_layout_test.dart",
+        'flutter test "$LAYOUT_TEST"',
+        "flow_mint2_first_experience_rente_capital_entry.yaml",
+        "flow_mint2_lpp_dossier_account_claim.yaml",
+        "flow_mint2_content_quality_surfaces.yaml",
+        "maestro_with_watchdog.sh",
+        "MINT_E2E_MINT2_FIRST_EXPERIENCE=true",
+        "MINT_E2E_PROOF_ANCHORS=true",
+        ".planning/runtime-evidence/mint2-quality-gate-",
+        "run-summary.txt",
+    ]
+    for fragment in required_fragments:
+        assert fragment in src, f"quality gate missing: {fragment}"
+
+
+def test_mint2_quality_gate_dry_run_lists_contract():
+    result = subprocess.run(
+        ["bash", str(GATE), "--dry-run"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "MINT iPhone 13 mini RvC" in result.stdout
+    assert "mint2_first_experience_iphone13mini_layout_test.dart" in result.stdout
+    assert "flow_mint2_lpp_dossier_account_claim.yaml" in result.stdout
+    assert "flow_mint2_content_quality_surfaces.yaml" in result.stdout
+    assert "https://mint-staging.up.railway.app/api/v1" in result.stdout
+    assert "keychain <UDID> reset" in result.stdout
+
+
+def test_mint2_content_quality_flow_blocks_stale_financial_residue():
+    src = CONTENT_FLOW.read_text(encoding="utf-8")
+
+    required_fragments = [
+        "flow_mint2_first_experience_rente_capital_entry.yaml",
+        "mintapp:///coach/chat",
+        "mintapp:///profile/bilan",
+        "37'600",
+        "6'640",
+        "Avoir LPP",
+        "Marge libre",
+        "NaN",
+        "Infinity",
+        "A RenderFlex overflowed",
+        "takeScreenshot",
+    ]
+    for fragment in required_fragments:
+        assert fragment in src, f"content quality flow missing: {fragment}"


### PR DESCRIPTION
## Summary
- Add a repo-local Mint2 runtime quality gate runner for the exact `MINT iPhone 13 mini RvC` simulator.
- Add a committed Maestro content-quality flow that rejects stale fresh-anon financial residue (`37'600`, `6'640`, `Avoir LPP`, `Marge libre`) across RvC, Coach, and dossier surfaces.
- Allow the S09 branch in active context so repo guards can run on the branch.

## Status in Mint 2.0 plan
- First RvC route proof is already merged.
- Dossier/account handoff has product/runtime coverage from PRs #710-#715/#717.
- Fresh anonymous financial residue is fixed by PR #719.
- This PR starts the remaining runtime-hardening gap by making the local quality gate executable and repeatable.

## Test Plan
- `bash tools/simulator/mint2_quality_gate.sh --dry-run`
- `bash -n tools/simulator/mint2_quality_gate.sh`
- `python3 -m pytest tools/simulator/test_mint2_quality_gate.py -q`
- `flutter test test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `git diff --check`

## Runtime note
The new full gate itself is not run in this PR creation step yet; it is the tool added here. It will build staging, reset simulator keychain, reinstall the app, and run the committed Maestro flows under `.planning/runtime-evidence/`.