### PR TITLE
test(mint2): add real-device restore preflight

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -32,6 +32,7 @@
     "feature/S06-mint2-admin-claim-readback",
     "feature/S09-mint2-runtime-quality-gate",
     "feature/S09-mint2-quality-gate-xattr-fix",
+    "feature/S10-mint2-real-device-restore-gate",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: mint-2-0-first-experience-rente-capital
 milestone_name: Mint 2.0 First Experience Rente/Capital
-status: runtime-proof-merged
-stopped_at: PR #705 proved the first Mint 2.0 runtime path to RvC; remaining phase work is dossier/account handoff and residual runtime hardening.
-last_updated: "2026-06-18T09:35:00.000Z"
-last_activity: 2026-06-18 -- PR #705 landed Mint 2.0 -> LPP/rente-capital -> /rente-vs-capital proof on dev; PR #706 added autonomous skill-access governance.
+status: local-quality-gate-merged-device-restore-blocked
+stopped_at: PRs #719-#721 closed fresh anonymous residue and local runtime quality gate; physical-device Keychain/iCloud restore proof is blocked by unavailable iPhone.
+last_updated: "2026-06-20T11:42:21.000Z"
+last_activity: 2026-06-20 -- PR #721 hardened the Mint 2.0 local quality gate on dev; S10 real-device restore preflight returned BLOCKED_NO_AVAILABLE_DEVICE for target Jul.
 progress:
   scope: runtime_path_proof
   total_phases: 2
@@ -33,9 +33,8 @@ router for Mint 2.0 product planning.
 navigation flow. The first active door is rente/capital; logement and fiscal
 remain signalétique until their own implementation gates exist.
 
-**Current focus:** close the residual phase gaps after the first runtime path:
-dossier/account handoff, Keychain/iCloud restore evidence, and less brittle
-runtime interaction proof.
+**Current focus:** close the only remaining non-simulator phase gap:
+physical-device/TestFlight Keychain/iCloud restore evidence.
 
 ## Strategic Frame
 
@@ -50,17 +49,20 @@ runtime interaction proof.
 
 ## Current Position
 
-Phase: mint-2-0-first-experience-rente-capital — RUNTIME PATH PROOF LANDED
-Plan: first route proof is merged; continue with the remaining user-value gaps
-instead of re-proving the same path.
+Phase: mint-2-0-first-experience-rente-capital — LOCAL QUALITY GATE LANDED,
+DEVICE RESTORE BLOCKED
+Plan: first route proof, local dossier/account handoff, fresh anonymous residue
+blocking, and local runtime quality gate are merged. Do not re-prove those paths
+unless a regression appears.
 Status: `dev` contains the Mint 2.0 first-entry route to the existing
-`/rente-vs-capital` surface with receipt gates and neutral compliance copy.
+`/rente-vs-capital` surface, dossier/account handoff coverage, fresh anonymous
+residue blocking, and `tools/simulator/mint2_quality_gate.sh`.
 Original dirty tree remains quarantine.
-Last activity: 2026-06-18 -- PR #705 squash-merged as `485b56ff9`; PR #706
-squash-merged as `7aee403d8`.
+Last activity: 2026-06-20 -- PR #721 merged as `e68272bcf`; S10 real-device
+restore preflight produced `BLOCKED_NO_AVAILABLE_DEVICE`.
 
-Progress counters now measure the initial route/runtime proof. They do not close
-the full dossier/account handoff promise.
+Progress counters now measure the initial route/runtime proof. The remaining
+open claim is physical-device/TestFlight restore evidence.
 
 **Promotion evidence:**
 
@@ -73,19 +75,24 @@ the full dossier/account handoff promise.
   `.planning/runtime-evidence/20260617T212912Z`.
 - Design-system runtime check artifacts under
   `.planning/runtime-evidence/20260618T055622Z-design-check-final`.
+- Local Mint 2.0 quality gate artifacts under
+  `.planning/runtime-evidence/mint2-quality-gate-20260620T111549Z`.
+- Real-device restore preflight artifacts under
+  `.planning/runtime-evidence/mint2-real-device-restore-gate-20260620T114221Z`.
 
 **Remaining open items:**
 
-- Dossier revisit and account handoff are not closed by the route proof.
-- Keychain/iCloud restore remains outside simulator-only proof.
-- Maestro proof is valid but still partly coordinate-tap based because iOS did
-  not expose every desired element action semantically.
+- Physical-device/TestFlight Keychain/iCloud restore remains outside
+  simulator-only proof.
+- Current real-device preflight evidence shows target `Jul` exists as iPhone 13
+  mini but is unavailable to CoreDevice.
 - Runtime evidence artifacts are local and untracked; the executable Maestro
   flow is committed under `tools/simulator/flows/maestro-perfect-set/`.
 
-**Next execution bias:** pick one remaining user-visible gap and prove it
-end-to-end, preferably dossier continuity/account handoff or semantic runtime
-actionability for the iPhone 13 mini flow.
+**Next execution bias:** reconnect the physical iPhone 13 mini and rerun
+`bash tools/simulator/mint2_real_device_restore_gate.sh`; only then proceed to a
+TestFlight/manual restore proof. Do not claim Keychain/iCloud closure while the
+gate is `BLOCKED_NO_AVAILABLE_DEVICE`.
 
 ## Historical Receipts
 

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md
@@ -38,8 +38,15 @@ iPhone 13 mini artifacts captured locally under
 `.planning/runtime-evidence/20260617T212912Z`. The committed executable flow is
 `tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml`.
 
-This closes the first route proof, not the whole phase. Dossier/account handoff,
-Keychain/iCloud restore, and coordinate-tap brittleness remain open.
+PRs #710-#721 then closed the local dossier/account handoff path, fresh
+anonymous financial-residue regression, and local Mint 2.0 runtime quality gate.
+The current local gate is `tools/simulator/mint2_quality_gate.sh`, with passing
+evidence under `.planning/runtime-evidence/mint2-quality-gate-20260620T111549Z`.
+
+This closes the simulator-backed local Mint 2.0 path. Keychain/iCloud restore
+still requires a physical iPhone/TestFlight proof; simulator-only evidence must
+not close that claim. The current device preflight is
+`tools/simulator/mint2_real_device_restore_gate.sh`.
 
 ## Dossier Minimum
 

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/PLAN.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/PLAN.md
@@ -78,5 +78,8 @@ Before mobile code, the Slice 2 plan must keep these binding gates:
 ## Active Decision
 
 Mint 2.0 first experience is the active context after router promotion. The
-first route proof landed through PR #705; the phase remains open for dossier/account
-handoff, Keychain/iCloud restore evidence, and runtime hardening.
+first route proof landed through PR #705. PRs #710-#721 closed the local
+dossier/account handoff path, fresh anonymous financial residue regression, and
+runtime quality gate. The phase remains open only for physical-device
+Keychain/iCloud restore evidence; simulator-only proof must not close that
+claim.

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md
@@ -80,8 +80,10 @@ handoff appears after value.
 
 Current implementation evidence: PR #705 covers the three-axis entry to the
 existing RvC surface, route-state proof, receipt gating, neutral copy, and
-iPhone 13 mini runtime artifacts. Dossier revisit/account handoff and
-Keychain/iCloud restore remain open.
+iPhone 13 mini runtime artifacts. PRs #710-#721 cover local dossier/account
+handoff, fresh anonymous residue blocking, and the local Mint 2.0 quality gate.
+Keychain/iCloud restore remains open until a physical iPhone/TestFlight proof
+exists.
 
 ```verify
 # tier: deterministic

--- a/.planning/phases/mint-2-0-first-experience-rente-capital/VERIFICATION.md
+++ b/.planning/phases/mint-2-0-first-experience-rente-capital/VERIFICATION.md
@@ -37,7 +37,8 @@ and version.
 
 G4 dossier continuity: answer visible outside chat; reset/new discussion clears
 local draft and conversation state; account handoff preserves or discards local
-dossier only after explicit user choice.
+dossier only after explicit user choice. Local simulator coverage exists through
+the Mint 2.0 quality gate; physical-device restore remains separate.
 
 G5 language: no banned LSFin terms, no financial number without receipt, no tax
 promise, future user-facing strings through ARB/i18n, French accents checked for
@@ -60,7 +61,9 @@ file before product code starts:
 
 ## Open Blockers
 
-The first Mint 2.0 runtime flow exists and landed through PR #705. Remaining
-blockers: dossier revisit/account handoff is not closed; Keychain/iCloud
-restore cannot be closed by simulator alone; Maestro still uses some
-coordinate-tap interaction where iOS does not expose a stable semantic action.
+The first Mint 2.0 runtime flow exists and landed through PR #705. PRs #710-#721
+closed the local dossier/account handoff path, fresh anonymous financial residue
+regression, and local quality gate. Remaining blocker: Keychain/iCloud restore
+cannot be closed by simulator alone. Current physical-device preflight evidence:
+`.planning/runtime-evidence/mint2-real-device-restore-gate-20260620T114221Z`
+returned `BLOCKED_NO_AVAILABLE_DEVICE` for target `Jul`.

--- a/tools/simulator/mint2_real_device_restore_gate.sh
+++ b/tools/simulator/mint2_real_device_restore_gate.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Real-device preflight for the Mint 2.0 Keychain/iCloud restore gap.
+#
+# This does not claim restore proof by itself. It records whether a physical
+# iPhone is available for a TestFlight/restore run and exits BLOCKED when it is
+# not. Simulator proof must not close the Keychain/iCloud restore requirement.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TARGET_DEVICE_NAME="${MINT2_DEVICE_NAME:-Jul}"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_ROOT="${MINT2_REAL_DEVICE_ARTIFACTS:-$REPO_ROOT/.planning/runtime-evidence/mint2-real-device-restore-gate-$RUN_ID}"
+DRY_RUN=0
+
+usage() {
+  cat <<EOF
+Usage: bash tools/simulator/mint2_real_device_restore_gate.sh [--dry-run]
+
+Checks whether a physical iPhone is available for the Mint 2.0
+Keychain/iCloud restore proof.
+
+Target device name:
+  $TARGET_DEVICE_NAME
+
+Evidence:
+  .planning/runtime-evidence/mint2-real-device-restore-gate-<timestamp>/
+
+Verdicts:
+  READY_FOR_MANUAL_RESTORE_PROOF  exit 0
+  BLOCKED_NO_AVAILABLE_DEVICE     exit 2
+
+This gate is a preflight, not a restore proof. A PASS restore claim still
+requires TestFlight/manual-device evidence captured after the device is
+available.
+EOF
+}
+
+if [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+
+cd "$REPO_ROOT"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  usage
+  cat <<EOF
+
+Commands:
+  xcrun devicectl list devices --json-output <raw-json>
+  xcrun xctrace list devices
+
+Artifacts:
+  device-inventory-redacted.json
+  xctrace-devices-redacted.txt
+  verdict.json
+  run-summary.txt
+EOF
+  exit 0
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+exec > >(tee "$ARTIFACT_ROOT/run.log") 2>&1
+
+log() {
+  printf '\n[mint2-device-gate] %s\n' "$*"
+}
+
+RAW_DEVICECTL_JSON="$ARTIFACT_ROOT/.devicectl-devices.raw.json"
+
+log "evidence: $ARTIFACT_ROOT"
+log "target device name: $TARGET_DEVICE_NAME"
+
+if [ -n "${MINT2_DEVICECTL_JSON:-}" ]; then
+  cp "$MINT2_DEVICECTL_JSON" "$RAW_DEVICECTL_JSON"
+else
+  xcrun devicectl list devices --json-output "$RAW_DEVICECTL_JSON" \
+    > "$ARTIFACT_ROOT/devicectl-devices.txt"
+fi
+
+if [ -n "${MINT2_DEVICECTL_JSON:-}" ]; then
+  printf 'xctrace skipped: MINT2_DEVICECTL_JSON fixture mode\n' \
+    > "$ARTIFACT_ROOT/xctrace-devices-redacted.txt"
+else
+  xcrun xctrace list devices 2>/dev/null \
+    | python3 -c '
+import re
+import sys
+
+text = sys.stdin.read()
+text = re.sub(
+    r"\(([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}|[0-9A-F]{8}-[0-9A-F]{16})\)",
+    "(redacted-device-id)",
+    text,
+)
+print(text, end="")
+' > "$ARTIFACT_ROOT/xctrace-devices-redacted.txt"
+fi
+
+set +e
+python3 - "$RAW_DEVICECTL_JSON" "$TARGET_DEVICE_NAME" "$ARTIFACT_ROOT" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+raw_path = Path(sys.argv[1])
+target_name = sys.argv[2]
+artifact_root = Path(sys.argv[3])
+
+data = json.loads(raw_path.read_text())
+devices = data.get("result", {}).get("devices", [])
+
+
+def short_hash(value: object) -> str:
+    if value in (None, ""):
+        return ""
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
+
+
+inventory = []
+matching_physical = []
+matching_available = []
+
+for device in devices:
+    props = device.get("deviceProperties", {})
+    hw = device.get("hardwareProperties", {})
+    connection = device.get("connectionProperties", {})
+    name = props.get("name", "")
+    model = hw.get("marketingName", "")
+    platform = hw.get("platform", "")
+    reality = hw.get("reality", "")
+    tunnel = connection.get("tunnelState", "")
+    ddi = props.get("ddiServicesAvailable")
+    raw_identity = hw.get("udid") or device.get("identifier")
+    is_physical_ios = reality == "physical" and platform == "iOS"
+    target_matches = not target_name or name == target_name
+    available = is_physical_ios and tunnel != "unavailable" and ddi is True
+    row = {
+        "name": name,
+        "model": model,
+        "platform": platform,
+        "reality": reality,
+        "tunnelState": tunnel,
+        "ddiServicesAvailable": ddi,
+        "identityHash": short_hash(raw_identity),
+        "targetMatch": target_matches,
+        "availableForDeviceGate": available,
+    }
+    inventory.append(row)
+    if is_physical_ios and target_matches:
+        matching_physical.append(row)
+        if available:
+            matching_available.append(row)
+
+status = "READY_FOR_MANUAL_RESTORE_PROOF"
+exit_code = 0
+reason = "physical iPhone is available; run the manual TestFlight restore proof next"
+
+if not matching_physical:
+    status = "BLOCKED_NO_TARGET_PHYSICAL_DEVICE"
+    exit_code = 2
+    reason = f"no physical iOS device named {target_name!r} is known to CoreDevice"
+elif not matching_available:
+    status = "BLOCKED_NO_AVAILABLE_DEVICE"
+    exit_code = 2
+    reason = (
+        f"physical iOS device named {target_name!r} exists but is not available "
+        "for CoreDevice automation"
+    )
+
+verdict = {
+    "status": status,
+    "reason": reason,
+    "targetDeviceName": target_name,
+    "matchingPhysicalCount": len(matching_physical),
+    "matchingAvailableCount": len(matching_available),
+    "restoreProofClaimed": False,
+    "nextRequiredEvidence": [
+        "TestFlight build identifier",
+        "fresh install or explicit app deletion on physical iPhone",
+        "restore/iCloud/Keychain residue attempt",
+        "screenshots or AX/device transcript showing no stale Mint2 financial residue",
+    ],
+}
+
+(artifact_root / "device-inventory-redacted.json").write_text(
+    json.dumps({"devices": inventory}, indent=2, ensure_ascii=False) + "\n"
+)
+(artifact_root / "verdict.json").write_text(
+    json.dumps(verdict, indent=2, ensure_ascii=False) + "\n"
+)
+(artifact_root / "run-summary.txt").write_text(
+    "\n".join(
+        [
+            f"status: {status}",
+            f"reason: {reason}",
+            f"target_device_name: {target_name}",
+            f"matching_physical_count: {len(matching_physical)}",
+            f"matching_available_count: {len(matching_available)}",
+            "restore_proof_claimed: false",
+            "",
+        ]
+    )
+)
+
+print(f"VERDICT: {status}")
+print(reason)
+sys.exit(exit_code)
+PY
+PY_EXIT=$?
+set -e
+
+rm -f "$RAW_DEVICECTL_JSON"
+exit "$PY_EXIT"

--- a/tools/simulator/test_mint2_real_device_restore_gate.py
+++ b/tools/simulator/test_mint2_real_device_restore_gate.py
@@ -1,0 +1,106 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools/simulator/mint2_real_device_restore_gate.sh"
+
+
+def _device(name: str, tunnel: str, ddi: bool) -> dict:
+    return {
+        "identifier": "EA7D1126-5BAD-5005-818E-698D205196F1",
+        "connectionProperties": {
+            "tunnelState": tunnel,
+        },
+        "deviceProperties": {
+            "name": name,
+            "ddiServicesAvailable": ddi,
+        },
+        "hardwareProperties": {
+            "marketingName": "iPhone 13 mini",
+            "platform": "iOS",
+            "reality": "physical",
+            "serialNumber": "SHOULD_NOT_LEAK",
+            "udid": "00008110-000E65903EA8201E",
+            "ecid": 4052319874850846,
+        },
+    }
+
+
+def _write_fixture(tmp_path: Path, devices: list[dict]) -> Path:
+    fixture = tmp_path / "devicectl.json"
+    fixture.write_text(json.dumps({"result": {"devices": devices}}))
+    return fixture
+
+
+def _run_gate(tmp_path: Path, fixture: Path) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "MINT2_DEVICECTL_JSON": str(fixture),
+        "MINT2_REAL_DEVICE_ARTIFACTS": str(tmp_path / "evidence"),
+        "MINT2_DEVICE_NAME": "Jul",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_real_device_restore_gate_blocks_when_target_device_is_unavailable(tmp_path):
+    fixture = _write_fixture(tmp_path, [_device("Jul", "unavailable", False)])
+
+    result = _run_gate(tmp_path, fixture)
+
+    assert result.returncode == 2
+    assert "VERDICT: BLOCKED_NO_AVAILABLE_DEVICE" in result.stdout
+    verdict = json.loads((tmp_path / "evidence/verdict.json").read_text())
+    assert verdict["restoreProofClaimed"] is False
+    assert verdict["matchingPhysicalCount"] == 1
+    assert verdict["matchingAvailableCount"] == 0
+
+
+def test_real_device_restore_gate_redacts_device_identifiers(tmp_path):
+    fixture = _write_fixture(tmp_path, [_device("Jul", "unavailable", False)])
+
+    _run_gate(tmp_path, fixture)
+
+    inventory_text = (tmp_path / "evidence/device-inventory-redacted.json").read_text()
+    assert "SHOULD_NOT_LEAK" not in inventory_text
+    assert "00008110-000E65903EA8201E" not in inventory_text
+    assert "4052319874850846" not in inventory_text
+    assert "identityHash" in inventory_text
+
+
+def test_real_device_restore_gate_reports_ready_but_not_proven_when_device_available(
+    tmp_path,
+):
+    fixture = _write_fixture(tmp_path, [_device("Jul", "connected", True)])
+
+    result = _run_gate(tmp_path, fixture)
+
+    assert result.returncode == 0
+    assert "VERDICT: READY_FOR_MANUAL_RESTORE_PROOF" in result.stdout
+    verdict = json.loads((tmp_path / "evidence/verdict.json").read_text())
+    assert verdict["restoreProofClaimed"] is False
+    assert verdict["matchingAvailableCount"] == 1
+
+
+def test_real_device_restore_gate_dry_run_lists_contract():
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--dry-run"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "xcrun devicectl list devices" in result.stdout
+    assert "device-inventory-redacted.json" in result.stdout
+    assert "BLOCKED_NO_AVAILABLE_DEVICE" in result.stdout


### PR DESCRIPTION
## Summary
- Add a Mint2 real-device restore preflight gate for the remaining Keychain/iCloud/TestFlight gap.
- Record redacted CoreDevice inventory and a machine-readable verdict instead of pretending simulator evidence closes restore behavior.
- Update active Mint2 planning state to reflect PRs #719-#721 and the current physical-device blocker.

## Test Plan
- bash -n tools/simulator/mint2_real_device_restore_gate.sh
- python3 -m pytest tools/simulator/test_mint2_real_device_restore_gate.py -q
- bash tools/simulator/mint2_real_device_restore_gate.sh --dry-run
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/agent_reference_guard.py
- python3 tools/checks/claude_hooks_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/phases/mint-2-0-first-experience-rente-capital
- git diff --check

## Runtime Evidence
- .planning/runtime-evidence/mint2-real-device-restore-gate-20260620T114221Z
- Verdict: BLOCKED_NO_AVAILABLE_DEVICE
- Target: Jul / iPhone 13 mini appears in CoreDevice inventory but is unavailable for automation
- Restore proof claimed: false

## Line Count
384 insertions / 33 deletions. This is over the 300-line target but under the 500 hard cap; scope is tooling, tests, and active planning evidence only.
