### PR TITLE
Integrate PR #723 onto staging

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -88,6 +88,10 @@ open claim is physical-device/TestFlight restore evidence.
   mini but is unavailable to CoreDevice.
 - Runtime evidence artifacts are local and untracked; the executable Maestro
   flow is committed under `tools/simulator/flows/maestro-perfect-set/`.
+- PR #723 contributes cleanup handoff provenance under
+  `.planning/handoffs/mint-cleanup-2026-06-21/`; this integration keeps the
+  newer staging state above as the active router instead of reverting to the
+  earlier cleanup-only milestone.
 
 **Next execution bias:** reconnect the physical iPhone 13 mini and rerun
 `bash tools/simulator/mint2_real_device_restore_gate.sh`; only then proceed to a
@@ -96,8 +100,8 @@ gate is `BLOCKED_NO_AVAILABLE_DEVICE`.
 
 ## Historical Receipts
 
-The sections below pre-date the Core Journey Truth convergence phase. They stay
-available for provenance, but they are no longer the active routing state.
+The sections below pre-date the current cleanup/account lifecycle session. They
+stay available for provenance, but they are not the active routing state.
 
 ## Phase 01.1 Planning Receipt (walkthrough-first-grounding, 2026-05-21)
 

--- a/.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md
+++ b/.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md
@@ -1,0 +1,240 @@
+---
+description: "Manifest for the 2026-06-21 MINT planning/repo/review hygiene cleanup before account lifecycle work resumes."
+status: inventory-manifest
+date: 2026-06-21
+scope: planning-hygiene
+---
+
+# Mint Cleanup Manifest — 2026-06-21
+
+## Purpose
+
+Close the planning/repo/review hygiene loop before resuming Mint 2.0 account
+lifecycle work. This manifest is not a new product matrix. It is the bounded
+ledger for what may be classified, patched, reviewed, and later committed.
+
+No product code change is proposed by this cleanup pass.
+
+## Preflight State
+
+| Check | Observed |
+|---|---|
+| `pwd` | `/Users/julienbattaglia/Desktop/MINT.nosync` |
+| `git rev-parse --show-toplevel` | `/Users/julienbattaglia/Desktop/MINT.nosync` |
+| Expected worktree | matched |
+| `git symbolic-ref --short HEAD` | `qa/runtime-navigation-spine-20260602` |
+| Expected branch | matched |
+| `git rev-parse HEAD` | `3d289b6b04256eb9cc9f0bad723b2ac85ad823ba` |
+| Expected base | matched exactly |
+| `git merge-base --is-ancestor BASE HEAD` | exit `0` |
+| `git diff --shortstat` | `43 files changed, 3679 insertions(+), 2322 deletions(-)` |
+| Repo size | `16G .`, `505M .git`, `5.8G .claude`, `5.8G .claude/worktrees`, `817M .planning`, `4.8G apps`, `3.6G services`, `87M tools` |
+
+Known warning: `git diff --shortstat` reports CRLF/LF replacement warnings for
+generated Flutter localization files. This is pre-existing in the handoff and
+is not a cleanup target here.
+
+Handshake gap: `memory/MEMORY.md` is absent in this worktree. Engram MCP was
+available and used instead.
+
+## Engram Context Loaded
+
+| Observation | Title | Cleanup relevance |
+|---|---|---|
+| `#2238` | Mint first experience lifecycle matrix reviewed | Matrix exists, expert-agent review incorporated, Claude Max produced no substantive verdict. |
+| `#2241` | Mint account lifecycle Slice 0 | Prompt listed this ID as matrix-reviewed, but Engram returns Slice 0. Treat prompt ID mapping as stale. |
+| `#2243` | Mint lifecycle routing Slice A | Lifecycle routing slice exists historically; local proof still required before classification. |
+| `#2245` | Mint planning and Claude review hygiene audit | Confirms repo size, stale `STATE.md`, phase/worktree sprawl, and bounded Claude review policy. |
+| `#2247` | Cleanup should run in fresh session | Confirms this cleanup should be strict, atomic, and non-destructive. |
+
+## Active Matrix Ledger
+
+| Item | Classification | Evidence | Remaining gates |
+|---|---|---|---|
+| `mint-first-experience-account-lifecycle` | `active/partial` | Matrix frontmatter status is `agent-reviewed-claude-timeout-ready-for-slice-0` at `.planning/phases/mint-first-experience-account-lifecycle/EXECUTABLE_MATRIX.md:1`; review gate records Claude Max no-verdict at lines 28-40. | Runtime gates G1-G10 remain open at lines 296-315. Deferred slices remain at lines 430-443. |
+| Slice 0 | `implemented-historically, verify-before-final-classification` | Engram `#2241`; matrix Slice 0 contract at lines 363-394. Backend Apple forged-token test exists as untracked `services/backend/tests/test_auth_apple.py`; local auth verification code exists at `services/backend/app/api/v1/endpoints/auth.py:1248`. | Current-session tests not rerun in this cleanup. Do not mark phase executed from history alone. |
+| Slice A | `partial/local-proof-present` | Engram `#2243`; lifecycle enum/value object at `apps/mobile/lib/models/auth_lifecycle_state.dart:3`; main-nav/public-entry tests at `apps/mobile/test/navigation/home_gate_contract_test.dart:1` and `apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart:1`; router uses lifecycle at `apps/mobile/lib/app.dart:230`. | No runtime relaunch/update proof in this cleanup. Boot barrier/hydration split remains later work per Engram `#2243`. |
+| Apple auth hardening | `partial/product-blocked-before-lifecycle-exit` | Backend verifies Apple JWS/JWKS, RS256, `aud`, `iss`, required `exp/iat/iss/aud/sub`, and nonce at `services/backend/app/api/v1/endpoints/auth.py:1248-1302`. | Before any account-lifecycle product commit exits Slice 0, Apple lookup must bind primarily by stable `sub`, not email/fallback; authorization-code revoke proof must be explicit; the relevant tests, including `services/backend/tests/test_auth_apple.py`, must be committed with the auth endpoint change. |
+| Claude Max validation | `gap-documented` | `.planning/phases/mint-first-experience-account-lifecycle/CLAUDE_MAX_REVIEW.md:5-10` says both attempts produced no substantive model output. | Routine review must use bounded `tools/claude_review.sh`; Opus/xhigh is reserved for clean PR-level review. |
+
+## Dirty Diff Lots
+
+| Lot | Files | Tracked diff | Classification |
+|---|---:|---:|---|
+| Mobile lifecycle/auth routing | 4 tracked + 2 untracked relevant files | `262 insertions`, `176 deletions` | Product code from lifecycle work. Do not touch in cleanup. |
+| Backend Apple auth | 2 tracked + 1 untracked test | `63 insertions`, `48 deletions` | Product/security code from lifecycle work. Do not touch in cleanup. Future auth commit must include the untracked test file and fix `sub`-primary binding before account lifecycle exits Slice 0. |
+| Planning handoff/current phase docs | `.planning/ROADMAP.md`, `.planning/config.json`, untracked handoff and phase dirs | tracked `43 insertions`, `1 deletion`; many untracked docs | Cleanup may add manifest and later update `STATE.md`; no archive movement without proof. |
+| Flutter l10n/generated | 13 tracked files | `150 insertions` | Product support/generated output. Do not touch in cleanup unless product code is explicitly resumed later. |
+| Anonymous/chat/auth UI and tests | 16 tracked files | `3080 insertions`, `2077 deletions` | Pre-existing product work. Do not touch in cleanup. |
+| Tooling/config/agent docs | 6 tracked + 2 untracked tool files | `81 insertions`, `20 deletions` tracked | Do not normalize in cleanup except bounded review docs if needed. |
+
+Untracked files/directories include:
+
+- `.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md`
+- `.planning/phases/mint-first-experience-account-lifecycle/`
+- `.planning/phases/mint-2-0-first-experience-rente-capital/`
+- `.planning/phases/mint-account-entry-apple-primary/`
+- `.planning/phases/mint-anonymous-chat-restore-control/`
+- `.planning/phases/mint-diagnostic-onboarding-v1/`
+- `.planning/phases/mint-onboarding-lifecycle-reset/`
+- `.planning/phases/mint-profile-clear-conversation-purge/`
+- `apps/mobile/lib/models/auth_lifecycle_state.dart`
+- `apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart`
+- `docs/MINT_AGENT_WORKFLOW.md`
+- `services/backend/tests/test_auth_apple.py`
+- `tools/checks/mint_variable_dictionary_lint.py`
+- `tools/checks/tests/test_mint_variable_dictionary_lint.py`
+
+## Worktree Classification
+
+| Path | Branch | Head | Size | Lock | Dirty entries | Classification |
+|---|---|---:|---:|---|---:|---|
+| `/Users/julienbattaglia/Desktop/MINT.nosync` | `qa/runtime-navigation-spine-20260602` | `3d289b6b0` | `16G` | active root | dirty | current worktree |
+| `/Users/julienbattaglia/Desktop/MINT.brand-refondation.nosync` | `feat/mint-v2-refondation` | `6053a6920` | not measured | none in porcelain | not checked | external known worktree; do not touch |
+| `/Users/julienbattaglia/Desktop/MINT.bump.nosync` | `staging` | `287c8ae07` | not measured | none in porcelain | not checked | external known worktree; do not touch |
+| `/Users/julienbattaglia/Desktop/MINT.foundation-clean.nosync` | `feature/S11-mint2-profile-value-ledger` | `de17ecf39` | not measured | none in porcelain | not checked | external known recent Mint2 worktree; do not touch |
+| `.claude/worktrees/agent-a02a8ae53f6475bb3` | `worktree-agent-a02a8ae53f6475bb3` | `22b127fed` | `407M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-a36c33cda66f755e5` | `worktree-agent-a36c33cda66f755e5` | `10699dd8b` | `404M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-a7c8747f5175fb884` | `worktree-agent-a7c8747f5175fb884` | `4bc6e05da` | `405M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-a7fdf7eecb8e77ed7` | `worktree-agent-a7fdf7eecb8e77ed7` | `208b91eef` | `363M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-a9de1300a388ae195` | `worktree-agent-a9de1300a388ae195` | `05f7dd23a` | `406M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-a9e19139d37c54945` | `worktree-01.5-03-02` | `dc5b7c032` | `316M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-ab3c0c431fe4c2cdd` | `worktree-01.5-03-01` | `a150bbd4f` | `316M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-abd158274e3229876` | `worktree-agent-abd158274e3229876` | `acc7a6134` | `338M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-ac0f4187efe51f8d3` | `worktree-agent-ac0f4187efe51f8d3` | `fc4b0ac9d` | `410M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/agent-ad20c9b62c2e7bdae` | `worktree-agent-ad20c9b62c2e7bdae` | `aa15cc09d` | `407M` | locked pid `18242` | `0` | expected locked agent worktree |
+| `.claude/worktrees/codex-mint-diagnostic-onboarding-v1-route` | `codex/mint-account-entry-apple-primary` | `9f15eedd2` | `2.1G` | unlocked | `0` | expected large Codex worktree, no cleanup without explicit GO |
+
+Delta vs handoff wording: handoff said "11 worktrees locked"; current porcelain
+shows 10 locked agent worktrees plus one unlocked Codex worktree under
+`.claude/worktrees`. All `.claude/worktrees/*` entries have `dirty_entries=0`.
+No worktree cleanup is proposed in this pass.
+
+## Phase Classification Table
+
+Classification is conservative. `historical-summary-present/no-move` means a
+summary exists according to the inventory command, but this manifest does not
+authorize archive movement or claim final phase closure. Any future archive
+candidate needs a separate review with file/line proof.
+
+| Phase directory | Evidence markers | Classification | Action now |
+|---|---|---|---|
+| `mint-first-experience-account-lifecycle` | `EXECUTABLE_MATRIX.md`, no summary | `active/partial` | Keep active. |
+| `mint-2-0-first-experience-rente-capital` | summary + plan + context, untracked | `active-on-hold` | Do not touch until hygiene cleanup ends. |
+| `mint-account-entry-apple-primary` | 4 summaries, untracked | `superseded-reference` | Keep as source evidence for lifecycle matrix; no move. |
+| `mint-anonymous-chat-restore-control` | summary + runtime audit, untracked | `superseded-reference` | Keep as source evidence; no move. |
+| `mint-diagnostic-onboarding-v1` | plan + reviews, untracked | `superseded-reference/unknown` | Keep as source evidence; no move. |
+| `mint-onboarding-lifecycle-reset` | 4 summaries, untracked | `superseded-reference` | Keep as source evidence; no move. |
+| `mint-profile-clear-conversation-purge` | 2 summaries, untracked | `superseded-reference` | Keep as source evidence; no move. |
+| `mint-prod-ready-core-journey-truth-20260601` | matrix + review synthesis says active | `historical-active-stale-router` | Update `STATE.md` only after review; no move. |
+| `mint-illogism-fixes` | 17 summaries + validation | `historical-summary-present/no-move` | No move in this pass. |
+| `mint-calc-engine-v1` | 22 summaries + validation + matrix | `historical-summary-present/no-move` | No move in this pass. |
+| `mint-data-spine-plan-vivant-v1` | 70 summaries | `historical-summary-present/no-move` | No move in this pass. |
+| `mon-argent-budget-cleanup-v2` | 69 summaries | `historical-summary-present/no-move` | No move in this pass. |
+| `money-trust-contract-v1-04` through `money-trust-contract-v1-40` | per-plan summaries present | `historical-summary-present/no-move` | No move in this pass. |
+| `mint-grounded-coach-m1` | 8 summaries | `historical-summary-present/no-move` | No move in this pass. |
+| `01.1-walkthrough-first-grounding` | 2 summaries + preconditions/observations | `historical-summary-present/no-move` | No move in this pass. |
+| `01.5-archetype-hard-gate-fatca` | 10 summaries | `historical-summary-present/no-move` | No move in this pass. |
+| `96-mvp-chat-as-verb` | 3 summaries + draft validation with pending markers | `unknown/pending` | No move. |
+| `wave-1a-backend-tools-refactor` | 9 summaries + validation | `historical-summary-present/no-move` | No move in this pass. |
+| `wave-1b-citation-chips` | 10 summaries + validation | `historical-summary-present/no-move` | No move in this pass. |
+| `wave-1c-coach-tool-dispatch-rca` | plans/context, no summary | `unknown/pending` | No move. |
+| `mint-data-architecture-v1-01-calc-engine-canonical` | 5 summaries + verification | `historical-summary-present/no-move` | No move in this pass. |
+| `mint-data-architecture-v1-02-event-log-projection` | 4 summaries + validation | `historical-summary-present/no-move` | No move in this pass. |
+| `mint-data-architecture-v1-02-deploy` | validation + plans, no summary | `unknown/pending` | No move. |
+| `mint-account-entry-apple-primary` predecessors listed in matrix | matrix lines 18-26 | `superseded-reference` | No move. |
+| `01-mint-production-readiness-audit-identify-top-blockers-to-fir` | validation/context, no summary | `unknown` | No move. |
+| `01.4-coach-runtime-stale-data` | 3 files, no summary/context | `unknown` | No move. |
+| `92.5-mvp-calc-rigor-foundations` | summary + plans/context | `historical-summary-present/no-move` | No move in this pass. |
+| `97-mvp-parfait-maestro-full-power-maestro-driven-on-device-grou` | context, no summary | `unknown` | No move. |
+| `97.5-product-completeness-for-ship` | plan, no summary | `unknown/pending` | No move. |
+| `mint-etat-des-lieux-20260612` | 6 files, no summary/context | `unknown` | No move. |
+| `mint-sense-making` | empty | `unknown/empty` | No move. |
+| `mon-argent-compact-selector-v1` | summary + plan | `historical-summary-present/no-move` | No move in this pass. |
+| `mon-argent-money-map-v1` | plan + context, no summary | `unknown/pending` | No move. |
+| `money-trust-contract-v1-00-figure-audit` | one file, no summary/plan | `unknown` | No move. |
+| `money-trust-contract-v1-01-spine-trust-chip` | plan only | `unknown/pending` | No move. |
+| `money-trust-contract-v1-02-coach-number-gate` | plan only | `unknown/pending` | No move. |
+| `money-trust-contract-v1-03-onboarding-3a-number-gate` | plan only | `unknown/pending` | No move. |
+| `salvage-SALVAGE-00` | 2 summaries | `historical-summary-present/no-move` | No move in this pass. |
+| `salvage-SALVAGE-01` | empty | `unknown/empty` | No move. |
+
+For compactness, the per-plan `money-trust-contract-v1-04` to
+`money-trust-contract-v1-40` sequence is grouped above because the inventory
+shows the same shape for each: one summary, one plan, three files, except:
+
+- `money-trust-contract-v1-20` and `money-trust-contract-v1-37` have five files.
+- `money-trust-contract-v1-40` has seven files.
+
+No directory in this grouped sequence is moved in this pass.
+
+## Proposed Atomic Commits
+
+No commit may be made without explicit user GO after review.
+
+| Commit | Purpose | Explicit allowed files |
+|---|---|---|
+| `planning cleanup manifest` | Record preflight, inventory, classifications, and stop conditions. | `.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md`; `.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md`. |
+| `planning active state hygiene` | Update stale `.planning/STATE.md` to point at cleanup/account lifecycle instead of Core Journey Truth. | `.planning/STATE.md`; this manifest. |
+| `planning registry scaffold` | Optional registry page if review asks for it. | `.planning/PHASE_REGISTRY.md`; this manifest only if updated. |
+
+Explicitly forbidden in these commits:
+
+- Product code under `apps/` or `services/`.
+- Generated localization files.
+- `.claude/worktrees` deletion or movement.
+- Bulk phase archive movement.
+- `git add .`.
+- Reset, stash, pull, rebase, clean, push, merge.
+
+## Review Plan
+
+Before any commit:
+
+1. Run Review Agent on the scope below:
+   - `.planning/STATE.md`
+   - `.planning/handoffs/mint-cleanup-2026-06-21/*`
+   - any phase registry/archive manifest touched in this cleanup
+2. Run targeted Claude review if `tools/claude_review.sh` exists:
+
+```bash
+MINT_CLAUDE_MODEL=sonnet MINT_CLAUDE_TIMEOUT=900 MINT_CLAUDE_MAX_BYTES=12000 tools/claude_review.sh -- .planning/handoffs/mint-cleanup-2026-06-21 .planning/STATE.md
+```
+
+3. Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+No product tests are required unless product code is touched by mistake. If that
+happens, stop and report before continuing.
+
+Product diffs referenced by this manifest, including Apple auth, anonymous chat,
+auth UI, lifecycle routing, generated localization files, and mobile tests, are
+outside this cleanup commit. They require their own targeted review and test
+gate before any product commit.
+
+## Risks And STOP Conditions
+
+Stop before state edits or archive movement if any of these occur:
+
+- New dirty files appear outside `.planning/handoffs/mint-cleanup-2026-06-21/`
+  or `.planning/STATE.md`.
+- Any phase classification requires inference without local file evidence or
+  Engram evidence.
+- A review asks to inspect product code beyond the cleanup scope.
+- Claude review widens scope or times out after being invoked with the bounded
+  command.
+- Any command suggests reset/stash/pull/rebase/clean/push/merge.
+- A worktree becomes dirty or lock state changes during the cleanup.
+
+Current cleanup diff is intentionally limited to:
+
+- `.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md`
+- `.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md`
+- `.planning/STATE.md`
+
+If Review Agent or targeted Claude review objects, fix only those planning
+files and rerun the same bounded checks.

--- a/.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md
+++ b/.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md
@@ -1,0 +1,310 @@
+# Mint Cleanup / Account Lifecycle Handoff Prompt
+
+Use this prompt in a fresh session. Do not start another product matrix before
+this cleanup is complete.
+
+```text
+Tu reprends MINT dans:
+WORKTREE=/Users/julienbattaglia/Desktop/MINT.nosync
+BRANCH=qa/runtime-navigation-spine-20260602
+BASE_COMMIT=3d289b6b04256eb9cc9f0bad723b2ac85ad823ba
+
+Objectif unique:
+Fermer proprement le chantier d'hygiène repo/planning/review avant de reprendre
+Mint 2.0 account lifecycle. Le but n'est PAS d'ajouter une nouvelle matrice:
+le but est de classer, fermer, archiver et rendre le prochain travail atomique.
+
+Préflight obligatoire, avant toute mutation:
+- pwd
+- git rev-parse --show-toplevel
+- git symbolic-ref --short HEAD
+- git rev-parse HEAD
+- git status --short
+- git diff --shortstat
+- git worktree list
+- du -sh . .git .claude .claude/worktrees .planning apps services tools 2>/dev/null || true
+
+Assertions STOP après préflight:
+- Si `git rev-parse --show-toplevel` n'est pas exactement `WORKTREE`, STOP.
+- Si `git symbolic-ref --short HEAD` n'est pas exactement `BRANCH`, STOP.
+- Si `git rev-parse HEAD` n'est ni `BASE_COMMIT` ni un descendant direct de
+  `BASE_COMMIT`, STOP et reporte HEAD/BASE/status. Ne pas merge/rebase/pull.
+- Si le worktree contient des changements non listés dans l'état connu ci-dessous,
+  STOP et reporte la différence. Ne pas supposer qu'ils sont sûrs.
+- Si `git worktree list` montre des worktrees inattendus ou dirty/locked dans un
+  état non documenté, STOP et reporte. Ne pas nettoyer.
+
+Contraintes:
+- Aucun reset, stash, pull, rebase, restore, checkout destructif, switch,
+  `git clean`, `rm -rf`, ou nettoyage manuel de worktree.
+- Aucun `git add .`.
+- Aucun push/merge.
+- Ne pas exécuter dans un autre worktree.
+- Ne pas supprimer `.claude/worktrees` à la main.
+- Ne pas déplacer manuellement `.claude/worktrees` avec `mv`; utiliser seulement
+  des commandes `git worktree` après preuve et GO explicite.
+- Ne pas archiver de phase sans preuve de statut.
+- Ne pas ouvrir de nouvelle phase/matrice produit pendant ce cleanup.
+- Tout staging doit être explicite par fichier.
+
+Contexte sauvegardé dans Engram:
+- "Mint lifecycle routing Slice A"
+- "Mint account lifecycle Slice 0"
+- "Mint planning and Claude review hygiene audit"
+- "Cleanup should run in fresh session"
+
+Engram obligatoire en début de session:
+- Appeler `mem_context(project="mint")`.
+- Appeler `mem_search(project="mint", query="Mint lifecycle routing Slice A")`.
+- Appeler `mem_search(project="mint", query="Mint planning and Claude review hygiene audit")`.
+- Appeler `mem_get_observation` pour les IDs correspondants, notamment si trouvés:
+  - #2241 `Mint first experience lifecycle matrix reviewed`
+  - #2243 `Mint lifecycle routing Slice A`
+  - #2245 `Mint planning and Claude review hygiene audit`
+  - #2247 `Cleanup should run in fresh session`
+- Si Engram est indisponible:
+  - suspendre les étapes qui dépendent d'Engram;
+  - continuer uniquement avec ce prompt comme contexte de fallback;
+  - exiger des preuves locales file:line pour toute classification;
+  - ne rien classifier/archiver si la preuve locale manque.
+- Lire les résultats avant de classifier ou modifier quoi que ce soit.
+
+État connu au moment du handoff:
+- HEAD: 3d289b6b04256eb9cc9f0bad723b2ac85ad823ba
+- Branch: qa/runtime-navigation-spine-20260602
+- Worktree dirty: environ 43 fichiers modifiés, ~3679 insertions, ~2322 deletions,
+  plus des fichiers non suivis.
+- Repo ~16G.
+- `.claude/worktrees` ~5.8G, 11 worktrees locked, plus gros ~2.1G:
+  `.claude/worktrees/codex-mint-diagnostic-onboarding-v1-route`.
+- `.planning/phases` contient 76 dossiers; beaucoup ont `SUMMARY.md`.
+- `.planning/milestones` n'a que `v2.0-phases` et `v2.1-phases`.
+- `.planning/STATE.md` est stale: il pointe encore sur Core Journey Truth,
+  pas sur le chantier account lifecycle / hygiene actuel.
+- Le worktree courant est `qa/runtime-navigation-spine-20260602`, alors que des
+  travaux Mint2 récents ont aussi vécu dans `/Users/julienbattaglia/Desktop/MINT.foundation-clean.nosync`
+  sur `feature/S11-mint2-profile-value-ledger`. Ne mélange pas les worktrees.
+
+Travail déjà réalisé dans cette session précédente:
+1. Matrice active:
+   `.planning/phases/mint-first-experience-account-lifecycle/EXECUTABLE_MATRIX.md`
+   avec statut `agent-reviewed-claude-timeout-ready-for-slice-0`.
+2. Claude Max:
+   `.planning/phases/mint-first-experience-account-lifecycle/CLAUDE_MAX_REVIEW.md`
+   documente deux timeouts sans verdict substantiel.
+3. Backend Apple auth:
+   `services/backend/app/api/v1/endpoints/auth.py`
+   vérifie Apple JWKS/RS256/aud/iss/exp/iat/nonce.
+   Test: `services/backend/tests/test_auth_apple.py`.
+4. Mobile lifecycle:
+   `apps/mobile/lib/models/auth_lifecycle_state.dart`
+   `apps/mobile/lib/providers/auth_provider.dart`
+   `apps/mobile/lib/app.dart`
+   Tests:
+   - `apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart`
+   - `apps/mobile/test/navigation/home_gate_contract_test.dart`
+   - lifecycle tests in `apps/mobile/test/providers/auth_provider_test.dart`
+5. Tests verts précédents:
+   Ces résultats sont une preuve historique de contexte, pas une vérification
+   courante. Toute session qui modifie les fichiers doit relancer ses propres
+   checks ciblés.
+   - `flutter test test/navigation/account_lifecycle_public_entry_redirect_test.dart`
+   - `flutter test test/navigation/home_gate_contract_test.dart`
+   - `flutter test test/providers/auth_provider_test.dart --plain-name "lifecycle"`
+   - `flutter analyze`
+   - `git diff --check` (CRLF warnings connus sur localizations générées)
+   - backend targeted Apple auth tests / ruff / pytest étaient verts avant la compaction.
+
+Cause Claude Max lenteur / review hygiene:
+- Claude minimal n'est pas lent; le blocage vient de l'enveloppe MINT.
+- `~/.claude/settings.json` force `claude-opus-4-8[1m]` + `effortLevel: xhigh`.
+- `.claude/settings.json` active Agent Teams et de nombreux hooks.
+- `.planning/config.json` utilise `model_profile: quality`, `cross_ai_timeout: 600`,
+  `subagent_timeout: 600000`.
+- Le diff courant est trop gros pour une review fréquente.
+- `.claude/worktrees` peut ralentir les scans filesystem.
+- `tools/claude_review.sh` existe déjà et doit être le chemin standard:
+  Sonnet par défaut, diff borné à 12KB, tools désactivés, pas de session persistence,
+  JSON output.
+- Claude Max Opus/xhigh est réservé aux reviews profondes de PR propres,
+  diff atomique, timeout minimum 30 minutes.
+
+Plan d'exécution attendu:
+
+Étape 1 — Inventory sans mutation:
+- Lire AGENTS.md, CLAUDE.md, docs/MINT_AGENT_WORKFLOW.md si présent.
+- Lire `.planning/STATE.md`, `.planning/MILESTONES.md`, `.planning/config.json`.
+- Inventorier `.planning/phases`:
+  - dossier
+  - présence SUMMARY/DONE/VALIDATION/PLAN/CONTEXT/EXECUTABLE_MATRIX
+  - statut inféré: active, executed, superseded, abandoned/unknown
+  - raison courte
+- Inventorier `.claude/worktrees`:
+  - path
+  - taille
+  - branch
+  - HEAD
+  - locked/unlocked
+  - dirty/clean si accessible
+  - statut attendu/inattendu par rapport au handoff
+- Inventorier le diff dirty en lots:
+  - lifecycle/auth
+  - backend auth/apple
+  - planning/handoff
+  - l10n/generated
+  - anonymous/chat/auth UI préexistants
+  - tooling/config
+
+Étape 2 — Produire un manifeste avant patch:
+Créer `.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md`
+avec:
+- Current git/worktree state.
+- Active matrix ledger:
+  - `mint-first-experience-account-lifecycle`: Slice 0 done à vérifier par
+    file:line ou Engram avant classification finale; Slice A partial/done à
+    vérifier de la même façon; classer `active/partial` si la preuve manque.
+    Reste attendu: Apple sub/revoke, delete/relaunch, Maestro/network-spy.
+- Phase classification table.
+- Worktree classification table.
+- Proposed commits, chacun atomique.
+- Explicit files allowed per commit.
+- Risks and STOP conditions.
+
+STOP ici et reporte le manifeste si une classification est ambiguë.
+
+Seuils mécaniques de classification:
+- `active`: dossier explicitement désigné comme chantier courant dans
+  `.planning/STATE.md`, dans ce prompt, ou dans le manifeste.
+- `executed`: preuve file:line ou Engram explicite, présence d'un `SUMMARY.md`
+  ou `*-SUMMARY.md` de phase, et aucun
+  marqueur évident `BLOCKED`, `STOP`, `TODO unresolved`, `pending operational gate`
+  non reporté dans le manifeste.
+- `superseded`: dossier remplacé par un chantier plus récent avec référence
+  explicite dans le manifeste.
+- `archive-candidate`: `executed` + destination d'archive claire.
+- `unknown`: tout le reste. Les dossiers `unknown` ne bougent pas.
+- Si `Slice A partial/done` ne peut pas être prouvé par file:line ou Engram,
+  le classer `active/partial`, pas `executed`.
+
+Étape 3 — Patch minimal seulement après manifeste:
+Autorisé:
+- Mettre à jour `.planning/STATE.md` pour refléter le chantier actif réel:
+  `mint-first-experience-account-lifecycle` / cleanup.
+- Ajouter un registre planning si utile:
+  `.planning/PHASE_REGISTRY.md` ou
+  `.planning/handoffs/mint-cleanup-2026-06-21/CLEANUP_MANIFEST.md`.
+- Ne pas déplacer/archiver de phase dans ce premier commit cleanup. Reporter
+  seulement les candidats éventuels dans le manifeste; tout mouvement demande
+  une passe séparée avec preuves file:line, Review Agent, Claude ciblé et GO
+  explicite.
+
+Interdit dans ce premier cleanup:
+- supprimer `.claude/worktrees`;
+- déplacer 76 dossiers d'un coup;
+- modifier du code produit;
+- mélanger cleanup planning et lifecycle/auth implementation;
+- corriger des tests non liés.
+
+Étape 4 — Review Agent obligatoire:
+Avant commit, préparer une review ciblée:
+
+Review Agent prompt:
+You are reviewing a repository/planning hygiene cleanup for MINT.
+Scope only:
+- `.planning/STATE.md`
+- `.planning/handoffs/mint-cleanup-2026-06-21/*`
+- any phase registry/archive manifest touched in this cleanup
+Do not review the full repo. Do not review product code unless changed in this cleanup.
+Check:
+- no destructive git guidance;
+- no accidental product scope;
+- phase classification is evidence-based;
+- active matrix closure is clear;
+- Claude review policy is practical and bounded;
+- proposed commits are atomic and reversible;
+- no instruction says to use `git add .`, reset, stash, blind delete, or full-repo Claude Max.
+Output:
+- Critical findings
+- Important findings
+- Minor findings
+- Ready/Not ready for cleanup commit
+
+Claude targeted review:
+Précheck:
+- `test -f tools/claude_review.sh`
+- Si le script existe mais n'est pas exécutable, utiliser `bash tools/claude_review.sh`.
+- Si le script est absent ou échoue avant d'appeler Claude, documenter la sortie
+  exacte et ne pas élargir le scope.
+
+Use:
+`MINT_CLAUDE_MODEL=sonnet MINT_CLAUDE_TIMEOUT=900 MINT_CLAUDE_MAX_BYTES=12000 tools/claude_review.sh -- .planning/handoffs/mint-cleanup-2026-06-21 .planning/STATE.md`
+
+If Claude review returns empty/times out:
+- capture exact command, timeout, stderr/stdout summary;
+- do not retry with a larger scope;
+- proceed only with local Review Agent/self-review if the diff is tiny and tests/checks pass.
+
+GO gate:
+- Après Review Agent + Claude targeted review + vérifications, STOP.
+- Reporter les résultats et attendre un GO explicite utilisateur avant tout commit.
+
+Étape 5 — Verification:
+Mandatory:
+- `git diff --check`
+- `git status --short`
+- targeted review command above, or documented failure
+- no product tests required unless product code changed
+
+Optional if code touched by mistake:
+- STOP and report before continuing.
+
+Commit policy:
+- No commit unless user explicitly says GO in the new session.
+- If committing, use explicit staging only.
+- Suggested commit message if only planning/hygiene docs changed:
+  `chore(planning): close mint cleanup handoff`
+
+Final expected:
+- HEAD/branch/status before and after.
+- What was classified.
+- What was changed.
+- What remains open.
+- Claude targeted review result.
+- Review Agent result.
+- GO/NO-GO for resuming account lifecycle + Maestro.
+- Clarifier explicitement que ce GO/NO-GO n'est pas une autorisation de commit,
+  push, merge, clean ou suppression; ces actions demandent un GO utilisateur
+  séparé et explicite.
+```
+
+## Review Agent Micro-Prompt
+
+Use this only to review the handoff prompt above, not the whole repo:
+
+```text
+You are a Review Agent. Review only:
+`.planning/handoffs/mint-cleanup-2026-06-21/PROMPT.md`
+
+Assess whether this prompt is safe and executable for a fresh cleanup session.
+
+Context:
+- MINT repo is dirty and large.
+- Current problem is planning/review/worktree hygiene, not product feature work.
+- Claude Max has timed out because reviews were too broad; routine reviews must use
+  `tools/claude_review.sh` with Sonnet, explicit paths, tools disabled, and bounded diff.
+
+Check for:
+1. Clear preflight and STOP conditions.
+2. No destructive operations.
+3. No blind deletion of `.claude/worktrees`.
+4. No `git add .`.
+5. No accidental full-repo Claude Max review.
+6. Correct separation between cleanup, lifecycle/auth implementation, and Maestro work.
+7. Enough context to continue from Engram and local files without reopening a new matrix.
+
+Return:
+- Critical findings
+- Important findings
+- Minor findings
+- Verdict: ready / ready with fixes / not ready
+```

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -16,7 +16,6 @@ import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/screens/landing_screen.dart';
-import 'package:mint_mobile/screens/anonymous/anonymous_chat_screen.dart';
 import 'package:mint_mobile/screens/coach/chat_as_verb_demo_screen.dart';
 import 'package:mint_mobile/screens/debug/debug_budget_bootstrap_screen.dart';
 import 'package:mint_mobile/screens/debug/debug_mint2_account_claim_screen.dart';
@@ -256,6 +255,30 @@ String? accountLifecycleAuthenticatedRedirect({
   return '/auth/register?redirect=$encodedPath';
 }
 
+const Set<String> _publicRoutePathFallbacks = {
+  '/',
+  '/start',
+  '/onb',
+  '/auth/login',
+  '/auth/register',
+  '/auth/forgot-password',
+  '/auth/verify-email',
+  '/auth/verify',
+  '/anonymous/chat',
+  '/waitlist',
+  '/legal/terms',
+};
+
+@visibleForTesting
+RouteScope routeScopeForRedirect({
+  required String path,
+  required RouteBase? topRoute,
+}) {
+  if (topRoute is ScopedGoRoute) return topRoute.scope;
+  if (_publicRoutePathFallbacks.contains(path)) return RouteScope.public;
+  return RouteScope.authenticated;
+}
+
 final _router = GoRouter(
   navigatorKey: _rootNavigatorKey,
   observers: _routerObservers,
@@ -321,9 +344,10 @@ final _router = GoRouter(
     }
 
     // Determine scope from matched route (fail-closed default)
-    final topRoute = state.topRoute;
-    final scope =
-        topRoute is ScopedGoRoute ? topRoute.scope : RouteScope.authenticated;
+    final scope = routeScopeForRedirect(
+      path: path,
+      topRoute: state.topRoute,
+    );
 
     switch (scope) {
       case RouteScope.public:
@@ -372,9 +396,9 @@ final _router = GoRouter(
       scope: RouteScope.public,
       builder: (context, state) => const LandingScreen(),
     ),
-    // Landing CTA target. Keep LandingScreen state-free, but fail closed to
-    // the structured diagnostic path. The legacy anonymous chat remains a
-    // public route, never the first-run fallback.
+    // Landing CTA target: chat-first anonymous cold-open is retired.
+    // Keep /start as a public alias for old links, but route users into
+    // the explicit first-experience onboarding flow instead.
     ScopedGoRoute(
       path: '/start',
       scope: RouteScope.public,
@@ -416,16 +440,13 @@ final _router = GoRouter(
       ),
     ),
 
-    // ── Anonymous chat (public — outside shell, no tabs/drawer) ──
-    // Phase 71a (2026-05-05) : /anonymous/intent route killed; the chat
-    // fallback carries the opener bubble + 3 chip suggestions inline.
+    // ── Retired anonymous chat entry (public alias) ─────────────
+    // The old cold-open chat prompt is no longer a product surface. Keep
+    // the path as a compatibility alias so deep links do not 404.
     ScopedGoRoute(
       path: '/anonymous/chat',
       scope: RouteScope.public,
-      builder: (context, state) {
-        final intent = state.uri.queryParameters['intent'];
-        return AnonymousChatScreen(intent: intent);
-      },
+      redirect: (_, __) => '/onb',
     ),
     // ── Sub-phase 01.5 W02-T03 — Hard-gate waitlist destination ──
     // Public scope: unauthenticated users coming through the onboarding
@@ -1255,8 +1276,7 @@ final _router = GoRouter(
         final result = state.extra as ExtractionResult?;
         if (result == null) {
           return Scaffold(
-            body: Center(
-                child: Text(S.of(context)!.documentNonDisponible)),
+            body: Center(child: Text(S.of(context)!.documentNonDisponible)),
           );
         }
         return ExtractionReviewScreen(result: result);
@@ -1271,8 +1291,7 @@ final _router = GoRouter(
             extra['result'] is! ExtractionResult ||
             extra['previousConfidence'] is! int) {
           return Scaffold(
-            body: Center(
-                child: Text(S.of(context)!.documentNonDisponible)),
+            body: Center(child: Text(S.of(context)!.documentNonDisponible)),
           );
         }
         return DocumentImpactScreen(

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -14,6 +14,7 @@ import 'package:mint_mobile/widgets/mint_shell.dart';
 import 'package:mint_mobile/providers/profile_provider.dart';
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/screens/landing_screen.dart';
 import 'package:mint_mobile/screens/anonymous/anonymous_chat_screen.dart';
 import 'package:mint_mobile/screens/coach/chat_as_verb_demo_screen.dart';
@@ -229,6 +230,32 @@ final List<NavigatorObserver> _routerObservers = [
   SentryNavigatorObserver(setRouteNameAsTransaction: true),
 ];
 
+@visibleForTesting
+String? accountLifecyclePublicEntryRedirect({
+  required AuthLifecycleState lifecycle,
+  required String path,
+}) {
+  if (!lifecycle.hasAccountSession) return null;
+  if (path == '/' || path == '/auth/login' || path == '/auth/register') {
+    return '/home';
+  }
+  return null;
+}
+
+@visibleForTesting
+String? accountLifecycleAuthenticatedRedirect({
+  required AuthLifecycleState lifecycle,
+  required String path,
+}) {
+  if (lifecycle.allowsMainNavigation) return null;
+  final encodedPath = Uri.encodeComponent(path);
+  if (lifecycle.state == AuthLifecycleKind.sessionExpired ||
+      lifecycle.state == AuthLifecycleKind.credentialRevoked) {
+    return '/auth/login?redirect=$encodedPath';
+  }
+  return '/auth/register?redirect=$encodedPath';
+}
+
 final _router = GoRouter(
   navigatorKey: _rootNavigatorKey,
   observers: _routerObservers,
@@ -241,7 +268,6 @@ final _router = GoRouter(
     // maintaining a manual prefix whitelist. Fail-closed: unknown
     // routes default to authenticated.
     final auth = context.read<AuthProvider>();
-    final isLoggedIn = auth.isLoggedIn;
     final path = state.uri.path;
 
     // Gate 0 #2 (splash gate): while checkAuth() is still resolving
@@ -301,8 +327,12 @@ final _router = GoRouter(
 
     switch (scope) {
       case RouteScope.public:
-        // Always allowed — no auth check
-        return null;
+        // A restored account must not see the signed-out landing/auth funnel
+        // on cold relaunch. Guest-local public entry remains allowed.
+        return accountLifecyclePublicEntryRedirect(
+          lifecycle: auth.authLifecycle,
+          path: path,
+        );
 
       case RouteScope.onboarding:
         // Onboarding routes are accessible without full auth;
@@ -311,11 +341,13 @@ final _router = GoRouter(
         return null;
 
       case RouteScope.authenticated:
-        // Require signed-in user OR opted-in anonymous local mode.
-        // Local mode is default-on for fresh installs per AuthProvider.checkAuth.
-        if (!isLoggedIn && !auth.isLocalMode) {
-          return '/auth/register?redirect=${Uri.encodeComponent(path)}';
-        }
+        final lifecycle = auth.authLifecycle;
+        // Require a deliberate guest dossier or a restored account lifecycle.
+        final authRedirect = accountLifecycleAuthenticatedRedirect(
+          lifecycle: lifecycle,
+          path: path,
+        );
+        if (authRedirect != null) return authRedirect;
         // ── GLOBAL archetype/FATCA gate (plan 08, oracle expat_us-1) ──
         // Before this branch the only FATCA gate lived at the coach entry,
         // so an expatUs profile reaching /home, /mon-argent, /profile/bilan
@@ -504,16 +536,10 @@ final _router = GoRouter(
                     ),
                   );
                 }
-                // Wave B-minimal B0 — Unblock tab Aujourd'hui for anonymous
-                // local-mode users. AuthProvider.dart:87 documents the
-                // intended gate as `isLoggedIn || isLocalMode`; the actual
-                // code shipped only `isLoggedIn`, making /home redirect to
-                // LandingScreen for every fresh-install user who hadn't
-                // explicitly signed in. Wave 0 walkthrough (iPhone 17 Pro
-                // sim, 2026-04-18) confirmed this empirically.
-                // Ref: `.planning/wave-0-walkthrough-verite/FINDINGS.md`,
-                // `.planning/wave-b-home-orchestrateur/PLAN.md` (B0).
-                return (auth.isLoggedIn || auth.isLocalMode)
+                // Account lifecycle is the product gate: fresh visitors stay
+                // on the landing/start flow, explicit guest mode and restored
+                // accounts can enter the tab shell.
+                return auth.authLifecycle.allowsMainNavigation
                     ? const AujourdhuiScreen()
                     : const LandingScreen();
               },

--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -2126,6 +2126,7 @@
   "financialSummaryNoProfile": "Kein Profil erfasst",
   "financialSummaryStartDiagnostic": "Diagnose starten",
   "financialSummaryRestartDiagnostic": "Diagnose neu starten",
+  "financialSummaryRestartDiagnosticError": "Ein Teil der lokalen Daten konnte nicht gelöscht werden. Versuch es gleich noch einmal.",
   "financialSummaryDefaultConjoint": "Ehepartner·in",
   "financialSummaryAvs1erPilier": "AHV (1. Säule)",
   "financialSummaryAnneesCotisees": "Beitragsjahre",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -2126,6 +2126,7 @@
   "financialSummaryNoProfile": "No profile entered",
   "financialSummaryStartDiagnostic": "Start the diagnostic",
   "financialSummaryRestartDiagnostic": "Restart the diagnostic",
+  "financialSummaryRestartDiagnosticError": "Some local data could not be cleared. Try again in a moment.",
   "financialSummaryDefaultConjoint": "Spouse",
   "financialSummaryAvs1erPilier": "AVS (1st pillar)",
   "financialSummaryAnneesCotisees": "Years contributed",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -2126,6 +2126,7 @@
   "financialSummaryNoProfile": "Ningún perfil registrado",
   "financialSummaryStartDiagnostic": "Comenzar el diagnóstico",
   "financialSummaryRestartDiagnostic": "Reiniciar el diagnóstico",
+  "financialSummaryRestartDiagnosticError": "No se ha podido borrar una parte de los datos locales. Inténtalo de nuevo en un momento.",
   "financialSummaryDefaultConjoint": "Cónyuge",
   "financialSummaryAvs1erPilier": "AVS (1er pilar)",
   "financialSummaryAnneesCotisees": "Años cotizados",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11680,7 +11680,7 @@
   },
   "landingV3AnonymousHomeLink": "Continuer sans compte",
   "@landingV3AnonymousHomeLink": {
-    "description": "Landing screen — anonymous local-mode entry point (S005, Phase 97 W7 iter#4). Sober text link below « J'ai déjà un compte ». Routes to /home (Aujourd'hui) ; the (isLoggedIn || isLocalMode) gate at app.dart:417 grants access since isLocalMode defaults true on fresh installs (auth_provider.dart:90, checkAuth() seeds it true line 142-145). Production-safe : exposes an existing anonymous-default path, no new bypass."
+    "description": "Landing screen — public onboarding entry point. Sober text link below « J'ai déjà un compte ». Routes through /start to /onb; retired anonymous chat entry points also resolve to onboarding."
   },
   "alertGenericFactPrefix": "MINT a remarqué",
   "@alertGenericFactPrefix": {

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -2144,6 +2144,7 @@
   "financialSummaryNoProfile": "Aucun profil renseigné",
   "financialSummaryStartDiagnostic": "Commencer le diagnostic",
   "financialSummaryRestartDiagnostic": "Recommencer le diagnostic",
+  "financialSummaryRestartDiagnosticError": "Une partie des données locales n’a pas pu être effacée. Réessaie dans un instant.",
   "financialSummaryDefaultConjoint": "Conjoint·e",
   "financialSummaryAvs1erPilier": "AVS (1er pilier)",
   "financialSummaryAnneesCotisees": "Années cotisées",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -2126,6 +2126,7 @@
   "financialSummaryNoProfile": "Nessun profilo inserito",
   "financialSummaryStartDiagnostic": "Iniziare la diagnosi",
   "financialSummaryRestartDiagnostic": "Ricominciare la diagnosi",
+  "financialSummaryRestartDiagnosticError": "Non è stato possibile eliminare una parte dei dati locali. Riprova tra un momento.",
   "financialSummaryDefaultConjoint": "Coniuge",
   "financialSummaryAvs1erPilier": "AVS (1° pilastro)",
   "financialSummaryAnneesCotisees": "Anni di contribuzione",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -8380,6 +8380,12 @@ abstract class S {
   /// **'Recommencer le diagnostic'**
   String get financialSummaryRestartDiagnostic;
 
+  /// No description provided for @financialSummaryRestartDiagnosticError.
+  ///
+  /// In fr, this message translates to:
+  /// **'Une partie des données locales n’a pas pu être effacée. Réessaie dans un instant.'**
+  String get financialSummaryRestartDiagnosticError;
+
   /// No description provided for @financialSummaryDefaultConjoint.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40030,7 +40030,7 @@ abstract class S {
   /// **'J’ai déjà un compte'**
   String get landingV2LoginLink;
 
-  /// Landing screen — anonymous local-mode entry point (S005, Phase 97 W7 iter#4). Sober text link below « J'ai déjà un compte ». Routes to /home (Aujourd'hui) ; the (isLoggedIn || isLocalMode) gate at app.dart:417 grants access since isLocalMode defaults true on fresh installs (auth_provider.dart:90, checkAuth() seeds it true line 142-145). Production-safe : exposes an existing anonymous-default path, no new bypass.
+  /// Landing screen — public onboarding entry point. Sober text link below « J'ai déjà un compte ». Routes through /start to /onb; retired anonymous chat entry points also resolve to onboarding.
   ///
   /// In fr, this message translates to:
   /// **'Continuer sans compte'**

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -4620,6 +4620,10 @@ class SDe extends S {
   String get financialSummaryRestartDiagnostic => 'Diagnose neu starten';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'Ein Teil der lokalen Daten konnte nicht gelöscht werden. Versuch es gleich noch einmal.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Ehepartner·in';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -4586,6 +4586,10 @@ class SEn extends S {
   String get financialSummaryRestartDiagnostic => 'Restart the diagnostic';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'Some local data could not be cleared. Try again in a moment.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Spouse';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -4609,6 +4609,10 @@ class SEs extends S {
   String get financialSummaryRestartDiagnostic => 'Reiniciar el diagnóstico';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'No se ha podido borrar una parte de los datos locales. Inténtalo de nuevo en un momento.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Cónyuge';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -4612,6 +4612,10 @@ class SFr extends S {
   String get financialSummaryRestartDiagnostic => 'Recommencer le diagnostic';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'Une partie des données locales n’a pas pu être effacée. Réessaie dans un instant.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Conjoint·e';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -4617,6 +4617,10 @@ class SIt extends S {
   String get financialSummaryRestartDiagnostic => 'Ricominciare la diagnosi';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'Non è stato possibile eliminare una parte dei dati locali. Riprova tra un momento.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Coniuge';
 
   @override

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -4606,6 +4606,10 @@ class SPt extends S {
   String get financialSummaryRestartDiagnostic => 'Reiniciar o diagnóstico';
 
   @override
+  String get financialSummaryRestartDiagnosticError =>
+      'Não foi possível apagar uma parte dos dados locais. Tenta novamente dentro de instantes.';
+
+  @override
   String get financialSummaryDefaultConjoint => 'Cônjuge';
 
   @override

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -2126,6 +2126,7 @@
   "financialSummaryNoProfile": "Nenhum perfil registado",
   "financialSummaryStartDiagnostic": "Iniciar o diagnóstico",
   "financialSummaryRestartDiagnostic": "Reiniciar o diagnóstico",
+  "financialSummaryRestartDiagnosticError": "Não foi possível apagar uma parte dos dados locais. Tenta novamente dentro de instantes.",
   "financialSummaryDefaultConjoint": "Cônjuge",
   "financialSummaryAvs1erPilier": "AVS (1.º pilar)",
   "financialSummaryAnneesCotisees": "Anos de contribuição",

--- a/apps/mobile/lib/models/auth_lifecycle_state.dart
+++ b/apps/mobile/lib/models/auth_lifecycle_state.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/foundation.dart';
+
+enum AuthLifecycleKind {
+  sessionRestoring,
+  freshVisitor,
+  guestEmpty,
+  guestHasLocalData,
+  migrationOffered,
+  migrationConflict,
+  signedInProfileLoading,
+  signedInProfileMissing,
+  signedInIncomplete,
+  signedInReady,
+  syncOffAccount,
+  cloudSyncOnAccount,
+  offlineSignedInStale,
+  sessionExpired,
+  credentialRevoked,
+  deletionConfirming,
+  deletionPending,
+  deletionFailed,
+  deletedLocalCleanup,
+  deletedSignedOut,
+}
+
+enum AuthAccessMode { visitor, guestLocal, account }
+
+enum AuthSyncMode { none, localOnly, cloudSyncOff, cloudSyncOn }
+
+enum AuthDataScopeKind { none, guest, user }
+
+@immutable
+class AuthDataScope {
+  const AuthDataScope._(this.kind, [this.ownerId]);
+
+  static const none = AuthDataScope._(AuthDataScopeKind.none);
+
+  factory AuthDataScope.guest(String installId) {
+    return AuthDataScope._(AuthDataScopeKind.guest, installId);
+  }
+
+  factory AuthDataScope.user(String userId) {
+    return AuthDataScope._(AuthDataScopeKind.user, userId);
+  }
+
+  final AuthDataScopeKind kind;
+  final String? ownerId;
+
+  @override
+  bool operator ==(Object other) {
+    return other is AuthDataScope &&
+        other.kind == kind &&
+        other.ownerId == ownerId;
+  }
+
+  @override
+  int get hashCode => Object.hash(kind, ownerId);
+
+  @override
+  String toString() {
+    final wireKind = kind.name;
+    if (ownerId == null) return wireKind;
+    return '$wireKind:$ownerId';
+  }
+}
+
+@immutable
+class AuthLifecycleState {
+  const AuthLifecycleState({
+    required this.state,
+    required this.accessMode,
+    required this.activeDataScope,
+    required this.syncMode,
+    this.userId,
+  });
+
+  factory AuthLifecycleState.sessionRestoring() {
+    return const AuthLifecycleState(
+      state: AuthLifecycleKind.sessionRestoring,
+      accessMode: AuthAccessMode.visitor,
+      activeDataScope: AuthDataScope.none,
+      syncMode: AuthSyncMode.none,
+    );
+  }
+
+  factory AuthLifecycleState.freshVisitor() {
+    return const AuthLifecycleState(
+      state: AuthLifecycleKind.freshVisitor,
+      accessMode: AuthAccessMode.visitor,
+      activeDataScope: AuthDataScope.none,
+      syncMode: AuthSyncMode.none,
+    );
+  }
+
+  factory AuthLifecycleState.guestEmpty({required String installId}) {
+    return AuthLifecycleState(
+      state: AuthLifecycleKind.guestEmpty,
+      accessMode: AuthAccessMode.guestLocal,
+      activeDataScope: AuthDataScope.guest(installId),
+      syncMode: AuthSyncMode.localOnly,
+    );
+  }
+
+  factory AuthLifecycleState.signedInProfileLoading({
+    required String userId,
+    required bool cloudSyncEnabled,
+  }) {
+    return AuthLifecycleState(
+      state: AuthLifecycleKind.signedInProfileLoading,
+      accessMode: AuthAccessMode.account,
+      activeDataScope: AuthDataScope.user(userId),
+      syncMode: cloudSyncEnabled
+          ? AuthSyncMode.cloudSyncOn
+          : AuthSyncMode.cloudSyncOff,
+      userId: userId,
+    );
+  }
+
+  factory AuthLifecycleState.sessionExpired() {
+    return const AuthLifecycleState(
+      state: AuthLifecycleKind.sessionExpired,
+      accessMode: AuthAccessMode.account,
+      activeDataScope: AuthDataScope.none,
+      syncMode: AuthSyncMode.none,
+    );
+  }
+
+  final AuthLifecycleKind state;
+  final AuthAccessMode accessMode;
+  final AuthDataScope activeDataScope;
+  final AuthSyncMode syncMode;
+  final String? userId;
+
+  bool get allowsMainNavigation {
+    return activeDataScope != AuthDataScope.none &&
+        (accessMode == AuthAccessMode.guestLocal ||
+            accessMode == AuthAccessMode.account);
+  }
+
+  bool get hasAccountSession {
+    return accessMode == AuthAccessMode.account &&
+        activeDataScope.kind == AuthDataScopeKind.user &&
+        userId != null;
+  }
+}

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -3382,6 +3382,11 @@ class CoachProfile {
       restoredDataSources['plannedContributions.3a'] =
           ProfileDataSource.userInput;
     }
+    if (coachAvoirLpp != null && coachAvoirLpp > 0) {
+      provided.add('avoirLpp');
+      restoredDataSources['prevoyance.avoirLppTotal'] =
+          ProfileDataSource.userInput;
+    }
     if (answers.containsKey('q_civil_status') ||
         answers.containsKey('q_civil_status_choice')) {
       provided.add('civilStatus');

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -3313,6 +3313,40 @@ class CoachProfile {
         restoredDataSources['fiscal.impots'] = ProfileDataSource.certificate;
       }
     }
+    if (answers['_coach_lpp_source'] == 'document_scan') {
+      if (coachAvoirLpp != null && coachAvoirLpp > 0) {
+        restoredDataSources['prevoyance.avoirLppTotal'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachAvoirLppOblig != null) {
+        restoredDataSources['prevoyance.avoirLppObligatoire'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachAvoirLppSuroblig != null) {
+        restoredDataSources['prevoyance.avoirLppSurobligatoire'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachTauxConversion != null) {
+        restoredDataSources['prevoyance.tauxConversion'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachTauxConvSuroblig != null) {
+        restoredDataSources['prevoyance.tauxConversionSuroblig'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachRachatMax != null) {
+        restoredDataSources['prevoyance.rachatMaximum'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachSalaireAssure != null) {
+        restoredDataSources['prevoyance.salaireAssure'] =
+            ProfileDataSource.certificate;
+      }
+      if (coachRendementCaisse != null) {
+        restoredDataSources['prevoyance.rendementCaisse'] =
+            ProfileDataSource.certificate;
+      }
+    }
 
     // S47: Build initial dataTimestamps for all populated fields.
     // Use persisted updatedAt as base (reflects when data was actually entered),
@@ -3384,8 +3418,10 @@ class CoachProfile {
     }
     if (coachAvoirLpp != null && coachAvoirLpp > 0) {
       provided.add('avoirLpp');
-      restoredDataSources['prevoyance.avoirLppTotal'] =
-          ProfileDataSource.userInput;
+      restoredDataSources.putIfAbsent(
+        'prevoyance.avoirLppTotal',
+        () => ProfileDataSource.userInput,
+      );
     }
     if (answers.containsKey('q_civil_status') ||
         answers.containsKey('q_civil_status_choice')) {

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -851,6 +851,12 @@ class AuthProvider extends ChangeNotifier {
       }
 
       _isLoggedIn = true;
+      if (_userId != null && _userId!.isNotEmpty) {
+        _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+          userId: _userId!,
+          cloudSyncEnabled: isCloudSyncEnabled,
+        );
+      }
       // Phase 52 (D-01): no longer auto-disable local mode on magic link.
       // Cloud sync is opt-in via Settings › Confidentialité.
       _requiresEmailVerification = false;

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -16,6 +16,7 @@ import 'package:mint_mobile/services/account_handoff_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/fresh_start_service.dart';
 import 'package:mint_mobile/services/install_lifecycle_service.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 
@@ -86,6 +87,59 @@ String localizeAuthError(AuthError error, S l) {
   }
 }
 
+/// Translate an exception-like auth failure into localized UI copy.
+///
+/// Use this in UI `catch` blocks instead of displaying `error.toString()`.
+String localizeAuthException(Object error, S l) {
+  return localizeAuthError(_authErrorFromException(error), l);
+}
+
+AuthError _authErrorFromException(Object error) {
+  final raw = error.toString().replaceAll('Exception: ', '').trim();
+  final lower = raw.toLowerCase();
+
+  if (lower.contains('socketexception') ||
+      lower.contains('clientexception') ||
+      lower.contains('failed host lookup') ||
+      lower.contains('connection refused') ||
+      lower.contains('errno = 8') ||
+      lower.contains('errno = 61')) {
+    return AuthError.networkUnavailable;
+  }
+
+  if (lower.contains('existe déjà')) {
+    return AuthError.emailAlreadyUsed;
+  }
+
+  if (lower.contains('incorrect')) {
+    return AuthError.incorrectCredentials;
+  }
+
+  if (lower.contains('registration failed') ||
+      lower.contains('inscription impossible') ||
+      lower.contains('service indisponible')) {
+    return AuthError.registrationUnavailable;
+  }
+
+  if (lower.contains('authentication requise') ||
+      lower.contains('unauthorized') ||
+      lower.contains('forbidden')) {
+    return AuthError.serviceUnavailable;
+  }
+
+  if (lower.contains('invalid') || lower.contains('invalide')) {
+    return AuthError.invalidInput;
+  }
+  if (lower.contains('expir')) {
+    return AuthError.linkExpired;
+  }
+  if (lower.contains('non vérifié') || lower.contains('not verified')) {
+    return AuthError.emailNotVerified;
+  }
+
+  return AuthError.genericError;
+}
+
 /// Provider for managing authentication state
 /// Handles login, register, logout, and auth persistence
 class AuthProvider extends ChangeNotifier {
@@ -97,11 +151,16 @@ class AuthProvider extends ChangeNotifier {
   AuthError? _error;
   bool _requiresEmailVerification = false;
   bool _isDeletingAccount = false;
+  AuthLifecycleState _authLifecycle = AuthLifecycleState.sessionRestoring();
   // Local-mode default-on: the router's "authenticated" scope passes when
   // `isLoggedIn || isLocalMode`. Starting true keeps tab navigation alive
   // even if `checkAuth()` throws before the prefs block runs (e.g. on a
   // keychain failure). `register()`/`login()` explicitly flip this to false.
+  // Cloud sync defaults off; this legacy bool now means "cloud sync off" for
+  // accounts, not "the user deliberately entered guest mode".
   bool _isLocalMode = true;
+  static const _authLocalModeKey = 'auth_local_mode';
+  static const _mintInstallIdKey = '_mint_install_id';
 
   static String _localDataSyncPendingKey(String userId) =>
       'local_data_sync_pending_$userId';
@@ -113,6 +172,7 @@ class AuthProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
   AuthError? get error => _error;
   bool get requiresEmailVerification => _requiresEmailVerification;
+  AuthLifecycleState get authLifecycle => _authLifecycle;
 
   @visibleForTesting
   static Map<String, dynamic> mergeBackendProfileDataForTest(
@@ -142,10 +202,12 @@ class AuthProvider extends ChangeNotifier {
         answers[entry.key] = entry.value;
       }
     }
-    final claimHasSelfEmployedAnnual =
-        claimAnswers.containsKey('q_self_employed_net_income_annual_chf');
-    final claimHasPillar3aAnnual =
-        claimAnswers.containsKey('q_3a_annual_contribution');
+    final claimHasSelfEmployedAnnual = claimAnswers.containsKey(
+      'q_self_employed_net_income_annual_chf',
+    );
+    final claimHasPillar3aAnnual = claimAnswers.containsKey(
+      'q_3a_annual_contribution',
+    );
     bool fillIfMissing(String key, dynamic value) {
       if (value == null) return false;
       if (!_isMissingAnswer(answers, key)) return false;
@@ -223,19 +285,20 @@ class AuthProvider extends ChangeNotifier {
     }
     if (data['selfEmployedNetIncome'] is num && !claimHasSelfEmployedAnnual) {
       final annual = (data['selfEmployedNetIncome'] as num).toDouble();
-      final previousAnnual =
-          numberAnswer('q_self_employed_net_income_annual_chf');
+      final previousAnnual = numberAnswer(
+        'q_self_employed_net_income_annual_chf',
+      );
       final previousMonthly = numberAnswer('q_net_income_period_chf');
       final previousMonthlySource = answers['q_net_income_period_source'];
       final previousEmployment = answers['q_employment_status'];
       final monthlyWasDerivedFromPreviousAnnual =
           previousMonthlySource == 'derived_self_employed_annual_proxy' &&
-              previousAnnual != null &&
-              previousMonthly != null &&
-              closeToAmount(previousMonthly, previousAnnual / 12);
+          previousAnnual != null &&
+          previousMonthly != null &&
+          closeToAmount(previousMonthly, previousAnnual / 12);
       final shouldUseIndependentStatus =
           _isMissingAnswer(answers, 'q_employment_status') ||
-              _isIndependentEmployment(previousEmployment);
+          _isIndependentEmployment(previousEmployment);
 
       answers['q_self_employed_net_income_annual_chf'] = annual;
       if (shouldUseIndependentStatus) {
@@ -255,8 +318,10 @@ class AuthProvider extends ChangeNotifier {
       fillNumIfMissing('q_gross_salary_annual', data['incomeGrossYearly']);
     }
     if (data['incomeNetMonthly'] != null) {
-      final filledMonthlyIncome =
-          fillNumIfMissing('q_net_income_period_chf', data['incomeNetMonthly']);
+      final filledMonthlyIncome = fillNumIfMissing(
+        'q_net_income_period_chf',
+        data['incomeNetMonthly'],
+      );
       if (filledMonthlyIncome) {
         answers['q_pay_frequency'] = 'monthly';
       }
@@ -428,18 +493,38 @@ class AuthProvider extends ChangeNotifier {
   /// Check stored auth on app startup
   Future<void> checkAuth() async {
     _isLoading = true;
+    _authLifecycle = AuthLifecycleState.sessionRestoring();
     notifyListeners();
 
     try {
+      final prefs = await SharedPreferences.getInstance();
+      final hasExplicitLocalMode = prefs.containsKey(_authLocalModeKey);
+      _isLocalMode = prefs.getBool(_authLocalModeKey) ?? true;
       final mayRestoreAuth =
           await InstallLifecycleService.prepareForAuthRestore();
-      final isLoggedIn =
-          mayRestoreAuth ? await AuthService.isLoggedIn() : false;
+      final isLoggedIn = mayRestoreAuth
+          ? await AuthService.isLoggedIn()
+          : false;
       if (isLoggedIn) {
         _userId = await AuthService.getUserId();
         _email = await AuthService.getUserEmail();
         _displayName = await AuthService.getDisplayName();
+        if (_userId == null || _userId!.isEmpty) {
+          await AuthService.logout();
+          _isLoggedIn = false;
+          _userId = null;
+          _email = null;
+          _displayName = null;
+          _authLifecycle = AuthLifecycleState.sessionExpired();
+          ConversationStore.setCurrentUserId(null);
+          _error = null;
+          return;
+        }
         _isLoggedIn = true;
+        _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+          userId: _userId!,
+          cloudSyncEnabled: isCloudSyncEnabled,
+        );
         // FIX-W11-7: Set user prefix for conversation isolation.
         ConversationStore.setCurrentUserId(_userId);
         _error = null;
@@ -453,25 +538,24 @@ class AuthProvider extends ChangeNotifier {
         } catch (e) {
           debugPrint('[Auth] best-effort failed: $e');
         }
+      } else {
+        _authLifecycle = _isLocalMode && hasExplicitLocalMode
+            ? AuthLifecycleState.guestEmpty(
+                installId: await _loadOrCreateInstallId(prefs),
+              )
+            : AuthLifecycleState.freshVisitor();
       }
       // F3-2: Restore email verification state from SharedPreferences.
       // Survives cold start so the verify-email screen is shown again.
-      final prefs = await SharedPreferences.getInstance();
       _requiresEmailVerification =
           prefs.getBool('requires_email_verification') ?? false;
-      // Local-mode default: true on fresh install. Phase 52 (D-01):
-      // register / login no longer auto-flip this to false; cloud sync
-      // is opt-in via Settings › Confidentialité (`toggleCloudSync`).
-      // Existing users registered pre-Phase-52 retain whatever value
-      // was persisted — their `auth_local_mode = false` stays, no
-      // surprise switch in their sync state.
-      if (!prefs.containsKey('auth_local_mode')) {
-        await prefs.setBool('auth_local_mode', true);
-      }
-      _isLocalMode = prefs.getBool('auth_local_mode') ?? true;
+      // Missing `auth_local_mode` means no explicit guest choice yet. For
+      // accounts, the legacy value still means cloud sync is opt-in/off by
+      // default; for signed-out users it must not unlock main navigation.
     } catch (e) {
       _error = _toUserFriendlyAuthError(e);
       _isLoggedIn = false;
+      _authLifecycle = AuthLifecycleState.sessionExpired();
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -511,6 +595,10 @@ class AuthProvider extends ChangeNotifier {
           refreshToken: response['refresh_token'] as String?,
         );
         _isLoggedIn = true;
+        _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+          userId: userId,
+          cloudSyncEnabled: isCloudSyncEnabled,
+        );
         // Phase 52 (D-01): no longer auto-disable local mode on register.
         // Cloud sync is opt-in via Settings › Confidentialité.
         // FIX-W11-7: Set user prefix for conversation isolation.
@@ -580,6 +668,10 @@ class AuthProvider extends ChangeNotifier {
       _email = userEmail;
       _displayName = response['display_name'] as String?;
       _isLoggedIn = true;
+      _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+        userId: userId,
+        cloudSyncEnabled: isCloudSyncEnabled,
+      );
       // Phase 52 (D-01): no longer auto-disable local mode on login.
       // Cloud sync is opt-in via Settings › Confidentialité.
       // FIX-W11-7: Set user prefix for conversation isolation.
@@ -660,6 +752,10 @@ class AuthProvider extends ChangeNotifier {
       _email = userEmail;
       _displayName = displayName;
       _isLoggedIn = true;
+      _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+        userId: userId,
+        cloudSyncEnabled: isCloudSyncEnabled,
+      );
       // Phase 52 (D-01): no longer auto-disable local mode on Apple SSO.
       // Cloud sync is opt-in via Settings › Confidentialité.
       _requiresEmailVerification = false;
@@ -787,8 +883,16 @@ class AuthProvider extends ChangeNotifier {
       _displayName = null;
       _requiresEmailVerification = false;
       _isLocalMode = false;
-      await (await SharedPreferences.getInstance())
-          .setBool('auth_local_mode', false);
+      _authLifecycle = const AuthLifecycleState(
+        state: AuthLifecycleKind.deletedSignedOut,
+        accessMode: AuthAccessMode.visitor,
+        activeDataScope: AuthDataScope.none,
+        syncMode: AuthSyncMode.none,
+      );
+      await (await SharedPreferences.getInstance()).setBool(
+        _authLocalModeKey,
+        false,
+      );
       _isDeletingAccount = false;
       _isLoading = false;
       notifyListeners();
@@ -881,10 +985,9 @@ class AuthProvider extends ChangeNotifier {
   Future<void> logout() async {
     final accessToken = await AuthService.getToken();
     final refreshToken = await AuthService.getRefreshToken();
-    unawaited(ApiService.logout(
-      accessToken: accessToken,
-      refreshToken: refreshToken,
-    ));
+    unawaited(
+      ApiService.logout(accessToken: accessToken, refreshToken: refreshToken),
+    );
     await AuthService.logout();
     // FIX-W11-7: Clear user prefix on logout.
     ConversationStore.setCurrentUserId(null);
@@ -895,11 +998,14 @@ class AuthProvider extends ChangeNotifier {
     _displayName = null;
     _requiresEmailVerification = false;
     _isLocalMode = false;
+    _authLifecycle = AuthLifecycleState.freshVisitor();
     // Persist AFTER _purgeLocalData (which prefs.clear()s the store).
     // Logout = fully out; the user can re-enable local mode by tapping
     // "Continuer en mode local" on the register/login screens.
-    await (await SharedPreferences.getInstance())
-        .setBool('auth_local_mode', false);
+    await (await SharedPreferences.getInstance()).setBool(
+      _authLocalModeKey,
+      false,
+    );
     _error = null;
     notifyListeners();
   }
@@ -950,8 +1056,8 @@ class AuthProvider extends ChangeNotifier {
       await ReportPersistenceService.clearDiagnostic();
       final ownedSecurePurged =
           await InstallLifecycleService.purgeMintSecureStorage(
-        includeAuthSession: false,
-      );
+            includeAuthSession: false,
+          );
       await InstallLifecycleService.recordOwnedSecurePurgeResult(
         ownedSecurePurged,
         prefs: prefs,
@@ -1027,7 +1133,8 @@ class AuthProvider extends ChangeNotifier {
         } catch (e) {
           if (kDebugMode) {
             debugPrint(
-                '[AuthProvider] Anonymous conversation migration failed: $e');
+              '[AuthProvider] Anonymous conversation migration failed: $e',
+            );
           }
         }
       }
@@ -1090,7 +1197,8 @@ class AuthProvider extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       final currentUserId = _userId;
-      final accountOwnsLocalAnswers = currentUserId != null &&
+      final accountOwnsLocalAnswers =
+          currentUserId != null &&
           prefs.getString('local_data_owner') == currentUserId &&
           (prefs.getBool('local_data_migrated_$currentUserId') ?? false);
       var existingAnswers = await ReportPersistenceService.loadAnswers();
@@ -1100,8 +1208,9 @@ class AuthProvider extends ChangeNotifier {
       }
 
       final profileData = await ApiService.get('/profiles/me');
-      final answers =
-          accountOwnsLocalAnswers ? existingAnswers : <String, dynamic>{};
+      final answers = accountOwnsLocalAnswers
+          ? existingAnswers
+          : <String, dynamic>{};
       final merged = _mergeBackendProfileData(answers, profileData);
 
       if (!accountOwnsLocalAnswers && profileData.isEmpty) {
@@ -1130,7 +1239,10 @@ class AuthProvider extends ChangeNotifier {
   Future<void> enableLocalMode() async {
     _isLocalMode = true;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('auth_local_mode', true);
+    await prefs.setBool(_authLocalModeKey, true);
+    _authLifecycle = AuthLifecycleState.guestEmpty(
+      installId: await _loadOrCreateInstallId(prefs),
+    );
     notifyListeners();
   }
 
@@ -1141,53 +1253,25 @@ class AuthProvider extends ChangeNotifier {
   Future<void> toggleCloudSync(bool enabled) async {
     _isLocalMode = !enabled;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool('auth_local_mode', _isLocalMode);
+    await prefs.setBool(_authLocalModeKey, _isLocalMode);
+    if (_isLoggedIn && _userId != null) {
+      _authLifecycle = AuthLifecycleState.signedInProfileLoading(
+        userId: _userId!,
+        cloudSyncEnabled: enabled,
+      );
+    }
     notifyListeners();
   }
 
+  Future<String> _loadOrCreateInstallId(SharedPreferences prefs) async {
+    final existing = prefs.getString(_mintInstallIdKey);
+    if (existing != null && existing.isNotEmpty) return existing;
+    final generated = const Uuid().v4();
+    await prefs.setString(_mintInstallIdKey, generated);
+    return generated;
+  }
+
   AuthError _toUserFriendlyAuthError(Object error) {
-    final raw = error.toString().replaceAll('Exception: ', '').trim();
-    final lower = raw.toLowerCase();
-
-    if (lower.contains('socketexception') ||
-        lower.contains('clientexception') ||
-        lower.contains('failed host lookup') ||
-        lower.contains('connection refused') ||
-        lower.contains('errno = 8') ||
-        lower.contains('errno = 61')) {
-      return AuthError.networkUnavailable;
-    }
-
-    if (lower.contains('existe déjà')) {
-      return AuthError.emailAlreadyUsed;
-    }
-
-    if (lower.contains('incorrect')) {
-      return AuthError.incorrectCredentials;
-    }
-
-    if (lower.contains('registration failed') ||
-        lower.contains('inscription impossible') ||
-        lower.contains('service indisponible')) {
-      return AuthError.registrationUnavailable;
-    }
-
-    if (lower.contains('authentication requise') ||
-        lower.contains('unauthorized') ||
-        lower.contains('forbidden')) {
-      return AuthError.serviceUnavailable;
-    }
-
-    if (lower.contains('invalid') || lower.contains('invalide')) {
-      return AuthError.invalidInput;
-    }
-    if (lower.contains('expir')) {
-      return AuthError.linkExpired;
-    }
-    if (lower.contains('non vérifié') || lower.contains('not verified')) {
-      return AuthError.emailNotVerified;
-    }
-
-    return AuthError.genericError;
+    return _authErrorFromException(error);
   }
 }

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -4,8 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
+import 'package:mint_mobile/providers/byok_provider.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/biography/biography_repository.dart';
 import 'package:mint_mobile/services/coach/conversation_store.dart';
 import 'package:mint_mobile/services/memory/coach_memory_service.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
@@ -18,6 +20,7 @@ import 'package:mint_mobile/services/fresh_start_service.dart';
 import 'package:mint_mobile/services/install_lifecycle_service.dart';
 import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/services/partner_estimate_service.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 
 /// Error codes for authentication operations.
@@ -293,12 +296,12 @@ class AuthProvider extends ChangeNotifier {
       final previousEmployment = answers['q_employment_status'];
       final monthlyWasDerivedFromPreviousAnnual =
           previousMonthlySource == 'derived_self_employed_annual_proxy' &&
-          previousAnnual != null &&
-          previousMonthly != null &&
-          closeToAmount(previousMonthly, previousAnnual / 12);
+              previousAnnual != null &&
+              previousMonthly != null &&
+              closeToAmount(previousMonthly, previousAnnual / 12);
       final shouldUseIndependentStatus =
           _isMissingAnswer(answers, 'q_employment_status') ||
-          _isIndependentEmployment(previousEmployment);
+              _isIndependentEmployment(previousEmployment);
 
       answers['q_self_employed_net_income_annual_chf'] = annual;
       if (shouldUseIndependentStatus) {
@@ -502,9 +505,8 @@ class AuthProvider extends ChangeNotifier {
       _isLocalMode = prefs.getBool(_authLocalModeKey) ?? true;
       final mayRestoreAuth =
           await InstallLifecycleService.prepareForAuthRestore();
-      final isLoggedIn = mayRestoreAuth
-          ? await AuthService.isLoggedIn()
-          : false;
+      final isLoggedIn =
+          mayRestoreAuth ? await AuthService.isLoggedIn() : false;
       if (isLoggedIn) {
         _userId = await AuthService.getUserId();
         _email = await AuthService.getUserEmail();
@@ -528,9 +530,10 @@ class AuthProvider extends ChangeNotifier {
         // FIX-W11-7: Set user prefix for conversation isolation.
         ConversationStore.setCurrentUserId(_userId);
         _error = null;
-        // Full auth contract: migrate anonymous data, hydrate profile,
-        // schedule fresh-start notifications. Required for Apple Sign-In
-        // which only calls checkAuth() (not login/register).
+        // Full restored-session contract: hydrate profile and schedule
+        // fresh-start notifications. Do not claim anonymous conversations on
+        // silent restore; a signed account must not inherit guest chat state
+        // by accident.
         await _migrateLocalDataIfNeeded();
         await _hydrateProfileFromBackend();
         try {
@@ -621,7 +624,7 @@ class AuthProvider extends ChangeNotifier {
       }
 
       if (_isLoggedIn) {
-        await _migrateLocalDataIfNeeded();
+        await _migrateLocalDataIfNeeded(claimAnonymousConversations: true);
         await _hydrateProfileFromBackend();
         // Best-effort: schedule fresh-start notifications
         try {
@@ -706,7 +709,7 @@ class AuthProvider extends ChangeNotifier {
   ///   1. Saving the JWT via AuthService
   ///   2. Setting _isLoggedIn, _userId, _email, _displayName
   ///   3. Setting the ConversationStore user prefix
-  ///   4. Migrating local anonymous data
+  ///   4. Optionally claiming local anonymous conversations
   ///   5. Hydrating profile from backend
   ///   6. Scheduling fresh-start notifications
   ///
@@ -714,7 +717,10 @@ class AuthProvider extends ChangeNotifier {
   /// optional (backend may omit them on Apple's hidden email flow).
   ///
   /// Returns `true` on success, `false` on failure (error is set).
-  Future<bool> completeAppleSignIn(Map<String, dynamic> response) async {
+  Future<bool> completeAppleSignIn(
+    Map<String, dynamic> response, {
+    required bool claimAnonymousConversations,
+  }) async {
     _isLoading = true;
     _error = null;
     notifyListeners();
@@ -763,7 +769,9 @@ class AuthProvider extends ChangeNotifier {
       // FIX-W11-7: Set user prefix for conversation isolation.
       ConversationStore.setCurrentUserId(_userId);
 
-      await _migrateLocalDataIfNeeded();
+      await _migrateLocalDataIfNeeded(
+        claimAnonymousConversations: claimAnonymousConversations,
+      );
       await _hydrateProfileFromBackend();
       try {
         await FreshStartService().scheduleAllFreshStartNotifications();
@@ -1056,11 +1064,24 @@ class AuthProvider extends ChangeNotifier {
       await ReportPersistenceService.clearDiagnostic();
       final ownedSecurePurged =
           await InstallLifecycleService.purgeMintSecureStorage(
-            includeAuthSession: false,
-          );
+        includeAuthSession: false,
+      );
       await InstallLifecycleService.recordOwnedSecurePurgeResult(
         ownedSecurePurged,
         prefs: prefs,
+      );
+      await _bestEffortPurge('BYOK key', () => ByokProvider.clearStoredKey());
+      await _bestEffortPurge(
+        'partner estimate',
+        () => PartnerEstimateService.clear(),
+      );
+      await _bestEffortPurge(
+        'anonymous session',
+        () => AnonymousSessionService.clearSession(),
+      );
+      await _bestEffortPurge(
+        'biography key',
+        () => BiographyRepository.clearEncryptionKey(),
       );
     } catch (e) {
       // Purge is best-effort — never block auth flow
@@ -1070,16 +1091,32 @@ class AuthProvider extends ChangeNotifier {
     }
   }
 
-  /// Migrate local anonymous data to the authenticated account.
+  Future<void> _bestEffortPurge(
+    String label,
+    Future<void> Function() action,
+  ) async {
+    try {
+      await action();
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[AuthProvider] Local $label purge failed: $e');
+      }
+    }
+  }
+
+  /// Migrate eligible local data to the authenticated account.
   ///
-  /// Called after a successful login or register to ensure any data
-  /// created before authentication (wizard answers, preferences, etc.)
-  /// is associated with the new user account for future cloud sync.
+  /// Called after successful auth to associate eligible pre-auth data
+  /// (wizard answers, preferences, etc.) with the account for future cloud
+  /// sync. Anonymous conversations are claimed only when explicitly requested
+  /// by a creation/claim path.
   ///
   /// Safety: captures userId at call-time to avoid race conditions
   /// if the user logs out/in rapidly. Refuses to overwrite ownership
   /// if local data already belongs to a different account.
-  Future<void> _migrateLocalDataIfNeeded() async {
+  Future<void> _migrateLocalDataIfNeeded({
+    bool claimAnonymousConversations = false,
+  }) async {
     final currentUserId = _userId;
     if (currentUserId == null || currentUserId.isEmpty) return;
 
@@ -1099,11 +1136,13 @@ class AuthProvider extends ChangeNotifier {
         await AccountHandoffService.clearChoice();
         shouldMigrate = await AccountHandoffService.hasLocalData();
       }
-      if (!shouldMigrate) return;
+      if (!shouldMigrate && !claimAnonymousConversations) return;
 
       final alreadyMigrated =
           prefs.getBool('local_data_migrated_$currentUserId') ?? false;
-      if (alreadyMigrated && !syncPending) return;
+      if (alreadyMigrated && !syncPending && !claimAnonymousConversations) {
+        return;
+      }
 
       // Check if local data already belongs to a different user.
       final existingOwner = prefs.getString('local_data_owner');
@@ -1124,9 +1163,10 @@ class AuthProvider extends ChangeNotifier {
         return;
       }
 
-      if (!alreadyMigrated) {
-        // Migrate anonymous conversations to authenticated user namespace.
-        // Must happen before wizard data push so conversation history is preserved.
+      // Claim anonymous conversations only for explicit creation/claim flows.
+      // Restored sessions and existing-account logins keep guest conversations
+      // in the anonymous namespace so account chat never reuses them by accident.
+      if (claimAnonymousConversations) {
         try {
           await ConversationStore.migrateAnonymousToUser(currentUserId);
           await AnonymousSessionService.clearSession();
@@ -1147,8 +1187,8 @@ class AuthProvider extends ChangeNotifier {
       // → wizard answers stay on device. If the user later flips
       // sync ON in Settings › Confidentialité, the next save
       // naturally pushes via _syncToBackend (also gated by B-1).
-      // Conversation migration above is local→local within the
-      // device's ConversationStore namespace and is unaffected.
+      // Conversation claiming above is local→local within the device's
+      // ConversationStore namespace and is unaffected.
       final cloudSyncEnabled = !(prefs.getBool('auth_local_mode') ?? true);
       if (cloudSyncEnabled) {
         // Push local wizard data to backend via claimLocalData.
@@ -1197,8 +1237,7 @@ class AuthProvider extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       final currentUserId = _userId;
-      final accountOwnsLocalAnswers =
-          currentUserId != null &&
+      final accountOwnsLocalAnswers = currentUserId != null &&
           prefs.getString('local_data_owner') == currentUserId &&
           (prefs.getBool('local_data_migrated_$currentUserId') ?? false);
       var existingAnswers = await ReportPersistenceService.loadAnswers();
@@ -1208,9 +1247,8 @@ class AuthProvider extends ChangeNotifier {
       }
 
       final profileData = await ApiService.get('/profiles/me');
-      final answers = accountOwnsLocalAnswers
-          ? existingAnswers
-          : <String, dynamic>{};
+      final answers =
+          accountOwnsLocalAnswers ? existingAnswers : <String, dynamic>{};
       final merged = _mergeBackendProfileData(answers, profileData);
 
       if (!accountOwnsLocalAnswers && profileData.isEmpty) {

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -19,6 +19,7 @@ import 'package:mint_mobile/services/minimal_profile_service.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
 import 'package:mint_mobile/services/coach/coach_cache_service.dart';
 import 'package:mint_mobile/services/coach/coach_profile_seeds.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
 import 'package:mint_mobile/services/coach_narrative_service.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
@@ -3135,6 +3136,8 @@ class CoachProfileProvider extends ChangeNotifier {
     notifyListeners();
     // Durable reset: wait for persisted diagnostic and companion local stores
     // to clear before callers navigate or relaunch.
+    final conversationNamespacePurge =
+        ConversationStore.clearCurrentNamespace();
     String? conversationUserId;
     try {
       conversationUserId = await AuthService.getUserId();
@@ -3144,6 +3147,7 @@ class CoachProfileProvider extends ChangeNotifier {
     await ReportPersistenceService.clear(
       conversationUserId: conversationUserId,
     );
+    await conversationNamespacePurge;
     final securePurged = await InstallLifecycleService.purgeMintSecureStorage(
       includeAuthSession: false,
     );

--- a/apps/mobile/lib/routes/route_metadata.dart
+++ b/apps/mobile/lib/routes/route_metadata.dart
@@ -124,7 +124,7 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     category: RouteCategory.alias,
     owner: RouteOwner.anonymous,
     requiresAuth: false,
-    description: 'Landing CTA redirect — always enters /onb',
+    description: 'Landing CTA compatibility redirect — redirects to /onb',
   ),
   '/onb': RouteMeta(
     path: '/onb',
@@ -139,7 +139,8 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     owner: RouteOwner.anonymous,
     requiresAuth: false,
     killFlag: 'enableCoachHardGate',
-    description: 'Sub-phase 01.5 FATCA hard-gate destination — non-calibrated archetypes (expat_us, frontalier, etc.) land here with UCA opt-in form',
+    description:
+        'Sub-phase 01.5 FATCA hard-gate destination — non-calibrated archetypes (expat_us, frontalier, etc.) land here with UCA opt-in form',
   ),
 
   // ── Auth flows (public) ────────────────────────────────────────
@@ -175,15 +176,15 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     description: 'Magic-link verification landing',
   ),
 
-  // ── Anonymous flow (public, outside shell) ─────────────────────
-  // Phase 71a (2026-05-05) : /anonymous/intent retired; /anonymous/chat
-  // remains the anonymous fallback with opener bubble + chip suggestions.
+  // ── Retired anonymous flow alias (public) ─────────────────────
+  // The old chat-first cold-open is no longer a product surface. Keep the
+  // route as a compatibility alias to /onb so old links do not 404.
   '/anonymous/chat': RouteMeta(
     path: '/anonymous/chat',
-    category: RouteCategory.destination,
+    category: RouteCategory.alias,
     owner: RouteOwner.anonymous,
     requiresAuth: false,
-    killFlag: 'enableAnonymousFlow',
+    description: 'Retired anonymous chat cold-open — redirects to /onb',
   ),
 
   // ── Shell tabs ─────────────────────────────────────────────────
@@ -837,7 +838,8 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     category: RouteCategory.alias,
     owner: RouteOwner.system,
     requiresAuth: true,
-    description: 'Exact-match redirect -> /profile/bilan (sub-routes pass through)',
+    description:
+        'Exact-match redirect -> /profile/bilan (sub-routes pass through)',
   ),
   // Nested profile children (composed paths per CONTEXT v4 D-04)
   '/profile/admin-observability': RouteMeta(
@@ -845,14 +847,16 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     category: RouteCategory.tool,
     owner: RouteOwner.admin,
     requiresAuth: true,
-    description: 'Admin observability screen (FeatureFlags.enableAdminScreens gate)',
+    description:
+        'Admin observability screen (FeatureFlags.enableAdminScreens gate)',
   ),
   '/profile/admin-analytics': RouteMeta(
     path: '/profile/admin-analytics',
     category: RouteCategory.tool,
     owner: RouteOwner.admin,
     requiresAuth: true,
-    description: 'Admin analytics screen (FeatureFlags.enableAdminScreens gate)',
+    description:
+        'Admin analytics screen (FeatureFlags.enableAdminScreens gate)',
   ),
   '/profile/byok': RouteMeta(
     path: '/profile/byok',

--- a/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
+++ b/apps/mobile/lib/screens/anonymous/anonymous_chat_screen.dart
@@ -15,7 +15,6 @@ import 'package:mint_mobile/services/coach/eclairage_models.dart';
 import 'package:mint_mobile/services/coach_llm_service.dart';
 // ADR-20260223: financial_core via barrel only — no direct sub-imports.
 import 'package:mint_mobile/services/premier_eclairage_selector.dart';
-import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/widgets/anonymous/eclairage_card.dart';
@@ -114,6 +113,10 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
   /// Set true the moment a card is attached to a coach message; restored from
   /// persisted messages on cold-restore (see [_hydrateFromStoreOrShowOpener]).
   bool _eclairageDelivered = false;
+
+  /// Whether the visible thread came from persisted anonymous storage.
+  /// Restored threads need an explicit escape hatch so a returning anonymous
+  /// user can start fresh without creating an account first.
   bool _restoredConversation = false;
 
   /// Number of completed coach responses in the current session. Increments
@@ -165,18 +168,21 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
         _conversationId = latestId;
         _openerFadeController.value = 1.0;
         setState(() {
-          _messages.addAll(restored.map(
-            (m) => _ChatMessage(
-              text: m.content,
-              isUser: m.role == 'user',
-              timestamp: m.timestamp,
+          _messages.addAll(
+            restored.map(
+              (m) => _ChatMessage(
+                text: m.content,
+                isUser: m.role == 'user',
+                timestamp: m.timestamp,
+              ),
             ),
-          ));
+          );
           // Conversation already had user-coach exchanges; opener should
           // not re-appear. Mark openerShown so chips also stay hidden.
           _openerShown = true;
-          final coachTurns =
-              restored.where((m) => m.role == 'assistant').length;
+          final coachTurns = restored
+              .where((m) => m.role == 'assistant')
+              .length;
           _coachTurnsCompleted = coachTurns;
           // ECL-01 restore (hotfix 2026-06-12): the Premier Éclairage card is
           // emitted by the backend once the conversation reaches ≥2 coach
@@ -203,18 +209,21 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
     if (_openerShown || _messages.isNotEmpty) return;
     final l = S.of(context)!;
     setState(() {
-      _messages.add(_ChatMessage(
-        text: l.anonymousChatOpener,
-        isUser: false,
-        timestamp: DateTime.now(),
-      ));
+      _messages.add(
+        _ChatMessage(
+          text: l.anonymousChatOpener,
+          isUser: false,
+          timestamp: DateTime.now(),
+        ),
+      );
       _openerShown = true;
     });
     _openerFadeController.forward();
   }
 
   Future<void> _startNewConversation() async {
-    await ReportPersistenceService.clearConversationNamespace(userId: null);
+    ConversationStore.setCurrentUserId(null);
+    await ConversationStore.clearCurrentNamespace();
     final canSend = await AnonymousSessionService.canSendMessage();
     if (!mounted) return;
 
@@ -231,7 +240,6 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
       _coachTurnsCompleted = 0;
       _restoredConversation = false;
     });
-
     if (!canSend) {
       _showAuthGate();
       return;
@@ -271,11 +279,9 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
     }
 
     setState(() {
-      _messages.add(_ChatMessage(
-        text: trimmed,
-        isUser: true,
-        timestamp: DateTime.now(),
-      ));
+      _messages.add(
+        _ChatMessage(text: trimmed, isUser: true, timestamp: DateTime.now()),
+      );
       _isLoading = true;
       _inputController.clear();
     });
@@ -308,11 +314,9 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
         _ => l.anonymousChatError,
       };
       setState(() {
-        _messages.add(_ChatMessage(
-          text: text,
-          isUser: false,
-          timestamp: DateTime.now(),
-        ));
+        _messages.add(
+          _ChatMessage(text: text, isUser: false, timestamp: DateTime.now()),
+        );
         _isLoading = false;
       });
       _scrollToBottom();
@@ -328,12 +332,14 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
     final eclairage = _resolveEclairageForTurn(response);
 
     setState(() {
-      _messages.add(_ChatMessage(
-        text: coachMessage,
-        isUser: false,
-        timestamp: DateTime.now(),
-        eclairage: eclairage,
-      ));
+      _messages.add(
+        _ChatMessage(
+          text: coachMessage,
+          isUser: false,
+          timestamp: DateTime.now(),
+          eclairage: eclairage,
+        ),
+      );
       _isLoading = false;
       // Phase 71a panel §4: increment ONLY after a real coach response.
       _coachTurnsCompleted += 1;
@@ -352,11 +358,13 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
       if (!mounted) return;
       final l = S.of(context)!;
       setState(() {
-        _messages.add(_ChatMessage(
-          text: l.anonymousChatConversionPrompt,
-          isUser: false,
-          timestamp: DateTime.now(),
-        ));
+        _messages.add(
+          _ChatMessage(
+            text: l.anonymousChatConversionPrompt,
+            isUser: false,
+            timestamp: DateTime.now(),
+          ),
+        );
       });
       _scrollToBottom();
 
@@ -488,7 +496,7 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
       estimatedFields: const [
         'currentSavings',
         'existingLpp',
-        'nationalityGroup'
+        'nationalityGroup',
       ],
     );
   }
@@ -514,19 +522,21 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
   /// Fire-and-forget — never blocks UI. Called after each coach response.
   void _persistToSharedPreferences() {
     final chatMessages = _messages
-        .map((m) => ChatMessage(
-              role: m.isUser ? 'user' : 'assistant',
-              content: m.text,
-              timestamp: m.timestamp,
-            ))
+        .map(
+          (m) => ChatMessage(
+            role: m.isUser ? 'user' : 'assistant',
+            content: m.text,
+            timestamp: m.timestamp,
+          ),
+        )
         .toList();
 
     ConversationStore.setCurrentUserId(null);
     ConversationStore()
         .saveConversation(_conversationId, chatMessages)
         .catchError((e) {
-      debugPrint('[AnonymousChat] Eager persist failed: $e');
-    });
+          debugPrint('[AnonymousChat] Eager persist failed: $e');
+        });
   }
 
   void _scrollToBottom() {
@@ -594,8 +604,9 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
                                 key: const ValueKey(
                                   'anonymous_chat_new_conversation',
                                 ),
-                                onPressed:
-                                    _isLoading ? null : _startNewConversation,
+                                onPressed: _isLoading
+                                    ? null
+                                    : _startNewConversation,
                                 icon: const Icon(Icons.add_comment_outlined),
                                 color: MintColors.inkPrimary,
                                 tooltip: l.anonymousChatNewConversation,
@@ -605,8 +616,9 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
                               key: const ValueKey(
                                 'anonymous_chat_new_conversation',
                               ),
-                              onPressed:
-                                  _isLoading ? null : _startNewConversation,
+                              onPressed: _isLoading
+                                  ? null
+                                  : _startNewConversation,
                               icon: const Icon(
                                 Icons.add_comment_outlined,
                                 size: 18,
@@ -635,8 +647,10 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
             Expanded(
               child: ListView.builder(
                 controller: _scrollController,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
                 itemCount: _messages.length + (_isLoading ? 1 : 0),
                 itemBuilder: (context, index) {
                   if (index == _messages.length) {
@@ -720,46 +734,53 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
     );
   }
 
-  /// Chips row (panel §1.3) — 3 outlined chips horizontally scrollable.
+  /// Chips row (panel §1.3) — 3 outlined chips wrapped without clipping.
   Widget _buildChipsRow(S l) {
     final chips = [
       l.anonymousChatChip1,
       l.anonymousChatChip2,
-      l.anonymousChatChip3
+      l.anonymousChatChip3,
     ];
-    return SizedBox(
-      height: 44,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
-        itemCount: chips.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 8),
-        itemBuilder: (context, i) {
-          return Center(
-            child: Semantics(
-              label: chips[i],
-              button: true,
-              child: InkWell(
-                onTap: () => _onChipTap(chips[i]),
-                borderRadius: BorderRadius.circular(20),
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: MintColors.craieHandoff,
-                    border:
-                        Border.all(color: MintColors.borderSubtle, width: 1),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Text(
-                    chips[i],
-                    style: MintTextStyles.bodyMedium(
-                      color: MintColors.inkPrimary,
-                    ).copyWith(fontWeight: FontWeight.w500),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final chip in chips)
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: constraints.maxWidth),
+                  child: Semantics(
+                    button: true,
+                    child: InkWell(
+                      onTap: () => _onChipTap(chip),
+                      borderRadius: BorderRadius.circular(20),
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                        decoration: BoxDecoration(
+                          color: MintColors.craieHandoff,
+                          border: Border.all(
+                            color: MintColors.borderSubtle,
+                            width: 1,
+                          ),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Text(
+                          chip,
+                          style: MintTextStyles.bodyMedium(
+                            color: MintColors.inkPrimary,
+                          ).copyWith(fontWeight: FontWeight.w500),
+                        ),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
+            ],
           );
         },
       ),
@@ -786,9 +807,7 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
           padding: const EdgeInsets.fromLTRB(16, 4, 8, 8),
           decoration: const BoxDecoration(
             color: MintColors.craieHandoff,
-            border: Border(
-              top: BorderSide(color: MintColors.borderSubtle),
-            ),
+            border: Border(top: BorderSide(color: MintColors.borderSubtle)),
           ),
           child: Row(
             children: [
@@ -810,9 +829,7 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
                   // Panel §5 row 2 : hard cap at 500 chars (paste-defence).
                   maxLength: 500,
                   inputFormatters: [LengthLimitingTextInputFormatter(500)],
-                  style: MintTextStyles.bodyLarge(
-                    color: MintColors.inkPrimary,
-                  ),
+                  style: MintTextStyles.bodyLarge(color: MintColors.inkPrimary),
                   decoration: InputDecoration(
                     hintText: l.anonymousChatInputHint,
                     hintStyle: MintTextStyles.bodyLarge(
@@ -820,7 +837,9 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
                     ),
                     border: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 10),
+                      horizontal: 12,
+                      vertical: 10,
+                    ),
                     // Hide counter unless > 400 chars (panel §5 row 2).
                     counterText: '',
                   ),
@@ -886,24 +905,22 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
                   strong: MintTextStyles.labelLarge(
                     color: MintColors.inkPrimary,
                   ).copyWith(fontWeight: FontWeight.w700, height: 1.45),
-                  em: MintTextStyles.labelLarge(
-                    color: MintColors.inkPrimary,
-                  ).copyWith(
-                    fontWeight: FontWeight.w400,
-                    fontStyle: FontStyle.italic,
-                    height: 1.45,
-                  ),
+                  em: MintTextStyles.labelLarge(color: MintColors.inkPrimary)
+                      .copyWith(
+                        fontWeight: FontWeight.w400,
+                        fontStyle: FontStyle.italic,
+                        height: 1.45,
+                      ),
                   listBullet: MintTextStyles.labelLarge(
                     color: MintColors.inkPrimary,
                   ).copyWith(fontWeight: FontWeight.w400, height: 1.45),
-                  h3: MintTextStyles.labelLarge(
-                    color: MintColors.inkPrimary,
-                  ).copyWith(
-                    fontWeight: FontWeight.w600,
-                    fontSize:
-                        15, // lint-ignore: prefer_mint_text_style — h3 markdown needs +1pt above labelLarge (14pt)
-                    height: 1.45,
-                  ),
+                  h3: MintTextStyles.labelLarge(color: MintColors.inkPrimary)
+                      .copyWith(
+                        fontWeight: FontWeight.w600,
+                        fontSize:
+                            15, // lint-ignore: prefer_mint_text_style — h3 markdown needs +1pt above labelLarge (14pt)
+                        height: 1.45,
+                      ),
                 ),
                 shrinkWrap: true,
                 softLineBreak: false,
@@ -925,13 +942,10 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
     final Key? assistantKey = isUser
         ? null
         : isOpener
-            ? const Key('anon-chat-opener-bubble')
-            : const Key('anon-chat-message-assistant');
+        ? const Key('anon-chat-opener-bubble')
+        : const Key('anon-chat-message-assistant');
     final renderedBubble = isOpener
-        ? FadeTransition(
-            opacity: _openerFadeController,
-            child: bubble,
-          )
+        ? FadeTransition(opacity: _openerFadeController, child: bubble)
         : bubble;
 
     if (message.eclairage == null) {
@@ -954,16 +968,18 @@ class _AnonymousChatScreenState extends State<AnonymousChatScreen>
           // 72 EclairageCard widget (anon path). Phase 80's typed
           // eclairage_models.dart stays the canonical model ; we just
           // adapt at the render boundary.
-          EclairageCard(payload: <String, dynamic>{
-            'kind': message.eclairage!.kind.wireName,
-            'headline': message.eclairage!.headline,
-            'body': message.eclairage!.body,
-            'chf_range_low': message.eclairage!.chfRangeLow,
-            'chf_range_high': message.eclairage!.chfRangeHigh,
-            'chf_range_period': message.eclairage!.chfRangePeriod,
-            'soft_account_hint': message.eclairage!.softAccountHint,
-            'lsfin_disclaimer': message.eclairage!.lsfinDisclaimer,
-          }),
+          EclairageCard(
+            payload: <String, dynamic>{
+              'kind': message.eclairage!.kind.wireName,
+              'headline': message.eclairage!.headline,
+              'body': message.eclairage!.body,
+              'chf_range_low': message.eclairage!.chfRangeLow,
+              'chf_range_high': message.eclairage!.chfRangeHigh,
+              'chf_range_period': message.eclairage!.chfRangePeriod,
+              'soft_account_hint': message.eclairage!.softAccountHint,
+              'lsfin_disclaimer': message.eclairage!.lsfinDisclaimer,
+            },
+          ),
         ],
       ),
     );
@@ -1025,9 +1041,10 @@ class _TypingDotState extends State<_TypingDot>
       vsync: this,
       duration: const Duration(milliseconds: 600),
     );
-    _animation = Tween<double>(begin: 0.3, end: 1.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
-    );
+    _animation = Tween<double>(
+      begin: 0.3,
+      end: 1.0,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
     Future.delayed(Duration(milliseconds: widget.delay), () {
       if (mounted) _controller.repeat(reverse: true);
     });

--- a/apps/mobile/lib/screens/auth/login_screen.dart
+++ b/apps/mobile/lib/screens/auth/login_screen.dart
@@ -164,10 +164,12 @@ class _LoginScreenState extends State<LoginScreen> {
       final response = await AppleSignInService.signIn();
       if (response != null && mounted) {
         // Single source of truth: AuthProvider owns the token persistence,
-        // state mutation, anonymous data migration, profile hydration, and
+        // state mutation, local claim policy, profile hydration, and
         // fresh-start scheduling. AppleSignInService does NOT touch state.
-        final ok =
-            await context.read<AuthProvider>().completeAppleSignIn(response);
+        final ok = await context.read<AuthProvider>().completeAppleSignIn(
+              response,
+              claimAnonymousConversations: false,
+            );
         if (!ok) {
           if (mounted) {
             setState(() {

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -150,7 +150,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
       final response = await AppleSignInService.signIn();
       if (response == null || !mounted) return;
 
-      final ok = await authProvider.completeAppleSignIn(response);
+      final ok = await authProvider.completeAppleSignIn(
+        response,
+        // Register is a creation path: claim the current guest conversation
+        // into the new local account namespace.
+        claimAnonymousConversations: true,
+      );
       if (!ok) {
         if (!mounted) return;
         setState(() {

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -90,7 +90,7 @@ class _LandingScreenState extends State<LandingScreen>
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context)!;
-    void openAnonymousChat() => context.go('/anonymous/chat');
+    void openOnboarding() => context.go('/onb');
 
     Widget ctaReveal(Widget child) {
       return AnimatedBuilder(
@@ -184,7 +184,7 @@ class _LandingScreenState extends State<LandingScreen>
                       excludeSemantics: true,
                       button: true,
                       label: l10n.landingV2CtaSober,
-                      onTap: openAnonymousChat,
+                      onTap: openOnboarding,
                       child: FilledButton(
                         style: FilledButton.styleFrom(
                           backgroundColor: MintColors.inkPrimary,
@@ -197,7 +197,7 @@ class _LandingScreenState extends State<LandingScreen>
                             color: MintColors.porcelaineHero,
                           ),
                         ),
-                        onPressed: openAnonymousChat,
+                        onPressed: openOnboarding,
                         child: Text(l10n.landingV2CtaSober),
                       ),
                     ),

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -172,7 +172,7 @@ class _LandingScreenState extends State<LandingScreen>
                             color: MintColors.porcelaineHero,
                           ),
                         ),
-                        onPressed: () => context.go('/start'),
+                        onPressed: () => context.go('/anonymous/chat'),
                         child: Text(l10n.landingV2CtaSober),
                       ),
                     ),

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -186,6 +186,7 @@ class _LandingScreenState extends State<LandingScreen>
                       label: l10n.landingV2CtaSober,
                       onTap: openOnboarding,
                       child: FilledButton(
+                        // lint-ignore: prefer_mint_cta
                         style: FilledButton.styleFrom(
                           backgroundColor: MintColors.inkPrimary,
                           foregroundColor: MintColors.porcelaineHero,

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -90,6 +90,27 @@ class _LandingScreenState extends State<LandingScreen>
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context)!;
+    void openAnonymousChat() => context.go('/anonymous/chat');
+
+    Widget ctaReveal(Widget child) {
+      return AnimatedBuilder(
+        animation: _ctaOpacity,
+        child: child,
+        builder: (context, child) {
+          final isActive = _ctaOpacity.isCompleted;
+          return IgnorePointer(
+            ignoring: !isActive,
+            child: ExcludeSemantics(
+              excluding: !isActive,
+              child: FadeTransition(
+                opacity: _ctaOpacity,
+                child: child,
+              ),
+            ),
+          );
+        },
+      );
+    }
 
     return Scaffold(
       backgroundColor: MintColors.warmWhite,
@@ -155,11 +176,15 @@ class _LandingScreenState extends State<LandingScreen>
                   const Spacer(flex: 4),
                   // 5. CTA primaire — FilledButton, RoundedRectangleBorder(14)
                   // (PAS StadiumBorder), 54pt, ink/porcelaine.
-                  FadeTransition(
-                    opacity: _ctaOpacity,
-                    child: Semantics(
+                  ctaReveal(
+                    Semantics(
+                      key: const Key('landing_talk_to_mint_cta'),
+                      identifier: 'landing_talk_to_mint_cta',
+                      container: true,
+                      excludeSemantics: true,
                       button: true,
                       label: l10n.landingV2CtaSober,
+                      onTap: openAnonymousChat,
                       child: FilledButton(
                         style: FilledButton.styleFrom(
                           backgroundColor: MintColors.inkPrimary,
@@ -172,7 +197,7 @@ class _LandingScreenState extends State<LandingScreen>
                             color: MintColors.porcelaineHero,
                           ),
                         ),
-                        onPressed: () => context.go('/anonymous/chat'),
+                        onPressed: openAnonymousChat,
                         child: Text(l10n.landingV2CtaSober),
                       ),
                     ),
@@ -180,9 +205,8 @@ class _LandingScreenState extends State<LandingScreen>
                   // 6. SizedBox 16.
                   const SizedBox(height: 16),
                   // 7. Login link — bodySmall(textSecondaryAaa), no underline.
-                  FadeTransition(
-                    opacity: _ctaOpacity,
-                    child: Semantics(
+                  ctaReveal(
+                    Semantics(
                       button: true,
                       label: l10n.landingV2LoginLink,
                       child: GestureDetector(
@@ -201,9 +225,8 @@ class _LandingScreenState extends State<LandingScreen>
                   // 7-bis. SizedBox 12 + anonymous local-mode link. Keep this
                   // on /start so the router owns the first-run rollout switch.
                   const SizedBox(height: 12),
-                  FadeTransition(
-                    opacity: _ctaOpacity,
-                    child: Semantics(
+                  ctaReveal(
+                    Semantics(
                       button: true,
                       label: l10n.landingV3AnonymousHomeLink,
                       child: GestureDetector(

--- a/apps/mobile/lib/screens/profile/financial_summary_screen.dart
+++ b/apps/mobile/lib/screens/profile/financial_summary_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
+import 'package:mint_mobile/services/cap_memory_store.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
+import 'package:mint_mobile/services/coach/precomputed_insights_service.dart';
+import 'package:mint_mobile/services/memory/coach_memory_service.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
@@ -25,6 +29,7 @@ import 'package:mint_mobile/widgets/profile/futur_drawer_content.dart';
 import 'package:mint_mobile/widgets/profile/enrichment_cta.dart';
 import 'package:mint_mobile/widgets/common/mint_empty_state.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // NOTE: This screen is a deep-dive view. Primary display is now in PulseScreen
 // via BudgetSnapshot. Keep for /profile/bilan deep link and ProfileScreen access.
@@ -36,7 +41,108 @@ import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 ///
 /// Accessible depuis /profile/bilan et depuis le ProfileScreen.
 class FinancialSummaryScreen extends StatelessWidget {
-  const FinancialSummaryScreen({super.key});
+  const FinancialSummaryScreen({
+    super.key,
+    @visibleForTesting this.restartDiagnosticResetOverride,
+  });
+
+  @visibleForTesting
+  final Future<List<Object>> Function()? restartDiagnosticResetOverride;
+
+  @visibleForTesting
+  static Future<List<Object>> runBestEffortResetForTest(
+    List<Future<void> Function()> operations,
+  ) {
+    return _runBestEffortReset(operations);
+  }
+
+  @visibleForTesting
+  static Future<List<Object>> runPersistentResetThenProfileClearForTest({
+    required List<Future<void> Function()> persistentOperations,
+    required Future<void> Function() profileClear,
+  }) {
+    return _runPersistentResetThenProfileClear(
+      persistentOperations: persistentOperations,
+      profileClear: profileClear,
+    );
+  }
+
+  static Future<List<Object>> _runBestEffortReset(
+    List<Future<void> Function()> operations,
+  ) async {
+    final failures = <Object>[];
+    for (final operation in operations) {
+      try {
+        await operation();
+      } catch (error, stackTrace) {
+        failures.add(error);
+        debugPrint(
+          '[FinancialSummary] restart diagnostic reset step failed: '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    return failures;
+  }
+
+  static Future<List<Object>> _runPersistentResetThenProfileClear({
+    required List<Future<void> Function()> persistentOperations,
+    required Future<void> Function() profileClear,
+  }) async {
+    final persistentFailures = await _runBestEffortReset(persistentOperations);
+    if (persistentFailures.isNotEmpty) return persistentFailures;
+    return _runBestEffortReset([profileClear]);
+  }
+
+  Future<List<Object>> _runRestartDiagnosticReset(
+    CoachProfileProvider coachProvider,
+  ) async {
+    return _runPersistentResetThenProfileClear(
+      persistentOperations: [
+        ReportPersistenceService.clear,
+        SmartOnboardingDraftService.clearDraft,
+        ConversationStore.clearCurrentNamespace,
+        () async {
+          final prefs = await SharedPreferences.getInstance();
+          await CoachMemoryService.clear(prefs: prefs);
+        },
+        CapMemoryStore.clear,
+        () async {
+          final prefs = await SharedPreferences.getInstance();
+          await PrecomputedInsightsService.clear(prefs);
+        },
+      ],
+      // CoachProfileProvider.clear() also fires report/conversation cleanup
+      // defensively. The awaited persistent purge above is the tracked path;
+      // keep profile clear last so partial failures do not make the UI look
+      // reset while stale local stores may still exist.
+      profileClear: () async => coachProvider.clear(),
+    );
+  }
+
+  Future<void> _handleRestartDiagnostic(BuildContext context) async {
+    final router = GoRouter.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = S.of(context)!;
+    final coachProvider = context.read<CoachProfileProvider>();
+    final failures = restartDiagnosticResetOverride != null
+        ? await restartDiagnosticResetOverride!()
+        : await _runRestartDiagnosticReset(coachProvider);
+
+    if (!context.mounted) return;
+    if (failures.isEmpty) {
+      router.go('/coach/chat');
+      return;
+    }
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          l10n.financialSummaryRestartDiagnosticError,
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -102,13 +208,17 @@ class FinancialSummaryScreen extends StatelessWidget {
       builder: (context, snapshot) {
         final mint2AxisHandoff = snapshot.data ?? const <String, dynamic>{};
         final hasMint2AxisHandoff = _hasMint2LiveAxis(mint2AxisHandoff);
-        if (profile == null ||
-            !profile.hasMaterialData ||
-            !_hasDefensibleDossierForFinancialSummary(profile)) {
+        if (profile == null || !profile.hasMaterialData) {
           if (!hasMint2AxisHandoff) return _buildEmptyState(context);
           return _buildHandoffOnlyContent(context);
         }
-        return _buildContent(context, profile);
+        if (!_hasDefensibleDossierForFinancialSummary(profile)) {
+          if (hasMint2AxisHandoff) return _buildHandoffOnlyContent(context);
+          return _buildIncompleteState(context);
+        }
+        final readiness = _financialSummaryReadiness(profile);
+        if (!readiness.isReady) return _buildIncompleteState(context);
+        return _buildContent(context, profile, readiness);
       },
     );
   }
@@ -134,11 +244,28 @@ class FinancialSummaryScreen extends StatelessWidget {
     );
   }
 
+  Widget _buildIncompleteState(BuildContext context) {
+    final s = S.of(context)!;
+    return SliverFillRemaining(
+      child: MintEmptyState(
+        icon: Icons.fact_check_outlined,
+        title: s.profileBilanSubtitleIncomplete,
+        subtitle: s.futurCompleterProfil,
+        ctaLabel: s.financialSummaryStartDiagnostic,
+        onCta: () => context.go('/coach/chat'),
+      ),
+    );
+  }
+
   // ══════════════════════════════════════════════════════════════
   //  MAIN CONTENT — Hero Gap + 3 Tiroirs + CTA + Disclaimer
   // ══════════════════════════════════════════════════════════════
 
-  Widget _buildContent(BuildContext context, CoachProfile profile) {
+  Widget _buildContent(
+    BuildContext context,
+    CoachProfile profile,
+    _FinancialSummaryReadiness readiness,
+  ) {
     final s = S.of(context)!;
     final prev = profile.prevoyance;
     final det = profile.dettes;
@@ -172,18 +299,8 @@ class FinancialSummaryScreen extends StatelessWidget {
     final projectedMonthly = renteAvs + renteLpp;
 
     // ── Confidence ──
-    final knownCount = [
-      profile.salaireBrutMensuel > 0,
-      profile.canton.isNotEmpty,
-      prev.avoirLppTotal != null && prev.avoirLppTotal! > 0,
-      prev.totalEpargne3a > 0,
-      pat.epargneLiquide > 0,
-      profile.depenses.loyer > 0 ||
-          (det.hypotheque != null && det.hypotheque! > 0),
-      profile.depenses.assuranceMaladie > 0,
-    ].where((b) => b).length;
-    final confidence = (knownCount / 7 * 100).clamp(0.0, 100.0);
-    final missingCount = 7 - knownCount;
+    final confidence = readiness.confidencePercent;
+    final missingCount = readiness.missingCount;
 
     // ── Patrimoine net (hero value for tiroir 1) ──
     final prevCapital = (prev.avoirLppTotal ?? 0) +
@@ -391,12 +508,9 @@ class FinancialSummaryScreen extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg),
               child: OutlinedButton.icon(
+                key: const ValueKey('financial_summary_restart_diagnostic'),
                 onPressed: () async {
-                  await context.read<CoachProfileProvider>().clear();
-                  await SmartOnboardingDraftService.clearDraft();
-                  if (context.mounted) {
-                    context.go('/coach/chat');
-                  }
+                  await _handleRestartDiagnostic(context);
                 },
                 icon: const Icon(Icons.refresh, size: 18),
                 label: Text(
@@ -915,6 +1029,133 @@ class FinancialSummaryScreen extends StatelessWidget {
     return counts;
   }
 
+  _FinancialSummaryReadiness _financialSummaryReadiness(CoachProfile profile) {
+    final hasIncome = _hasIncomeFact(profile);
+    final hasCanton = _hasFieldEvidence(
+      profile,
+      valuePresent: profile.canton.isNotEmpty,
+      providedKeys: const {'canton'},
+      sourceKeys: const {'canton'},
+    );
+    final hasHousing = _hasFieldEvidence(
+      profile,
+      valuePresent: profile.depenses.loyer > 0,
+      providedKeys: const {'housingCost'},
+      sourceKeys: const {'depenses.loyer'},
+    );
+    final hasLamal = _hasFieldEvidence(
+      profile,
+      valuePresent: profile.depenses.assuranceMaladie > 0,
+      providedKeys: const {'lamalPremium'},
+      sourceKeys: const {'depenses.assuranceMaladie'},
+    );
+    final hasLpp = _hasFieldEvidence(
+      profile,
+      valuePresent: (profile.prevoyance.avoirLppTotal ?? 0) > 0,
+      providedKeys: const {'avoirLpp'},
+      sourceKeys: const {'prevoyance.avoirLppTotal'},
+    );
+    final hasAvs = _hasFieldEvidence(
+      profile,
+      valuePresent: (profile.prevoyance.renteAVSEstimeeMensuelle ?? 0) > 0,
+      providedKeys: const {'avsRente'},
+      sourceKeys: const {'prevoyance.renteAVSEstimeeMensuelle'},
+    );
+    final hasPatrimoine = _hasFieldEvidence(
+      profile,
+      valuePresent: profile.patrimoine.epargneLiquide > 0 ||
+          profile.patrimoine.investissements > 0,
+      providedKeys: const {'liquidSavings', 'investments'},
+      sourceKeys: const {
+        'patrimoine.epargneLiquide',
+        'patrimoine.investissements',
+      },
+    );
+    final hasDebt = _hasDebtFact(profile);
+
+    final knownCount = [
+      hasIncome,
+      hasCanton,
+      hasHousing,
+      hasLamal,
+      hasLpp,
+      hasAvs,
+      _hasFieldEvidence(
+        profile,
+        valuePresent: profile.prevoyance.totalEpargne3a > 0 ||
+            profile.plannedContributions.any((c) => c.category == '3a'),
+        providedKeys: const {'pillar3aBalance'},
+        sourceKeys: const {
+          'prevoyance.totalEpargne3a',
+          'plannedContributions.3a',
+        },
+      ),
+      hasPatrimoine,
+      hasDebt,
+    ].where((known) => known).length;
+
+    final hasRequiredFacts = hasIncome &&
+        hasCanton &&
+        hasHousing &&
+        hasLamal &&
+        hasLpp &&
+        hasAvs &&
+        hasPatrimoine &&
+        hasDebt;
+
+    return _FinancialSummaryReadiness(
+      knownCount: knownCount,
+      totalCount: 9,
+      isReady: profile.hasMaterialData && hasRequiredFacts,
+    );
+  }
+
+  bool _hasIncomeFact(CoachProfile profile) {
+    return _hasFieldEvidence(
+      profile,
+      valuePresent: profile.revenuBrutAnnuel > 0 ||
+          (profile.independentNetProfessionalIncomeAnnual ?? 0) > 0,
+      providedKeys: const {
+        'salary',
+        'independentNetProfessionalIncomeAnnual',
+      },
+      sourceKeys: const {
+        'revenuBrutAnnuel',
+        'salaireBrutMensuel',
+        'independentNetProfessionalIncomeAnnual',
+      },
+    );
+  }
+
+  bool _hasDebtFact(CoachProfile profile) {
+    const sourceKeys = {
+      'dettes.totalDettes',
+      'dettes.hypotheque',
+      'dettes.creditConsommation',
+      'dettes.leasing',
+      'dettes.autresDettes',
+    };
+    if (profile.userProvidedFields.contains('debt')) return true;
+    return sourceKeys.any((key) {
+      final source = profile.dataSources[key];
+      return source != null && source != ProfileDataSource.estimated;
+    });
+  }
+
+  bool _hasFieldEvidence(
+    CoachProfile profile, {
+    required bool valuePresent,
+    required Set<String> providedKeys,
+    required Set<String> sourceKeys,
+  }) {
+    if (!valuePresent) return false;
+    if (providedKeys.any(profile.userProvidedFields.contains)) return true;
+    return sourceKeys.any((key) {
+      final source = profile.dataSources[key];
+      return source != null && source != ProfileDataSource.estimated;
+    });
+  }
+
   // ══════════════════════════════════════════════════════════════
   //  DISCLAIMER
   // ══════════════════════════════════════════════════════════════
@@ -1188,4 +1429,21 @@ class _EditField {
     this.initialValue,
     required this.key,
   });
+}
+
+class _FinancialSummaryReadiness {
+  const _FinancialSummaryReadiness({
+    required this.knownCount,
+    required this.totalCount,
+    required this.isReady,
+  });
+
+  final int knownCount;
+  final int totalCount;
+  final bool isReady;
+
+  int get missingCount => (totalCount - knownCount).clamp(0, totalCount);
+
+  double get confidencePercent =>
+      (knownCount / totalCount * 100).clamp(0.0, 100.0);
 }

--- a/apps/mobile/lib/services/coach/conversation_store.dart
+++ b/apps/mobile/lib/services/coach/conversation_store.dart
@@ -54,14 +54,16 @@ class ConversationMeta {
     return ConversationMeta(
       id: json['id'] as String,
       title: json['title'] as String,
-      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ?? DateTime.now(),
-      lastMessageAt: DateTime.tryParse(json['lastMessageAt'] as String? ?? '') ?? DateTime.now(),
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+          DateTime.now(),
+      lastMessageAt:
+          DateTime.tryParse(json['lastMessageAt'] as String? ?? '') ??
+              DateTime.now(),
       messageCount: json['messageCount'] as int? ?? 0,
       summary: json['summary'] as String?,
-      tags: (json['tags'] as List<dynamic>?)
-              ?.map((t) => t as String)
-              .toList() ??
-          const [],
+      tags:
+          (json['tags'] as List<dynamic>?)?.map((t) => t as String).toList() ??
+              const [],
       lastMessagePreview: json['lastMessagePreview'] as String?,
     );
   }
@@ -126,8 +128,10 @@ class ConversationStore {
   /// Call on login (with userId) and on logout (with null).
   static void setCurrentUserId(String? userId) => _currentUserId = userId;
 
-  static String _userPrefix() =>
-      _currentUserId != null ? '${_currentUserId}_' : '';
+  static String _prefixForUser(String? userId) =>
+      userId != null ? '${userId}_' : '';
+
+  static String _userPrefix() => _prefixForUser(_currentUserId);
 
   // ── Migration ────────────────────────────────────────────
 
@@ -178,6 +182,33 @@ class ConversationStore {
 
     // Step 4: Remove old index LAST
     await prefs.remove(oldIndexKey);
+  }
+
+  /// Clear every conversation key in the currently active namespace.
+  static Future<void> clearCurrentNamespace() async {
+    await _clearNamespace(_userPrefix());
+  }
+
+  /// Clear every conversation key for a specific user namespace.
+  ///
+  /// Pass `null` to clear the anonymous namespace.
+  static Future<void> clearNamespaceForUser(String? userId) async {
+    await _clearNamespace(_prefixForUser(userId));
+  }
+
+  static Future<void> _clearNamespace(String prefix) async {
+    final prefs = await SharedPreferences.getInstance();
+    final keysToRemove = prefs
+        .getKeys()
+        .where(
+          (key) =>
+              key == '$prefix$_indexKey' ||
+              key.startsWith('$prefix$_messagesPrefix'),
+        )
+        .toList();
+    for (final key in keysToRemove) {
+      await prefs.remove(key);
+    }
   }
 
   // ── Public API ──────────────────────────────────────────
@@ -261,7 +292,8 @@ class ConversationStore {
           .map((e) => _messageFromJson(e as Map<String, dynamic>))
           .toList();
     } catch (e) {
-      debugPrint('[ConversationStore] Corrupted conversation $conversationId: $e');
+      debugPrint(
+          '[ConversationStore] Corrupted conversation $conversationId: $e');
       return [];
     }
   }
@@ -277,7 +309,9 @@ class ConversationStore {
   /// Delete a conversation (messages + metadata).
   Future<void> deleteConversation(String conversationId) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('${_userPrefix()}$_messagesPrefix$conversationId');
+    final key = '${_userPrefix()}$_messagesPrefix$conversationId';
+    await prefs.remove(key);
+    await prefs.remove('${key}_tmp');
 
     final index = await _loadIndex(prefs);
     index.removeWhere((m) => m.id == conversationId);
@@ -313,23 +347,29 @@ class ConversationStore {
     RegExp(r"\b\d{4,}(?:\.\d{1,2})?\b"),
     // "mon salaire est de X" / "je gagne X" patterns
     // FIX: ReDoS — replaced [^.]{0,20} (backtracking) with \s+\S{0,20} (linear)
-    RegExp(r'(?:salaire|gagne|touche|revenu)\s+\S{0,20}\d{4,}', caseSensitive: false),
+    RegExp(r'(?:salaire|gagne|touche|revenu)\s+\S{0,20}\d{4,}',
+        caseSensitive: false),
     // Email addresses
     RegExp(r'\b[\w.+-]+@[\w-]+\.[\w.]+\b'),
     // Swiss phone numbers: +41..., 07x... (FIX-W12: stricter Swiss format)
-    RegExp(r'(?:\+41|0)[\s.-]?(?:76|77|78|79|[1-4]\d)[\s.-]?\d{3}[\s.-]?\d{2}[\s.-]?\d{2}'),
+    RegExp(
+        r'(?:\+41|0)[\s.-]?(?:76|77|78|79|[1-4]\d)[\s.-]?\d{3}[\s.-]?\d{2}[\s.-]?\d{2}'),
     // Swiss AHV/AVS numbers: 756.xxxx.xxxx.xx (FIX-W12)
     RegExp(r'\b756[.\s]?\d{4}[.\s]?\d{4}[.\s]?\d{2}\b'),
     // Swiss NPA (4-digit postal codes before city names)
     RegExp(r'\b[1-9]\d{3}\s+[A-Z]', caseSensitive: false),
     // Employer patterns: "je travaille chez X", "mon employeur X"
-    RegExp(r'(travaille\s+chez|employeur\s+est|boîte|entreprise)\s+\S+', caseSensitive: false),
+    RegExp(r'(travaille\s+chez|employeur\s+est|boîte|entreprise)\s+\S+',
+        caseSensitive: false),
     // IBAN (CH + 19 digits, with optional spaces)
-    RegExp(r'CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1,2}', caseSensitive: false),
+    RegExp(r'CH\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{1,2}',
+        caseSensitive: false),
     // IBAN compact format (no spaces)
     RegExp(r'CH\d{19}', caseSensitive: false),
     // Written-out amounts: "septante mille", "cent vingt mille"
-    RegExp(r'(septante|huitante|nonante|cinquante|soixante|vingt|trente|quarante)\s+(mille|cents?)', caseSensitive: false),
+    RegExp(
+        r'(septante|huitante|nonante|cinquante|soixante|vingt|trente|quarante)\s+(mille|cents?)',
+        caseSensitive: false),
   ];
 
   /// Strip zero-width and invisible Unicode characters that could bypass PII
@@ -386,8 +426,7 @@ class ConversationStore {
 
   /// Auto-tag by keywords found in message content.
   List<String> _inferTags(List<ChatMessage> messages) {
-    final allText =
-        messages.map((m) => m.content.toLowerCase()).join(' ');
+    final allText = messages.map((m) => m.content.toLowerCase()).join(' ');
     final tags = <String>{};
 
     const tagKeywords = {
@@ -396,7 +435,13 @@ class ConversationStore {
       '3a': ['3a', 'pilier 3a', 'troisième pilier', '3ème pilier'],
       'impôts': ['impôt', 'fiscal', 'déduction', 'tax', 'lifd'],
       'budget': ['budget', 'dépenses', 'épargne', 'économiser'],
-      'immobilier': ['hypothèque', 'immobilier', 'maison', 'appartement', 'epl'],
+      'immobilier': [
+        'hypothèque',
+        'immobilier',
+        'maison',
+        'appartement',
+        'epl'
+      ],
       'famille': ['mariage', 'divorce', 'enfant', 'concubinage', 'naissance'],
       'emploi': ['emploi', 'salaire', 'chômage', 'indépendant', 'travail'],
       'succession': ['succession', 'héritage', 'donation', 'décès'],
@@ -474,7 +519,8 @@ class ConversationStore {
     return ChatMessage(
       role: json['role'] as String,
       content: json['content'] as String,
-      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ?? DateTime.now(),
+      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.now(),
       tier: tier,
       suggestedActions: (json['suggestedActions'] as List<dynamic>?)
           ?.map((e) => e as String)

--- a/apps/mobile/lib/widgets/profile/financial_summary_card.dart
+++ b/apps/mobile/lib/widgets/profile/financial_summary_card.dart
@@ -343,10 +343,8 @@ class FinancialSummaryCard extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: TextStyle(
-          fontSize: 10,
+        style: MintTextStyles.micro(color: color).copyWith(
           fontWeight: FontWeight.w700,
-          color: color,
         ),
       ),
     );

--- a/apps/mobile/lib/widgets/profile/financial_summary_card.dart
+++ b/apps/mobile/lib/widgets/profile/financial_summary_card.dart
@@ -241,42 +241,87 @@ class FinancialSummaryCard extends StatelessWidget {
         bottom: 6,
         left: line.indent ? 16 : 0,
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Indent prefix
-          if (line.indent)
-            Padding(
-              padding: const EdgeInsets.only(right: 4),
-              child: Text(
-                line.isLast ? '\u2514 ' : '\u251C ',
-                style: MintTextStyles.labelMedium(color: MintColors.textMuted),
-              ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final indentPrefix = line.indent
+              ? Padding(
+                  padding: const EdgeInsets.only(right: 4),
+                  child: Text(
+                    line.isLast ? '\u2514 ' : '\u251C ',
+                    style:
+                        MintTextStyles.labelMedium(color: MintColors.textMuted),
+                  ),
+                )
+              : null;
+          final label = Text(
+            line.label,
+            style: MintTextStyles.bodyMedium(
+              color: isBold ? MintColors.textPrimary : MintColors.textSecondary,
+            ).copyWith(
+              fontSize: isBold ? 13 : 12,
+              fontWeight: isBold ? FontWeight.w700 : FontWeight.w400,
             ),
-          // Label
-          Expanded(
-            child: Text(
-              line.label,
-              style: MintTextStyles.bodyMedium(color: isBold ? MintColors.textPrimary : MintColors.textSecondary).copyWith(fontSize: isBold ? 13 : 12, fontWeight: isBold ? FontWeight.w700 : FontWeight.w400),
-            ),
-          ),
-          // Value + source indicator
-          if (line.formattedValue.isNotEmpty)
-            Row(
-              mainAxisSize: MainAxisSize.min,
+          );
+          final value = line.formattedValue.isEmpty
+              ? null
+              : _buildValueWithSource(line, isBold: isBold);
+
+          if (constraints.maxWidth < 280 && value != null) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text(
-                  line.formattedValue,
-                  style: MintTextStyles.bodyMedium(color: line.isDeduction ? MintColors.error : MintColors.textPrimary).copyWith(fontSize: isBold ? 14 : 13, fontWeight: isBold ? FontWeight.w700 : FontWeight.w600),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (indentPrefix != null) indentPrefix,
+                    Expanded(child: label),
+                  ],
                 ),
-                if (line.source != null) ...[
-                  const SizedBox(width: 6),
-                  _sourceIndicator(line.source!),
-                ],
+                Padding(
+                  padding: EdgeInsets.only(
+                    top: 2,
+                    left: line.indent ? 20 : 0,
+                  ),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: value,
+                  ),
+                ),
               ],
-            ),
-        ],
+            );
+          }
+
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (indentPrefix != null) indentPrefix,
+              Expanded(child: label),
+              if (value != null) value,
+            ],
+          );
+        },
       ),
+    );
+  }
+
+  Widget _buildValueWithSource(FinancialLine line, {required bool isBold}) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          line.formattedValue,
+          style: MintTextStyles.bodyMedium(
+            color: line.isDeduction ? MintColors.error : MintColors.textPrimary,
+          ).copyWith(
+            fontSize: isBold ? 14 : 13,
+            fontWeight: isBold ? FontWeight.w700 : FontWeight.w600,
+          ),
+        ),
+        if (line.source != null) ...[
+          const SizedBox(width: 6),
+          _sourceIndicator(line.source!),
+        ],
+      ],
     );
   }
 

--- a/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
+++ b/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/app.dart'
+    show
+        accountLifecycleAuthenticatedRedirect,
+        accountLifecyclePublicEntryRedirect;
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
+
+void main() {
+  group('account lifecycle public entry redirect', () {
+    test('restored account skips landing and auth entry points', () {
+      final lifecycle = AuthLifecycleState.signedInProfileLoading(
+        userId: 'user-1',
+        cloudSyncEnabled: false,
+      );
+
+      expect(
+        accountLifecyclePublicEntryRedirect(lifecycle: lifecycle, path: '/'),
+        '/home',
+      );
+      expect(
+        accountLifecyclePublicEntryRedirect(
+          lifecycle: lifecycle,
+          path: '/auth/login',
+        ),
+        '/home',
+      );
+      expect(
+        accountLifecyclePublicEntryRedirect(
+          lifecycle: lifecycle,
+          path: '/auth/register',
+        ),
+        '/home',
+      );
+    });
+
+    test('guest local mode stays allowed on public entry points', () {
+      final lifecycle = AuthLifecycleState.guestEmpty(installId: 'install-1');
+
+      expect(
+        accountLifecyclePublicEntryRedirect(lifecycle: lifecycle, path: '/'),
+        isNull,
+      );
+      expect(
+        accountLifecyclePublicEntryRedirect(
+          lifecycle: lifecycle,
+          path: '/auth/login',
+        ),
+        isNull,
+      );
+    });
+
+    test('fresh visitor stays on public entry points', () {
+      final lifecycle = AuthLifecycleState.freshVisitor();
+
+      expect(
+        accountLifecyclePublicEntryRedirect(lifecycle: lifecycle, path: '/'),
+        isNull,
+      );
+    });
+
+    test('expired account session stays on public entry points', () {
+      final lifecycle = AuthLifecycleState.sessionExpired();
+
+      expect(
+        accountLifecyclePublicEntryRedirect(
+          lifecycle: lifecycle,
+          path: '/auth/login',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('account lifecycle authenticated redirect', () {
+    test(
+      'fresh visitor is sent to account creation with redirect preserved',
+      () {
+        final lifecycle = AuthLifecycleState.freshVisitor();
+
+        expect(
+          accountLifecycleAuthenticatedRedirect(
+            lifecycle: lifecycle,
+            path: '/home',
+          ),
+          '/auth/register?redirect=%2Fhome',
+        );
+      },
+    );
+
+    test(
+      'expired account session is sent to login with redirect preserved',
+      () {
+        final lifecycle = AuthLifecycleState.sessionExpired();
+
+        expect(
+          accountLifecycleAuthenticatedRedirect(
+            lifecycle: lifecycle,
+            path: '/profile/bilan',
+          ),
+          '/auth/login?redirect=%2Fprofile%2Fbilan',
+        );
+      },
+    );
+
+    test(
+      'explicit guest and restored account can enter authenticated routes',
+      () {
+        expect(
+          accountLifecycleAuthenticatedRedirect(
+            lifecycle: AuthLifecycleState.guestEmpty(installId: 'install-1'),
+            path: '/home',
+          ),
+          isNull,
+        );
+        expect(
+          accountLifecycleAuthenticatedRedirect(
+            lifecycle: AuthLifecycleState.signedInProfileLoading(
+              userId: 'user-1',
+              cloudSyncEnabled: false,
+            ),
+            path: '/home',
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+}

--- a/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
+++ b/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
@@ -2,8 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/app.dart'
     show
         accountLifecycleAuthenticatedRedirect,
-        accountLifecyclePublicEntryRedirect;
+        accountLifecyclePublicEntryRedirect,
+        routeScopeForRedirect;
 import 'package:mint_mobile/models/auth_lifecycle_state.dart';
+import 'package:mint_mobile/router/route_scope.dart';
+import 'package:mint_mobile/router/scoped_go_route.dart';
 
 void main() {
   group('account lifecycle public entry redirect', () {
@@ -124,5 +127,38 @@ void main() {
         );
       },
     );
+  });
+
+  group('route scope fallback for redirect-only routes', () {
+    test('keeps public redirect-only entry points public', () {
+      expect(
+        routeScopeForRedirect(path: '/start', topRoute: null),
+        RouteScope.public,
+      );
+      expect(
+        routeScopeForRedirect(path: '/anonymous/chat', topRoute: null),
+        RouteScope.public,
+      );
+    });
+
+    test('keeps unknown routes fail-closed', () {
+      expect(
+        routeScopeForRedirect(path: '/unregistered', topRoute: null),
+        RouteScope.authenticated,
+      );
+    });
+
+    test('uses explicit ScopedGoRoute scope when available', () {
+      final route = ScopedGoRoute(
+        path: '/scoped',
+        scope: RouteScope.onboarding,
+        builder: (_, __) => throw UnimplementedError(),
+      );
+
+      expect(
+        routeScopeForRedirect(path: '/scoped', topRoute: route),
+        RouteScope.onboarding,
+      );
+    });
   });
 }

--- a/apps/mobile/test/navigation/anonymous_chat_route_retirement_test.dart
+++ b/apps/mobile/test/navigation/anonymous_chat_route_retirement_test.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('anonymous chat route retirement', () {
+    test('/anonymous/chat no longer renders AnonymousChatScreen', () {
+      final appSource = File('lib/app.dart').readAsStringSync();
+      final routeMatch = RegExp(
+        r"ScopedGoRoute\(\s*path:\s*'/anonymous/chat',[\s\S]*?\n    \),",
+      ).firstMatch(appSource);
+
+      expect(routeMatch, isNotNull);
+      final routeBlock = routeMatch!.group(0)!;
+
+      expect(routeBlock, contains('redirect:'));
+      expect(routeBlock, isNot(contains('AnonymousChatScreen')));
+    });
+  });
+}

--- a/apps/mobile/test/navigation/home_gate_contract_test.dart
+++ b/apps/mobile/test/navigation/home_gate_contract_test.dart
@@ -1,133 +1,84 @@
-/// Home gate contract tests — Wave B-minimal B0.
+/// Home gate contract tests.
 ///
-/// Guards the gate at [app.dart:345]:
-/// `return (auth.isLoggedIn || auth.isLocalMode) ? AujourdhuiScreen : LandingScreen;`
-///
-/// Wave 0 walkthrough (iPhone 17 Pro sim, 2026-04-18) revealed that the
-/// previous gate `auth.isLoggedIn ? AujourdhuiScreen : LandingScreen`
-/// redirected EVERY fresh-install user to LandingScreen when they tapped
-/// the Aujourd'hui tab, because `isLocalMode=true` default does not flip
-/// `isLoggedIn` to true. The intended contract was documented in
-/// `auth_provider.dart:87` but never implemented in the router.
-///
-/// Refs:
-/// - `.planning/wave-0-walkthrough-verite/FINDINGS.md`
-/// - `.planning/wave-b-home-orchestrateur/PLAN.md` (B0)
-/// - `.planning/wave-b-home-orchestrateur/REVIEW-PLAN.md`
+/// The main navigation gate is now driven by [AuthLifecycleState], not by the
+/// overloaded `isLoggedIn || isLocalMode` pair. This prevents a fresh visitor
+/// from being treated as a guest dossier while preserving explicit guest mode
+/// and signed-in account access.
 library;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  group('Home route gate — B0 contract', () {
+  group('Home route gate — lifecycle contract', () {
     setUp(() {
-      // Ensure a clean SharedPreferences between tests so
-      // `_isLocalMode` is read from defaults (true), not from a previous
-      // test's logout.
       SharedPreferences.setMockInitialValues({});
       WidgetsFlutterBinding.ensureInitialized();
     });
 
+    test('fresh visitor does not enter main navigation', () {
+      final state = AuthLifecycleState.freshVisitor();
+
+      expect(state.allowsMainNavigation, isFalse);
+      expect(state.accessMode, AuthAccessMode.visitor);
+    });
+
+    test('explicit guest local mode enters main navigation', () {
+      final state = AuthLifecycleState.guestEmpty(installId: 'install-1');
+
+      expect(state.allowsMainNavigation, isTrue);
+      expect(state.accessMode, AuthAccessMode.guestLocal);
+      expect(state.activeDataScope, AuthDataScope.guest('install-1'));
+    });
+
     test(
-      'fresh install: anonymous + isLocalMode=true → gate resolves to '
-      'AujourdhuiScreen',
+      'signed-in account enters main navigation regardless of sync mode',
       () {
-        final auth = AuthProvider();
-
-        // Defaults on fresh install:
-        expect(auth.isLoggedIn, isFalse,
-            reason: 'AuthProvider._isLoggedIn defaults to false.');
-        expect(auth.isLocalMode, isTrue,
-            reason: 'AuthProvider._isLocalMode defaults to true '
-                '(auth_provider.dart:90).');
-
-        // The gate shipped at app.dart:345.
-        final gate = auth.isLoggedIn || auth.isLocalMode;
-        expect(
-          gate,
-          isTrue,
-          reason: 'Wave B-minimal B0 (app.dart:345) must allow anonymous '
-              'local-mode users onto AujourdhuiScreen. Regression = tab '
-              'Aujourd\'hui redirects to LandingScreen for every fresh '
-              'install (confirmed on iPhone 17 Pro sim, 2026-04-18).',
+        final syncOff = AuthLifecycleState.signedInProfileLoading(
+          userId: 'u1',
+          cloudSyncEnabled: false,
         );
-      },
-    );
-
-    test(
-      'explicit no-local-mode + not logged in → gate resolves to '
-      'LandingScreen',
-      () async {
-        // Simulate a post-logout state where the prefs explicitly disable
-        // local mode.
-        SharedPreferences.setMockInitialValues({
-          'auth_local_mode': false,
-        });
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getBool('auth_local_mode'), isFalse);
-
-        final auth = AuthProvider();
-        // We cannot call checkAuth() here without mocking AuthService,
-        // so we assert the pref contract that drives isLocalMode:
-        // auth_provider.dart:136 reads `prefs.getBool('auth_local_mode') ?? true`.
-        // Post-logout, isLocalMode must be false once checkAuth runs.
-        // This test documents the pref contract; the widgetTest in
-        // `home_gate_widget_test.dart` (if/when added) exercises the
-        // full flow.
-        final localModeFromPref = prefs.getBool('auth_local_mode') ?? true;
-        expect(localModeFromPref, isFalse);
-        expect(auth.isLoggedIn, isFalse);
-
-        final gate = auth.isLoggedIn || localModeFromPref;
-        expect(
-          gate,
-          isFalse,
-          reason: 'Post-logout (auth_local_mode=false pref + not logged) '
-              'must route to LandingScreen. Otherwise stale data persists '
-              'after logout (adversarial panel BUG 1).',
+        final syncOn = AuthLifecycleState.signedInProfileLoading(
+          userId: 'u1',
+          cloudSyncEnabled: true,
         );
+
+        expect(syncOff.allowsMainNavigation, isTrue);
+        expect(syncOn.allowsMainNavigation, isTrue);
+        expect(syncOff.hasAccountSession, isTrue);
+        expect(syncOn.hasAccountSession, isTrue);
+        expect(syncOff.accessMode, AuthAccessMode.account);
+        expect(syncOn.accessMode, AuthAccessMode.account);
       },
     );
 
     test(
-      'logged-in user → gate resolves to AujourdhuiScreen regardless of '
-      'local mode',
+      'guest mode is main-navigation capable but not an account session',
       () {
-        final auth = AuthProvider();
+        final state = AuthLifecycleState.guestEmpty(installId: 'install-1');
 
-        // Simulate the effect of signInLocal / signIn (private fields,
-        // so we use the public gate contract directly). In production,
-        // auth_provider.dart:178,246,327,413 set both `_isLoggedIn=true`
-        // and `_isLocalMode=false`.
-        // We assert the gate against both canonical logged-in combinations.
-        bool evalGate(bool isLoggedIn, bool isLocalMode) =>
-            isLoggedIn || isLocalMode;
-        expect(evalGate(true, false), isTrue);
-        expect(evalGate(true, true), isTrue);
-
-        // And the default-state gate (pre-action) must still resolve to
-        // true because isLocalMode=true default.
-        expect(auth.isLoggedIn || auth.isLocalMode, isTrue);
+        expect(state.allowsMainNavigation, isTrue);
+        expect(state.hasAccountSession, isFalse);
       },
     );
 
+    test('expired account session cannot enter main navigation', () {
+      final state = AuthLifecycleState.sessionExpired();
+
+      expect(state.allowsMainNavigation, isFalse);
+      expect(state.hasAccountSession, isFalse);
+    });
+
     test(
-      'contract: gate expression matches app.dart:345 exactly',
+      'AuthProvider default object is not enough to enter main navigation',
       () {
-        // Regression guard: if someone reverts the gate to the pre-B0
-        // form `auth.isLoggedIn` only, this test should FAIL.
-        //
-        // The test reads the gate expression semantically. It does not
-        // mock the router. A widget-level integration test is out of
-        // scope for this unit file — see `home_gate_widget_test.dart`
-        // if/when the private `_router` in app.dart is refactored for
-        // test accessibility.
         final auth = AuthProvider();
-        const goodGate = true; // auth.isLoggedIn=false || auth.isLocalMode=true
-        expect(goodGate, auth.isLoggedIn || auth.isLocalMode);
+
+        expect(auth.authLifecycle.state, AuthLifecycleKind.sessionRestoring);
+        expect(auth.authLifecycle.allowsMainNavigation, isFalse);
       },
     );
   });

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -173,6 +173,17 @@ void main() {
         expect(seenPaths, contains('/api/v1/auth/me'));
         expect(provider.userId, 'magic-user');
         expect(provider.email, 'magic@example.ch');
+        expect(
+          provider.authLifecycle.state,
+          AuthLifecycleKind.signedInProfileLoading,
+        );
+        expect(provider.authLifecycle.accessMode, AuthAccessMode.account);
+        expect(
+          provider.authLifecycle.activeDataScope,
+          AuthDataScope.user('magic-user'),
+        );
+        expect(provider.authLifecycle.syncMode, AuthSyncMode.cloudSyncOff);
+        expect(provider.authLifecycle.allowsMainNavigation, isTrue);
         expect(await AuthService.getToken(), 'magic-token');
         expect(await AuthService.getUserId(), 'magic-user');
         expect(await AuthService.getUserEmail(), 'magic@example.ch');

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
@@ -22,8 +25,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  const secureStorageChannel =
-      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  const secureStorageChannel = MethodChannel(
+    'plugins.it_nomads.com/flutter_secure_storage',
+  );
   final secureStorage = <String, String>{};
   var deleteAllCalls = 0;
 
@@ -36,33 +40,30 @@ void main() {
     deleteAllCalls = 0;
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      secureStorageChannel,
-      (call) async {
-        final key = call.arguments['key'] as String?;
-        switch (call.method) {
-          case 'write':
-            final value = call.arguments['value'] as String?;
-            if (key != null && value != null) {
-              secureStorage[key] = value;
-            }
-            return null;
-          case 'read':
-            return key == null ? null : secureStorage[key];
-          case 'delete':
-            if (key != null) {
-              secureStorage.remove(key);
-            }
-            return null;
-          case 'deleteAll':
-            deleteAllCalls += 1;
-            secureStorage.clear();
-            return null;
-          default:
-            return null;
-        }
-      },
-    );
+        .setMockMethodCallHandler(secureStorageChannel, (call) async {
+          final key = call.arguments['key'] as String?;
+          switch (call.method) {
+            case 'write':
+              final value = call.arguments['value'] as String?;
+              if (key != null && value != null) {
+                secureStorage[key] = value;
+              }
+              return null;
+            case 'read':
+              return key == null ? null : secureStorage[key];
+            case 'delete':
+              if (key != null) {
+                secureStorage.remove(key);
+              }
+              return null;
+            case 'deleteAll':
+              deleteAllCalls += 1;
+              secureStorage.clear();
+              return null;
+            default:
+              return null;
+          }
+        });
   });
 
   tearDown(() {
@@ -130,167 +131,174 @@ void main() {
       expect(provider.error, isNull);
     });
 
-    test('magic-link verification fetches user info before saving session',
-        () async {
-      final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/magic-link/verify') {
-            return http.Response(
-              '{"accessToken":"magic-token","tokenType":"bearer"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/auth/me') {
-            expect(request.headers['Authorization'], 'Bearer magic-token');
-            return http.Response(
-              '{"id":"magic-user","email":"magic@example.ch","display_name":"Magic User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
-
-      final success = await provider.verifyMagicLink('magic-code');
-
-      expect(success, isTrue);
-      expect(seenPaths, contains('/api/v1/auth/magic-link/verify'));
-      expect(seenPaths, contains('/api/v1/auth/me'));
-      expect(provider.userId, 'magic-user');
-      expect(provider.email, 'magic@example.ch');
-      expect(await AuthService.getToken(), 'magic-token');
-      expect(await AuthService.getUserId(), 'magic-user');
-      expect(await AuthService.getUserEmail(), 'magic@example.ch');
-    });
-
     test(
-        'magic-link verification waits for explicit handoff choice when Mint2 axis exists',
-        () async {
-      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-      final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          return http.Response(
-            '{"accessToken":"magic-token","tokenType":"bearer"}',
-            200,
-            headers: {'content-type': 'application/json'},
-          );
-        }),
-      ));
-      await ReportPersistenceService.saveMint2AxisHandoff({
-        'onb_axis_v2': 'lpp_rente_capital',
-        'onb_axis_schema_version': 2,
-      });
+      'magic-link verification fetches user info before saving session',
+      () async {
+        final seenPaths = <String>[];
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/auth/magic-link/verify') {
+                return http.Response(
+                  '{"accessToken":"magic-token","tokenType":"bearer"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/auth/me') {
+                expect(request.headers['Authorization'], 'Bearer magic-token');
+                return http.Response(
+                  '{"id":"magic-user","email":"magic@example.ch","display_name":"Magic User"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/profiles/me') {
+                return http.Response(
+                  '{}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
+        );
 
-      try {
-        final provider = AuthProvider();
         final success = await provider.verifyMagicLink('magic-code');
 
-        expect(success, isFalse);
-        expect(seenPaths, isEmpty);
-        expect(provider.isLoggedIn, isFalse);
-        expect(
-          (await ReportPersistenceService.loadMint2AxisHandoff())[
-              'onb_axis_v2'],
-          'lpp_rente_capital',
-        );
-      } finally {
-        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
-      }
-    });
-
-    test(
-        'existing account login keeps local dossier separate without explicit handoff choice',
-        () async {
-      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('auth_local_mode', false);
-      await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
-      await ConversationStore().saveConversation('local-before-login', [
-        ChatMessage(
-          role: 'user',
-          content: 'Je veux comprendre ma situation.',
-          timestamp: DateTime(2026, 6, 13, 12),
-        ),
-      ]);
-
-      final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/login') {
-            return http.Response(
-              '{"access_token":"existing-token","refresh_token":"existing-refresh","user_id":"existing-user","email":"existing@example.ch","display_name":"Existing User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            return http.Response(
-              '{"detail":"local dossier must not be claimed without choice"}',
-              500,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
-
-      try {
-        final success =
-            await provider.login('existing@example.ch', 'correct-password');
-
         expect(success, isTrue);
-        expect(provider.userId, 'existing-user');
-        expect(await ReportPersistenceService.loadAnswers(), isEmpty);
-        expect(await ReportPersistenceService.loadHeldAnonymousAnswers(), {
-          'q_canton': 'VD',
-        });
-        expect(
-          await ConversationStore().loadConversation('local-before-login'),
-          isEmpty,
-        );
-        expect(prefs.getString('local_data_owner'), isNull);
-        expect(prefs.getBool('local_data_migrated_existing-user'), isNull);
-
-        ConversationStore.setCurrentUserId(null);
-        expect(
-          await ConversationStore().loadConversation('local-before-login'),
-          isNotEmpty,
-        );
-        expect(
-          seenPaths,
-          isNot(contains('/api/v1/sync/claim-local-data')),
-        );
-      } finally {
-        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
-        ConversationStore.setCurrentUserId(null);
-      }
-    });
+        expect(seenPaths, contains('/api/v1/auth/magic-link/verify'));
+        expect(seenPaths, contains('/api/v1/auth/me'));
+        expect(provider.userId, 'magic-user');
+        expect(provider.email, 'magic@example.ch');
+        expect(await AuthService.getToken(), 'magic-token');
+        expect(await AuthService.getUserId(), 'magic-user');
+        expect(await AuthService.getUserEmail(), 'magic@example.ch');
+      },
+    );
 
     test(
-        'existing account login clears active local dossier even when profile '
+      'magic-link verification waits for explicit handoff choice when Mint2 axis exists',
+      () async {
+        final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+        FeatureFlags.enableMvpWedgeOnboarding = true;
+        final seenPaths = <String>[];
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              return http.Response(
+                '{"accessToken":"magic-token","tokenType":"bearer"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }),
+          ),
+        );
+        await ReportPersistenceService.saveMint2AxisHandoff({
+          'onb_axis_v2': 'lpp_rente_capital',
+          'onb_axis_schema_version': 2,
+        });
+
+        try {
+          final provider = AuthProvider();
+          final success = await provider.verifyMagicLink('magic-code');
+
+          expect(success, isFalse);
+          expect(seenPaths, isEmpty);
+          expect(provider.isLoggedIn, isFalse);
+          expect(
+            (await ReportPersistenceService.loadMint2AxisHandoff())['onb_axis_v2'],
+            'lpp_rente_capital',
+          );
+        } finally {
+          FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+        }
+      },
+    );
+
+    test(
+      'existing account login keeps local dossier separate without explicit handoff choice',
+      () async {
+        final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+        FeatureFlags.enableMvpWedgeOnboarding = true;
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('auth_local_mode', false);
+        await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
+        await ConversationStore().saveConversation('local-before-login', [
+          ChatMessage(
+            role: 'user',
+            content: 'Je veux comprendre ma situation.',
+            timestamp: DateTime(2026, 6, 13, 12),
+          ),
+        ]);
+
+        final seenPaths = <String>[];
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/auth/login') {
+                return http.Response(
+                  '{"access_token":"existing-token","refresh_token":"existing-refresh","user_id":"existing-user","email":"existing@example.ch","display_name":"Existing User"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/profiles/me') {
+                return http.Response(
+                  '{}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/sync/claim-local-data') {
+                return http.Response(
+                  '{"detail":"local dossier must not be claimed without choice"}',
+                  500,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
+        );
+
+        try {
+          final success = await provider.login(
+            'existing@example.ch',
+            'correct-password',
+          );
+
+          expect(success, isTrue);
+          expect(provider.userId, 'existing-user');
+          expect(await ReportPersistenceService.loadAnswers(), isEmpty);
+          expect(await ReportPersistenceService.loadHeldAnonymousAnswers(), {
+            'q_canton': 'VD',
+          });
+          expect(
+            await ConversationStore().loadConversation('local-before-login'),
+            isEmpty,
+          );
+          expect(prefs.getString('local_data_owner'), isNull);
+          expect(prefs.getBool('local_data_migrated_existing-user'), isNull);
+
+          ConversationStore.setCurrentUserId(null);
+          expect(
+            await ConversationStore().loadConversation('local-before-login'),
+            isNotEmpty,
+          );
+          expect(seenPaths, isNot(contains('/api/v1/sync/claim-local-data')));
+        } finally {
+          FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+          ConversationStore.setCurrentUserId(null);
+        }
+      },
+    );
+
+    test('existing account login clears active local dossier even when profile '
         'hydration fails', () async {
       final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
       FeatureFlags.enableMvpWedgeOnboarding = true;
@@ -299,37 +307,41 @@ void main() {
       await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
 
       final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/login') {
-            return http.Response(
-              '{"access_token":"existing-token","refresh_token":"existing-refresh","user_id":"existing-user","email":"existing@example.ch","display_name":"Existing User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{"detail":"profile temporarily unavailable"}',
-              500,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            return http.Response(
-              '{"detail":"local dossier must not be claimed without choice"}',
-              500,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
+      ApiService.setHttpClientForTesting(
+        MintHttpClient(
+          MockClient((request) async {
+            seenPaths.add(request.url.path);
+            if (request.url.path == '/api/v1/auth/login') {
+              return http.Response(
+                '{"access_token":"existing-token","refresh_token":"existing-refresh","user_id":"existing-user","email":"existing@example.ch","display_name":"Existing User"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            if (request.url.path == '/api/v1/profiles/me') {
+              return http.Response(
+                '{"detail":"profile temporarily unavailable"}',
+                500,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            if (request.url.path == '/api/v1/sync/claim-local-data') {
+              return http.Response(
+                '{"detail":"local dossier must not be claimed without choice"}',
+                500,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{"detail":"not found"}', 404);
+          }),
+        ),
+      );
 
       try {
-        final success =
-            await provider.login('existing@example.ch', 'correct-password');
+        final success = await provider.login(
+          'existing@example.ch',
+          'correct-password',
+        );
 
         expect(success, isTrue);
         expect(provider.userId, 'existing-user');
@@ -340,18 +352,14 @@ void main() {
         expect(prefs.getString('local_data_owner'), isNull);
         expect(prefs.getBool('local_data_migrated_existing-user'), isNull);
         expect(seenPaths, contains('/api/v1/profiles/me'));
-        expect(
-          seenPaths,
-          isNot(contains('/api/v1/sync/claim-local-data')),
-        );
+        expect(seenPaths, isNot(contains('/api/v1/sync/claim-local-data')));
       } finally {
         FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
         ConversationStore.setCurrentUserId(null);
       }
     });
 
-    test(
-        'flag-off legacy login still migrates anonymous dossier without '
+    test('flag-off legacy login still migrates anonymous dossier without '
         'handoff UI choice', () async {
       final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
       FeatureFlags.enableMvpWedgeOnboarding = false;
@@ -367,37 +375,41 @@ void main() {
       ]);
 
       final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/login') {
-            return http.Response(
-              '{"access_token":"legacy-token","refresh_token":"legacy-refresh","user_id":"legacy-user","email":"legacy@example.ch","display_name":"Legacy User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            return http.Response(
-              '{"status":"ok"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
+      ApiService.setHttpClientForTesting(
+        MintHttpClient(
+          MockClient((request) async {
+            seenPaths.add(request.url.path);
+            if (request.url.path == '/api/v1/auth/login') {
+              return http.Response(
+                '{"access_token":"legacy-token","refresh_token":"legacy-refresh","user_id":"legacy-user","email":"legacy@example.ch","display_name":"Legacy User"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            if (request.url.path == '/api/v1/profiles/me') {
+              return http.Response(
+                '{}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            if (request.url.path == '/api/v1/sync/claim-local-data') {
+              return http.Response(
+                '{"status":"ok"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{"detail":"not found"}', 404);
+          }),
+        ),
+      );
 
       try {
-        final success =
-            await provider.login('legacy@example.ch', 'correct-password');
+        final success = await provider.login(
+          'legacy@example.ch',
+          'correct-password',
+        );
 
         expect(success, isTrue);
         expect(provider.userId, 'legacy-user');
@@ -419,228 +431,246 @@ void main() {
       }
     });
 
-    test('failed local data claim keeps retryable account-local dossier',
-        () async {
-      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-      await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('auth_local_mode', false);
-      await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
-      await ConversationStore().saveConversation('local-before-claim-fails', [
-        ChatMessage(
-          role: 'user',
-          content: 'Je veux garder mon diagnostic.',
-          timestamp: DateTime(2026, 6, 13, 13),
-        ),
-      ]);
-
-      final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/login') {
-            return http.Response(
-              '{"access_token":"claim-token","refresh_token":"claim-refresh","user_id":"claim-user","email":"claim@example.ch","display_name":"Claim User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            return http.Response(
-              '{"detail":"staging unavailable"}',
-              503,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
-
-      try {
-        final success = await provider.login('claim@example.ch', 'password');
-
-        expect(success, isTrue);
-        expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
-        expect(await ReportPersistenceService.loadAnswers(), {
-          'q_canton': 'VD',
-        });
-        expect(
-          await ConversationStore().loadConversation(
-            'local-before-claim-fails',
+    test(
+      'failed local data claim keeps retryable account-local dossier',
+      () async {
+        final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+        FeatureFlags.enableMvpWedgeOnboarding = true;
+        await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('auth_local_mode', false);
+        await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
+        await ConversationStore().saveConversation('local-before-claim-fails', [
+          ChatMessage(
+            role: 'user',
+            content: 'Je veux garder mon diagnostic.',
+            timestamp: DateTime(2026, 6, 13, 13),
           ),
-          isNotEmpty,
-        );
-        expect(prefs.getString('local_data_owner'), 'claim-user');
-        expect(prefs.getBool('local_data_migrated_claim-user'), isTrue);
-        expect(prefs.getBool('local_data_sync_pending_claim-user'), isTrue);
-      } finally {
-        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
-        ConversationStore.setCurrentUserId(null);
-        await AccountHandoffService.clearChoice();
-      }
-    });
+        ]);
 
-    test('account claim sends Mint2 axis handoff without wizard pollution',
-        () async {
-      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-      await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('auth_local_mode', false);
-      await ReportPersistenceService.saveMint2AxisHandoff({
-        'onb_axis_v2': 'lpp_rente_capital',
-        'onb_axis_schema_version': 2,
-        'legacy_onb_intent': 'retraite',
-        'onb_signal_axes_v2': ['logement_signal', 'fiscal_signal'],
-      });
+        final seenPaths = <String>[];
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/auth/login') {
+                return http.Response(
+                  '{"access_token":"claim-token","refresh_token":"claim-refresh","user_id":"claim-user","email":"claim@example.ch","display_name":"Claim User"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/profiles/me') {
+                return http.Response(
+                  '{}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/sync/claim-local-data') {
+                return http.Response(
+                  '{"detail":"staging unavailable"}',
+                  503,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
+        );
 
-      final seenPaths = <String>[];
-      Map<String, dynamic>? claimBody;
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/login') {
-            return http.Response(
-              '{"access_token":"axis-token","refresh_token":"axis-refresh","user_id":"axis-user","email":"axis@example.ch","display_name":"Axis User"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              jsonEncode({
-                'id': 'axis-profile',
-                'householdType': 'single',
-                'hasDebt': false,
-                'goal': 'other',
-                'factfindCompletionIndex': 0.0,
-                'voiceCursorPreference': 'direct',
-                'n5IssuedThisWeek': 0,
-                'recentGravityEvents': [],
-              }),
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            claimBody = json.decode(request.body) as Map<String, dynamic>;
-            return http.Response(
-              '{"status":"ok"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
+        try {
+          final success = await provider.login('claim@example.ch', 'password');
 
-      try {
-        final success = await provider.login('axis@example.ch', 'password');
+          expect(success, isTrue);
+          expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
+          expect(await ReportPersistenceService.loadAnswers(), {
+            'q_canton': 'VD',
+          });
+          expect(
+            await ConversationStore().loadConversation(
+              'local-before-claim-fails',
+            ),
+            isNotEmpty,
+          );
+          expect(prefs.getString('local_data_owner'), 'claim-user');
+          expect(prefs.getBool('local_data_migrated_claim-user'), isTrue);
+          expect(prefs.getBool('local_data_sync_pending_claim-user'), isTrue);
+        } finally {
+          FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+          ConversationStore.setCurrentUserId(null);
+          await AccountHandoffService.clearChoice();
+        }
+      },
+    );
 
-        expect(success, isTrue);
-        expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
-        expect(claimBody, isNotNull);
-        expect(claimBody!['wizard_answers'], isEmpty);
-        expect(
-          claimBody!['wizard_answers'],
-          isNot(contains('onb_axis_v2')),
+    test(
+      'account claim sends Mint2 axis handoff without wizard pollution',
+      () async {
+        final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+        FeatureFlags.enableMvpWedgeOnboarding = true;
+        await AccountHandoffService.saveChoice(AccountHandoffChoice.keepLocal);
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('auth_local_mode', false);
+        await ReportPersistenceService.saveMint2AxisHandoff({
+          'onb_axis_v2': 'lpp_rente_capital',
+          'onb_axis_schema_version': 2,
+          'legacy_onb_intent': 'retraite',
+          'onb_signal_axes_v2': ['logement_signal', 'fiscal_signal'],
+        });
+
+        final seenPaths = <String>[];
+        Map<String, dynamic>? claimBody;
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/auth/login') {
+                return http.Response(
+                  '{"access_token":"axis-token","refresh_token":"axis-refresh","user_id":"axis-user","email":"axis@example.ch","display_name":"Axis User"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/profiles/me') {
+                return http.Response(
+                  jsonEncode({
+                    'id': 'axis-profile',
+                    'householdType': 'single',
+                    'hasDebt': false,
+                    'goal': 'other',
+                    'factfindCompletionIndex': 0.0,
+                    'voiceCursorPreference': 'direct',
+                    'n5IssuedThisWeek': 0,
+                    'recentGravityEvents': [],
+                  }),
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/sync/claim-local-data') {
+                claimBody = json.decode(request.body) as Map<String, dynamic>;
+                return http.Response(
+                  '{"status":"ok"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
         );
-        expect(
-          claimBody!['wizard_answers'],
-          isNot(contains('onb_axis_schema_version')),
-        );
-        expect(
-          claimBody!['wizard_answers'],
-          isNot(contains('legacy_onb_intent')),
-        );
-        expect(
-          claimBody!['wizard_answers'],
-          isNot(contains('onb_signal_axes_v2')),
-        );
-        expect(
-          claimBody!['mint2_axis_handoff'],
-          {
+
+        try {
+          final success = await provider.login('axis@example.ch', 'password');
+
+          expect(success, isTrue);
+          expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
+          expect(claimBody, isNotNull);
+          expect(claimBody!['wizard_answers'], isEmpty);
+          expect(claimBody!['wizard_answers'], isNot(contains('onb_axis_v2')));
+          expect(
+            claimBody!['wizard_answers'],
+            isNot(contains('onb_axis_schema_version')),
+          );
+          expect(
+            claimBody!['wizard_answers'],
+            isNot(contains('legacy_onb_intent')),
+          );
+          expect(
+            claimBody!['wizard_answers'],
+            isNot(contains('onb_signal_axes_v2')),
+          );
+          expect(claimBody!['mint2_axis_handoff'], {
             'onb_axis_v2': 'lpp_rente_capital',
             'onb_axis_schema_version': 2,
             'legacy_onb_intent': 'retraite',
             'onb_signal_axes_v2': ['logement_signal', 'fiscal_signal'],
-          },
-        );
-        expect(prefs.getString('local_data_owner'), 'axis-user');
-        expect(prefs.getBool('local_data_migrated_axis-user'), isTrue);
-        expect(prefs.getBool('local_data_sync_pending_axis-user'), isNull);
-        expect(await ReportPersistenceService.loadAnswers(), isEmpty);
-        expect(
-          (await ReportPersistenceService.loadMint2AxisHandoff())[
-              'onb_axis_v2'],
-          'lpp_rente_capital',
-        );
-      } finally {
-        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
-        ConversationStore.setCurrentUserId(null);
-        await AccountHandoffService.clearChoice();
-      }
-    });
+          });
+          expect(prefs.getString('local_data_owner'), 'axis-user');
+          expect(prefs.getBool('local_data_migrated_axis-user'), isTrue);
+          expect(prefs.getBool('local_data_sync_pending_axis-user'), isNull);
+          expect(await ReportPersistenceService.loadAnswers(), isEmpty);
+          expect(
+            (await ReportPersistenceService.loadMint2AxisHandoff())['onb_axis_v2'],
+            'lpp_rente_capital',
+          );
+        } finally {
+          FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+          ConversationStore.setCurrentUserId(null);
+          await AccountHandoffService.clearChoice();
+        }
+      },
+    );
 
-    test('pending local data claim retries on auth restore and clears flag',
-        () async {
-      final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('mint_install_marker_v1', true);
-      await prefs.setBool('auth_local_mode', false);
-      await prefs.setString('local_data_owner', 'claim-user');
-      await prefs.setBool('local_data_migrated_claim-user', true);
-      await prefs.setBool('local_data_sync_pending_claim-user', true);
-      await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
-      await AuthService.saveToken(
-        'retry-token',
-        'claim-user',
-        'claim@example.ch',
+    test(
+      'pending local data claim retries on auth restore and clears flag',
+      () async {
+        final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
+        FeatureFlags.enableMvpWedgeOnboarding = true;
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('mint_install_marker_v1', true);
+        await prefs.setBool('auth_local_mode', false);
+        await prefs.setString('local_data_owner', 'claim-user');
+        await prefs.setBool('local_data_migrated_claim-user', true);
+        await prefs.setBool('local_data_sync_pending_claim-user', true);
+        await ReportPersistenceService.saveAnswers({'q_canton': 'VD'});
+        await AuthService.saveToken(
+          'retry-token',
+          'claim-user',
+          'claim@example.ch',
+        );
+
+        final seenPaths = <String>[];
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/sync/claim-local-data') {
+                return http.Response(
+                  '{"status":"ok"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/profiles/me') {
+                return http.Response(
+                  '{}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
+        );
+
+        try {
+          await provider.checkAuth();
+
+          expect(provider.isLoggedIn, isTrue);
+          expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
+          expect(prefs.getBool('local_data_sync_pending_claim-user'), isNull);
+          expect(prefs.getBool('local_data_migrated_claim-user'), isTrue);
+          expect(prefs.getString('local_data_owner'), 'claim-user');
+        } finally {
+          FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
+          ConversationStore.setCurrentUserId(null);
+        }
+      },
+    );
+
+    test('localizeAuthException hides raw technical exception text', () async {
+      final l10n = await S.delegate.load(const Locale('fr'));
+
+      final message = localizeAuthException(
+        Exception('Apple Sign-In returned no identity token'),
+        l10n,
       );
 
-      final seenPaths = <String>[];
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/sync/claim-local-data') {
-            return http.Response(
-              '{"status":"ok"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/profiles/me') {
-            return http.Response(
-              '{}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
-
-      try {
-        await provider.checkAuth();
-
-        expect(provider.isLoggedIn, isTrue);
-        expect(seenPaths, contains('/api/v1/sync/claim-local-data'));
-        expect(prefs.getBool('local_data_sync_pending_claim-user'), isNull);
-        expect(prefs.getBool('local_data_migrated_claim-user'), isTrue);
-        expect(prefs.getString('local_data_owner'), 'claim-user');
-      } finally {
-        FeatureFlags.enableMvpWedgeOnboarding = previousWedgeFlag;
-        ConversationStore.setCurrentUserId(null);
-      }
+      expect(message, l10n.authErrorGeneric);
+      expect(message, isNot(contains('identity token')));
+      expect(message, isNot(contains('Apple Sign-In')));
     });
 
     // ── Listener notification pattern ──
@@ -683,72 +713,75 @@ void main() {
       expect(provider.isLoading, isFalse);
     });
 
-    test('account data state distinguishes anonymous, signed-out and sync',
-        () async {
-      expect(provider.accountDataState, MintAccountDataState.anonymousLocal);
+    test(
+      'account data state distinguishes anonymous, signed-out and sync',
+      () async {
+        expect(provider.accountDataState, MintAccountDataState.anonymousLocal);
 
-      await provider.logout();
-      expect(provider.accountDataState, MintAccountDataState.signedOut);
+        await provider.logout();
+        expect(provider.accountDataState, MintAccountDataState.signedOut);
 
-      await AuthService.saveToken('jwt', 'u1', 'u1@example.ch');
-      var prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('auth_local_mode', true);
-      await provider.checkAuth();
-      expect(provider.accountDataState, MintAccountDataState.accountSyncOff);
+        await AuthService.saveToken('jwt', 'u1', 'u1@example.ch');
+        var prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('auth_local_mode', true);
+        await provider.checkAuth();
+        expect(provider.accountDataState, MintAccountDataState.accountSyncOff);
 
-      await AuthService.logout();
-      AuthService.resetMemoryCacheForTest();
-      await AuthService.saveToken('jwt', 'u1', 'u1@example.ch');
-      prefs = await SharedPreferences.getInstance();
-      await prefs.setBool('auth_local_mode', false);
-      await provider.checkAuth();
-      expect(provider.accountDataState, MintAccountDataState.cloudSyncOn);
-    });
+        await AuthService.logout();
+        AuthService.resetMemoryCacheForTest();
+        await AuthService.saveToken('jwt', 'u1', 'u1@example.ch');
+        prefs = await SharedPreferences.getInstance();
+        await prefs.setBool('auth_local_mode', false);
+        await provider.checkAuth();
+        expect(provider.accountDataState, MintAccountDataState.cloudSyncOn);
+      },
+    );
 
     test(
-        'fresh install marker absence with empty prefs purges stale MINT keychain '
-        'before auth restore', () async {
-      secureStorage.addAll({
-        'jwt_token': 'old-jwt',
-        'refresh_token': 'old-refresh',
-        'user_id': 'old-user',
-        'user_email': 'old@example.ch',
-        'display_name': 'Old User',
-        'byok_provider': 'openai',
-        'byok_api_key': 'sk-old',
-        'mint_partner_estimate': '{"estimated_salary":100000}',
-        'anonymous_session_id': 'anon-old',
-        'anonymous_message_count': '2',
-        'mint_biography_key': 'bio-old',
-        '_mint_wizard_secure_keys_v1': '["q_net_income_period_chf"]',
-        'q_net_income_period_chf': '8000',
-        'foreign_app_key': 'must-stay',
-      });
+      'fresh install marker absence with empty prefs purges stale MINT keychain '
+      'before auth restore',
+      () async {
+        secureStorage.addAll({
+          'jwt_token': 'old-jwt',
+          'refresh_token': 'old-refresh',
+          'user_id': 'old-user',
+          'user_email': 'old@example.ch',
+          'display_name': 'Old User',
+          'byok_provider': 'openai',
+          'byok_api_key': 'sk-old',
+          'mint_partner_estimate': '{"estimated_salary":100000}',
+          'anonymous_session_id': 'anon-old',
+          'anonymous_message_count': '2',
+          'mint_biography_key': 'bio-old',
+          '_mint_wizard_secure_keys_v1': '["q_net_income_period_chf"]',
+          'q_net_income_period_chf': '8000',
+          'foreign_app_key': 'must-stay',
+        });
 
-      await provider.checkAuth();
+        await provider.checkAuth();
 
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool('mint_install_marker_v1'), isTrue);
-      expect(provider.isLoggedIn, isFalse);
-      expect(provider.accountDataState, MintAccountDataState.anonymousLocal);
-      expect(deleteAllCalls, 0);
-      expect(secureStorage['foreign_app_key'], 'must-stay');
-      expect(secureStorage.containsKey('jwt_token'), isFalse);
-      expect(secureStorage.containsKey('refresh_token'), isFalse);
-      expect(secureStorage.containsKey('user_id'), isFalse);
-      expect(secureStorage.containsKey('user_email'), isFalse);
-      expect(secureStorage.containsKey('display_name'), isFalse);
-      expect(secureStorage.containsKey('byok_provider'), isFalse);
-      expect(secureStorage.containsKey('byok_api_key'), isFalse);
-      expect(secureStorage.containsKey('mint_partner_estimate'), isFalse);
-      expect(secureStorage.containsKey('anonymous_session_id'), isFalse);
-      expect(secureStorage.containsKey('anonymous_message_count'), isFalse);
-      expect(secureStorage.containsKey('mint_biography_key'), isFalse);
-      expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
-    });
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('mint_install_marker_v1'), isTrue);
+        expect(provider.isLoggedIn, isFalse);
+        expect(provider.accountDataState, MintAccountDataState.anonymousLocal);
+        expect(deleteAllCalls, 0);
+        expect(secureStorage['foreign_app_key'], 'must-stay');
+        expect(secureStorage.containsKey('jwt_token'), isFalse);
+        expect(secureStorage.containsKey('refresh_token'), isFalse);
+        expect(secureStorage.containsKey('user_id'), isFalse);
+        expect(secureStorage.containsKey('user_email'), isFalse);
+        expect(secureStorage.containsKey('display_name'), isFalse);
+        expect(secureStorage.containsKey('byok_provider'), isFalse);
+        expect(secureStorage.containsKey('byok_api_key'), isFalse);
+        expect(secureStorage.containsKey('mint_partner_estimate'), isFalse);
+        expect(secureStorage.containsKey('anonymous_session_id'), isFalse);
+        expect(secureStorage.containsKey('anonymous_message_count'), isFalse);
+        expect(secureStorage.containsKey('mint_biography_key'), isFalse);
+        expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
+      },
+    );
 
-    test(
-        'missing install marker on an existing prefs store adopts marker '
+    test('missing install marker on an existing prefs store adopts marker '
         'without deleting current keychain session', () async {
       SharedPreferences.setMockInitialValues({'auth_local_mode': false});
       secureStorage.addAll({
@@ -768,8 +801,7 @@ void main() {
       expect(deleteAllCalls, 0);
     });
 
-    test(
-        'fresh install purge failure stays pending and blocks stale auth '
+    test('fresh install purge failure stays pending and blocks stale auth '
         'on the next launch', () async {
       var failJwtDelete = true;
       secureStorage.addAll({
@@ -779,36 +811,33 @@ void main() {
       });
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        secureStorageChannel,
-        (call) async {
-          final key = call.arguments['key'] as String?;
-          switch (call.method) {
-            case 'write':
-              final value = call.arguments['value'] as String?;
-              if (key != null && value != null) {
-                secureStorage[key] = value;
-              }
-              return null;
-            case 'read':
-              return key == null ? null : secureStorage[key];
-            case 'delete':
-              if (key == 'jwt_token' && failJwtDelete) {
-                throw PlatformException(code: '-34018');
-              }
-              if (key != null) {
-                secureStorage.remove(key);
-              }
-              return null;
-            case 'deleteAll':
-              deleteAllCalls += 1;
-              secureStorage.clear();
-              return null;
-            default:
-              return null;
-          }
-        },
-      );
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            final key = call.arguments['key'] as String?;
+            switch (call.method) {
+              case 'write':
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) {
+                  secureStorage[key] = value;
+                }
+                return null;
+              case 'read':
+                return key == null ? null : secureStorage[key];
+              case 'delete':
+                if (key == 'jwt_token' && failJwtDelete) {
+                  throw PlatformException(code: '-34018');
+                }
+                if (key != null) {
+                  secureStorage.remove(key);
+                }
+                return null;
+              case 'deleteAll':
+                deleteAllCalls += 1;
+                secureStorage.clear();
+                return null;
+              default:
+                return null;
+            }
+          });
 
       await provider.checkAuth();
       var prefs = await SharedPreferences.getInstance();
@@ -829,6 +858,95 @@ void main() {
       expect(prefs.getBool('mint_install_secure_purge_pending_v1'), isNull);
       expect(secureStorage.containsKey('jwt_token'), isFalse);
       expect(deleteAllCalls, 0);
+    });
+
+    test('checkAuth without token exposes fresh visitor lifecycle', () async {
+      await provider.checkAuth();
+
+      expect(provider.authLifecycle.state, AuthLifecycleKind.freshVisitor);
+      expect(provider.authLifecycle.accessMode, AuthAccessMode.visitor);
+      expect(provider.authLifecycle.activeDataScope, AuthDataScope.none);
+      expect(provider.authLifecycle.allowsMainNavigation, isFalse);
+      expect(provider.isLoggedIn, isFalse);
+      expect(provider.isLocalMode, isTrue);
+    });
+
+    test(
+      'checkAuth with token but missing user id expires the session',
+      () async {
+        secureStorage['jwt_token'] = 'jwt-without-user-id';
+        secureStorage['user_email'] = 'user@example.ch';
+
+        await provider.checkAuth();
+
+        expect(provider.authLifecycle.state, AuthLifecycleKind.sessionExpired);
+        expect(provider.authLifecycle.allowsMainNavigation, isFalse);
+        expect(provider.isLoggedIn, isFalse);
+        expect(provider.userId, isNull);
+        expect(secureStorage.containsKey('jwt_token'), isFalse);
+      },
+    );
+
+    test('enableLocalMode exposes explicit guest lifecycle', () async {
+      await provider.enableLocalMode();
+
+      expect(provider.authLifecycle.state, AuthLifecycleKind.guestEmpty);
+      expect(provider.authLifecycle.accessMode, AuthAccessMode.guestLocal);
+      expect(
+        provider.authLifecycle.activeDataScope.kind,
+        AuthDataScopeKind.guest,
+      );
+      expect(provider.authLifecycle.activeDataScope.ownerId, isNotEmpty);
+      expect(provider.authLifecycle.syncMode, AuthSyncMode.localOnly);
+      expect(provider.authLifecycle.allowsMainNavigation, isTrue);
+      expect(provider.isLoggedIn, isFalse);
+      expect(provider.isLocalMode, isTrue);
+    });
+
+    test(
+      'checkAuth with persisted local mode restores explicit guest lifecycle',
+      () async {
+        SharedPreferences.setMockInitialValues({'auth_local_mode': true});
+        provider = AuthProvider();
+
+        await provider.checkAuth();
+
+        expect(provider.authLifecycle.state, AuthLifecycleKind.guestEmpty);
+        expect(provider.authLifecycle.accessMode, AuthAccessMode.guestLocal);
+        expect(
+          provider.authLifecycle.activeDataScope.kind,
+          AuthDataScopeKind.guest,
+        );
+        expect(provider.authLifecycle.activeDataScope.ownerId, isNotEmpty);
+        expect(provider.authLifecycle.allowsMainNavigation, isTrue);
+        expect(provider.isLoggedIn, isFalse);
+        expect(provider.isLocalMode, isTrue);
+      },
+    );
+
+    test('checkAuth with stored token exposes account lifecycle', () async {
+      await AuthService.saveToken(
+        'jwt',
+        'user-1',
+        'user@example.ch',
+        refreshToken: 'refresh',
+      );
+
+      await provider.checkAuth();
+
+      expect(
+        provider.authLifecycle.state,
+        AuthLifecycleKind.signedInProfileLoading,
+      );
+      expect(provider.authLifecycle.accessMode, AuthAccessMode.account);
+      expect(
+        provider.authLifecycle.activeDataScope,
+        AuthDataScope.user('user-1'),
+      );
+      expect(provider.authLifecycle.syncMode, AuthSyncMode.cloudSyncOff);
+      expect(provider.authLifecycle.allowsMainNavigation, isTrue);
+      expect(provider.isLoggedIn, isTrue);
+      expect(provider.userId, 'user-1');
     });
 
     // ── requiresEmailVerification starts false ──
@@ -882,21 +1000,23 @@ void main() {
       final seenPaths = <String>[];
       String? authHeader;
       Map<String, dynamic>? logoutBody;
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/logout') {
-            authHeader = request.headers['Authorization'];
-            logoutBody = jsonDecode(request.body) as Map<String, dynamic>;
-            return http.Response(
-              '{"status":"logged_out"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
+      ApiService.setHttpClientForTesting(
+        MintHttpClient(
+          MockClient((request) async {
+            seenPaths.add(request.url.path);
+            if (request.url.path == '/api/v1/auth/logout') {
+              authHeader = request.headers['Authorization'];
+              logoutBody = jsonDecode(request.body) as Map<String, dynamic>;
+              return http.Response(
+                '{"status":"logged_out"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{"detail":"not found"}', 404);
+          }),
+        ),
+      );
 
       await provider.logout();
 
@@ -907,112 +1027,122 @@ void main() {
       expect(await AuthService.getRefreshToken(), isNull);
     });
 
-    test('logout retries backend revocation after captured refresh succeeds',
-        () async {
-      await AuthService.saveToken(
-        'expired-jwt',
-        'u1',
-        'u1@example.ch',
-        refreshToken: 'refresh-token',
-      );
+    test(
+      'logout retries backend revocation after captured refresh succeeds',
+      () async {
+        await AuthService.saveToken(
+          'expired-jwt',
+          'u1',
+          'u1@example.ch',
+          refreshToken: 'refresh-token',
+        );
 
-      var logoutCalls = 0;
-      final seenPaths = <String>[];
-      final secondLogoutSeen = Completer<void>();
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          seenPaths.add(request.url.path);
-          if (request.url.path == '/api/v1/auth/logout') {
-            logoutCalls += 1;
-            if (logoutCalls == 1) {
-              expect(request.headers['Authorization'], 'Bearer expired-jwt');
-              return http.Response(
-                '{"detail":"expired"}',
-                401,
-                headers: {'content-type': 'application/json'},
-              );
-            }
-            expect(request.headers['Authorization'], 'Bearer fresh-jwt');
-            expect(jsonDecode(request.body), {
-              'refresh_token': 'fresh-refresh',
-            });
-            if (!secondLogoutSeen.isCompleted) {
-              secondLogoutSeen.complete();
-            }
-            return http.Response(
-              '{"status":"logged_out"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          if (request.url.path == '/api/v1/auth/refresh') {
-            expect(jsonDecode(request.body), {
-              'refresh_token': 'refresh-token',
-            });
-            return http.Response(
-              '{"access_token":"fresh-jwt","refresh_token":"fresh-refresh","user_id":"u1","email":"u1@example.ch"}',
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }
-          return http.Response('{"detail":"not found"}', 404);
-        }),
-      ));
+        var logoutCalls = 0;
+        final seenPaths = <String>[];
+        final secondLogoutSeen = Completer<void>();
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              seenPaths.add(request.url.path);
+              if (request.url.path == '/api/v1/auth/logout') {
+                logoutCalls += 1;
+                if (logoutCalls == 1) {
+                  expect(
+                    request.headers['Authorization'],
+                    'Bearer expired-jwt',
+                  );
+                  return http.Response(
+                    '{"detail":"expired"}',
+                    401,
+                    headers: {'content-type': 'application/json'},
+                  );
+                }
+                expect(request.headers['Authorization'], 'Bearer fresh-jwt');
+                expect(jsonDecode(request.body), {
+                  'refresh_token': 'fresh-refresh',
+                });
+                if (!secondLogoutSeen.isCompleted) {
+                  secondLogoutSeen.complete();
+                }
+                return http.Response(
+                  '{"status":"logged_out"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              if (request.url.path == '/api/v1/auth/refresh') {
+                expect(jsonDecode(request.body), {
+                  'refresh_token': 'refresh-token',
+                });
+                return http.Response(
+                  '{"access_token":"fresh-jwt","refresh_token":"fresh-refresh","user_id":"u1","email":"u1@example.ch"}',
+                  200,
+                  headers: {'content-type': 'application/json'},
+                );
+              }
+              return http.Response('{"detail":"not found"}', 404);
+            }),
+          ),
+        );
 
-      await provider.logout();
-      await secondLogoutSeen.future.timeout(const Duration(seconds: 1));
+        await provider.logout();
+        await secondLogoutSeen.future.timeout(const Duration(seconds: 1));
 
-      expect(seenPaths, [
-        '/api/v1/auth/logout',
-        '/api/v1/auth/refresh',
-        '/api/v1/auth/logout',
-      ]);
-      expect(await AuthService.getToken(), isNull);
-      expect(await AuthService.getRefreshToken(), isNull);
-    });
+        expect(seenPaths, [
+          '/api/v1/auth/logout',
+          '/api/v1/auth/refresh',
+          '/api/v1/auth/logout',
+        ]);
+        expect(await AuthService.getToken(), isNull);
+        expect(await AuthService.getRefreshToken(), isNull);
+      },
+    );
 
     test(
-        'logout clears local session before delayed backend revocation returns',
-        () async {
-      await AuthService.saveToken(
-        'jwt-token',
-        'u1',
-        'u1@example.ch',
-        refreshToken: 'refresh-token',
-      );
+      'logout clears local session before delayed backend revocation returns',
+      () async {
+        await AuthService.saveToken(
+          'jwt-token',
+          'u1',
+          'u1@example.ch',
+          refreshToken: 'refresh-token',
+        );
 
-      final requestSeen = Completer<void>();
-      final releaseResponse = Completer<void>();
-      final responseReturned = Completer<void>();
-      ApiService.setHttpClientForTesting(MintHttpClient(
-        MockClient((request) async {
-          if (request.url.path == '/api/v1/auth/logout' &&
-              !requestSeen.isCompleted) {
-            requestSeen.complete();
-          }
-          await releaseResponse.future;
-          if (!responseReturned.isCompleted) {
-            responseReturned.complete();
-          }
-          return http.Response(
-            '{"status":"logged_out"}',
-            200,
-            headers: {'content-type': 'application/json'},
-          );
-        }),
-      ));
+        final requestSeen = Completer<void>();
+        final releaseResponse = Completer<void>();
+        final responseReturned = Completer<void>();
+        ApiService.setHttpClientForTesting(
+          MintHttpClient(
+            MockClient((request) async {
+              if (request.url.path == '/api/v1/auth/logout' &&
+                  !requestSeen.isCompleted) {
+                requestSeen.complete();
+              }
+              await releaseResponse.future;
+              if (!responseReturned.isCompleted) {
+                responseReturned.complete();
+              }
+              return http.Response(
+                '{"status":"logged_out"}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }),
+          ),
+        );
 
-      final logoutFuture = provider.logout();
-      await requestSeen.future;
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+        final logoutFuture = provider.logout();
+        await requestSeen.future;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(await AuthService.getToken(), isNull);
-      expect(await AuthService.getRefreshToken(), isNull);
+        expect(await AuthService.getToken(), isNull);
+        expect(await AuthService.getRefreshToken(), isNull);
 
-      releaseResponse.complete();
-      await logoutFuture;
-      await responseReturned.future.timeout(const Duration(seconds: 1));
-    });
+        releaseResponse.complete();
+        await logoutFuture;
+        await responseReturned.future.timeout(const Duration(seconds: 1));
+      },
+    );
 
     test('logout purges only MINT-owned secure storage keys', () async {
       secureStorage.addAll({
@@ -1047,62 +1177,61 @@ void main() {
       expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
     });
 
-    test('logout continues scoped secure purges when one key delete fails',
-        () async {
-      secureStorage.addAll({
-        'byok_provider': 'openai',
-        'byok_api_key': 'sk-delete-fails',
-        'mint_partner_estimate': '{"estimated_salary":100000}',
-        'anonymous_session_id': 'anon-1',
-        'anonymous_message_count': '1',
-        'mint_biography_key': 'bio-key',
-        '_mint_wizard_secure_keys_v1': '["q_net_income_period_chf"]',
-        'q_net_income_period_chf': '8000',
-        'foreign_app_key': 'must-stay',
-      });
+    test(
+      'logout continues scoped secure purges when one key delete fails',
+      () async {
+        secureStorage.addAll({
+          'byok_provider': 'openai',
+          'byok_api_key': 'sk-delete-fails',
+          'mint_partner_estimate': '{"estimated_salary":100000}',
+          'anonymous_session_id': 'anon-1',
+          'anonymous_message_count': '1',
+          'mint_biography_key': 'bio-key',
+          '_mint_wizard_secure_keys_v1': '["q_net_income_period_chf"]',
+          'q_net_income_period_chf': '8000',
+          'foreign_app_key': 'must-stay',
+        });
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        secureStorageChannel,
-        (call) async {
-          final key = call.arguments['key'] as String?;
-          switch (call.method) {
-            case 'read':
-              return key == null ? null : secureStorage[key];
-            case 'delete':
-              if (key == 'byok_api_key') {
-                throw PlatformException(code: '-34018');
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(secureStorageChannel, (call) async {
+              final key = call.arguments['key'] as String?;
+              switch (call.method) {
+                case 'read':
+                  return key == null ? null : secureStorage[key];
+                case 'delete':
+                  if (key == 'byok_api_key') {
+                    throw PlatformException(code: '-34018');
+                  }
+                  if (key != null) {
+                    secureStorage.remove(key);
+                  }
+                  return null;
+                case 'deleteAll':
+                  deleteAllCalls += 1;
+                  secureStorage.clear();
+                  return null;
+                default:
+                  return null;
               }
-              if (key != null) {
-                secureStorage.remove(key);
-              }
-              return null;
-            case 'deleteAll':
-              deleteAllCalls += 1;
-              secureStorage.clear();
-              return null;
-            default:
-              return null;
-          }
-        },
-      );
+            });
 
-      await provider.logout();
+        await provider.logout();
 
-      expect(deleteAllCalls, 0);
-      expect(secureStorage['foreign_app_key'], 'must-stay');
-      expect(secureStorage['byok_api_key'], 'sk-delete-fails');
-      expect(secureStorage.containsKey('mint_partner_estimate'), isFalse);
-      expect(secureStorage.containsKey('anonymous_session_id'), isFalse);
-      expect(secureStorage.containsKey('anonymous_message_count'), isFalse);
-      expect(secureStorage.containsKey('mint_biography_key'), isFalse);
-      expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
-      final prefs = await SharedPreferences.getInstance();
-      expect(
-        prefs.getBool(InstallLifecycleService.ownedSecurePurgePendingKey),
-        isTrue,
-      );
-    });
+        expect(deleteAllCalls, 0);
+        expect(secureStorage['foreign_app_key'], 'must-stay');
+        expect(secureStorage['byok_api_key'], 'sk-delete-fails');
+        expect(secureStorage.containsKey('mint_partner_estimate'), isFalse);
+        expect(secureStorage.containsKey('anonymous_session_id'), isFalse);
+        expect(secureStorage.containsKey('anonymous_message_count'), isFalse);
+        expect(secureStorage.containsKey('mint_biography_key'), isFalse);
+        expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool(InstallLifecycleService.ownedSecurePurgePendingKey),
+          isTrue,
+        );
+      },
+    );
 
     test('profile clearAll purges owned secure feature keys', () async {
       secureStorage.addAll({
@@ -1130,54 +1259,52 @@ void main() {
       expect(secureStorage.containsKey('q_net_income_period_chf'), isFalse);
     });
 
-    test('profile clearAll records pending secure purge on partial failure',
-        () async {
-      secureStorage.addAll({
-        'byok_provider': 'openai',
-        'byok_api_key': 'sk-profile-reset',
-        'mint_partner_estimate': '{"estimated_salary":100000}',
-        'foreign_app_key': 'must-stay',
-      });
-
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        secureStorageChannel,
-        (call) async {
-          final key = call.arguments['key'] as String?;
-          switch (call.method) {
-            case 'read':
-              return key == null ? null : secureStorage[key];
-            case 'delete':
-              if (key == 'byok_api_key') {
-                throw PlatformException(code: '-34018');
-              }
-              if (key != null) {
-                secureStorage.remove(key);
-              }
-              return null;
-            case 'deleteAll':
-              deleteAllCalls += 1;
-              secureStorage.clear();
-              return null;
-            default:
-              return null;
-          }
-        },
-      );
-
-      await CoachProfileProvider().clearAll();
-
-      final prefs = await SharedPreferences.getInstance();
-      expect(
-        prefs.getBool(InstallLifecycleService.ownedSecurePurgePendingKey),
-        isTrue,
-      );
-      expect(secureStorage['byok_api_key'], 'sk-profile-reset');
-      expect(secureStorage['foreign_app_key'], 'must-stay');
-    });
-
     test(
-        'normal install retries pending owned secure purge without deleting '
+      'profile clearAll records pending secure purge on partial failure',
+      () async {
+        secureStorage.addAll({
+          'byok_provider': 'openai',
+          'byok_api_key': 'sk-profile-reset',
+          'mint_partner_estimate': '{"estimated_salary":100000}',
+          'foreign_app_key': 'must-stay',
+        });
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(secureStorageChannel, (call) async {
+              final key = call.arguments['key'] as String?;
+              switch (call.method) {
+                case 'read':
+                  return key == null ? null : secureStorage[key];
+                case 'delete':
+                  if (key == 'byok_api_key') {
+                    throw PlatformException(code: '-34018');
+                  }
+                  if (key != null) {
+                    secureStorage.remove(key);
+                  }
+                  return null;
+                case 'deleteAll':
+                  deleteAllCalls += 1;
+                  secureStorage.clear();
+                  return null;
+                default:
+                  return null;
+              }
+            });
+
+        await CoachProfileProvider().clearAll();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool(InstallLifecycleService.ownedSecurePurgePendingKey),
+          isTrue,
+        );
+        expect(secureStorage['byok_api_key'], 'sk-profile-reset');
+        expect(secureStorage['foreign_app_key'], 'must-stay');
+      },
+    );
+
+    test('normal install retries pending owned secure purge without deleting '
         'auth session', () async {
       secureStorage.addAll({
         'jwt_token': 'jwt',
@@ -1246,16 +1373,13 @@ void main() {
     });
 
     test('backend profile merge accepts legacy nested data payload', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'data': {
-            'birthYear': 1990,
-            'incomeGrossYearly': 90000,
-            'householdType': 'family',
-          },
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'data': {
+          'birthYear': 1990,
+          'incomeGrossYearly': 90000,
+          'householdType': 'family',
         },
-      );
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['q_birth_year'], 1990);
@@ -1267,24 +1391,21 @@ void main() {
     });
 
     test('backend profile merge hydrates material planning fields', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'dateOfBirth': '1981-06-15',
-          'incomeGrossYearly': 120000,
-          'avoirLpp': 250000,
-          'lppInsuredSalary': 88000,
-          'lppBuybackMax': 42000,
-          'pillar3aBalance': 36000,
-          'pillar3aAnnual': 7056,
-          'savingsMonthly': 1500,
-          'totalSavings': 18000,
-          'hasDebt': true,
-          'totalDebt': 9000,
-          'avsContributionYears': 20,
-          'targetRetirementAge': 64,
-        },
-      );
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'dateOfBirth': '1981-06-15',
+        'incomeGrossYearly': 120000,
+        'avoirLpp': 250000,
+        'lppInsuredSalary': 88000,
+        'lppBuybackMax': 42000,
+        'pillar3aBalance': 36000,
+        'pillar3aAnnual': 7056,
+        'savingsMonthly': 1500,
+        'totalSavings': 18000,
+        'hasDebt': true,
+        'totalDebt': 9000,
+        'avsContributionYears': 20,
+        'targetRetirementAge': 64,
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['_coach_avoir_lpp'], 250000.0);
@@ -1316,17 +1437,14 @@ void main() {
     });
 
     test('backend profile merge hydrates save_fact parity fields', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'householdType': 'couple',
-          'selfEmployedNetIncome': 96000,
-          'hasVoluntaryLpp': true,
-          'spouseBirthYear': 1982,
-          'spouseIncomeNetMonthly': 5000,
-          'spouseAvsContributionYears': 18,
-        },
-      );
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'householdType': 'couple',
+        'selfEmployedNetIncome': 96000,
+        'hasVoluntaryLpp': true,
+        'spouseBirthYear': 1982,
+        'spouseIncomeNetMonthly': 5000,
+        'spouseAvsContributionYears': 18,
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['q_household_type'], 'couple');
@@ -1351,47 +1469,44 @@ void main() {
       expect(profile.conjoint!.prevoyance!.anneesContribuees, 18);
     });
 
-    test('backend profile merge preserves existing independent budget cashflow',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_employment_status': 'independant',
-          'q_self_employed_net_income_annual_chf': 86400,
-          'q_net_income_period_chf': 6900,
-          'q_pay_frequency': 'monthly',
-        },
-        {
-          'selfEmployedNetIncome': 96000,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+    test(
+      'backend profile merge preserves existing independent budget cashflow',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {
+            'q_employment_status': 'independant',
+            'q_self_employed_net_income_annual_chf': 86400,
+            'q_net_income_period_chf': 6900,
+            'q_pay_frequency': 'monthly',
+          },
+          {'selfEmployedNetIncome': 96000},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
-      expect(merged['q_net_income_period_chf'], 6900);
-      expect(merged['q_pay_frequency'], 'monthly');
-      expect(profile.independentNetProfessionalIncomeAnnual, 96000);
-      expect(profile.explicitMonthlyNetIncome, 6900);
-    });
+        expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
+        expect(merged['q_net_income_period_chf'], 6900);
+        expect(merged['q_pay_frequency'], 'monthly');
+        expect(profile.independentNetProfessionalIncomeAnnual, 96000);
+        expect(profile.explicitMonthlyNetIncome, 6900);
+      },
+    );
 
     test('backend localDataClaim wizard answers beat stale flat income', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'data': {
-            'selfEmployedNetIncome': 86400,
-            'localDataClaim': {
-              'wizardAnswers': {
-                'q_employment_status': 'independant',
-                'q_self_employed_net_income_annual_chf': 90000,
-                'q_net_income_period_chf': 7500,
-                'q_pay_frequency': 'monthly',
-                'q_net_income_period_source':
-                    'derived_self_employed_annual_proxy',
-              },
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'data': {
+          'selfEmployedNetIncome': 86400,
+          'localDataClaim': {
+            'wizardAnswers': {
+              'q_employment_status': 'independant',
+              'q_self_employed_net_income_annual_chf': 90000,
+              'q_net_income_period_chf': 7500,
+              'q_pay_frequency': 'monthly',
+              'q_net_income_period_source':
+                  'derived_self_employed_annual_proxy',
             },
           },
         },
-      );
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['q_self_employed_net_income_annual_chf'], 90000);
@@ -1402,20 +1517,14 @@ void main() {
     });
 
     test('backend localDataClaim zero 3a beats stale flat contribution', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'data': {
-            'pillar3aAnnual': 6000,
-            'localDataClaim': {
-              'wizardAnswers': {
-                'q_3a_annual_contribution': 0,
-                'q_has_3a': false,
-              },
-            },
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'data': {
+          'pillar3aAnnual': 6000,
+          'localDataClaim': {
+            'wizardAnswers': {'q_3a_annual_contribution': 0, 'q_has_3a': false},
           },
         },
-      );
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['q_3a_annual_contribution'], 0);
@@ -1425,18 +1534,13 @@ void main() {
     });
 
     test('backend localDataClaim 3a annual derives missing has3a flag', () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
-          'data': {
-            'localDataClaim': {
-              'wizardAnswers': {
-                'q_3a_annual_contribution': 7056,
-              },
-            },
+      final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
+        'data': {
+          'localDataClaim': {
+            'wizardAnswers': {'q_3a_annual_contribution': 7056},
           },
         },
-      );
+      });
       final profile = CoachProfile.fromWizardAnswers(merged);
 
       expect(merged['q_3a_annual_contribution'], 7056);
@@ -1446,94 +1550,88 @@ void main() {
     });
 
     test(
-        'backend profile merge refreshes monthly cashflow derived from old annual',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_employment_status': 'independant',
-          'q_self_employed_net_income_annual_chf': 86400,
-          'q_net_income_period_chf': 7200,
-          'q_pay_frequency': 'monthly',
-          'q_net_income_period_source': 'derived_self_employed_annual_proxy',
-        },
-        {
-          'selfEmployedNetIncome': 96000,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+      'backend profile merge refreshes monthly cashflow derived from old annual',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {
+            'q_employment_status': 'independant',
+            'q_self_employed_net_income_annual_chf': 86400,
+            'q_net_income_period_chf': 7200,
+            'q_pay_frequency': 'monthly',
+            'q_net_income_period_source': 'derived_self_employed_annual_proxy',
+          },
+          {'selfEmployedNetIncome': 96000},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
-      expect(merged['q_net_income_period_chf'], closeTo(8000, 0.01));
-      expect(merged['q_pay_frequency'], 'monthly');
-      expect(
-        merged['q_net_income_period_source'],
-        'derived_self_employed_annual_proxy',
-      );
-      expect(profile.independentNetProfessionalIncomeAnnual, 96000);
-      expect(profile.explicitMonthlyNetIncome, closeTo(8000, 0.01));
-    });
-
-    test('backend self-employed income preserves stale local employee status',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_employment_status': 'salarie',
-          'q_self_employed_net_income_annual_chf': 86400,
-          'q_net_income_period_chf': 7200,
-          'q_pay_frequency': 'monthly',
-        },
-        {
-          'selfEmployedNetIncome': 96000,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
-
-      expect(merged['q_employment_status'], 'salarie');
-      expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
-      expect(merged['q_net_income_period_chf'], 7200);
-      expect(profile.employmentStatus, 'salarie');
-      expect(profile.independentNetProfessionalIncomeAnnual, 96000);
-    });
+        expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
+        expect(merged['q_net_income_period_chf'], closeTo(8000, 0.01));
+        expect(merged['q_pay_frequency'], 'monthly');
+        expect(
+          merged['q_net_income_period_source'],
+          'derived_self_employed_annual_proxy',
+        );
+        expect(profile.independentNetProfessionalIncomeAnnual, 96000);
+        expect(profile.explicitMonthlyNetIncome, closeTo(8000, 0.01));
+      },
+    );
 
     test(
-        'backend self-employed income preserves explicit local employee status',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_employment_status': 'salarie',
-          'q_net_income_period_chf': 7600,
-          'q_pay_frequency': 'monthly',
-        },
-        {
-          'selfEmployedNetIncome': 96000,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+      'backend self-employed income preserves stale local employee status',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {
+            'q_employment_status': 'salarie',
+            'q_self_employed_net_income_annual_chf': 86400,
+            'q_net_income_period_chf': 7200,
+            'q_pay_frequency': 'monthly',
+          },
+          {'selfEmployedNetIncome': 96000},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_employment_status'], 'salarie');
-      expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
-      expect(merged['q_net_income_period_chf'], 7600);
-      expect(profile.employmentStatus, 'salarie');
-      expect(profile.explicitMonthlyNetIncome, 7600);
-    });
+        expect(merged['q_employment_status'], 'salarie');
+        expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
+        expect(merged['q_net_income_period_chf'], 7200);
+        expect(profile.employmentStatus, 'salarie');
+        expect(profile.independentNetProfessionalIncomeAnnual, 96000);
+      },
+    );
 
-    test('backend profile merge fills null placeholders but preserves zero',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_net_income_period_chf': null,
-          'q_3a_total': 0,
-        },
-        {
-          'incomeNetMonthly': 7600,
-          'pillar3aBalance': 36000,
-        },
-      );
+    test(
+      'backend self-employed income preserves explicit local employee status',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {
+            'q_employment_status': 'salarie',
+            'q_net_income_period_chf': 7600,
+            'q_pay_frequency': 'monthly',
+          },
+          {'selfEmployedNetIncome': 96000},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_net_income_period_chf'], 7600.0);
-      expect(merged['q_pay_frequency'], 'monthly');
-      expect(merged['q_3a_total'], 0);
-    });
+        expect(merged['q_employment_status'], 'salarie');
+        expect(merged['q_self_employed_net_income_annual_chf'], 96000.0);
+        expect(merged['q_net_income_period_chf'], 7600);
+        expect(profile.employmentStatus, 'salarie');
+        expect(profile.explicitMonthlyNetIncome, 7600);
+      },
+    );
+
+    test(
+      'backend profile merge fills null placeholders but preserves zero',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {'q_net_income_period_chf': null, 'q_3a_total': 0},
+          {'incomeNetMonthly': 7600, 'pillar3aBalance': 36000},
+        );
+
+        expect(merged['q_net_income_period_chf'], 7600.0);
+        expect(merged['q_pay_frequency'], 'monthly');
+        expect(merged['q_3a_total'], 0);
+      },
+    );
 
     test('backend profile merge preserves local financial truth', () {
       final merged = AuthProvider.mergeBackendProfileDataForTest(
@@ -1572,56 +1670,52 @@ void main() {
       expect(merged['q_target_retirement_age'], 63);
     });
 
-    test('backend pillar3aAnnual correction to zero clears contribution signal',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_3a_annual_contribution': 6000,
-          'q_has_3a': true,
-        },
-        {
-          'pillar3aAnnual': 0,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+    test(
+      'backend pillar3aAnnual correction to zero clears contribution signal',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {'q_3a_annual_contribution': 6000, 'q_has_3a': true},
+          {'pillar3aAnnual': 0},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_3a_annual_contribution'], 0.0);
-      expect(merged['q_has_3a'], isFalse);
-      expect(profile.total3aMensuel, 0);
-      expect(profile.prevoyance.nombre3a, 0);
-    });
+        expect(merged['q_3a_annual_contribution'], 0.0);
+        expect(merged['q_has_3a'], isFalse);
+        expect(profile.total3aMensuel, 0);
+        expect(profile.prevoyance.nombre3a, 0);
+      },
+    );
 
-    test('backend pillar3aAnnual positive correction revives 3a contribution',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {
-          'q_3a_annual_contribution': 0,
-          'q_has_3a': false,
-        },
-        {
-          'pillar3aAnnual': 7056,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+    test(
+      'backend pillar3aAnnual positive correction revives 3a contribution',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {'q_3a_annual_contribution': 0, 'q_has_3a': false},
+          {'pillar3aAnnual': 7056},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_3a_annual_contribution'], 7056.0);
-      expect(merged['q_has_3a'], isTrue);
-      expect(profile.total3aMensuel, closeTo(588, 0.01));
-      expect(profile.prevoyance.nombre3a, 1);
-    });
+        expect(merged['q_3a_annual_contribution'], 7056.0);
+        expect(merged['q_has_3a'], isTrue);
+        expect(profile.total3aMensuel, closeTo(588, 0.01));
+        expect(profile.prevoyance.nombre3a, 1);
+      },
+    );
 
-    test('backend profile merge does not synthesize debt capital from boolean',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {'q_birth_year': 1981, 'q_gross_salary_annual': 120000},
-        {'hasDebt': true},
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+    test(
+      'backend profile merge does not synthesize debt capital from boolean',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest(
+          {'q_birth_year': 1981, 'q_gross_salary_annual': 120000},
+          {'hasDebt': true},
+        );
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged['q_has_consumer_debt'], 'yes');
-      expect(merged.containsKey('q_total_debt_balance_chf'), isFalse);
-      expect(profile.dettes.totalDettes, 0);
-    });
+        expect(merged['q_has_consumer_debt'], 'yes');
+        expect(merged.containsKey('q_total_debt_balance_chf'), isFalse);
+        expect(profile.dettes.totalDettes, 0);
+      },
+    );
 
     test('backend profile merge keeps net monthly income units coherent', () {
       final merged = AuthProvider.mergeBackendProfileDataForTest(
@@ -1634,25 +1728,24 @@ void main() {
       expect(merged.containsKey('q_gross_salary_annual'), isFalse);
     });
 
-    test('backend profile merge does not infer LPP balance from partial facts',
-        () {
-      final merged = AuthProvider.mergeBackendProfileDataForTest(
-        {},
-        {
+    test(
+      'backend profile merge does not infer LPP balance from partial facts',
+      () {
+        final merged = AuthProvider.mergeBackendProfileDataForTest({}, {
           'dateOfBirth': '1981-06-15',
           'incomeGrossYearly': 120000,
           'lppInsuredSalary': 88000,
           'lppBuybackMax': 42000,
-        },
-      );
-      final profile = CoachProfile.fromWizardAnswers(merged);
+        });
+        final profile = CoachProfile.fromWizardAnswers(merged);
 
-      expect(merged.containsKey('q_has_pension_fund'), isFalse);
-      expect(merged.containsKey('_coach_avoir_lpp'), isFalse);
-      expect(profile.prevoyance.avoirLppTotal, 0);
-      expect(profile.prevoyance.salaireAssure, 88000);
-      expect(profile.prevoyance.rachatMaximum, 42000);
-    });
+        expect(merged.containsKey('q_has_pension_fund'), isFalse);
+        expect(merged.containsKey('_coach_avoir_lpp'), isFalse);
+        expect(profile.prevoyance.avoirLppTotal, 0);
+        expect(profile.prevoyance.salaireAssure, 88000);
+        expect(profile.prevoyance.rachatMaximum, 42000);
+      },
+    );
 
     test('backend profile merge preserves explicit local zero values', () {
       final merged = AuthProvider.mergeBackendProfileDataForTest(

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -41,29 +41,29 @@ void main() {
 
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(secureStorageChannel, (call) async {
-          final key = call.arguments['key'] as String?;
-          switch (call.method) {
-            case 'write':
-              final value = call.arguments['value'] as String?;
-              if (key != null && value != null) {
-                secureStorage[key] = value;
-              }
-              return null;
-            case 'read':
-              return key == null ? null : secureStorage[key];
-            case 'delete':
-              if (key != null) {
-                secureStorage.remove(key);
-              }
-              return null;
-            case 'deleteAll':
-              deleteAllCalls += 1;
-              secureStorage.clear();
-              return null;
-            default:
-              return null;
+      final key = call.arguments['key'] as String?;
+      switch (call.method) {
+        case 'write':
+          final value = call.arguments['value'] as String?;
+          if (key != null && value != null) {
+            secureStorage[key] = value;
           }
-        });
+          return null;
+        case 'read':
+          return key == null ? null : secureStorage[key];
+        case 'delete':
+          if (key != null) {
+            secureStorage.remove(key);
+          }
+          return null;
+        case 'deleteAll':
+          deleteAllCalls += 1;
+          secureStorage.clear();
+          return null;
+        default:
+          return null;
+      }
+    });
   });
 
   tearDown(() {
@@ -210,7 +210,8 @@ void main() {
           expect(seenPaths, isEmpty);
           expect(provider.isLoggedIn, isFalse);
           expect(
-            (await ReportPersistenceService.loadMint2AxisHandoff())['onb_axis_v2'],
+            (await ReportPersistenceService.loadMint2AxisHandoff())[
+                'onb_axis_v2'],
             'lpp_rente_capital',
           );
         } finally {
@@ -298,7 +299,8 @@ void main() {
       },
     );
 
-    test('existing account login clears active local dossier even when profile '
+    test(
+        'existing account login clears active local dossier even when profile '
         'hydration fails', () async {
       final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
       FeatureFlags.enableMvpWedgeOnboarding = true;
@@ -359,8 +361,8 @@ void main() {
       }
     });
 
-    test('flag-off legacy login still migrates anonymous dossier without '
-        'handoff UI choice', () async {
+    test('flag-off legacy login claims dossier without guest conversations',
+        () async {
       final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
       FeatureFlags.enableMvpWedgeOnboarding = false;
       final prefs = await SharedPreferences.getInstance();
@@ -417,6 +419,12 @@ void main() {
         expect(await ReportPersistenceService.loadAnswers(), {
           'q_canton': 'VD',
         });
+        ConversationStore.setCurrentUserId('legacy-user');
+        expect(
+          await ConversationStore().loadConversation('legacy-local-chat'),
+          isEmpty,
+        );
+        ConversationStore.setCurrentUserId(null);
         expect(
           await ConversationStore().loadConversation('legacy-local-chat'),
           isNotEmpty,
@@ -432,7 +440,7 @@ void main() {
     });
 
     test(
-      'failed local data claim keeps retryable account-local dossier',
+      'failed local data claim keeps retryable dossier without guest conversations',
       () async {
         final previousWedgeFlag = FeatureFlags.enableMvpWedgeOnboarding;
         FeatureFlags.enableMvpWedgeOnboarding = true;
@@ -487,6 +495,14 @@ void main() {
           expect(await ReportPersistenceService.loadAnswers(), {
             'q_canton': 'VD',
           });
+          ConversationStore.setCurrentUserId('claim-user');
+          expect(
+            await ConversationStore().loadConversation(
+              'local-before-claim-fails',
+            ),
+            isEmpty,
+          );
+          ConversationStore.setCurrentUserId(null);
           expect(
             await ConversationStore().loadConversation(
               'local-before-claim-fails',
@@ -592,7 +608,8 @@ void main() {
           expect(prefs.getBool('local_data_sync_pending_axis-user'), isNull);
           expect(await ReportPersistenceService.loadAnswers(), isEmpty);
           expect(
-            (await ReportPersistenceService.loadMint2AxisHandoff())['onb_axis_v2'],
+            (await ReportPersistenceService.loadMint2AxisHandoff())[
+                'onb_axis_v2'],
             'lpp_rente_capital',
           );
         } finally {
@@ -781,7 +798,8 @@ void main() {
       },
     );
 
-    test('missing install marker on an existing prefs store adopts marker '
+    test(
+        'missing install marker on an existing prefs store adopts marker '
         'without deleting current keychain session', () async {
       SharedPreferences.setMockInitialValues({'auth_local_mode': false});
       secureStorage.addAll({
@@ -801,7 +819,8 @@ void main() {
       expect(deleteAllCalls, 0);
     });
 
-    test('fresh install purge failure stays pending and blocks stale auth '
+    test(
+        'fresh install purge failure stays pending and blocks stale auth '
         'on the next launch', () async {
       var failJwtDelete = true;
       secureStorage.addAll({
@@ -812,32 +831,32 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            final key = call.arguments['key'] as String?;
-            switch (call.method) {
-              case 'write':
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) {
-                  secureStorage[key] = value;
-                }
-                return null;
-              case 'read':
-                return key == null ? null : secureStorage[key];
-              case 'delete':
-                if (key == 'jwt_token' && failJwtDelete) {
-                  throw PlatformException(code: '-34018');
-                }
-                if (key != null) {
-                  secureStorage.remove(key);
-                }
-                return null;
-              case 'deleteAll':
-                deleteAllCalls += 1;
-                secureStorage.clear();
-                return null;
-              default:
-                return null;
+        final key = call.arguments['key'] as String?;
+        switch (call.method) {
+          case 'write':
+            final value = call.arguments['value'] as String?;
+            if (key != null && value != null) {
+              secureStorage[key] = value;
             }
-          });
+            return null;
+          case 'read':
+            return key == null ? null : secureStorage[key];
+          case 'delete':
+            if (key == 'jwt_token' && failJwtDelete) {
+              throw PlatformException(code: '-34018');
+            }
+            if (key != null) {
+              secureStorage.remove(key);
+            }
+            return null;
+          case 'deleteAll':
+            deleteAllCalls += 1;
+            secureStorage.clear();
+            return null;
+          default:
+            return null;
+        }
+      });
 
       await provider.checkAuth();
       var prefs = await SharedPreferences.getInstance();
@@ -874,6 +893,8 @@ void main() {
     test(
       'checkAuth with token but missing user id expires the session',
       () async {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setBool(InstallLifecycleService.installMarkerKey, true);
         secureStorage['jwt_token'] = 'jwt-without-user-id';
         secureStorage['user_email'] = 'user@example.ch';
 
@@ -925,6 +946,8 @@ void main() {
     );
 
     test('checkAuth with stored token exposes account lifecycle', () async {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(InstallLifecycleService.installMarkerKey, true);
       await AuthService.saveToken(
         'jwt',
         'user-1',
@@ -948,6 +971,92 @@ void main() {
       expect(provider.isLoggedIn, isTrue);
       expect(provider.userId, 'user-1');
     });
+
+    test(
+      'checkAuth does not claim anonymous conversations on restored account',
+      () async {
+        ConversationStore.setCurrentUserId(null);
+        final store = ConversationStore();
+        await store.saveConversation('guest-thread', [
+          ChatMessage(
+            role: 'user',
+            content: 'Question invitee',
+            timestamp: DateTime(2026, 6, 21, 9),
+          ),
+        ]);
+        await AuthService.saveToken(
+          'jwt',
+          'user-1',
+          'user@example.ch',
+          refreshToken: 'refresh',
+        );
+
+        await provider.checkAuth();
+
+        ConversationStore.setCurrentUserId('user-1');
+        expect(await store.listConversations(), isEmpty);
+
+        ConversationStore.setCurrentUserId(null);
+        final anonymousConversations = await store.listConversations();
+        expect(anonymousConversations, hasLength(1));
+        expect(anonymousConversations.single.id, 'guest-thread');
+      },
+    );
+
+    test(
+      'completeAppleSignIn leaves anonymous conversations unclaimed when not requested',
+      () async {
+        ConversationStore.setCurrentUserId(null);
+        final store = ConversationStore();
+        await store.saveConversation('apple-guest-thread', [
+          ChatMessage(
+            role: 'user',
+            content: 'Question avant Apple',
+            timestamp: DateTime(2026, 6, 21, 10),
+          ),
+        ]);
+
+        final ok = await provider.completeAppleSignIn({
+          'accessToken': 'apple-jwt',
+          'userId': 'apple-user',
+          'email': 'apple@example.ch',
+        }, claimAnonymousConversations: false);
+
+        expect(ok, isTrue);
+        ConversationStore.setCurrentUserId('apple-user');
+        expect(await store.listConversations(), isEmpty);
+
+        ConversationStore.setCurrentUserId(null);
+        expect(await store.listConversations(), hasLength(1));
+      },
+    );
+
+    test(
+      'completeAppleSignIn claims anonymous conversations when requested',
+      () async {
+        ConversationStore.setCurrentUserId(null);
+        final store = ConversationStore();
+        await store.saveConversation('apple-guest-thread', [
+          ChatMessage(
+            role: 'user',
+            content: 'Question avant Apple',
+            timestamp: DateTime(2026, 6, 21, 10),
+          ),
+        ]);
+
+        final claimed = await provider.completeAppleSignIn({
+          'accessToken': 'apple-jwt',
+          'userId': 'apple-user',
+          'email': 'apple@example.ch',
+        }, claimAnonymousConversations: true);
+
+        expect(claimed, isTrue);
+        ConversationStore.setCurrentUserId('apple-user');
+        final claimedConversations = await store.listConversations();
+        expect(claimedConversations, hasLength(1));
+        expect(claimedConversations.single.id, 'apple-guest-thread');
+      },
+    );
 
     // ── requiresEmailVerification starts false ──
 
@@ -1194,26 +1303,26 @@ void main() {
 
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(secureStorageChannel, (call) async {
-              final key = call.arguments['key'] as String?;
-              switch (call.method) {
-                case 'read':
-                  return key == null ? null : secureStorage[key];
-                case 'delete':
-                  if (key == 'byok_api_key') {
-                    throw PlatformException(code: '-34018');
-                  }
-                  if (key != null) {
-                    secureStorage.remove(key);
-                  }
-                  return null;
-                case 'deleteAll':
-                  deleteAllCalls += 1;
-                  secureStorage.clear();
-                  return null;
-                default:
-                  return null;
+          final key = call.arguments['key'] as String?;
+          switch (call.method) {
+            case 'read':
+              return key == null ? null : secureStorage[key];
+            case 'delete':
+              if (key == 'byok_api_key') {
+                throw PlatformException(code: '-34018');
               }
-            });
+              if (key != null) {
+                secureStorage.remove(key);
+              }
+              return null;
+            case 'deleteAll':
+              deleteAllCalls += 1;
+              secureStorage.clear();
+              return null;
+            default:
+              return null;
+          }
+        });
 
         await provider.logout();
 
@@ -1271,26 +1380,26 @@ void main() {
 
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(secureStorageChannel, (call) async {
-              final key = call.arguments['key'] as String?;
-              switch (call.method) {
-                case 'read':
-                  return key == null ? null : secureStorage[key];
-                case 'delete':
-                  if (key == 'byok_api_key') {
-                    throw PlatformException(code: '-34018');
-                  }
-                  if (key != null) {
-                    secureStorage.remove(key);
-                  }
-                  return null;
-                case 'deleteAll':
-                  deleteAllCalls += 1;
-                  secureStorage.clear();
-                  return null;
-                default:
-                  return null;
+          final key = call.arguments['key'] as String?;
+          switch (call.method) {
+            case 'read':
+              return key == null ? null : secureStorage[key];
+            case 'delete':
+              if (key == 'byok_api_key') {
+                throw PlatformException(code: '-34018');
               }
-            });
+              if (key != null) {
+                secureStorage.remove(key);
+              }
+              return null;
+            case 'deleteAll':
+              deleteAllCalls += 1;
+              secureStorage.clear();
+              return null;
+            default:
+              return null;
+          }
+        });
 
         await CoachProfileProvider().clearAll();
 
@@ -1304,7 +1413,8 @@ void main() {
       },
     );
 
-    test('normal install retries pending owned secure purge without deleting '
+    test(
+        'normal install retries pending owned secure purge without deleting '
         'auth session', () async {
       secureStorage.addAll({
         'jwt_token': 'jwt',

--- a/apps/mobile/test/providers/coach_profile_provider_secure_failure_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_secure_failure_test.dart
@@ -8,6 +8,8 @@ import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/observability/mint_http_client.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -90,6 +92,61 @@ void main() {
     final loaded = await ReportPersistenceService.loadAnswers();
     expect(loaded, isEmpty);
     expect(provider.profile, isNull);
+  });
+
+  test('clearAll purges active conversation namespace', () async {
+    ConversationStore.setCurrentUserId(null);
+    final store = ConversationStore();
+    await store.saveConversation('anonymous-profile-reset', [
+      ChatMessage(
+        role: 'user',
+        content: 'Ancienne conversation',
+        timestamp: DateTime(2026, 6, 13, 10),
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: 'Ancienne réponse',
+        timestamp: DateTime(2026, 6, 13, 10, 1),
+      ),
+    ]);
+
+    final provider = CoachProfileProvider();
+    await provider.clearAll();
+
+    expect(await store.listConversations(), isEmpty);
+  });
+
+  test('clearAll does not purge a namespace selected after the call', () async {
+    final oldStore = ConversationStore();
+    ConversationStore.setCurrentUserId('old-user');
+    await oldStore.saveConversation('old-conversation', [
+      ChatMessage(
+        role: 'user',
+        content: 'Ancien contexte',
+        timestamp: DateTime(2026, 6, 13, 10),
+      ),
+    ]);
+
+    final newStore = ConversationStore();
+    ConversationStore.setCurrentUserId('new-user');
+    await newStore.saveConversation('new-conversation', [
+      ChatMessage(
+        role: 'user',
+        content: 'Nouveau contexte',
+        timestamp: DateTime(2026, 6, 13, 11),
+      ),
+    ]);
+
+    final provider = CoachProfileProvider();
+    ConversationStore.setCurrentUserId('old-user');
+    final clearFuture = provider.clearAll();
+    ConversationStore.setCurrentUserId('new-user');
+    await clearFuture;
+
+    ConversationStore.setCurrentUserId('old-user');
+    expect(await oldStore.listConversations(), isEmpty);
+    ConversationStore.setCurrentUserId('new-user');
+    expect(await newStore.listConversations(), hasLength(1));
   });
 
   test('dateOfBirth is not demoted to SharedPreferences on seal failure',

--- a/apps/mobile/test/routes/route_metadata_test.dart
+++ b/apps/mobile/test/routes/route_metadata_test.dart
@@ -137,7 +137,9 @@ void main() {
           reason: 'expected all 4 categories used, got $used');
     });
 
-    test('owner ambiguity rule: /explore/retraite owner=explore (D-01 v4 first-segment)', () {
+    test(
+        'owner ambiguity rule: /explore/retraite owner=explore (D-01 v4 first-segment)',
+        () {
       final meta = kRouteRegistry['/explore/retraite'];
       expect(meta, isNotNull);
       expect(meta!.owner, RouteOwner.explore);
@@ -155,6 +157,17 @@ void main() {
       final meta = kRouteRegistry['/coach/chat'];
       expect(meta, isNotNull);
       expect(meta!.owner, RouteOwner.coach);
+    });
+
+    test('/anonymous/chat is a retired public alias', () {
+      final meta = kRouteRegistry['/anonymous/chat'];
+      expect(meta, isNotNull);
+      expect(meta!.category, RouteCategory.alias);
+      expect(meta.requiresAuth, isFalse);
+      expect(
+        meta.description,
+        contains('redirects to /onb'),
+      );
     });
 
     test('/ root owner=anonymous, requiresAuth=false', () {
@@ -179,7 +192,8 @@ void main() {
         expect(
           entry.value.requiresAuth,
           isFalse,
-          reason: '${entry.key} should be public (RouteScope.public in app.dart)',
+          reason:
+              '${entry.key} should be public (RouteScope.public in app.dart)',
         );
         expect(entry.value.owner, RouteOwner.auth);
       }

--- a/apps/mobile/test/screens/anonymous/anonymous_chat_screen_phase71_test.dart
+++ b/apps/mobile/test/screens/anonymous/anonymous_chat_screen_phase71_test.dart
@@ -6,7 +6,7 @@
 //   3. Sending first message hides chips + opener stays in scroll-back
 //   4. `intent` query param still auto-sends (back-compat)
 //   5. Golden — anonymous_chat_cold_open.png (fr_CH)
-//   6. Routing back-compat : /anonymous/chat stays directly reachable
+//   6. Routing : legacy /start no longer reaches anonymous chat
 //   7. Unit : _coachTurnsCompleted increments only on coach response
 //
 // Tests intentionally use direct widget pumps; the `CoachChatApiService`
@@ -58,7 +58,8 @@ void main() {
   });
 
   group('Phase 71a — Anonymous chat cold-open layout', () {
-    testWidgets('Test 1 — cold open renders opener + 3 chips + disclaimer + input',
+    testWidgets(
+        'Test 1 — cold open renders opener + 3 chips + disclaimer + input',
         (tester) async {
       _setLargeSurface(tester);
       await tester.pumpWidget(_testApp());
@@ -93,7 +94,8 @@ void main() {
       expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
     });
 
-    testWidgets('Test 2 — chip tap pre-fills input, NOT auto-send', (tester) async {
+    testWidgets('Test 2 — chip tap pre-fills input, NOT auto-send',
+        (tester) async {
       _setLargeSurface(tester);
       await tester.pumpWidget(_testApp());
       await tester.pump();
@@ -166,7 +168,8 @@ void main() {
       expect(find.text('Mon test intent'), findsOneWidget);
     });
 
-    testWidgets('Test 7 — _coachTurnsCompleted increments only on coach response',
+    testWidgets(
+        'Test 7 — _coachTurnsCompleted increments only on coach response',
         (tester) async {
       // This is a structural / black-box test. We exercise:
       //   • cold-open : counter starts at 0 (opener bubble does NOT count)
@@ -208,23 +211,34 @@ void main() {
     });
   });
 
-  group('Phase 71a — Routing back-compat', () {
-    testWidgets('Test 6 — /anonymous/chat remains directly reachable',
+  group('Phase 71a — Routing tombstone', () {
+    testWidgets('Test 6 — legacy /start redirects to /onb, not anonymous chat',
         (tester) async {
       final router = GoRouter(
-        initialLocation: '/anonymous/chat',
+        initialLocation: '/start',
         routes: [
+          GoRoute(
+            path: '/start',
+            redirect: (_, __) => '/onb',
+          ),
           GoRoute(
             path: '/anonymous/chat',
             builder: (_, __) => const Scaffold(
               body: Center(child: Text('ANONYMOUS_CHAT_REACHED')),
             ),
           ),
+          GoRoute(
+            path: '/onb',
+            builder: (_, __) => const Scaffold(
+              body: Center(child: Text('ONB_REACHED')),
+            ),
+          ),
         ],
       );
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
       await tester.pumpAndSettle();
-      expect(find.text('ANONYMOUS_CHAT_REACHED'), findsOneWidget);
+      expect(find.text('ONB_REACHED'), findsOneWidget);
+      expect(find.text('ANONYMOUS_CHAT_REACHED'), findsNothing);
     });
   });
 
@@ -250,6 +264,8 @@ void main() {
         find.byType(AnonymousChatScreen),
         matchesGoldenFile('goldens/anonymous_chat_cold_open.png'),
       );
-    }, skip: true /* Golden generation deferred — `flutter test --update-goldens` required on first run, font-rendering varies across hosts (CI vs local). Tracked as Phase 71b follow-up. */);
+    },
+        skip:
+            true /* Golden generation deferred — `flutter test --update-goldens` required on first run, font-rendering varies across hosts (CI vs local). Tracked as Phase 71b follow-up. */);
   });
 }

--- a/apps/mobile/test/screens/anonymous/anonymous_chat_screen_test.dart
+++ b/apps/mobile/test/screens/anonymous/anonymous_chat_screen_test.dart
@@ -21,10 +21,7 @@ Widget _testApp({
     localizationsDelegates: S.localizationsDelegates,
     supportedLocales: S.supportedLocales,
     locale: const Locale('fr'),
-    home: AnonymousChatScreen(
-      intent: intent,
-      sendOverride: sendOverride,
-    ),
+    home: AnonymousChatScreen(intent: intent, sendOverride: sendOverride),
   );
 }
 
@@ -53,6 +50,24 @@ void main() {
       expect(find.byIcon(Icons.send_rounded), findsOneWidget);
     });
 
+    testWidgets('suggestion chips do not use a clipped horizontal rail', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_testApp());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is ListView && widget.scrollDirection == Axis.horizontal,
+        ),
+        findsNothing,
+      );
+      expect(find.text("J'ai un projet d'achat"), findsOneWidget);
+      expect(find.text('Je change de boulot'), findsOneWidget);
+      expect(find.text('Je veux y voir clair'), findsOneWidget);
+    });
+
     testWidgets('send button is visible when not locked', (tester) async {
       await tester.pumpWidget(_testApp());
       await tester.pumpAndSettle();
@@ -73,8 +88,9 @@ void main() {
       expect(find.text('Test message'), findsOneWidget);
     });
 
-    testWidgets('displays user message in chat after sending with intent',
-        (tester) async {
+    testWidgets('displays user message in chat after sending with intent', (
+      tester,
+    ) async {
       await tester.pumpWidget(_testApp(intent: 'Mon test'));
       // Pump once to trigger initState postFrameCallback
       await tester.pump();
@@ -85,8 +101,9 @@ void main() {
       expect(find.text('Mon test'), findsOneWidget);
     });
 
-    testWidgets('restored conversation keeps first bubble visible',
-        (tester) async {
+    testWidgets('restored conversation keeps first bubble visible', (
+      tester,
+    ) async {
       ConversationStore.setCurrentUserId(null);
       final store = ConversationStore();
       await store.saveConversation('anonymous_restore_visibility', [
@@ -108,26 +125,30 @@ void main() {
       expect(find.text('Message restaure'), findsOneWidget);
       expect(find.text('Reponse restauree'), findsOneWidget);
 
-      final fades = tester.widgetList<FadeTransition>(find.ancestor(
-        of: find.text('Message restaure'),
-        matching: find.byType(FadeTransition),
-      ));
+      final fades = tester.widgetList<FadeTransition>(
+        find.ancestor(
+          of: find.text('Message restaure'),
+          matching: find.byType(FadeTransition),
+        ),
+      );
       expect(fades.map((fade) => fade.opacity.value), everyElement(1.0));
     });
 
-    testWidgets('restored conversation can restart locally', (tester) async {
+    testWidgets('restored conversation can be cleared into a new discussion', (
+      tester,
+    ) async {
       ConversationStore.setCurrentUserId(null);
       final store = ConversationStore();
-      await store.saveConversation('anonymous_restore_restart', [
+      await store.saveConversation('anonymous_restore_clear', [
         ChatMessage(
           role: 'user',
           content: 'Ancienne question',
-          timestamp: DateTime(2026, 6, 13, 9),
+          timestamp: DateTime(2026, 6, 1, 8, 0),
         ),
         ChatMessage(
           role: 'assistant',
-          content: 'Ancienne reponse',
-          timestamp: DateTime(2026, 6, 13, 9, 1),
+          content: 'Ancienne réponse',
+          timestamp: DateTime(2026, 6, 1, 8, 1),
         ),
       ]);
 
@@ -135,19 +156,29 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Ancienne question'), findsOneWidget);
+      expect(find.text('Ancienne réponse'), findsOneWidget);
       expect(find.text('Nouvelle discussion'), findsOneWidget);
 
-      await tester.tap(find.text('Nouvelle discussion'));
+      await tester.tap(
+        find.byKey(const ValueKey('anonymous_chat_new_conversation')),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Ancienne question'), findsNothing);
+      expect(find.text('Ancienne réponse'), findsNothing);
+      expect(
+        find.text(
+          'Salut. Dis-moi ce qui te trotte en tête côté finances en ce moment — un projet, une question, un truc flou.',
+        ),
+        findsOneWidget,
+      );
       expect(find.text('Nouvelle discussion'), findsNothing);
-      expect(find.textContaining('Salut.'), findsOneWidget);
       expect(await store.listConversations(), isEmpty);
     });
 
-    testWidgets('restored conversation appends to the same conversation id',
-        (tester) async {
+    testWidgets('restored conversation appends to the same conversation id', (
+      tester,
+    ) async {
       ConversationStore.setCurrentUserId(null);
       final store = ConversationStore();
       const restoredId = 'anonymous_restore_append';
@@ -164,12 +195,14 @@ void main() {
         ),
       ]);
 
-      await tester.pumpWidget(_testApp(
-        sendOverride: (_) async => {
-          'message': 'Nouvelle reponse',
-          'messagesRemaining': 2,
-        },
-      ));
+      await tester.pumpWidget(
+        _testApp(
+          sendOverride: (_) async => {
+            'message': 'Nouvelle reponse',
+            'messagesRemaining': 2,
+          },
+        ),
+      );
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField), 'Nouvelle question');
@@ -183,20 +216,22 @@ void main() {
       expect(messages.map((m) => m.content), contains('Nouvelle reponse'));
     });
 
-    testWidgets('restored restart opens account gate when quota is spent',
-        (tester) async {
+    testWidgets(
+        'restored conversation reset opens auth gate when quota is spent', (
+      tester,
+    ) async {
       ConversationStore.setCurrentUserId(null);
       final store = ConversationStore();
       await store.saveConversation('anonymous_restore_quota_spent', [
         ChatMessage(
           role: 'user',
           content: 'Ancienne question quota',
-          timestamp: DateTime(2026, 6, 13, 10),
+          timestamp: DateTime(2026, 6, 1, 8, 0),
         ),
         ChatMessage(
           role: 'assistant',
-          content: 'Ancienne reponse quota',
-          timestamp: DateTime(2026, 6, 13, 10, 1),
+          content: 'Ancienne réponse quota',
+          timestamp: DateTime(2026, 6, 1, 8, 1),
         ),
       ]);
       await AnonymousSessionService.updateFromResponse(0);
@@ -206,17 +241,31 @@ void main() {
 
       expect(find.text('Nouvelle discussion'), findsOneWidget);
 
-      await tester.tap(find.text('Nouvelle discussion'));
+      await tester.tap(
+        find.byKey(const ValueKey('anonymous_chat_new_conversation')),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Ancienne question quota'), findsNothing);
-      expect(find.textContaining('Salut.'), findsNothing);
-      expect(find.textContaining('créer un compte'), findsWidgets);
+      expect(find.text('Ancienne réponse quota'), findsNothing);
+      expect(
+        find.text(
+          'Salut. Dis-moi ce qui te trotte en tête côté finances en ce moment — un projet, une question, un truc flou.',
+        ),
+        findsNothing,
+      );
+      expect(
+        find.text(
+          'Je peux garder tout ça en mémoire pour toi — il te suffit de créer un compte.',
+        ),
+        findsOneWidget,
+      );
       expect(await store.listConversations(), isEmpty);
     });
 
-    testWidgets('restored restart action remains reachable on short viewport',
-        (tester) async {
+    testWidgets('restored restart action remains reachable on short viewport', (
+      tester,
+    ) async {
       tester.view.devicePixelRatio = 1;
       tester.view.physicalSize = const Size(320, 568);
       addTearDown(tester.view.reset);
@@ -239,12 +288,14 @@ void main() {
       await tester.pumpWidget(_testApp());
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const ValueKey('anonymous_chat_new_conversation')),
-          findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('anonymous_chat_new_conversation')),
+        findsOneWidget,
+      );
 
-      await tester.tap(find.byKey(const ValueKey(
-        'anonymous_chat_new_conversation',
-      )));
+      await tester.tap(
+        find.byKey(const ValueKey('anonymous_chat_new_conversation')),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Ancienne question mobile'), findsNothing);
@@ -252,8 +303,46 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets('quota-spent auth gate fits a short viewport', (tester) async {
+      tester.view.physicalSize = const Size(390, 568);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      ConversationStore.setCurrentUserId(null);
+      final store = ConversationStore();
+      await store.saveConversation('anonymous_restore_short_viewport_quota', [
+        ChatMessage(
+          role: 'user',
+          content: 'Ancienne question viewport',
+          timestamp: DateTime(2026, 6, 1, 8, 0),
+        ),
+        ChatMessage(
+          role: 'assistant',
+          content: 'Ancienne réponse viewport',
+          timestamp: DateTime(2026, 6, 1, 8, 1),
+        ),
+      ]);
+      await AnonymousSessionService.updateFromResponse(0);
+
+      await tester.pumpWidget(_testApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('anonymous_chat_new_conversation')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('créer un compte'), findsWidgets);
+      await tester.ensureVisible(find.text('Plus tard'));
+      await tester.pumpAndSettle();
+      expect(find.text('Plus tard'), findsOneWidget);
+    });
+
     testWidgets('auth gate routes account actions back to active conversation',
-        (tester) async {
+        (
+      tester,
+    ) async {
       final router = GoRouter(
         initialLocation: '/',
         routes: [
@@ -285,12 +374,14 @@ void main() {
         ],
       );
 
-      await tester.pumpWidget(MaterialApp.router(
-        localizationsDelegates: S.localizationsDelegates,
-        supportedLocales: S.supportedLocales,
-        locale: const Locale('fr'),
-        routerConfig: router,
-      ));
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          locale: const Locale('fr'),
+          routerConfig: router,
+        ),
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('open'));
@@ -309,94 +400,106 @@ void main() {
 
   group('Anonymous conversation eager persistence', () {
     test(
-        'saveConversation stores data under unprefixed keys when userId is null',
-        () async {
-      SharedPreferences.setMockInitialValues({});
+      'saveConversation stores data under unprefixed keys when userId is null',
+      () async {
+        SharedPreferences.setMockInitialValues({});
 
-      // Simulate the eager persistence path: null userId = anonymous (unprefixed).
-      ConversationStore.setCurrentUserId(null);
-      final store = ConversationStore();
-      const conversationId = 'anonymous_1234567890';
+        // Simulate the eager persistence path: null userId = anonymous (unprefixed).
+        ConversationStore.setCurrentUserId(null);
+        final store = ConversationStore();
+        const conversationId = 'anonymous_1234567890';
 
-      final messages = [
-        ChatMessage(
-          role: 'user',
-          content: 'Je me sens perdu financierement',
-          timestamp: DateTime(2026, 4, 12, 10, 0),
-        ),
-        ChatMessage(
-          role: 'assistant',
-          content: 'Ce sentiment est normal et courant.',
-          timestamp: DateTime(2026, 4, 12, 10, 1),
-        ),
-      ];
+        final messages = [
+          ChatMessage(
+            role: 'user',
+            content: 'Je me sens perdu financierement',
+            timestamp: DateTime(2026, 4, 12, 10, 0),
+          ),
+          ChatMessage(
+            role: 'assistant',
+            content: 'Ce sentiment est normal et courant.',
+            timestamp: DateTime(2026, 4, 12, 10, 1),
+          ),
+        ];
 
-      await store.saveConversation(conversationId, messages);
+        await store.saveConversation(conversationId, messages);
 
-      // Verify: SharedPreferences should contain unprefixed conversation data.
-      final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString('_chat_conversations_$conversationId');
-      expect(raw, isNotNull,
-          reason: 'Conversation data should be in SharedPreferences');
+        // Verify: SharedPreferences should contain unprefixed conversation data.
+        final prefs = await SharedPreferences.getInstance();
+        final raw = prefs.getString('_chat_conversations_$conversationId');
+        expect(
+          raw,
+          isNotNull,
+          reason: 'Conversation data should be in SharedPreferences',
+        );
 
-      final decoded = jsonDecode(raw!) as List<dynamic>;
-      expect(decoded.length, 2);
-      expect((decoded[0] as Map<String, dynamic>)['role'], 'user');
-      expect((decoded[1] as Map<String, dynamic>)['role'], 'assistant');
+        final decoded = jsonDecode(raw!) as List<dynamic>;
+        expect(decoded.length, 2);
+        expect((decoded[0] as Map<String, dynamic>)['role'], 'user');
+        expect((decoded[1] as Map<String, dynamic>)['role'], 'assistant');
 
-      // Verify: index should also exist (unprefixed).
-      final indexRaw = prefs.getString('_chat_conversation_index');
-      expect(indexRaw, isNotNull, reason: 'Conversation index should exist');
-      final indexDecoded = jsonDecode(indexRaw!) as List<dynamic>;
-      expect(indexDecoded.length, 1);
-      expect((indexDecoded[0] as Map<String, dynamic>)['id'], conversationId);
-    });
+        // Verify: index should also exist (unprefixed).
+        final indexRaw = prefs.getString('_chat_conversation_index');
+        expect(indexRaw, isNotNull, reason: 'Conversation index should exist');
+        final indexDecoded = jsonDecode(indexRaw!) as List<dynamic>;
+        expect(indexDecoded.length, 1);
+        expect((indexDecoded[0] as Map<String, dynamic>)['id'], conversationId);
+      },
+    );
 
-    test('migrateAnonymousToUser finds eagerly persisted anonymous data',
-        () async {
-      SharedPreferences.setMockInitialValues({});
+    test(
+      'migrateAnonymousToUser finds eagerly persisted anonymous data',
+      () async {
+        SharedPreferences.setMockInitialValues({});
 
-      // Step 1: Simulate eager persistence (anonymous chat screen saves after
-      // each coach response with userId = null).
-      ConversationStore.setCurrentUserId(null);
-      final store = ConversationStore();
-      const conversationId = 'anonymous_9876543210';
+        // Step 1: Simulate eager persistence (anonymous chat screen saves after
+        // each coach response with userId = null).
+        ConversationStore.setCurrentUserId(null);
+        final store = ConversationStore();
+        const conversationId = 'anonymous_9876543210';
 
-      final messages = [
-        ChatMessage(
-          role: 'user',
-          content: 'Est-ce que mon 3a est optimal',
-          timestamp: DateTime(2026, 4, 12, 11, 0),
-        ),
-        ChatMessage(
-          role: 'assistant',
-          content: 'Bonne question. Votre 3a depend de votre situation.',
-          timestamp: DateTime(2026, 4, 12, 11, 1),
-        ),
-      ];
+        final messages = [
+          ChatMessage(
+            role: 'user',
+            content: 'Est-ce que mon 3a est optimal',
+            timestamp: DateTime(2026, 4, 12, 11, 0),
+          ),
+          ChatMessage(
+            role: 'assistant',
+            content: 'Bonne question. Votre 3a depend de votre situation.',
+            timestamp: DateTime(2026, 4, 12, 11, 1),
+          ),
+        ];
 
-      await store.saveConversation(conversationId, messages);
+        await store.saveConversation(conversationId, messages);
 
-      // Step 2: Simulate auth_provider._migrateLocalDataIfNeeded() calling
-      // migrateAnonymousToUser after account creation.
-      const userId = 'user_abc123';
-      await ConversationStore.migrateAnonymousToUser(userId);
+        // Step 2: Simulate auth_provider._migrateLocalDataIfNeeded() calling
+        // migrateAnonymousToUser after account creation.
+        const userId = 'user_abc123';
+        await ConversationStore.migrateAnonymousToUser(userId);
 
-      // Step 3: Verify data is now under user-prefixed keys.
-      ConversationStore.setCurrentUserId(userId);
-      final migrated = await store.loadConversation(conversationId);
-      expect(migrated.length, 2, reason: 'Both messages should be migrated');
-      expect(migrated[0].role, 'user');
-      expect(migrated[1].role, 'assistant');
+        // Step 3: Verify data is now under user-prefixed keys.
+        ConversationStore.setCurrentUserId(userId);
+        final migrated = await store.loadConversation(conversationId);
+        expect(migrated.length, 2, reason: 'Both messages should be migrated');
+        expect(migrated[0].role, 'user');
+        expect(migrated[1].role, 'assistant');
 
-      // Step 4: Verify anonymous (unprefixed) data was cleaned up.
-      final prefs = await SharedPreferences.getInstance();
-      final anonData = prefs.getString('_chat_conversations_$conversationId');
-      expect(anonData, isNull,
-          reason: 'Anonymous data should be removed after migration');
-      final anonIndex = prefs.getString('_chat_conversation_index');
-      expect(anonIndex, isNull,
-          reason: 'Anonymous index should be removed after migration');
-    });
+        // Step 4: Verify anonymous (unprefixed) data was cleaned up.
+        final prefs = await SharedPreferences.getInstance();
+        final anonData = prefs.getString('_chat_conversations_$conversationId');
+        expect(
+          anonData,
+          isNull,
+          reason: 'Anonymous data should be removed after migration',
+        );
+        final anonIndex = prefs.getString('_chat_conversation_index');
+        expect(
+          anonIndex,
+          isNull,
+          reason: 'Anonymous index should be removed after migration',
+        );
+      },
+    );
   });
 }

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -171,6 +171,95 @@ void main() {
       }
     });
 
+    testWidgets('primary CTA exposes stable Maestro identifier',
+        (tester) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(_wrap());
+        await tester.pumpAndSettle();
+
+        final cta = find.byKey(const Key('landing_talk_to_mint_cta'));
+        expect(cta, findsOneWidget);
+        expect(find.bySemanticsLabel('Parle à Mint'), findsOneWidget);
+        final node = tester.getSemantics(cta);
+        expect(node.identifier, 'landing_talk_to_mint_cta');
+        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+        RendererBinding.instance.performSemanticsAction(
+          ui.SemanticsActionEvent(
+            type: SemanticsAction.tap,
+            viewId: tester.view.viewId,
+            nodeId: node.id,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+        expect(find.text('ONB_STUB'), findsNothing);
+      } finally {
+        semantics.dispose();
+      }
+    });
+
+    testWidgets('CTA actions are inert before reveal animation completes',
+        (tester) async {
+      Future<void> expectEarlyTapIgnored(
+        Finder target, {
+        required String unexpectedDestination,
+      }) async {
+        await tester.pumpWidget(_wrap());
+
+        await tester.tap(target, warnIfMissed: false);
+        await tester.pumpAndSettle();
+
+        expect(find.text(unexpectedDestination), findsNothing);
+        expect(find.text('Parle à Mint'), findsOneWidget);
+      }
+
+      await expectEarlyTapIgnored(
+        find.byType(FilledButton),
+        unexpectedDestination: 'ANONYMOUS_CHAT_STUB',
+      );
+      await expectEarlyTapIgnored(
+        find.text('Continuer sans compte'),
+        unexpectedDestination: 'ONB_STUB',
+      );
+    });
+
+    testWidgets('primary CTA hit area is isolated from /onb link',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pumpAndSettle();
+
+      final cta = find.byKey(const Key('landing_talk_to_mint_cta'));
+      final primaryRect = tester.getRect(cta);
+      final onbRect = tester.getRect(find.text('Continuer sans compte'));
+      final onbTapTargetRect = tester.getRect(
+        find.widgetWithText(GestureDetector, 'Continuer sans compte'),
+      );
+      expect(primaryRect.overlaps(onbRect), isFalse);
+      expect(primaryRect.overlaps(onbTapTargetRect), isFalse);
+
+      final tapPoints = <Offset>[
+        primaryRect.center,
+        primaryRect.centerLeft + const Offset(8, 0),
+        primaryRect.centerRight - const Offset(8, 0),
+        primaryRect.topCenter + const Offset(0, 8),
+        primaryRect.bottomCenter - const Offset(0, 8),
+      ];
+
+      for (final point in tapPoints) {
+        await tester.pumpWidget(_wrap());
+        await tester.pumpAndSettle();
+
+        await tester.tapAt(point);
+        await tester.pumpAndSettle();
+
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+        expect(find.text('ONB_STUB'), findsNothing);
+      }
+    });
+
     // S005 — anonymous local-mode link also delegates to /start so the router,
     // not LandingScreen, owns the first-run entry contract.
     testWidgets(

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -5,7 +5,7 @@
 // Asserts:
 //   • The text surfaces render (wordmark, hero, CTA, legal, login link).
 //   • No banned term (retirement framing, aggressive CTAs) is rendered.
-//   • CTA navigates to /anonymous/chat (Phase 71a: chat-first cold-open).
+//   • CTA navigates to /onb; the retired anonymous chat cold-open is not used.
 //   • Reduced-motion fallback renders content on first pump (no wait).
 //
 // CONTEXT.md §2 D-01..D-13 | LAND-01, LAND-02, LAND-04, LAND-05, LAND-06.
@@ -20,7 +20,6 @@ import 'package:go_router/go_router.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/screens/landing_screen.dart';
-import 'package:mint_mobile/services/feature_flags.dart';
 
 GoRouter _buildRouter() {
   return GoRouter(
@@ -30,7 +29,8 @@ GoRouter _buildRouter() {
         path: '/',
         builder: (_, __) => const LandingScreen(),
       ),
-      // Mirror production /start redirect while keeping landing state-free.
+      // Mirror production /start redirect: the chat-first anonymous cold-open
+      // is retired; first experience enters the explicit onboarding flow.
       GoRoute(
         path: '/start',
         redirect: (_, __) => '/onb',
@@ -79,14 +79,6 @@ Widget _wrap({MediaQueryData? mediaQuery}) {
 
 void main() {
   group('LandingScreen — Phase 73 v3 éditorial surface', () {
-    setUp(() {
-      FeatureFlags.enableMvpWedgeOnboarding = false;
-    });
-
-    tearDown(() {
-      FeatureFlags.enableMvpWedgeOnboarding = false;
-    });
-
     testWidgets('renders elements: wordmark + hero + CTA + login + legal',
         (tester) async {
       await tester.pumpWidget(_wrap());
@@ -134,7 +126,7 @@ void main() {
       }
     });
 
-    testWidgets('CTA routes to /anonymous/chat (Phase 71a chat-first)',
+    testWidgets('CTA routes to /onb, not the retired anonymous chat',
         (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
@@ -142,11 +134,11 @@ void main() {
       await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
-      expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+      expect(find.text('ONB_STUB'), findsOneWidget);
+      expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
     });
 
-    testWidgets('AX tap on primary CTA routes to anonymous chat',
-        (tester) async {
+    testWidgets('AX tap on primary CTA routes to onboarding', (tester) async {
       final semantics = tester.ensureSemantics();
       try {
         await tester.pumpWidget(_wrap());
@@ -164,7 +156,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+        expect(find.text('ONB_STUB'), findsOneWidget);
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
         expect(find.text('LOGIN_STUB'), findsNothing);
       } finally {
         semantics.dispose();
@@ -194,8 +187,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
-        expect(find.text('ONB_STUB'), findsNothing);
+        expect(find.text('ONB_STUB'), findsOneWidget);
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
       } finally {
         semantics.dispose();
       }
@@ -218,7 +211,7 @@ void main() {
 
       await expectEarlyTapIgnored(
         find.byType(FilledButton),
-        unexpectedDestination: 'ANONYMOUS_CHAT_STUB',
+        unexpectedDestination: 'ONB_STUB',
       );
       await expectEarlyTapIgnored(
         find.text('Continuer sans compte'),
@@ -255,15 +248,16 @@ void main() {
         await tester.tapAt(point);
         await tester.pumpAndSettle();
 
-        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
-        expect(find.text('ONB_STUB'), findsNothing);
+        expect(find.text('ONB_STUB'), findsOneWidget);
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
       }
     });
 
-    // S005 — anonymous local-mode link also delegates to /start so the router,
-    // not LandingScreen, owns the first-run entry contract.
+    // S005 (Phase 97 W7 iter#4 + fix 517774aa) — anonymous CTA routes to /onb
+    // (not /home) so FATCA Q (T2.5) fires before coach chat — otherwise
+    // archetype=unknown silently redirects to /waitlist on first message.
     testWidgets(
-        'S005 — « Continuer sans compte » routes to /onb when flag is off',
+        'S005 — « Continuer sans compte » link renders + routes to /onb',
         (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
@@ -275,22 +269,6 @@ void main() {
 
       expect(find.text('ONB_STUB'), findsOneWidget);
       expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
-    });
-
-    testWidgets(
-        'S005 — « Continuer sans compte » routes to /onb when flag is on',
-        (tester) async {
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-
-      await tester.pumpWidget(_wrap());
-      await tester.pumpAndSettle();
-
-      expect(find.text('Continuer sans compte'), findsOneWidget);
-
-      await tester.tap(find.text('Continuer sans compte'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('ONB_STUB'), findsOneWidget);
     });
 
     testWidgets('reduced-motion: content visible on first pump',

--- a/apps/mobile/test/screens/landing_screen_test.dart
+++ b/apps/mobile/test/screens/landing_screen_test.dart
@@ -5,13 +5,15 @@
 // Asserts:
 //   • The text surfaces render (wordmark, hero, CTA, legal, login link).
 //   • No banned term (retirement framing, aggressive CTAs) is rendered.
-//   • CTA navigates through /start into diagnostic onboarding even when
-//     backend feature flags are disabled or unavailable.
+//   • CTA navigates to /anonymous/chat (Phase 71a: chat-first cold-open).
 //   • Reduced-motion fallback renders content on first pump (no wait).
 //
 // CONTEXT.md §2 D-01..D-13 | LAND-01, LAND-02, LAND-04, LAND-05, LAND-06.
 
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -132,7 +134,7 @@ void main() {
       }
     });
 
-    testWidgets('CTA routes to /onb when diagnostic flag is off',
+    testWidgets('CTA routes to /anonymous/chat (Phase 71a chat-first)',
         (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
@@ -140,8 +142,33 @@ void main() {
       await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
-      expect(find.text('ONB_STUB'), findsOneWidget);
-      expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
+      expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+    });
+
+    testWidgets('AX tap on primary CTA routes to anonymous chat',
+        (tester) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(_wrap());
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(find.byType(FilledButton));
+        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+        RendererBinding.instance.performSemanticsAction(
+          ui.SemanticsActionEvent(
+            type: SemanticsAction.tap,
+            viewId: tester.view.viewId,
+            nodeId: node.id,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('ANONYMOUS_CHAT_STUB'), findsOneWidget);
+        expect(find.text('LOGIN_STUB'), findsNothing);
+      } finally {
+        semantics.dispose();
+      }
     });
 
     // S005 — anonymous local-mode link also delegates to /start so the router,

--- a/apps/mobile/test/screens/landing_v3_test.dart
+++ b/apps/mobile/test/screens/landing_v3_test.dart
@@ -7,7 +7,7 @@
 //   • Wordmark letterSpacing = 2 (not 4).
 //   • Long-press wordmark → /auth/login.
 //   • Tap login link → /auth/login.
-//   • Tap CTA → /start → /onb.
+//   • Tap CTA → /onb.
 //   • Golden screenshot baseline for fr_CH (skipped first-run).
 
 import 'package:flutter/material.dart';
@@ -17,7 +17,6 @@ import 'package:go_router/go_router.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/screens/landing_screen.dart';
-import 'package:mint_mobile/services/feature_flags.dart';
 
 GoRouter _buildRouter() {
   return GoRouter(
@@ -30,12 +29,6 @@ GoRouter _buildRouter() {
       GoRoute(
         path: '/start',
         redirect: (_, __) => '/onb',
-      ),
-      GoRoute(
-        path: '/anonymous/chat',
-        builder: (_, __) => const Scaffold(
-          body: Center(child: Text('ANONYMOUS_CHAT_STUB')),
-        ),
       ),
       GoRoute(
         path: '/onb',
@@ -69,14 +62,6 @@ Widget _wrap({Locale locale = const Locale('fr')}) {
 
 void main() {
   group('Phase 73 — Landing v3 structural panel-lock', () {
-    setUp(() {
-      FeatureFlags.enableMvpWedgeOnboarding = false;
-    });
-
-    tearDown(() {
-      FeatureFlags.enableMvpWedgeOnboarding = false;
-    });
-
     testWidgets('Test 1: hero renders landingV3Hero in Fraunces italic',
         (tester) async {
       await tester.pumpWidget(_wrap());
@@ -154,32 +139,14 @@ void main() {
       expect(find.text('LOGIN_STUB'), findsOneWidget);
     });
 
-    testWidgets('Test 6: tap CTA navigates to /start → /onb by default',
-        (tester) async {
+    testWidgets('Test 6: tap CTA navigates to /onb', (tester) async {
       await tester.pumpWidget(_wrap());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byType(FilledButton));
       await tester.pumpAndSettle();
 
-      expect(find.text('ONB_STUB'), findsOneWidget,
-          reason: 'CTA → /start, which enters diagnostic onboarding.');
-      expect(find.text('ANONYMOUS_CHAT_STUB'), findsNothing);
-    });
-
-    testWidgets('Test 6b: tap CTA navigates to /start → /onb when flag is on',
-        (tester) async {
-      FeatureFlags.enableMvpWedgeOnboarding = true;
-
-      await tester.pumpWidget(_wrap());
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.byType(FilledButton));
-      await tester.pumpAndSettle();
-
-      expect(find.text('ONB_STUB'), findsOneWidget,
-          reason:
-              'CTA → /start, which redirects to /onb when the diagnostic flag is on.');
+      expect(find.text('ONB_STUB'), findsOneWidget);
     });
 
     // Test 7: Golden baseline. Skipped on first run; flip to false once

--- a/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
+++ b/apps/mobile/test/screens/profile/financial_summary_screen_test.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/profile/financial_summary_screen.dart';
+import 'package:mint_mobile/services/coach/conversation_store.dart';
 import 'package:mint_mobile/services/coach/coach_profile_seeds.dart';
+import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:provider/provider.dart';
@@ -34,6 +37,7 @@ class _FakeAuthProvider extends AuthProvider {
 Widget _pumpable(
   CoachProfile? profile, {
   AuthProvider? authProvider,
+  Future<List<Object>> Function()? restartDiagnosticResetOverride,
 }) {
   return MultiProvider(
     providers: [
@@ -44,16 +48,63 @@ Widget _pumpable(
         value: authProvider ?? AuthProvider(),
       ),
     ],
-    child: const MaterialApp(
-      locale: Locale('fr'),
-      localizationsDelegates: [
+    child: MaterialApp(
+      locale: const Locale('fr'),
+      localizationsDelegates: const [
         S.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: S.supportedLocales,
-      home: FinancialSummaryScreen(),
+      home: FinancialSummaryScreen(
+        restartDiagnosticResetOverride: restartDiagnosticResetOverride,
+      ),
+    ),
+  );
+}
+
+Widget _pumpableWithRouter(
+  CoachProfile? profile, {
+  AuthProvider? authProvider,
+  Future<List<Object>> Function()? restartDiagnosticResetOverride,
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => FinancialSummaryScreen(
+          restartDiagnosticResetOverride: restartDiagnosticResetOverride,
+        ),
+      ),
+      GoRoute(
+        path: '/coach/chat',
+        builder: (_, __) => const Scaffold(
+          body: SizedBox(key: ValueKey('coach_route_after_reset')),
+        ),
+      ),
+    ],
+  );
+
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<CoachProfileProvider>.value(
+        value: _FakeCoachProfileProvider(profile),
+      ),
+      ChangeNotifierProvider<AuthProvider>.value(
+        value: authProvider ?? AuthProvider(),
+      ),
+    ],
+    child: MaterialApp.router(
+      locale: const Locale('fr'),
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: S.supportedLocales,
+      routerConfig: router,
     ),
   );
 }
@@ -65,8 +116,14 @@ CoachProfile _defensibleJulienProfile() {
     ),
   );
   return profile.copyWith(
+    prevoyance: profile.prevoyance.copyWith(
+      avoirLppTotal: profile.prevoyance.avoirLppTotal ?? 50000,
+      renteAVSEstimeeMensuelle:
+          profile.prevoyance.renteAVSEstimeeMensuelle ?? 1200,
+    ),
     dataSources: {
       ...profile.dataSources,
+      'canton': ProfileDataSource.userInput,
       'revenuBrutAnnuel': ProfileDataSource.userInput,
       'salaireBrutMensuel': ProfileDataSource.userInput,
       'depenses.loyer': ProfileDataSource.userInput,
@@ -74,6 +131,7 @@ CoachProfile _defensibleJulienProfile() {
       'patrimoine.epargneLiquide': ProfileDataSource.userInput,
       'patrimoine.investissements': ProfileDataSource.userInput,
       'prevoyance.avoirLppTotal': ProfileDataSource.certificate,
+      'prevoyance.renteAVSEstimeeMensuelle': ProfileDataSource.userInput,
       'prevoyance.totalEpargne3a': ProfileDataSource.userInput,
       'dettes.totalDettes': ProfileDataSource.userInput,
       'dettes.hypotheque': ProfileDataSource.userInput,
@@ -81,15 +139,65 @@ CoachProfile _defensibleJulienProfile() {
       'dettes.leasing': ProfileDataSource.userInput,
       'dettes.autresDettes': ProfileDataSource.userInput,
     },
-    userProvidedFields: {...profile.userProvidedFields, 'salary'},
+    userProvidedFields: {
+      ...profile.userProvidedFields,
+      'salary',
+      'canton',
+      'housingCost',
+      'lamalPremium',
+      'avoirLpp',
+      'avsRente',
+      'pillar3aBalance',
+      'liquidSavings',
+      'investments',
+      'debt',
+    },
   );
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const secureStorageChannel =
+      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final secureStorage = <String, String>{};
+
   setUp(() {
     SharedPreferences.setMockInitialValues({});
-    FlutterSecureStorage.setMockInitialValues({});
     FeatureFlags.enableMint2FirstExperienceEntry = false;
+    secureStorage.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      secureStorageChannel,
+      (call) async {
+        final key = call.arguments['key'] as String?;
+        switch (call.method) {
+          case 'write':
+            final value = call.arguments['value'] as String?;
+            if (key != null && value != null) {
+              secureStorage[key] = value;
+            }
+            return null;
+          case 'read':
+            return key == null ? null : secureStorage[key];
+          case 'delete':
+            if (key != null) {
+              secureStorage.remove(key);
+            }
+            return null;
+          case 'deleteAll':
+            secureStorage.clear();
+            return null;
+          default:
+            return null;
+        }
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(secureStorageChannel, null);
   });
 
   testWidgets('empty material profile shows diagnostic state, not covered gap',
@@ -180,6 +288,49 @@ void main() {
     expect(find.text('À la retraite, il te manquera'), findsNothing);
   });
 
+  testWidgets(
+      'income-only restored profile stays neutral without CHF projection',
+      (tester) async {
+    final profile = CoachProfile.fromWizardAnswers({
+      'q_date_of_birth': '1981-06-15',
+      'q_canton': 'VD',
+      'q_gross_salary_annual': 120000.0,
+    });
+
+    await tester.pumpWidget(_pumpable(profile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Complète ton profil pour voir tes chiffres'),
+        findsOneWidget);
+    expect(find.text('Commencer le diagnostic'), findsOneWidget);
+    expect(find.text('À la retraite, il te manquera'), findsNothing);
+    expect(find.text('Tu es bien couvert·e'), findsNothing);
+    expect(find.textContaining('CHF'), findsNothing);
+  });
+
+  testWidgets(
+      'expense-complete profile stays neutral until pension sources are real',
+      (tester) async {
+    final profile = CoachProfile.fromWizardAnswers({
+      'q_date_of_birth': '1981-06-15',
+      'q_canton': 'VD',
+      'q_gross_salary_annual': 120000.0,
+      'q_housing_cost_period_chf': 2800.0,
+      'q_lamal_premium_monthly_chf': 430.0,
+      'q_cash_total': 25000.0,
+      'q_has_consumer_debt': false,
+    });
+
+    await tester.pumpWidget(_pumpable(profile));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Complète ton profil pour voir tes chiffres'),
+        findsOneWidget);
+    expect(find.text('À la retraite, il te manquera'), findsNothing);
+    expect(find.text('Tu es bien couvert·e'), findsNothing);
+    expect(find.textContaining('CHF'), findsNothing);
+  });
+
   testWidgets('material profile leads with dossier facts before projection',
       (tester) async {
     tester.view.physicalSize = const Size(368, 800);
@@ -265,5 +416,151 @@ void main() {
     expect(
         find.text('Synchronisation cloud (multi-appareils)'), findsOneWidget);
     expect(find.text('Activée'), findsOneWidget);
+  });
+
+  testWidgets(
+      'restart diagnostic clears active coach conversations before entering chat',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    ConversationStore.setCurrentUserId('user-42');
+    final store = ConversationStore();
+    await store.saveConversation('stale-conversation', [
+      ChatMessage(
+        role: 'user',
+        content: 'ancien contexte',
+        timestamp: DateTime(2026, 6, 13, 9),
+      ),
+    ]);
+    expect(await store.listConversations(), hasLength(1));
+
+    tester.view.physicalSize = const Size(368, 3400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      ConversationStore.setCurrentUserId(null);
+    });
+
+    final profile = _defensibleJulienProfile();
+
+    await tester.pumpWidget(_pumpableWithRouter(profile));
+    await tester.pumpAndSettle();
+
+    final restartButton =
+        find.byKey(const ValueKey('financial_summary_restart_diagnostic'));
+    await tester.tap(restartButton);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
+
+    ConversationStore.setCurrentUserId('user-42');
+    expect(await store.listConversations(), isEmpty);
+    expect(
+        find.byKey(const ValueKey('coach_route_after_reset')), findsOneWidget);
+  });
+
+  test('restart diagnostic reset keeps running after one operation fails',
+      () async {
+    final calls = <String>[];
+
+    final failures = await FinancialSummaryScreen.runBestEffortResetForTest([
+      () async {
+        calls.add('first');
+        throw StateError('first failed');
+      },
+      () async {
+        calls.add('second');
+      },
+      () async {
+        calls.add('third');
+        throw StateError('third failed');
+      },
+    ]);
+
+    expect(calls, ['first', 'second', 'third']);
+    expect(failures, hasLength(2));
+  });
+
+  test('restart diagnostic skips profile clear when persistent purge fails',
+      () async {
+    final calls = <String>[];
+
+    final failures =
+        await FinancialSummaryScreen.runPersistentResetThenProfileClearForTest(
+      persistentOperations: [
+        () async {
+          calls.add('conversation');
+        },
+        () async {
+          calls.add('memory');
+          throw StateError('memory failed');
+        },
+      ],
+      profileClear: () async {
+        calls.add('profile-clear');
+      },
+    );
+
+    expect(calls, ['conversation', 'memory']);
+    expect(failures, hasLength(1));
+  });
+
+  test('restart diagnostic clears profile after persistent purges succeed',
+      () async {
+    final calls = <String>[];
+
+    final failures =
+        await FinancialSummaryScreen.runPersistentResetThenProfileClearForTest(
+      persistentOperations: [
+        () async {
+          calls.add('conversation');
+        },
+        () async {
+          calls.add('memory');
+        },
+      ],
+      profileClear: () async {
+        calls.add('profile-clear');
+      },
+    );
+
+    expect(calls, ['conversation', 'memory', 'profile-clear']);
+    expect(failures, isEmpty);
+  });
+
+  testWidgets('restart diagnostic stays put and shows error on partial reset',
+      (tester) async {
+    tester.view.physicalSize = const Size(368, 3400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final profile = _defensibleJulienProfile();
+
+    await tester.pumpWidget(
+      _pumpableWithRouter(
+        profile,
+        restartDiagnosticResetOverride: () async => [StateError('boom')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('financial_summary_restart_diagnostic')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('coach_route_after_reset')),
+      findsNothing,
+    );
+    expect(
+      find.text(
+        'Une partie des données locales n’a pas pu être effacée. Réessaie dans un instant.',
+      ),
+      findsOneWidget,
+    );
   });
 }

--- a/apps/mobile/test/services/coach/conversation_store_test.dart
+++ b/apps/mobile/test/services/coach/conversation_store_test.dart
@@ -209,6 +209,55 @@ void main() {
     });
   });
 
+  // ── Namespace clearing ─────────────────────────────────────────
+
+  group('namespace clearing', () {
+    test('clearCurrentNamespace removes only active user conversations',
+        () async {
+      ConversationStore.setCurrentUserId(null);
+      await store.saveConversation('anon-conv', [
+        msg('user', 'Anonymous context'),
+      ]);
+
+      ConversationStore.setCurrentUserId('user-42');
+      await store.saveConversation('user-conv', [
+        msg('user', 'User context'),
+      ]);
+
+      await ConversationStore.clearCurrentNamespace();
+
+      expect(await store.listConversations(), isEmpty);
+
+      ConversationStore.setCurrentUserId(null);
+      final anonymousConversations = await store.listConversations();
+      expect(anonymousConversations, hasLength(1));
+      expect(anonymousConversations.single.id, 'anon-conv');
+    });
+
+    test('clearNamespaceForUser removes a named namespace without switching',
+        () async {
+      ConversationStore.setCurrentUserId('user-42');
+      await store.saveConversation('user-42-conv', [
+        msg('user', 'User 42 context'),
+      ]);
+
+      ConversationStore.setCurrentUserId('user-77');
+      await store.saveConversation('user-77-conv', [
+        msg('user', 'User 77 context'),
+      ]);
+
+      await ConversationStore.clearNamespaceForUser('user-42');
+
+      expect(
+        (await store.listConversations()).map((m) => m.id),
+        contains('user-77-conv'),
+      );
+
+      ConversationStore.setCurrentUserId('user-42');
+      expect(await store.listConversations(), isEmpty);
+    });
+  });
+
   // ── renameConversation ──────────────────────────────────────────
 
   group('renameConversation', () {

--- a/apps/mobile/test/widgets/auth_gate_bottom_sheet_test.dart
+++ b/apps/mobile/test/widgets/auth_gate_bottom_sheet_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/widgets/auth/auth_gate_bottom_sheet.dart';
+
+void main() {
+  testWidgets('AuthGateBottomSheet stays scrollable on constrained heights',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 360);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        locale: Locale('fr'),
+        localizationsDelegates: [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: AuthGateBottomSheet(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    final viewportHeight =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    expect(
+      tester.getSize(find.byType(AuthGateBottomSheet)).height,
+      lessThanOrEqualTo(viewportHeight * 0.55 + 0.01),
+    );
+  });
+}

--- a/services/backend/alembic/versions/p124_user_apple_sub.py
+++ b/services/backend/alembic/versions/p124_user_apple_sub.py
@@ -1,0 +1,90 @@
+"""Add stable Apple subject to users.
+
+Revision ID: p124_user_apple_sub
+Revises: p120_fact_event_idempotency
+Create Date: 2026-06-21 09:05:00 UTC
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "p124_user_apple_sub"
+down_revision = "p120_fact_event_idempotency"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return column_name in {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return index_name in {index["name"] for index in inspector.get_indexes(table_name)}
+
+
+def _backfill_synthetic_apple_subs() -> None:
+    """Recover stable subs from legacy synthetic Apple relay emails."""
+    bind = op.get_bind()
+    prefix = "apple_"
+    suffix = "@privaterelay.appleid.com"
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, email FROM users "
+            "WHERE apple_sub IS NULL AND email LIKE :pattern"
+        ),
+        {"pattern": f"{prefix}%{suffix}"},
+    )
+    for row in rows:
+        email = row.email
+        if not email.startswith(prefix) or not email.endswith(suffix):
+            continue
+        apple_sub = email[len(prefix) : -len(suffix)]
+        if not apple_sub:
+            continue
+        bind.execute(
+            sa.text(
+                "UPDATE users SET apple_sub = :apple_sub "
+                "WHERE id = :user_id AND apple_sub IS NULL"
+            ),
+            {"apple_sub": apple_sub, "user_id": row.id},
+        )
+
+
+def upgrade() -> None:
+    """Add nullable unique Apple sub for stable Sign in with Apple binding."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "users" not in inspector.get_table_names():
+        return
+
+    if not _has_column("users", "apple_sub"):
+        with op.batch_alter_table("users", schema=None) as batch_op:
+            batch_op.add_column(sa.Column("apple_sub", sa.String(), nullable=True))
+
+    _backfill_synthetic_apple_subs()
+
+    if not _has_index("users", "ix_users_apple_sub"):
+        op.create_index(
+            "ix_users_apple_sub",
+            "users",
+            ["apple_sub"],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    """Remove stable Apple sub column and index if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "users" not in inspector.get_table_names():
+        return
+
+    if _has_index("users", "ix_users_apple_sub"):
+        op.drop_index("ix_users_apple_sub", table_name="users")
+
+    if _has_column("users", "apple_sub"):
+        with op.batch_alter_table("users", schema=None) as batch_op:
+            batch_op.drop_column("apple_sub")

--- a/services/backend/app/api/v1/endpoints/anonymous_chat.py
+++ b/services/backend/app/api/v1/endpoints/anonymous_chat.py
@@ -76,6 +76,65 @@ def _scrub_pii(text: str) -> str:
     return text
 
 
+_ANONYMOUS_STATE_CONFIRMATION_RE = re.compile(
+    r"("
+    r"\b(?:je|on)\s+repars?\b.{0,40}\bz[eé]ro\b|"
+    r"\brepart(?:ir|ons?|ez|ent)?\b.{0,40}\bz[eé]ro\b|"
+    r"\bplus\s+acc[èe]s\s+[àa]\s+aucune\b|"
+    r"\bsans\s+laisser\s+de\s+trace\b|"
+    r"\b(?:je|on)\s+repar(?:s|t)\b[^.\n!?]{0,40}\bfeuille\s+blanche\b|"
+    r"\b(?:aucun|aucune)\s+(?:donn[ée]es?|informations?|historique|trace)\b"
+    r"[^.\n!?]{0,80}\b(?:conserv[ée]e?s?|gard[ée]e?s?|stock[ée]e?s?|"
+    r"enregistr[ée]e?s?|rest(?:e|ent)?)\b|"
+    r"\b(?:ton|ta|tes|votre|vos|ce|cet|cette|ces|des|l['’]|la|le|les)?\s*"
+    r"(?:historique|conversation|donn[ée]es?|informations?)\b(?:\s+locales?)?"
+    r"[^.\n!?]{0,80}\b(?:effac[ée]e?s?|supprim[ée]e?s?|"
+    r"r[ée]initialis[ée]e?s?|purg[ée]e?s?|vid[ée]e?s?|nettoy[ée]e?s?)\b|"
+    r"\b(?:suppression|effacement|r[ée]initialisation)\b[^.\n!?]{0,40}"
+    r"\b(?:locale|donn[ée]es?|informations?|app|compte|conversation|historique)\b"
+    r"[^.\n!?]{0,80}\b(?:termin[ée]e?|faite?|confirm[ée]e?|r[ée]ussie?)\b|"
+    r"\b(?:start(?:ing)?|restart(?:ing)?|reset(?:ting)?)\b[^.\n!?]{0,40}"
+    r"\b(?:from zero|fresh|blank slate)\b|"
+    r"\bno\s+(?:data|trace)\s+(?:left|kept|stored|remain(?:s|ing)?)\b|"
+    r"\bwithout(?:\s+leaving)?\s+(?:a\s+)?trace\b|"
+    r"\b(?:local\s+)?(?:deletion|reset)\b[^.\n!?]{0,80}"
+    r"\b(?:complete|completed|confirmed|done|successful)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _guard_anonymous_state_claims(text: str, language: str = "fr") -> str:
+    """Prevent LLM text from confirming local deletion or persistence state."""
+    match = _ANONYMOUS_STATE_CONFIRMATION_RE.search(text)
+    if not match:
+        return text
+
+    logger.warning(
+        "Anonymous state-claim guard fired",
+        extra={
+            "matched": _scrub_pii(match.group(0)[:160]),
+            "language": language,
+        },
+    )
+
+    if language.lower().startswith("fr"):
+        return (
+            "Je ne peux pas confirmer depuis cette discussion qu'une suppression "
+            "locale est terminée. L'app doit l'indiquer explicitement dans "
+            "ses paramètres ou dans le diagnostic de redémarrage. "
+            "Pour cette réponse, je m'appuie sur ce que tu viens d'écrire : "
+            "quel sujet veux-tu explorer ?"
+        )
+
+    return (
+        "I cannot confirm from this chat that a local deletion has completed. "
+        "The app has to show that explicitly in its settings or in the restart "
+        "diagnostic. For this reply, I am using what you just wrote: what topic "
+        "do you want to explore?"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Discovery system prompt — written from scratch (T-13-05)
 # ---------------------------------------------------------------------------
@@ -102,7 +161,8 @@ def build_discovery_system_prompt(
         "Tu es MINT, un compagnon de lucidit\u00e9 financi\u00e8re suisse.",
         "",
         "Contexte : mode d\u00e9couverte. La personne n'a pas encore de compte.",
-        "Tu ne disposes d'aucune donn\u00e9e biographique pr\u00e9alable sur elle.",
+        "Tu ne disposes pas d'informations biographiques pr\u00e9alables sur elle.",
+        "Tu r\u00e9ponds \u00e0 partir du message re\u00e7u dans ce tour.",
         "",
     ]
 
@@ -126,6 +186,9 @@ def build_discovery_system_prompt(
         "- Si tu cites un chiffre suisse (taux, plafond, m\u00e9diane) qui ne provient ni du message ni d'une source l\u00e9gale cit\u00e9e (OPP3, LIFD, LPP, LAVS, LFLP), encadre-le explicitement comme \u00ab ordre de grandeur \u00bb et n'avance jamais une valeur exacte sans la qualifier.",
         "- Quand tu cites un plafond, taux ou bar\u00e8me suisse provenant d'une source l\u00e9gale (OPP3, LIFD, LPP, LAVS, LFLP), reproduis la valeur exactement et int\u00e8gre la r\u00e9f\u00e9rence l\u00e9gale verbatim (ex : \u00ab OPP3 art. 7 \u00bb, \u00ab LIFD art. 33 \u00bb) dans la m\u00eame phrase, juste apr\u00e8s le chiffre.",
         "- Ne reproduis jamais textuellement un IBAN, un num\u00e9ro AVS ou un montant exact que la personne aurait \u00e9crit \u2014 paraphrase-le.",
+        "- Ne conclus jamais qu'une suppression, une r\u00e9initialisation ou un nouveau d\u00e9part a eu lieu. Tu ne peux pas confirmer l'\u00e9tat local de l'app depuis cette conversation.",
+        "- Si la personne demande si des informations ont \u00e9t\u00e9 effac\u00e9es ou conserv\u00e9es, dis que seule l'app peut le confirmer, puis propose de continuer \u00e0 partir de ce qu'elle \u00e9crit maintenant.",
+        "- \u00c9vite ces formulations sur l'\u00e9tat local : \u00ab je repars de z\u00e9ro \u00bb, \u00ab aucune donn\u00e9e \u00bb, \u00ab sans trace \u00bb, \u00ab feuille blanche \u00bb.",
         "- Maximum 1 question de relance \u00e0 la fin.",
         "- Jamais de recommandation de produit sp\u00e9cifique.",
         "- Jamais de promesse de rendement ni de certitude sur les r\u00e9sultats.",
@@ -412,6 +475,7 @@ class _NoRagOrchestrator:
         # Compliance filter (banned-term sanitization, accent normalization,
         # disclaimer injection). Same gate as before but applied to the
         # grounded text from the tool-use loop.
+        final_text = _guard_anonymous_state_claims(final_text, language)
         filtered = guardrails.filter_response(final_text, language)
 
         tokens_used = tokens_total if tokens_total > 0 else len(question) // 4

--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -137,6 +137,10 @@ def _apple_allowed_audiences() -> list[str]:
     return audiences
 
 
+def _apple_signing_key_for_token(identity_token: str):
+    return _APPLE_JWKS_CLIENT.get_signing_key_from_jwt(identity_token).key
+
+
 def _email_verification_required() -> bool:
     raw = os.getenv("AUTH_REQUIRE_EMAIL_VERIFICATION")
     if raw is not None:
@@ -1283,12 +1287,10 @@ def _verify_apple_identity_token(
         )
 
     try:
-        signing_key = _APPLE_JWKS_CLIENT.get_signing_key_from_jwt(
-            identity_token,
-        )
+        signing_key = _apple_signing_key_for_token(identity_token)
         payload = jwt.decode(
             identity_token,
-            signing_key.key,
+            signing_key,
             algorithms=["RS256"],
             audience=_apple_allowed_audiences(),
             issuer="https://appleid.apple.com",

--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -126,6 +126,17 @@ def _request_ip(request: Request) -> Optional[str]:
     return request.client.host if request.client else None
 
 
+def _apple_allowed_audiences() -> list[str]:
+    raw = os.getenv("APPLE_SIGN_IN_AUDIENCE", settings.APPLE_SIGN_IN_AUDIENCE)
+    audiences = [audience.strip() for audience in raw.split(",") if audience.strip()]
+    if not audiences:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Apple Sign-In audience not configured",
+        )
+    return audiences
+
+
 def _email_verification_required() -> bool:
     raw = os.getenv("AUTH_REQUIRE_EMAIL_VERIFICATION")
     if raw is not None:
@@ -1279,7 +1290,7 @@ def _verify_apple_identity_token(
             identity_token,
             signing_key.key,
             algorithms=["RS256"],
-            audience=settings.APPLE_SIGN_IN_AUDIENCE,
+            audience=_apple_allowed_audiences(),
             issuer="https://appleid.apple.com",
             options={"require": ["exp", "iat", "iss", "aud", "sub"]},
         )

--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -4,17 +4,19 @@ Authentication endpoints - register, login, and user info.
 
 from uuid import uuid4
 from datetime import datetime, timezone, date, timedelta
-from typing import Any, Optional
+from typing import Optional
 import hashlib
 import os
 import logging
 import csv
 import io
 import jwt
+from jwt import PyJWKClient
 from fastapi import APIRouter, HTTPException, Depends, Request, status
 from fastapi import Query
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import StreamingResponse
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.core.auth import require_current_user
@@ -96,10 +98,11 @@ from app.services.auth_admin_service import (
     build_onboarding_quality_cohorts,
 )
 
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+_APPLE_JWKS_CLIENT = PyJWKClient(APPLE_JWKS_URL)
+
 router = APIRouter()
 logger = logging.getLogger(__name__)
-APPLE_IDENTITY_ISSUER = "https://appleid.apple.com"
-APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
 
 
 def log_audit_event(*args, **kwargs) -> None:
@@ -121,86 +124,6 @@ def _request_ip(request: Request) -> Optional[str]:
         # Use RIGHTMOST IP — closest to the server, hardest to spoof
         return forwarded.split(",")[-1].strip()
     return request.client.host if request.client else None
-
-
-def _apple_allowed_audiences() -> list[str]:
-    raw = os.getenv("APPLE_SIGN_IN_AUDIENCE", settings.APPLE_SIGN_IN_AUDIENCE)
-    audiences = [audience.strip() for audience in raw.split(",") if audience.strip()]
-    if not audiences:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Apple Sign-In audience not configured",
-        )
-    return audiences
-
-
-def _apple_signing_key_for_token(identity_token: str) -> Any:
-    return jwt.PyJWKClient(APPLE_JWKS_URL).get_signing_key_from_jwt(
-        identity_token
-    ).key
-
-
-def _verify_apple_identity_token(
-    identity_token: str,
-    raw_nonce: Optional[str],
-) -> dict[str, Any]:
-    if not raw_nonce:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Apple nonce required",
-        )
-
-    try:
-        header = jwt.get_unverified_header(identity_token)
-    except jwt.InvalidTokenError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid Apple identity token format",
-        )
-
-    if header.get("alg") != "RS256" or not header.get("kid"):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Apple identity token header",
-        )
-
-    try:
-        claims = jwt.decode(
-            identity_token,
-            _apple_signing_key_for_token(identity_token),
-            algorithms=["RS256"],
-            audience=_apple_allowed_audiences(),
-            issuer=APPLE_IDENTITY_ISSUER,
-        )
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Apple identity token expired",
-        )
-    except jwt.InvalidIssuerError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Apple token issuer",
-        )
-    except jwt.InvalidAudienceError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Apple token audience",
-        )
-    except (jwt.PyJWKClientError, jwt.InvalidTokenError):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Apple identity token",
-        )
-
-    expected_nonce = hashlib.sha256(raw_nonce.encode("utf-8")).hexdigest()
-    if claims.get("nonce") != expected_nonce:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Apple nonce",
-        )
-
-    return claims
 
 
 def _email_verification_required() -> bool:
@@ -1324,6 +1247,68 @@ def magic_link_verify(
 # Apple Sign-In Authentication
 # ---------------------------------------------------------------------------
 
+def _verify_apple_identity_token(
+    identity_token: str,
+    nonce: Optional[str],
+) -> dict:
+    if nonce is None or not nonce.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Apple identity token nonce required",
+        )
+
+    try:
+        header = jwt.get_unverified_header(identity_token)
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Apple identity token format",
+        )
+
+    if header.get("alg") != "RS256" or not header.get("kid"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Apple identity token signature",
+        )
+
+    try:
+        signing_key = _APPLE_JWKS_CLIENT.get_signing_key_from_jwt(
+            identity_token,
+        )
+        payload = jwt.decode(
+            identity_token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=settings.APPLE_SIGN_IN_AUDIENCE,
+            issuer="https://appleid.apple.com",
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Apple identity token expired",
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Apple identity token",
+        )
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Apple identity verification unavailable",
+        )
+
+    expected_nonce = hashlib.sha256(nonce.encode("utf-8")).hexdigest()
+    if payload.get("nonce") != expected_nonce:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Apple identity token nonce",
+        )
+
+    return payload
+
+
 @router.post("/apple/verify", response_model=AppleVerifyResponse)
 @limiter.limit("5/minute")
 def apple_verify(
@@ -1351,16 +1336,25 @@ def apple_verify(
             detail="Apple identity token missing subject",
         )
 
-    # Find or create user by email (or Apple sub as fallback identifier)
-    user = None
-    if apple_email:
+    # Find by Apple's stable subject first. Relay email can change.
+    user = db.query(User).filter(User.apple_sub == apple_sub).first()
+    if user is None and apple_email:
         user = db.query(User).filter(User.email == apple_email).first()
+        if user is not None:
+            if user.apple_sub is None:
+                user.apple_sub = apple_sub
+            elif user.apple_sub != apple_sub:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Apple email is already linked to another account",
+                )
 
     if user is None:
         # Auto-create user (frictionless onboarding, same pattern as magic link)
         user = User(
             id=str(uuid4()),
             email=apple_email or f"apple_{apple_sub}@privaterelay.appleid.com",
+            apple_sub=apple_sub,
             hashed_password="",  # No password for Apple Sign-In users
             email_verified=True,  # Apple verifies email
             created_at=datetime.now(timezone.utc),
@@ -1370,9 +1364,6 @@ def apple_verify(
         # P0 FIX: same as /register — materialise an empty profile so the
         # user is not stuck with a 404 on /profiles/me post Apple Sign-In.
         _ensure_empty_profile(db, user.id)
-
-    # Create JWT
-    access_token = create_access_token(user.id, user.email)
 
     log_audit_event(
         db,
@@ -1384,7 +1375,31 @@ def apple_verify(
         ip_address=_request_ip(request),
         user_agent=request.headers.get("user-agent"),
     )
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        user = db.query(User).filter(User.apple_sub == apple_sub).first()
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Apple account conflict",
+            )
+        log_audit_event(
+            db,
+            event_type="auth.apple_verify",
+            status="success",
+            source="api",
+            user_id=user.id,
+            actor_email=user.email,
+            ip_address=_request_ip(request),
+            user_agent=request.headers.get("user-agent"),
+        )
+        db.commit()
+
+    # Create JWT after commit so racing first-time Apple sign-ins reuse the
+    # persisted winner instead of returning a failed transient user.
+    access_token = create_access_token(user.id, user.email)
 
     return AppleVerifyResponse(
         access_token=access_token,

--- a/services/backend/app/models/user.py
+++ b/services/backend/app/models/user.py
@@ -15,6 +15,7 @@ class User(Base):
 
     id = Column(String, primary_key=True, default=lambda: str(uuid4()))
     email = Column(String, unique=True, nullable=False, index=True)
+    apple_sub = Column(String, unique=True, nullable=True, index=True)
     hashed_password = Column(String, nullable=False)
     display_name = Column(String, nullable=True)
     email_verified = Column(Boolean, nullable=False, default=False)

--- a/services/backend/tests/fixtures/test_pg_fixture_self.py
+++ b/services/backend/tests/fixtures/test_pg_fixture_self.py
@@ -58,6 +58,9 @@ def test_pg_fixture_spins_postgres_and_alembic_upgrade_head_idempotent(pg_engine
     #   (g) Phase 02 event substrate idempotency applied :
     #       {p120_fact_event_idempotency} (canonical post-2026-06-02
     #       CJT-013 local substrate hardening).
+    #   (h) Apple subject binding applied :
+    #       {p124_user_apple_sub} (canonical post-2026-06 account lifecycle
+    #       integration).
     expected_heads = {
         "p112_audit_event_user_hash",
         "p86_eclairage_delivered",
@@ -66,6 +69,7 @@ def test_pg_fixture_spins_postgres_and_alembic_upgrade_head_idempotent(pg_engine
         "p122_orm_orphan_safety_net",
         "p123_waitlist_entry",
         "p120_fact_event_idempotency",
+        "p124_user_apple_sub",
     }
     assert heads_in_db & expected_heads, (
         f"alembic_version table missing expected heads. "

--- a/services/backend/tests/test_anonymous_chat.py
+++ b/services/backend/tests/test_anonymous_chat.py
@@ -230,6 +230,79 @@ def test_discovery_prompt_no_tool_references():
         assert banned not in prompt_lower, f"Discovery prompt must not contain '{banned}'"
 
 
+def test_discovery_prompt_forbids_state_confirmation_claims():
+    """Anonymous discovery must not confirm deletion/reset state from LLM text."""
+    from app.api.v1.endpoints.anonymous_chat import build_discovery_system_prompt
+
+    prompt = build_discovery_system_prompt(intent=None, language="fr")
+    prompt_lower = prompt.lower()
+    assert "suppression" in prompt_lower
+    assert "réinitialisation" in prompt_lower
+    assert "seule l'app peut le confirmer" in prompt_lower
+    assert "je repars de zéro" in prompt_lower
+    assert "sans trace" in prompt_lower
+
+
+def test_anonymous_state_claim_guard_rewrites_privacy_claims():
+    """Runtime guard rewrites unsafe deletion/privacy claims if the LLM ignores the prompt."""
+    from app.api.v1.endpoints.anonymous_chat import _guard_anonymous_state_claims
+
+    unsafe = (
+        "Oui, je repars vraiment de zéro. Je n'ai plus accès à aucune donnée. "
+        "Tu peux tester sans laisser de trace."
+    )
+    guarded = _guard_anonymous_state_claims(unsafe, language="fr")
+
+    assert guarded != unsafe
+    assert "Je ne peux pas confirmer" in guarded
+    guarded_lower = guarded.lower()
+    assert "repars" not in guarded_lower
+    assert "aucune donnée" not in guarded_lower
+    assert "sans laisser de trace" not in guarded_lower
+
+    blank_slate = "En gros, on repart d'une feuille blanche."
+    assert _guard_anonymous_state_claims(blank_slate, language="fr") != blank_slate
+
+    natural_claims = [
+        "Aucune donnée n'a été conservée.",
+        "Ton historique est effacé.",
+        "Tes informations locales ont été supprimées.",
+    ]
+    for claim in natural_claims:
+        assert _guard_anonymous_state_claims(claim, language="fr") != claim
+
+
+def test_anonymous_state_claim_guard_allows_legitimate_financial_caveats():
+    """Guard must not replace normal caveats or financial uses of similar words."""
+    from app.api.v1.endpoints.anonymous_chat import _guard_anonymous_state_claims
+
+    allowed = [
+        "Je n'ai aucune donnée sur ton salaire, peux-tu me le préciser ?",
+        "Il n'existe aucune donnée officielle sur ce taux.",
+        "La suppression d'une déduction LPP réduit ton assiette fiscale.",
+        "L'effacement de dettes peut être une procédure encadrée.",
+        "Ce virement a été effectué sans trace de commission dans les livres.",
+        "Je te propose de partir sur une feuille blanche pour ton plan d'épargne.",
+    ]
+
+    for text in allowed:
+        assert _guard_anonymous_state_claims(text, language="fr") == text
+
+
+def test_anonymous_state_claim_guard_rewrites_english_privacy_claims():
+    """English state claims are guarded too."""
+    from app.api.v1.endpoints.anonymous_chat import _guard_anonymous_state_claims
+
+    unsafe = "You are starting fresh with no data left and no trace remains."
+    guarded = _guard_anonymous_state_claims(unsafe, language="en")
+
+    assert guarded != unsafe
+    assert "I cannot confirm" in guarded
+    guarded_lower = guarded.lower()
+    assert "no data left" not in guarded_lower
+    assert "no trace remains" not in guarded_lower
+
+
 # ---------------------------------------------------------------------------
 # Test 9: Intent field is optional; when provided, included in prompt
 # ---------------------------------------------------------------------------

--- a/services/backend/tests/test_auth.py
+++ b/services/backend/tests/test_auth.py
@@ -1323,11 +1323,13 @@ def _signed_apple_token(
     email: str = "apple-valid@example.com",
 ) -> str:
     nonce_hash = hashlib.sha256(raw_nonce.encode()).hexdigest()
+    issued_at = int(time.time())
     return jwt.encode(
         {
             "iss": "https://appleid.apple.com",
             "aud": audience,
-            "exp": int(time.time()) + 600,
+            "exp": issued_at + 600,
+            "iat": issued_at,
             "sub": f"apple-sub-{email}",
             "email": email,
             "nonce": nonce_hash,

--- a/services/backend/tests/test_auth_apple.py
+++ b/services/backend/tests/test_auth_apple.py
@@ -1,0 +1,215 @@
+"""Apple Sign-In auth contract tests."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import auth as auth_endpoint
+from app.core.auth import get_current_user, require_current_user
+from app.main import app
+
+
+def _b64url_json(payload: dict[str, object]) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _forged_apple_identity_token() -> str:
+    header = _b64url_json({"alg": "none", "kid": "forged"})
+    payload = _b64url_json(
+        {
+            "iss": "https://appleid.apple.com",
+            "aud": "ch.mint.app",
+            "exp": int(time.time()) + 3600,
+            "iat": int(time.time()),
+            "sub": "001999.forged-apple-sub",
+            "email": "forged-apple@example.invalid",
+        }
+    )
+    return f"{header}.{payload}.forged-signature"
+
+
+def test_apple_verify_rejects_forged_identity_token(client: TestClient):
+    """Unsigned Apple-shaped JWTs must not create or restore Mint accounts."""
+    app.dependency_overrides.pop(require_current_user, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+    response = client.post(
+        "/api/v1/auth/apple/verify",
+        json={
+            "identity_token": _forged_apple_identity_token(),
+            "nonce": "plain-nonce-from-client",
+        },
+    )
+
+    assert response.status_code in {400, 401}
+
+
+class _FakeAppleSigningKey:
+    key = object()
+
+
+def _patch_valid_apple_header_and_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auth_endpoint.jwt,
+        "get_unverified_header",
+        lambda identity_token: {"alg": "RS256", "kid": "apple-key"},
+    )
+    monkeypatch.setattr(
+        auth_endpoint._APPLE_JWKS_CLIENT,
+        "get_signing_key_from_jwt",
+        lambda identity_token: _FakeAppleSigningKey(),
+    )
+
+
+def test_verify_apple_identity_token_requires_nonce():
+    with pytest.raises(auth_endpoint.HTTPException) as exc_info:
+        auth_endpoint._verify_apple_identity_token("signed-token", "")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_verify_apple_identity_token_requires_non_null_nonce():
+    with pytest.raises(auth_endpoint.HTTPException) as exc_info:
+        auth_endpoint._verify_apple_identity_token("signed-token", None)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_verify_apple_identity_token_rejects_nonce_mismatch(monkeypatch):
+    _patch_valid_apple_header_and_key(monkeypatch)
+    monkeypatch.setattr(
+        auth_endpoint.jwt,
+        "decode",
+        lambda *args, **kwargs: {
+            "sub": "001999.apple-sub",
+            "nonce": "wrong-nonce-hash",
+        },
+    )
+
+    with pytest.raises(auth_endpoint.HTTPException) as exc_info:
+        auth_endpoint._verify_apple_identity_token("signed-token", "plain-nonce")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_verify_apple_identity_token_rejects_wrong_audience(monkeypatch):
+    _patch_valid_apple_header_and_key(monkeypatch)
+
+    def fake_decode(*args, **kwargs):
+        raise auth_endpoint.jwt.InvalidAudienceError("bad audience")
+
+    monkeypatch.setattr(auth_endpoint.jwt, "decode", fake_decode)
+
+    with pytest.raises(auth_endpoint.HTTPException) as exc_info:
+        auth_endpoint._verify_apple_identity_token("signed-token", "nonce")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_verify_apple_identity_token_returns_503_when_jwks_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        auth_endpoint.jwt,
+        "get_unverified_header",
+        lambda identity_token: {"alg": "RS256", "kid": "apple-key"},
+    )
+    monkeypatch.setattr(
+        auth_endpoint._APPLE_JWKS_CLIENT,
+        "get_signing_key_from_jwt",
+        lambda identity_token: (_ for _ in ()).throw(RuntimeError("jwks down")),
+    )
+
+    with pytest.raises(auth_endpoint.HTTPException) as exc_info:
+        auth_endpoint._verify_apple_identity_token("signed-token", "nonce")
+
+    assert exc_info.value.status_code == 503
+
+
+def test_apple_verify_reuses_account_by_stable_sub_when_email_changes(
+    client: TestClient,
+    monkeypatch,
+):
+    """Apple relay email changes must not create a second Mint account."""
+    app.dependency_overrides.pop(require_current_user, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+    payloads = {
+        "first-token": {
+            "sub": "001999.stable-apple-sub",
+            "email": "first-relay@privaterelay.appleid.com",
+        },
+        "second-token": {
+            "sub": "001999.stable-apple-sub",
+            "email": "second-relay@privaterelay.appleid.com",
+        },
+    }
+
+    def fake_verify(identity_token: str, nonce: str | None) -> dict[str, str]:
+        return payloads[identity_token]
+
+    monkeypatch.setattr(
+        auth_endpoint,
+        "_verify_apple_identity_token",
+        fake_verify,
+    )
+
+    first = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "first-token", "nonce": "nonce"},
+    )
+    second = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "second-token", "nonce": "nonce"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["userId"] == first.json()["userId"]
+
+
+def test_apple_verify_rejects_email_already_linked_to_different_sub(
+    client: TestClient,
+    monkeypatch,
+):
+    """A reused relay email must not let a different Apple sub into an account."""
+    app.dependency_overrides.pop(require_current_user, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+    payloads = {
+        "first-token": {
+            "sub": "001999.original-apple-sub",
+            "email": "shared-relay@privaterelay.appleid.com",
+        },
+        "second-token": {
+            "sub": "001999.other-apple-sub",
+            "email": "shared-relay@privaterelay.appleid.com",
+        },
+    }
+
+    def fake_verify(identity_token: str, nonce: str | None) -> dict[str, str]:
+        return payloads[identity_token]
+
+    monkeypatch.setattr(
+        auth_endpoint,
+        "_verify_apple_identity_token",
+        fake_verify,
+    )
+
+    first = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "first-token", "nonce": "nonce"},
+    )
+    second = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "second-token", "nonce": "nonce"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409

--- a/services/backend/tests/test_auth_apple.py
+++ b/services/backend/tests/test_auth_apple.py
@@ -98,6 +98,31 @@ def test_verify_apple_identity_token_rejects_nonce_mismatch(monkeypatch):
     assert exc_info.value.status_code == 401
 
 
+def test_verify_apple_identity_token_accepts_configured_audience_list(monkeypatch):
+    _patch_valid_apple_header_and_key(monkeypatch)
+    captured = {}
+    expected_nonce = auth_endpoint.hashlib.sha256(b"plain-nonce").hexdigest()
+
+    monkeypatch.setenv("APPLE_SIGN_IN_AUDIENCE", "ch.mint.dev, ch.mint.app")
+
+    def fake_decode(*args, **kwargs):
+        captured["audience"] = kwargs["audience"]
+        return {
+            "sub": "001999.apple-sub",
+            "nonce": expected_nonce,
+        }
+
+    monkeypatch.setattr(auth_endpoint.jwt, "decode", fake_decode)
+
+    payload = auth_endpoint._verify_apple_identity_token(
+        "signed-token",
+        "plain-nonce",
+    )
+
+    assert payload["sub"] == "001999.apple-sub"
+    assert captured["audience"] == ["ch.mint.dev", "ch.mint.app"]
+
+
 def test_verify_apple_identity_token_rejects_wrong_audience(monkeypatch):
     _patch_valid_apple_header_and_key(monkeypatch)
 

--- a/tools/simulator/flows/maestro-perfect-set/flow_landing_to_register.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_landing_to_register.yaml
@@ -29,7 +29,7 @@
 # Semantic locators ONLY :
 #   - landing hero    : `Voir clair, décider seul.` (l10n.landingV3Hero)
 #   - landing CTA     : `id: landing_talk_to_mint_cta`
-#   - onboarding title : `Il est temps que tu comprennes.`
+#   - onboarding title : `Un premier aperçu suisse.`
 #
 # IMPORTANT — the retired anonymous chat opener text and input placeholder
 # are asserted absent so this gate catches accidental resurrection of that
@@ -66,7 +66,7 @@ tags:
     id: "landing_talk_to_mint_cta"
 - extendedWaitUntil:
     visible:
-      text: "Il est temps que tu comprennes."
+      text: "Un premier aperçu suisse."
     timeout: 6000
 - assertNotVisible:
     text: ".*Dis-moi ce qui te trotte.*"

--- a/tools/simulator/flows/maestro-perfect-set/flow_landing_to_register.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_landing_to_register.yaml
@@ -1,12 +1,12 @@
 # tools/simulator/flows/maestro-perfect-set/flow_landing_to_register.yaml
 #
 # ─── PURPOSE ───────────────────────────────────────────────────────────
-# Validates the anon-to-register happy-path funnel :
-#   landing → "Parle à Mint" → anonymous chat → "Créer un compte" →
-#   /auth/register screen visible.
+# Validates the first-experience entry funnel after the anonymous chat
+# cold-open retirement:
+#   landing → "Parle à Mint" → onboarding entry.
 #
-# This is the canonical conversion path. Any locator drift here breaks
-# the anon-funnel acquisition metric, so Maestro green is a release gate.
+# This is the canonical first screen path. The old anonymous chat opener
+# must not be visible here.
 #
 # ─── ARCHETYPE SCOPE ───────────────────────────────────────────────────
 # Archetype-agnostic. Reads literal FR strings from app_fr.arb so it
@@ -14,8 +14,8 @@
 # éclairage kind pipeline (that's flows/julien_swiss.yaml).
 #
 # ─── EXPECTED DURATION ─────────────────────────────────────────────────
-# < 25s wall-clock on iPhone 17 Pro sim (cold launch + 4 taps + register
-# screen render + 4 screenshots).
+# < 15s wall-clock on iPhone 17 Pro sim (cold launch + tap + onboarding
+# entry render + screenshots).
 #
 # ─── PRE-CONDITION ─────────────────────────────────────────────────────
 # - App installed on booted iPhone 17 Pro sim with bundle id ch.mint.app
@@ -28,39 +28,27 @@
 # ─── LOCATOR STRATEGY ──────────────────────────────────────────────────
 # Semantic locators ONLY :
 #   - landing hero    : `Voir clair, décider seul.` (l10n.landingV3Hero)
-#   - landing CTA     : `Parle à Mint` (l10n.landingV2CtaSober)
-#   - anon input hint : `Écris ce qui te trotte en tête…` (l10n.anonymousChatInputHint)
-#   - anon LSFin line : `Information générale, pas un conseil financier personnalisé.`
-#                       (l10n.anonymousChatLsfinDisclaimer)
-#   - register CTA    : `Créer un compte` (l10n.anonymousChatCreateAccount)
-#                       — visible AFTER auth-gate triggers (3 messages
-#                       sent OR _isAuthGateLocked=true). For pure happy-
-#                       path we exit via login link instead, see below.
-#   - register screen : `Créer ton compte` (l10n.authRegisterTitle)
-#                       OR `Adresse e-mail` (l10n.authEmail)
+#   - landing CTA     : `id: landing_talk_to_mint_cta`
+#   - onboarding title : `Il est temps que tu comprennes.`
 #
-# IMPORTANT — `anon-chat-opener-bubble` / `anon-chat-input` /
-# `anon-chat-register-cta` ValueKeys referenced in flows/julien_swiss.yaml
-# DO NOT EXIST in the Flutter source (verified 2026-05-08 grep on
-# apps/mobile/lib/). This flow uses text-based locators that are present
-# in the codebase to avoid the same drift.
+# IMPORTANT — the retired anonymous chat opener text and input placeholder
+# are asserted absent so this gate catches accidental resurrection of that
+# screen.
 #
 # ─── OUTPUT ────────────────────────────────────────────────────────────
 # Screenshots written to maestro's --output-dir (set by harness, never
 # /tmp). Convention :
-#   .planning/walker/maestro-flows/landing-to-register/<run-id>/
+#   .planning/walker/maestro-flows/landing-to-onboarding/<run-id>/
 #     ├── 01-landing.png
-#     ├── 02-anon-chat-opener.png
-#     ├── 03-message-sent.png
-#     └── 04-register-screen.png
+#     └── 02-onboarding-entry.png
 
 appId: ch.mint.app
 tags:
   - acquisition
   - funnel
-  - anon
-  - register
-  - happy-path
+  - onboarding
+  - first-experience
+  - runtime-gate
 ---
 
 # 01 — cold launch landing visible
@@ -68,80 +56,22 @@ tags:
     clearState: false   # do NOT wipe state ; preserves dart-defines
 - extendedWaitUntil:
     visible:
-      text: "Parle à Mint"
+      id: "landing_talk_to_mint_cta"
     timeout: 8000
+- waitForAnimationToEnd
 - takeScreenshot: "01-landing"
 
-# 02 — tap landing CTA → anonymous chat opener
+# 02 — tap landing CTA → onboarding entry
 - tapOn:
-    text: "Parle à Mint"
+    id: "landing_talk_to_mint_cta"
 - extendedWaitUntil:
     visible:
-      text: "Écris ce qui te trotte en tête…"
+      text: "Il est temps que tu comprennes."
     timeout: 6000
-# LSFin disclaimer must be visible per anonymous_chat_screen.dart §1.4
-- assertVisible:
+- assertNotVisible:
+    text: ".*Dis-moi ce qui te trotte.*"
+- assertNotVisible:
+    text: "Écris ce qui te trotte en tête…"
+- assertNotVisible:
     text: "Information générale, pas un conseil financier personnalisé."
-- takeScreenshot: "02-anon-chat-opener"
-
-# 03 — send 3 messages. The anonymous funnel opens the auth gate only
-# after the third coach response (`messagesRemaining == 0`), then shows
-# an AuthGateBottomSheet with the register CTA.
-- tapOn:
-    text: "Écris ce qui te trotte en tête…"
-- inputText: "J'aimerais comprendre comment optimiser mon 3e pilier"
-- pressKey: Enter
-- extendedWaitUntil:
-    visible:
-      text: "Écris ce qui te trotte en tête…"
-    timeout: 60000
-- tapOn:
-    text: "Écris ce qui te trotte en tête…"
-- inputText: "Et concrètement, combien je peux mettre cette année ?"
-- pressKey: Enter
-- extendedWaitUntil:
-    visible:
-      text: "Écris ce qui te trotte en tête…"
-    timeout: 60000
-- tapOn:
-    text: "Écris ce qui te trotte en tête…"
-- inputText: "Et si je change d'employeur ?"
-- pressKey: Enter
-- takeScreenshot: "03-message-sent"
-
-# 04 — auth gate bottom sheet visible.
-- extendedWaitUntil:
-    visible:
-      text: ".*(Je peux garder tout.*en mémoire|Je suis toujours là).*"
-    timeout: 30000
-- runFlow:
-    when:
-      visible:
-        text: ".*Je suis toujours là.*"
-    commands:
-      - assertVisible:
-          text: "Créer un compte"
-      - tapOn:
-          text: "Créer un compte"
-      - extendedWaitUntil:
-          visible:
-            text: ".*Je peux garder tout.*en mémoire.*"
-          timeout: 8000
-
-# 05 — tap register CTA → /auth/register
-- tapOn:
-    text: "Créer un compte"
-- runFlow:
-    when:
-      visible:
-        text: "Connexion"
-    commands:
-      - tapOn:
-          text: "Créer un compte"
-- extendedWaitUntil:
-    visible:
-      text: "Créer ton compte"
-    timeout: 6000
-- assertVisible:
-    text: "Adresse e-mail"
-- takeScreenshot: "04-register-screen"
+- takeScreenshot: "02-onboarding-entry"


### PR DESCRIPTION
## Summary
- Replays PR #723 onto current `origin/staging` in a clean worktree.
- Preserves the account lifecycle, Apple-sub binding, anonymous conversation isolation, incomplete financial value gating, and retired anonymous chat public entry doctrine.
- Adds post-review fixes for magic-link lifecycle state, multiple Apple Sign-In audiences, and stale landing l10n metadata.

## Verification
- `flutter test` targeted A/B/C/landing/routes suite: 242 passed, 2 skipped goldens.
- `flutter analyze`
- `flutter gen-l10n`
- ARB parity MCP: 6 locales, 6936 keys each.
- `./tools/mint-routes check`
- `pytest tests/test_auth_apple.py tests/test_anonymous_chat.py -q`: 25 passed.
- `ruff check app/api/v1/endpoints/auth.py tests/test_auth_apple.py tests/test_anonymous_chat.py`
- `flutter build ios --simulator --debug --dart-define=MINT_DISABLE_BETA_MODAL=true`
- Maestro iPhone 13 mini RvC `flow_landing_to_register.yaml`: passed on HEAD `abdc7d2e4`.
- Review Agent: GO, no Critical/Important blockers.

## Notes
- This supersedes the direct #723 branch for staging integration; no force-push to `staging` was used.
- Runtime artifacts under `.planning/_walker/*` stayed untracked and are not part of this PR.