### PR TITLE
fix(mobile): expose account deletion in profile drawer

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Vervollständige dein Profil, um deine Zahlen zu sehen",
   "profileLanguageTitle": "Sprache",
   "profileAdminObservability": "Admin Observability",
-  "profileDeleteCloudAccount": "Mein Cloud-Konto löschen",
+  "profileDeleteCloudAccount": "Mein Konto löschen",
   "dashboardGoalRetirement": "Pensionierung",
   "dashboardAppBarWithName": "Pensionierung · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2416,7 +2416,7 @@
   "profileFamilySection": "Familie",
   "profileAnalyticsBeta": "Analytics Beta-Tester",
   "profileDeleteAccountTitle": "Konto löschen?",
-  "profileDeleteAccountContent": "Diese Aktion löscht dein Cloud-Konto und die zugehörigen Daten. Deine lokalen Daten bleiben auf diesem Gerät.",
+  "profileDeleteAccountContent": "Dadurch werden dein MINT-Konto und die zugehörigen Daten von unseren Servern gelöscht. Lokale Daten auf diesem Gerät werden ebenfalls gelöscht.",
   "profileDeleteCancel": "Abbrechen",
   "profileDeleteConfirm": "Löschen",
   "consentAllRevoked": "Alle optionalen Einwilligungen wurden widerrufen.",

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Complete your profile to see your numbers",
   "profileLanguageTitle": "Language",
   "profileAdminObservability": "Admin observability",
-  "profileDeleteCloudAccount": "Delete my cloud account",
+  "profileDeleteCloudAccount": "Delete my account",
   "dashboardGoalRetirement": "Retirement",
   "dashboardAppBarWithName": "Retirement · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2416,7 +2416,7 @@
   "profileFamilySection": "Family",
   "profileAnalyticsBeta": "Analytics beta testers",
   "profileDeleteAccountTitle": "Delete account?",
-  "profileDeleteAccountContent": "This action deletes your cloud account and associated data. Your local data remains on this device.",
+  "profileDeleteAccountContent": "This will delete your MINT account and the associated data from our servers. Local data on this device will also be erased.",
   "profileDeleteCancel": "Cancel",
   "profileDeleteConfirm": "Delete",
   "consentAllRevoked": "All optional consents have been revoked.",

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Completa tu perfil para ver tus cifras",
   "profileLanguageTitle": "Idioma",
   "profileAdminObservability": "Admin observability",
-  "profileDeleteCloudAccount": "Eliminar mi cuenta en la nube",
+  "profileDeleteCloudAccount": "Eliminar mi cuenta",
   "dashboardGoalRetirement": "Jubilación",
   "dashboardAppBarWithName": "Jubilación · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2416,7 +2416,7 @@
   "profileFamilySection": "Familia",
   "profileAnalyticsBeta": "Analytics beta testers",
   "profileDeleteAccountTitle": "¿Eliminar cuenta?",
-  "profileDeleteAccountContent": "Esta acción elimina tu cuenta en la nube y los datos asociados. Tus datos locales permanecen en este dispositivo.",
+  "profileDeleteAccountContent": "Esto eliminará tu cuenta MINT y los datos asociados de nuestros servidores. Los datos locales de este dispositivo también se borrarán.",
   "profileDeleteCancel": "Cancelar",
   "profileDeleteConfirm": "Eliminar",
   "consentAllRevoked": "Todos los consentimientos opcionales han sido revocados.",

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Complète ton profil pour voir tes chiffres",
   "profileLanguageTitle": "Langue",
   "profileAdminObservability": "Admin observability",
-  "profileDeleteCloudAccount": "Supprimer mon compte cloud",
+  "profileDeleteCloudAccount": "Supprimer mon compte",
   "dashboardGoalRetirement": "Retraite",
   "dashboardAppBarWithName": "Retraite · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2434,7 +2434,7 @@
   "profileFamilySection": "Famille",
   "profileAnalyticsBeta": "Analytics beta testeurs",
   "profileDeleteAccountTitle": "Supprimer le compte ?",
-  "profileDeleteAccountContent": "Cette action supprime ton compte cloud et les données associées. Tes données locales restent sur cet appareil.",
+  "profileDeleteAccountContent": "Cette action supprime ton compte MINT et les données associées de nos serveurs. Les données locales de cet appareil seront aussi effacées.",
   "profileDeleteCancel": "Annuler",
   "profileDeleteConfirm": "Supprimer",
   "consentAllRevoked": "Tous les consentements optionnels ont été révoqués.",

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Completa il tuo profilo per vedere i tuoi numeri",
   "profileLanguageTitle": "Lingua",
   "profileAdminObservability": "Admin observability",
-  "profileDeleteCloudAccount": "Elimina il mio account cloud",
+  "profileDeleteCloudAccount": "Elimina il mio account",
   "dashboardGoalRetirement": "Pensionamento",
   "dashboardAppBarWithName": "Pensionamento · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2416,7 +2416,7 @@
   "profileFamilySection": "Famiglia",
   "profileAnalyticsBeta": "Analytics beta tester",
   "profileDeleteAccountTitle": "Eliminare l'account?",
-  "profileDeleteAccountContent": "Questa azione elimina il tuo account cloud e i dati associati. I tuoi dati locali restano su questo dispositivo.",
+  "profileDeleteAccountContent": "Questa azione eliminerà il tuo account MINT e i dati associati dai nostri server. Anche i dati locali su questo dispositivo saranno eliminati.",
   "profileDeleteCancel": "Annulla",
   "profileDeleteConfirm": "Elimina",
   "consentAllRevoked": "Tutti i consensi opzionali sono stati revocati.",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -2994,7 +2994,7 @@ abstract class S {
   /// No description provided for @profileDeleteCloudAccount.
   ///
   /// In fr, this message translates to:
-  /// **'Supprimer mon compte cloud'**
+  /// **'Supprimer mon compte'**
   String get profileDeleteCloudAccount;
 
   /// No description provided for @dashboardGoalRetirement.
@@ -9319,7 +9319,7 @@ abstract class S {
   /// No description provided for @profileDeleteAccountContent.
   ///
   /// In fr, this message translates to:
-  /// **'Cette action supprime ton compte cloud et les données associées. Tes données locales restent sur cet appareil.'**
+  /// **'Cette action supprime ton compte MINT et les données associées de nos serveurs. Les données locales de cet appareil seront aussi effacées.'**
   String get profileDeleteAccountContent;
 
   /// No description provided for @profileDeleteCancel.

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -1606,7 +1606,7 @@ class SDe extends S {
   String get profileAdminObservability => 'Admin Observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Mein Cloud-Konto löschen';
+  String get profileDeleteCloudAccount => 'Mein Konto löschen';
 
   @override
   String get dashboardGoalRetirement => 'Pensionierung';
@@ -5159,7 +5159,7 @@ class SDe extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'Diese Aktion löscht dein Cloud-Konto und die zugehörigen Daten. Deine lokalen Daten bleiben auf diesem Gerät.';
+      'Dadurch werden dein MINT-Konto und die zugehörigen Daten von unseren Servern gelöscht. Lokale Daten auf diesem Gerät werden ebenfalls gelöscht.';
 
   @override
   String get profileDeleteCancel => 'Abbrechen';

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -1590,7 +1590,7 @@ class SEn extends S {
   String get profileAdminObservability => 'Admin observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Delete my cloud account';
+  String get profileDeleteCloudAccount => 'Delete my account';
 
   @override
   String get dashboardGoalRetirement => 'Retirement';
@@ -5115,7 +5115,7 @@ class SEn extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'This action deletes your cloud account and associated data. Your local data remains on this device.';
+      'This will delete your MINT account and the associated data from our servers. Local data on this device will also be erased.';
 
   @override
   String get profileDeleteCancel => 'Cancel';

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -1595,7 +1595,7 @@ class SEs extends S {
   String get profileAdminObservability => 'Admin observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Eliminar mi cuenta en la nube';
+  String get profileDeleteCloudAccount => 'Eliminar mi cuenta';
 
   @override
   String get dashboardGoalRetirement => 'Jubilación';
@@ -5147,7 +5147,7 @@ class SEs extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'Esta acción elimina tu cuenta en la nube y los datos asociados. Tus datos locales permanecen en este dispositivo.';
+      'Esto eliminará tu cuenta MINT y los datos asociados de nuestros servidores. Los datos locales de este dispositivo también se borrarán.';
 
   @override
   String get profileDeleteCancel => 'Cancelar';

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -1599,7 +1599,7 @@ class SFr extends S {
   String get profileAdminObservability => 'Admin observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Supprimer mon compte cloud';
+  String get profileDeleteCloudAccount => 'Supprimer mon compte';
 
   @override
   String get dashboardGoalRetirement => 'Retraite';
@@ -5149,7 +5149,7 @@ class SFr extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'Cette action supprime ton compte cloud et les données associées. Tes données locales restent sur cet appareil.';
+      'Cette action supprime ton compte MINT et les données associées de nos serveurs. Les données locales de cet appareil seront aussi effacées.';
 
   @override
   String get profileDeleteCancel => 'Annuler';

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -1598,7 +1598,7 @@ class SIt extends S {
   String get profileAdminObservability => 'Admin observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Elimina il mio account cloud';
+  String get profileDeleteCloudAccount => 'Elimina il mio account';
 
   @override
   String get dashboardGoalRetirement => 'Pensionamento';
@@ -5157,7 +5157,7 @@ class SIt extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'Questa azione elimina il tuo account cloud e i dati associati. I tuoi dati locali restano su questo dispositivo.';
+      'Questa azione eliminerà il tuo account MINT e i dati associati dai nostri server. Anche i dati locali su questo dispositivo saranno eliminati.';
 
   @override
   String get profileDeleteCancel => 'Annulla';

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -1593,7 +1593,7 @@ class SPt extends S {
   String get profileAdminObservability => 'Admin observability';
 
   @override
-  String get profileDeleteCloudAccount => 'Eliminar a minha conta cloud';
+  String get profileDeleteCloudAccount => 'Eliminar a minha conta';
 
   @override
   String get dashboardGoalRetirement => 'Reforma';
@@ -5145,7 +5145,7 @@ class SPt extends S {
 
   @override
   String get profileDeleteAccountContent =>
-      'Esta ação elimina a tua conta cloud e os dados associados. Os teus dados locais permanecem neste dispositivo.';
+      'Esta ação eliminará a tua conta MINT e os dados associados dos nossos servidores. Os dados locais neste dispositivo também serão eliminados.';
 
   @override
   String get profileDeleteCancel => 'Cancelar';

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -655,7 +655,7 @@
   "profileBilanSubtitleIncomplete": "Completa o teu perfil para ver os teus números",
   "profileLanguageTitle": "Idioma",
   "profileAdminObservability": "Admin observability",
-  "profileDeleteCloudAccount": "Eliminar a minha conta cloud",
+  "profileDeleteCloudAccount": "Eliminar a minha conta",
   "dashboardGoalRetirement": "Reforma",
   "dashboardAppBarWithName": "Reforma · {firstName}",
   "@dashboardAppBarWithName": {
@@ -2416,7 +2416,7 @@
   "profileFamilySection": "Família",
   "profileAnalyticsBeta": "Analytics beta testers",
   "profileDeleteAccountTitle": "Eliminar conta?",
-  "profileDeleteAccountContent": "Esta ação elimina a tua conta cloud e os dados associados. Os teus dados locais permanecem neste dispositivo.",
+  "profileDeleteAccountContent": "Esta ação eliminará a tua conta MINT e os dados associados dos nossos servidores. Os dados locais neste dispositivo também serão eliminados.",
   "profileDeleteCancel": "Cancelar",
   "profileDeleteConfirm": "Eliminar",
   "consentAllRevoked": "Todos os consentimentos opcionais foram revogados.",

--- a/apps/mobile/lib/widgets/profile_drawer.dart
+++ b/apps/mobile/lib/widgets/profile_drawer.dart
@@ -133,24 +133,35 @@ class ProfileDrawer extends StatelessWidget {
 
             const SizedBox(height: MintSpacing.xl),
 
-            // ── Connexion / Déconnexion ──
+            // ── Compte ──
             Builder(
               builder: (context) {
                 final auth = context.watch<AuthProvider>();
                 if (auth.isLoggedIn) {
-                  return _buildSection(
-                    context,
-                    icon: Icons.logout_outlined,
-                    title: l10n.drawerLogout,
-                    onTap: () async {
-                      Navigator.of(context).pop();
-                      final authProvider = context.read<AuthProvider>();
-                      await authProvider.logout();
-                      if (context.mounted) {
-                        context.go('/');
-                      }
-                    },
-                    textColor: MintColors.corailDiscret,
+                  return Column(
+                    children: [
+                      _buildSection(
+                        context,
+                        icon: Icons.delete_outline,
+                        title: l10n.profileDeleteCloudAccount,
+                        onTap: () => _confirmDeleteAccount(context, l10n),
+                        textColor: MintColors.error,
+                      ),
+                      _buildSection(
+                        context,
+                        icon: Icons.logout_outlined,
+                        title: l10n.drawerLogout,
+                        onTap: () async {
+                          Navigator.of(context).pop();
+                          final authProvider = context.read<AuthProvider>();
+                          await authProvider.logout();
+                          if (context.mounted) {
+                            context.go('/');
+                          }
+                        },
+                        textColor: MintColors.corailDiscret,
+                      ),
+                    ],
                   );
                 } else {
                   return _buildSection(
@@ -172,6 +183,50 @@ class ProfileDrawer extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _confirmDeleteAccount(BuildContext context, S l10n) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(l10n.profileDeleteAccountTitle),
+          content: Text(l10n.profileDeleteAccountContent),
+          actions: [
+            TextButton(
+              // lint-ignore: prefer_mint_cta
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(l10n.profileDeleteCancel),
+            ),
+            TextButton(
+              // lint-ignore: prefer_mint_cta
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(
+                l10n.profileDeleteConfirm,
+                style: const TextStyle(color: MintColors.error),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldDelete != true || !context.mounted) return;
+
+    final authProvider = context.read<AuthProvider>();
+    final deleted = await authProvider.deleteAccount();
+    if (!context.mounted) return;
+
+    if (deleted) {
+      Navigator.of(context).pop();
+      if (context.mounted) {
+        context.go('/');
+      }
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.profileDeleteAccountError)),
+      );
+    }
   }
 
   Widget _buildProfileHeader(
@@ -207,8 +262,7 @@ class ProfileDrawer extends StatelessWidget {
         children: [
           Text(
             profile.firstName ?? l10n.drawerDefaultName,
-            style:
-                MintTextStyles.headlineMedium(color: MintColors.textPrimary),
+            style: MintTextStyles.headlineMedium(color: MintColors.textPrimary),
           ),
           if (ageDisplay.isNotEmpty || cantonDisplay.isNotEmpty) ...[
             const SizedBox(height: MintSpacing.xs),

--- a/apps/mobile/test/widgets/profile_drawer_test.dart
+++ b/apps/mobile/test/widgets/profile_drawer_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/widgets/profile_drawer.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {
+  @override
+  bool isLoggedIn = true;
+
+  bool deleteAccountCalled = false;
+
+  @override
+  Future<bool> deleteAccount() async {
+    deleteAccountCalled = true;
+    isLoggedIn = false;
+    notifyListeners();
+    return true;
+  }
+
+  @override
+  Future<void> logout() async {
+    isLoggedIn = false;
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _buildDrawerApp({
+  required AuthProvider authProvider,
+  CoachProfileProvider? coachProfileProvider,
+}) {
+  final scaffoldKey = GlobalKey<ScaffoldState>();
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) {
+          return Scaffold(
+            key: scaffoldKey,
+            endDrawer: const ProfileDrawer(),
+            body: Center(
+              child: TextButton(
+                key: const ValueKey('open-profile-drawer'),
+                onPressed: () => scaffoldKey.currentState!.openEndDrawer(),
+                child: const Text('open'),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  );
+
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AuthProvider>.value(value: authProvider),
+      ChangeNotifierProvider<CoachProfileProvider>.value(
+        value: coachProfileProvider ?? CoachProfileProvider(),
+      ),
+    ],
+    child: MaterialApp.router(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      locale: const Locale('fr'),
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  tearDown(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.single.resetPhysicalSize();
+    binding.platformDispatcher.views.single.resetDevicePixelRatio();
+  });
+
+  testWidgets('logged-in drawer exposes account deletion', (tester) async {
+    tester.view.physicalSize = const Size(1170, 2532);
+    tester.view.devicePixelRatio = 3;
+
+    final authProvider = _FakeAuthProvider();
+
+    await tester.pumpWidget(_buildDrawerApp(authProvider: authProvider));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('open-profile-drawer')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Se déconnecter'), findsOneWidget);
+    expect(find.text('Supprimer mon compte'), findsOneWidget);
+  });
+
+  testWidgets('account deletion confirmation calls auth provider',
+      (tester) async {
+    tester.view.physicalSize = const Size(1170, 2532);
+    tester.view.devicePixelRatio = 3;
+
+    final authProvider = _FakeAuthProvider();
+
+    await tester.pumpWidget(_buildDrawerApp(authProvider: authProvider));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('open-profile-drawer')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Supprimer mon compte'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Supprimer le compte ?'), findsOneWidget);
+    expect(find.text('Supprimer'), findsOneWidget);
+
+    await tester.tap(find.text('Supprimer'));
+    await tester.pumpAndSettle();
+
+    expect(authProvider.deleteAccountCalled, isTrue);
+  });
+}


### PR DESCRIPTION
## Context
Physical TestFlight feedback on build 2.12.4 showed that local data deletion is reachable, but account deletion is not reachable from the profile drawer after data wipe.

## Fix
- Expose the existing `AuthProvider.deleteAccount()` flow in `ProfileDrawer` for logged-in users.
- Add a destructive confirmation dialog before deletion.
- Reuse and correct existing `profileDeleteAccount*` localization copy so it states account deletion also clears local data.
- Add a widget test proving the logged-in drawer exposes `Supprimer mon compte` and confirmation calls the auth provider.

## Scope
Mobile UI/l10n only. No backend deletion semantics changed. No claim that physical iPhone, signed TestFlight IPA, iCloud restore, or Apple account lifecycle is fully proven by this PR.

## Verification
- `flutter gen-l10n`
- `dart format apps/mobile/lib/widgets/profile_drawer.dart apps/mobile/test/widgets/profile_drawer_test.dart`
- `flutter test test/widgets/profile_drawer_test.dart test/screens/profile/privacy_control_screen_test.dart`
- `flutter analyze`
- ARB parity: 6 locales OK
- French banned-terms/accent lint clean
- pre-commit hooks green
