### PR TITLE
fix(mobile): align coach gate with salaried LPP cohort

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-06-18",
+  "updated": "2026-06-23",
   "active_milestone": "mint-2-0-first-experience-rente-capital",
   "active_phase_dir": ".planning/phases/mint-2-0-first-experience-rente-capital",
   "active_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md",
@@ -33,6 +33,7 @@
     "feature/S09-mint2-runtime-quality-gate",
     "feature/S09-mint2-quality-gate-xattr-fix",
     "feature/S10-mint2-real-device-restore-gate",
+    "feature/S10-mint2-waitlist-eligibility-gate",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -2097,6 +2097,31 @@ class CoachProfile {
     return FinancialArchetype.expatNonEu;
   }
 
+  /// Current MINT coach calibration cohort.
+  ///
+  /// This is intentionally separate from [archetype]: a null nationality must
+  /// not be silently coerced to `CH`, while the product perimeter is residents
+  /// in Switzerland who are salaried and LPP-covered or salary-eligible.
+  bool get isCoachCalibrationEligible {
+    if (usTaxPerson == true || nationality == 'US') return false;
+    if (normalizeResidencePermit(residencePermit) == 'G') return false;
+
+    if (!resolveCanton(canton).isResolved) return false;
+
+    if (!userProvidedFields.contains('employmentStatus') ||
+        employmentStatus != 'salarie') {
+      return false;
+    }
+
+    final hasLppValue = (prevoyance.avoirLppTotal ?? 0) > 0;
+    final explicitlyNoLpp = userProvidedFields.contains('pensionFundNo');
+    if (explicitlyNoLpp) return false;
+
+    final aboveLppEntryThreshold = userProvidedFields.contains('salary') &&
+        revenuBrutAnnuel >= reg('lpp.entry_threshold', lppSeuilEntree);
+    return hasLppValue || aboveLppEntryThreshold;
+  }
+
   /// Whether the main user can contribute to pillar 3a.
   ///
   /// Returns false for US citizens/green card holders (FATCA — most 3a
@@ -3402,9 +3427,16 @@ class CoachProfile {
       provided.add('age');
     }
     if (answers.containsKey('q_canton')) provided.add('canton');
+    if (answers.containsKey('q_employment_status')) {
+      provided.add('employmentStatus');
+    }
     if (hasExplicitNetIncome || answers.containsKey('q_gross_salary_annual')) {
       provided.add('salary');
       restoredDataSources['revenuBrutAnnuel'] = ProfileDataSource.userInput;
+    }
+    if (answers.containsKey('q_has_pension_fund')) {
+      provided.add('pensionFund');
+      provided.add(hasPensionFund ? 'pensionFundYes' : 'pensionFundNo');
     }
     if (independentNetProfessionalIncomeAnnual != null &&
         independentNetProfessionalIncomeAnnual > 0) {

--- a/apps/mobile/lib/screens/coach/coach_archetype_guard.dart
+++ b/apps/mobile/lib/screens/coach/coach_archetype_guard.dart
@@ -2,11 +2,14 @@
 ///
 /// Pure decision helper that the [_CoachChatScreenState] reads BEFORE
 /// constructing a [CoachContext]. Profiles whose archetype falls
-/// outside the route-accessible set are redirected to /waitlist. Calibrated
-/// profiles fall through to the normal coach build path; narrowly
+/// outside the route-accessible set are redirected to /waitlist. Current
+/// calibration is a product cohort, not a nationality fallback: resident in
+/// Switzerland, salaried, and LPP-covered or salary-eligible. Narrowly
 /// route-accessible profiles may still be hard-gated by the orchestrator.
 ///
-/// The calibrated set remains `{FinancialArchetype.swissNative}`.
+/// `FinancialArchetype.swissNative` stays route-accessible for legacy and
+/// explicit-CH profiles, but a null nationality no longer forces waitlist when
+/// the current calibration cohort is otherwise satisfied.
 /// `FinancialArchetype.independentNoLpp` is route-accessible only so the
 /// audited deterministic no-LPP/3a fallback can build a real CoachContext;
 /// generic questions and streaming remain blocked at the orchestrator.
@@ -54,8 +57,15 @@ class CoachArchetypeGateVerdict {
 CoachArchetypeGateVerdict evaluateCoachArchetypeGate(CoachProfile profile) {
   final archetype = profile.archetype;
 
-  // Calibrated set = {swissNative}. Couple status does NOT change the gate
-  // decision because the typed getter returns swissNative for nationality=CH.
+  if (profile.isCoachCalibrationEligible) {
+    return const CoachArchetypeGateVerdict(
+      shouldBlock: false,
+      archetypeSlug: null,
+    );
+  }
+
+  // Legacy explicit-CH route: couple status does NOT change the gate decision
+  // because the typed getter returns swissNative for nationality=CH.
   if (archetype == FinancialArchetype.swissNative) {
     return const CoachArchetypeGateVerdict(
       shouldBlock: false,

--- a/apps/mobile/test/router/coach_route_archetype_guard_test.dart
+++ b/apps/mobile/test/router/coach_route_archetype_guard_test.dart
@@ -128,20 +128,40 @@ void main() {
     });
 
     test(
-        'fresh user with NO q_nationality → NOT swissNative → still gated '
-        '(no silent CH fallback — regression guard, closed 2026-05-22)', () {
+        'resident salaried LPP-eligible user with NO q_nationality → '
+        'not swissNative, but coach reachable', () {
       final profile = CoachProfile.fromWizardAnswers(<String, dynamic>{
         'q_birth_year': 1996,
-        'q_canton': 'VD',
+        'q_canton': 'VS',
         'q_employment_status': 'salarie',
-        'q_has_pension_fund': true,
+        'q_net_income_period_chf': 7500,
+        'q_pay_frequency': 'monthly',
       });
       expect(profile.nationality, isNull,
           reason: 'absent q_nationality must NOT coerce to CH');
       expect(profile.archetype, isNot(FinancialArchetype.swissNative));
       final verdict = evaluateCoachArchetypeGate(profile);
-      expect(verdict.shouldBlock, isTrue,
-          reason: 'null nationality stays gated, never silent swissNative');
+      expect(verdict.shouldBlock, isFalse,
+          reason:
+              'current calibration is resident in Switzerland + salaried + LPP-eligible, not nationality=CH');
+    });
+
+    test('resident salaried user with explicit no-LPP answer → still gated',
+        () {
+      final profile = CoachProfile.fromWizardAnswers(<String, dynamic>{
+        'q_birth_year': 1996,
+        'q_canton': 'VS',
+        'q_employment_status': 'salarie',
+        'q_net_income_period_chf': 7500,
+        'q_pay_frequency': 'monthly',
+        'q_has_pension_fund': false,
+      });
+      expect(profile.userProvidedFields, contains('pensionFund'),
+          reason:
+              'the gate must distinguish missing LPP answer from explicit no-LPP');
+      expect(profile.userProvidedFields, contains('pensionFundNo'));
+      final verdict = evaluateCoachArchetypeGate(profile);
+      expect(verdict.shouldBlock, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- separate current coach calibration eligibility from FinancialArchetype
- allow resident Swiss-canton, salaried, LPP-covered or salary-eligible profiles even when q_nationality is absent
- preserve FATCA/US, permit G, explicit no-LPP, and existing independent no-LPP behavior

## Verification
- flutter test test/router/coach_route_archetype_guard_test.dart test/models/coach_profile_copywith_tristate_test.dart test/services/minimal_profile_service_test.dart
- flutter analyze

## Notes
- Railway staging for PR #726 was verified on commit 0dee4c5355ccd0d3bf0f5020f7d54d3fe0112a24 and active DB service pgvector before this fix.
- This does not claim physical device/TestFlight/iCloud coverage is solved; it fixes the local gate logic for the reported false waitlist case.