### PR TITLE
fix(mobile): gate restored accounts on settled profile

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -35,6 +35,7 @@
     "feature/S10-mint2-real-device-restore-gate",
     "feature/S10-mint2-waitlist-eligibility-gate",
     "feature/S10-mint2-account-lifecycle-fatca-lock",
+    "feature/S10-mint2-reinstall-entry-gate",
     "docs/agent-skill-authority",
     "docs/mint2-rvc-runtime-closeout"
   ],

--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -238,6 +238,7 @@ String? accountLifecyclePublicEntryRedirect({
   required String path,
 }) {
   if (!lifecycle.hasAccountSession) return null;
+  if (!lifecycle.allowsMainNavigation) return null;
   if (path == '/' || path == '/auth/login' || path == '/auth/register') {
     return '/home';
   }
@@ -250,12 +251,58 @@ String? accountLifecycleAuthenticatedRedirect({
   required String path,
 }) {
   if (lifecycle.allowsMainNavigation) return null;
+  if (lifecycle.state == AuthLifecycleKind.signedInProfileMissing ||
+      lifecycle.state == AuthLifecycleKind.signedInIncomplete) {
+    return '/onb';
+  }
   final encodedPath = Uri.encodeComponent(path);
   if (lifecycle.state == AuthLifecycleKind.sessionExpired ||
       lifecycle.state == AuthLifecycleKind.credentialRevoked) {
     return '/auth/login?redirect=$encodedPath';
   }
   return '/auth/register?redirect=$encodedPath';
+}
+
+bool _isMainShellPath(String path) {
+  return path == '/home' ||
+      path == '/mon-argent' ||
+      path == '/coach' ||
+      path.startsWith('/coach/') ||
+      path == '/explore' ||
+      path.startsWith('/explore/') ||
+      path == '/profile' ||
+      path.startsWith('/profile/');
+}
+
+bool _isProfileCorrectionPath(String path) {
+  return path == '/onb' ||
+      path.startsWith('/onb/') ||
+      path == '/waitlist' ||
+      path.startsWith('/waitlist/') ||
+      path == '/auth/login' ||
+      path == '/auth/register' ||
+      path.startsWith('/auth/');
+}
+
+String? _profileRequiredEntryRedirect({
+  required AuthLifecycleState lifecycle,
+  required String path,
+  required CoachProfile? profile,
+  required bool profileSettled,
+}) {
+  if (profile != null) return null;
+  if (_isProfileCorrectionPath(path)) return null;
+
+  final profileRequired = _isMainShellPath(path) ||
+      lifecycle.state == AuthLifecycleKind.signedInProfileMissing ||
+      lifecycle.state == AuthLifecycleKind.signedInIncomplete ||
+      (path == '/' &&
+          lifecycle.hasAccountSession &&
+          lifecycle.allowsMainNavigation);
+  if (!profileRequired) return null;
+
+  if (!profileSettled) return path == '/' ? null : '/';
+  return '/onb';
 }
 
 const Set<String> _publicRoutePathFallbacks = {
@@ -289,12 +336,21 @@ String? accountLifecycleAndArchetypeRedirect({
   required String path,
   required RouteBase? topRoute,
   required CoachProfile? profile,
+  bool profileSettled = true,
 }) {
   final archetypeRedirect = archetypeRedirectTarget(
     profile: profile,
     path: path,
   );
   if (archetypeRedirect != null) return archetypeRedirect;
+
+  final profileRedirect = _profileRequiredEntryRedirect(
+    lifecycle: lifecycle,
+    path: path,
+    profile: profile,
+    profileSettled: profileSettled,
+  );
+  if (profileRedirect != null) return profileRedirect;
 
   final scope = routeScopeForRedirect(
     path: path,
@@ -305,6 +361,7 @@ String? accountLifecycleAndArchetypeRedirect({
     case RouteScope.public:
       // A restored account must not see the signed-out landing/auth funnel
       // on cold relaunch. Guest-local public entry remains allowed.
+      if (profile == null) return null;
       return accountLifecyclePublicEntryRedirect(
         lifecycle: lifecycle,
         path: path,
@@ -387,12 +444,16 @@ final _router = GoRouter(
       // tab=0 or no tab → stay on /home (Aujourd'hui)
     }
 
+    final profileProvider = context.read<CoachProfileProvider>();
     return accountLifecycleAndArchetypeRedirect(
       lifecycle: auth.authLifecycle,
       location: state.uri.toString(),
       path: path,
       topRoute: state.topRoute,
-      profile: context.read<CoachProfileProvider>().profile,
+      profile: profileProvider.profile,
+      profileSettled: profileProvider.isLoaded &&
+          !profileProvider.isLoading &&
+          !profileProvider.isHydrating,
     );
   },
   routes: [

--- a/apps/mobile/lib/models/auth_lifecycle_state.dart
+++ b/apps/mobile/lib/models/auth_lifecycle_state.dart
@@ -116,6 +116,41 @@ class AuthLifecycleState {
     );
   }
 
+  factory AuthLifecycleState.signedInProfileMissing({
+    required String userId,
+    required bool cloudSyncEnabled,
+  }) {
+    return AuthLifecycleState(
+      state: AuthLifecycleKind.signedInProfileMissing,
+      accessMode: AuthAccessMode.account,
+      activeDataScope: AuthDataScope.user(userId),
+      syncMode: cloudSyncEnabled
+          ? AuthSyncMode.cloudSyncOn
+          : AuthSyncMode.cloudSyncOff,
+      userId: userId,
+    );
+  }
+
+  factory AuthLifecycleState.syncOffAccount({required String userId}) {
+    return AuthLifecycleState(
+      state: AuthLifecycleKind.syncOffAccount,
+      accessMode: AuthAccessMode.account,
+      activeDataScope: AuthDataScope.user(userId),
+      syncMode: AuthSyncMode.cloudSyncOff,
+      userId: userId,
+    );
+  }
+
+  factory AuthLifecycleState.cloudSyncOnAccount({required String userId}) {
+    return AuthLifecycleState(
+      state: AuthLifecycleKind.cloudSyncOnAccount,
+      accessMode: AuthAccessMode.account,
+      activeDataScope: AuthDataScope.user(userId),
+      syncMode: AuthSyncMode.cloudSyncOn,
+      userId: userId,
+    );
+  }
+
   factory AuthLifecycleState.sessionExpired() {
     return const AuthLifecycleState(
       state: AuthLifecycleKind.sessionExpired,
@@ -132,9 +167,32 @@ class AuthLifecycleState {
   final String? userId;
 
   bool get allowsMainNavigation {
-    return activeDataScope != AuthDataScope.none &&
-        (accessMode == AuthAccessMode.guestLocal ||
-            accessMode == AuthAccessMode.account);
+    if (activeDataScope == AuthDataScope.none) return false;
+    switch (state) {
+      case AuthLifecycleKind.guestEmpty:
+      case AuthLifecycleKind.guestHasLocalData:
+      case AuthLifecycleKind.signedInReady:
+      case AuthLifecycleKind.syncOffAccount:
+      case AuthLifecycleKind.cloudSyncOnAccount:
+      case AuthLifecycleKind.offlineSignedInStale:
+        return accessMode == AuthAccessMode.guestLocal ||
+            accessMode == AuthAccessMode.account;
+      case AuthLifecycleKind.sessionRestoring:
+      case AuthLifecycleKind.freshVisitor:
+      case AuthLifecycleKind.migrationOffered:
+      case AuthLifecycleKind.migrationConflict:
+      case AuthLifecycleKind.signedInProfileLoading:
+      case AuthLifecycleKind.signedInProfileMissing:
+      case AuthLifecycleKind.signedInIncomplete:
+      case AuthLifecycleKind.sessionExpired:
+      case AuthLifecycleKind.credentialRevoked:
+      case AuthLifecycleKind.deletionConfirming:
+      case AuthLifecycleKind.deletionPending:
+      case AuthLifecycleKind.deletionFailed:
+      case AuthLifecycleKind.deletedLocalCleanup:
+      case AuthLifecycleKind.deletedSignedOut:
+        return false;
+    }
   }
 
   bool get hasAccountSession {

--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -535,7 +535,8 @@ class AuthProvider extends ChangeNotifier {
         // silent restore; a signed account must not inherit guest chat state
         // by accident.
         await _migrateLocalDataIfNeeded();
-        await _hydrateProfileFromBackend();
+        final hasProfile = await _hydrateProfileFromBackend();
+        _authLifecycle = _settledAccountLifecycle(hasProfile: hasProfile);
         try {
           await FreshStartService().scheduleAllFreshStartNotifications();
         } catch (e) {
@@ -625,7 +626,8 @@ class AuthProvider extends ChangeNotifier {
 
       if (_isLoggedIn) {
         await _migrateLocalDataIfNeeded(claimAnonymousConversations: true);
-        await _hydrateProfileFromBackend();
+        final hasProfile = await _hydrateProfileFromBackend();
+        _authLifecycle = _settledAccountLifecycle(hasProfile: hasProfile);
         // Best-effort: schedule fresh-start notifications
         try {
           await FreshStartService().scheduleAllFreshStartNotifications();
@@ -685,7 +687,8 @@ class AuthProvider extends ChangeNotifier {
 
       await _migrateLocalDataIfNeeded();
       // FIX-W11-5: Hydrate local state from backend on new device login
-      await _hydrateProfileFromBackend();
+      final hasProfile = await _hydrateProfileFromBackend();
+      _authLifecycle = _settledAccountLifecycle(hasProfile: hasProfile);
       // Schedule fresh-start notifications (best-effort)
       try {
         await FreshStartService().scheduleAllFreshStartNotifications();
@@ -772,7 +775,8 @@ class AuthProvider extends ChangeNotifier {
       await _migrateLocalDataIfNeeded(
         claimAnonymousConversations: claimAnonymousConversations,
       );
-      await _hydrateProfileFromBackend();
+      final hasProfile = await _hydrateProfileFromBackend();
+      _authLifecycle = _settledAccountLifecycle(hasProfile: hasProfile);
       try {
         await FreshStartService().scheduleAllFreshStartNotifications();
       } catch (_) {}
@@ -866,7 +870,8 @@ class AuthProvider extends ChangeNotifier {
       if (_userId != null) {
         ConversationStore.setCurrentUserId(_userId);
         await _migrateLocalDataIfNeeded();
-        await _hydrateProfileFromBackend();
+        final hasProfile = await _hydrateProfileFromBackend();
+        _authLifecycle = _settledAccountLifecycle(hasProfile: hasProfile);
       }
 
       notifyListeners();
@@ -1239,14 +1244,31 @@ class AuthProvider extends ChangeNotifier {
   /// On a new device the local SharedPreferences are empty. This fetches
   /// the cloud profile and seeds the most critical fields so screens
   /// don't show an empty state.
-  Future<void> _hydrateProfileFromBackend() async {
+  AuthLifecycleState _settledAccountLifecycle({required bool hasProfile}) {
+    final currentUserId = _userId;
+    if (currentUserId == null || currentUserId.isEmpty) {
+      return AuthLifecycleState.sessionExpired();
+    }
+    if (!hasProfile) {
+      return AuthLifecycleState.signedInProfileMissing(
+        userId: currentUserId,
+        cloudSyncEnabled: isCloudSyncEnabled,
+      );
+    }
+    return isCloudSyncEnabled
+        ? AuthLifecycleState.cloudSyncOnAccount(userId: currentUserId)
+        : AuthLifecycleState.syncOffAccount(userId: currentUserId);
+  }
+
+  Future<bool> _hydrateProfileFromBackend() async {
+    var existingAnswers = <String, dynamic>{};
     try {
       final prefs = await SharedPreferences.getInstance();
       final currentUserId = _userId;
       final accountOwnsLocalAnswers = currentUserId != null &&
           prefs.getString('local_data_owner') == currentUserId &&
           (prefs.getBool('local_data_migrated_$currentUserId') ?? false);
-      var existingAnswers = await ReportPersistenceService.loadAnswers();
+      existingAnswers = await ReportPersistenceService.loadAnswers();
       if (!accountOwnsLocalAnswers && existingAnswers.isNotEmpty) {
         await ReportPersistenceService.holdActiveDiagnosticForAnonymous();
         existingAnswers = const {};
@@ -1258,17 +1280,19 @@ class AuthProvider extends ChangeNotifier {
       final merged = _mergeBackendProfileData(answers, profileData);
 
       if (!accountOwnsLocalAnswers && profileData.isEmpty) {
-        return;
+        return false;
       }
 
       if (merged.isNotEmpty && !mapEquals(merged, existingAnswers)) {
         await ReportPersistenceService.saveAnswers(merged);
       }
+      return merged.isNotEmpty;
     } catch (e) {
       // Hydration is best-effort — never block login flow
       if (kDebugMode) {
         debugPrint('[AuthProvider] Profile hydration failed: $e');
       }
+      return existingAnswers.isNotEmpty;
     }
   }
 
@@ -1299,10 +1323,15 @@ class AuthProvider extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_authLocalModeKey, _isLocalMode);
     if (_isLoggedIn && _userId != null) {
-      _authLifecycle = AuthLifecycleState.signedInProfileLoading(
-        userId: _userId!,
-        cloudSyncEnabled: enabled,
-      );
+      _authLifecycle =
+          _authLifecycle.state == AuthLifecycleKind.signedInProfileMissing
+              ? AuthLifecycleState.signedInProfileMissing(
+                  userId: _userId!,
+                  cloudSyncEnabled: enabled,
+                )
+              : _settledAccountLifecycle(
+                  hasProfile: _authLifecycle.allowsMainNavigation,
+                );
     }
     notifyListeners();
   }

--- a/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
+++ b/apps/mobile/test/navigation/account_lifecycle_public_entry_redirect_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart' show RouteBase;
 import 'package:mint_mobile/app.dart'
     show
         accountLifecycleAndArchetypeRedirect,
@@ -10,48 +11,59 @@ import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/router/route_scope.dart';
 import 'package:mint_mobile/router/scoped_go_route.dart';
 
+String? _redirect({
+  required AuthLifecycleState lifecycle,
+  required String path,
+  RouteBase? topRoute,
+  CoachProfile? profile,
+  bool profileSettled = true,
+}) {
+  return accountLifecycleAndArchetypeRedirect(
+    lifecycle: lifecycle,
+    location: path,
+    path: path,
+    topRoute: topRoute,
+    profile: profile,
+    profileSettled: profileSettled,
+  );
+}
+
+ScopedGoRoute _publicShellRoute(String path) {
+  return ScopedGoRoute(
+    path: path,
+    scope: RouteScope.public,
+    builder: (_, __) => throw UnimplementedError(),
+  );
+}
+
 void main() {
   group('account lifecycle public entry redirect', () {
     test('restored account skips landing and auth entry points', () {
-      final lifecycle = AuthLifecycleState.signedInProfileLoading(
-        userId: 'user-1',
-        cloudSyncEnabled: false,
-      );
+      final lifecycle = AuthLifecycleState.syncOffAccount(userId: 'user-1');
 
-      expect(
-        accountLifecyclePublicEntryRedirect(lifecycle: lifecycle, path: '/'),
-        '/home',
-      );
-      expect(
-        accountLifecyclePublicEntryRedirect(
-          lifecycle: lifecycle,
-          path: '/auth/login',
-        ),
-        '/home',
-      );
-      expect(
-        accountLifecyclePublicEntryRedirect(
-          lifecycle: lifecycle,
-          path: '/auth/register',
-        ),
-        '/home',
-      );
+      for (final path in ['/', '/auth/login', '/auth/register']) {
+        expect(
+          accountLifecyclePublicEntryRedirect(
+            lifecycle: lifecycle,
+            path: path,
+          ),
+          '/home',
+        );
+      }
     });
 
     test('guest local mode stays allowed on public entry points', () {
       final lifecycle = AuthLifecycleState.guestEmpty(installId: 'install-1');
 
-      expect(
-        accountLifecyclePublicEntryRedirect(lifecycle: lifecycle, path: '/'),
-        isNull,
-      );
-      expect(
-        accountLifecyclePublicEntryRedirect(
-          lifecycle: lifecycle,
-          path: '/auth/login',
-        ),
-        isNull,
-      );
+      for (final path in ['/', '/auth/login']) {
+        expect(
+          accountLifecyclePublicEntryRedirect(
+            lifecycle: lifecycle,
+            path: path,
+          ),
+          isNull,
+        );
+      }
     });
 
     test('fresh visitor stays on public entry points', () {
@@ -119,10 +131,7 @@ void main() {
         );
         expect(
           accountLifecycleAuthenticatedRedirect(
-            lifecycle: AuthLifecycleState.signedInProfileLoading(
-              userId: 'user-1',
-              cloudSyncEnabled: false,
-            ),
+            lifecycle: AuthLifecycleState.syncOffAccount(userId: 'user-1'),
             path: '/home',
           ),
           isNull,
@@ -187,6 +196,47 @@ void main() {
           }),
         ),
         '/waitlist',
+      );
+    });
+
+    test('restored account without settled profile is sent to onboarding', () {
+      final lifecycle = AuthLifecycleState.signedInProfileMissing(
+        userId: 'user-1',
+        cloudSyncEnabled: false,
+      );
+
+      expect(
+        _redirect(
+          lifecycle: lifecycle,
+          path: '/coach/chat',
+          topRoute: _publicShellRoute('/coach/chat'),
+        ),
+        '/onb',
+      );
+    });
+
+    test('profile-ready account waits on landing during profile hydration', () {
+      final lifecycle = AuthLifecycleState.syncOffAccount(userId: 'user-1');
+
+      expect(
+        _redirect(
+          lifecycle: lifecycle,
+          path: '/',
+          profileSettled: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('explicit guest without local profile cannot enter shell', () {
+      final lifecycle = AuthLifecycleState.guestEmpty(installId: 'install-1');
+
+      expect(
+        _redirect(
+          lifecycle: lifecycle,
+          path: '/home',
+        ),
+        '/onb',
       );
     });
   });

--- a/apps/mobile/test/navigation/home_gate_contract_test.dart
+++ b/apps/mobile/test/navigation/home_gate_contract_test.dart
@@ -34,26 +34,28 @@ void main() {
       expect(state.activeDataScope, AuthDataScope.guest('install-1'));
     });
 
-    test(
-      'signed-in account enters main navigation regardless of sync mode',
-      () {
-        final syncOff = AuthLifecycleState.signedInProfileLoading(
-          userId: 'u1',
-          cloudSyncEnabled: false,
-        );
-        final syncOn = AuthLifecycleState.signedInProfileLoading(
-          userId: 'u1',
-          cloudSyncEnabled: true,
-        );
+    test('profile-ready account enters main navigation regardless of sync mode',
+        () {
+      final syncOff = AuthLifecycleState.syncOffAccount(userId: 'u1');
+      final syncOn = AuthLifecycleState.cloudSyncOnAccount(userId: 'u1');
 
-        expect(syncOff.allowsMainNavigation, isTrue);
-        expect(syncOn.allowsMainNavigation, isTrue);
-        expect(syncOff.hasAccountSession, isTrue);
-        expect(syncOn.hasAccountSession, isTrue);
-        expect(syncOff.accessMode, AuthAccessMode.account);
-        expect(syncOn.accessMode, AuthAccessMode.account);
-      },
-    );
+      expect(syncOff.allowsMainNavigation, isTrue);
+      expect(syncOn.allowsMainNavigation, isTrue);
+      expect(syncOff.hasAccountSession, isTrue);
+      expect(syncOn.hasAccountSession, isTrue);
+      expect(syncOff.accessMode, AuthAccessMode.account);
+      expect(syncOn.accessMode, AuthAccessMode.account);
+    });
+
+    test('profile-loading account cannot enter main navigation yet', () {
+      final state = AuthLifecycleState.signedInProfileLoading(
+        userId: 'u1',
+        cloudSyncEnabled: false,
+      );
+
+      expect(state.allowsMainNavigation, isFalse);
+      expect(state.hasAccountSession, isTrue);
+    });
 
     test(
       'guest mode is main-navigation capable but not an account session',

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -175,7 +175,7 @@ void main() {
         expect(provider.email, 'magic@example.ch');
         expect(
           provider.authLifecycle.state,
-          AuthLifecycleKind.signedInProfileLoading,
+          AuthLifecycleKind.signedInProfileMissing,
         );
         expect(provider.authLifecycle.accessMode, AuthAccessMode.account);
         expect(
@@ -183,7 +183,7 @@ void main() {
           AuthDataScope.user('magic-user'),
         );
         expect(provider.authLifecycle.syncMode, AuthSyncMode.cloudSyncOff);
-        expect(provider.authLifecycle.allowsMainNavigation, isTrue);
+        expect(provider.authLifecycle.allowsMainNavigation, isFalse);
         expect(await AuthService.getToken(), 'magic-token');
         expect(await AuthService.getUserId(), 'magic-user');
         expect(await AuthService.getUserEmail(), 'magic@example.ch');
@@ -956,7 +956,8 @@ void main() {
       },
     );
 
-    test('checkAuth with stored token exposes account lifecycle', () async {
+    test('checkAuth with stored token but no profile blocks main navigation',
+        () async {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(InstallLifecycleService.installMarkerKey, true);
       await AuthService.saveToken(
@@ -965,12 +966,26 @@ void main() {
         'user@example.ch',
         refreshToken: 'refresh',
       );
+      ApiService.setHttpClientForTesting(
+        MintHttpClient(
+          MockClient((request) async {
+            if (request.url.path == '/api/v1/profiles/me') {
+              return http.Response(
+                '{}',
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }
+            return http.Response('{"detail":"not found"}', 404);
+          }),
+        ),
+      );
 
       await provider.checkAuth();
 
       expect(
         provider.authLifecycle.state,
-        AuthLifecycleKind.signedInProfileLoading,
+        AuthLifecycleKind.signedInProfileMissing,
       );
       expect(provider.authLifecycle.accessMode, AuthAccessMode.account);
       expect(
@@ -978,7 +993,7 @@ void main() {
         AuthDataScope.user('user-1'),
       );
       expect(provider.authLifecycle.syncMode, AuthSyncMode.cloudSyncOff);
-      expect(provider.authLifecycle.allowsMainNavigation, isTrue);
+      expect(provider.authLifecycle.allowsMainNavigation, isFalse);
       expect(provider.isLoggedIn, isTrue);
       expect(provider.userId, 'user-1');
     });


### PR DESCRIPTION
## Summary
- close the restored-account entry gap by making main shell access require a settled profile
- classify signed-in sessions after backend profile hydration as profile-missing, sync-off ready, or cloud-sync ready
- route restored accounts without a profile back to onboarding instead of Today/Coach/Explorer
- keep FATCA/waitlist hard-gate behavior ahead of the profile shell gate

## Verification
- flutter test test/integration/profile_hydration_test.dart test/providers/coach_profile_provider_fatca_boot_test.dart test/navigation/account_lifecycle_public_entry_redirect_test.dart test/navigation/home_gate_contract_test.dart test/providers/auth_provider_test.dart test/screens/auth_screens_smoke_test.dart test/screens/onboarding/us_tax_person_screen_test.dart test/widgets/profile_drawer_test.dart test/screens/fatca_gate_test.dart test/services/response_card_service_fatca_test.dart
- flutter analyze
- git diff --check
- lefthook pre-commit
- lefthook pre-push

## Runtime note
This fixes the app-side lifecycle gate. Physical iPhone / signed TestFlight / iCloud-Keychain restore still need to be re-tested on the next build before claiming the real-device path is closed.