### PR TITLE
fix(auth): block deleted Apple account rehydration

### DIFF
--- a/services/backend/app/api/v1/endpoints/auth.py
+++ b/services/backend/app/api/v1/endpoints/auth.py
@@ -23,6 +23,7 @@ from app.core.auth import require_current_user
 from app.core.config import settings
 from app.core.rate_limit import limiter
 from app.models.analytics_event import AnalyticsEvent
+from app.models.audit_event import AuditEventModel
 from app.models.profile_model import ProfileModel
 from app.models.session_model import SessionModel
 from app.models.user import User
@@ -77,6 +78,7 @@ from app.services.auth_service import (
     is_jti_blacklisted,
 )
 from app.services.audit_service import log_audit_event as _raw_log_audit_event
+from app.services.audit.hmac_pepper import hmac_pii
 from app.services.auth_security_service import (
     get_login_block_seconds,
     record_failed_login,
@@ -182,6 +184,68 @@ def _ensure_empty_profile(db: Session, user_id: str) -> None:
     from app.services.profile_bootstrap import ensure_empty_profile
 
     ensure_empty_profile(db, user_id, commit=False)
+
+
+def _provider_subject_hash(provider: str, subject: Optional[str]) -> Optional[str]:
+    if subject is None or not subject.strip():
+        return None
+    return hmac_pii(f"{provider}:{subject.strip()}")
+
+
+def _deleted_provider_subject_hashes(user: User) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    apple_hash = _provider_subject_hash("apple", user.apple_sub)
+    if apple_hash is not None:
+        hashes["apple"] = apple_hash
+    return hashes
+
+
+def _has_deleted_provider_subject(
+    db: Session,
+    *,
+    provider: str,
+    subject: str,
+) -> bool:
+    subject_hash = _provider_subject_hash(provider, subject)
+    if subject_hash is None:
+        return False
+    return (
+        db.query(AuditEventModel.id)
+        .filter(
+            AuditEventModel.event_type == "auth.account_delete",
+            AuditEventModel.status == "success",
+            AuditEventModel.details_json.contains(subject_hash),
+        )
+        .first()
+        is not None
+    )
+
+
+def _recreate_required_for_deleted_provider_subject(
+    db: Session,
+    *,
+    provider: str,
+    subject: str,
+    request: Request,
+) -> None:
+    subject_hash = _provider_subject_hash(provider, subject)
+    log_audit_event(
+        db,
+        event_type="auth.apple_verify",
+        status="recreate_required",
+        source="api",
+        ip_address=_request_ip(request),
+        user_agent=request.headers.get("user-agent"),
+        details={
+            "provider": provider,
+            "provider_subject_hash": subject_hash,
+        },
+    )
+    db.commit()
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="recreate_required",
+    )
 
 
 @router.post("/register", response_model=RegisterResponse, status_code=status.HTTP_201_CREATED)
@@ -1028,6 +1092,7 @@ def delete_account(
     - Keep aggregate analytics rows by anonymizing user_id.
     """
     user_id = current_user.id
+    deleted_provider_subject_hashes = _deleted_provider_subject_hashes(current_user)
 
     # P0-3: Blacklist the current access token BEFORE deleting user data.
     # Prevents the token from being reused after account deletion.
@@ -1101,7 +1166,17 @@ def delete_account(
             db.query(SubscriptionModel).filter(
                 SubscriptionModel.id.in_(sub_ids)
             ).delete(synchronize_session=False)
-        log_audit_event(
+        audit_details = {
+            "deleted_profiles": deleted_profiles,
+            "deleted_sessions": deleted_sessions,
+            "anonymized_analytics_events": anonymized_analytics_events,
+        }
+        if deleted_provider_subject_hashes:
+            audit_details[
+                "deleted_provider_subject_hashes"
+            ] = deleted_provider_subject_hashes
+
+        _raw_log_audit_event(
             db,
             event_type="auth.account_delete",
             status="success",
@@ -1110,11 +1185,7 @@ def delete_account(
             actor_email=current_user.email,
             ip_address=_request_ip(request),
             user_agent=request.headers.get("user-agent"),
-            details={
-                "deleted_profiles": deleted_profiles,
-                "deleted_sessions": deleted_sessions,
-                "anonymized_analytics_events": anonymized_analytics_events,
-            },
+            details=audit_details,
         )
 
         # P0-2: Purge conversation memory — consents (including conversation_memory consent)
@@ -1347,6 +1418,14 @@ def apple_verify(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Apple identity token missing subject",
+        )
+
+    if _has_deleted_provider_subject(db, provider="apple", subject=apple_sub):
+        _recreate_required_for_deleted_provider_subject(
+            db,
+            provider="apple",
+            subject=apple_sub,
+            request=request,
         )
 
     # Find by Apple's stable subject first. Relay email can change.

--- a/services/backend/tests/test_auth_apple.py
+++ b/services/backend/tests/test_auth_apple.py
@@ -199,6 +199,66 @@ def test_apple_verify_reuses_account_by_stable_sub_when_email_changes(
     assert second.json()["userId"] == first.json()["userId"]
 
 
+def test_apple_verify_after_account_delete_returns_recreate_required_without_token(
+    client: TestClient,
+    monkeypatch,
+):
+    """Deleted Apple subjects must not silently create a fresh authenticated session."""
+    app.dependency_overrides.pop(require_current_user, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+    payloads = {
+        "first-token": {
+            "sub": "001999.deleted-apple-sub",
+            "email": "deleted-apple@example.invalid",
+        },
+        "second-token": {
+            "sub": "001999.deleted-apple-sub",
+            "email": "deleted-apple@example.invalid",
+        },
+    }
+
+    def fake_verify(identity_token: str, nonce: str | None) -> dict[str, str]:
+        return payloads[identity_token]
+
+    monkeypatch.setattr(
+        auth_endpoint,
+        "_verify_apple_identity_token",
+        fake_verify,
+    )
+
+    first = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "first-token", "nonce": "nonce"},
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    access_token = first_body["accessToken"]
+
+    deleted = client.delete(
+        "/api/v1/auth/account",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert deleted.status_code == 200
+
+    stale_me = client.get(
+        "/api/v1/auth/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert stale_me.status_code == 401
+
+    second = client.post(
+        "/api/v1/auth/apple/verify",
+        json={"identity_token": "second-token", "nonce": "nonce"},
+    )
+
+    assert second.status_code == 409
+    second_body = second.json()
+    assert second_body["detail"] == "recreate_required"
+    assert "accessToken" not in second_body
+    assert "access_token" not in second_body
+
+
 def test_apple_verify_rejects_email_already_linked_to_different_sub(
     client: TestClient,
     monkeypatch,


### PR DESCRIPTION
Selected lot: Lot A account deletion/session lifecycle

Summary:
- Adds a privacy-preserving deleted Apple provider-sub tombstone using the existing audit HMAC pepper path.
- Blocks auth apple verify from silently recreating a user when Apple returns the same sub after account deletion.
- Returns 409 recreate_required without issuing an access token for a deleted Apple subject.

Verification:
- Red test before fix: services/backend pytest delete_returns_recreate_required failed because the second Apple verify returned 200.
- Green targeted tests: services/backend pytest tests/test_auth_apple.py delete_returns_recreate_required.
- Green auth tests: services/backend pytest tests/test_auth_apple.py tests/test_auth.py apple or delete_account_purges.
- Green full backend: services/backend pytest tests/.
- Green guards: active_context_guard, phase_contract_guard, mint_rules_guard, agent_reference_guard, claude_hooks_guard, verify_phase_acceptance.
- Routes unchanged and checked with tools/mint-routes check.
- Static runtime tooling gate passed with mint_runtime_debug_tooling_gate --ci-static-only; this does not prove iOS runtime Gate A.

Limitations:
- No Apple revocation implementation; Lot C is out of scope.
- No Railway deploy or Railway production behavior claim.
- No physical TestFlight or iCloud restore proof.
- Existing automated iOS Gate A same-simulator uninstall install relaunch proof was not available in this lot.