### PR TITLE
Journey OS PR2 generated views

### DIFF
--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -1,0 +1,7 @@
+# Mint Journey OS
+
+Generated from `.planning/journeys/records/*.json`. Do not edit directly.
+
+| ID | Tier | Status | Promise | Accountable team | Routes | Evidence |
+|---|---|---|---|---|---|---|
+| money_truth_spine | T0 | partial | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | green |

--- a/.planning/journeys/diagrams/money_truth_spine.mmd
+++ b/.planning/journeys/diagrams/money_truth_spine.mmd
@@ -1,0 +1,22 @@
+%% Generated from .planning/journeys/records/money_truth_spine.json
+flowchart TD
+  promise["My money numbers are consistent."]
+  team["mint-quality-gate"]
+  route_budget["/budget"]
+  promise --> route_budget
+  route_budget --> team
+  route_mon_argent["/mon-argent"]
+  promise --> route_mon_argent
+  route_mon_argent --> team
+  route_rapport["/rapport"]
+  promise --> route_rapport
+  route_rapport --> team
+  route_coach_chat["/coach/chat"]
+  promise --> route_coach_chat
+  route_coach_chat --> team
+  surface_BudgetSnapshot["BudgetSnapshot"]
+  promise -.-> surface_BudgetSnapshot
+  surface_DataSpineSnapshot["DataSpineSnapshot"]
+  promise -.-> surface_DataSpineSnapshot
+  surface_CoachContextPacket["CoachContextPacket"]
+  promise -.-> surface_CoachContextPacket

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate Mint Journey OS PR1 records and scope."""
+"""Validate Mint Journey OS records, scope, and generated views."""
 from __future__ import annotations
 
 import argparse, json, subprocess, sys
@@ -8,12 +8,13 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
+from tools.checks import journey_os_generate
 from tools.checks.route_registry_parity import extract_registry_keys
 JOURNEYS = Path(".planning/journeys")
 RECORDS = JOURNEYS / "records"
 SCHEMA = JOURNEYS / "journey.schema.json"
 ROUTES = Path("apps/mobile/lib/routes/route_metadata.dart")
-ALLOW = {str(SCHEMA), str(JOURNEYS / "README.md"), "tools/checks/journey_os_check.py", "tools/checks/tests/test_journey_os_check.py"}
+ALLOW = {str(SCHEMA), str(JOURNEYS / "README.md"), str(journey_os_generate.SUMMARY), "tools/checks/journey_os_check.py", "tools/checks/journey_os_generate.py", "tools/checks/tests/test_journey_os_check.py"}
 TEAMS = {"mint-lead", "mint-quality-gate", "mint-mobile", "mint-backend", "mint-swiss-brain"}
 STATUS = {"draft", "partial", "live_proven", "blocked", "deferred", "out_of_beta"}
 TIERS = {"T0", "T1", "T2", "T3"}
@@ -37,14 +38,31 @@ def _scope_errors(root: Path, changed: list[str]) -> list[str]:
     errors: list[str] = []
     for path in changed:
         allowed_record = path.startswith(str(RECORDS) + "/") and path.endswith(".json") and "/" not in path[len(str(RECORDS)) + 1 :]
-        if not (path in ALLOW or allowed_record):
-            errors.append(f"changed file outside PR1 whitelist: {path}")
+        allowed_diagram = path.startswith(str(journey_os_generate.DIAGRAMS) + "/") and path.endswith(".mmd") and "/" not in path[len(str(journey_os_generate.DIAGRAMS)) + 1 :]
+        if not (path in ALLOW or allowed_record or allowed_diagram):
+            errors.append(f"changed file outside Journey OS whitelist: {path}")
         suffix = Path(path).suffix
-        if path.startswith(str(JOURNEYS) + "/") and (suffix in {".mmd", ".svg", ".html"} or (suffix == ".md" and path != str(JOURNEYS / "README.md"))):
-            errors.append(f"generated Journey OS view is forbidden in PR1: {path}")
+        if path.startswith(str(JOURNEYS) + "/") and (suffix in {".svg", ".html"} or (suffix == ".md" and path not in ALLOW)):
+            errors.append(f"unsupported Journey OS generated view: {path}")
     readme = root / JOURNEYS / "README.md"
     if readme.exists() and "```mermaid" in readme.read_text(encoding="utf-8", errors="ignore").lower():
         errors.append("Mermaid fenced blocks are forbidden in .planning/journeys/README.md")
+    return errors
+
+def _generated_errors(root: Path) -> list[str]:
+    errors: list[str] = []
+    expected = journey_os_generate.expected(root)
+    for rel, content in expected.items():
+        path = root / rel
+        if not path.exists():
+            errors.append(f"missing generated Journey OS view: {rel}")
+        elif path.read_text(encoding="utf-8") != content:
+            errors.append(f"stale generated Journey OS view: {rel}")
+    expected_paths = {str(path) for path in expected}
+    for path in (root / journey_os_generate.DIAGRAMS).glob("*.mmd"):
+        rel = str(path.relative_to(root))
+        if rel not in expected_paths:
+            errors.append(f"orphan generated Journey OS diagram: {rel}")
     return errors
 
 def _load_records(root: Path) -> tuple[list[tuple[Path, dict[str, Any]]], list[str]]:
@@ -154,6 +172,7 @@ def check(root: Path, changed_files: list[str] | None = None, base_ref: str = "o
         if isinstance(rid, str):
             seen.add(rid)
         errors += _record_errors(root, path, data, routes)
+    errors += _generated_errors(root)
     return errors
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/checks/journey_os_generate.py
+++ b/tools/checks/journey_os_generate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate Journey OS Markdown and Mermaid views from JSON records."""
+from __future__ import annotations
+
+import argparse, json, re
+from pathlib import Path
+from typing import Any
+
+JOURNEYS = Path(".planning/journeys")
+RECORDS = JOURNEYS / "records"
+SUMMARY = JOURNEYS / "JOURNEYS.md"
+DIAGRAMS = JOURNEYS / "diagrams"
+
+def load_records(root: Path) -> list[dict[str, Any]]:
+    return [json.loads(path.read_text(encoding="utf-8")) for path in sorted((root / RECORDS).glob("*.json"))]
+
+def _cell(value: object) -> str:
+    text = ", ".join(value) if isinstance(value, list) else str(value)
+    return text.replace("|", "\\|")
+
+def markdown(records: list[dict[str, Any]]) -> str:
+    lines = ["# Mint Journey OS", "", "Generated from `.planning/journeys/records/*.json`. Do not edit directly.", "", "| ID | Tier | Status | Promise | Accountable team | Routes | Evidence |", "|---|---|---|---|---|---|---|"]
+    for rec in records:
+        statuses = sorted({str(e.get("status")) for e in rec.get("evidence", []) if isinstance(e, dict)})
+        lines.append("| {id} | {tier} | {status} | {promise} | {team} | {routes} | {evidence} |".format(id=_cell(rec.get("id", "")), tier=_cell(rec.get("tier", "")), status=_cell(rec.get("status", "")), promise=_cell(rec.get("human_promise", "")), team=_cell(rec.get("accountable_team", "")), routes=_cell(rec.get("route_paths", [])), evidence=_cell(statuses)))
+    return "\n".join(lines) + "\n"
+
+def _node(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]+", "_", value).strip("_") or "root"
+
+def _label(value: object) -> str:
+    return str(value).replace('"', "'").replace("\n", " ")
+
+def mermaid(rec: dict[str, Any]) -> str:
+    rid = str(rec["id"])
+    lines = [f"%% Generated from .planning/journeys/records/{rid}.json", "flowchart TD", f'  promise["{_label(rec["human_promise"])}"]', f'  team["{_label(rec["accountable_team"])}"]']
+    for route in rec.get("route_paths", []):
+        node = "route_" + _node(str(route))
+        lines += [f'  {node}["{_label(route)}"]', f"  promise --> {node}", f"  {node} --> team"]
+    for surface in rec.get("surfaces", []):
+        node = "surface_" + _node(str(surface))
+        lines += [f'  {node}["{_label(surface)}"]', f"  promise -.-> {node}"]
+    return "\n".join(lines) + "\n"
+
+def expected(root: Path) -> dict[Path, str]:
+    records = load_records(root)
+    out = {SUMMARY: markdown(records)}
+    out.update({DIAGRAMS / f"{rec['id']}.mmd": mermaid(rec) for rec in records})
+    return out
+
+def write(root: Path) -> None:
+    for rel, content in expected(root).items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    write(args.root.resolve())
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from tools.checks import journey_os_check
+from tools.checks import journey_os_check, journey_os_generate
 
 def _root(tmp_path: Path) -> Path:
     (tmp_path / "apps/mobile/lib/routes").mkdir(parents=True)
@@ -42,17 +42,20 @@ def _errors(root: Path, changed: list[str] | None = None) -> list[str]:
 def test_valid_fixture_passes(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)
+    journey_os_generate.write(root)
     assert _errors(root) == []
 
 def test_missing_baseline_fails_closed(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)
+    journey_os_generate.write(root)
     assert any("origin/dev" in error or "baseline" in error for error in journey_os_check.check(root, []))
 
 def test_changed_file_outside_whitelist_fails(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)
-    assert any("outside PR1 whitelist" in error for error in _errors(root, ["apps/mobile/lib/app.dart"]))
+    journey_os_generate.write(root)
+    assert any("outside Journey OS whitelist" in error for error in _errors(root, ["apps/mobile/lib/app.dart"]))
 
 def test_route_owner_status_and_artifact_rules(tmp_path: Path) -> None:
     cases = [
@@ -85,3 +88,11 @@ def test_shape_filename_and_generated_view_rules(tmp_path: Path) -> None:
     readme = root / ".planning/journeys/README.md"
     readme.write_text("```mermaid\ngraph TD\n```", encoding="utf-8")
     assert any("Mermaid" in error for error in _errors(root, [".planning/journeys/README.md"]))
+
+def test_generated_views_are_required_and_current(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    assert any("missing generated" in error for error in _errors(root))
+    journey_os_generate.write(root)
+    (root / ".planning/journeys/JOURNEYS.md").write_text("stale\n", encoding="utf-8")
+    assert any("stale generated" in error for error in _errors(root))


### PR DESCRIPTION
## Scope\n- Adds generated Journey OS Markdown summary and Mermaid diagram from JSON records.\n- Adds a deterministic stdlib generator for Journey OS views.\n- Evolves journey_os_check.py to reject missing, stale, or orphan generated views.\n\n## Evidence\n- python3 tools/checks/journey_os_generate.py && git diff --exit-code -> exit 0\n- python3 tools/checks/journey_os_check.py -> OK journey_os_check\n- python3 -m pytest tools/checks/tests/test_journey_os_check.py -q -> 6 passed\n- ./tools/mint-routes check -> 145 routes parity OK\n- python3 tools/checks/phase_contract_guard.py -> OK\n- python3 tools/checks/mint_rules_guard.py -> OK\n- git diff --check origin/dev...HEAD -> exit 0\n- git diff --shortstat origin/dev...HEAD -> 5 files changed, 132 insertions, 8 deletions\n- Claude CLI safe-mode Opus audit -> GO\n\n## Known Exception\n- Local active_context_guard reports ACTIVE_CONTEXT_BRANCH_MISMATCH_EXPECTED because this dedicated Journey OS branch is intentionally not listed in ACTIVE_CONTEXT allowed_branches. No ACTIVE_CONTEXT files are changed.\n\n## Out of Scope\n- No product code, Dart, backend/API/database, route additions, SVG/HTML rendering, admin UI, or auto-discovery.