### PR TITLE
docs: seed Journey OS critical records

### DIFF
--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -4,4 +4,8 @@ Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 
 | ID | Tier | Status | Promise | Accountable team | Routes | Evidence |
 |---|---|---|---|---|---|---|
+| account_lifecycle_delete | T0 | draft | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | missing |
+| coach_advice_turn | T0 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green |
 | money_truth_spine | T0 | partial | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | green |
+| onboarding_first_value | T0 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /coach/chat, /home | green |
+| profile_privacy_control | T0 | partial | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | green |

--- a/.planning/journeys/diagrams/account_lifecycle_delete.mmd
+++ b/.planning/journeys/diagrams/account_lifecycle_delete.mmd
@@ -1,0 +1,25 @@
+%% Generated from .planning/journeys/records/account_lifecycle_delete.json
+flowchart TD
+  promise["I can recover, delete, and control my account data."]
+  team["mint-quality-gate"]
+  route_auth_login["/auth/login"]
+  promise --> route_auth_login
+  route_auth_login --> team
+  route_auth_register["/auth/register"]
+  promise --> route_auth_register
+  route_auth_register --> team
+  route_auth_forgot_password["/auth/forgot-password"]
+  promise --> route_auth_forgot_password
+  route_auth_forgot_password --> team
+  route_profile_privacy_control["/profile/privacy-control"]
+  promise --> route_profile_privacy_control
+  route_profile_privacy_control --> team
+  route_profile_privacy["/profile/privacy"]
+  promise --> route_profile_privacy
+  route_profile_privacy --> team
+  surface_AuthProvider["AuthProvider"]
+  promise -.-> surface_AuthProvider
+  surface_PrivacyControlScreen["PrivacyControlScreen"]
+  promise -.-> surface_PrivacyControlScreen
+  surface_AccountDeletionFlow["AccountDeletionFlow"]
+  promise -.-> surface_AccountDeletionFlow

--- a/.planning/journeys/diagrams/coach_advice_turn.mmd
+++ b/.planning/journeys/diagrams/coach_advice_turn.mmd
@@ -1,0 +1,13 @@
+%% Generated from .planning/journeys/records/coach_advice_turn.json
+flowchart TD
+  promise["When Coach gives a number, it is current, cited, and bounded."]
+  team["mint-swiss-brain"]
+  route_coach_chat["/coach/chat"]
+  promise --> route_coach_chat
+  route_coach_chat --> team
+  surface_CoachOrchestrator["CoachOrchestrator"]
+  promise -.-> surface_CoachOrchestrator
+  surface_CoachContextPacket["CoachContextPacket"]
+  promise -.-> surface_CoachContextPacket
+  surface_ComplianceGuard["ComplianceGuard"]
+  promise -.-> surface_ComplianceGuard

--- a/.planning/journeys/diagrams/onboarding_first_value.mmd
+++ b/.planning/journeys/diagrams/onboarding_first_value.mmd
@@ -1,0 +1,19 @@
+%% Generated from .planning/journeys/records/onboarding_first_value.json
+flowchart TD
+  promise["I get useful value before I commit more data."]
+  team["mint-quality-gate"]
+  route_onb["/onb"]
+  promise --> route_onb
+  route_onb --> team
+  route_coach_chat["/coach/chat"]
+  promise --> route_coach_chat
+  route_coach_chat --> team
+  route_home["/home"]
+  promise --> route_home
+  route_home --> team
+  surface_OnboardingShellScreen["OnboardingShellScreen"]
+  promise -.-> surface_OnboardingShellScreen
+  surface_CoachProfileProvider["CoachProfileProvider"]
+  promise -.-> surface_CoachProfileProvider
+  surface_MintStateProvider["MintStateProvider"]
+  promise -.-> surface_MintStateProvider

--- a/.planning/journeys/diagrams/profile_privacy_control.mmd
+++ b/.planning/journeys/diagrams/profile_privacy_control.mmd
@@ -1,0 +1,21 @@
+%% Generated from .planning/journeys/records/profile_privacy_control.json
+flowchart TD
+  promise["I can see and control what MINT knows about me."]
+  team["mint-quality-gate"]
+  route_profile_privacy_control["/profile/privacy-control"]
+  promise --> route_profile_privacy_control
+  route_profile_privacy_control --> team
+  route_profile_privacy["/profile/privacy"]
+  promise --> route_profile_privacy
+  route_profile_privacy --> team
+  route_settings_confidentialite["/settings/confidentialite"]
+  promise --> route_settings_confidentialite
+  route_settings_confidentialite --> team
+  surface_PrivacyControlScreen["PrivacyControlScreen"]
+  promise -.-> surface_PrivacyControlScreen
+  surface_ConsentSheet["ConsentSheet"]
+  promise -.-> surface_ConsentSheet
+  surface_ConsentReceiptService["ConsentReceiptService"]
+  promise -.-> surface_ConsentReceiptService
+  surface_PiiScrubber["PiiScrubber"]
+  promise -.-> surface_PiiScrubber

--- a/.planning/journeys/records/account_lifecycle_delete.json
+++ b/.planning/journeys/records/account_lifecycle_delete.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "id": "account_lifecycle_delete",
+  "title": "Account lifecycle delete",
+  "tier": "T0",
+  "status": "draft",
+  "human_promise": "I can recover, delete, and control my account data.",
+  "accountable_team": "mint-quality-gate",
+  "route_paths": [
+    "/auth/login",
+    "/auth/register",
+    "/auth/forgot-password",
+    "/profile/privacy-control",
+    "/profile/privacy"
+  ],
+  "surfaces": [
+    "AuthProvider",
+    "PrivacyControlScreen",
+    "AccountDeletionFlow"
+  ],
+  "external_apis": [
+    "DELETE /auth/account",
+    "GET /api/v1/privacy/delete-count"
+  ],
+  "issues": [
+    "JOURNEY-TRUTH-MATRIX-005"
+  ],
+  "evidence": [
+    {
+      "kind": "manual",
+      "status": "missing",
+      "command": null,
+      "artifact": null,
+      "reason": "Journey Truth Matrix row 5 says recovery/delete/control account data has routes but no current end-to-end proof."
+    }
+  ]
+}

--- a/.planning/journeys/records/coach_advice_turn.json
+++ b/.planning/journeys/records/coach_advice_turn.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "coach_advice_turn",
+  "title": "Coach advice turn",
+  "tier": "T0",
+  "status": "partial",
+  "human_promise": "When Coach gives a number, it is current, cited, and bounded.",
+  "accountable_team": "mint-swiss-brain",
+  "route_paths": [
+    "/coach/chat"
+  ],
+  "surfaces": [
+    "CoachOrchestrator",
+    "CoachContextPacket",
+    "ComplianceGuard"
+  ],
+  "external_apis": [
+    "POST /api/v1/coach/chat"
+  ],
+  "issues": [
+    "CJT-011",
+    "JOURNEY-TRUTH-MATRIX-014"
+  ],
+  "evidence": [
+    {
+      "kind": "runtime",
+      "status": "green",
+      "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml tools/simulator/flows/maestro-perfect-set/flow_hero_marge_fiscale_3a.yaml",
+      "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml",
+      "reason": "CJT-011 durable runtime proof shows the 3a answer path reached Coach and asserted current cited 3a values; broader advice quality remains partial."
+    }
+  ]
+}

--- a/.planning/journeys/records/onboarding_first_value.json
+++ b/.planning/journeys/records/onboarding_first_value.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "id": "onboarding_first_value",
+  "title": "Onboarding first value",
+  "tier": "T0",
+  "status": "partial",
+  "human_promise": "I get useful value before I commit more data.",
+  "accountable_team": "mint-quality-gate",
+  "route_paths": [
+    "/onb",
+    "/coach/chat",
+    "/home"
+  ],
+  "surfaces": [
+    "OnboardingShellScreen",
+    "CoachProfileProvider",
+    "MintStateProvider"
+  ],
+  "external_apis": [],
+  "issues": [
+    "CJT-018",
+    "JOURNEY-TRUTH-MATRIX-006"
+  ],
+  "evidence": [
+    {
+      "kind": "runtime",
+      "status": "green",
+      "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml tools/simulator/flows/regression/bug__S005__landing_anonymous_cta_to_home.yaml",
+      "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml",
+      "reason": "S005 iPhone 16e regression proof supports the onboarding-to-home first-value path; signed-device and broader beta access remain outside this record."
+    }
+  ]
+}

--- a/.planning/journeys/records/profile_privacy_control.json
+++ b/.planning/journeys/records/profile_privacy_control.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "profile_privacy_control",
+  "title": "Profile privacy control",
+  "tier": "T0",
+  "status": "partial",
+  "human_promise": "I can see and control what MINT knows about me.",
+  "accountable_team": "mint-quality-gate",
+  "route_paths": [
+    "/profile/privacy-control",
+    "/profile/privacy",
+    "/settings/confidentialite"
+  ],
+  "surfaces": [
+    "PrivacyControlScreen",
+    "ConsentSheet",
+    "ConsentReceiptService",
+    "PiiScrubber"
+  ],
+  "external_apis": [
+    "GET /api/v1/privacy/delete-count"
+  ],
+  "issues": [
+    "JOURNEY-TRUTH-MATRIX-024"
+  ],
+  "evidence": [
+    {
+      "kind": "runtime",
+      "status": "green",
+      "command": "MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101/result.xml tools/simulator/flows/maestro-perfect-set/flow_row24_privacy_control_runtime.yaml",
+      "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101/result.xml",
+      "reason": "Row 24 runtime proof opens privacy-control and shows known-data controls; export/delete and production log sampling remain partial."
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Adds the PR1-B Journey OS seed records for:

- account_lifecycle_delete
- coach_advice_turn
- onboarding_first_value
- profile_privacy_control

Also regenerates the derived Journey OS Markdown/Mermaid views from JSON. No product code, Dart, backend, API, DB, route, l10n, or ACTIVE_CONTEXT changes.

## Evidence

- python3 tools/checks/journey_os_check.py -> OK
- python3 -m pytest tools/checks/tests/test_journey_os_check.py -q -> 6 passed
- ./tools/mint-routes check -> OK, 145 routes parity OK
- python3 tools/checks/phase_contract_guard.py -> OK
- python3 tools/checks/mint_rules_guard.py -> OK
- git diff --check --cached -> clean
- git diff --shortstat origin/dev...HEAD -> 9 files changed, 220 insertions
- Claude CLI safe-mode Opus audit -> GO, no blockers

## Expected local exception

- python3 tools/checks/active_context_guard.py fails only because codex/mint-journey-os-pr1b-20260626 is not listed in ACTIVE_CONTEXT allowed_branches.
- python3 tools/checks/verify_phase_acceptance.py fails only through the same active-context criterion.
- Per handoff, ACTIVE_CONTEXT edits are out of scope for this Journey OS PR.

## Notes

- Non-route APIs are in external_apis, not route_paths.
- account_lifecycle_delete is intentionally draft/missing because Journey Truth Matrix row 5 has no current end-to-end proof.
