### PR TITLE
Make regulatory freshness monitoring durable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
             backend:
               - 'services/backend/**'
               - 'tools/openapi/**'
+              - 'tools/checks/regulatory_freshness_monitor.py'
+              - 'tools/checks/tests/test_regulatory_freshness_monitor.py'
+              - '.github/workflows/regulatory-freshness-monitor.yml'
             flutter:
               - 'apps/mobile/**'
               - '.github/workflows/ci.yml'
@@ -156,6 +159,12 @@ jobs:
 
       - name: Install dependencies (app + dev/test)
         run: pip install ".[dev]" pytest-cov diff-cover
+
+      - name: Regulatory freshness monitor (warning-only)
+        working-directory: ${{ github.workspace }}
+        run: |
+          python3 -m pytest tools/checks/tests/test_regulatory_freshness_monitor.py -q
+          python3 tools/checks/regulatory_freshness_monitor.py
 
       - name: Security audit (pip-audit)
         run: |

--- a/.github/workflows/regulatory-freshness-monitor.yml
+++ b/.github/workflows/regulatory-freshness-monitor.yml
@@ -1,0 +1,44 @@
+name: Regulatory freshness monitor
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    name: Warn and open issue when review is due
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install backend dependencies
+        run: pip install ./services/backend
+      - name: Check regulatory review freshness
+        id: freshness
+        run: |
+          python3 tools/checks/regulatory_freshness_monitor.py \
+            --markdown-out /tmp/regulatory-freshness.md \
+            --github-output "$GITHUB_OUTPUT"
+      - name: Open or update freshness issue
+        if: steps.freshness.outputs.stale_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Regulatory constants review due"
+          existing="$(gh issue list \
+            --state open \
+            --search "$title in:title" \
+            --json number \
+            --jq '.[0].number // ""')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file /tmp/regulatory-freshness.md
+          else
+            gh issue create --title "$title" --body-file /tmp/regulatory-freshness.md
+          fi

--- a/services/backend/app/models/regulatory_parameter.py
+++ b/services/backend/app/models/regulatory_parameter.py
@@ -64,11 +64,12 @@ class RegulatoryParameter:
             return False
         return True
 
-    def is_stale(self, max_age_days: int = 90) -> bool:
+    def is_stale(self, max_age_days: int = 90, on_date: Optional[date] = None) -> bool:
         """Check if the parameter needs review (reviewed_at older than max_age_days)."""
         if self.reviewed_at is None:
             return True
-        return (date.today() - self.reviewed_at).days > max_age_days
+        check_date = on_date or date.today()
+        return (check_date - self.reviewed_at).days > max_age_days
 
     def to_dict(self) -> dict:
         """Serialize to a JSON-compatible dict for API responses."""

--- a/services/backend/app/services/regulatory/registry.py
+++ b/services/backend/app/services/regulatory/registry.py
@@ -10,7 +10,7 @@ Architecture:
     - Singleton pattern: one registry instance per process.
     - Constants are hardcoded in _PARAMETERS for now (DB migration planned P4).
     - Every constant from social_insurance.py is mirrored here with full metadata.
-    - Freshness tracking: reviewed_at must be within 90 days or flagged stale.
+    - Freshness tracking: reviewed_at powers runtime/scheduled stale reports.
 
 Sources:
     - CLAUDE.md §5 (Key Constants 2025/2026)
@@ -1368,11 +1368,16 @@ class RegulatoryRegistry:
             return [p for p in all_params if p.key.lower().startswith(prefix)]
         return all_params
 
-    def check_freshness(self, max_age_days: int = 90) -> list[RegulatoryParameter]:
+    def check_freshness(
+        self,
+        max_age_days: int = 90,
+        as_of: Optional[date] = None,
+    ) -> list[RegulatoryParameter]:
         """Return parameters that are stale (reviewed_at older than max_age_days).
 
         Args:
             max_age_days: Maximum number of days since last review.
+            as_of: Date to evaluate freshness against. Defaults to today.
 
         Returns:
             List of stale parameters needing review.
@@ -1380,7 +1385,7 @@ class RegulatoryRegistry:
         stale = []
         for params in self._params.values():
             for p in params:
-                if p.is_stale(max_age_days):
+                if p.is_stale(max_age_days, on_date=as_of):
                     stale.append(p)
         return stale
 

--- a/services/backend/tests/test_regulatory_registry.py
+++ b/services/backend/tests/test_regulatory_registry.py
@@ -4,7 +4,7 @@ Verifies:
     1. All constants from social_insurance.py are present in the registry.
     2. Values match exactly between registry and social_insurance.py.
     3. All parameters have source_url set.
-    4. All parameters have reviewed_at within 90 days.
+    4. All parameters have reviewed_at and deterministic freshness semantics.
     5. No expired parameter without a replacement.
     6. All 26 cantonal tax rates are present.
     7. 3a historical limits 2016-2026 are all present.
@@ -25,7 +25,7 @@ Sources:
 """
 
 import pytest
-from datetime import date
+from datetime import date, timedelta
 
 from app.models.regulatory_parameter import RegulatoryParameter
 from app.services.regulatory.registry import RegulatoryRegistry
@@ -327,16 +327,20 @@ class TestMetadataQuality:
 
 
 # ---------------------------------------------------------------------------
-# 4. All parameters have reviewed_at within 90 days
+# 4. Freshness metadata contract
 # ---------------------------------------------------------------------------
 
 
 class TestFreshness:
-    """All parameters must have been reviewed recently."""
+    """All parameters must have review metadata without calendar-flaky CI."""
 
-    def test_all_reviewed_within_90_days(self, registry):
-        """No parameter should be stale (reviewed_at > 90 days ago)."""
-        stale = registry.check_freshness(max_age_days=90)
+    def test_all_reviewed_within_90_days_of_review_snapshot(self, registry):
+        """The hard test is deterministic; scheduled monitoring handles wall-clock age."""
+        latest_review = max(p.reviewed_at for p in registry.get_all() if p.reviewed_at)
+        stale = registry.check_freshness(
+            max_age_days=90,
+            as_of=latest_review + timedelta(days=90),
+        )
         stale_keys = [p.key for p in stale]
         assert stale_keys == [], f"Stale parameters: {stale_keys}"
 
@@ -347,10 +351,14 @@ class TestFreshness:
                 f"Missing reviewed_at for {param.key}"
             )
 
-    def test_freshness_check_empty(self, registry):
-        """check_freshness returns empty list when all are fresh."""
-        stale = registry.check_freshness(max_age_days=90)
-        assert len(stale) == 0
+    def test_calendar_staleness_can_be_evaluated_without_date_today(self, registry):
+        """A caller can evaluate the future review-due state explicitly."""
+        latest_review = max(p.reviewed_at for p in registry.get_all() if p.reviewed_at)
+        stale = registry.check_freshness(
+            max_age_days=90,
+            as_of=latest_review + timedelta(days=91),
+        )
+        assert {p.key for p in stale} == {p.key for p in registry.get_all()}
 
 
 # ---------------------------------------------------------------------------
@@ -484,10 +492,14 @@ class TestAvsReferenceAges:
 
 
 class TestFreshnessCheck:
-    """The freshness check should confirm all parameters are recently reviewed."""
+    """Freshness checks are explicit-date capable and deterministic."""
 
     def test_check_freshness_returns_empty(self, registry):
-        stale = registry.check_freshness(max_age_days=90)
+        latest_review = max(p.reviewed_at for p in registry.get_all() if p.reviewed_at)
+        stale = registry.check_freshness(
+            max_age_days=90,
+            as_of=latest_review + timedelta(days=90),
+        )
         assert stale == []
 
     def test_stale_detection_works(self):
@@ -497,16 +509,16 @@ class TestFreshnessCheck:
             value=42.0,
             reviewed_at=date(2020, 1, 1),
         )
-        assert param.is_stale(max_age_days=90)
+        assert param.is_stale(max_age_days=90, on_date=date(2020, 4, 1))
 
     def test_fresh_detection_works(self):
         """A recently reviewed parameter should not be stale."""
         param = RegulatoryParameter(
             key="test.fresh",
             value=42.0,
-            reviewed_at=date.today(),
+            reviewed_at=date(2026, 6, 26),
         )
-        assert not param.is_stale(max_age_days=90)
+        assert not param.is_stale(max_age_days=90, on_date=date(2026, 9, 24))
 
     def test_none_reviewed_at_is_stale(self):
         """A parameter with no reviewed_at should be stale."""
@@ -717,21 +729,22 @@ class TestCoachToolsIntegration:
 
 
 # ---------------------------------------------------------------------------
-# 15. Freshness — all parameters reviewed within 180 days
+# 15. Freshness — all parameters reviewed within the review snapshot SLA
 # ---------------------------------------------------------------------------
 
 
 class TestFreshness180Days:
-    """All parameters must have reviewed_at within 180 days of today."""
+    """All parameters must have reviewed_at within the deterministic review SLA."""
 
     def test_all_reviewed_within_180_days(self, registry):
-        """Every parameter must have been reviewed in the last 180 days."""
-        today = date.today()
+        """Every parameter must be fresh at 180 days after latest review."""
+        latest_review = max(p.reviewed_at for p in registry.get_all() if p.reviewed_at)
+        as_of = latest_review + timedelta(days=180)
         for param in registry.get_all():
             assert param.reviewed_at is not None, (
                 f"Missing reviewed_at for {param.key}"
             )
-            age_days = (today - param.reviewed_at).days
+            age_days = (as_of - param.reviewed_at).days
             assert age_days <= 180, (
                 f"Parameter {param.key} is stale: reviewed {age_days} days ago "
                 f"(max 180). reviewed_at={param.reviewed_at}"
@@ -781,7 +794,8 @@ class TestFreshness90DaysWarning:
 
     def test_warn_params_older_than_90_days(self, registry, capsys):
         """Informational: list parameters reviewed >90 days ago."""
-        today = date.today()
+        latest_review = max(p.reviewed_at for p in registry.get_all() if p.reviewed_at)
+        today = latest_review + timedelta(days=91)
         warnings = []
         for param in registry.get_all():
             if param.reviewed_at is None:

--- a/tools/checks/regulatory_freshness_monitor.py
+++ b/tools/checks/regulatory_freshness_monitor.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Warn when regulatory constants are due for human review.
+
+This monitor is intentionally warning-first by default. Product/runtime callers
+can still use RegulatoryRegistry.check_freshness() to identify stale constants,
+but ordinary PR/push CI should not go red only because the calendar advanced.
+Use --strict for a deliberate fail-closed review gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "services" / "backend"
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.services.regulatory.registry import RegulatoryRegistry  # noqa: E402
+
+
+def _build_markdown(*, as_of: date, max_age_days: int, stale: list) -> str:
+    lines = [
+        "# Regulatory Constants Review Due",
+        "",
+        f"- Checked at: `{as_of.isoformat()}`",
+        f"- SLA: `{max_age_days}` days since `reviewed_at`",
+        f"- Stale constants: `{len(stale)}`",
+        "",
+    ]
+    if not stale:
+        lines.append("No constants are stale.")
+        return "\n".join(lines) + "\n"
+
+    lines.append("| key | reviewed_at | age_days | source |")
+    lines.append("|---|---:|---:|---|")
+    for param in stale:
+        reviewed_at = param.reviewed_at.isoformat() if param.reviewed_at else "missing"
+        age = "missing" if param.reviewed_at is None else str((as_of - param.reviewed_at).days)
+        source = param.source_url or "missing"
+        lines.append(f"| `{param.key}` | `{reviewed_at}` | `{age}` | {source} |")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Regulatory constants freshness monitor.")
+    parser.add_argument("--max-age-days", type=int, default=90)
+    parser.add_argument("--as-of", type=date.fromisoformat)
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--markdown-out", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args(argv)
+
+    as_of = args.as_of or date.today()
+    registry = RegulatoryRegistry.instance()
+    stale = registry.check_freshness(max_age_days=args.max_age_days, as_of=as_of)
+    stale_keys = [param.key for param in stale]
+
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(
+            _build_markdown(as_of=as_of, max_age_days=args.max_age_days, stale=stale),
+            encoding="utf-8",
+        )
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as fh:
+            fh.write(f"stale_count={len(stale)}\n")
+
+    if stale:
+        print(
+            f"::warning::Regulatory constants review due: {len(stale)} "
+            f"stale parameter(s) as of {as_of.isoformat()}.",
+            file=sys.stderr,
+        )
+        for key in stale_keys[:20]:
+            print(f"stale: {key}", file=sys.stderr)
+        if len(stale_keys) > 20:
+            print(f"stale: ... {len(stale_keys) - 20} more", file=sys.stderr)
+        return 1 if args.strict else 0
+
+    print(
+        f"Regulatory freshness OK: 0 stale parameters as of {as_of.isoformat()}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/checks/tests/test_regulatory_freshness_monitor.py
+++ b/tools/checks/tests/test_regulatory_freshness_monitor.py
@@ -1,0 +1,64 @@
+"""Tests for tools/checks/regulatory_freshness_monitor.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "tools" / "checks" / "regulatory_freshness_monitor.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("regulatory_freshness_monitor", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_monitor_passes_before_review_sla_expires(capsys):
+    module = _load_module()
+    latest_review = max(
+        p.reviewed_at for p in module.RegulatoryRegistry.instance().get_all() if p.reviewed_at
+    )
+
+    rc = module.main(["--as-of", (latest_review + timedelta(days=90)).isoformat()])
+
+    assert rc == 0
+    assert "Regulatory freshness OK" in capsys.readouterr().out
+
+
+def test_monitor_warns_without_failing_by_default(tmp_path, capsys):
+    module = _load_module()
+    markdown_out = tmp_path / "freshness.md"
+    github_output = tmp_path / "github_output.txt"
+    latest_review = max(
+        p.reviewed_at for p in module.RegulatoryRegistry.instance().get_all() if p.reviewed_at
+    )
+    stale_date = (latest_review + timedelta(days=91)).isoformat()
+
+    rc = module.main(
+        [
+            "--as-of",
+            stale_date,
+            "--markdown-out",
+            str(markdown_out),
+            "--github-output",
+            str(github_output),
+        ]
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "::warning::Regulatory constants review due" in captured.err
+    assert "Regulatory Constants Review Due" in markdown_out.read_text(encoding="utf-8")
+    github_lines = github_output.read_text(encoding="utf-8").splitlines()
+    assert github_lines
+    assert github_lines[0].startswith("stale_count=")
+    assert int(github_lines[0].split("=", 1)[1]) > 0
+
+    strict_rc = module.main(["--as-of", stale_date, "--strict"])
+    assert strict_rc == 1


### PR DESCRIPTION
## Summary
- Make regulatory freshness checks deterministic by adding explicit evaluation dates to `is_stale()` / `check_freshness()` and removing wall-clock hard gates from backend tests.
- Add `tools/checks/regulatory_freshness_monitor.py` plus tests for warning-only and strict review-due behavior.
- Add a weekly GitHub workflow that installs backend deps, runs the monitor, and opens/comments a GitHub issue when regulatory review is due instead of reddening push-to-dev.

## Verification
- `python3 -m pytest services/backend/tests/test_regulatory_registry.py -q`
- `python3 -m pytest tools/checks/tests/test_regulatory_freshness_monitor.py -q`
- `python -m pytest tests/ -q --tb=short -x` from `services/backend`
- `python3 tools/codegen/regulatory_constants_to_dart.py --source local --check`
- `python3 tools/codegen/regulatory_constants_to_dart.py --check-determinism`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/agent_reference_guard.py`
- `git diff --check`
- Claude CLI safe-mode Opus final audit: GO

## Notes
- Local `active_context_guard` still fails on this feature branch name because `.planning/ACTIVE_CONTEXT.json` allowlists only dev/staging/main and `codex/account-lifecycle-gate-20260624`; this is the same local false positive seen on PR #737.
- Shortstat: `7 files changed, 262 insertions(+), 34 deletions(-)`.
