### PR TITLE
JOS-001 privacy center account deletion entry

### DIFF
--- a/apps/mobile/lib/screens/profile/privacy_center_screen.dart
+++ b/apps/mobile/lib/screens/profile/privacy_center_screen.dart
@@ -3,8 +3,11 @@
 //
 // v2.7 Phase 29 / PRIV-01.
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/services/consent/consent_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -66,6 +69,45 @@ class _PrivacyCenterScreenState extends State<PrivacyCenterScreen> {
     }
   }
 
+  Future<void> _confirmDeleteAccount() async {
+    final l = S.of(context)!;
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l.profileDeleteAccountTitle),
+        content: Text(l.profileDeleteAccountContent),
+        actions: [
+          TextButton(
+            // lint-ignore: prefer_mint_cta
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l.profileDeleteCancel),
+          ),
+          TextButton(
+            // lint-ignore: prefer_mint_cta
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(
+              l.profileDeleteConfirm,
+              style: const TextStyle(color: MintColors.error),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (shouldDelete != true || !mounted) return;
+
+    final deleted = await context.read<AuthProvider>().deleteAccount();
+    if (!mounted) return;
+
+    if (deleted) {
+      context.go('/');
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l.profileDeleteAccountError)),
+      );
+    }
+  }
+
   String _labelForPurpose(S l, ConsentPurpose p) {
     switch (p) {
       case ConsentPurpose.visionExtraction:
@@ -82,6 +124,7 @@ class _PrivacyCenterScreenState extends State<PrivacyCenterScreen> {
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
+    final isLoggedIn = context.watch<AuthProvider>().isLoggedIn;
     return Scaffold(
       backgroundColor: MintColors.white,
       appBar: AppBar(
@@ -130,11 +173,45 @@ class _PrivacyCenterScreenState extends State<PrivacyCenterScreen> {
                     grantedAt: r.consentTimestamp,
                     revokedAt: r.revokedAt,
                   ),
+                if (isLoggedIn) ...[
+                  const SizedBox(height: 24),
+                  const Divider(color: MintColors.lightBorder),
+                  _DeleteAccountRow(onTap: _confirmDeleteAccount),
+                ],
               ],
             ),
           );
         },
       ),
+    );
+  }
+}
+
+class _DeleteAccountRow extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _DeleteAccountRow({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = S.of(context)!;
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: const Icon(
+        Icons.delete_outline,
+        color: MintColors.error,
+        size: 22,
+      ),
+      title: Text(
+        l.profileDeleteCloudAccount,
+        style: MintTextStyles.bodyMedium(color: MintColors.error),
+      ),
+      trailing: const Icon(
+        Icons.chevron_right,
+        color: MintColors.error,
+        size: 20,
+      ),
+      onTap: onTap,
     );
   }
 }

--- a/apps/mobile/test/screens/profile/privacy_center_screen_test.dart
+++ b/apps/mobile/test/screens/profile/privacy_center_screen_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/screens/profile/privacy_center_screen.dart';
+import 'package:mint_mobile/services/api_service.dart';
+import 'package:mint_mobile/services/auth_service.dart';
+import 'package:mint_mobile/services/observability/mint_http_client.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {
+  @override
+  bool isLoggedIn = true;
+
+  bool deleteAccountCalled = false;
+
+  @override
+  Future<bool> deleteAccount() async {
+    deleteAccountCalled = true;
+    isLoggedIn = false;
+    notifyListeners();
+    return true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _buildPrivacyCenterApp(_FakeAuthProvider authProvider) {
+  final router = GoRouter(
+    initialLocation: '/profile/privacy',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const Scaffold(body: Text('home')),
+      ),
+      GoRoute(
+        path: '/profile/privacy',
+        builder: (_, __) => const PrivacyCenterScreen(),
+      ),
+    ],
+  );
+
+  return ChangeNotifierProvider<AuthProvider>.value(
+    value: authProvider,
+    child: MaterialApp.router(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      locale: const Locale('fr'),
+      routerConfig: router,
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    AuthService.resetMemoryCacheForTest();
+    ApiService.setHttpClientForTesting(
+      MintHttpClient(
+        MockClient((request) async {
+          if (request.url.path == '/api/v1/consents') {
+            return http.Response(
+              '{"consents":[]}',
+              200,
+              headers: {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('{"detail":"not found"}', 404);
+        }),
+      ),
+    );
+  });
+
+  tearDown(() {
+    ApiService.setHttpClientForTesting(null);
+  });
+
+  testWidgets(
+    'logged-in privacy center exposes account deletion and confirms it',
+    (tester) async {
+      final authProvider = _FakeAuthProvider();
+
+      await tester.pumpWidget(_buildPrivacyCenterApp(authProvider));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ma vie privée'), findsOneWidget);
+      expect(find.text('Supprimer mon compte'), findsOneWidget);
+
+      await tester.tap(find.text('Supprimer mon compte'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Supprimer le compte ?'), findsOneWidget);
+
+      await tester.tap(find.text('Supprimer'));
+      await tester.pumpAndSettle();
+
+      expect(authProvider.deleteAccountCalled, isTrue);
+      expect(find.text('home'), findsOneWidget);
+    },
+  );
+}

--- a/tools/simulator/flows/maestro-perfect-set/flow_jos001_privacy_center_runtime.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_jos001_privacy_center_runtime.yaml
@@ -1,0 +1,80 @@
+# tools/simulator/flows/maestro-perfect-set/flow_jos001_privacy_center_runtime.yaml
+#
+# PURPOSE
+# JOS-001 runtime smoke for the account lifecycle privacy hub:
+# a fresh simulator can deep-link into `/profile/privacy` from the shell and
+# render the privacy center without crashing the AuthProvider-backed screen.
+# Account deletion itself requires an authenticated account session; the
+# connected deletion branch is covered by a widget/provider contract until a
+# seeded-auth runtime fixture exists on dev.
+
+appId: ch.mint.app
+tags:
+  - jos-001
+  - account-lifecycle
+  - privacy-center
+  - runtime
+  - maestro-proof
+---
+
+- launchApp:
+    clearState: true
+- waitForAnimationToEnd:
+    timeout: 6000
+- runFlow:
+    when:
+      visible: "Je comprends, on y va"
+    commands:
+      - tapOn: "Je comprends, on y va"
+      - waitForAnimationToEnd
+
+- openLink: "mintapp:///explore"
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Continuer en mode local"
+    commands:
+      - tapOn: "Continuer en mode local"
+      - waitForAnimationToEnd
+      - openLink: "mintapp:///explore"
+      - waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      text: "Explorer"
+    timeout: 12000
+
+- openLink: "mintapp:///profile/privacy"
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      text: "Ma vie privée"
+    timeout: 12000
+- assertVisible:
+    text: "CONSENTEMENTS ACTIFS"
+- assertVisible:
+    text: "HISTORIQUE"
+- takeScreenshot: "jos001-privacy-center-runtime"


### PR DESCRIPTION
## Summary
- expose the existing account deletion action from `/profile/privacy` for logged-in users
- add a widget contract proving the privacy center calls `AuthProvider.deleteAccount()` and returns home
- add a JOS-001 Maestro runtime smoke for `/profile/privacy` via explicit local mode

## Verification
- RED: `flutter test test/screens/profile/privacy_center_screen_test.dart` failed on missing `Supprimer mon compte`
- `flutter test test/screens/profile/privacy_center_screen_test.dart test/screens/profile/privacy_control_screen_test.dart test/widgets/profile_drawer_test.dart test/providers/auth_provider_test.dart test/navigation/account_lifecycle_public_entry_redirect_test.dart` -> 91 passed
- `flutter test test/screens/profile/privacy_center_screen_test.dart test/widgets/profile_drawer_test.dart test/navigation/account_lifecycle_public_entry_redirect_test.dart` -> 17 passed
- `flutter analyze` -> No issues found
- `./tools/mint-routes check` -> 145 routes parity OK
- `flutter build ios --simulator --no-codesign --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready` -> built `Runner.app`
- `MINT_WALKER_ARTIFACTS=.planning/runtime-evidence/jos001-privacy-center-20260626T181102Z MAESTRO_HARD_LIMIT=240 bash tools/simulator/maestro_with_watchdog.sh test tools/simulator/flows/maestro-perfect-set/flow_jos001_privacy_center_runtime.yaml` -> passed on iPhone 17 Pro iOS 26.2
- Claude CLI safe-mode Opus audit -> no blockers

## Known Limitations
- `active_context_guard` and `journey_os_check.py` still fail on this product branch because their current branch/scope rules whitelist Journey OS/no-product-code work only; I did not edit active context or weaken those guards.
- Runtime proof covers privacy center reachability in local mode. Actual connected account deletion is covered by widget/provider tests until a seeded-auth runtime fixture exists on `dev`.
- Global `maestro_locator_audit.py` has pre-existing failures in older flows; the new JOS-001 flow was not listed in those failures.