### PR TITLE
Track JOS-001 account lifecycle proof

### DIFF
--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -4,4 +4,4 @@ Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
 | Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
 |---|---|---|---|---:|---|---|---|
-| JOS-001 | P0 | triaged | account_lifecycle_delete | 27 | mint-quality-gate | missing | Create the smallest deterministic runtime proof for recovery, privacy control, and account deletion. |
+| JOS-001 | P0 | proof_needed | account_lifecycle_delete | 27 | mint-quality-gate | green | Add seeded-auth runtime proof for recovery entry, privacy controls, and actual account deletion with durable repo evidence. |

--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -4,7 +4,7 @@ Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 
 | ID | Tier | Priority | Status | Promise | Accountable team | Routes | Evidence |
 |---|---:|---:|---|---|---|---|---|
-| account_lifecycle_delete | T0 | 27 | draft | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | missing |
+| account_lifecycle_delete | T0 | 27 | partial | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | green, missing |
 | coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green |
 | money_truth_spine | T0 | 28 | partial | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | green |
 | onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /coach/chat, /home | green |

--- a/.planning/journeys/issues/JOS-001.json
+++ b/.planning/journeys/issues/JOS-001.json
@@ -3,10 +3,10 @@
   "id": "JOS-001",
   "title": "Prove account lifecycle delete and recovery",
   "journey_id": "account_lifecycle_delete",
-  "status": "triaged",
+  "status": "proof_needed",
   "owner": "mint-quality-gate",
   "severity": "P0",
-  "evidence_status": "missing",
-  "next_action": "Create the smallest deterministic runtime proof for recovery, privacy control, and account deletion.",
-  "source": "JOURNEY-TRUTH-MATRIX-005"
+  "evidence_status": "green",
+  "next_action": "Add seeded-auth runtime proof for recovery entry, privacy controls, and actual account deletion with durable repo evidence.",
+  "source": "JOURNEY-TRUTH-MATRIX-005; PR #740"
 }

--- a/.planning/journeys/records/account_lifecycle_delete.json
+++ b/.planning/journeys/records/account_lifecycle_delete.json
@@ -3,7 +3,7 @@
   "id": "account_lifecycle_delete",
   "title": "Account lifecycle delete",
   "tier": "T0",
-  "status": "draft",
+  "status": "partial",
   "human_promise": "I can recover, delete, and control my account data.",
   "accountable_team": "mint-quality-gate",
   "route_paths": [
@@ -39,11 +39,18 @@
   },
   "evidence": [
     {
-      "kind": "manual",
+      "kind": "widget",
+      "status": "green",
+      "command": "cd apps/mobile && flutter test test/screens/profile/privacy_center_screen_test.dart",
+      "artifact": "apps/mobile/test/screens/profile/privacy_center_screen_test.dart",
+      "reason": "PR #740 proves the authenticated /profile/privacy deletion entry opens confirmation, calls AuthProvider.deleteAccount(), and redirects home on success."
+    },
+    {
+      "kind": "runtime",
       "status": "missing",
       "command": null,
       "artifact": null,
-      "reason": "Journey Truth Matrix row 5 says recovery/delete/control account data has routes but no current end-to-end proof."
+      "reason": "The privacy-center route smoke exists, but full account lifecycle closure still needs seeded-auth runtime proof for recovery entry, privacy controls, and actual account deletion with durable repo evidence."
     }
   ]
 }

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -239,6 +239,30 @@ def _issue_errors(root: Path, path: Path, data: dict[str, Any], journey_ids: set
         errors.append(f"{rel} evidence_status has unknown enum: {data.get('evidence_status')}")
     return errors
 
+def _issue_progress_errors(root: Path, records: list[tuple[Path, dict[str, Any]]], issues: list[tuple[Path, dict[str, Any]]]) -> list[str]:
+    has_green_evidence: set[str] = set()
+    for _path, data in records:
+        if not isinstance(data.get("id"), str):
+            continue
+        evidence = data.get("evidence")
+        if not isinstance(evidence, list):
+            continue
+        if any(isinstance(item, dict) and item.get("status") == "green" and _artifact_ok(root, item.get("artifact")) for item in evidence):
+            has_green_evidence.add(str(data["id"]))
+    errors: list[str] = []
+    for path, data in issues:
+        has_green = data.get("journey_id") in has_green_evidence
+        rel = path.relative_to(root)
+        if data.get("evidence_status") == "green" and not has_green:
+            errors.append(f"{rel} cannot be green without durable green evidence on referenced journey")
+        if not has_green:
+            continue
+        if data.get("status") in {"found", "triaged"}:
+            errors.append(f"{rel} cannot stay {data.get('status')} after referenced journey has durable green evidence")
+        if data.get("evidence_status") == "missing":
+            errors.append(f"{rel} cannot stay missing after referenced journey has durable green evidence")
+    return errors
+
 def check(root: Path, changed_files: list[str] | None = None, base_ref: str = "origin/dev") -> list[str]:
     root = root.resolve()
     changed, errors = (changed_files, []) if changed_files else _changed(root, base_ref)
@@ -267,6 +291,7 @@ def check(root: Path, changed_files: list[str] | None = None, base_ref: str = "o
         if isinstance(iid, str):
             issue_ids.add(iid)
         errors += _issue_errors(root, path, data, seen)
+    errors += _issue_progress_errors(root, records, issues)
     for path, data in records:
         rel = path.relative_to(root)
         for issue in data.get("issues", []) if isinstance(data.get("issues"), list) else []:

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -55,10 +55,10 @@ def _issue(root: Path, **updates: object) -> None:
         "id": "JOS-001",
         "title": "Prove money truth spine",
         "journey_id": "money_truth_spine",
-        "status": "triaged",
+        "status": "proof_needed",
         "owner": "mint-quality-gate",
         "severity": "P0",
-        "evidence_status": "missing",
+        "evidence_status": "green",
         "next_action": "Create the next deterministic runtime proof for the highest-scoring journey.",
         "source": "CJT-003",
     }
@@ -105,6 +105,20 @@ def test_issue_registry_and_generated_board(tmp_path: Path) -> None:
     assert "Next Journey OS Work" in board
     assert "JOS-001" in board
     assert "money_truth_spine" in board
+
+def test_issue_status_tracks_referenced_record_evidence(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root, status="triaged", evidence_status="missing")
+    journey_os_generate.write(root)
+    errors = _errors(root)
+    assert any("cannot stay triaged" in error for error in errors)
+    assert any("cannot stay missing" in error for error in errors)
+    root = _root(tmp_path / "overclaim")
+    _record(root, evidence=[{"kind": "runtime", "status": "missing", "command": None, "artifact": None}])
+    _issue(root, status="proof_needed", evidence_status="green")
+    journey_os_generate.write(root)
+    assert any("cannot be green" in error for error in _errors(root))
 
 def test_issue_registry_shape_rules(tmp_path: Path) -> None:
     cases = [


### PR DESCRIPTION
## Summary
- record PR #740 widget proof in `account_lifecycle_delete`
- move JOS-001 from `triaged/missing` to `proof_needed/green`
- keep seeded-auth runtime recovery/delete proof explicitly missing
- add reciprocal Journey OS guard against stale issue evidence status and overclaiming green issue evidence

## Verification
- `python3 tools/checks/journey_os_check.py`
- `python3 -m pytest tools/checks/tests/test_journey_os_check.py -q`
- `./tools/mint-routes check`
- `cd apps/mobile && flutter test test/screens/profile/privacy_center_screen_test.dart`
- `git diff --check origin/dev...HEAD`
- Claude CLI safe-mode Opus final audit: no blockers

## Known exception
- `active_context_guard.py` fails locally only because this dedicated feature branch is not listed in `.planning/ACTIVE_CONTEXT.json`; this is the documented `ACTIVE_CONTEXT_BRANCH_MISMATCH_EXPECTED` case for Journey OS feature branches.