### PR TITLE
Make PR size budget dynamic

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -12,7 +12,8 @@
     "staging",
     "main",
     "codex/account-lifecycle-gate-20260624",
-    "codex/jos001-seeded-auth-runtime-20260626"
+    "codex/jos001-seeded-auth-runtime-20260626",
+    "codex/dynamic-pr-size-rule-20260626"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -17,6 +17,8 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary runtime-proof branch: `codex/jos001-seeded-auth-runtime-20260626`
   is authorized only for the JOS-001 account lifecycle seeded-auth runtime
   proof and any directly required gate fix.
+- Temporary workflow branch: `codex/dynamic-pr-size-rule-20260626` is
+  authorized only for the PR-size-budget doctrine correction.
 
 ## Required Session Start
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,15 @@ Revolut) from ones that turn in circles. Apply religiously.
 1. **TDD first.** Write the failing test (or contract shape) before the
    code. Agents fill specs well; they *design* them poorly. The failing
    test is the ground truth for « done ».
-2. **< 300 lines per PR.** Beyond that, you and the agent lose the plot.
-   Run `git diff --shortstat origin/dev...HEAD` before pushing. Split if
-   over.
+2. **Dynamic PR-size budget, not a hard cap.** Always run
+   `git diff --shortstat origin/dev...HEAD` before pushing. For routine
+   bugfix/doc/guard work, use ~300 changed lines as the default review budget.
+   For one coherent vertical, runtime proof, generated view, or evidence update,
+   exceeding that budget is allowed when splitting would make review, rollback,
+   or verification worse. In that case, isolate generated/evidence files and
+   write the reason in the PR body. If non-generated product changes span
+   multiple surfaces, split unless `mint-lead` or Julien explicitly accepts the
+   larger unit.
 3. **Atomic, revertable commits.** One concern per commit. If `git revert
    <sha>` would break something orthogonal, split.
 4. **Grep before assume.** If you name a symbol (method, var, tool, ARB

--- a/rules.md
+++ b/rules.md
@@ -60,6 +60,11 @@ there is an actual tool call, command output, or artifact path.
 - Use test-driven development for feature, bugfix, guard, and behavior changes.
 - Verify the diff, not the explanation: `git diff --stat`, `git diff --check`,
   and focused tests before commit.
+- Treat PR size as a dynamic review budget, not a fixed line cap. Always run
+  `git diff --shortstat origin/dev...HEAD`; keep routine bugfix/doc/guard PRs
+  around the small-PR budget, and when a coherent vertical legitimately exceeds
+  it, isolate generated/evidence files and state in the PR why splitting would
+  make review or rollback worse.
 - Save Engram via `mem_save` after durable decisions, discoveries,
   conventions, and bug fixes.
 - Use simulator/runtime evidence before claiming mobile user flow quality.


### PR DESCRIPTION
## Summary

This makes the repository rule explicit: PR size is a dynamic review budget, not a fixed 300-line cap.

## Changes

- Adds the rule to `rules.md`, the highest repo-local authority.
- Rewrites the AGENTS vibe-coding rule from `< 300 lines per PR` to a dynamic budget:
  - routine bugfix/doc/guard work should stay near the small-PR budget;
  - coherent verticals, runtime proofs, generated views, and evidence updates may exceed it when splitting would make review/rollback/verification worse;
  - generated/evidence files must be isolated and the PR body must explain the reason;
  - multi-surface non-generated product changes still split unless `mint-lead` or Julien accepts the larger unit.
- Authorizes this temporary workflow branch in ACTIVE_CONTEXT so repo guards pass on the branch.

## Verification

- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `git diff --check`
- pre-commit hooks
- pre-push hooks

## Diff Budget

`4 files changed, 18 insertions(+), 4 deletions(-)`
