### PR TITLE
Prove JOS-002A onboarding persistence gate

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-06-24",
+  "updated": "2026-06-27",
   "active_milestone": "mint-2-0-first-experience-rente-capital",
   "active_phase_dir": ".planning/phases/mint-2-0-first-experience-rente-capital",
   "active_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md",
@@ -14,7 +14,8 @@
     "codex/account-lifecycle-gate-20260624",
     "codex/jos001-seeded-auth-runtime-20260626",
     "codex/dynamic-pr-size-rule-20260626",
-    "codex/jos002-money-truth-spine-20260626"
+    "codex/jos002-money-truth-spine-20260626",
+    "codex/jos002a-onboarding-persistence-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -21,6 +21,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
   authorized only for the PR-size-budget doctrine correction.
 - Temporary runtime-proof branch: `codex/jos002-money-truth-spine-20260626`
   is authorized only for the Money truth spine Journey OS vertical.
+- Temporary hotfix branch: `codex/jos002a-onboarding-persistence-20260627`
+  is authorized only for the JOS-002A onboarding persistence gate needed before
+  the downstream Money truth spine proof.
 
 ## Required Session Start
 

--- a/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
@@ -1480,6 +1480,7 @@ class _BifurcationStepState extends State<_BifurcationStep> {
     if (_sealing) return;
     final provider = context.read<OnboardingProvider>();
     final coach = context.read<CoachProfileProvider>();
+    final auth = context.read<AuthProvider>();
     final messenger = ScaffoldMessenger.maybeOf(context);
     final l10n = S.of(context)!;
     final router = GoRouter.of(context);
@@ -1489,7 +1490,7 @@ class _BifurcationStepState extends State<_BifurcationStep> {
     try {
       await provider.completeAndFlushToProfile(coach);
       if (coach.hasProfile) {
-        context.read<AuthProvider>().markAccountProfileAvailable();
+        auth.markAccountProfileAvailable();
       }
     } catch (e, stack) {
       dev.log(

--- a/apps/mobile/test/screens/onboarding/mvp_wedge/onboarding_persistence_gate_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge/onboarding_persistence_gate_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
+import 'package:mint_mobile/models/onboarding_intent.dart';
+import 'package:mint_mobile/app.dart' show accountLifecycleAndArchetypeRedirect;
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/screens/onboarding/mvp_wedge/onboarding_provider.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _secureStorageChannel =
+    MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final secureStorage = <String, String>{};
+
+  setUp(() {
+    secureStorage.clear();
+    SharedPreferences.setMockInitialValues(const <String, Object>{
+      'auth_local_mode': true,
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureStorageChannel, (call) async {
+      final key = call.arguments['key'] as String?;
+      switch (call.method) {
+        case 'write':
+          final value = call.arguments['value'] as String?;
+          if (key != null && value != null) secureStorage[key] = value;
+          return null;
+        case 'read':
+          return key == null ? null : secureStorage[key];
+        case 'delete':
+          if (key != null) secureStorage.remove(key);
+          return null;
+        case 'deleteAll':
+          secureStorage.clear();
+          return null;
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureStorageChannel, null);
+  });
+
+  test('JOS-002A: terminal onboarding persists sealed profile for cold restart',
+      () async {
+    final onboarding = OnboardingProvider()
+      ..setIntent(OnboardingIntent.retraite, 'Ma prévoyance')
+      ..setDateOfBirth(DateTime(1981, 6, 15))
+      ..setNationality('CH')
+      ..setEmploymentStatus('salarie')
+      ..setCivilStatus('marie')
+      ..setAvsLacunes('no_gaps')
+      ..setCanton('VD', 'Vaud')
+      ..setNetMonthlyExact(7200)
+      ..setWantsDeeper(true);
+    final currentSession = CoachProfileProvider();
+
+    await onboarding.completeAndFlushToProfile(currentSession);
+
+    final prefs = await SharedPreferences.getInstance();
+    final raw = json.decode(prefs.getString('wizard_answers_v2')!)
+        as Map<String, dynamic>;
+    expect(raw['q_canton'], 'VD');
+    expect(raw['q_date_of_birth'], '__secure__');
+    expect(raw['q_birth_year'], '__secure__');
+    expect(raw['q_nationality'], '__secure__');
+    expect(raw['q_employment_status'], '__secure__');
+    expect(raw['q_civil_status'], '__secure__');
+    expect(raw['q_avs_lacunes_status'], '__secure__');
+    expect(raw['q_net_income_period_chf'], '__secure__');
+    expect(raw.containsValue('1981-06-15'), isFalse);
+    expect(raw.containsValue('1981-06-15T00:00:00.000'), isFalse);
+    expect(raw.containsValue(7200), isFalse);
+
+    final loaded = await ReportPersistenceService.loadAnswers();
+    expect(loaded['q_date_of_birth'], '1981-06-15T00:00:00.000');
+    expect(loaded['q_canton'], 'VD');
+    expect(loaded['q_net_income_period_chf'], 7200);
+    expect(loaded['q_employment_status'], 'salarie');
+    expect(loaded['q_has_pension_fund'], isTrue);
+
+    final coldStart = CoachProfileProvider();
+    await coldStart.loadFromWizard();
+
+    expect(coldStart.profile, isNotNull);
+    expect(coldStart.profile!.dateOfBirth, DateTime(1981, 6, 15));
+    expect(coldStart.profile!.canton, 'VD');
+    expect(coldStart.profile!.nationality, 'CH');
+    expect(coldStart.profile!.employmentStatus, 'salarie');
+    expect(coldStart.profile!.salaireBrutMensuel, greaterThan(0));
+    expect(
+      accountLifecycleAndArchetypeRedirect(
+        lifecycle: AuthLifecycleState.guestEmpty(installId: 'install-1'),
+        location: '/mon-argent',
+        path: '/mon-argent',
+        topRoute: null,
+        profile: coldStart.profile,
+        profileSettled: true,
+      ),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Add a JOS-002A gate proving terminal onboarding persists a sealed profile through a cold-start reload.
- Assert SEC-10 behavior: DOB, birth year, nationality, employment, civil status, AVS status and income stay behind `__secure__` placeholders in SharedPreferences while loading back through secure storage.
- Fix one existing `use_build_context_synchronously` analyzer issue by capturing `AuthProvider` before the async seal.

## Scope Notes
- This proves the production secure-store path; it does not claim the downstream Money Truth simulator runtime proof is green.
- The previous JOS-002 red remains a separate simulator/harness proof item for JOS-002B.
- Active context is temporarily authorized for `codex/jos002a-onboarding-persistence-20260627` only.

## Audit
- Claude CLI safe-mode Opus audit ran against the staged diff and returned verdict: MERGE.
- Two audit nits were applied before commit: full ISO DOB leak check and explicit `__secure__` assertions for sensitive onboarding keys.

## Verification
- `cd apps/mobile && dart format --set-exit-if-changed lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart test/screens/onboarding/mvp_wedge/onboarding_persistence_gate_test.dart`
- `cd apps/mobile && flutter analyze`
- `cd apps/mobile && flutter test test/screens/onboarding/mvp_wedge/onboarding_persistence_gate_test.dart test/screens/onboarding/mvp_wedge_storyboard_test.dart test/providers/coach_profile_provider_secure_failure_test.dart test/services/report_persistence_service_test.dart test/navigation/account_lifecycle_public_entry_redirect_test.dart`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && git diff --cached --check`
- pre-commit hooks passed on `cffaea6dc`.
- pre-push hooks passed.

## Diff Budget
- `git diff --shortstat origin/dev...HEAD`: `4 files changed, 120 insertions(+), 3 deletions(-)`.