### PR TITLE
Prove JOS-002B money truth runtime chain

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -15,7 +15,8 @@
     "codex/jos001-seeded-auth-runtime-20260626",
     "codex/dynamic-pr-size-rule-20260626",
     "codex/jos002-money-truth-spine-20260626",
-    "codex/jos002a-onboarding-persistence-20260627"
+    "codex/jos002a-onboarding-persistence-20260627",
+    "codex/jos002b-money-truth-runtime-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -24,6 +24,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary hotfix branch: `codex/jos002a-onboarding-persistence-20260627`
   is authorized only for the JOS-002A onboarding persistence gate needed before
   the downstream Money truth spine proof.
+- Temporary runtime-proof branch: `codex/jos002b-money-truth-runtime-20260627`
+  is authorized only for the JOS-002B Money truth runtime proof harness and any
+  directly required SEC-10-preserving simulator fixture fix.
 
 ## Required Session Start
 

--- a/apps/mobile/lib/screens/debug/debug_profile_bootstrap_screen.dart
+++ b/apps/mobile/lib/screens/debug/debug_profile_bootstrap_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/services/debug_profile_bootstrap_service.dart';
+import 'package:provider/provider.dart';
 
 class DebugProfileBootstrapScreen extends StatefulWidget {
   final String slug;
@@ -27,12 +29,20 @@ class _DebugProfileBootstrapScreenState
   @override
   void initState() {
     super.initState();
-    _result = DebugProfileBootstrapService.persistFixture(
+    _result = _persistFixture();
+  }
+
+  Future<DebugProfileBootstrapResult> _persistFixture() async {
+    final result = await DebugProfileBootstrapService.persistFixture(
       slug: widget.slug,
       mode: widget.mode,
       selfEmployedNetIncomeAnnual: widget.selfEmployedNetIncomeAnnual,
       annual3aContribution: widget.annual3aContribution,
     );
+    if (result.ok && mounted) {
+      await context.read<AuthProvider>().enableLocalMode();
+    }
+    return result;
   }
 
   @override

--- a/apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart
+++ b/apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart
@@ -119,9 +119,32 @@ class _MonArgentScreenState extends State<MonArgentScreen> {
     final mintState = context.watch<MintStateProvider>().state;
     final dataSpine = mintState?.dataSpineSnapshot;
     final budgetSnapshot = dataSpine?.budget ?? mintState?.budgetSnapshot;
+    final providerPresentBudget =
+        budgetProvider.hasFreshInputs && budgetProvider.inputs != null
+            ? PresentBudgetBuilder.fromInputs(
+                inputs: budgetProvider.inputs!,
+                plan: budgetProvider.plan ??
+                    const BudgetPlan(
+                      available: 0,
+                      variables: 0,
+                      future: 0,
+                      stopRuleTriggered: false,
+                      emergencyFundMonths: 0,
+                    ),
+              )
+            : null;
     final preferProfileBudgetProvider =
         budgetProvider.source == BudgetDataSource.profile &&
-            budgetProvider.hasFreshInputs;
+            providerPresentBudget != null &&
+            (budgetSnapshot == null ||
+                !_hasSameMonthlyBudgetBase(
+                  budgetSnapshot.present,
+                  providerPresentBudget,
+                ) ||
+                _providerCarriesFutureOverride(
+                  budgetSnapshot.present,
+                  providerPresentBudget,
+                ));
     final budgetSnapshotForBudgetCard =
         preferProfileBudgetProvider ? null : budgetSnapshot;
     final budgetConfidenceScore = preferProfileBudgetProvider
@@ -257,6 +280,22 @@ class _MonArgentScreenState extends State<MonArgentScreen> {
       ),
     );
   }
+
+  bool _hasSameMonthlyBudgetBase(PresentBudget a, PresentBudget b) {
+    return _sameChf(a.monthlyNet, b.monthlyNet) &&
+        _sameChf(a.monthlyCharges, b.monthlyCharges);
+  }
+
+  bool _providerCarriesFutureOverride(
+    PresentBudget snapshot,
+    PresentBudget provider,
+  ) {
+    return provider.monthlySavings > 0 &&
+        !_sameChf(snapshot.monthlySavings, provider.monthlySavings);
+  }
+
+  bool _sameChf(double a, double b) =>
+      PresentBudgetBuilder.displayChf(a) == PresentBudgetBuilder.displayChf(b);
 }
 
 enum _MonArgentSection { today, month, wealth, pension, future }

--- a/apps/mobile/lib/services/debug_profile_bootstrap_service.dart
+++ b/apps/mobile/lib/services/debug_profile_bootstrap_service.dart
@@ -80,23 +80,38 @@ class DebugProfileBootstrapService {
       );
     }
 
-    final annualIncome = selfEmployedNetIncomeAnnual ??
-        seed.independentNetProfessionalIncomeAnnual;
-    final monthlyNetIncome = annualIncome != null ? annualIncome / 12 : null;
-    final annual3a = annual3aContribution ?? seed.annual3aContribution;
+    final appliesIndependentNoLppPatch = selfEmployedNetIncomeAnnual != null ||
+        seed.independentNetProfessionalIncomeAnnual != null ||
+        answers.containsKey('q_self_employed_net_income_annual_chf');
+    final annualIncome = appliesIndependentNoLppPatch
+        ? selfEmployedNetIncomeAnnual ??
+            _parseDouble(answers['q_self_employed_net_income_annual_chf']) ??
+            seed.independentNetProfessionalIncomeAnnual
+        : null;
 
-    answers['q_employment_status'] = 'independant';
-    answers['q_has_pension_fund'] = false;
-    answers['q_pay_frequency'] = 'monthly';
-    if (annualIncome != null) {
-      answers['q_self_employed_net_income_annual_chf'] = annualIncome;
-      answers['q_net_income_period_chf'] = monthlyNetIncome;
+    if (appliesIndependentNoLppPatch) {
+      answers['q_employment_status'] = 'independant';
+      answers['q_has_pension_fund'] = false;
+      answers['q_pay_frequency'] = 'monthly';
+      if (annualIncome != null) {
+        answers['q_self_employed_net_income_annual_chf'] = annualIncome;
+        answers['q_net_income_period_chf'] = annualIncome / 12;
+      }
     }
-    if (annual3a != null) {
+
+    final annual3a = annual3aContribution ??
+        _parseDouble(answers['q_3a_annual_contribution']) ??
+        seed.annual3aContribution;
+    if (annual3a != null &&
+        (annual3aContribution != null || appliesIndependentNoLppPatch)) {
       answers['q_3a_annual_contribution'] = annual3a;
       answers['q_has_3a'] = annual3a > 0;
-      answers['q_3a_accounts_count'] = annual3a > 0 ? 1 : 0;
+      if (appliesIndependentNoLppPatch) {
+        answers['q_3a_accounts_count'] = annual3a > 0 ? 1 : 0;
+      }
     }
+    final monthlyNetIncome = _parseDouble(answers['q_net_income_period_chf']) ??
+        (annualIncome == null ? null : annualIncome / 12);
 
     var storageMode = 'secureSeal';
     var sealed = await ReportPersistenceService.saveAnswers(answers);
@@ -142,5 +157,11 @@ class DebugProfileBootstrapService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('wizard_answers_v2', json.encode(answers));
     return true;
+  }
+
+  static double? _parseDouble(Object? value) {
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+    return null;
   }
 }

--- a/apps/mobile/test/screens/debug/debug_profile_bootstrap_screen_test.dart
+++ b/apps/mobile/test/screens/debug/debug_profile_bootstrap_screen_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/providers/auth_provider.dart';
+import 'package:mint_mobile/screens/debug/debug_profile_bootstrap_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _secureStorageChannel =
+    MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final secureStorage = <String, String>{};
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    secureStorage.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureStorageChannel, (call) async {
+      final key = call.arguments['key'] as String?;
+      switch (call.method) {
+        case 'write':
+          final value = call.arguments['value'] as String?;
+          if (key != null && value != null) secureStorage[key] = value;
+          return null;
+        case 'read':
+          return key == null ? null : secureStorage[key];
+        case 'delete':
+          if (key != null) secureStorage.remove(key);
+          return null;
+        case 'deleteAll':
+          secureStorage.clear();
+          return null;
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureStorageChannel, null);
+  });
+
+  testWidgets('enables local mode after applying the profile fixture',
+      (tester) async {
+    final auth = AuthProvider();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthProvider>.value(
+        value: auth,
+        child: const MaterialApp(
+          home: DebugProfileBootstrapScreen(
+            slug: 'cadre_salarie_lpp_suisse_ready',
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('e2e_profile_fixture_applied')),
+      findsOneWidget,
+    );
+    expect(auth.authLifecycle.allowsMainNavigation, isTrue);
+    expect(auth.isLocalMode, isTrue);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('auth_local_mode'), isTrue);
+  });
+}

--- a/apps/mobile/test/screens/mon_argent_screen_test.dart
+++ b/apps/mobile/test/screens/mon_argent_screen_test.dart
@@ -979,6 +979,74 @@ void main() {
     expect(find.byKey(const Key('mon_argent_budget_summary')), findsOneWidget);
   });
 
+  testWidgets(
+      'month section keeps canonical snapshot over fresh profile inputs',
+      (tester) async {
+    final budgetProvider = BudgetProvider();
+    await budgetProvider.refreshFromProfile(
+      _profileWithBudget(housingCost: 1100, healthInsurance: 390),
+    );
+    final providerPresent = PresentBudgetBuilder.fromInputs(
+      inputs: budgetProvider.inputs!,
+      plan: budgetProvider.plan!,
+    );
+    final canonicalSnapshot = BudgetSnapshot(
+      present: PresentBudget(
+        monthlyNet: providerPresent.monthlyNet,
+        monthlyCharges: providerPresent.monthlyCharges,
+        monthlySavings: 700,
+        monthlyFree:
+            providerPresent.monthlyNet - providerPresent.monthlyCharges - 700,
+      ),
+      capImpacts: const [],
+      stage: BudgetStage.presentOnly,
+      confidenceScore: 64,
+    );
+    final mintState = MintStateProvider()
+      ..injectStateForTest(
+        _stateWithDataSpine(spine: _dataSpineWithBudget(canonicalSnapshot)),
+      );
+
+    expect(budgetProvider.source, BudgetDataSource.profile);
+    expect(budgetProvider.hasFreshInputs, isTrue);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<BudgetProvider>.value(value: budgetProvider),
+          ChangeNotifierProvider<CoachProfileProvider>(
+            create: (_) => CoachProfileProvider(),
+          ),
+          ChangeNotifierProvider<MintStateProvider>.value(value: mintState),
+        ],
+        child: const MaterialApp(
+          locale: Locale('fr'),
+          localizationsDelegates: [
+            S.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: S.supportedLocales,
+          home: MonArgentScreen(initialSection: 'month'),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text(_formatChf(providerPresent.monthlyFree)), findsNothing);
+    expect(find.text(_formatChf(canonicalSnapshot.present.monthlyFree)),
+        findsWidgets);
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('mon_argent_budget_summary')))
+          .label,
+      contains('Reste ${_formatChf(canonicalSnapshot.present.monthlyFree)}'),
+    );
+  });
+
   testWidgets('direct section aliases route to stable Mon Argent sections',
       (tester) async {
     Future<void> pumpSection(String? initialSection) async {
@@ -1087,6 +1155,30 @@ void main() {
       findsOneWidget,
     );
   });
+}
+
+CoachProfile _profileWithBudget({
+  required double housingCost,
+  required double healthInsurance,
+}) {
+  return CoachProfile(
+    birthYear: 1988,
+    canton: 'VD',
+    salaireBrutMensuel: 6000,
+    depenses: DepensesProfile(
+      loyer: housingCost,
+      assuranceMaladie: healthInsurance,
+    ),
+    dataSources: const {
+      'depenses.loyer': ProfileDataSource.userInput,
+      'depenses.assuranceMaladie': ProfileDataSource.userInput,
+    },
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(2055),
+      label: 'Retraite',
+    ),
+  );
 }
 
 MintUserState _stateWithDataSpine({DataSpineSnapshot? spine}) {

--- a/apps/mobile/test/services/debug_profile_bootstrap_service_test.dart
+++ b/apps/mobile/test/services/debug_profile_bootstrap_service_test.dart
@@ -132,6 +132,77 @@ void main() {
     expect(provider.profile!.prevoyance.avoirLppTotal, 0);
   });
 
+  test('preserves rich salaried LPP fixture through the real store', () async {
+    final result = await DebugProfileBootstrapService.persistFixture(
+      slug: 'cadre_salarie_lpp_suisse_ready',
+    );
+
+    expect(result.ok, isTrue);
+    expect(result.slug, 'cadre_salarie_lpp_suisse_ready');
+    expect(result.storageMode, 'secureSeal');
+    expect(result.selfEmployedNetIncomeAnnual, isNull);
+    expect(result.monthlyNetIncome, 7500);
+    expect(result.annual3aContribution, 7056);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers['q_firstname'], 'Alex');
+    expect(answers['q_employment_status'], 'employed');
+    expect(answers['q_has_pension_fund'], isTrue);
+    expect(
+      answers.containsKey('q_self_employed_net_income_annual_chf'),
+      isFalse,
+    );
+    expect(answers['q_3a_annual_contribution'], 7056);
+    expect(answers['q_3a_accounts_count'], 2);
+    expect(answers['_coach_avoir_lpp'], 94000);
+
+    final provider = CoachProfileProvider();
+    await provider.loadFromWizard();
+
+    expect(provider.profile, isNotNull);
+    expect(provider.isPartialProfile, isFalse);
+    expect(provider.profile!.firstName, 'Alex');
+    expect(provider.profile!.employmentStatus, 'salarie');
+    expect(provider.profile!.explicitMonthlyNetIncome, 7500);
+    expect(provider.profile!.prevoyance.avoirLppTotal, 94000);
+    expect(provider.profile!.prevoyance.salaireAssure, 86000);
+    expect(provider.profile!.prevoyance.rachatMaximum, 42000);
+    expect(provider.profile!.prevoyance.nombre3a, 2);
+  });
+
+  test('preserves rich salaried LPP fixture through simulator fallback',
+      () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureStorageChannel, (call) async {
+      if (call.method == 'write') {
+        throw PlatformException(
+          code: '-34018',
+          message: 'Missing iOS simulator keychain entitlement',
+        );
+      }
+      return null;
+    });
+
+    final result = await DebugProfileBootstrapService.persistFixture(
+      slug: 'cadre_salarie_lpp_suisse_ready',
+    );
+
+    expect(result.ok, isTrue);
+    expect(result.storageMode, 'debugPlainFallback');
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers['q_employment_status'], 'employed');
+    expect(answers['q_has_pension_fund'], isTrue);
+    expect(answers['_coach_avoir_lpp'], 94000);
+
+    final provider = CoachProfileProvider();
+    await provider.loadFromWizard();
+
+    expect(provider.profile!.employmentStatus, 'salarie');
+    expect(provider.profile!.explicitMonthlyNetIncome, 7500);
+    expect(provider.profile!.prevoyance.avoirLppTotal, 94000);
+  });
+
   test('rejects unknown fixture slugs without writing profile state', () async {
     final result = await DebugProfileBootstrapService.persistFixture(
       slug: 'unknown_fixture',

--- a/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml
@@ -2,18 +2,23 @@
 #
 # PURPOSE
 # Canonical runtime proof for the MINT money trust chain:
-# onboarding persists a supported Swiss-native profile, Budget setup exposes
-# deterministic monthly fixed-charge entry, Budget restores the persisted read
-# model after restart, Mon Argent and Coach expose the same money value, Rapport
-# shows only the executive summary (no Budget-screen duplicate), and no absurd
-# captured values leak into visible surfaces.
+# a debug-only route persists the rich `cadre_salarie_lpp_suisse_ready` persona
+# through the report store, Budget setup exposes deterministic monthly
+# fixed-charge entry, Budget restores the persisted read model after restart,
+# Mon Argent and Coach expose the same money value, Rapport shows only the
+# executive summary (no Budget-screen duplicate), and no absurd captured values
+# leak into visible surfaces.
+#
+# JOS-002A owns the production onboarding persistence proof. JOS-002B owns this
+# downstream runtime chain proof and uses a non-release E2E route so simulator
+# keychain failures do not make the Money Truth surface proof unreplayable.
 #
 # PRE-CONDITION
 # - App ch.mint.app installed on a booted iPhone simulator.
 # - Recommended build:
 #     --dart-define=MINT_DISABLE_BETA_MODAL=true
 # - Do not build this proof with `MINT_E2E_ARCHETYPE`. That seed is in-memory
-#   only and is not a persistence proof. CJT-023 documents the stale contract.
+#   only and is not this persisted-runtime proof.
 
 appId: ch.mint.app
 tags:
@@ -34,107 +39,17 @@ tags:
       - tapOn: "Je comprends, on y va"
       - waitForAnimationToEnd
 
-# Build the profile through the production onboarding writer, not a debug seed.
-- openLink: "mintapp:///onb"
+# Establish persisted Alex through the real report store, not via
+# MINT_E2E_ARCHETYPE. The route and simulator fallback are debug-only.
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?slug=cadre_salarie_lpp_suisse_ready"
 - extendedWaitUntil:
     visible:
-      text: "Il est temps que tu comprennes."
+      id: "e2e_profile_fixture_applied"
     timeout: 10000
-- tapOn:
-    text: "Ouvrir"
-- extendedWaitUntil:
-    visible:
-      text: ".*Ce que je toucherai.*"
-    timeout: 5000
-- tapOn:
-    id: "onboarding-intent-retraite"
-- extendedWaitUntil:
-    visible:
-      text: "Es-tu citoyen ou résident fiscal aux États-Unis ?"
-    timeout: 5000
-- tapOn:
-    text: "Non"
-- runFlow:
-    when:
-      visible: "Quelle est ta nationalité ?"
-    commands:
-      - tapOn:
-          text: "Suisse"
-- runFlow:
-    when:
-      visible: "Quel âge tu as ?"
-    commands:
-      - takeScreenshot: "money-trust-legacy-age-only-screen"
-      - tapOn:
-          text: "Continuer"
-- extendedWaitUntil:
-    visible:
-      text: "Choisir ma date"
-    timeout: 5000
-- tapOn: "Choisir ma date"
-- waitForAnimationToEnd
-- extendedWaitUntil:
-    visible:
-      text: "OK"
-    timeout: 5000
-- tapOn:
-    text: ".*15.*juillet.*1992.*"
-- tapOn: "OK"
-- extendedWaitUntil:
-    visible:
-      text: "15.07.1992"
-    timeout: 5000
-- tapOn:
-    text: "Continuer"
-- runFlow:
-    when:
-      visible: "Quelle est ta nationalité ?"
-    commands:
-      - tapOn:
-          text: "Suisse"
-- extendedWaitUntil:
-    visible:
-      text: "Où tu vis ?"
-    timeout: 5000
-- tapOn:
-    id: "onboarding-canton-vd"
-- extendedWaitUntil:
-    visible:
-      text: "Combien te tombe net par mois ?"
-    timeout: 5000
-- tapOn:
-    id: "onboarding-revenue-range-continue"
-- extendedWaitUntil:
-    visible:
-      text: "Avant de te montrer…"
-    timeout: 12000
-- tapOn:
-    id: "onboarding-insight-view"
-- extendedWaitUntil:
-    visible:
-      text: "Continuer"
-    timeout: 8000
-- tapOn:
-    id: "onboarding-scene-continue"
-- runFlow:
-    when:
-      visible:
-        text: "Continuer"
-    commands:
-      - tapOn:
-          id: "onboarding-scene-continue"
-- extendedWaitUntil:
-    visible:
-      text: "Creuser"
-    timeout: 5000
-- tapOn:
-    id: "onboarding-bifurcation-creuser"
-- extendedWaitUntil:
-    visible:
-      id: "coach_chat_screen"
-    timeout: 15000
-- assertVisible:
-    id: "coach_input_field"
+- copyTextFrom:
+    id: "e2e_profile_fixture_applied"
+- evalScript: ${output.money_trust_bootstrap = maestro.copiedText}
+- runScript: "money_trust_assert_profile_bootstrap.js"
 
 - openLink: "mintapp:///budget/setup"
 

--- a/tools/simulator/flows/maestro-perfect-set/money_trust_assert_profile_bootstrap.js
+++ b/tools/simulator/flows/maestro-perfect-set/money_trust_assert_profile_bootstrap.js
@@ -1,0 +1,47 @@
+function normalize(raw) {
+  if (raw == null) {
+    throw new Error('Money Trust: bootstrap capture was null/undefined');
+  }
+  return String(raw).replace(/ /g, ' ').replace(/’/g, "'");
+}
+
+var bootstrap = normalize(output.money_trust_bootstrap);
+
+for (var expected of [
+  'slug=cadre_salarie_lpp_suisse_ready',
+  'mode=establish',
+  'seed=absent',
+  'planned3a=7056',
+]) {
+  if (!bootstrap.includes(expected)) {
+    throw new Error(
+      'Money Trust: bootstrap missing ' + expected + ': "' + bootstrap + '"'
+    );
+  }
+}
+
+if (
+  !bootstrap.includes('storage=secureSeal') &&
+  !bootstrap.includes('storage=debugPlainFallback')
+) {
+  throw new Error(
+    'Money Trust: bootstrap did not expose storage mode: "' + bootstrap + '"'
+  );
+}
+
+if (bootstrap.includes('annual=')) {
+  throw new Error(
+    'Money Trust: salaried fixture was demoted to self-employed: "' +
+      bootstrap +
+      '"'
+  );
+}
+
+output.money_trust_profile_bootstrap_assertion = 'PASS';
+console.log(
+  'MONEY_TRUST_PROFILE_BOOTSTRAP ' +
+    JSON.stringify({
+      verdict: output.money_trust_profile_bootstrap_assertion,
+      bootstrap: bootstrap,
+    })
+);

--- a/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
+++ b/tools/simulator/flows/maestro-perfect-set/sc4_assert_value_convergence.js
@@ -3,7 +3,7 @@
 // The heart of SALVAGE-00 SC-4: prove the SAME "Disponible/mois"
 // (argent libre / present.monthlyFree) value renders IDENTICALLY across the
 // three money surfaces — Mon Argent, /budget, and the coach chat-open surface
-// — for the `cadre_3a_contributing` persona.
+// — for the active persisted runtime persona.
 //
 // Each surface formats the figure differently in layout/wording, so we extract
 // the relevant CHF numeric token (Swiss apostrophe thousands sep, e.g. 3'152):


### PR DESCRIPTION
## What

Proves the JOS-002B Money Truth runtime chain after JOS-002A: persisted rich Swiss salaried/LPP persona -> Budget setup -> cold restart -> Budget -> Mon Argent -> Rapport -> Coach value convergence.

## Scope

- Keeps the JOS-002B branch explicitly authorized in ACTIVE_CONTEXT.
- Preserves `cadre_salarie_lpp_suisse_ready` through the debug-only report-store fixture without demoting it to independent/no-LPP.
- Enables local auth mode after successful debug fixture application, only through the existing non-release `__e2e` route.
- Fixes Mon Argent source selection so a canonical BudgetSnapshot keeps the future savings envelope when fresh profile inputs have the same monthly net/charges but lost future savings, while preserving profile override for truly stale DataSpine bases.
- Replaces the brittle onboarding tap-chain in the Money Trust Maestro flow with the existing debug-only route. JOS-002A remains the production onboarding persistence proof.

## Dynamic PR-size budget

`git diff --shortstat origin/dev...HEAD`:

`11 files changed, 394 insertions(+), 121 deletions(-)`

This is above the routine ~300-line review budget because the PR removes the old long Maestro onboarding tap-chain and adds focused regression tests plus the runtime assertion script. It is still one real flow, one branch, one commit, with no backend or broad product work.

## Verification

- `flutter test test/screens/debug/debug_profile_bootstrap_screen_test.dart test/services/debug_profile_bootstrap_service_test.dart test/services/coach_profile_seeds_test.dart test/screens/onboarding/mvp_wedge/onboarding_persistence_gate_test.dart test/screens/mon_argent_screen_test.dart` => PASS, 39 tests.
- `flutter analyze` => PASS.
- `CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_PROOF_ANCHORS=true` => PASS.
- Maestro watchdog Money Trust flow => PASS, 1/1 flow, 63s.
  - Evidence: `.planning/runtime-evidence/money-truth-spine-20260627T001212Z/result.xml` (ignored runtime artifact).
- `./tools/mint-routes check` => PASS.
- `python3 tools/checks/active_context_guard.py` => PASS.
- `python3 tools/checks/phase_contract_guard.py` => PASS.
- `python3 tools/checks/mint_rules_guard.py` => PASS.
- `python3 tools/checks/verify_phase_acceptance.py` => PASS.
- `python3 tools/checks/agent_reference_guard.py` => PASS.
- `python3 tools/checks/claude_hooks_guard.py` => PASS.
- `git diff --check` => PASS.
- Lefthook pre-commit and pre-push hooks => PASS. Memory-retention emitted a non-blocking warning outside this diff.

## External audit

Claude CLI safe-mode Opus high-effort audit ran for this diff:

`claude --safe-mode --model opus --effort high --no-session-persistence -p <audit prompt>`

Verdict: no blockers found.

Residual non-blocking risks noted by audit:
- This flow no longer proves production onboarding; JOS-002A owns that proof.
- Mon Argent intentionally keeps canonical snapshot savings when the provider drops future savings to zero.
- The Maestro assertion is tightly coupled to the `cadre_salarie_lpp_suisse_ready` seed values and should fail loudly if that seed changes.

## Proves / does not prove

Proves: the downstream Money Truth runtime chain can replay on simulator from persisted report-store data and converge Budget / Mon Argent / Rapport / Coach money values.

Does not prove: the full production onboarding writer end to end; that is covered by JOS-002A (#745).