### PR TITLE
chore(journey-os): verify money truth spine

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -16,7 +16,8 @@
     "codex/dynamic-pr-size-rule-20260626",
     "codex/jos002-money-truth-spine-20260626",
     "codex/jos002a-onboarding-persistence-20260627",
-    "codex/jos002b-money-truth-runtime-20260627"
+    "codex/jos002b-money-truth-runtime-20260627",
+    "codex/jos003-next-journey-vertical-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -27,6 +27,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary runtime-proof branch: `codex/jos002b-money-truth-runtime-20260627`
   is authorized only for the JOS-002B Money truth runtime proof harness and any
   directly required SEC-10-preserving simulator fixture fix.
+- Temporary Journey OS branch: `codex/jos003-next-journey-vertical-20260627`
+  is authorized only for selecting and executing the next scoped Journey OS
+  vertical from clean `origin/dev`.
 
 ## Required Session Start
 

--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -4,5 +4,5 @@ Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
 | Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
 |---|---|---|---|---:|---|---|---|
-| JOS-002 | P0 | proof_needed | money_truth_spine | 28 | mint-quality-gate | red | Do not promote Money truth spine yet. Split the next proof into a production-onboarding persistence gate for the simulator secure-storage seal failure, plus a downstream Money Truth gate using the existing kReleaseMode-guarded runtime fixture only as non-production evidence. |
 | JOS-001 | P0 | verified | account_lifecycle_delete | 27 | mint-quality-gate | green | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
+| JOS-002 | P0 | verified | money_truth_spine | 26 | mint-quality-gate | green | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |

--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -6,6 +6,6 @@ Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 |---|---:|---:|---|---|---|---|---|
 | account_lifecycle_delete | T0 | 27 | live_proven | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | green |
 | coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green |
-| money_truth_spine | T0 | 28 | partial | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | green, red |
+| money_truth_spine | T0 | 26 | live_proven | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | baselined, green |
 | onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /coach/chat, /home | green |
 | profile_privacy_control | T0 | 27 | partial | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | green |

--- a/.planning/journeys/diagrams/money_truth_spine.mmd
+++ b/.planning/journeys/diagrams/money_truth_spine.mmd
@@ -2,7 +2,7 @@
 flowchart TD
   promise["My money numbers are consistent."]
   team["mint-quality-gate"]
-  priority["priority score 28"]
+  priority["priority score 26"]
   priority --> promise
   route_budget["/budget"]
   promise --> route_budget

--- a/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/diagnostic.md
+++ b/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/diagnostic.md
@@ -1,0 +1,30 @@
+# Money Truth Spine Runtime Proof
+
+- Verified at: `2026-06-27T00:38:40Z`
+- Verified commit: `5d8b970cb04f346b8a00c63bf120aa35fa0c4616`
+- Device: `iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9`
+- Flow: `tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml`
+- Result: `1/1 Flow Passed in 1m 2s`
+
+Command:
+
+```sh
+CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign \
+  --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
+  --dart-define=MINT_DISABLE_BETA_MODAL=true \
+  --dart-define=MINT_E2E_PROOF_ANCHORS=true
+
+MINT_WALKER_ARTIFACTS=.planning/journeys/evidence/money_truth_spine/20260627T003738Z \
+  MAESTRO_HARD_LIMIT=600 \
+  MAESTRO_STALL_THRESHOLD=150 \
+  bash tools/simulator/maestro_with_watchdog.sh test \
+    --debug-output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/debug \
+    --format junit \
+    --output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml \
+    tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml
+```
+
+This rerun proves the downstream Money Truth chain after PR #745 and PR #746:
+Budget, Mon Argent, Rapport, and Coach all completed with the E2E proof anchors
+enabled. The prior red diagnostic from `20260626T213202Z` is preserved as
+baselined historical evidence.

--- a/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/maestro.txt
+++ b/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/maestro.txt
@@ -1,0 +1,15 @@
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/Users/julienbattaglia/.maestro/lib/jansi-2.4.1.jar)
+WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
+WARNING: Restricted methods will be blocked in a future release unless native access is enabled
+
+
+Waiting for flows to complete...
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.oracle.truffle.api.dsl.InlineSupport$UnsafeField (file:/Users/julienbattaglia/.maestro/lib/truffle-api-24.2.0.jar)
+WARNING: Please consider reporting this to the maintainers of class com.oracle.truffle.api.dsl.InlineSupport$UnsafeField
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[Passed] flow_money_trust_chain_budget_mon_argent_rapport_coach (1m 2s)
+
+1/1 Flow Passed in 1m 2s
+

--- a/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml
+++ b/.planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" device="iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9" tests="1" failures="0" time="62.0">
+    <testcase id="flow_money_trust_chain_budget_mon_argent_rapport_coach" name="flow_money_trust_chain_budget_mon_argent_rapport_coach" classname="flow_money_trust_chain_budget_mon_argent_rapport_coach" time="62.0" status="SUCCESS">
+      <properties>
+        <property name="tags" value="money-trust-chain, budget, mon-argent, rapport, coach, maestro-proof"/>
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/.planning/journeys/issues/JOS-002.json
+++ b/.planning/journeys/issues/JOS-002.json
@@ -3,10 +3,10 @@
   "id": "JOS-002",
   "title": "Prove Money truth spine across Budget, Mon Argent, Rapport, and Coach",
   "journey_id": "money_truth_spine",
-  "status": "proof_needed",
+  "status": "verified",
   "owner": "mint-quality-gate",
   "severity": "P0",
-  "evidence_status": "red",
-  "next_action": "Do not promote Money truth spine yet. Split the next proof into a production-onboarding persistence gate for the simulator secure-storage seal failure, plus a downstream Money Truth gate using the existing kReleaseMode-guarded runtime fixture only as non-production evidence.",
-  "source": "JOURNEY-TRUTH-MATRIX-008; CJT-003; CJT-024; Journey OS priority 28; latest CJT-024 Money Trust rerun 2026-06-04"
+  "evidence_status": "green",
+  "next_action": "Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records.",
+  "source": "JOURNEY-TRUTH-MATRIX-008; CJT-003; CJT-024; PR #745; PR #746; Journey OS evidence 20260627T003738Z"
 }

--- a/.planning/journeys/records/money_truth_spine.json
+++ b/.planning/journeys/records/money_truth_spine.json
@@ -3,7 +3,7 @@
   "id": "money_truth_spine",
   "title": "Money truth spine",
   "tier": "T0",
-  "status": "partial",
+  "status": "live_proven",
   "human_promise": "My money numbers are consistent.",
   "accountable_team": "mint-quality-gate",
   "route_paths": [
@@ -27,7 +27,7 @@
     "trust_blast_radius": 5,
     "release_blocker_weight": 5,
     "user_frequency": 5,
-    "evidence_gap": 2,
+    "evidence_gap": 0,
     "route_centrality": 5,
     "compliance_risk": 4,
     "learning_value": 5,
@@ -44,10 +44,20 @@
     },
     {
       "kind": "runtime",
-      "status": "red",
+      "status": "baselined",
       "command": "MINT_WALKER_ARTIFACTS=.planning/runtime-evidence/money-truth-spine-20260626T213202Z MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=150 bash tools/simulator/maestro_with_watchdog.sh test --debug-output .planning/runtime-evidence/money-truth-spine-20260626T213202Z/debug --format junit --output .planning/runtime-evidence/money-truth-spine-20260626T213202Z/result.xml tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml",
       "artifact": ".planning/journeys/evidence/money_truth_spine/20260626T213202Z/result.xml",
-      "reason": "Fresh diagnostic rerun with temporary local Maestro harness alignment reached production onboarding, local-mode gate, Budget setup, app restart, and /budget budget_hero_formula. It failed on /mon-argent?section=month because simulator secure-storage seal left no persisted wizard_answers_v2 and no hydrated CoachProfile after restart, so the profile-required route redirected to /onb. This is not a Money value mismatch; land harness YAML changes in a separate runtime-proof PR."
+      "reason": "Historical red diagnostic superseded by the JOS-002A onboarding persistence fix and JOS-002B Money Truth runtime proof on dev.",
+      "debt_ref": "Superseded by PR #745 and PR #746."
+    },
+    {
+      "kind": "runtime",
+      "status": "green",
+      "command": "CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_PROOF_ANCHORS=true && MINT_WALKER_ARTIFACTS=.planning/journeys/evidence/money_truth_spine/20260627T003738Z MAESTRO_HARD_LIMIT=600 MAESTRO_STALL_THRESHOLD=150 bash tools/simulator/maestro_with_watchdog.sh test --debug-output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/debug --format junit --output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml",
+      "artifact": ".planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml",
+      "reason": "Fresh runtime proof from clean origin/dev after PR #746: Budget to Mon Argent to Rapport to Coach passed with Money Trust Chain anchors.",
+      "verified_at": "2026-06-27T00:38:40Z",
+      "verified_commit": "5d8b970cb04f346b8a00c63bf120aa35fa0c4616"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add durable Journey OS runtime evidence for `money_truth_spine` at `20260627T003738Z`
- mark `money_truth_spine` as `live_proven` and `JOS-002` as `verified`/green
- regenerate Journey OS board, summary, and money truth diagram

## Verification
- `CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_PROOF_ANCHORS=true`
- `MINT_WALKER_ARTIFACTS=.planning/journeys/evidence/money_truth_spine/20260627T003738Z MAESTRO_HARD_LIMIT=600 MAESTRO_STALL_THRESHOLD=150 bash tools/simulator/maestro_with_watchdog.sh test --debug-output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/debug --format junit --output .planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/verify_phase_acceptance.py`
- `./tools/mint-routes check`
- `python3 tools/checks/journey_os_check.py --base-ref origin/dev`
- `git diff --check`

## Audit
- Claude CLI Opus safe-mode audit: no code-level blockers; mechanical evidence staging point handled before PR.

## Scope
- No product code. Journey OS metadata and durable evidence only.
- Shortstat: 10 files changed, 81 insertions, 12 deletions.