### PR TITLE
Add JOS-004 Coach advice red proof

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -18,7 +18,8 @@
     "codex/jos002a-onboarding-persistence-20260627",
     "codex/jos002b-money-truth-runtime-20260627",
     "codex/jos003-next-journey-vertical-20260627",
-    "codex/jos004-profile-privacy-control-20260627"
+    "codex/jos004-profile-privacy-control-20260627",
+    "codex/jos005-coach-advice-turn-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -33,6 +33,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary Journey OS branch: `codex/jos004-profile-privacy-control-20260627`
   is authorized only for the Profile Privacy Control Journey OS vertical from
   clean `origin/dev`.
+- Temporary Journey OS branch: `codex/jos005-coach-advice-turn-20260627`
+  is authorized only for the Coach Advice Turn Journey OS vertical from clean
+  `origin/dev`.
 
 ## Required Session Start
 

--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -4,6 +4,7 @@ Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
 | Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
 |---|---|---|---|---:|---|---|---|
+| JOS-004 | P0 | proof_needed | coach_advice_turn | 27 | mint-backend | red | Fix the Coach regulatory-value dispatch or freshness-gate interaction so the salaried-LPP 2026 3a ceiling returns 7'258 CHF with OPP3/LIFD provenance instead of the freshness fallback, then rerun the JOS-004 runtime proof. |
 | JOS-001 | P0 | verified | account_lifecycle_delete | 27 | mint-quality-gate | green | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
 | JOS-002 | P0 | verified | money_truth_spine | 26 | mint-quality-gate | green | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |
 | JOS-003 | P0 | verified | profile_privacy_control | 25 | mint-quality-gate | green | Keep the Profile Privacy Control runtime gate in Journey OS monitoring; add authenticated backend privacy E2E sampling when a stable seed exists. |

--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -5,7 +5,7 @@ Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 | ID | Tier | Priority | Status | Promise | Accountable team | Routes | Evidence |
 |---|---:|---:|---|---|---|---|---|
 | account_lifecycle_delete | T0 | 27 | live_proven | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | green |
-| coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green |
+| coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green, red |
 | money_truth_spine | T0 | 26 | live_proven | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | baselined, green |
 | onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /coach/chat, /home | green |
 | profile_privacy_control | T0 | 25 | live_proven | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | green |

--- a/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/diagnostic.md
+++ b/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/diagnostic.md
@@ -1,0 +1,25 @@
+description: Diagnostic for the JOS-004 Coach advice turn red runtime proof.
+
+# JOS-004 Coach Advice Turn Diagnostic
+
+Verdict: red.
+
+Runtime path:
+- Build: iOS simulator debug, staging API, `MINT_DISABLE_BETA_MODAL=true`, `MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready`.
+- Flow: `tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml`.
+- Device: iPhone 17 Pro, iOS 26.2.
+
+Observed behavior:
+- The flow reached `/coach/chat`.
+- The user prompt was sent: `Quel est le plafond legal 3a 2026 avec LPP ?`.
+- The visible assistant reply was: `Je n'ai pas cette donnée à jour pour l'instant.`
+- The flow failed because no visible `OPP3`, `LIFD`, `art. 7`, `art. 33`, or `art. 38` citation appeared.
+
+Expected behavior:
+- Coach should return the 2026 salaried-LPP 3a ceiling, `7'258 CHF`, with OPP3/LIFD provenance and bounded educational wording.
+
+Regulatory source check:
+- `get_swiss_constants({"category":"pillar3a"})` returned `pillar3a.historical_limits.2026 = 7258.0 CHF`, source `OPP3 art. 7 — OFAS publication annuelle`, tax year `2026`.
+
+Likely root-cause area:
+- Backend Coach regulatory dispatch / citation grammar / runtime freshness gate interaction. The canonical salaried-LPP seed also carries a `7056` 3a contribution value, which is a stale historical regulatory value if interpreted as an official ceiling. The fix must distinguish user/profile amounts from stale official regulatory ceilings instead of falling back for the whole turn.

--- a/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/maestro.txt
+++ b/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/maestro.txt
@@ -1,0 +1,19 @@
+[watchdog] artifacts → /tmp/mint-jos004-coach-advice-turn-20260627T023232Z
+[watchdog] hard limit 600s ; stall threshold 150s ; probe 30s
+[watchdog] maestro pid=76141 (running in own process group)
+WARNING: A restricted method in java.lang.System has been called
+WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/Users/julienbattaglia/.maestro/lib/jansi-2.4.1.jar)
+WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
+WARNING: Restricted methods will be blocked in a future release unless native access is enabled
+
+
+Waiting for flows to complete...
+WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
+WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.oracle.truffle.api.dsl.InlineSupport$UnsafeField (file:/Users/julienbattaglia/.maestro/lib/truffle-api-24.2.0.jar)
+WARNING: Please consider reporting this to the maintainers of class com.oracle.truffle.api.dsl.InlineSupport$UnsafeField
+WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
+[Failed] flow_jos004_coach_advice_turn_runtime (1m 29s) (Assertion is false: ".*(OPP3|art\.?\s*7|art\.?\s*33|art\.?\s*38|LIFD).*" is visible)
+
+1/1 Flow Failed
+
+[watchdog] EXIT — maestro returned 1

--- a/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/result.xml
+++ b/.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/result.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" device="iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9" tests="1" failures="1" time="89.0">
+    <testcase id="flow_jos004_coach_advice_turn_runtime" name="flow_jos004_coach_advice_turn_runtime" classname="flow_jos004_coach_advice_turn_runtime" time="89.0" status="ERROR">
+      <properties>
+        <property name="tags" value="journey-os, jos-004, coach-advice-turn, pillar-3a, opp3-art-7, runtime-proof"/>
+      </properties>
+      <failure>Assertion is false: ".*(OPP3|art\.?\s*7|art\.?\s*33|art\.?\s*38|LIFD).*" is visible</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/.planning/journeys/issues/JOS-004.json
+++ b/.planning/journeys/issues/JOS-004.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "JOS-004",
+  "title": "Fix Coach 3a ceiling advice freshness fallback",
+  "journey_id": "coach_advice_turn",
+  "status": "proof_needed",
+  "owner": "mint-backend",
+  "severity": "P0",
+  "evidence_status": "red",
+  "next_action": "Fix the Coach regulatory-value dispatch or freshness-gate interaction so the salaried-LPP 2026 3a ceiling returns 7'258 CHF with OPP3/LIFD provenance instead of the freshness fallback, then rerun the JOS-004 runtime proof.",
+  "source": "JOS-004 runtime proof 20260627T023232Z; mint-quality-gate and mint-swiss-brain roster audit"
+}

--- a/.planning/journeys/records/coach_advice_turn.json
+++ b/.planning/journeys/records/coach_advice_turn.json
@@ -19,7 +19,8 @@
   ],
   "issues": [
     "CJT-011",
-    "JOURNEY-TRUTH-MATRIX-014"
+    "JOURNEY-TRUTH-MATRIX-014",
+    "JOS-004"
   ],
   "priority": {
     "trust_blast_radius": 5,
@@ -39,6 +40,15 @@
       "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml tools/simulator/flows/maestro-perfect-set/flow_hero_marge_fiscale_3a.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml",
       "reason": "CJT-011 durable runtime proof shows the 3a answer path reached Coach and asserted current cited 3a values; broader advice quality remains partial."
+    },
+    {
+      "kind": "runtime",
+      "status": "red",
+      "command": "cd apps/mobile && CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --debug --no-codesign --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready && cd ../.. && MINT_WALKER_ARTIFACTS=/tmp/mint-jos004-coach-advice-turn-20260627T023232Z MAESTRO_HARD_LIMIT=600 MAESTRO_STALL_THRESHOLD=150 bash tools/simulator/maestro_with_watchdog.sh test --debug-output /tmp/mint-jos004-coach-advice-turn-20260627T023232Z/debug --format junit --output .planning/journeys/evidence/coach_advice_turn/20260627T023232Z/result.xml tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
+      "artifact": ".planning/journeys/evidence/coach_advice_turn/20260627T023232Z/result.xml",
+      "reason": "Fresh Journey OS proof reaches Coach with the canonical salaried-LPP seed, asks the 2026 3a/LPP ceiling question, and receives the freshness fallback instead of a visible 7'258 CHF cited answer.",
+      "verified_at": "2026-06-27T02:35:11Z",
+      "verified_commit": "0ba2497df9e670fed74f88c8648a2bd03aa810ed"
     }
   ]
 }

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -26,6 +26,7 @@ ALLOW = {
     ".planning/ACTIVE_CONTEXT.md",
     ".planning/ACTIVE_CONTEXT.json",
     "tools/simulator/flows/maestro-perfect-set/flow_row24_privacy_control_runtime.yaml",
+    "tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
     "tools/checks/journey_os_check.py",
     "tools/checks/journey_os_generate.py",
     "tools/checks/tests/test_journey_os_check.py",

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -120,6 +120,21 @@ def test_row24_privacy_runtime_flow_is_in_scope(tmp_path: Path) -> None:
 
     assert not any("outside Journey OS whitelist" in error for error in errors)
 
+def test_jos004_coach_advice_runtime_flow_is_in_scope(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    errors = _errors(
+        root,
+        [
+            "tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
+        ],
+    )
+
+    assert not any("outside Journey OS whitelist" in error for error in errors)
+
 def test_journey_evidence_artifacts_are_in_scope(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)

--- a/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
@@ -1,0 +1,130 @@
+# tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
+#
+# PURPOSE
+# Journey OS JOS-004 runtime proof for one Coach advice turn: the canonical
+# salaried-LPP Swiss persona asks a natural legal 3a ceiling question in /coach/chat,
+# and the visible answer must include the current 2026 salaried ceiling,
+# a legal citation, and no banned LSFin certainty terms.
+#
+# SCOPE LIMIT
+# This proves one high-risk Coach turn, not the whole Coach number universe.
+# Other Swiss financial numbers remain covered by backend/eval gates until
+# dedicated runtime flows exist.
+#
+# PRE-CONDITION
+# - App ch.mint.app installed on a booted iPhone simulator.
+# - Recommended build:
+#     flutter build ios --simulator --debug --no-codesign \
+#       --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
+#       --dart-define=MINT_DISABLE_BETA_MODAL=true \
+#       --dart-define=MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready
+# - The E2E seed is kReleaseMode-guarded and only proves this Coach turn,
+#   not onboarding persistence.
+
+appId: ch.mint.app
+env:
+  MINT_E2E_ARCHETYPE: cadre_salarie_lpp_suisse_ready
+tags:
+  - journey-os
+  - jos-004
+  - coach-advice-turn
+  - pillar-3a
+  - opp3-art-7
+  - runtime-proof
+---
+
+- launchApp:
+    clearState: true
+    arguments:
+      MINT_E2E_ARCHETYPE: ${MINT_E2E_ARCHETYPE}
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- runFlow:
+    when:
+      visible: "Je comprends, on y va"
+    commands:
+      - tapOn: "Je comprends, on y va"
+      - waitForAnimationToEnd
+
+- openLink: "mintapp:///coach/chat"
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      id: "coach_chat_screen"
+    timeout: 15000
+- assertVisible:
+    id: "coach_input_field"
+- assertVisible:
+    id: "coach_send_button"
+- assertNotVisible: "Encore en chantier pour ton profil"
+- assertNotVisible: "A RenderFlex overflowed"
+- assertNotVisible: "Exception caught"
+- assertNotVisible: "NoSuchMethodError"
+
+- tapOn:
+    id: "coach_input_field"
+- inputText: "Quel est le plafond legal 3a 2026 avec LPP ?"
+- tapOn:
+    id: "coach_send_button"
+- waitForAnimationToEnd:
+    timeout: 6000
+- takeScreenshot: "jos004-coach-advice-turn-after-send"
+
+# Confirm the prompt was sent, then wait for the assistant response to surface
+# a legal citation. The visible citation can be OPP3 art. 7 or LIFD art. 33/38
+# depending on the gated narrator wording; the required number stays fixed.
+- extendedWaitUntil:
+    visible:
+      text: ".*(3a|pilier).*"
+    timeout: 8000
+- extendedWaitUntil:
+    visible:
+      text: ".*(OPP3|art\\.?\\s*7|art\\.?\\s*33|art\\.?\\s*38|LIFD).*"
+    timeout: 60000
+- waitForAnimationToEnd:
+    timeout: 5000
+- takeScreenshot: "jos004-coach-advice-turn-response"
+
+# Current 2026 salaried 3a ceiling with LPP: CHF 7'258.
+- assertVisible:
+    text: ".*7['’\\s ]?258.*"
+- assertVisible:
+    text: ".*(OPP3|art\\.?\\s*7|art\\.?\\s*33|art\\.?\\s*38|LIFD).*"
+
+# The advice must stay bounded and non-promissory.
+- assertNotVisible: ".*\\{\\{cite:.*"
+- assertNotVisible: ".*source non affichée.*"
+- assertNotVisible: ".*API Claude.*"
+- assertNotVisible: ".*Encore en chantier pour ton profil.*"
+- assertNotVisible: ".*meilleur.*"
+- assertNotVisible: ".*Meilleur.*"
+- assertNotVisible: ".*optimal.*"
+- assertNotVisible: ".*Optimal.*"
+- assertNotVisible: ".*garanti.*"
+- assertNotVisible: ".*Garanti.*"
+- assertNotVisible: ".*sans risque.*"
+- assertNotVisible: ".*Sans risque.*"
+- assertNotVisible: ".*certain.*"
+- assertNotVisible: ".*Certain.*"
+- assertNotVisible: ".*assuré.*"
+- assertNotVisible: ".*Assuré.*"
+- assertNotVisible: ".*parfait.*"
+- assertNotVisible: ".*Parfait.*"
+- assertNotVisible: "NaN"
+- assertNotVisible: "Infinity"
+- assertNotVisible: "A RenderFlex overflowed"
+- assertNotVisible: "Exception caught"
+- assertNotVisible: "NoSuchMethodError"


### PR DESCRIPTION
## Summary
- Adds the Journey OS JOS-004 runtime harness for `coach_advice_turn` on `/coach/chat`.
- Records fresh red evidence: staging Coach returns the freshness fallback for the 2026 salaried-LPP 3a ceiling instead of a visible `7'258 CHF` answer with OPP3/LIFD provenance.
- Keeps `coach_advice_turn` as `partial`; no `live_proven` promotion and no product code changes.

## Runtime Verdict
Red by design for this PR:
`flow_jos004_coach_advice_turn_runtime.yaml` reaches Coach with `MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready`, sends `Quel est le plafond legal 3a 2026 avec LPP ?`, then fails because no citation anchor appears. Manual simulator inspection showed the visible fallback: `Je n'ai pas cette donnée à jour pour l'instant.`

## Evidence
- `.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/result.xml`
- `.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/maestro.txt`
- `.planning/journeys/evidence/coach_advice_turn/20260627T023232Z/diagnostic.md`
- `JOS-004` tracks the required backend/regulatory dispatch or freshness-gate fix.

## Verification
- `python3 tools/checks/journey_os_check.py --base-ref origin/dev` => OK
- `python3 -m pytest tools/checks/tests/test_journey_os_check.py -q` => 14 passed
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/verify_phase_acceptance.py` => PASS
- `./tools/mint-routes check` => OK
- `python3 tools/checks/mint_quality_os_check.py` => OK
- `git diff --check` => OK
- Backend Coach/citation/regulatory targeted pytest => 424 passed
- Flutter Coach targeted tests => 1214 passed, 5 skipped
- Claude CLI Opus safe-mode audit => no blocker findings; noted this is safe as evidence-only PR and must be described as a point-in-time live runtime snapshot

## Notes
This PR should not be interpreted as Coach being ready for the advice-turn promise. It exists to make the failing vertical durable and assignable before the product fix.
