### PR TITLE
Deploy JOS-004 coach fix to staging

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -11,7 +11,8 @@
     "dev",
     "staging",
     "main",
-    "codex/account-lifecycle-gate-20260624"
+    "codex/account-lifecycle-gate-20260624",
+    "codex/jos004-staging-deploy-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -14,6 +14,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
   phase is queued yet.
 - Temporary hotfix branch: `codex/account-lifecycle-gate-20260624` is
   authorized only for the account lifecycle/onboarding gate hotfix.
+- Temporary staging deploy branch: `codex/jos004-staging-deploy-20260627` is
+  authorized only to promote the JOS-004 authenticated Coach 3a/LPP freshness
+  fix to `staging` for Railway runtime proof.
 
 ## Required Session Start
 

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -1912,6 +1912,135 @@ def _classify_user_intent(message: Optional[str]) -> set[str]:
     return detected
 
 
+_REGULATORY_CONSTANT_SUBJECT_TERMS: tuple[str, ...] = (
+    "3a",
+    "3 a",
+    "pilier 3a",
+    "pilier3a",
+    "opp3",
+)
+
+_REGULATORY_CONSTANT_LOOKUP_TERMS: tuple[str, ...] = (
+    "plafond",
+    "maximum",
+    "limite",
+    "montant",
+    "bon montant",
+    "juste",
+    "correct",
+    "combien",
+    "verser",
+    "cotiser",
+    "deduction",
+    "deduire",
+)
+
+_REGULATORY_CONSTANT_LPP_TERMS: tuple[str, ...] = (
+    "lpp",
+    "salarie",
+    "salariee",
+    "employe",
+    "employee",
+)
+
+_REGULATORY_CONSTANT_WITHOUT_LPP_TERMS: tuple[str, ...] = (
+    "sans lpp",
+    "sans la lpp",
+    "sans 2e pilier",
+    "sans deuxieme pilier",
+    "sans second pilier",
+    "independant",
+    "independante",
+    "non affilie",
+)
+
+_PILLAR3A_2026_WITH_LPP_KEY = "pillar3a.historical_limits.2026"
+
+
+def _normalise_intent_text(message: Optional[str]) -> str:
+    if not message:
+        return ""
+    import unicodedata
+
+    return "".join(
+        c
+        for c in unicodedata.normalize("NFD", message.lower())
+        if unicodedata.category(c) != "Mn"
+    )
+
+
+def _should_force_regulatory_constant(
+    *,
+    question: Optional[str],
+    detected_intents: Optional[set[str]],
+    tools: list[dict],
+) -> bool:
+    if not any(t.get("name") == "get_regulatory_constant" for t in tools):
+        return False
+    if not ((detected_intents or set()) & _TOOL_ELIGIBLE_INTENTS):
+        return False
+
+    return _looks_like_3a_regulatory_constant_lookup(
+        question=question,
+        detected_intents=detected_intents,
+    )
+
+
+def _looks_like_3a_regulatory_constant_lookup(
+    *,
+    question: Optional[str],
+    detected_intents: Optional[set[str]],
+) -> bool:
+    if not ((detected_intents or set()) & _TOOL_ELIGIBLE_INTENTS):
+        return False
+    normalized = _normalise_intent_text(question)
+    if not normalized:
+        return False
+    has_subject = any(term in normalized for term in _REGULATORY_CONSTANT_SUBJECT_TERMS)
+    has_lookup = any(term in normalized for term in _REGULATORY_CONSTANT_LOOKUP_TERMS)
+    return has_subject and has_lookup
+
+
+def _should_default_to_3a_2026_with_lpp(
+    *,
+    question: Optional[str],
+    detected_intents: Optional[set[str]],
+) -> bool:
+    normalized = _normalise_intent_text(question)
+    if "2026" not in normalized:
+        return False
+    if any(term in normalized for term in _REGULATORY_CONSTANT_WITHOUT_LPP_TERMS):
+        return False
+    if not any(term in normalized for term in _REGULATORY_CONSTANT_LPP_TERMS):
+        return False
+    return _looks_like_3a_regulatory_constant_lookup(
+        question=question,
+        detected_intents=detected_intents,
+    )
+
+
+def _repair_regulatory_constant_input_for_question(
+    tool_input: dict,
+    *,
+    last_user_message: Optional[str],
+    detected_intents: Optional[set[str]],
+) -> dict:
+    if not _should_default_to_3a_2026_with_lpp(
+        question=last_user_message,
+        detected_intents=detected_intents,
+    ):
+        return tool_input
+
+    key = tool_input.get("key")
+    key_text = key.strip().lower() if isinstance(key, str) else ""
+    if key_text and key_text == _PILLAR3A_2026_WITH_LPP_KEY:
+        return tool_input
+
+    repaired = dict(tool_input)
+    repaired["key"] = _PILLAR3A_2026_WITH_LPP_KEY
+    return repaired
+
+
 # Wave 1c-A2 (2026-05-15) — gating set for the orchestration-layer RAG cut.
 # When detected_intents intersects this set AND the agent-loop tools include
 # at least one entry from _TOOL_ELIGIBLE_TOOL_NAMES, n_results is set to 0
@@ -1938,6 +2067,7 @@ _TOOL_ELIGIBLE_TOOL_NAMES: frozenset[str] = frozenset(
         "get_cross_pillar_analysis",
         "get_couple_optimization",
         "get_cap_status",
+        "get_regulatory_constant",
         # NOTE: retrieve_memories is NOT in this set — it's a Wave 1b memory
         # retrieval tool, not a financial calculation. Its presence in the
         # advertised tools should NOT trigger RAG suppression.
@@ -2739,6 +2869,11 @@ def _execute_internal_tool(
     # <<< dispatch: get_couple_optimization
 
     if name == "get_regulatory_constant":
+        tool_input = _repair_regulatory_constant_input_for_question(
+            tool_input,
+            last_user_message=last_user_message,
+            detected_intents=detected_intents,
+        )
         return _handle_regulatory_constant(tool_input)
 
     # WS-B Plan 05: explain_concept resolves the curated CONCEPT_REGISTRY page
@@ -4273,19 +4408,31 @@ async def _run_agent_loop(
             # anonymous_chat.py:204). Iterations 2..MAX revert to auto (None)
             # — otherwise every iteration re-forces the tool and the loop never
             # emits the final text answer (mirrors "force turn 1, answer turn 2").
-            _forced_tool_choice = (
-                {"type": "tool", "name": "explain_concept"}
-                if (
-                    iteration == 0
-                    and "definition_request" in (detected_intents or set())
-                    and any(
-                        (t.get("name") if isinstance(t, dict) else None)
-                        == "explain_concept"
-                        for t in (stripped_tools or [])
-                    )
+            _force_regulatory_constant = (
+                iteration == 0
+                and _should_force_regulatory_constant(
+                    question=question,
+                    detected_intents=detected_intents,
+                    tools=stripped_tools,
                 )
-                else None
             )
+            if _force_regulatory_constant:
+                _forced_tool_choice = {
+                    "type": "tool",
+                    "name": "get_regulatory_constant",
+                }
+            elif (
+                iteration == 0
+                and "definition_request" in (detected_intents or set())
+                and any(
+                    (t.get("name") if isinstance(t, dict) else None)
+                    == "explain_concept"
+                    for t in (stripped_tools or [])
+                )
+            ):
+                _forced_tool_choice = {"type": "tool", "name": "explain_concept"}
+            else:
+                _forced_tool_choice = None
 
             # v2.7 Task 3: route through graceful model fallback (Sonnet→Haiku).
             # _call_with_fallback has its own inner timeout; outer wait_for keeps

--- a/services/backend/app/services/regulatory/registry.py
+++ b/services/backend/app/services/regulatory/registry.py
@@ -37,7 +37,7 @@ _OFAS_LPP_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/bv/don
 _OFAS_AVS_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/ahv/donnees-de-base-et-parametres/rentes.html"
 _OFAS_3A_URL = "https://www.bsv.admin.ch/bsv/fr/home/assurances-sociales/bv/donnees-de-base-et-parametres/pilier-3a.html"
 _FINMA_URL = "https://www.finma.ch/fr/"
-_REVIEWED = date(2026, 3, 26)
+_REVIEWED = date(2026, 6, 26)
 
 # ══════════════════════════════════════════════════════════════════════════════
 # All regulatory parameters — seeded from social_insurance.py

--- a/services/backend/tests/test_coach_chat_intent_force.py
+++ b/services/backend/tests/test_coach_chat_intent_force.py
@@ -32,6 +32,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from app.api.v1.endpoints.coach_chat import (
     _classify_user_intent,
+    _execute_internal_tool,
     _gate_fact_card_against_registry,
     _guard_tool_payload_text_fields,
     _run_agent_loop,
@@ -76,6 +77,11 @@ def _tool_choices(orch: MagicMock) -> list:
 _DEFINITION_MSG = "c'est quoi un rachat LPP ?"
 _CHITCHAT_MSG = "salut, comment ça va aujourd'hui ?"
 _FACT_DECLARATION_MSG = "je gagne 8500 CHF par mois et j'ai 35 ans"
+_JOS004_3A_CEILING_MSG = "Quel est le plafond légal 3a 2026 avec LPP ?"
+_JOS004_3A_DEFINITION_COLLISION_MSG = "C'est quoi le plafond 3a 2026 avec LPP ?"
+_JOS004_3A_STALE_AMOUNT_MSG = (
+    "Est-ce que 7'056 CHF est le bon montant 3a 2026 avec LPP ?"
+)
 
 
 def _base_kwargs(question: str, detected_intents: set[str]) -> dict:
@@ -122,6 +128,10 @@ class TestDefinitionIntentClassifier:
 
     def test_chitchat_is_not_definition_request(self):
         assert "definition_request" not in _classify_user_intent(_CHITCHAT_MSG)
+
+    def test_jos004_3a_lpp_ceiling_is_financial_intent(self):
+        intents = _classify_user_intent(_JOS004_3A_CEILING_MSG)
+        assert "retirement" in intents
 
 
 class TestDefinitionIntentBroadenedInterrogatives:
@@ -171,6 +181,141 @@ class TestDefinitionIntentBroadenedInterrogatives:
 
 
 class TestForcedToolChoiceFirstCallOnly:
+    def test_3a_ceiling_definition_wording_prefers_regulatory_constant(self):
+        """A value lookup that starts with "c'est quoi" is not a definition card."""
+        intents = _classify_user_intent(_JOS004_3A_DEFINITION_COLLISION_MSG)
+        assert "definition_request" in intents
+        assert "retirement" in intents
+
+        orch = _make_mock_orchestrator(
+            _make_result(
+                answer="",
+                tool_calls=[
+                    {
+                        "name": "get_regulatory_constant",
+                        "input": {"key": "pillar3a.historical_limits.2026"},
+                    }
+                ],
+            ),
+            _make_result(answer="Le plafond 3a 2026 avec LPP est 7'258 CHF."),
+        )
+        _run(
+            _run_agent_loop(
+                orchestrator=orch,
+                tools=[
+                    {"name": "explain_concept"},
+                    {"name": "get_regulatory_constant"},
+                ],
+                **_base_kwargs(_JOS004_3A_DEFINITION_COLLISION_MSG, intents),
+            )
+        )
+
+        assert _tool_choices(orch)[0] == {
+            "type": "tool",
+            "name": "get_regulatory_constant",
+        }
+
+    def test_3a_stale_amount_check_forces_regulatory_constant(self):
+        """A user-supplied stale amount must not bypass the current registry."""
+        orch = _make_mock_orchestrator(
+            _make_result(
+                answer="",
+                tool_calls=[
+                    {
+                        "name": "get_regulatory_constant",
+                        "input": {"key": "pillar3a.historical_limits.2026"},
+                    }
+                ],
+            ),
+            _make_result(
+                answer="Non: 7'056 CHF est le plafond 2024; pour 2026 c'est 7'258 CHF."
+            ),
+        )
+        _run(
+            _run_agent_loop(
+                orchestrator=orch,
+                tools=[{"name": "get_regulatory_constant"}],
+                **_base_kwargs(
+                    _JOS004_3A_STALE_AMOUNT_MSG,
+                    _classify_user_intent(_JOS004_3A_STALE_AMOUNT_MSG),
+                ),
+            )
+        )
+
+        assert _tool_choices(orch)[0] == {
+            "type": "tool",
+            "name": "get_regulatory_constant",
+        }
+
+    def test_3a_2026_missing_tool_key_defaults_to_historical_registry_value(self):
+        """Forced 2026 3a lookups recover from an empty LLM tool input."""
+        result = _execute_internal_tool(
+            {"name": "get_regulatory_constant", "input": {}},
+            memory_block=None,
+            last_user_message=_JOS004_3A_CEILING_MSG,
+            detected_intents={"retirement"},
+            persistence_consent=True,
+        )
+
+        assert "pillar3a.historical_limits.2026 = 7258.0 CHF" in result
+        assert "OPP3 art. 7" in result
+
+    def test_3a_2026_without_lpp_does_not_repair_to_with_lpp_key(self):
+        """A sans-LPP prompt must not be coerced to the salaried-LPP ceiling."""
+        result = _execute_internal_tool(
+            {
+                "name": "get_regulatory_constant",
+                "input": {"key": "pillar3a.max_without_lpp"},
+            },
+            memory_block=None,
+            last_user_message="Quel est le plafond 3a 2026 sans LPP ?",
+            detected_intents={"retirement"},
+            persistence_consent=True,
+        )
+
+        assert "pillar3a.max_without_lpp = 36288.0 CHF" in result
+        assert "pillar3a.historical_limits.2026" not in result
+
+    def test_3a_ceiling_forces_regulatory_constant_on_first_call_only(self):
+        """JOS-004: current-year 3a/LPP ceiling must retrieve the registry.
+
+        The first LLM call is forced to `get_regulatory_constant` so the
+        answer cannot come from model weights or stale profile amounts. After
+        the tool result, the second call reverts to auto so the loop can emit
+        final text.
+        """
+        orch = _make_mock_orchestrator(
+            _make_result(
+                answer="",
+                tool_calls=[
+                    {
+                        "name": "get_regulatory_constant",
+                        "input": {"key": "pillar3a.max_with_lpp"},
+                    }
+                ],
+            ),
+            _make_result(
+                answer=(
+                    "Pour 2026, le plafond 3a avec LPP est de 7'258 CHF "
+                    "(OPP3 art. 7)."
+                ),
+            ),
+        )
+        result = _run(
+            _run_agent_loop(
+                orchestrator=orch,
+                tools=[{"name": "get_regulatory_constant"}],
+                **_base_kwargs(_JOS004_3A_CEILING_MSG, {"retirement"}),
+            )
+        )
+
+        choices = _tool_choices(orch)
+        assert len(choices) == 2, f"expected 2 calls, got {len(choices)}"
+        assert choices[0] == {"type": "tool", "name": "get_regulatory_constant"}
+        assert choices[1] is None
+        assert orch.query.call_args_list[0].kwargs.get("n_results") == 0
+        assert "7'258" in result["answer"]
+
     def test_definition_forces_explain_concept_on_first_call_only(self):
         """Force turn 1; the follow-up after the tool_result reverts to auto."""
         orch = _make_mock_orchestrator(


### PR DESCRIPTION
## Summary
- Staging-only promotion of the JOS-004 authenticated Coach 3a/LPP freshness fix already merged into `dev` via #750.
- Carries only the backend fix/test plus temporary ACTIVE_CONTEXT authorization for this staging deploy branch.
- Avoids promoting the full `dev` backlog to `staging` in one PR; `origin/staging` is currently behind `dev` by multiple Journey OS commits.

## Test Plan
- [x] `python3 -m pytest services/backend/tests/test_coach_chat_intent_force.py -q` -> 37 passed
- [x] Focused Coach/regulatory suite -> 142 passed
- [x] `cd services/backend && ruff check app/api/v1/endpoints/coach_chat.py tests/test_coach_chat_intent_force.py` -> passed
- [x] `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py` -> passed
- [x] `git diff --cached --check` before commit -> passed

## Runtime Gate After Merge
Merging this PR to `staging` should trigger Railway staging deploy via `.github/workflows/deploy-backend.yml`. After deploy, rerun `tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml` from the dev/Journey OS checkout and require visible `7'258` plus legal citation before marking JOS-004 green.
