### PR TITLE
Fix JOS-004 coach empty response after forced tool use

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -20,7 +20,8 @@
     "codex/jos003-next-journey-vertical-20260627",
     "codex/jos004-profile-privacy-control-20260627",
     "codex/jos005-coach-advice-turn-20260627",
-    "codex/jos004-coach-advice-fix-20260627"
+    "codex/jos004-coach-advice-fix-20260627",
+    "codex/jos004-coach-empty-answer-fix-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -39,6 +39,10 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary hotfix branch: `codex/jos004-coach-advice-fix-20260627` is
   authorized only for the JOS-004 Coach advice turn regulatory freshness fix
   from clean `origin/dev`.
+- Temporary hotfix branch: `codex/jos004-coach-empty-answer-fix-20260627` is
+  authorized only for the JOS-004 authenticated Coach empty-answer fix, the
+  directly required runtime-proof harness update, and evidence from clean
+  `origin/dev`.
 
 ## Required Session Start
 

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -4337,6 +4337,7 @@ async def _run_agent_loop(
     # P0-5: Counter for unknown tool calls — stop loop after 2 to prevent infinite retry
     _MAX_UNKNOWN_TOOL_CALLS = 2
     unknown_tool_count = 0
+    allow_completion_after_internal_tools = False
     # WS-B Plan 05 — set when the registry gate drops a show_fact_card so the
     # no-text path can substitute a calm fallback instead of an empty answer.
     _fact_card_blocked = False
@@ -4348,7 +4349,13 @@ async def _run_agent_loop(
 
     for iteration in range(MAX_AGENT_LOOP_ITERATIONS):
         # Check token budget BEFORE calling (except first iteration)
-        if iteration > 0 and total_tokens >= MAX_AGENT_LOOP_TOKENS:
+        budget_override_for_tool_completion = allow_completion_after_internal_tools
+        allow_completion_after_internal_tools = False
+        if (
+            iteration > 0
+            and total_tokens >= MAX_AGENT_LOOP_TOKENS
+            and not budget_override_for_tool_completion
+        ):
             logger.warning(
                 "Agent loop token budget exhausted (%d/%d) at iteration %d for user %s",
                 total_tokens,
@@ -4359,8 +4366,17 @@ async def _run_agent_loop(
             # Append a completion note to the last answer
             if answer_text:
                 answer_text += "\n\n_Note\u00a0: certaines informations n'ont pas pu être chargées. Repose ta question pour plus de détails._"
-            final_answer = answer_text
+                final_answer = answer_text
+            else:
+                final_answer = _EMPTY_AGENT_LOOP_FALLBACK_FR
+                degraded_any = True
             break
+        if iteration > 0 and total_tokens >= MAX_AGENT_LOOP_TOKENS:
+            logger.warning(
+                "Agent loop token budget exceeded after internal tool_use; "
+                "allowing one completion iteration for user %s",
+                user_id,
+            )
 
         try:
             # Only include conversation_history on the first iteration.
@@ -4477,11 +4493,6 @@ async def _run_agent_loop(
 
         answer_text = result.get("answer", "")
 
-        # FIX-W12: Per-request token budget guard
-        if request_tokens_used >= MAX_REQUEST_TOKENS:
-            logger.warning("Per-request token budget exceeded: %d", request_tokens_used)
-            final_answer = answer_text
-            break
         raw_tool_calls = result.get("tool_calls") or []
 
         # P0-5: Collect known tool names for unknown-call detection
@@ -4522,6 +4533,27 @@ async def _run_agent_loop(
                 )
                 final_answer = answer_text or "Désolé, une erreur interne est survenue."
                 break
+        # FIX-W12: Per-request token budget guard. Anthropic usage includes
+        # prompt/input tokens; forced tool-use turns can be high-token with
+        # empty text. Do not cut before executing internal tools, otherwise
+        # regulatory lookups return a 200 with message="".
+        has_answer_text = bool(answer_text and answer_text.strip())
+        if request_tokens_used >= MAX_REQUEST_TOKENS and (
+            not internal_calls or has_answer_text
+        ):
+            logger.warning("Per-request token budget exceeded: %d", request_tokens_used)
+            if has_answer_text:
+                final_answer = answer_text
+            else:
+                final_answer = _EMPTY_AGENT_LOOP_FALLBACK_FR
+                degraded_any = True
+            break
+        if request_tokens_used >= MAX_REQUEST_TOKENS:
+            logger.warning(
+                "Per-request token budget exceeded with internal tool_use; "
+                "deferring cap until tool result is narrated: %d",
+                request_tokens_used,
+            )
         # Sanitize PII from Flutter-bound tool inputs before returning
         for tc in external_calls:
             inp = tc.get("input", {})
@@ -4667,6 +4699,7 @@ async def _run_agent_loop(
             f"Utilise ces résultats pour compléter ta réponse à l'utilisateur. "
             f"Ne mentionne pas les outils internes dans ta réponse."
         )
+        allow_completion_after_internal_tools = not has_answer_text
     else:
         # for/else: max iterations reached without break
         logger.warning(

--- a/services/backend/tests/coach/test_agent_loop_reflective.py
+++ b/services/backend/tests/coach/test_agent_loop_reflective.py
@@ -149,6 +149,164 @@ async def test_empty_end_turn_exhaustion_returns_degraded_fallback():
 
 
 @pytest.mark.asyncio
+async def test_high_token_internal_tool_use_still_reaches_text_answer():
+    """High input-token tool_use turns must not be cut before tool execution."""
+    high_token_count = max(cc.MAX_REQUEST_TOKENS, cc.MAX_AGENT_LOOP_TOKENS) + 1
+    orchestrator = _MockOrchestrator([
+        {
+            "answer": "",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": high_token_count,
+            "tool_calls": [
+                {
+                    "name": "get_regulatory_constant",
+                    "input": {"key": "pillar3a.max_with_lpp"},
+                },
+            ],
+        },
+        {
+            "answer": "Le plafond 3a 2026 avec LPP est 7'258 CHF.",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 120,
+        },
+    ])
+
+    result = await cc._run_agent_loop(
+        orchestrator=orchestrator,
+        question="Quel est le plafond legal 3a 2026 avec LPP ?",
+        api_key="sk-test",
+        provider="claude",
+        model="claude-sonnet-4-5-20250929",
+        profile_context={"age": 33, "has_2nd_pillar": True},
+        memory_block=None,
+        language="fr",
+        system_prompt="test-prompt",
+        user_id="user-4",
+        db=None,
+        conversation_history=None,
+    )
+
+    assert result["answer"] == "Le plafond 3a 2026 avec LPP est 7'258 CHF."
+    assert len(orchestrator.calls) == 2
+    assert "Résultats outils internes" in orchestrator.calls[1]["question"]
+    assert "get_regulatory_constant" in orchestrator.calls[1]["question"]
+
+
+@pytest.mark.asyncio
+async def test_cumulative_token_budget_appends_note_to_partial_answer(monkeypatch):
+    """Cumulative cap preserves a partial answer instead of replacing it."""
+    monkeypatch.setattr(cc, "MAX_AGENT_LOOP_TOKENS", 100)
+    monkeypatch.setattr(cc, "MAX_REQUEST_TOKENS", 10_000)
+    orchestrator = _MockOrchestrator([
+        {
+            "answer": "Je vérifie ta mémoire.",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 60,
+            "tool_calls": [
+                {"name": "retrieve_memories", "input": {"topic": "3a"}},
+            ],
+        },
+        {
+            "answer": "Le plafond 3a dépend de ton affiliation LPP.",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 60,
+            "tool_calls": [
+                {"name": "retrieve_memories", "input": {"topic": "lpp"}},
+            ],
+        },
+    ])
+
+    result = await cc._run_agent_loop(
+        orchestrator=orchestrator,
+        question="Quel plafond 3a pour moi ?",
+        api_key="sk-test",
+        provider="claude",
+        model="claude-sonnet-4-5-20250929",
+        profile_context={"has_2nd_pillar": True},
+        memory_block="3a: plafond à vérifier",
+        language="fr",
+        system_prompt="test-prompt",
+        user_id="user-5",
+        db=None,
+        conversation_history=None,
+    )
+
+    assert len(orchestrator.calls) == 2
+    assert result["answer"].startswith("Le plafond 3a dépend")
+    assert "certaines informations" in result["answer"]
+
+
+@pytest.mark.asyncio
+async def test_cumulative_token_budget_empty_answer_returns_degraded_fallback(monkeypatch):
+    """Cumulative cap must not return message='' after empty end_turn retries."""
+    monkeypatch.setattr(cc, "MAX_AGENT_LOOP_TOKENS", 100)
+    monkeypatch.setattr(cc, "MAX_REQUEST_TOKENS", 10_000)
+    orchestrator = _MockOrchestrator([
+        {
+            "answer": "",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 120,
+        },
+    ])
+
+    result = await cc._run_agent_loop(
+        orchestrator=orchestrator,
+        question="Quel plafond 3a pour moi ?",
+        api_key="sk-test",
+        provider="claude",
+        model="claude-sonnet-4-5-20250929",
+        profile_context={"has_2nd_pillar": True},
+        memory_block=None,
+        language="fr",
+        system_prompt="test-prompt",
+        user_id="user-6",
+        db=None,
+        conversation_history=None,
+    )
+
+    assert len(orchestrator.calls) == 1
+    assert result["answer"] == cc._EMPTY_AGENT_LOOP_FALLBACK_FR
+    assert result["degraded"] is True
+
+
+@pytest.mark.asyncio
+async def test_request_token_budget_empty_no_tool_returns_degraded_fallback():
+    """Per-request cap also fails closed when Claude returns no text and no tool."""
+    orchestrator = _MockOrchestrator([
+        {
+            "answer": "",
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": cc.MAX_REQUEST_TOKENS,
+        },
+    ])
+
+    result = await cc._run_agent_loop(
+        orchestrator=orchestrator,
+        question="Quel plafond 3a pour moi ?",
+        api_key="sk-test",
+        provider="claude",
+        model="claude-sonnet-4-5-20250929",
+        profile_context={"has_2nd_pillar": True},
+        memory_block=None,
+        language="fr",
+        system_prompt="test-prompt",
+        user_id="user-7",
+        db=None,
+        conversation_history=None,
+    )
+
+    assert len(orchestrator.calls) == 1
+    assert result["answer"] == cc._EMPTY_AGENT_LOOP_FALLBACK_FR
+    assert result["degraded"] is True
+
+
+@pytest.mark.asyncio
 async def test_reprompt_constants_are_module_level():
     """Re-prompt strings are constants, not magic inline strings."""
     assert cc._REPROMPT_EMPTY_NARRATION

--- a/services/backend/tests/test_agent_loop.py
+++ b/services/backend/tests/test_agent_loop.py
@@ -148,6 +148,7 @@ class TestAgentLoopTermination:
         result = _run(_run_agent_loop(orchestrator=orch, **_BASE_KWARGS))
         # 3 calls: iter 0 (1500), iter 1 (3000), iter 2 (4500 >= 4000 → break)
         assert orch.query.call_count == 3
+        assert result["answer"] == "Iteration 2"
         assert result["tokens_used"] == 4500
 
 

--- a/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
@@ -18,6 +18,8 @@
 #       --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 \
 #       --dart-define=MINT_DISABLE_BETA_MODAL=true \
 #       --dart-define=MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready
+# - A disposable staging user exists. Pass credentials with:
+#     --env MINT_E2E_EMAIL=<email> --env MINT_E2E_PASSWORD=<password>
 # - The E2E seed is kReleaseMode-guarded and only proves this Coach turn,
 #   not onboarding persistence.
 
@@ -47,7 +49,7 @@ tags:
       - tapOn: "Je comprends, on y va"
       - waitForAnimationToEnd
 
-- openLink: "mintapp:///coach/chat"
+- openLink: "mintapp:///auth/login?redirect=%2Fcoach%2Fchat"
 - runFlow:
     when:
       visible: "Ouvrir"
@@ -60,6 +62,25 @@ tags:
     commands:
       - tapOn: "Open"
       - waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible: "Connexion"
+    timeout: 15000
+- assertVisible: "Adresse e-mail"
+- tapOn: "Adresse e-mail"
+- inputText: ${MINT_E2E_EMAIL}
+- pressKey: Enter
+
+- tapOn: "Se connecter avec un mot de passe"
+- extendedWaitUntil:
+    visible: "Mot de passe"
+    timeout: 8000
+- tapOn: "Mot de passe"
+- inputText: ${MINT_E2E_PASSWORD}
+- pressKey: Enter
+- tapOn: "Se connecter"
+- waitForAnimationToEnd:
+    timeout: 6000
 
 - extendedWaitUntil:
     visible:
@@ -107,7 +128,7 @@ tags:
 # The advice must stay bounded and non-promissory.
 - assertNotVisible: ".*\\{\\{cite:.*"
 - assertNotVisible: ".*source non affichée.*"
-- assertNotVisible: ".*API Claude.*"
+- assertNotVisible: ".*Je n'ai pas cette donnée à jour.*"
 - assertNotVisible: ".*Encore en chantier pour ton profil.*"
 - assertNotVisible: ".*meilleur.*"
 - assertNotVisible: ".*Meilleur.*"


### PR DESCRIPTION
## Summary
- Fix the authenticated Coach agent loop so high-token forced internal tool-use turns are not cut before `get_regulatory_constant` executes.
- Return a non-empty degraded fallback if token caps are hit without any answer text.
- Make the JOS-004 Maestro runtime proof authenticate via staging credentials instead of accidentally exercising `/anonymous/chat`.

## Runtime finding
Staging runtime proof reached `POST /api/v1/coach/chat` with status 200, but the response was `message: ""`, `sources: []`, `toolCalls: null` after the first forced regulatory-constant turn consumed about 24k input+output tokens. The old per-request token guard ran before internal tool execution, so the tool result never reached the narrator.

## Verification
- `cd services/backend && pytest tests/coach/test_agent_loop_reflective.py -q`
- `cd services/backend && pytest tests/coach tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_savefact_return.py -q`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/verify_phase_acceptance.py`
- `python3 tools/checks/mint_quality_os_check.py`

## Known check issue
- `python3 tools/checks/maestro_locator_audit.py tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml` currently scans all 58 flows and fails on unrelated historical locator drift outside this PR.
- `python3 tools/checks/journey_os_check.py --base-ref origin/dev` is now red because this PR intentionally includes the directly required backend hotfix; I am checking whether the Journey OS whitelist needs a scoped update for JOS-004 hotfix branches.
