### PR TITLE
Fix JOS-004 3a regulatory citation hint

### DIFF
--- a/services/backend/app/services/regulatory/tool_handler.py
+++ b/services/backend/app/services/regulatory/tool_handler.py
@@ -12,6 +12,7 @@ Single source of truth for both anonymous and authenticated paths.
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 from typing import Any
 
 try:
@@ -20,6 +21,39 @@ except Exception:  # pragma: no cover — fail-open if SDK absent
     sentry_sdk = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+_CLOSED_CITATION_KEY_BY_REGULATORY_KEY: dict[str, str] = {
+    "pillar3a.historical_limits.2026": "r3a_plafond_salarie_2026",
+}
+
+
+def _format_tool_value(value: Any, unit: str) -> str:
+    """Format a registry value for narrator-facing tool text."""
+    if isinstance(value, (int, float, Decimal)) and float(value).is_integer():
+        formatted = f"{int(value):,}".replace(",", "'")
+    else:
+        formatted = str(value)
+    return f"{formatted} {unit}".strip()
+
+
+def _closed_citation_hint(param: Any) -> str:
+    """Return narrator guidance linking regulatory keys to closed cite keys."""
+    cite_key = _CLOSED_CITATION_KEY_BY_REGULATORY_KEY.get(getattr(param, "key", ""))
+    if not cite_key:
+        return ""
+
+    tax_year = getattr(param, "tax_year", None)
+    year_text = f" {tax_year}" if tax_year else ""
+    value_text = _format_tool_value(
+        getattr(param, "value", ""),
+        getattr(param, "unit", ""),
+    )
+    return (
+        f"\nCitation fermée à utiliser : {{{{cite:{cite_key}}}}}"
+        f"\nFormulation citable : Le plafond 3a{year_text} avec LPP est de "
+        f"{value_text} {{{{cite:{cite_key}}}}}."
+    )
 
 
 def handle_regulatory_constant(tool_input: dict[str, Any]) -> str:
@@ -90,6 +124,7 @@ def handle_regulatory_constant(tool_input: dict[str, Any]) -> str:
                     f"Source : {param.source_title}\n"
                     f"Description : {param.description}\n"
                     f"En vigueur depuis : {param.effective_from.isoformat()}"
+                    f"{_closed_citation_hint(param)}"
                 )
         jurisdiction = canton_upper
 
@@ -141,4 +176,5 @@ def handle_regulatory_constant(tool_input: dict[str, Any]) -> str:
         f"Source : {param.source_title}\n"
         f"Description : {param.description}\n"
         f"En vigueur depuis : {param.effective_from.isoformat()}"
+        f"{_closed_citation_hint(param)}"
     )

--- a/services/backend/tests/test_coach_chat_endpoint.py
+++ b/services/backend/tests/test_coach_chat_endpoint.py
@@ -756,6 +756,42 @@ class TestCoachChatCitationGate:
         assert payload["citationChips"][0]["toolName"] == "budget_snapshot"
         assert loop.await_count == 2
 
+    def test_endpoint_accepts_jos004_closed_regulatory_citation(
+        self, client_with_auth, monkeypatch
+    ):
+        """JOS-004: a closed 2026 3a/LPP citation survives the endpoint gate."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "COACH_CITATION_GATE_ENABLED", True)
+        loop_result = {
+            "answer": (
+                "Le plafond 3a 2026 avec LPP est de 7'258 CHF "
+                "{{cite:r3a_plafond_salarie_2026}}."
+            ),
+            "tool_calls": None,
+            "citation_chips": None,
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 123,
+            "degraded": False,
+            "model_used": "test-model",
+        }
+        loop = AsyncMock(return_value=loop_result)
+
+        body = {
+            **_VALID_BODY,
+            "message": "Quel est le plafond legal 3a 2026 avec LPP ?",
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert "7'258" in payload["message"]
+        assert "OPP3 art. 7" in payload["message"]
+        assert "{{cite:" not in payload["message"]
+
     def test_endpoint_falls_back_when_retry_cites_tool_without_tool_use(
         self, client_with_auth, monkeypatch
     ):

--- a/services/backend/tests/test_regulatory_tool_handler.py
+++ b/services/backend/tests/test_regulatory_tool_handler.py
@@ -85,6 +85,22 @@ def test_handle_returns_formatted_param_on_hit():
     assert "2025-01-01" in result
 
 
+def test_handle_2026_3a_lpp_result_includes_closed_citation_hint():
+    """JOS-004: tool result must tell the narrator which closed cite key to use."""
+    from app.services.coach.citation_registry import CITATION_REGISTRY
+    from app.services.regulatory.tool_handler import handle_regulatory_constant
+
+    assert "r3a_plafond_salarie_2026" in CITATION_REGISTRY
+
+    result = handle_regulatory_constant({"key": "pillar3a.historical_limits.2026"})
+
+    assert "{{cite:r3a_plafond_salarie_2026}}" in result
+    assert "Formulation citable" in result
+    assert "pillar3a.historical_limits.2026 = 7258.0 CHF" in result
+    assert "7'258 CHF" in result
+    assert "OPP3 art. 7" in result
+
+
 def test_handle_miss_emits_sentry_breadcrumb_with_suggestions():
     """Code-reviewer FLAG #2 — registry miss must not be silent."""
     from app.services.regulatory.tool_handler import handle_regulatory_constant


### PR DESCRIPTION
## Summary
- Add a closed citation hint to `get_regulatory_constant` results for the 2026 salaried/LPP pillar 3a ceiling only (`pillar3a.historical_limits.2026`).
- Keep the shared regulatory handler isolated from the authenticated coach stack.
- Add regression coverage for the real registry key, the closed citation key, and the endpoint citation gate path.

## Why
After #752/#753, staging no longer returned an empty Coach message, but the authenticated JOS-004 runtime proof still fell back through the citation gate for:

`Quel est le plafond legal 3a 2026 avec LPP ?`

The tool lookup had the official value, but the narrator was not handed the closed citation key expected by the citation gate.

## Verification
- `pytest tests/test_regulatory_tool_handler.py::test_handle_2026_3a_lpp_result_includes_closed_citation_hint tests/test_coach_chat_endpoint.py::TestCoachChatCitationGate::test_endpoint_accepts_jos004_closed_regulatory_citation -q` -> 2 passed
- `pytest tests/test_regulatory_tool_handler.py tests/test_coach_chat_endpoint.py::TestCoachChatCitationGate tests/test_coach_chat_intent_force.py tests/coach/test_agent_loop_reflective.py -q` -> 56 passed
- `pytest tests/coach tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_savefact_return.py tests/test_regulatory_tool_handler.py --cov=app --cov-report=xml:coverage.xml -q && diff-cover coverage.xml --compare-branch=origin/dev --fail-under=80` -> 270 passed, diff coverage 93%
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py` -> OK
- `git diff --check` -> OK

## Audit response
Claude Opus safe-mode initially requested changes. Addressed by:
- removing the year-agnostic `pillar3a.max_with_lpp` mapping;
- testing the real `pillar3a.historical_limits.2026` registry value;
- asserting `r3a_plafond_salarie_2026` exists in the closed citation registry;
- adding endpoint-level coverage proving the JOS-004 closed citation survives substitution and no `{{cite:` leaks to the client.

## Runtime follow-up
After merge to `dev`, cherry-pick this single squash onto `staging`, wait for deploy, then rerun the authenticated direct `/api/v1/coach/chat` proof and the JOS-004 Maestro flow.
