### PR TITLE
Deploy JOS-004 closed citation normalizer to staging

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -1955,6 +1955,10 @@ _REGULATORY_CONSTANT_WITHOUT_LPP_TERMS: tuple[str, ...] = (
 )
 
 _PILLAR3A_2026_WITH_LPP_KEY = "pillar3a.historical_limits.2026"
+_PILLAR3A_2026_WITH_LPP_CITE = "{{cite:r3a_plafond_salarie_2026}}"
+_PILLAR3A_2026_WITH_LPP_AMOUNT_RE = re.compile(
+    r"\b(?:7['’ ]?258|7258)(?:[.,]0{1,2})?\s*(?:CHF|chf|fr\.?|francs?)\b"
+)
 
 
 def _normalise_intent_text(message: Optional[str]) -> str:
@@ -2039,6 +2043,46 @@ def _repair_regulatory_constant_input_for_question(
     repaired = dict(tool_input)
     repaired["key"] = _PILLAR3A_2026_WITH_LPP_KEY
     return repaired
+
+
+def _normalize_closed_regulatory_citation_placeholders(
+    answer_text: str,
+    *,
+    user_message: str,
+) -> str:
+    """Attach the closed 2026 3a/LPP cite when Claude wrote the prose source.
+
+    The runtime gate requires `{{cite:<key>}}` adjacency. For this closed
+    registry fact, the tool result already carries one exact cite key, but the
+    narrator may still write "OPP3 art. 7" in prose. Normalize only that narrow
+    shape before the gate, instead of broad auto-citing arbitrary numbers.
+    """
+    if (
+        not answer_text
+        or "{{cite:" in answer_text
+    ):
+        return answer_text
+
+    if not _PILLAR3A_2026_WITH_LPP_AMOUNT_RE.search(answer_text):
+        return answer_text
+
+    normalized_answer = _normalise_intent_text(answer_text)
+    normalized_question = _normalise_intent_text(user_message)
+    combined = f"{normalized_question}\n{normalized_answer}"
+    if any(term in combined for term in _REGULATORY_CONSTANT_WITHOUT_LPP_TERMS):
+        return answer_text
+    if "2026" not in combined or "3a" not in combined:
+        return answer_text
+    if not any(term in combined for term in _REGULATORY_CONSTANT_LPP_TERMS):
+        return answer_text
+    if "opp3" not in normalized_answer and "art. 7" not in answer_text.lower():
+        return answer_text
+
+    return _PILLAR3A_2026_WITH_LPP_AMOUNT_RE.sub(
+        lambda match: f"{match.group(0)} {_PILLAR3A_2026_WITH_LPP_CITE}",
+        answer_text,
+        count=1,
+    )
 
 
 # Wave 1c-A2 (2026-05-15) — gating set for the orchestration-layer RAG cut.
@@ -5497,6 +5541,11 @@ async def coach_chat(
         if not settings.COACH_CITATION_GATE_ENABLED:
             # D-20 byte-identical bypass.
             return loop_result
+
+        loop_result["answer"] = _normalize_closed_regulatory_citation_placeholders(
+            loop_result["answer"],
+            user_message=body.message,
+        )
 
         # Phase mint-calc-engine-v1 Plan 18 — D-CE-16(c) runtime banned-verb
         # gate. Runs BEFORE the Phase 94 citation parser (Q5 = before) on the

--- a/services/backend/tests/test_coach_chat_endpoint.py
+++ b/services/backend/tests/test_coach_chat_endpoint.py
@@ -792,6 +792,43 @@ class TestCoachChatCitationGate:
         assert "OPP3 art. 7" in payload["message"]
         assert "{{cite:" not in payload["message"]
 
+    def test_endpoint_normalizes_jos004_prose_regulatory_citation(
+        self, client_with_auth, monkeypatch
+    ):
+        """JOS-004: prose OPP3 citation is normalized before citation gate."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "COACH_CITATION_GATE_ENABLED", True)
+        loop_result = {
+            "answer": (
+                "Le plafond 3a 2026 avec LPP est de 7'258 CHF selon "
+                "l'OPP3 art. 7 al. 1 let. a."
+            ),
+            "tool_calls": None,
+            "citation_chips": None,
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 123,
+            "degraded": False,
+            "model_used": "test-model",
+        }
+        loop = AsyncMock(return_value=loop_result)
+
+        body = {
+            **_VALID_BODY,
+            "message": "Quel est le plafond legal 3a 2026 avec LPP ?",
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert "7'258" in payload["message"]
+        assert "OPP3 art. 7" in payload["message"]
+        assert "Je n'ai pas cette donnée" not in payload["message"]
+        assert "{{cite:" not in payload["message"]
+
     def test_endpoint_falls_back_when_retry_cites_tool_without_tool_use(
         self, client_with_auth, monkeypatch
     ):

--- a/services/backend/tests/test_coach_chat_intent_force.py
+++ b/services/backend/tests/test_coach_chat_intent_force.py
@@ -35,6 +35,7 @@ from app.api.v1.endpoints.coach_chat import (
     _execute_internal_tool,
     _gate_fact_card_against_registry,
     _guard_tool_payload_text_fields,
+    _normalize_closed_regulatory_citation_placeholders,
     _run_agent_loop,
     _TOOL_PAYLOAD_FALLBACK_FR,
 )
@@ -275,6 +276,64 @@ class TestForcedToolChoiceFirstCallOnly:
 
         assert "pillar3a.max_without_lpp = 36288.0 CHF" in result
         assert "pillar3a.historical_limits.2026" not in result
+
+    def test_3a_closed_citation_normalizer_refuses_without_lpp(self):
+        text = "Le plafond 3a 2026 est de 7'258 CHF selon l'OPP3 art. 7."
+
+        assert (
+            _normalize_closed_regulatory_citation_placeholders(
+                text,
+                user_message="Quel est le plafond 3a 2026 ?",
+            )
+            == text
+        )
+
+    def test_3a_closed_citation_normalizer_refuses_sans_lpp(self):
+        text = "Le plafond 3a 2026 sans LPP est de 7'258 CHF selon l'OPP3 art. 7."
+
+        assert (
+            _normalize_closed_regulatory_citation_placeholders(
+                text,
+                user_message="Quel est le plafond 3a 2026 sans LPP ?",
+            )
+            == text
+        )
+
+    def test_3a_closed_citation_normalizer_refuses_without_opp3_source(self):
+        text = "Le plafond 3a 2026 avec LPP est de 7'258 CHF."
+
+        assert (
+            _normalize_closed_regulatory_citation_placeholders(
+                text,
+                user_message="Quel est le plafond 3a 2026 avec LPP ?",
+            )
+            == text
+        )
+
+    def test_3a_closed_citation_normalizer_refuses_wrong_year(self):
+        text = "Le plafond 3a 2025 avec LPP est de 7'258 CHF selon l'OPP3 art. 7."
+
+        assert (
+            _normalize_closed_regulatory_citation_placeholders(
+                text,
+                user_message="Quel est le plafond 3a 2025 avec LPP ?",
+            )
+            == text
+        )
+
+    def test_3a_closed_citation_normalizer_does_not_duplicate_existing_cite(self):
+        text = (
+            "Le plafond 3a 2026 avec LPP est de 7'258 CHF "
+            "{{cite:r3a_plafond_salarie_2026}}."
+        )
+
+        assert (
+            _normalize_closed_regulatory_citation_placeholders(
+                text,
+                user_message="Quel est le plafond 3a 2026 avec LPP ?",
+            )
+            == text
+        )
 
     def test_3a_ceiling_forces_regulatory_constant_on_first_call_only(self):
         """JOS-004: current-year 3a/LPP ceiling must retrieve the registry.


### PR DESCRIPTION
## Summary
- Cherry-picks dev merge `9ec7c4b200ef97527259fa7eb147f6308b5a1c09` / PR #756 to staging.
- Keeps the staging promotion to one backend hotfix commit: deterministic normalization for the closed JOS-004 2026 3a/LPP OPP3 prose citation case.

## Verification on staging branch
- `pytest tests/coach tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_savefact_return.py tests/test_regulatory_tool_handler.py --cov=app --cov-report=xml:coverage.xml -q`
- `diff-cover coverage.xml --compare-branch=origin/staging --fail-under=80`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `git diff --check origin/staging...HEAD`

## Audit
- Claude CLI safe-mode Opus audit on PR #756: APPROVE, no blockers.

## Runtime proof
- To run after merge/deploy: authenticated direct `/api/v1/coach/chat`, then Maestro JOS-004 flow.