### PR TITLE
Deploy JOS-004 retry citation normalizer to staging

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -5737,7 +5737,10 @@ async def coach_chat(
             _run_agent_loop(question=retry_message, **_initial_loop_kwargs),
             timeout=AGENT_LOOP_DEADLINE_SECONDS,
         )
-        retry_raw_answer = retry_result["answer"]
+        retry_raw_answer = _normalize_closed_regulatory_citation_placeholders(
+            retry_result["answer"],
+            user_message=body.message,
+        )
         retry_gated = _citation_gate(
             response_text=retry_raw_answer,
             ctx=coach_ctx,

--- a/services/backend/tests/test_coach_chat_endpoint.py
+++ b/services/backend/tests/test_coach_chat_endpoint.py
@@ -829,6 +829,54 @@ class TestCoachChatCitationGate:
         assert "Je n'ai pas cette donnée" not in payload["message"]
         assert "{{cite:" not in payload["message"]
 
+    def test_endpoint_normalizes_jos004_retry_prose_regulatory_citation(
+        self, client_with_auth, monkeypatch
+    ):
+        """JOS-004: D-08 retry prose citation is normalized before hard fallback."""
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "COACH_CITATION_GATE_ENABLED", True)
+        first = {
+            "answer": "Le plafond 3a 2026 avec LPP est de 7'258 CHF.",
+            "tool_calls": None,
+            "citation_chips": None,
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 123,
+            "degraded": False,
+            "model_used": "test-model",
+        }
+        retry = {
+            "answer": (
+                "Le plafond 3a 2026 avec LPP est de 7'258 CHF selon "
+                "l'OPP3 art. 7 al. 1 let. a."
+            ),
+            "tool_calls": None,
+            "citation_chips": None,
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 456,
+            "degraded": False,
+            "model_used": "test-model",
+        }
+        loop = AsyncMock(side_effect=[first, retry])
+
+        body = {
+            **_VALID_BODY,
+            "message": "Quel est le plafond legal 3a 2026 avec LPP ?",
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert "7'258" in payload["message"]
+        assert "OPP3 art. 7" in payload["message"]
+        assert "Je n'ai pas cette donnée" not in payload["message"]
+        assert "{{cite:" not in payload["message"]
+        assert loop.await_count == 2
+
     def test_endpoint_falls_back_when_retry_cites_tool_without_tool_use(
         self, client_with_auth, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- Cherry-picks dev merge `37c77b3975a7df5f1a0739b786e0cf4316920b09` / PR #758 to staging.
- This is the narrow D-08 retry-path companion to #756/#757: normalize the closed 2026 3a/LPP prose OPP3 citation before `_citation_gate(..., is_retry=True)`.

## Verification on staging branch
- `pytest tests/coach tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_savefact_return.py tests/test_regulatory_tool_handler.py --cov=app --cov-report=xml:coverage.xml -q`
- `diff-cover coverage.xml --compare-branch=origin/staging --fail-under=80`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `git diff --check origin/staging...HEAD`

## Audit
- Claude CLI safe-mode Opus audit on PR #758: APPROVE, no blockers.

## Runtime proof
- Direct staging proof before this PR remained red after #757; rerun authenticated `/api/v1/coach/chat` after deploy.
- Maestro JOS-004 follows only after direct proof is green.