### PR TITLE
fix(coach): add deterministic 3a regulatory floor

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -21,7 +21,8 @@
     "codex/jos004-profile-privacy-control-20260627",
     "codex/jos005-coach-advice-turn-20260627",
     "codex/jos004-coach-advice-fix-20260627",
-    "codex/jos004-coach-empty-answer-fix-20260627"
+    "codex/jos004-coach-empty-answer-fix-20260627",
+    "codex/jos004-regulatory-floor-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -43,6 +43,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
   authorized only for the JOS-004 authenticated Coach empty-answer fix, the
   directly required runtime-proof harness update, and evidence from clean
   `origin/dev`.
+- Temporary hotfix branch: `codex/jos004-regulatory-floor-20260627` is
+  authorized only for the JOS-004 closed regulatory 3a/LPP deterministic
+  runtime floor and evidence from clean `origin/dev`.
 
 ## Required Session Start
 

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -2085,6 +2085,34 @@ def _normalize_closed_regulatory_citation_placeholders(
     )
 
 
+def _extract_closed_regulatory_floor_answer(
+    tool_result_text: str,
+    *,
+    user_message: Optional[str],
+    detected_intents: Optional[set[str]],
+) -> Optional[str]:
+    if not _should_default_to_3a_2026_with_lpp(
+        question=user_message,
+        detected_intents=detected_intents,
+    ):
+        return None
+    if _PILLAR3A_2026_WITH_LPP_CITE not in tool_result_text:
+        return None
+
+    prefix = "Formulation citable :"
+    for line in tool_result_text.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith(prefix):
+            continue
+        answer = candidate[len(prefix) :].strip()
+        if (
+            _PILLAR3A_2026_WITH_LPP_CITE in answer
+            and _PILLAR3A_2026_WITH_LPP_AMOUNT_RE.search(answer)
+        ):
+            return answer
+    return None
+
+
 # Wave 1c-A2 (2026-05-15) — gating set for the orchestration-layer RAG cut.
 # When detected_intents intersects this set AND the agent-loop tools include
 # at least one entry from _TOOL_ELIGIBLE_TOOL_NAMES, n_results is set to 0
@@ -4368,6 +4396,7 @@ async def _run_agent_loop(
     total_tokens = 0
     request_tokens_used = 0
     final_answer = ""
+    closed_regulatory_floor_answer: Optional[str] = None
     current_question = question
     answer_text = ""  # initialized to prevent NameError in for/else
     # v2.7 STAB-02 Task 3: track degraded state across iterations.
@@ -4698,6 +4727,15 @@ async def _run_agent_loop(
                 fact_keys_saved_this_turn=fact_keys_saved_this_turn,
                 background_tasks=background_tasks,
             )
+            if call.get("name") == "get_regulatory_constant":
+                closed_regulatory_floor_answer = (
+                    _extract_closed_regulatory_floor_answer(
+                        result_text,
+                        user_message=question,
+                        detected_intents=detected_intents,
+                    )
+                    or closed_regulatory_floor_answer
+                )
             # WS-D (mint-grounded-coach-m1 Plan 06) — echo a successful save_fact
             # back to the mobile so the chat-stated value reaches the local
             # CoachProfile the screens read (split-brain bridge, audit 04
@@ -4757,6 +4795,12 @@ async def _run_agent_loop(
             )
             final_answer = _EMPTY_AGENT_LOOP_FALLBACK_FR
             degraded_any = True
+
+    if (
+        closed_regulatory_floor_answer
+        and _PILLAR3A_2026_WITH_LPP_CITE not in final_answer
+    ):
+        final_answer = closed_regulatory_floor_answer
 
     # Deduplicate sources by (file, section) key
     seen_sources: set = set()

--- a/services/backend/tests/test_coach_chat_intent_force.py
+++ b/services/backend/tests/test_coach_chat_intent_force.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, MagicMock
 from app.api.v1.endpoints.coach_chat import (
     _classify_user_intent,
     _execute_internal_tool,
+    _extract_closed_regulatory_floor_answer,
     _gate_fact_card_against_registry,
     _guard_tool_payload_text_fields,
     _normalize_closed_regulatory_citation_placeholders,
@@ -374,6 +375,51 @@ class TestForcedToolChoiceFirstCallOnly:
         assert choices[1] is None
         assert orch.query.call_args_list[0].kwargs.get("n_results") == 0
         assert "7'258" in result["answer"]
+
+    def test_3a_closed_regulatory_tool_result_supplies_cited_floor(self):
+        """JOS-004: a closed tool result beats uncited narrator prose."""
+        orch = _make_mock_orchestrator(
+            _make_result(
+                answer="",
+                tool_calls=[
+                    {
+                        "name": "get_regulatory_constant",
+                        "input": {"key": "pillar3a.max_with_lpp"},
+                    }
+                ],
+            ),
+            _make_result(answer="Le plafond 3a 2026 avec LPP est de 7'258 CHF."),
+        )
+        result = _run(
+            _run_agent_loop(
+                orchestrator=orch,
+                tools=[{"name": "get_regulatory_constant"}],
+                **_base_kwargs(_JOS004_3A_CEILING_MSG, {"retirement"}),
+            )
+        )
+
+        assert "7'258 CHF {{cite:r3a_plafond_salarie_2026}}" in result["answer"]
+        assert "Je n'ai pas cette donnée" not in result["answer"]
+
+    def test_3a_closed_regulatory_floor_refuses_missing_cite(self):
+        assert (
+            _extract_closed_regulatory_floor_answer(
+                "Formulation citable : Le plafond 3a 2026 avec LPP est de 7'258 CHF.",
+                user_message=_JOS004_3A_CEILING_MSG,
+                detected_intents={"retirement"},
+            )
+            is None
+        )
+
+    def test_3a_closed_regulatory_floor_refuses_malformed_formulation(self):
+        assert (
+            _extract_closed_regulatory_floor_answer(
+                "Citation fermée à utiliser : {{cite:r3a_plafond_salarie_2026}}",
+                user_message=_JOS004_3A_CEILING_MSG,
+                detected_intents={"retirement"},
+            )
+            is None
+        )
 
     def test_definition_forces_explain_concept_on_first_call_only(self):
         """Force turn 1; the follow-up after the tool_result reverts to auto."""


### PR DESCRIPTION
## Summary
- Add an ACTIVE_CONTEXT authorization for the JOS-004 regulatory-floor hotfix branch.
- Capture the closed 2026 3a/LPP regulatory tool formulation before tool-result truncation.
- Use that exact cited formulation when the narrator omits the closed citation, preventing citation-gate fallback for the JOS-004 runtime proof.

## Verification
- pytest tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py::TestCoachChatCitationGate::test_endpoint_accepts_jos004_closed_regulatory_citation tests/test_coach_chat_endpoint.py::TestCoachChatCitationGate::test_endpoint_normalizes_jos004_prose_regulatory_citation tests/test_coach_chat_endpoint.py::TestCoachChatCitationGate::test_endpoint_normalizes_jos004_retry_prose_regulatory_citation tests/test_regulatory_tool_handler.py -q → 54 passed
- pytest tests/coach tests/test_coach_chat_intent_force.py tests/test_coach_chat_endpoint.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_savefact_return.py tests/test_regulatory_tool_handler.py --cov=app --cov-report=xml:coverage.xml -q → 280 passed
- diff-cover coverage.xml --compare-branch=origin/dev --fail-under=80 → 100%
- git diff --check origin/dev → OK
- python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py → OK
- Claude CLI safe-mode Opus audit → APPROVE, no blocking findings

## Runtime Plan
After merge to dev: promote to staging, wait for Deploy Backend, rerun direct /api/v1/coach/chat proof, then run Maestro only if direct proof is green.