### PR TITLE
Fix JOS-004 closed 3a regulatory tool loop

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -22,7 +22,8 @@
     "codex/jos005-coach-advice-turn-20260627",
     "codex/jos004-coach-advice-fix-20260627",
     "codex/jos004-coach-empty-answer-fix-20260627",
-    "codex/jos004-regulatory-floor-20260627"
+    "codex/jos004-regulatory-floor-20260627",
+    "codex/jos004-regulatory-floor-close-loop-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -46,6 +46,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary hotfix branch: `codex/jos004-regulatory-floor-20260627` is
   authorized only for the JOS-004 closed regulatory 3a/LPP deterministic
   runtime floor and evidence from clean `origin/dev`.
+- Temporary hotfix branch: `codex/jos004-regulatory-floor-close-loop-20260627`
+  is authorized only for closing the JOS-004 3a/LPP regulatory tool loop
+  deterministically before a fallback response can overwrite it.
 
 ## Required Session Start
 

--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -4771,6 +4771,16 @@ async def _run_agent_loop(
                 len(result_text),
             )
 
+        # The registry result is already a closed-world answer. A second LLM
+        # turn can overwrite it with the generic high-token fallback.
+        if closed_regulatory_floor_answer:
+            logger.info(
+                "Agent loop closed on deterministic regulatory floor for user %s",
+                user_id,
+            )
+            final_answer = closed_regulatory_floor_answer
+            break
+
         # Build augmented question for the next iteration.
         # V1: append tool results as text.  The LLM sees its own prior
         # answer + the tool results and can continue the conversation.

--- a/services/backend/tests/test_coach_chat_intent_force.py
+++ b/services/backend/tests/test_coach_chat_intent_force.py
@@ -336,13 +336,13 @@ class TestForcedToolChoiceFirstCallOnly:
             == text
         )
 
-    def test_3a_ceiling_forces_regulatory_constant_on_first_call_only(self):
+    def test_3a_ceiling_forces_regulatory_constant_and_closes_on_tool_result(self):
         """JOS-004: current-year 3a/LPP ceiling must retrieve the registry.
 
-        The first LLM call is forced to `get_regulatory_constant` so the
-        answer cannot come from model weights or stale profile amounts. After
-        the tool result, the second call reverts to auto so the loop can emit
-        final text.
+        The LLM call is forced to `get_regulatory_constant` so the answer
+        cannot come from model weights or stale profile amounts. When the
+        tool returns the closed formulation, the loop must answer directly
+        instead of spending another high-token LLM turn that may fall back.
         """
         orch = _make_mock_orchestrator(
             _make_result(
@@ -354,12 +354,6 @@ class TestForcedToolChoiceFirstCallOnly:
                     }
                 ],
             ),
-            _make_result(
-                answer=(
-                    "Pour 2026, le plafond 3a avec LPP est de 7'258 CHF "
-                    "(OPP3 art. 7)."
-                ),
-            ),
         )
         result = _run(
             _run_agent_loop(
@@ -370,11 +364,10 @@ class TestForcedToolChoiceFirstCallOnly:
         )
 
         choices = _tool_choices(orch)
-        assert len(choices) == 2, f"expected 2 calls, got {len(choices)}"
+        assert len(choices) == 1, f"expected 1 call, got {len(choices)}"
         assert choices[0] == {"type": "tool", "name": "get_regulatory_constant"}
-        assert choices[1] is None
         assert orch.query.call_args_list[0].kwargs.get("n_results") == 0
-        assert "7'258" in result["answer"]
+        assert "7'258 CHF {{cite:r3a_plafond_salarie_2026}}" in result["answer"]
 
     def test_3a_closed_regulatory_tool_result_supplies_cited_floor(self):
         """JOS-004: a closed tool result beats uncited narrator prose."""
@@ -398,6 +391,40 @@ class TestForcedToolChoiceFirstCallOnly:
             )
         )
 
+        assert "7'258 CHF {{cite:r3a_plafond_salarie_2026}}" in result["answer"]
+        assert "Je n'ai pas cette donnée" not in result["answer"]
+
+    def test_3a_closed_regulatory_tool_result_skips_high_token_fallback_turn(self):
+        """JOS-004: staging-scale prompts must not re-ask the LLM after the tool."""
+        orch = _make_mock_orchestrator(
+            _make_result(
+                answer="",
+                tokens_used=49_000,
+                tool_calls=[
+                    {
+                        "name": "get_regulatory_constant",
+                        "input": {"key": "pillar3a.max_with_lpp"},
+                    }
+                ],
+            ),
+            _make_result(
+                answer=(
+                    "Je n'ai pas cette donnée pour l'instant. Pour avancer "
+                    "ensemble, dis-moi un peu plus sur ta situation."
+                ),
+                tokens_used=600,
+            ),  # Must never be consumed once the closed tool result exists.
+        )
+        result = _run(
+            _run_agent_loop(
+                orchestrator=orch,
+                tools=[{"name": "get_regulatory_constant"}],
+                **_base_kwargs(_JOS004_3A_CEILING_MSG, {"retirement"}),
+            )
+        )
+
+        assert len(_tool_choices(orch)) == 1
+        assert result["tokens_used"] == 49_000
         assert "7'258 CHF {{cite:r3a_plafond_salarie_2026}}" in result["answer"]
         assert "Je n'ai pas cette donnée" not in result["answer"]
 


### PR DESCRIPTION
## Summary
- close the Coach agent loop immediately when `get_regulatory_constant` returns the closed 2026 3a/LPP formulation
- prevent the high-token second LLM turn from replacing the cited registry value with the generic fallback
- add branch authorization and regression coverage for the single-call closed-floor path

## Evidence
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py` PASS
- `python3 tools/checks/verify_phase_acceptance.py` PASS
- `cd services/backend && python3 -m ruff check app/api/v1/endpoints/coach_chat.py tests/test_coach_chat_intent_force.py` PASS
- `cd services/backend && python3 -m pytest tests/test_coach_chat_intent_force.py -q` -> 46 passed
- `cd services/backend && python3 -m pytest tests/test_coach_chat_intent_force.py tests/test_coach_chat_tool_use_gate.py tests/test_coach_chat_temporal_gate_wire.py tests/test_coach_chat_verb_gate_wire.py tests/test_rag_orchestrator_empty_text_no_fallback.py tests/test_citation_gate/ -q` -> 280 passed
- `cd services/backend && python3 -m pytest tests/ -q` -> 7872 passed, 85 skipped, 3 xfailed, 1 warning in 128.80s
- `python3 -m diff_cover.diff_cover_tool /tmp/mint-jos004-coverage.xml --compare-branch=origin/dev --fail-under=80` -> 100% diff coverage

## Audit
Claude CLI safe-mode Opus audit: APPROVE. Low notes: the second synthesis turn is intentionally skipped for this closed regulatory fact; the post-loop override remains as a safety net.

## Runtime
Staging direct proof remains pending for this PR. Previous staging deployment at `20cdc9636` still returned the fallback after the second LLM turn, with Railway logs showing the closed tool result was present before fallback.
