### PR TITLE
test(journey-os): prove JOS-004 Coach turn flow

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -23,7 +23,8 @@
     "codex/jos004-coach-advice-fix-20260627",
     "codex/jos004-coach-empty-answer-fix-20260627",
     "codex/jos004-regulatory-floor-20260627",
-    "codex/jos004-regulatory-floor-close-loop-20260627"
+    "codex/jos004-regulatory-floor-close-loop-20260627",
+    "codex/jos004-maestro-first-experience-proof-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -49,6 +49,10 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Temporary hotfix branch: `codex/jos004-regulatory-floor-close-loop-20260627`
   is authorized only for closing the JOS-004 3a/LPP regulatory tool loop
   deterministically before a fallback response can overwrite it.
+- Temporary runtime-proof branch:
+  `codex/jos004-maestro-first-experience-proof-20260627` is authorized only
+  for the JOS-004 Coach advice turn Maestro runtime proof harness update from
+  clean `origin/dev`; no product code changes.
 
 ## Required Session Start
 

--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -4,7 +4,7 @@ Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
 | Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
 |---|---|---|---|---:|---|---|---|
-| JOS-004 | P0 | fixing | coach_advice_turn | 27 | mint-backend | red | Deploy the authenticated Coach regulatory-constant force fix to staging, then rerun the JOS-004 runtime proof until the salaried-LPP 2026 3a ceiling returns 7'258 CHF with OPP3/LIFD provenance instead of the freshness fallback. |
 | JOS-001 | P0 | verified | account_lifecycle_delete | 27 | mint-quality-gate | green | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
+| JOS-004 | P0 | verified | coach_advice_turn | 27 | mint-quality-gate | green | Keep the JOS-004 Maestro proof in Journey OS monitoring; reuse it for future Coach regulatory-number changes before promoting broader Coach advice coverage. |
 | JOS-002 | P0 | verified | money_truth_spine | 26 | mint-quality-gate | green | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |
 | JOS-003 | P0 | verified | profile_privacy_control | 25 | mint-quality-gate | green | Keep the Profile Privacy Control runtime gate in Journey OS monitoring; add authenticated backend privacy E2E sampling when a stable seed exists. |

--- a/.planning/journeys/evidence/coach_advice_turn/20260627T172841Z/claude-opus-audit.txt
+++ b/.planning/journeys/evidence/coach_advice_turn/20260627T172841Z/claude-opus-audit.txt
@@ -1,0 +1,26 @@
+Command:
+timeout 600 claude --safe-mode --model opus --permission-mode plan -p "Audit the current uncommitted diff in this worktree as a hostile code reviewer. Scope: Mint Journey OS JOS-004 Maestro first-experience proof harness. Requirements: no product code changes, clean origin/dev worktree branch, existing route/debug helper only, no secrets in committed artifacts, Journey OS issue may be verified but coach_advice_turn record must not overclaim broader Coach advice coverage, generated Journey OS views must be consistent, tests/guards must be meaningful. Do not edit files. Use read-only inspection only. Return findings first with severity and file:line references; if there are no blocking findings, say so explicitly and list residual risks."
+
+Claude CLI:
+2.1.170 (Claude Code), safe-mode, model alias opus, permission-mode plan.
+
+Verdict:
+No blocking findings.
+
+Checklist:
+- No product code changes.
+- Branch is cleanly based on origin/dev and authorized in ACTIVE_CONTEXT.
+- The Maestro flow uses the existing kReleaseMode-guarded debug route /__e2e/row23-independent-no-lpp-profile and the existing e2e_profile_fixture_applied element id.
+- No staging credentials are present in committed artifacts; command lines use [REDACTED_EMAIL] and [REDACTED_PASSWORD].
+- JOS-004 is verified without promoting the broader coach_advice_turn journey beyond partial.
+- Generated Journey OS BOARD view is consistent.
+- The new guard test checks login -> fixture -> coach ordering.
+
+Residual risks noted by audit:
+- The evidence file must be committed with the record change.
+- Backend staging provenance is dual-branch: mobile/dev proof base is 4cb5c173b998868cd73f9bdf6aebc718bc4bffa6, while staging deployment was 454084bdecf8a87f16191b8dbf64fd536f87f3fa.
+- The proof depends on the debug route and proves this seeded Coach turn, not real onboarding persistence.
+- The static YAML guard is intentionally cheap and must remain paired with runtime proof.
+
+Audit log:
+/tmp/jos004-claude-opus-audit-20260627T172841Z.txt

--- a/.planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt
+++ b/.planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt
@@ -1,0 +1,95 @@
+Command:
+bash -lc 'source /tmp/mint-jos004-staging-account.env; /Users/julienbattaglia/.maestro/bin/maestro test --env MINT_E2E_EMAIL=[REDACTED_EMAIL] --env MINT_E2E_PASSWORD=[REDACTED_PASSWORD] tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml'
+
+Runtime:
+iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9
+
+Base app/backend:
+- App bundle already installed on the booted simulator.
+- Mobile build was the debug staging build installed for the JOS-004 proof loop.
+- Backend staging active deployment was verified separately at commit 454084bdecf8a87f16191b8dbf64fd536f87f3fa after PR #763.
+
+Flow result:
+Running on iPhone 17 Pro - iOS 26.2 - B03E429D-0422-4357-B754-536637D979F9
+ > Flow flow_jos004_coach_advice_turn_runtime
+Launch app "ch.mint.app" with clear state (launch arguments: {MINT_E2E_ARCHETYPE=${MINT_E2E_ARCHETYPE}})... COMPLETED
+Wait for animation to end within 6000 ms... COMPLETED
+Run flow when "Je comprends, on y va" is visible...
+Run flow when "Je comprends, on y va" is visible... SKIPPED
+Open mintapp:///auth/login?redirect=%2Fcoach%2Fchat... COMPLETED
+Run flow when "Ouvrir" is visible...
+Run flow when "Ouvrir" is visible... SKIPPED
+Run flow when "Open" is visible...
+Run flow when "Open" is visible... SKIPPED
+Assert that "Connexion" is visible... COMPLETED
+Assert that "Adresse e-mail" is visible... COMPLETED
+Tap on "Adresse e-mail"... COMPLETED
+Input text ${MINT_E2E_EMAIL}... COMPLETED
+Press Enter key... COMPLETED
+Tap on "Se connecter avec un mot de passe"... COMPLETED
+Assert that "Mot de passe" is visible... COMPLETED
+Tap on "Mot de passe"... COMPLETED
+Input text ${MINT_E2E_PASSWORD}... COMPLETED
+Press Enter key... COMPLETED
+Tap on "Se connecter"... COMPLETED
+Wait for animation to end within 6000 ms... COMPLETED
+Open mintapp:///__e2e/row23-independent-no-lpp-profile?slug=cadre_salarie_lpp_suisse_ready... COMPLETED
+Run flow when "Ouvrir" is visible...
+Run flow when "Ouvrir" is visible... SKIPPED
+Run flow when "Open" is visible...
+Run flow when "Open" is visible... SKIPPED
+Assert that id: e2e_profile_fixture_applied is visible... COMPLETED
+Copy text from element with id: e2e_profile_fixture_applied... COMPLETED
+Run ${output.jos004_profile_bootstrap = maestro.copiedText}... COMPLETED
+Open mintapp:///coach/chat... COMPLETED
+Run flow when "Ouvrir" is visible...
+Run flow when "Ouvrir" is visible... SKIPPED
+Run flow when "Open" is visible...
+Run flow when "Open" is visible... SKIPPED
+Assert that id: coach_chat_screen is visible... COMPLETED
+Assert that id: coach_input_field is visible... COMPLETED
+Assert that id: coach_send_button is visible... COMPLETED
+Assert that "Encore en chantier pour ton profil" is not visible... COMPLETED
+Assert that "A RenderFlex overflowed" is not visible... COMPLETED
+Assert that "Exception caught" is not visible... COMPLETED
+Assert that "NoSuchMethodError" is not visible... COMPLETED
+Tap on id: coach_input_field... COMPLETED
+Input text Quel est le plafond legal 3a 2026 avec LPP ?... COMPLETED
+Tap on id: coach_send_button... COMPLETED
+Wait for animation to end within 6000 ms... COMPLETED
+Take screenshot jos004-coach-advice-turn-after-send... COMPLETED
+Assert that ".*(3a|pilier).*" is visible... COMPLETED
+Assert that ".*(OPP3|art\.?\s*7|art\.?\s*33|art\.?\s*38|LIFD).*" is visible... COMPLETED
+Wait for animation to end within 5000 ms... COMPLETED
+Take screenshot jos004-coach-advice-turn-response... COMPLETED
+Assert that ".*7['’\s ]?258.*" is visible... COMPLETED
+Assert that ".*(OPP3|art\.?\s*7|art\.?\s*33|art\.?\s*38|LIFD).*" is visible... COMPLETED
+Assert that ".*\{\{cite:.*" is not visible... COMPLETED
+Assert that ".*source non affichée.*" is not visible... COMPLETED
+Assert that ".*Je n'ai pas cette donnée à jour.*" is not visible... COMPLETED
+Assert that ".*Encore en chantier pour ton profil.*" is not visible... COMPLETED
+Assert that ".*meilleur.*" is not visible... COMPLETED
+Assert that ".*Meilleur.*" is not visible... COMPLETED
+Assert that ".*optimal.*" is not visible... COMPLETED
+Assert that ".*Optimal.*" is not visible... COMPLETED
+Assert that ".*garanti.*" is not visible... COMPLETED
+Assert that ".*Garanti.*" is not visible... COMPLETED
+Assert that ".*sans risque.*" is not visible... COMPLETED
+Assert that ".*Sans risque.*" is not visible... COMPLETED
+Assert that ".*certain.*" is not visible... COMPLETED
+Assert that ".*Certain.*" is not visible... COMPLETED
+Assert that ".*assuré.*" is not visible... COMPLETED
+Assert that ".*Assuré.*" is not visible... COMPLETED
+Assert that ".*parfait.*" is not visible... COMPLETED
+Assert that ".*Parfait.*" is not visible... COMPLETED
+Assert that "NaN" is not visible... COMPLETED
+Assert that "Infinity" is not visible... COMPLETED
+Assert that "A RenderFlex overflowed" is not visible... COMPLETED
+Assert that "Exception caught" is not visible... COMPLETED
+Assert that "NoSuchMethodError" is not visible... COMPLETED
+
+Evidence interpretation:
+- The patched flow no longer stalls at Mint first-experience after login.
+- The existing debug-only E2E route persisted the salaried-LPP fixture and marked mini-onboarding complete before opening /coach/chat.
+- The visible Coach answer contained the 2026 salaried-LPP 3a ceiling 7'258 and a legal citation token accepted by the flow.
+- The visible answer did not contain the freshness fallback, unfinished-profile warning, NaN/Infinity, Flutter exception strings, or the listed bounded-advice banned terms.

--- a/.planning/journeys/issues/JOS-004.json
+++ b/.planning/journeys/issues/JOS-004.json
@@ -3,10 +3,10 @@
   "id": "JOS-004",
   "title": "Fix Coach 3a ceiling advice freshness fallback",
   "journey_id": "coach_advice_turn",
-  "status": "fixing",
-  "owner": "mint-backend",
+  "status": "verified",
+  "owner": "mint-quality-gate",
   "severity": "P0",
-  "evidence_status": "red",
-  "next_action": "Deploy the authenticated Coach regulatory-constant force fix to staging, then rerun the JOS-004 runtime proof until the salaried-LPP 2026 3a ceiling returns 7'258 CHF with OPP3/LIFD provenance instead of the freshness fallback.",
-  "source": "JOS-004 runtime proof 20260627T023232Z; mint-quality-gate and mint-swiss-brain roster audit"
+  "evidence_status": "green",
+  "next_action": "Keep the JOS-004 Maestro proof in Journey OS monitoring; reuse it for future Coach regulatory-number changes before promoting broader Coach advice coverage.",
+  "source": "JOS-004 runtime proofs 20260627T023232Z red and 20260627T172841Z green; PR #762/#763 staging deployment; mint-quality-gate and mint-swiss-brain roster audit"
 }

--- a/.planning/journeys/records/coach_advice_turn.json
+++ b/.planning/journeys/records/coach_advice_turn.json
@@ -49,6 +49,15 @@
       "reason": "Fresh Journey OS proof reaches Coach with the canonical salaried-LPP seed, asks the 2026 3a/LPP ceiling question, and receives the freshness fallback instead of a visible 7'258 CHF cited answer.",
       "verified_at": "2026-06-27T02:35:11Z",
       "verified_commit": "0ba2497df9e670fed74f88c8648a2bd03aa810ed"
+    },
+    {
+      "kind": "runtime",
+      "status": "green",
+      "command": "source /tmp/mint-jos004-staging-account.env && /Users/julienbattaglia/.maestro/bin/maestro test --env MINT_E2E_EMAIL=[REDACTED_EMAIL] --env MINT_E2E_PASSWORD=[REDACTED_PASSWORD] tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
+      "artifact": ".planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt",
+      "reason": "Fresh Journey OS proof logs into staging, uses the existing debug-only profile route to complete first-experience state, reaches /coach/chat, asks the 2026 3a/LPP ceiling question, and sees 7'258 with OPP3/LIFD provenance while the fallback and bounded-advice banned terms stay absent.",
+      "verified_at": "2026-06-27T17:28:41Z",
+      "verified_commit": "4cb5c173b998868cd73f9bdf6aebc718bc4bffa6"
     }
   ]
 }

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -135,6 +135,25 @@ def test_jos004_coach_advice_runtime_flow_is_in_scope(tmp_path: Path) -> None:
 
     assert not any("outside Journey OS whitelist" in error for error in errors)
 
+def test_jos004_runtime_flow_completes_first_experience_before_coach() -> None:
+    flow = (
+        journey_os_check.REPO_ROOT
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos004_coach_advice_turn_runtime.yaml"
+    ).read_text(encoding="utf-8")
+
+    login = "mintapp:///auth/login?redirect=%2Fcoach%2Fchat"
+    fixture = (
+        "mintapp:///__e2e/row23-independent-no-lpp-profile?"
+        "slug=cadre_salarie_lpp_suisse_ready"
+    )
+    coach = 'openLink: "mintapp:///coach/chat"'
+
+    assert login in flow
+    assert fixture in flow
+    assert 'id: "e2e_profile_fixture_applied"' in flow
+    assert flow.index(login) < flow.index(fixture) < flow.index(coach)
+
 def test_journey_evidence_artifacts_are_in_scope(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)

--- a/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml
@@ -20,8 +20,10 @@
 #       --dart-define=MINT_E2E_ARCHETYPE=cadre_salarie_lpp_suisse_ready
 # - A disposable staging user exists. Pass credentials with:
 #     --env MINT_E2E_EMAIL=<email> --env MINT_E2E_PASSWORD=<password>
-# - The E2E seed is kReleaseMode-guarded and only proves this Coach turn,
-#   not onboarding persistence.
+# - After authenticated login, the flow uses the existing debug-only E2E
+#   profile route to persist the same salaried-LPP fixture and mark the
+#   mini-onboarding/first-experience gate complete. This proves this Coach
+#   turn, not onboarding persistence.
 
 appId: ch.mint.app
 env:
@@ -81,6 +83,44 @@ tags:
 - tapOn: "Se connecter"
 - waitForAnimationToEnd:
     timeout: 6000
+
+# Authenticated seeded accounts can be routed into Mint first-experience before
+# Coach. Use the existing kReleaseMode-guarded E2E profile route helper to
+# persist the fixture through ReportPersistenceService and mark the gate done.
+- openLink: "mintapp:///__e2e/row23-independent-no-lpp-profile?slug=cadre_salarie_lpp_suisse_ready"
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "e2e_profile_fixture_applied"
+    timeout: 10000
+- copyTextFrom:
+    id: "e2e_profile_fixture_applied"
+- evalScript: ${output.jos004_profile_bootstrap = maestro.copiedText}
+
+- openLink: "mintapp:///coach/chat"
+- runFlow:
+    when:
+      visible: "Ouvrir"
+    commands:
+      - tapOn: "Ouvrir"
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "Open"
+    commands:
+      - tapOn: "Open"
+      - waitForAnimationToEnd
 
 - extendedWaitUntil:
     visible:


### PR DESCRIPTION
## Scope
- Patch the existing JOS-004 Maestro flow so authenticated seeded accounts complete the first-experience gate via the existing debug-only E2E profile route before opening /coach/chat.
- Add a Journey OS guard test for login -> fixture -> coach ordering.
- Add durable JOS-004 evidence and mark issue JOS-004 verified/green while leaving coach_advice_turn status partial to avoid broader Coach overclaim.

## Evidence
- Maestro on iPhone 17 Pro / iOS 26.2 reached coach_chat_screen, asked the 2026 3a/LPP ceiling question, and asserted visible 7'258 plus OPP3/LIFD provenance.
- Durable transcript: .planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt.
- Claude CLI safe-mode Opus audit: no blocking findings; residual risks recorded in .planning/journeys/evidence/coach_advice_turn/20260627T172841Z/claude-opus-audit.txt.

## Local checks
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- python3 tools/checks/journey_os_check.py
- python3 -m pytest tools/checks/tests/test_journey_os_check.py -q
- python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/ACTIVE_CONTEXT.md .planning/journeys tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml tools/checks/tests/test_journey_os_check.py
- ./tools/mint-routes check
- git diff --check origin/dev...HEAD
