### PR TITLE
test(journey-os): record JOS-005 onboarding red proof

### DIFF
--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -24,7 +24,8 @@
     "codex/jos004-coach-empty-answer-fix-20260627",
     "codex/jos004-regulatory-floor-20260627",
     "codex/jos004-regulatory-floor-close-loop-20260627",
-    "codex/jos004-maestro-first-experience-proof-20260627"
+    "codex/jos004-maestro-first-experience-proof-20260627",
+    "codex/jos005-onboarding-first-value-20260627"
   ],
   "base_ref": "origin/dev",
   "required_phase_files": [

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -53,6 +53,9 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
   `codex/jos004-maestro-first-experience-proof-20260627` is authorized only
   for the JOS-004 Coach advice turn Maestro runtime proof harness update from
   clean `origin/dev`; no product code changes.
+- Temporary Journey OS branch: `codex/jos005-onboarding-first-value-20260627`
+  is authorized only for classifying and proving the Onboarding First Value
+  Journey OS vertical from clean `origin/dev`.
 
 ## Required Session Start
 

--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -4,6 +4,7 @@ Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
 | Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
 |---|---|---|---|---:|---|---|---|
+| JOS-005 | P0 | regressed | onboarding_first_value | 24 | mint-mobile | red | Fix the Mint2 LPP/rente-capital first-value path so selecting the live axis reaches /rente-vs-capital before account creation, then rerun the iPhone 13 mini Mint2 quality gate. |
 | JOS-001 | P0 | verified | account_lifecycle_delete | 27 | mint-quality-gate | green | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
 | JOS-004 | P0 | verified | coach_advice_turn | 27 | mint-quality-gate | green | Keep the JOS-004 Maestro proof in Journey OS monitoring; reuse it for future Coach regulatory-number changes before promoting broader Coach advice coverage. |
 | JOS-002 | P0 | verified | money_truth_spine | 26 | mint-quality-gate | green | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |

--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -7,5 +7,5 @@ Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 | account_lifecycle_delete | T0 | 27 | live_proven | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | green |
 | coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green, red |
 | money_truth_spine | T0 | 26 | live_proven | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | baselined, green |
-| onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /coach/chat, /home | green |
+| onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /rente-vs-capital, /coach/chat, /home | green, red |
 | profile_privacy_control | T0 | 25 | live_proven | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | green |

--- a/.planning/journeys/diagrams/onboarding_first_value.mmd
+++ b/.planning/journeys/diagrams/onboarding_first_value.mmd
@@ -7,6 +7,9 @@ flowchart TD
   route_onb["/onb"]
   promise --> route_onb
   route_onb --> team
+  route_rente_vs_capital["/rente-vs-capital"]
+  promise --> route_rente_vs_capital
+  route_rente_vs_capital --> team
   route_coach_chat["/coach/chat"]
   promise --> route_coach_chat
   route_coach_chat --> team

--- a/.planning/journeys/evidence/onboarding_first_value/20260627T175336Z/claude-opus-audit.txt
+++ b/.planning/journeys/evidence/onboarding_first_value/20260627T175336Z/claude-opus-audit.txt
@@ -1,0 +1,25 @@
+Command:
+timeout 600 claude --safe-mode --model opus --permission-mode plan -p "Audit the current uncommitted diff in this worktree as a hostile code reviewer. Scope: Mint Journey OS JOS-005 onboarding_first_value red proof/classification. Requirements: no product code changes, clean origin/dev worktree branch, evidence must be durable and repo-relative, JOS-005 status must not overclaim a fix, onboarding_first_value must remain partial, route_paths must match actual registered routes, generated Journey OS views must be consistent, no secrets or local-only absolute artifacts in committed records, tests/guards must be meaningful. Do not edit files. Use read-only inspection only. Return findings first with severity and file:line references; if no blocking findings, say so explicitly and list residual risks."
+
+Claude CLI:
+2.1.170 (Claude Code), safe-mode, model alias opus, permission-mode plan.
+
+Verdict:
+No blocking findings.
+
+Checklist:
+- No product code changes.
+- Branch is cleanly based on origin/dev and authorized in ACTIVE_CONTEXT.
+- Evidence artifact is repo-relative under .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/.
+- JOS-005 records a red/regressed proof and does not claim a fix.
+- onboarding_first_value remains partial.
+- /rente-vs-capital is a registered route and now appears in the Journey OS record.
+- Generated Journey OS views are consistent with the JSON records.
+- No secrets are present in the diff.
+- The new guard test checks that onboarding_first_value tracks the current Mint2 route and JOS-005 issue.
+
+Residual risks noted by audit:
+- The committed Maestro evidence is a curated transcript, not the full raw runtime log.
+- The record command uses a /tmp artifact destination for the local run; the committed artifact path remains repo-relative.
+- The new static test prevents record drift but does not replace runtime proof.
+- The audit did not rerun the simulator gate; it reviewed the diff and local guard results.

--- a/.planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt
+++ b/.planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt
@@ -1,0 +1,47 @@
+Command:
+MINT2_QUALITY_ARTIFACTS=/tmp/mint-jos005-onboarding-first-value-20260627T175336Z bash tools/simulator/mint2_quality_gate.sh
+
+Runtime:
+- Branch: codex/jos005-onboarding-first-value-20260627
+- Head: cc58ad2a0e5113679412118ae9631c52a328496d
+- Simulator: MINT iPhone 13 mini RvC
+- Device UDID: 3D0534A9-8C3A-4663-9348-106D0599E9D6
+- API base URL: https://mint-staging.up.railway.app/api/v1
+- Fresh state: simulator keychain reset; ch.mint.app uninstalled before run
+- Build defines: MINT_DISABLE_BETA_MODAL=true, MINT_E2E_MINT2_FIRST_EXPERIENCE=true, MINT_E2E_PROOF_ANCHORS=true
+
+Pre-runtime gate:
+apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_iphone13mini_layout_test.dart
+Result: 3 tests passed.
+
+Maestro flow:
+tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml
+
+Transcript excerpt:
+Running on MINT iPhone 13 mini RvC - iOS 26.2 - 3D0534A9-8C3A-4663-9348-106D0599E9D6
+ > Flow flow_mint2_first_experience_rente_capital_entry
+Launch app "ch.mint.app" with clear state... COMPLETED
+Assert that "Parle à Mint" is visible... COMPLETED
+Tap on "Parle à Mint"... COMPLETED
+Assert that "Un premier aperçu suisse." is visible... COMPLETED
+Tap on point (200, 620)... COMPLETED
+Assert that id: mint2-axis-lpp_rente_capital is visible... COMPLETED
+Assert that "CHF/mois" is not visible... COMPLETED
+Tap on point (200, 340)... COMPLETED
+Assert that id: rente_vs_capital_screen is visible... FAILED
+
+Failure:
+Assertion is false: id: rente_vs_capital_screen is visible.
+
+Current AX excerpt after failure:
+- text: Créer ton compte
+- text: Crée un compte chiffré. La synchronisation cloud est désactivée par défaut ; tu peux l'activer depuis Réglages › Confidentialité.
+- switch: J'ai lu et j'accepte les Conditions Générales et la politique de confidentialité
+- switch: Je confirme avoir 18 ans révolus (CGU art. 4.1)
+- button: Continuer avec Apple
+- button: Créer avec e-mail
+- button: Continuer en mode local
+- button: Se connecter
+
+Evidence interpretation:
+The first-value path reaches the Mint2 LPP/rente-capital axis, but selecting it lands on the account-creation gate instead of the expected /rente-vs-capital screen. This contradicts the Journey OS promise "I get useful value before I commit more data." This PR records the failure and scopes JOS-005; it does not change product code.

--- a/.planning/journeys/issues/JOS-005.json
+++ b/.planning/journeys/issues/JOS-005.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "JOS-005",
+  "title": "Restore onboarding first value before account gate",
+  "journey_id": "onboarding_first_value",
+  "status": "regressed",
+  "owner": "mint-mobile",
+  "severity": "P0",
+  "evidence_status": "red",
+  "next_action": "Fix the Mint2 LPP/rente-capital first-value path so selecting the live axis reaches /rente-vs-capital before account creation, then rerun the iPhone 13 mini Mint2 quality gate.",
+  "source": "Mint2 quality gate 20260627T175336Z; flow_mint2_first_experience_rente_capital_entry.yaml"
+}

--- a/.planning/journeys/records/onboarding_first_value.json
+++ b/.planning/journeys/records/onboarding_first_value.json
@@ -8,6 +8,7 @@
   "accountable_team": "mint-quality-gate",
   "route_paths": [
     "/onb",
+    "/rente-vs-capital",
     "/coach/chat",
     "/home"
   ],
@@ -19,7 +20,8 @@
   "external_apis": [],
   "issues": [
     "CJT-018",
-    "JOURNEY-TRUTH-MATRIX-006"
+    "JOURNEY-TRUTH-MATRIX-006",
+    "JOS-005"
   ],
   "priority": {
     "trust_blast_radius": 4,
@@ -39,6 +41,15 @@
       "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml tools/simulator/flows/regression/bug__S005__landing_anonymous_cta_to_home.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml",
       "reason": "S005 iPhone 16e regression proof supports the onboarding-to-home first-value path; signed-device and broader beta access remain outside this record."
+    },
+    {
+      "kind": "runtime",
+      "status": "red",
+      "command": "MINT2_QUALITY_ARTIFACTS=/tmp/mint-jos005-onboarding-first-value-20260627T175336Z bash tools/simulator/mint2_quality_gate.sh",
+      "artifact": ".planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt",
+      "reason": "Fresh Mint2 iPhone 13 mini quality gate reaches the LPP/rente-capital first-value axis, but selecting it lands on the account-creation gate instead of /rente-vs-capital.",
+      "verified_at": "2026-06-27T17:55:32Z",
+      "verified_commit": "cc58ad2a0e5113679412118ae9631c52a328496d"
     }
   ]
 }

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -154,6 +154,17 @@ def test_jos004_runtime_flow_completes_first_experience_before_coach() -> None:
     assert 'id: "e2e_profile_fixture_applied"' in flow
     assert flow.index(login) < flow.index(fixture) < flow.index(coach)
 
+def test_onboarding_first_value_tracks_mint2_route_and_issue() -> None:
+    record = json.loads(
+        (
+            journey_os_check.REPO_ROOT
+            / ".planning/journeys/records/onboarding_first_value.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert "/rente-vs-capital" in record["route_paths"]
+    assert "JOS-005" in record["issues"]
+
 def test_journey_evidence_artifacts_are_in_scope(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)


### PR DESCRIPTION
## Scope
- Create JOS-005 for onboarding_first_value after the fresh Mint2 gate showed the first-value axis routes to account creation instead of /rente-vs-capital.
- Add /rente-vs-capital to the Journey OS record because it is the current Mint2 first-value destination.
- Keep onboarding_first_value partial and record the fresh runtime result as red/regressed; no product code changes.

## Evidence
- Ran: MINT2_QUALITY_ARTIFACTS=/tmp/mint-jos005-onboarding-first-value-20260627T175336Z bash tools/simulator/mint2_quality_gate.sh
- Layout test passed: mint2_first_experience_iphone13mini_layout_test.dart reported 3 tests passed.
- Maestro reached mint2-axis-lpp_rente_capital, then failed waiting for rente_vs_capital_screen; current AX tree showed Créer ton compte.
- Durable transcript: .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt.
- Claude CLI safe-mode Opus audit: no blocking findings; residual risks recorded in .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/claude-opus-audit.txt.

## Local checks
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- ./tools/mint-routes check
- python3 tools/checks/journey_os_check.py
- python3 -m pytest tools/checks/tests/test_journey_os_check.py -q
- python3 tools/checks/no_legal_admission_in_public_docs.py --paths .planning/ACTIVE_CONTEXT.md .planning/journeys tools/checks/tests/test_journey_os_check.py
- git diff --check origin/dev...HEAD
