### PR TITLE
chore(journey-os): enforce operating workflow guard

### DIFF
--- a/.claude/AGENT_BOOTSTRAP.md
+++ b/.claude/AGENT_BOOTSTRAP.md
@@ -21,6 +21,7 @@ Then run these commands:
 python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
+python3 tools/checks/journey_os_check.py
 git status --short --branch
 
 Hard boundaries:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,9 +66,11 @@ $ flutter test test/...
 
 ### 5 — Size + revertability
 
-- [ ] `git diff --shortstat origin/dev...HEAD` is **under 300 lines** of
-      real code (excluding generated l10n + lockfiles). If over, I
-      justified why in the summary.
+- [ ] `git diff --shortstat origin/dev...HEAD` was reviewed against the
+      dynamic PR-size budget. Routine bugfix/doc/guard work stays around the
+      small-PR budget; coherent vertical/runtime/evidence updates may exceed it
+      only when the PR summary explains why splitting would make review or
+      rollback worse.
 - [ ] This PR is **atomically revertable**. `git revert <sha>` wouldn't
       break an orthogonal feature.
 

--- a/.github/workflows/ai-workflow-guards.yml
+++ b/.github/workflows/ai-workflow-guards.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -33,6 +35,8 @@ jobs:
         run: python3 tools/checks/agent_reference_guard.py
       - name: Claude hooks guard
         run: python3 tools/checks/claude_hooks_guard.py
+      - name: Journey OS guard
+        run: python3 tools/checks/journey_os_check.py
       - name: Phase acceptance verifier
         run: |
           ACTIVE_MILESTONE=$(python3 - <<'PY'
@@ -56,5 +60,6 @@ jobs:
           tools/checks/tests/test_mint_rules_guard.py
           tools/checks/tests/test_agent_reference_guard.py
           tools/checks/tests/test_claude_hooks_guard.py
+          tools/checks/tests/test_journey_os_check.py
           tools/checks/tests/test_verify_phase_acceptance.py
           -q

--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -27,6 +27,10 @@
     "codex/jos004-maestro-first-experience-proof-20260627",
     "codex/jos005-onboarding-first-value-20260627"
   ],
+  "allowed_branch_patterns": [
+    "codex/jos[0-9][0-9][0-9]*",
+    "codex/journey-os-*"
+  ],
   "base_ref": "origin/dev",
   "required_phase_files": [
     "CONTEXT.md",
@@ -42,6 +46,7 @@
   "agent_reference_guard": "tools/checks/agent_reference_guard.py",
   "claude_hooks_guard": "tools/checks/claude_hooks_guard.py",
   "phase_acceptance_verifier": "tools/checks/verify_phase_acceptance.py",
+  "journey_os_guard": "tools/checks/journey_os_check.py",
   "must_read_first": [
     "AGENTS.md",
     "CLAUDE.md",

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -9,6 +9,10 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
 - Active context: `.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md`
 - Active spec: `.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md`
 - Active integration branch: `dev`
+- Active operating overlay: `.planning/journeys/` is the canonical Journey OS
+  board, issue registry, evidence map, and priority queue for proving the next
+  Mint vertical.
+- Journey OS guard: `python3 tools/checks/journey_os_check.py`.
 - Next product phase: `.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md`
   self-references the active context as a placeholder; no successor product
   phase is queued yet.
@@ -73,6 +77,7 @@ Then run:
 python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
+python3 tools/checks/journey_os_check.py
 git status --short --branch
 ```
 
@@ -138,6 +143,7 @@ Run these guards before phase execution:
 python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
+python3 tools/checks/journey_os_check.py
 python3 tools/checks/agent_reference_guard.py
 python3 tools/checks/claude_hooks_guard.py
 ```

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,6 +8,9 @@ receipts; they are not the active router for new product work.
 
 - Mint 2.0 active context: [`.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md`](phases/mint-2-0-first-experience-rente-capital/CONTEXT.md)
 - Mint 2.0 active spec: [`.planning/phases/mint-2-0-first-experience-rente-capital/SPEC.md`](phases/mint-2-0-first-experience-rente-capital/SPEC.md)
+- Journey OS operating overlay: [`.planning/journeys/JOURNEYS.md`](journeys/JOURNEYS.md)
+  and [`.planning/journeys/BOARD.md`](journeys/BOARD.md), guarded by
+  `python3 tools/checks/journey_os_check.py`.
 - Next product phase: [`.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md`](phases/mint-2-0-first-experience-rente-capital/CONTEXT.md) — self-reference placeholder; no successor product phase is queued yet.
 
 ## Milestones

--- a/.planning/journeys/evidence/system_closeout/20260627T215858Z/claude-opus-audit.txt
+++ b/.planning/journeys/evidence/system_closeout/20260627T215858Z/claude-opus-audit.txt
@@ -1,0 +1,30 @@
+Claude CLI Opus audit, text-only safe review
+Timestamp: 2026-06-27T21:58:58Z
+Command: claude -p --model opus --tools "" --disallowed-tools "Bash,Write,Edit,Read,Glob,Grep" --no-session-persistence --output-format json --permission-mode bypassPermissions --max-turns 1
+Scope: local diff wiring Journey OS into workflow guards, lefthook, bootstrap, rules, branch patterns, and PR template.
+
+Verdict:
+- Conditional blocking finding: the new wiring is unsafe only if tools/checks/journey_os_check.py, tools/checks/tests/test_journey_os_check.py, or .planning/journeys/ are absent.
+- Local disposition: all three already exist on origin/dev and were exercised by local guards/tests in this session.
+- Non-blocking note: lefthook runs journey_os_check.py unconditionally. This is intentional for Journey OS coherence; the guard is cheap and should fail if the board, issues, evidence, or generated views drift.
+- Non-blocking note: branch patterns are broader than one-off branch allowlisting. This is intentional to stop accumulating one temporary JOS branch per vertical in ACTIVE_CONTEXT.json.
+- Missing test accepted: add a negative test where allowed_branch_patterns exists but the current branch matches neither an explicit allowed branch nor a pattern.
+
+Follow-up applied in this PR:
+- tools/checks/tests/test_active_context_guard.py now covers the non-matching pattern error path and asserts the "patterns:" suffix is reported.
+- tools/checks/journey_os_check.py now includes local tracked/staged changes in
+  pre-commit scope detection and whitelists the workflow files that make Journey
+  OS mandatory.
+- .github/workflows/ai-workflow-guards.yml now checks out full history so the
+  CI runner has `origin/dev` for `journey_os_check.py`'s `origin/dev...HEAD`
+  diff.
+- GitHub Actions then exposed a second CI-only false positive:
+  `pip install -e services/backend` creates
+  `services/backend/mint_backend.egg-info/*` in the checkout, and the Journey OS
+  guard saw those generated untracked files as product-code changes. The guard
+  now ignores that exact generated packaging prefix and keeps the product-code
+  whitelist closed.
+- A second Opus text-only audit was launched on the final diff and left running
+  for more than 10 minutes; it produced no verdict and was interrupted with
+  exit 130. Local deterministic checks are the controlling evidence for the
+  post-audit follow-up changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,12 +133,15 @@ rampart. After ship:
 7. Run `python3 tools/checks/active_context_guard.py`.
 8. Run `python3 tools/checks/phase_contract_guard.py`.
 9. Run `python3 tools/checks/mint_rules_guard.py`.
-10. Run `python3 tools/checks/verify_phase_acceptance.py` when an active
+10. Run `python3 tools/checks/journey_os_check.py`; `.planning/journeys/`
+   is the canonical Journey OS board, issue registry, evidence map, and
+   priority queue for vertical work.
+11. Run `python3 tools/checks/verify_phase_acceptance.py` when an active
    `SPEC.md` has a `verify` block.
-11. When the user names a subsystem, read the matching `docs/*.md` **before
+12. When the user names a subsystem, read the matching `docs/*.md` **before
    the first code change**.
-12. Run the grep verification from the table.
-13. *Only then* change code.
+13. Run the grep verification from the table.
+14. *Only then* change code.
 
 If a step was skipped, revert and redo. That's cheaper than debugging
 the ghost in prod.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -12,8 +12,9 @@ Order of truth:
 3. `AGENTS.md`.
 4. `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json`.
 5. `.agents/skills/mint-*`.
-6. Current code, tests, scripts, CI, runtime evidence.
-7. Engram MCP memories for prior root causes and decisions.
+6. `.planning/journeys/` Journey OS records, issues, board, and evidence.
+7. Current code, tests, scripts, CI, runtime evidence.
+8. Engram MCP memories for prior root causes and decisions.
 
 Engram helps recall. It never outranks the repo.
 
@@ -49,11 +50,14 @@ surface change:
 
 1. Name the concrete user flow.
 2. Name the seeded persona if needed.
-3. Run or create the smallest failing contract.
-4. Fix the root cause.
-5. Run the local tests.
-6. Run the simulator/runtime proof.
-7. Only then open or merge.
+3. Link or create the Journey OS issue/record when the surface is part of a
+   T0/T1 vertical.
+4. Run or create the smallest failing contract.
+5. Fix the root cause.
+6. Run the local tests.
+7. Run the simulator/runtime proof.
+8. Update the Journey OS evidence/status when the proof changes.
+9. Only then open or merge.
 
 TestFlight is distribution evidence, not a debugging harness.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,6 +58,11 @@ pre-commit:
       # active context router.
       run: python3 tools/checks/mint_rules_guard.py
       tags: [agents, planning, rules]
+    journey-os-guard:
+      # Journey OS — records, issues, generated board, durable evidence, and
+      # branch authorization stay mechanically coherent before commits.
+      run: python3 tools/checks/journey_os_check.py
+      tags: [agents, planning, journeys]
     agent-reference-guard:
       # MINT Karpathy rules infra — active agent docs must not point at the
       # quarantined original checkout.

--- a/rules.md
+++ b/rules.md
@@ -56,6 +56,8 @@ there is an actual tool call, command output, or artifact path.
 - Run `python3 tools/checks/phase_contract_guard.py` before executing a phase.
 - Run `python3 tools/checks/mint_rules_guard.py` before committing workflow
   changes.
+- Run `python3 tools/checks/journey_os_check.py` before Journey OS, vertical,
+  issue-tracker, runtime-evidence, or workflow-guard changes.
 - Write the active phase `SPEC.md` before implementation.
 - Use test-driven development for feature, bugfix, guard, and behavior changes.
 - Verify the diff, not the explanation: `git diff --stat`, `git diff --check`,
@@ -134,6 +136,7 @@ Planning guards:
 python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
+python3 tools/checks/journey_os_check.py
 python3 tools/checks/agent_reference_guard.py
 python3 tools/checks/claude_hooks_guard.py
 ```

--- a/tools/checks/active_context_guard.py
+++ b/tools/checks/active_context_guard.py
@@ -8,6 +8,7 @@ history is not being treated as current authority.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import subprocess
@@ -92,6 +93,12 @@ def _is_ci_integration_branch(branch: str) -> bool:
     return os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CI") == "true"
 
 
+def _is_allowed_branch(branch: str, allowed: list[str], patterns: list[str]) -> bool:
+    return branch in allowed or any(
+        fnmatch.fnmatchcase(branch, pattern) for pattern in patterns
+    )
+
+
 def check(root: Path) -> list[str]:
     errors: list[str] = []
 
@@ -137,6 +144,9 @@ def check(root: Path) -> list[str]:
         str(item) for item in manifest.get("historical_not_active", [])
     ]
     allowed_branches = [str(item) for item in manifest.get("allowed_branches", [])]
+    allowed_branch_patterns = [
+        str(item) for item in manifest.get("allowed_branch_patterns", [])
+    ]
     required_phase_files = [
         str(item) for item in manifest.get("required_phase_files", [])
     ]
@@ -175,12 +185,15 @@ def check(root: Path) -> list[str]:
     if (
         branch
         and allowed_branches
-        and branch not in allowed_branches
+        and not _is_allowed_branch(branch, allowed_branches, allowed_branch_patterns)
         and not _is_ci_integration_branch(branch)
     ):
+        allowed_summary = ", ".join(allowed_branches)
+        if allowed_branch_patterns:
+            allowed_summary += " ; patterns: " + ", ".join(allowed_branch_patterns)
         errors.append(
             f"{MANIFEST} current branch {branch!r} not in allowed_branches: "
-            + ", ".join(allowed_branches)
+            + allowed_summary
         )
 
     resolved_root = str(root.resolve())

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -23,14 +23,30 @@ ALLOW = {
     str(JOURNEYS / "PRIORITY_RUBRIC.md"),
     str(journey_os_generate.SUMMARY),
     str(journey_os_generate.BOARD),
+    ".claude/AGENT_BOOTSTRAP.md",
+    ".github/pull_request_template.md",
+    ".github/workflows/ai-workflow-guards.yml",
     ".planning/ACTIVE_CONTEXT.md",
     ".planning/ACTIVE_CONTEXT.json",
+    ".planning/ROADMAP.md",
+    "AGENTS.md",
+    "docs/MINT_AGENT_WORKFLOW.md",
+    "lefthook.yml",
+    "rules.md",
     "tools/simulator/flows/maestro-perfect-set/flow_row24_privacy_control_runtime.yaml",
     "tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
+    "tools/claude_review.sh",
+    "tools/checks/active_context_guard.py",
     "tools/checks/journey_os_check.py",
     "tools/checks/journey_os_generate.py",
+    "tools/checks/mint_rules_guard.py",
+    "tools/checks/tests/test_active_context_guard.py",
     "tools/checks/tests/test_journey_os_check.py",
+    "tools/checks/tests/test_mint_rules_guard.py",
 }
+IGNORED_GENERATED_PREFIXES = (
+    "services/backend/mint_backend.egg-info/",
+)
 TEAMS = {"mint-lead", "mint-quality-gate", "mint-mobile", "mint-backend", "mint-swiss-brain"}
 STATUS = {"draft", "partial", "live_proven", "blocked", "deferred", "out_of_beta"}
 ISSUE_STATUS = {"found", "triaged", "assigned", "fixing", "proof_needed", "verified", "merged", "regressed", "blocked"}
@@ -47,14 +63,31 @@ EKEYS = {"kind", "status", "command", "artifact", "reason", "debt_ref", "verifie
 PRIORITY_POSITIVE = {"trust_blast_radius", "release_blocker_weight", "user_frequency", "evidence_gap", "route_centrality", "compliance_risk", "learning_value"}
 PRIORITY_KEYS = PRIORITY_POSITIVE | {"proof_cost", "rationale"}
 
+def _is_ignored_generated(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in IGNORED_GENERATED_PREFIXES)
+
 def _changed(root: Path, base: str) -> tuple[list[str], list[str]]:
     proc = subprocess.run(["git", "diff", "--name-only", f"{base}...HEAD"], cwd=root, text=True, capture_output=True)
     if proc.returncode:
         return [], [f"baseline {base} unavailable: {proc.stderr.strip() or proc.stdout.strip()}"]
-    extra = subprocess.run(["git", "ls-files", "--others", "--exclude-standard"], cwd=root, text=True, capture_output=True)
-    if extra.returncode:
-        return [], [f"unable to resolve untracked files: {extra.stderr.strip() or extra.stdout.strip()}"]
-    return sorted({line for line in (proc.stdout + extra.stdout).splitlines() if line}), []
+    outputs = [proc.stdout]
+    for args, label in (
+        (["git", "diff", "--name-only"], "working tree changes"),
+        (["git", "diff", "--cached", "--name-only"], "staged changes"),
+        (["git", "ls-files", "--others", "--exclude-standard"], "untracked files"),
+    ):
+        extra = subprocess.run(args, cwd=root, text=True, capture_output=True)
+        if extra.returncode:
+            return [], [f"unable to resolve {label}: {extra.stderr.strip() or extra.stdout.strip()}"]
+        outputs.append(extra.stdout)
+    return sorted(
+        {
+            line
+            for output in outputs
+            for line in output.splitlines()
+            if line and not _is_ignored_generated(line)
+        }
+    ), []
 
 def _scope_errors(root: Path, changed: list[str]) -> list[str]:
     errors: list[str] = []
@@ -285,6 +318,7 @@ def _issue_progress_errors(root: Path, records: list[tuple[Path, dict[str, Any]]
 def check(root: Path, changed_files: list[str] | None = None, base_ref: str = "origin/dev") -> list[str]:
     root = root.resolve()
     changed, errors = (changed_files, []) if changed_files else _changed(root, base_ref)
+    changed = [path for path in changed if not _is_ignored_generated(path)]
     errors += _scope_errors(root, changed)
     records, load_errors = _load_records(root)
     errors += load_errors

--- a/tools/checks/mint_rules_guard.py
+++ b/tools/checks/mint_rules_guard.py
@@ -23,6 +23,7 @@ SECTION_PATTERNS = {
     "ALWAYS DO": [
         (".planning/ACTIVE_CONTEXT.md", ".planning/ACTIVE_CONTEXT.json"),
         ("active_context_guard.py",),
+        ("journey_os_check.py",),
         ("SPEC.md",),
         ("Engram", "mem_save"),
     ],
@@ -48,6 +49,7 @@ BOOTSTRAP_NEEDLES = (
     ".planning/ACTIVE_CONTEXT.md",
     ".planning/ACTIVE_CONTEXT.json",
     "active_context_guard.py",
+    "journey_os_check.py",
 )
 
 

--- a/tools/checks/tests/test_active_context_guard.py
+++ b/tools/checks/tests/test_active_context_guard.py
@@ -37,6 +37,7 @@ def _write_valid_fixture(root: Path) -> None:
         "active_spec": ".planning/phases/mint-foundation-cleanup-20260614/SPEC.md",
         "next_product_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/mint-2-0-first-experience-rente-capital-CONTEXT.md",
         "allowed_branches": ["dev", "codex/mint-foundation-cleanup-20260614"],
+        "allowed_branch_patterns": [],
         "base_ref": "origin/dev",
         "required_phase_files": [
             "CONTEXT.md",
@@ -215,6 +216,55 @@ def test_guard_fails_when_local_branch_is_not_allowed(tmp_path: Path) -> None:
 
     assert proc.returncode == 1
     assert "not in allowed_branches" in proc.stderr
+
+
+def test_guard_allows_local_branch_pattern(tmp_path: Path) -> None:
+    _write_valid_fixture(tmp_path)
+    manifest = json.loads(
+        (tmp_path / ".planning/ACTIVE_CONTEXT.json").read_text(encoding="utf-8")
+    )
+    manifest["allowed_branch_patterns"] = ["codex/journey-os-*"]
+    (tmp_path / ".planning/ACTIVE_CONTEXT.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "codex/journey-os-system-closeout-20260627"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 0
+    assert "OK active_context_guard" in proc.stderr
+
+
+def test_guard_reports_patterns_when_local_branch_matches_none(tmp_path: Path) -> None:
+    _write_valid_fixture(tmp_path)
+    manifest = json.loads(
+        (tmp_path / ".planning/ACTIVE_CONTEXT.json").read_text(encoding="utf-8")
+    )
+    manifest["allowed_branch_patterns"] = ["codex/journey-os-*"]
+    (tmp_path / ".planning/ACTIVE_CONTEXT.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "codex/unrelated"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "not in allowed_branches" in proc.stderr
+    assert "patterns: codex/journey-os-*" in proc.stderr
 
 
 def test_guard_allows_integration_branch_inside_ci(

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from tools.checks import journey_os_check, journey_os_generate
 
@@ -105,6 +106,50 @@ def test_active_context_branch_authorization_is_in_scope(tmp_path: Path) -> None
 
     assert not any("outside Journey OS whitelist" in error for error in errors)
 
+def test_journey_os_workflow_files_are_in_scope(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    errors = _errors(
+        root,
+        [
+            ".claude/AGENT_BOOTSTRAP.md",
+            ".github/pull_request_template.md",
+            ".github/workflows/ai-workflow-guards.yml",
+            ".planning/ROADMAP.md",
+            "AGENTS.md",
+            "docs/MINT_AGENT_WORKFLOW.md",
+            "lefthook.yml",
+            "rules.md",
+            "tools/claude_review.sh",
+            "tools/checks/active_context_guard.py",
+            "tools/checks/mint_rules_guard.py",
+            "tools/checks/tests/test_active_context_guard.py",
+            "tools/checks/tests/test_mint_rules_guard.py",
+        ],
+    )
+
+    assert not any("outside Journey OS whitelist" in error for error in errors)
+
+def test_python_editable_install_egg_info_is_ignored(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    errors = _errors(
+        root,
+        [
+            "services/backend/mint_backend.egg-info/PKG-INFO",
+            "services/backend/mint_backend.egg-info/SOURCES.txt",
+            "services/backend/mint_backend.egg-info/requires.txt",
+        ],
+    )
+
+    assert not any("outside Journey OS whitelist" in error for error in errors)
+
 def test_row24_privacy_runtime_flow_is_in_scope(tmp_path: Path) -> None:
     root = _root(tmp_path)
     _record(root)
@@ -183,6 +228,48 @@ def test_journey_evidence_artifacts_are_in_scope(tmp_path: Path) -> None:
 
     assert not any("outside Journey OS whitelist" in error for error in errors)
     assert not any("unsupported Journey OS generated view" in error for error in errors)
+
+def test_changed_includes_local_tracked_worktree_changes(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+    (root / "rules.md").write_text("before\n", encoding="utf-8")
+
+    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/dev", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+
+    (root / "rules.md").write_text("after\n", encoding="utf-8")
+
+    changed, errors = journey_os_check._changed(root, "origin/dev")
+
+    assert errors == []
+    assert "rules.md" in changed
+    assert journey_os_check.check(root, base_ref="origin/dev") == []
 
 def test_jos_issue_refs_require_registry_files(tmp_path: Path) -> None:
     root = _root(tmp_path)

--- a/tools/checks/tests/test_mint_rules_guard.py
+++ b/tools/checks/tests/test_mint_rules_guard.py
@@ -14,6 +14,7 @@ VALID_RULES = """# Mint rules
 
 - Read `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json`.
 - Run `python3 tools/checks/active_context_guard.py`.
+- Run `python3 tools/checks/journey_os_check.py`.
 - Write the phase `SPEC.md` before implementation.
 - Save Engram after decisions, discoveries, conventions, and bug fixes.
 
@@ -37,6 +38,7 @@ VALID_BOOTSTRAP = """# Bootstrap
 Read `AGENTS.md`, `CLAUDE.md`, `docs/MINT_AGENT_WORKFLOW.md`,
 `.planning/ACTIVE_CONTEXT.md`, and `.planning/ACTIVE_CONTEXT.json`.
 Run `python3 tools/checks/active_context_guard.py` before product work.
+Run `python3 tools/checks/journey_os_check.py` before Journey OS work.
 """
 
 VALID_DICTIONARY_LINT = """from __future__ import annotations

--- a/tools/claude_review.sh
+++ b/tools/claude_review.sh
@@ -75,7 +75,11 @@ fi
 diff_file="$(mktemp -t mint-claude-review-diff.XXXXXX)"
 trap 'rm -f "$diff_file"' EXIT
 
-git diff "${diff_args[@]}" > "$diff_file"
+if ((${#diff_args[@]})); then
+  git diff "${diff_args[@]}" > "$diff_file"
+else
+  git diff > "$diff_file"
+fi
 if [[ ! -s "$diff_file" ]]; then
   echo "No diff to review." >&2
   exit 1


### PR DESCRIPTION
## Summary

This PR closes the workflow gap between "Journey OS exists" and "agents must use it":

- wires `python3 tools/checks/journey_os_check.py` into session bootstrap, `AGENTS.md`, `rules.md`, lefthook, and the AI workflow guard.
- makes `.planning/journeys/` explicit as the Journey OS records/issues/board/evidence layer in the active router and agent workflow doc.
- replaces the PR template's hard 300-line wording with the dynamic PR-size budget doctrine.
- adds branch allow patterns for future `codex/jos*` and `codex/journey-os-*` branches instead of adding one temporary branch per vertical.
- fixes `tools/claude_review.sh` so it works when called without explicit path arguments.

## Verification

- `python3 tools/checks/journey_os_check.py $(git diff --name-only | sed 's/^/--changed-file /') $(git ls-files --others --exclude-standard | sed 's/^/--changed-file /')`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/agent_reference_guard.py && python3 tools/checks/claude_hooks_guard.py`
- `python3 -m pytest tools/checks/tests/test_active_context_guard.py tools/checks/tests/test_phase_contract_guard.py tools/checks/tests/test_mint_rules_guard.py tools/checks/tests/test_agent_reference_guard.py tools/checks/tests/test_claude_hooks_guard.py tools/checks/tests/test_journey_os_check.py tools/checks/tests/test_verify_phase_acceptance.py -q`
- `python3 tools/checks/verify_phase_acceptance.py`
- `python3 -m py_compile tools/checks/active_context_guard.py tools/checks/journey_os_check.py tools/checks/mint_rules_guard.py && bash -n tools/claude_review.sh`
- fake-Claude smoke for `tools/claude_review.sh` no-path invocation returned `No blocking findings.`

## Audit

Claude CLI Opus text-only audit artifact:
`.planning/journeys/evidence/system_closeout/20260627T215858Z/claude-opus-audit.txt`

The first Opus audit produced actionable notes; the accepted missing test and local-change detection fix are included. A second final-diff Opus run was left for more than 10 minutes and interrupted without verdict; deterministic checks above are the controlling evidence.

## Scope

No product code. No deploy. Workflow/guard/docs only.
