### PR TITLE
chore(journey-os): harden operating evidence gates

### DIFF
--- a/.claude/AGENT_BOOTSTRAP.md
+++ b/.claude/AGENT_BOOTSTRAP.md
@@ -22,6 +22,7 @@ python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
 python3 tools/checks/journey_os_check.py
+python3 tools/checks/workflow_contract_guard.py
 git status --short --branch
 
 Hard boundaries:

--- a/.github/workflows/ai-workflow-guards.yml
+++ b/.github/workflows/ai-workflow-guards.yml
@@ -21,9 +21,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: Install guard dependencies
         run: |
-          python3 -m pip install pytest
+          python3 -m pip install pytest jsonschema pyyaml
           python3 -m pip install -e services/backend
       - name: Active context guard
         run: python3 tools/checks/active_context_guard.py
@@ -37,21 +40,12 @@ jobs:
         run: python3 tools/checks/claude_hooks_guard.py
       - name: Journey OS guard
         run: python3 tools/checks/journey_os_check.py
+      - name: Workflow contract guard
+        run: python3 tools/checks/workflow_contract_guard.py
+      - name: Mermaid render guard
+        run: python3 tools/checks/mermaid_render_guard.py
       - name: Phase acceptance verifier
-        run: |
-          ACTIVE_MILESTONE=$(python3 - <<'PY'
-          import json
-          from pathlib import Path
-
-          manifest = json.loads(Path(".planning/ACTIVE_CONTEXT.json").read_text())
-          print(manifest.get("active_milestone", ""))
-          PY
-          )
-          if [ "$ACTIVE_MILESTONE" = "mint-karpathy-rules-infra-20260614" ]; then
-            python3 tools/checks/verify_phase_acceptance.py
-          else
-            echo "Skipping generic phase acceptance for ${ACTIVE_MILESTONE}; use the phase-specific toolchain job."
-          fi
+        run: python3 tools/checks/verify_phase_acceptance.py
       - name: Guard tests
         run: >
           python3 -m pytest
@@ -61,5 +55,6 @@ jobs:
           tools/checks/tests/test_agent_reference_guard.py
           tools/checks/tests/test_claude_hooks_guard.py
           tools/checks/tests/test_journey_os_check.py
+          tools/checks/tests/test_workflow_contract_guard.py
           tools/checks/tests/test_verify_phase_acceptance.py
           -q

--- a/.planning/ACTIVE_CONTEXT.json
+++ b/.planning/ACTIVE_CONTEXT.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-06-27",
+  "updated": "2026-06-28",
   "active_milestone": "mint-2-0-first-experience-rente-capital",
   "active_phase_dir": ".planning/phases/mint-2-0-first-experience-rente-capital",
   "active_phase_context": ".planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md",
@@ -47,6 +47,7 @@
   "claude_hooks_guard": "tools/checks/claude_hooks_guard.py",
   "phase_acceptance_verifier": "tools/checks/verify_phase_acceptance.py",
   "journey_os_guard": "tools/checks/journey_os_check.py",
+  "workflow_contract_guard": "tools/checks/workflow_contract_guard.py",
   "must_read_first": [
     "AGENTS.md",
     "CLAUDE.md",

--- a/.planning/ACTIVE_CONTEXT.md
+++ b/.planning/ACTIVE_CONTEXT.md
@@ -13,6 +13,7 @@ file and `.planning/ACTIVE_CONTEXT.json` win until the disagreement is fixed.
   board, issue registry, evidence map, and priority queue for proving the next
   Mint vertical.
 - Journey OS guard: `python3 tools/checks/journey_os_check.py`.
+- Workflow contract guard: `python3 tools/checks/workflow_contract_guard.py`.
 - Next product phase: `.planning/phases/mint-2-0-first-experience-rente-capital/CONTEXT.md`
   self-references the active context as a placeholder; no successor product
   phase is queued yet.
@@ -78,6 +79,7 @@ python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
 python3 tools/checks/journey_os_check.py
+python3 tools/checks/workflow_contract_guard.py
 git status --short --branch
 ```
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: mint-2-0-first-experience-rente-capital
 milestone_name: Mint 2.0 First Experience Rente/Capital
-status: local-quality-gate-merged-device-restore-blocked
-stopped_at: PRs #719-#721 closed fresh anonymous residue and local runtime quality gate; physical-device Keychain/iCloud restore proof is blocked by unavailable iPhone.
-last_updated: "2026-06-20T11:42:21.000Z"
-last_activity: 2026-06-20 -- PR #721 hardened the Mint 2.0 local quality gate on dev; S10 real-device restore preflight returned BLOCKED_NO_AVAILABLE_DEVICE for target Jul.
+status: historical-receipt-superseded-by-journey-os
+stopped_at: Journey OS is now the active daily router; see .planning/journeys/TODAY.md and BOARD.md. Current top issue is JOS-005 onboarding_first_value red regression.
+last_updated: "2026-06-28T00:00:00.000Z"
+last_activity: 2026-06-28 -- PR #767 made Journey OS mandatory in guards; this file is retained as historical GSD receipt, not the current product router.
 progress:
   scope: runtime_path_proof
   total_phases: 2
@@ -16,6 +16,20 @@ progress:
 ---
 
 # GSD State: Mint 2.0 First Experience Rente/Capital
+
+## Current Router
+
+This file is historical. Current Mint product routing now lives in:
+
+- `.planning/journeys/TODAY.md`
+- `.planning/journeys/BOARD.md`
+- `.planning/journeys/JOURNEYS.md`
+- `.planning/ACTIVE_CONTEXT.md`
+- `.planning/ACTIVE_CONTEXT.json`
+
+As of 2026-06-28, the Journey OS top queue item is `JOS-005`: restore the
+Mint2 LPP/rente-capital first-value path before the account gate, then rerun
+the iPhone 13 mini Mint2 quality gate.
 
 ## Project Reference
 

--- a/.planning/journeys/BOARD.md
+++ b/.planning/journeys/BOARD.md
@@ -2,10 +2,10 @@
 
 Generated from `.planning/journeys/issues/*.json`. Do not edit directly.
 
-| Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |
-|---|---|---|---|---:|---|---|---|
-| JOS-005 | P0 | regressed | onboarding_first_value | 24 | mint-mobile | red | Fix the Mint2 LPP/rente-capital first-value path so selecting the live axis reaches /rente-vs-capital before account creation, then rerun the iPhone 13 mini Mint2 quality gate. |
-| JOS-001 | P0 | verified | account_lifecycle_delete | 27 | mint-quality-gate | green | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
-| JOS-004 | P0 | verified | coach_advice_turn | 27 | mint-quality-gate | green | Keep the JOS-004 Maestro proof in Journey OS monitoring; reuse it for future Coach regulatory-number changes before promoting broader Coach advice coverage. |
-| JOS-002 | P0 | verified | money_truth_spine | 26 | mint-quality-gate | green | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |
-| JOS-003 | P0 | verified | profile_privacy_control | 25 | mint-quality-gate | green | Keep the Profile Privacy Control runtime gate in Journey OS monitoring; add authenticated backend privacy E2E sampling when a stable seed exists. |
+| Issue | Severity | Status | Journey | Journey status | Journey priority | Owner | Evidence | Latest proof | Artifact | Next action |
+|---|---|---|---|---|---:|---|---|---|---|---|
+| JOS-005 | P0 | regressed | onboarding_first_value | partial | 24 | mint-mobile | red | red / runtime / 2026-06-27T17:55:32Z / cc58ad2a | .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt | Fix the Mint2 LPP/rente-capital first-value path so selecting the live axis reaches /rente-vs-capital before account creation, then rerun the iPhone 13 mini Mint2 quality gate. |
+| JOS-004 | P0 | proof_needed | coach_advice_turn | partial | 27 | mint-quality-gate | baselined | baselined / runtime / 2026-06-27T17:28:41Z / 4cb5c173 | .planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt | Rerun the JOS-004 Coach advice Maestro proof with JUnit output or a captured flow-level [Passed]/Flow Passed marker before marking the issue verified. |
+| JOS-001 | P0 | verified | account_lifecycle_delete | live_proven | 27 | mint-quality-gate | green | green / runtime / 2026-06-26T20:05:41Z / c13e48a9 | .planning/journeys/evidence/account_lifecycle_delete/20260626T200541Z/result.xml | Keep the seeded-auth runtime proof in CI/backlog monitoring and watch PR checks for regressions before merge. |
+| JOS-002 | P0 | verified | money_truth_spine | live_proven | 26 | mint-quality-gate | green | green / runtime / 2026-06-27T00:38:40Z / 5d8b970c | .planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml | Keep the Money Truth Chain runtime gate in Journey OS monitoring and select the next highest-priority partial T0 vertical from the remaining journey records. |
+| JOS-003 | P0 | verified | profile_privacy_control | live_proven | 25 | mint-quality-gate | green | green / runtime / 2026-06-27T00:57:37Z / 104c92d1 | .planning/journeys/evidence/profile_privacy_control/20260627T005708Z/result.xml | Keep the Profile Privacy Control runtime gate in Journey OS monitoring; add authenticated backend privacy E2E sampling when a stable seed exists. |

--- a/.planning/journeys/JOURNEYS.md
+++ b/.planning/journeys/JOURNEYS.md
@@ -2,10 +2,10 @@
 
 Generated from `.planning/journeys/records/*.json`. Do not edit directly.
 
-| ID | Tier | Priority | Status | Promise | Accountable team | Routes | Evidence |
-|---|---:|---:|---|---|---|---|---|
-| account_lifecycle_delete | T0 | 27 | live_proven | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | green |
-| coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | green, red |
-| money_truth_spine | T0 | 26 | live_proven | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | baselined, green |
-| onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /rente-vs-capital, /coach/chat, /home | green, red |
-| profile_privacy_control | T0 | 25 | live_proven | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | green |
+| ID | Tier | Priority | Status | Promise | Accountable team | Routes | Issues | Evidence | Latest proof | Latest artifact |
+|---|---:|---:|---|---|---|---|---|---|---|---|
+| account_lifecycle_delete | T0 | 27 | live_proven | I can recover, delete, and control my account data. | mint-quality-gate | /auth/login, /auth/register, /auth/forgot-password, /profile/privacy-control, /profile/privacy | JOS-001:verified/green | green | green / runtime / 2026-06-26T20:05:41Z / c13e48a9 | .planning/journeys/evidence/account_lifecycle_delete/20260626T200541Z/result.xml |
+| coach_advice_turn | T0 | 27 | partial | When Coach gives a number, it is current, cited, and bounded. | mint-swiss-brain | /coach/chat | JOS-004:proof_needed/baselined | baselined, green, red | baselined / runtime / 2026-06-27T17:28:41Z / 4cb5c173 | .planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt |
+| money_truth_spine | T0 | 26 | live_proven | My money numbers are consistent. | mint-quality-gate | /budget, /mon-argent, /rapport, /coach/chat | JOS-002:verified/green | baselined, green | green / runtime / 2026-06-27T00:38:40Z / 5d8b970c | .planning/journeys/evidence/money_truth_spine/20260627T003738Z/result.xml |
+| onboarding_first_value | T0 | 24 | partial | I get useful value before I commit more data. | mint-quality-gate | /onb, /rente-vs-capital, /coach/chat, /home | JOS-005:regressed/red | green, red | red / runtime / 2026-06-27T17:55:32Z / cc58ad2a | .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt |
+| profile_privacy_control | T0 | 25 | live_proven | I can see and control what MINT knows about me. | mint-quality-gate | /profile/privacy-control, /profile/privacy, /settings/confidentialite | JOS-003:verified/green | green | green / runtime / 2026-06-27T00:57:37Z / 104c92d1 | .planning/journeys/evidence/profile_privacy_control/20260627T005708Z/result.xml |

--- a/.planning/journeys/TODAY.md
+++ b/.planning/journeys/TODAY.md
@@ -1,0 +1,17 @@
+# Journey OS Today
+
+Generated from Journey OS records and issues. Do not edit directly.
+
+## Top Queue Item
+
+| Issue | Severity | Status | Journey | Journey status | Journey priority | Owner | Evidence | Latest proof | Artifact | Next action |
+|---|---|---|---|---|---:|---|---|---|---|---|
+| JOS-005 | P0 | regressed | onboarding_first_value | partial | 24 | mint-mobile | red | red / runtime / 2026-06-27T17:55:32Z / cc58ad2a | .planning/journeys/evidence/onboarding_first_value/20260627T175336Z/maestro-red.txt | Fix the Mint2 LPP/rente-capital first-value path so selecting the live axis reaches /rente-vs-capital before account creation, then rerun the iPhone 13 mini Mint2 quality gate. |
+
+## Operating Rule
+
+Pick the highest ranked red, missing, or baselined T0 issue unless the PR explicitly names the override.
+
+## Proof Discipline
+
+A journey proof is valid only when the referenced artifact is durable, repo-relative, and accepted by `python3 tools/checks/journey_os_check.py`.

--- a/.planning/journeys/diagrams/account_lifecycle_delete.mmd
+++ b/.planning/journeys/diagrams/account_lifecycle_delete.mmd
@@ -2,26 +2,54 @@
 flowchart TD
   promise["I can recover, delete, and control my account data."]
   team["mint-quality-gate"]
+  latest["latest proof: green / runtime / 2026-06-26T20:05:41Z / c13e48a9"]
+  promise --> latest
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  class latest green
   priority["priority score 27"]
   priority --> promise
   route_auth_login["/auth/login"]
   promise --> route_auth_login
   route_auth_login --> team
+  class route_auth_login route
   route_auth_register["/auth/register"]
   promise --> route_auth_register
   route_auth_register --> team
+  class route_auth_register route
   route_auth_forgot_password["/auth/forgot-password"]
   promise --> route_auth_forgot_password
   route_auth_forgot_password --> team
+  class route_auth_forgot_password route
   route_profile_privacy_control["/profile/privacy-control"]
   promise --> route_profile_privacy_control
   route_profile_privacy_control --> team
+  class route_profile_privacy_control route
   route_profile_privacy["/profile/privacy"]
   promise --> route_profile_privacy
   route_profile_privacy --> team
+  class route_profile_privacy route
   surface_AuthProvider["AuthProvider"]
   promise -.-> surface_AuthProvider
+  class surface_AuthProvider surface
   surface_PrivacyControlScreen["PrivacyControlScreen"]
   promise -.-> surface_PrivacyControlScreen
+  class surface_PrivacyControlScreen surface
   surface_AccountDeletionFlow["AccountDeletionFlow"]
   promise -.-> surface_AccountDeletionFlow
+  class surface_AccountDeletionFlow surface
+  api_POST_auth_register["POST /auth/register"]
+  promise -.-> api_POST_auth_register
+  class api_POST_auth_register api
+  api_DELETE_auth_account["DELETE /auth/account"]
+  promise -.-> api_DELETE_auth_account
+  class api_DELETE_auth_account api
+  issue_JOS_001["JOS-001 verified/green"]
+  issue_JOS_001 --> promise
+  class issue_JOS_001 green

--- a/.planning/journeys/diagrams/coach_advice_turn.mmd
+++ b/.planning/journeys/diagrams/coach_advice_turn.mmd
@@ -2,14 +2,35 @@
 flowchart TD
   promise["When Coach gives a number, it is current, cited, and bounded."]
   team["mint-swiss-brain"]
+  latest["latest proof: baselined / runtime / 2026-06-27T17:28:41Z / 4cb5c173"]
+  promise --> latest
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  class latest amber
   priority["priority score 27"]
   priority --> promise
   route_coach_chat["/coach/chat"]
   promise --> route_coach_chat
   route_coach_chat --> team
+  class route_coach_chat route
   surface_CoachOrchestrator["CoachOrchestrator"]
   promise -.-> surface_CoachOrchestrator
+  class surface_CoachOrchestrator surface
   surface_CoachContextPacket["CoachContextPacket"]
   promise -.-> surface_CoachContextPacket
+  class surface_CoachContextPacket surface
   surface_ComplianceGuard["ComplianceGuard"]
   promise -.-> surface_ComplianceGuard
+  class surface_ComplianceGuard surface
+  api_POST_api_v1_coach_chat["POST /api/v1/coach/chat"]
+  promise -.-> api_POST_api_v1_coach_chat
+  class api_POST_api_v1_coach_chat api
+  issue_JOS_004["JOS-004 proof_needed/baselined"]
+  issue_JOS_004 --> promise
+  class issue_JOS_004 amber

--- a/.planning/journeys/diagrams/money_truth_spine.mmd
+++ b/.planning/journeys/diagrams/money_truth_spine.mmd
@@ -2,23 +2,44 @@
 flowchart TD
   promise["My money numbers are consistent."]
   team["mint-quality-gate"]
+  latest["latest proof: green / runtime / 2026-06-27T00:38:40Z / 5d8b970c"]
+  promise --> latest
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  class latest green
   priority["priority score 26"]
   priority --> promise
   route_budget["/budget"]
   promise --> route_budget
   route_budget --> team
+  class route_budget route
   route_mon_argent["/mon-argent"]
   promise --> route_mon_argent
   route_mon_argent --> team
+  class route_mon_argent route
   route_rapport["/rapport"]
   promise --> route_rapport
   route_rapport --> team
+  class route_rapport route
   route_coach_chat["/coach/chat"]
   promise --> route_coach_chat
   route_coach_chat --> team
+  class route_coach_chat route
   surface_BudgetSnapshot["BudgetSnapshot"]
   promise -.-> surface_BudgetSnapshot
+  class surface_BudgetSnapshot surface
   surface_DataSpineSnapshot["DataSpineSnapshot"]
   promise -.-> surface_DataSpineSnapshot
+  class surface_DataSpineSnapshot surface
   surface_CoachContextPacket["CoachContextPacket"]
   promise -.-> surface_CoachContextPacket
+  class surface_CoachContextPacket surface
+  issue_JOS_002["JOS-002 verified/green"]
+  issue_JOS_002 --> promise
+  class issue_JOS_002 green

--- a/.planning/journeys/diagrams/onboarding_first_value.mmd
+++ b/.planning/journeys/diagrams/onboarding_first_value.mmd
@@ -2,23 +2,44 @@
 flowchart TD
   promise["I get useful value before I commit more data."]
   team["mint-quality-gate"]
+  latest["latest proof: red / runtime / 2026-06-27T17:55:32Z / cc58ad2a"]
+  promise --> latest
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  class latest red
   priority["priority score 24"]
   priority --> promise
   route_onb["/onb"]
   promise --> route_onb
   route_onb --> team
+  class route_onb route
   route_rente_vs_capital["/rente-vs-capital"]
   promise --> route_rente_vs_capital
   route_rente_vs_capital --> team
+  class route_rente_vs_capital route
   route_coach_chat["/coach/chat"]
   promise --> route_coach_chat
   route_coach_chat --> team
+  class route_coach_chat route
   route_home["/home"]
   promise --> route_home
   route_home --> team
+  class route_home route
   surface_OnboardingShellScreen["OnboardingShellScreen"]
   promise -.-> surface_OnboardingShellScreen
+  class surface_OnboardingShellScreen surface
   surface_CoachProfileProvider["CoachProfileProvider"]
   promise -.-> surface_CoachProfileProvider
+  class surface_CoachProfileProvider surface
   surface_MintStateProvider["MintStateProvider"]
   promise -.-> surface_MintStateProvider
+  class surface_MintStateProvider surface
+  issue_JOS_005["JOS-005 regressed/red"]
+  issue_JOS_005 --> promise
+  class issue_JOS_005 red

--- a/.planning/journeys/diagrams/profile_privacy_control.mmd
+++ b/.planning/journeys/diagrams/profile_privacy_control.mmd
@@ -2,22 +2,46 @@
 flowchart TD
   promise["I can see and control what MINT knows about me."]
   team["mint-quality-gate"]
+  latest["latest proof: green / runtime / 2026-06-27T00:57:37Z / 104c92d1"]
+  promise --> latest
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  class latest green
   priority["priority score 25"]
   priority --> promise
   route_profile_privacy_control["/profile/privacy-control"]
   promise --> route_profile_privacy_control
   route_profile_privacy_control --> team
+  class route_profile_privacy_control route
   route_profile_privacy["/profile/privacy"]
   promise --> route_profile_privacy
   route_profile_privacy --> team
+  class route_profile_privacy route
   route_settings_confidentialite["/settings/confidentialite"]
   promise --> route_settings_confidentialite
   route_settings_confidentialite --> team
+  class route_settings_confidentialite route
   surface_PrivacyControlScreen["PrivacyControlScreen"]
   promise -.-> surface_PrivacyControlScreen
+  class surface_PrivacyControlScreen surface
   surface_ConsentSheet["ConsentSheet"]
   promise -.-> surface_ConsentSheet
+  class surface_ConsentSheet surface
   surface_ConsentReceiptService["ConsentReceiptService"]
   promise -.-> surface_ConsentReceiptService
+  class surface_ConsentReceiptService surface
   surface_PiiScrubber["PiiScrubber"]
   promise -.-> surface_PiiScrubber
+  class surface_PiiScrubber surface
+  api_GET_api_v1_privacy_delete_count["GET /api/v1/privacy/delete-count"]
+  promise -.-> api_GET_api_v1_privacy_delete_count
+  class api_GET_api_v1_privacy_delete_count api
+  issue_JOS_003["JOS-003 verified/green"]
+  issue_JOS_003 --> promise
+  class issue_JOS_003 green

--- a/.planning/journeys/diagrams/system_map.mmd
+++ b/.planning/journeys/diagrams/system_map.mmd
@@ -1,0 +1,134 @@
+%% Generated from .planning/journeys/records/*.json and issues/*.json
+flowchart LR
+  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
+  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;
+  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
+  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;
+  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;
+  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;
+  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;
+  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;
+  journey_account_lifecycle_delete["account_lifecycle_delete<br/>live_proven<br/>latest green"]
+  class journey_account_lifecycle_delete green
+  route_auth_login["/auth/login"]
+  journey_account_lifecycle_delete --> route_auth_login
+  class route_auth_login route
+  route_auth_register["/auth/register"]
+  journey_account_lifecycle_delete --> route_auth_register
+  class route_auth_register route
+  route_auth_forgot_password["/auth/forgot-password"]
+  journey_account_lifecycle_delete --> route_auth_forgot_password
+  class route_auth_forgot_password route
+  route_profile_privacy_control["/profile/privacy-control"]
+  journey_account_lifecycle_delete --> route_profile_privacy_control
+  class route_profile_privacy_control route
+  route_profile_privacy["/profile/privacy"]
+  journey_account_lifecycle_delete --> route_profile_privacy
+  class route_profile_privacy route
+  surface_AuthProvider["AuthProvider"]
+  journey_account_lifecycle_delete -.-> surface_AuthProvider
+  class surface_AuthProvider surface
+  surface_PrivacyControlScreen["PrivacyControlScreen"]
+  journey_account_lifecycle_delete -.-> surface_PrivacyControlScreen
+  class surface_PrivacyControlScreen surface
+  surface_AccountDeletionFlow["AccountDeletionFlow"]
+  journey_account_lifecycle_delete -.-> surface_AccountDeletionFlow
+  class surface_AccountDeletionFlow surface
+  api_POST_auth_register["POST /auth/register"]
+  journey_account_lifecycle_delete -.-> api_POST_auth_register
+  class api_POST_auth_register api
+  api_DELETE_auth_account["DELETE /auth/account"]
+  journey_account_lifecycle_delete -.-> api_DELETE_auth_account
+  class api_DELETE_auth_account api
+  issue_JOS_001["JOS-001<br/>verified/green"]
+  issue_JOS_001 --> journey_account_lifecycle_delete
+  class issue_JOS_001 green
+  journey_coach_advice_turn["coach_advice_turn<br/>partial<br/>latest baselined"]
+  class journey_coach_advice_turn amber
+  route_coach_chat["/coach/chat"]
+  journey_coach_advice_turn --> route_coach_chat
+  class route_coach_chat route
+  surface_CoachOrchestrator["CoachOrchestrator"]
+  journey_coach_advice_turn -.-> surface_CoachOrchestrator
+  class surface_CoachOrchestrator surface
+  surface_CoachContextPacket["CoachContextPacket"]
+  journey_coach_advice_turn -.-> surface_CoachContextPacket
+  class surface_CoachContextPacket surface
+  surface_ComplianceGuard["ComplianceGuard"]
+  journey_coach_advice_turn -.-> surface_ComplianceGuard
+  class surface_ComplianceGuard surface
+  api_POST_api_v1_coach_chat["POST /api/v1/coach/chat"]
+  journey_coach_advice_turn -.-> api_POST_api_v1_coach_chat
+  class api_POST_api_v1_coach_chat api
+  issue_JOS_004["JOS-004<br/>proof_needed/baselined"]
+  issue_JOS_004 --> journey_coach_advice_turn
+  class issue_JOS_004 amber
+  journey_money_truth_spine["money_truth_spine<br/>live_proven<br/>latest green"]
+  class journey_money_truth_spine green
+  route_budget["/budget"]
+  journey_money_truth_spine --> route_budget
+  class route_budget route
+  route_mon_argent["/mon-argent"]
+  journey_money_truth_spine --> route_mon_argent
+  class route_mon_argent route
+  route_rapport["/rapport"]
+  journey_money_truth_spine --> route_rapport
+  class route_rapport route
+  journey_money_truth_spine --> route_coach_chat
+  surface_BudgetSnapshot["BudgetSnapshot"]
+  journey_money_truth_spine -.-> surface_BudgetSnapshot
+  class surface_BudgetSnapshot surface
+  surface_DataSpineSnapshot["DataSpineSnapshot"]
+  journey_money_truth_spine -.-> surface_DataSpineSnapshot
+  class surface_DataSpineSnapshot surface
+  journey_money_truth_spine -.-> surface_CoachContextPacket
+  issue_JOS_002["JOS-002<br/>verified/green"]
+  issue_JOS_002 --> journey_money_truth_spine
+  class issue_JOS_002 green
+  journey_onboarding_first_value["onboarding_first_value<br/>partial<br/>latest red"]
+  class journey_onboarding_first_value red
+  route_onb["/onb"]
+  journey_onboarding_first_value --> route_onb
+  class route_onb route
+  route_rente_vs_capital["/rente-vs-capital"]
+  journey_onboarding_first_value --> route_rente_vs_capital
+  class route_rente_vs_capital route
+  journey_onboarding_first_value --> route_coach_chat
+  route_home["/home"]
+  journey_onboarding_first_value --> route_home
+  class route_home route
+  surface_OnboardingShellScreen["OnboardingShellScreen"]
+  journey_onboarding_first_value -.-> surface_OnboardingShellScreen
+  class surface_OnboardingShellScreen surface
+  surface_CoachProfileProvider["CoachProfileProvider"]
+  journey_onboarding_first_value -.-> surface_CoachProfileProvider
+  class surface_CoachProfileProvider surface
+  surface_MintStateProvider["MintStateProvider"]
+  journey_onboarding_first_value -.-> surface_MintStateProvider
+  class surface_MintStateProvider surface
+  issue_JOS_005["JOS-005<br/>regressed/red"]
+  issue_JOS_005 --> journey_onboarding_first_value
+  class issue_JOS_005 red
+  journey_profile_privacy_control["profile_privacy_control<br/>live_proven<br/>latest green"]
+  class journey_profile_privacy_control green
+  journey_profile_privacy_control --> route_profile_privacy_control
+  journey_profile_privacy_control --> route_profile_privacy
+  route_settings_confidentialite["/settings/confidentialite"]
+  journey_profile_privacy_control --> route_settings_confidentialite
+  class route_settings_confidentialite route
+  journey_profile_privacy_control -.-> surface_PrivacyControlScreen
+  surface_ConsentSheet["ConsentSheet"]
+  journey_profile_privacy_control -.-> surface_ConsentSheet
+  class surface_ConsentSheet surface
+  surface_ConsentReceiptService["ConsentReceiptService"]
+  journey_profile_privacy_control -.-> surface_ConsentReceiptService
+  class surface_ConsentReceiptService surface
+  surface_PiiScrubber["PiiScrubber"]
+  journey_profile_privacy_control -.-> surface_PiiScrubber
+  class surface_PiiScrubber surface
+  api_GET_api_v1_privacy_delete_count["GET /api/v1/privacy/delete-count"]
+  journey_profile_privacy_control -.-> api_GET_api_v1_privacy_delete_count
+  class api_GET_api_v1_privacy_delete_count api
+  issue_JOS_003["JOS-003<br/>verified/green"]
+  issue_JOS_003 --> journey_profile_privacy_control
+  class issue_JOS_003 green

--- a/.planning/journeys/issues/JOS-004.json
+++ b/.planning/journeys/issues/JOS-004.json
@@ -3,10 +3,10 @@
   "id": "JOS-004",
   "title": "Fix Coach 3a ceiling advice freshness fallback",
   "journey_id": "coach_advice_turn",
-  "status": "verified",
+  "status": "proof_needed",
   "owner": "mint-quality-gate",
   "severity": "P0",
-  "evidence_status": "green",
-  "next_action": "Keep the JOS-004 Maestro proof in Journey OS monitoring; reuse it for future Coach regulatory-number changes before promoting broader Coach advice coverage.",
-  "source": "JOS-004 runtime proofs 20260627T023232Z red and 20260627T172841Z green; PR #762/#763 staging deployment; mint-quality-gate and mint-swiss-brain roster audit"
+  "evidence_status": "baselined",
+  "next_action": "Rerun the JOS-004 Coach advice Maestro proof with JUnit output or a captured flow-level [Passed]/Flow Passed marker before marking the issue verified.",
+  "source": "JOS-004 runtime proofs 20260627T023232Z red and 20260627T172841Z baselined; the latest raw step log lacks a flow-level pass marker even though the step assertions completed."
 }

--- a/.planning/journeys/records/coach_advice_turn.json
+++ b/.planning/journeys/records/coach_advice_turn.json
@@ -39,7 +39,9 @@
       "status": "green",
       "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml tools/simulator/flows/maestro-perfect-set/flow_hero_marge_fiscale_3a.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/coach-trust/maestro-hero-20260602T075658/result.xml",
-      "reason": "CJT-011 durable runtime proof shows the 3a answer path reached Coach and asserted current cited 3a values; broader advice quality remains partial."
+      "reason": "CJT-011 durable runtime proof shows the 3a answer path reached Coach and asserted current cited 3a values; broader advice quality remains partial.",
+      "verified_at": "2026-06-02T07:56:58Z",
+      "verified_commit": "4c15b8a7ba10aceb790339200b617e854738759d"
     },
     {
       "kind": "runtime",
@@ -52,12 +54,13 @@
     },
     {
       "kind": "runtime",
-      "status": "green",
+      "status": "baselined",
       "command": "source /tmp/mint-jos004-staging-account.env && /Users/julienbattaglia/.maestro/bin/maestro test --env MINT_E2E_EMAIL=[REDACTED_EMAIL] --env MINT_E2E_PASSWORD=[REDACTED_PASSWORD] tools/simulator/flows/maestro-perfect-set/flow_jos004_coach_advice_turn_runtime.yaml",
       "artifact": ".planning/journeys/evidence/coach_advice_turn/20260627T172841Z/maestro.txt",
-      "reason": "Fresh Journey OS proof logs into staging, uses the existing debug-only profile route to complete first-experience state, reaches /coach/chat, asks the 2026 3a/LPP ceiling question, and sees 7'258 with OPP3/LIFD provenance while the fallback and bounded-advice banned terms stay absent.",
+      "reason": "Fresh Journey OS run logs into staging, uses the existing debug-only profile route to complete first-experience state, reaches /coach/chat, asks the 2026 3a/LPP ceiling question, and sees 7'258 with OPP3/LIFD provenance while the fallback and bounded-advice banned terms stay absent. The raw log lacks a flow-level [Passed]/Flow Passed marker, so Journey OS treats it as baselined, not green.",
       "verified_at": "2026-06-27T17:28:41Z",
-      "verified_commit": "4cb5c173b998868cd73f9bdf6aebc718bc4bffa6"
+      "verified_commit": "4cb5c173b998868cd73f9bdf6aebc718bc4bffa6",
+      "debt_ref": "JOS-004-flow-pass-marker-required"
     }
   ]
 }

--- a/.planning/journeys/records/money_truth_spine.json
+++ b/.planning/journeys/records/money_truth_spine.json
@@ -40,7 +40,9 @@
       "status": "green",
       "command": "MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/money-trust/maestro-money-trust-20260602T084449 MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=75 bash tools/simulator/maestro_with_watchdog.sh test tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/money-trust/maestro-money-trust-20260602T084449/result.xml",
-      "reason": "Historical durable runtime artifact seeded as baseline provenance; record remains partial, not live_proven."
+      "reason": "Historical durable runtime artifact seeded as baseline provenance; record remains partial, not live_proven.",
+      "verified_at": "2026-06-02T08:44:49Z",
+      "verified_commit": "7796477a6699ca139603f07a1fdeb7bcc54d3b60"
     },
     {
       "kind": "runtime",
@@ -48,7 +50,9 @@
       "command": "MINT_WALKER_ARTIFACTS=.planning/runtime-evidence/money-truth-spine-20260626T213202Z MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=150 bash tools/simulator/maestro_with_watchdog.sh test --debug-output .planning/runtime-evidence/money-truth-spine-20260626T213202Z/debug --format junit --output .planning/runtime-evidence/money-truth-spine-20260626T213202Z/result.xml tools/simulator/flows/maestro-perfect-set/flow_money_trust_chain_budget_mon_argent_rapport_coach.yaml",
       "artifact": ".planning/journeys/evidence/money_truth_spine/20260626T213202Z/result.xml",
       "reason": "Historical red diagnostic superseded by the JOS-002A onboarding persistence fix and JOS-002B Money Truth runtime proof on dev.",
-      "debt_ref": "Superseded by PR #745 and PR #746."
+      "debt_ref": "Superseded by PR #745 and PR #746.",
+      "verified_at": "2026-06-26T21:32:02Z",
+      "verified_commit": "3a820336fa80b38ac5922ce5a5e97ee900e0a1ba"
     },
     {
       "kind": "runtime",

--- a/.planning/journeys/records/onboarding_first_value.json
+++ b/.planning/journeys/records/onboarding_first_value.json
@@ -40,7 +40,9 @@
       "status": "green",
       "command": "MAESTRO_HARD_LIMIT=420 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml tools/simulator/flows/regression/bug__S005__landing_anonymous_cta_to_home.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-26-iphone16e-s005-regression-20260606T152734/result.xml",
-      "reason": "S005 iPhone 16e regression proof supports the onboarding-to-home first-value path; signed-device and broader beta access remain outside this record."
+      "reason": "S005 iPhone 16e regression proof supports the onboarding-to-home first-value path; signed-device and broader beta access remain outside this record.",
+      "verified_at": "2026-06-06T15:27:34Z",
+      "verified_commit": "b1e2567b06489c4d1159a29876ce806a1f7b68b2"
     },
     {
       "kind": "runtime",

--- a/.planning/journeys/records/profile_privacy_control.json
+++ b/.planning/journeys/records/profile_privacy_control.json
@@ -41,7 +41,9 @@
       "status": "green",
       "command": "MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=90 MINT_WALKER_ARTIFACTS=.planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101 bash tools/simulator/maestro_with_watchdog.sh test --format junit --output .planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101/result.xml tools/simulator/flows/maestro-perfect-set/flow_row24_privacy_control_runtime.yaml",
       "artifact": ".planning/phases/mint-prod-ready-core-journey-truth-20260601/evidence/maestro-ci/row-24-privacy-control-runtime-20260604T182101/result.xml",
-      "reason": "Historical Row 24 runtime proof opens privacy-control and shows known-data controls."
+      "reason": "Historical Row 24 runtime proof opens privacy-control and shows known-data controls.",
+      "verified_at": "2026-06-04T18:21:01Z",
+      "verified_commit": "630a3c2692215cfa5a5eff85e777d336d6e57514"
     },
     {
       "kind": "widget",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,12 +136,13 @@ rampart. After ship:
 10. Run `python3 tools/checks/journey_os_check.py`; `.planning/journeys/`
    is the canonical Journey OS board, issue registry, evidence map, and
    priority queue for vertical work.
-11. Run `python3 tools/checks/verify_phase_acceptance.py` when an active
+11. Run `python3 tools/checks/workflow_contract_guard.py`.
+12. Run `python3 tools/checks/verify_phase_acceptance.py` when an active
    `SPEC.md` has a `verify` block.
-12. When the user names a subsystem, read the matching `docs/*.md` **before
+13. When the user names a subsystem, read the matching `docs/*.md` **before
    the first code change**.
-13. Run the grep verification from the table.
-14. *Only then* change code.
+14. Run the grep verification from the table.
+15. *Only then* change code.
 
 If a step was skipped, revert and redo. That's cheaper than debugging
 the ghost in prod.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -11,12 +11,28 @@ Order of truth:
 2. `CLAUDE.md`.
 3. `AGENTS.md`.
 4. `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json`.
-5. `.agents/skills/mint-*`.
-6. `.planning/journeys/` Journey OS records, issues, board, and evidence.
+5. `.planning/journeys/` Journey OS records, issues, generated views, and
+   evidence.
+6. `.agents/skills/mint-*`.
 7. Current code, tests, scripts, CI, runtime evidence.
 8. Engram MCP memories for prior root causes and decisions.
 
 Engram helps recall. It never outranks the repo.
+
+## Journey OS Views
+
+`.planning/journeys/` is the product operating overlay:
+
+- `TODAY.md` is the generated one-screen cockpit for the next vertical.
+- `BOARD.md` is the generated priority queue.
+- `JOURNEYS.md` is the generated portfolio map.
+- `diagrams/system_map.mmd` is the generated Mermaid map of journeys, shared
+  routes, surfaces, and issue state.
+- `records/*.json` and `issues/*.json` are the editable source of truth.
+
+Generated Journey OS views are never edited by hand. Update the JSON source,
+run `python3 tools/checks/journey_os_generate.py`, then verify with
+`python3 tools/checks/journey_os_check.py`.
 
 ## Default Roster
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,6 +63,11 @@ pre-commit:
       # branch authorization stay mechanically coherent before commits.
       run: python3 tools/checks/journey_os_check.py
       tags: [agents, planning, journeys]
+    workflow-contract-guard:
+      # MINT operating system — AGENTS/rules/bootstrap/hooks/CI must keep the
+      # same mandatory guard contract.
+      run: python3 tools/checks/workflow_contract_guard.py
+      tags: [agents, planning, workflow]
     agent-reference-guard:
       # MINT Karpathy rules infra — active agent docs must not point at the
       # quarantined original checkout.

--- a/rules.md
+++ b/rules.md
@@ -58,6 +58,8 @@ there is an actual tool call, command output, or artifact path.
   changes.
 - Run `python3 tools/checks/journey_os_check.py` before Journey OS, vertical,
   issue-tracker, runtime-evidence, or workflow-guard changes.
+- Run `python3 tools/checks/workflow_contract_guard.py` before workflow,
+  agent-bootstrap, hook, or CI guard changes.
 - Write the active phase `SPEC.md` before implementation.
 - Use test-driven development for feature, bugfix, guard, and behavior changes.
 - Verify the diff, not the explanation: `git diff --stat`, `git diff --check`,
@@ -137,6 +139,7 @@ python3 tools/checks/active_context_guard.py
 python3 tools/checks/phase_contract_guard.py
 python3 tools/checks/mint_rules_guard.py
 python3 tools/checks/journey_os_check.py
+python3 tools/checks/workflow_contract_guard.py
 python3 tools/checks/agent_reference_guard.py
 python3 tools/checks/claude_hooks_guard.py
 ```

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -2,9 +2,17 @@
 """Validate Mint Journey OS records, scope, and generated views."""
 from __future__ import annotations
 
-import argparse, json, subprocess, sys
+import argparse, json, re, subprocess, sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from xml.etree import ElementTree
+
+try:
+    from jsonschema import Draft202012Validator, exceptions as jsonschema_exceptions
+except ImportError:  # pragma: no cover - exercised only on incomplete local envs.
+    Draft202012Validator = None
+    jsonschema_exceptions = None
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -23,12 +31,14 @@ ALLOW = {
     str(JOURNEYS / "PRIORITY_RUBRIC.md"),
     str(journey_os_generate.SUMMARY),
     str(journey_os_generate.BOARD),
+    str(journey_os_generate.TODAY),
     ".claude/AGENT_BOOTSTRAP.md",
     ".github/pull_request_template.md",
     ".github/workflows/ai-workflow-guards.yml",
     ".planning/ACTIVE_CONTEXT.md",
     ".planning/ACTIVE_CONTEXT.json",
     ".planning/ROADMAP.md",
+    ".planning/STATE.md",
     "AGENTS.md",
     "docs/MINT_AGENT_WORKFLOW.md",
     "lefthook.yml",
@@ -39,10 +49,13 @@ ALLOW = {
     "tools/checks/active_context_guard.py",
     "tools/checks/journey_os_check.py",
     "tools/checks/journey_os_generate.py",
+    "tools/checks/mermaid_render_guard.py",
     "tools/checks/mint_rules_guard.py",
+    "tools/checks/workflow_contract_guard.py",
     "tools/checks/tests/test_active_context_guard.py",
     "tools/checks/tests/test_journey_os_check.py",
     "tools/checks/tests/test_mint_rules_guard.py",
+    "tools/checks/tests/test_workflow_contract_guard.py",
 }
 IGNORED_GENERATED_PREFIXES = (
     "services/backend/mint_backend.egg-info/",
@@ -62,6 +75,9 @@ IREQ = ITOP
 EKEYS = {"kind", "status", "command", "artifact", "reason", "debt_ref", "verified_at", "verified_commit"}
 PRIORITY_POSITIVE = {"trust_blast_radius", "release_blocker_weight", "user_frequency", "evidence_gap", "route_centrality", "compliance_risk", "learning_value"}
 PRIORITY_KEYS = PRIORITY_POSITIVE | {"proof_cost", "rationale"}
+TEXT_FAILURE_MARKERS = ("[Failed]", "Flow Failed", "FAILED", "Assertion is false", "EXIT — maestro returned 1")
+TEXT_SUCCESS_MARKERS = ("[Passed]", "Flow Passed")
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 def _is_ignored_generated(path: str) -> bool:
     return any(path.startswith(prefix) for prefix in IGNORED_GENERATED_PREFIXES)
@@ -126,6 +142,32 @@ def _generated_errors(root: Path) -> list[str]:
             errors.append(f"orphan generated Journey OS diagram: {rel}")
     return errors
 
+def _schema_validation_errors(root: Path, records: list[tuple[Path, dict[str, Any]]], issues: list[tuple[Path, dict[str, Any]]]) -> list[str]:
+    errors: list[str] = []
+    if Draft202012Validator is None or jsonschema_exceptions is None:
+        return ["python package jsonschema is required for Journey OS schema validation"]
+    schema_specs = (
+        (SCHEMA, "Journey OS record", records),
+        (ISSUE_SCHEMA, "Journey OS issue", issues),
+    )
+    for rel_schema, label, items in schema_specs:
+        path = root / rel_schema
+        try:
+            schema = json.loads(path.read_text(encoding="utf-8"))
+            Draft202012Validator.check_schema(schema)
+        except (OSError, json.JSONDecodeError, jsonschema_exceptions.SchemaError) as exc:
+            errors.append(f"{rel_schema} is not an executable JSON schema: {exc}")
+            continue
+        required = schema.get("required")
+        if not isinstance(required, list) or len(required) < 5:
+            errors.append(f"{rel_schema} must define a non-trivial required field list")
+            continue
+        validator = Draft202012Validator(schema)
+        for item_path, data in items:
+            for error in sorted(validator.iter_errors(data), key=lambda err: list(err.path)):
+                errors.append(f"{item_path.relative_to(root)} schema violation ({label}): {error.message}")
+    return errors
+
 def _load_records(root: Path) -> tuple[list[tuple[Path, dict[str, Any]]], list[str]]:
     errors: list[str] = []
     if not (root / SCHEMA).exists():
@@ -167,6 +209,78 @@ def _artifact_ok(root: Path, value: Any) -> bool:
     if path.is_absolute() or ".." in path.parts or "tmp" in path.parts:
         return False
     return (root / path).exists()
+
+def _junit_counts(path: Path) -> tuple[int, int, int, int]:
+    root = ElementTree.parse(path).getroot()
+    declared_tests = sum(int(node.attrib.get("tests", "0") or 0) for node in root.iter() if node.tag.endswith("testsuite"))
+    testcase_nodes = sum(1 for node in root.iter() if node.tag.endswith("testcase"))
+    tests = max(declared_tests, testcase_nodes)
+    failures = sum(int(node.attrib.get("failures", "0") or 0) for node in root.iter() if node.tag.endswith("testsuite"))
+    errors = sum(int(node.attrib.get("errors", "0") or 0) for node in root.iter() if node.tag.endswith("testsuite"))
+    failure_nodes = sum(1 for node in root.iter() if node.tag.endswith("failure") or node.tag.endswith("error"))
+    return tests, failures, errors, failure_nodes
+
+def _valid_verified_at(value: Any) -> bool:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo == timezone.utc
+
+def _valid_verified_commit(value: Any) -> bool:
+    return isinstance(value, str) and bool(FULL_SHA_RE.fullmatch(value))
+
+def _artifact_status_errors(root: Path, label: str, item: dict[str, Any]) -> list[str]:
+    status = item.get("status")
+    artifact = item.get("artifact")
+    kind = item.get("kind")
+    if status not in {"green", "red", "baselined"} or not _artifact_ok(root, artifact):
+        return []
+    artifact_path = root / str(artifact)
+    errors: list[str] = []
+    if kind == "runtime" and artifact_path.suffix not in {".xml", ".txt"}:
+        errors.append(f"{label} runtime evidence must use a parseable .xml or .txt result artifact")
+    if kind == "runtime" and artifact_path.suffix == ".txt" and not str(artifact).startswith(str(JOURNEYS / "evidence") + "/"):
+        errors.append(f"{label} runtime text evidence must live under .planning/journeys/evidence/")
+    if artifact_path.suffix == ".xml":
+        try:
+            tests, failures, junit_errors, failure_nodes = _junit_counts(artifact_path)
+        except (OSError, ElementTree.ParseError, ValueError) as exc:
+            return [f"{label} has unreadable JUnit artifact: {exc}"]
+        failed = failures > 0 or junit_errors > 0 or failure_nodes > 0
+        if kind == "runtime" and tests == 0:
+            errors.append(f"{label} runtime JUnit artifact reports zero executed tests")
+        if status == "green" and failed:
+            errors.append(f"{label} is green but JUnit artifact reports failures/errors")
+        if status == "red" and not failed:
+            errors.append(f"{label} is red but JUnit artifact reports no failures/errors")
+    elif artifact_path.suffix == ".txt" and str(artifact).startswith(str(JOURNEYS / "evidence") + "/"):
+        text = artifact_path.read_text(encoding="utf-8", errors="ignore")
+        has_failure = any(marker in text for marker in TEXT_FAILURE_MARKERS)
+        has_success = any(marker in text for marker in TEXT_SUCCESS_MARKERS)
+        if status == "green" and has_failure:
+            errors.append(f"{label} is green but text artifact contains failure markers")
+        if status == "red" and not has_failure:
+            errors.append(f"{label} is red but text artifact has no failure marker")
+        if status == "green" and not has_success:
+            errors.append(f"{label} green text artifact needs an explicit success marker")
+    return errors
+
+def _latest_evidence(data: dict[str, Any]) -> dict[str, Any] | None:
+    latest = journey_os_generate._latest_evidence(data)
+    return latest or None
+
+def _latest_runtime_evidence(data: dict[str, Any]) -> dict[str, Any] | None:
+    items = [
+        item
+        for item in data.get("evidence", [])
+        if isinstance(item, dict) and item.get("kind") == "runtime"
+    ]
+    if not items:
+        return None
+    return items[-1]
 
 def _priority_score(priority: dict[str, Any]) -> int:
     return sum(int(priority[key]) for key in PRIORITY_POSITIVE) - int(priority["proof_cost"])
@@ -227,7 +341,6 @@ def _record_errors(root: Path, path: Path, data: dict[str, Any], routes: set[str
     if not isinstance(evidence, list) or not evidence:
         errors.append(f"{rel} evidence must be a non-empty array")
         return errors
-    live_runtime = False
     for index, item in enumerate(evidence):
         label = f"{rel} evidence[{index}]"
         if not isinstance(item, dict):
@@ -248,14 +361,27 @@ def _record_errors(root: Path, path: Path, data: dict[str, Any], routes: set[str
         if status in {"green", "red", "baselined"}:
             if not isinstance(item.get("command"), str) or not item["command"].strip() or not has_artifact:
                 errors.append(f"{label} {status} evidence needs command and durable repo-relative artifact")
+        if kind == "runtime" and status in {"green", "red", "baselined"} and has_artifact:
+            if not _valid_verified_at(item.get("verified_at")):
+                errors.append(f"{label} durable runtime evidence requires verified_at as UTC ISO timestamp")
+            if not _valid_verified_commit(item.get("verified_commit")):
+                errors.append(f"{label} durable runtime evidence requires verified_commit as a full SHA")
         if status == "baselined" and not item.get("debt_ref"):
             errors.append(f"{label} baselined evidence requires debt_ref")
         if status == "missing" and item.get("artifact") is not None:
             errors.append(f"{label} missing evidence cannot have an artifact")
-        if data.get("status") == "live_proven" and kind == "runtime" and status == "green" and has_artifact:
-            live_runtime = bool(item.get("verified_at") and item.get("verified_commit"))
-    if data.get("status") == "live_proven" and not live_runtime:
-        errors.append(f"{rel} live_proven requires green runtime evidence with verified_at and verified_commit")
+        errors += _artifact_status_errors(root, label, item)
+    if data.get("status") == "live_proven":
+        latest_runtime = _latest_runtime_evidence(data)
+        if not latest_runtime:
+            errors.append(f"{rel} live_proven requires runtime evidence")
+        elif (
+            latest_runtime.get("status") != "green"
+            or not _artifact_ok(root, latest_runtime.get("artifact"))
+            or not latest_runtime.get("verified_at")
+            or not latest_runtime.get("verified_commit")
+        ):
+            errors.append(f"{rel} live_proven requires latest runtime evidence to be green with verified_at and verified_commit")
     return errors
 
 def _issue_errors(root: Path, path: Path, data: dict[str, Any], journey_ids: set[str]) -> list[str]:
@@ -293,6 +419,7 @@ def _issue_errors(root: Path, path: Path, data: dict[str, Any], journey_ids: set
 
 def _issue_progress_errors(root: Path, records: list[tuple[Path, dict[str, Any]]], issues: list[tuple[Path, dict[str, Any]]]) -> list[str]:
     has_green_evidence: set[str] = set()
+    latest_by_journey: dict[str, dict[str, Any]] = {}
     for _path, data in records:
         if not isinstance(data.get("id"), str):
             continue
@@ -301,12 +428,20 @@ def _issue_progress_errors(root: Path, records: list[tuple[Path, dict[str, Any]]
             continue
         if any(isinstance(item, dict) and item.get("status") == "green" and _artifact_ok(root, item.get("artifact")) for item in evidence):
             has_green_evidence.add(str(data["id"]))
+        latest = _latest_evidence(data)
+        if latest:
+            latest_by_journey[str(data["id"])] = latest
     errors: list[str] = []
     for path, data in issues:
         has_green = data.get("journey_id") in has_green_evidence
         rel = path.relative_to(root)
         if data.get("evidence_status") == "green" and not has_green:
             errors.append(f"{rel} cannot be green without durable green evidence on referenced journey")
+        latest = latest_by_journey.get(str(data.get("journey_id")))
+        if latest and data.get("evidence_status") != latest.get("status"):
+            errors.append(f"{rel} evidence_status must match latest evidence status {latest.get('status')}")
+        if data.get("status") == "verified" and data.get("evidence_status") != "green":
+            errors.append(f"{rel} verified issues must have green evidence_status")
         if not has_green:
             continue
         if data.get("status") in {"found", "triaged"}:
@@ -324,6 +459,7 @@ def check(root: Path, changed_files: list[str] | None = None, base_ref: str = "o
     errors += load_errors
     issues, issue_load_errors = _load_issues(root)
     errors += issue_load_errors
+    errors += _schema_validation_errors(root, records, issues)
     try:
         routes = extract_registry_keys((root / ROUTES).read_text(encoding="utf-8"))
     except OSError as exc:

--- a/tools/checks/journey_os_generate.py
+++ b/tools/checks/journey_os_generate.py
@@ -11,8 +11,11 @@ RECORDS = JOURNEYS / "records"
 ISSUES = JOURNEYS / "issues"
 SUMMARY = JOURNEYS / "JOURNEYS.md"
 BOARD = JOURNEYS / "BOARD.md"
+TODAY = JOURNEYS / "TODAY.md"
 DIAGRAMS = JOURNEYS / "diagrams"
+SYSTEM_MAP = DIAGRAMS / "system_map.mmd"
 PRIORITY_POSITIVE = {"trust_blast_radius", "release_blocker_weight", "user_frequency", "evidence_gap", "route_centrality", "compliance_risk", "learning_value"}
+EVIDENCE_STATUS_RANK = {"red": 0, "missing": 1, "baselined": 2, "green": 3}
 
 def load_records(root: Path) -> list[dict[str, Any]]:
     return [json.loads(path.read_text(encoding="utf-8")) for path in sorted((root / RECORDS).glob("*.json"))]
@@ -33,71 +36,219 @@ def priority_score(rec: dict[str, Any]) -> str:
     except (TypeError, ValueError):
         return ""
 
-def markdown(records: list[dict[str, Any]]) -> str:
-    lines = ["# Mint Journey OS", "", "Generated from `.planning/journeys/records/*.json`. Do not edit directly.", "", "| ID | Tier | Priority | Status | Promise | Accountable team | Routes | Evidence |", "|---|---:|---:|---|---|---|---|---|"]
-    for rec in records:
-        statuses = sorted({str(e.get("status")) for e in rec.get("evidence", []) if isinstance(e, dict)})
-        lines.append("| {id} | {tier} | {priority} | {status} | {promise} | {team} | {routes} | {evidence} |".format(id=_cell(rec.get("id", "")), tier=_cell(rec.get("tier", "")), priority=priority_score(rec), status=_cell(rec.get("status", "")), promise=_cell(rec.get("human_promise", "")), team=_cell(rec.get("accountable_team", "")), routes=_cell(rec.get("route_paths", [])), evidence=_cell(statuses)))
-    return "\n".join(lines) + "\n"
+def _issues_for(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {str(rec.get("id")): [] for rec in records}
+    for issue in issues:
+        grouped.setdefault(str(issue.get("journey_id", "")), []).append(issue)
+    for items in grouped.values():
+        items.sort(key=lambda item: str(item.get("id", "")))
+    return grouped
 
-def board(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> str:
+def _latest_evidence(rec: dict[str, Any]) -> dict[str, Any]:
+    items = [item for item in rec.get("evidence", []) if isinstance(item, dict)]
+    if not items:
+        return {}
+    return items[-1]
+
+def _short_commit(value: object) -> str:
+    text = str(value or "")
+    return text[:8] if text else ""
+
+def _artifact(value: object) -> str:
+    return str(value or "")
+
+def _latest_summary(rec: dict[str, Any]) -> str:
+    latest = _latest_evidence(rec)
+    if not latest:
+        return ""
+    status = str(latest.get("status", ""))
+    kind = str(latest.get("kind", ""))
+    verified_at = str(latest.get("verified_at", ""))
+    commit = _short_commit(latest.get("verified_commit"))
+    parts = [part for part in (status, kind, verified_at, commit) if part]
+    return " / ".join(parts)
+
+def _ranked_issues(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
     by_id = {str(rec.get("id")): rec for rec in records}
     severity_rank = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
-    ranked = sorted(
+    evidence_rank = {"red": 0, "missing": 1, "baselined": 2, "green": 3}
+    return sorted(
         issues,
         key=lambda issue: (
-            0 if issue.get("evidence_status") in {"missing", "red"} else 1,
+            evidence_rank.get(str(issue.get("evidence_status")), 9),
             severity_rank.get(str(issue.get("severity")), 9),
             -int(priority_score(by_id.get(str(issue.get("journey_id")), {})) or 0),
             str(issue.get("id", "")),
         ),
     )
+
+def _board_row(issue: dict[str, Any], journey: dict[str, Any]) -> str:
+    latest = _latest_evidence(journey)
+    return "| {id} | {severity} | {status} | {journey} | {journey_status} | {priority} | {owner} | {evidence} | {latest} | {artifact} | {action} |".format(
+        id=_cell(issue.get("id", "")),
+        severity=_cell(issue.get("severity", "")),
+        status=_cell(issue.get("status", "")),
+        journey=_cell(issue.get("journey_id", "")),
+        journey_status=_cell(journey.get("status", "")),
+        priority=priority_score(journey),
+        owner=_cell(issue.get("owner", "")),
+        evidence=_cell(issue.get("evidence_status", "")),
+        latest=_cell(_latest_summary(journey)),
+        artifact=_cell(_artifact(latest.get("artifact"))),
+        action=_cell(issue.get("next_action", "")),
+    )
+
+def markdown(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> str:
+    grouped = _issues_for(records, issues)
+    lines = ["# Mint Journey OS", "", "Generated from `.planning/journeys/records/*.json`. Do not edit directly.", "", "| ID | Tier | Priority | Status | Promise | Accountable team | Routes | Issues | Evidence | Latest proof | Latest artifact |", "|---|---:|---:|---|---|---|---|---|---|---|---|"]
+    for rec in records:
+        statuses = sorted({str(e.get("status")) for e in rec.get("evidence", []) if isinstance(e, dict)})
+        latest = _latest_evidence(rec)
+        issue_labels = [
+            f"{issue.get('id')}:{issue.get('status')}/{issue.get('evidence_status')}"
+            for issue in grouped.get(str(rec.get("id")), [])
+        ]
+        lines.append("| {id} | {tier} | {priority} | {status} | {promise} | {team} | {routes} | {issues} | {evidence} | {latest} | {artifact} |".format(id=_cell(rec.get("id", "")), tier=_cell(rec.get("tier", "")), priority=priority_score(rec), status=_cell(rec.get("status", "")), promise=_cell(rec.get("human_promise", "")), team=_cell(rec.get("accountable_team", "")), routes=_cell(rec.get("route_paths", [])), issues=_cell(issue_labels), evidence=_cell(statuses), latest=_cell(_latest_summary(rec)), artifact=_cell(_artifact(latest.get("artifact")))))
+    return "\n".join(lines) + "\n"
+
+def board(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> str:
+    by_id = {str(rec.get("id")): rec for rec in records}
+    ranked = _ranked_issues(records, issues)
     lines = [
         "# Next Journey OS Work",
         "",
         "Generated from `.planning/journeys/issues/*.json`. Do not edit directly.",
         "",
-        "| Issue | Severity | Status | Journey | Journey priority | Owner | Evidence | Next action |",
-        "|---|---|---|---|---:|---|---|---|",
+        "| Issue | Severity | Status | Journey | Journey status | Journey priority | Owner | Evidence | Latest proof | Artifact | Next action |",
+        "|---|---|---|---|---|---:|---|---|---|---|---|",
     ]
     for issue in ranked:
         journey = by_id.get(str(issue.get("journey_id")), {})
-        lines.append("| {id} | {severity} | {status} | {journey} | {priority} | {owner} | {evidence} | {action} |".format(
-            id=_cell(issue.get("id", "")),
-            severity=_cell(issue.get("severity", "")),
-            status=_cell(issue.get("status", "")),
-            journey=_cell(issue.get("journey_id", "")),
-            priority=priority_score(journey),
-            owner=_cell(issue.get("owner", "")),
-            evidence=_cell(issue.get("evidence_status", "")),
-            action=_cell(issue.get("next_action", "")),
-        ))
+        lines.append(_board_row(issue, journey))
+    return "\n".join(lines) + "\n"
+
+def today(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> str:
+    by_id = {str(rec.get("id")): rec for rec in records}
+    top_issue = next(
+        (
+            issue for issue in _ranked_issues(records, issues)
+            if issue.get("evidence_status") in {"missing", "red", "baselined"}
+            or issue.get("status") in {"proof_needed", "regressed", "blocked"}
+        ),
+        None,
+    )
+    header = "| Issue | Severity | Status | Journey | Journey status | Journey priority | Owner | Evidence | Latest proof | Artifact | Next action |"
+    separator = "|---|---|---|---|---|---:|---|---|---|---|---|"
+    top_row = (
+        _board_row(top_issue, by_id.get(str(top_issue.get("journey_id")), {}))
+        if top_issue
+        else "No red, missing, or baselined Journey OS issue is currently queued."
+    )
+    lines = [
+        "# Journey OS Today",
+        "",
+        "Generated from Journey OS records and issues. Do not edit directly.",
+        "",
+        "## Top Queue Item",
+        "",
+        header,
+        separator,
+        top_row or "No Journey OS issue is currently queued.",
+        "",
+        "## Operating Rule",
+        "",
+        "Pick the highest ranked red, missing, or baselined T0 issue unless the PR explicitly names the override.",
+        "",
+        "## Proof Discipline",
+        "",
+        "A journey proof is valid only when the referenced artifact is durable, repo-relative, and accepted by `python3 tools/checks/journey_os_check.py`.",
+    ]
     return "\n".join(lines) + "\n"
 
 def _node(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", value).strip("_") or "root"
 
 def _label(value: object) -> str:
-    return str(value).replace('"', "'").replace("\n", " ")
+    return str(value).replace('"', "'").replace("\n", " ").replace("|", "/")
 
-def mermaid(rec: dict[str, Any]) -> str:
+def _class_for(status: object) -> str:
+    text = str(status or "")
+    if text in {"live_proven", "verified", "green"}:
+        return "green"
+    if text in {"regressed", "red"}:
+        return "red"
+    if text in {"partial", "baselined"}:
+        return "amber"
+    if text in {"blocked", "missing"}:
+        return "blocked"
+    return "neutral"
+
+def _class_defs() -> list[str]:
+    return [
+        "  classDef green fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;",
+        "  classDef red fill:#ffebee,stroke:#b71c1c,color:#5f1111;",
+        "  classDef amber fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;",
+        "  classDef blocked fill:#eceff1,stroke:#455a64,color:#263238;",
+        "  classDef neutral fill:#f5f5f5,stroke:#616161,color:#212121;",
+        "  classDef route fill:#e3f2fd,stroke:#0d47a1,color:#082f66;",
+        "  classDef surface fill:#f3e5f5,stroke:#4a148c,color:#2b0d52;",
+        "  classDef api fill:#e0f2f1,stroke:#00695c,color:#003d35;",
+    ]
+
+def mermaid(rec: dict[str, Any], issues: list[dict[str, Any]]) -> str:
     rid = str(rec["id"])
-    lines = [f"%% Generated from .planning/journeys/records/{rid}.json", "flowchart TD", f'  promise["{_label(rec["human_promise"])}"]', f'  team["{_label(rec["accountable_team"])}"]']
+    latest = _latest_evidence(rec)
+    latest_label = _latest_summary(rec) or "no proof"
+    lines = [f"%% Generated from .planning/journeys/records/{rid}.json", "flowchart TD", f'  promise["{_label(rec["human_promise"])}"]', f'  team["{_label(rec["accountable_team"])}"]', f'  latest["latest proof: {_label(latest_label)}"]', "  promise --> latest"]
+    lines += _class_defs()
+    lines += [f"  class latest {_class_for(latest.get('status'))}"]
     if priority_score(rec):
         lines += [f'  priority["priority score {priority_score(rec)}"]', "  priority --> promise"]
     for route in rec.get("route_paths", []):
         node = "route_" + _node(str(route))
-        lines += [f'  {node}["{_label(route)}"]', f"  promise --> {node}", f"  {node} --> team"]
+        lines += [f'  {node}["{_label(route)}"]', f"  promise --> {node}", f"  {node} --> team", f"  class {node} route"]
     for surface in rec.get("surfaces", []):
         node = "surface_" + _node(str(surface))
-        lines += [f'  {node}["{_label(surface)}"]', f"  promise -.-> {node}"]
+        lines += [f'  {node}["{_label(surface)}"]', f"  promise -.-> {node}", f"  class {node} surface"]
+    for api in rec.get("external_apis", []):
+        node = "api_" + _node(str(api))
+        lines += [f'  {node}["{_label(api)}"]', f"  promise -.-> {node}", f"  class {node} api"]
+    for issue in issues:
+        node = "issue_" + _node(str(issue.get("id", "")))
+        label = f"{issue.get('id')} {issue.get('status')}/{issue.get('evidence_status')}"
+        lines += [f'  {node}["{_label(label)}"]', f"  {node} --> promise", f"  class {node} {_class_for(issue.get('evidence_status'))}"]
     return "\n".join(lines) + "\n"
+
+def system_map(records: list[dict[str, Any]], issues: list[dict[str, Any]]) -> str:
+    grouped = _issues_for(records, issues)
+    lines = ["%% Generated from .planning/journeys/records/*.json and issues/*.json", "flowchart LR"]
+    lines += _class_defs()
+    for rec in records:
+        jid = "journey_" + _node(str(rec.get("id", "")))
+        latest = _latest_evidence(rec)
+        label = f"{rec.get('id')}<br/>{rec.get('status')}<br/>latest {latest.get('status', 'missing')}"
+        lines += [f'  {jid}["{_label(label)}"]', f"  class {jid} {_class_for(latest.get('status') or rec.get('status'))}"]
+        for route in rec.get("route_paths", []):
+            route_node = "route_" + _node(str(route))
+            lines += [f'  {route_node}["{_label(route)}"]', f"  {jid} --> {route_node}", f"  class {route_node} route"]
+        for surface in rec.get("surfaces", []):
+            surface_node = "surface_" + _node(str(surface))
+            lines += [f'  {surface_node}["{_label(surface)}"]', f"  {jid} -.-> {surface_node}", f"  class {surface_node} surface"]
+        for api in rec.get("external_apis", []):
+            api_node = "api_" + _node(str(api))
+            lines += [f'  {api_node}["{_label(api)}"]', f"  {jid} -.-> {api_node}", f"  class {api_node} api"]
+        for issue in grouped.get(str(rec.get("id")), []):
+            issue_node = "issue_" + _node(str(issue.get("id", "")))
+            label = f"{issue.get('id')}<br/>{issue.get('status')}/{issue.get('evidence_status')}"
+            lines += [f'  {issue_node}["{_label(label)}"]', f"  {issue_node} --> {jid}", f"  class {issue_node} {_class_for(issue.get('evidence_status'))}"]
+    return "\n".join(dict.fromkeys(lines)) + "\n"
 
 def expected(root: Path) -> dict[Path, str]:
     records = load_records(root)
     issues = load_issues(root)
-    out = {SUMMARY: markdown(records), BOARD: board(records, issues)}
-    out.update({DIAGRAMS / f"{rec['id']}.mmd": mermaid(rec) for rec in records})
+    grouped = _issues_for(records, issues)
+    out = {SUMMARY: markdown(records, issues), BOARD: board(records, issues), TODAY: today(records, issues), SYSTEM_MAP: system_map(records, issues)}
+    out.update({DIAGRAMS / f"{rec['id']}.mmd": mermaid(rec, grouped.get(str(rec.get("id")), [])) for rec in records})
     return out
 
 def write(root: Path) -> None:

--- a/tools/checks/mermaid_render_guard.py
+++ b/tools/checks/mermaid_render_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import shutil
 import subprocess
 import sys
@@ -13,10 +14,10 @@ DIAGRAMS = Path(".planning/journeys/diagrams")
 MERMAID_CLI = "@mermaid-js/mermaid-cli@11.4.2"
 
 
-def _render(root: Path, diagram: Path, out_dir: Path) -> str | None:
+def _render(root: Path, diagram: Path, out_dir: Path, puppeteer_config: Path) -> str | None:
     output = out_dir / f"{diagram.stem}.svg"
     proc = subprocess.run(
-        ["npx", "-y", MERMAID_CLI, "-i", str(diagram), "-o", str(output)],
+        ["npx", "-y", MERMAID_CLI, "-p", str(puppeteer_config), "-i", str(diagram), "-o", str(output)],
         cwd=root,
         text=True,
         capture_output=True,
@@ -43,8 +44,13 @@ def check(root: Path) -> list[str]:
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="mint-mermaid-render-") as tmp:
         out_dir = Path(tmp)
+        puppeteer_config = out_dir / "puppeteer-config.json"
+        puppeteer_config.write_text(
+            json.dumps({"args": ["--no-sandbox", "--disable-setuid-sandbox"]}),
+            encoding="utf-8",
+        )
         for diagram in diagrams:
-            error = _render(root, diagram, out_dir)
+            error = _render(root, diagram, out_dir, puppeteer_config)
             if error:
                 errors.append(error)
     return errors

--- a/tools/checks/mermaid_render_guard.py
+++ b/tools/checks/mermaid_render_guard.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Render generated Journey OS Mermaid diagrams to catch syntax drift."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DIAGRAMS = Path(".planning/journeys/diagrams")
+MERMAID_CLI = "@mermaid-js/mermaid-cli@11.4.2"
+
+
+def _render(root: Path, diagram: Path, out_dir: Path) -> str | None:
+    output = out_dir / f"{diagram.stem}.svg"
+    proc = subprocess.run(
+        ["npx", "-y", MERMAID_CLI, "-i", str(diagram), "-o", str(output)],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        timeout=120,
+    )
+    if proc.returncode:
+        return f"{diagram.relative_to(root)} failed to render: {proc.stderr.strip() or proc.stdout.strip()}"
+    try:
+        svg = output.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        return f"{diagram.relative_to(root)} did not produce an SVG: {exc}"
+    if "<svg" not in svg or len(svg.strip()) < 100:
+        return f"{diagram.relative_to(root)} produced an empty or invalid SVG"
+    return None
+
+
+def check(root: Path) -> list[str]:
+    root = root.resolve()
+    if shutil.which("npx") is None:
+        return ["npx is required to render Journey OS Mermaid diagrams"]
+    diagrams = sorted((root / DIAGRAMS).glob("*.mmd"))
+    if not diagrams:
+        return [f"missing Journey OS Mermaid diagrams under {DIAGRAMS}"]
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="mint-mermaid-render-") as tmp:
+        out_dir = Path(tmp)
+        for diagram in diagrams:
+            error = _render(root, diagram, out_dir)
+            if error:
+                errors.append(error)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    errors = check(args.root)
+    if not errors:
+        print("OK mermaid_render_guard: generated Journey OS Mermaid diagrams render.")
+        return 0
+    print("FAIL mermaid_render_guard: generated Journey OS Mermaid diagrams do not render.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/mint_rules_guard.py
+++ b/tools/checks/mint_rules_guard.py
@@ -24,6 +24,7 @@ SECTION_PATTERNS = {
         (".planning/ACTIVE_CONTEXT.md", ".planning/ACTIVE_CONTEXT.json"),
         ("active_context_guard.py",),
         ("journey_os_check.py",),
+        ("workflow_contract_guard.py",),
         ("SPEC.md",),
         ("Engram", "mem_save"),
     ],
@@ -50,6 +51,7 @@ BOOTSTRAP_NEEDLES = (
     ".planning/ACTIVE_CONTEXT.json",
     "active_context_guard.py",
     "journey_os_check.py",
+    "workflow_contract_guard.py",
 )
 
 

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -5,14 +5,25 @@ import subprocess
 from pathlib import Path
 from tools.checks import journey_os_check, journey_os_generate
 
+GOOD_XML = """<?xml version='1.0' encoding='UTF-8'?><testsuites><testsuite tests="1" failures="0" errors="0"><testcase name="ok"/></testsuite></testsuites>"""
+FAILING_XML = """<?xml version='1.0' encoding='UTF-8'?><testsuites><testsuite tests="1" failures="1" errors="0"><testcase name="x"><failure>boom</failure></testcase></testsuite></testsuites>"""
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
 def _root(tmp_path: Path) -> Path:
     (tmp_path / "apps/mobile/lib/routes").mkdir(parents=True)
     (tmp_path / ".planning/journeys/records").mkdir(parents=True)
     (tmp_path / ".planning/journeys/issues").mkdir(parents=True)
-    (tmp_path / ".planning/journeys/journey.schema.json").write_text("{}", encoding="utf-8")
-    (tmp_path / ".planning/journeys/issue.schema.json").write_text("{}", encoding="utf-8")
+    (tmp_path / ".planning/journeys/journey.schema.json").write_text(
+        (journey_os_check.REPO_ROOT / ".planning/journeys/journey.schema.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / ".planning/journeys/issue.schema.json").write_text(
+        (journey_os_check.REPO_ROOT / ".planning/journeys/issue.schema.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
     (tmp_path / "artifacts").mkdir()
-    (tmp_path / "artifacts/result.xml").write_text("<testsuite/>", encoding="utf-8")
+    (tmp_path / "artifacts/result.xml").write_text(GOOD_XML, encoding="utf-8")
     routes = ["/budget", "/mon-argent", "/rapport", "/coach/chat", "/profile/bilan"]
     (tmp_path / "apps/mobile/lib/routes/route_metadata.dart").write_text(
         "\n".join(f"  '{route}': RouteMeta(path: '{route}')," for route in routes),
@@ -44,7 +55,16 @@ def _record(root: Path, **updates: object) -> None:
             "proof_cost": 3,
             "rationale": "Money consistency is the central Mint trust promise.",
         },
-        "evidence": [{"kind": "runtime", "status": "green", "command": "maestro test flow.yaml", "artifact": "artifacts/result.xml"}],
+        "evidence": [
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/result.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
     }
     stem = str(updates.pop("_stem", data["id"]))
     data.update(updates)
@@ -279,14 +299,91 @@ def test_jos_issue_refs_require_registry_files(tmp_path: Path) -> None:
 
 def test_issue_registry_and_generated_board(tmp_path: Path) -> None:
     root = _root(tmp_path)
-    _record(root)
+    _record(root, external_apis=["POST /api/v1/coach/chat"])
     _issue(root)
     journey_os_generate.write(root)
     assert _errors(root) == []
     board = (root / ".planning/journeys/BOARD.md").read_text(encoding="utf-8")
+    today = (root / ".planning/journeys/TODAY.md").read_text(encoding="utf-8")
+    system_map = (root / ".planning/journeys/diagrams/system_map.mmd").read_text(encoding="utf-8")
     assert "Next Journey OS Work" in board
+    assert "Latest proof" in board
     assert "JOS-001" in board
     assert "money_truth_spine" in board
+    assert "Journey OS Today" in today
+    assert "flowchart LR" in system_map
+    assert "route_coach_chat" in system_map
+    assert "api_POST_api_v1_coach_chat" in system_map
+    assert "classDef green" in system_map
+    assert "classDef api" in system_map
+    assert "\\n" not in system_map
+
+def test_today_does_not_promote_green_issue_when_no_actionable_work(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root, status="live_proven")
+    _issue(root, status="verified", evidence_status="green")
+    journey_os_generate.write(root)
+    today = (root / ".planning/journeys/TODAY.md").read_text(encoding="utf-8")
+
+    assert "No red, missing, or baselined Journey OS issue is currently queued." in today
+    assert "| JOS-001 |" not in today
+
+def test_today_routes_red_before_higher_priority_baselined_issue(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(
+        root,
+        id="coach_advice_turn",
+        title="Coach advice turn",
+        _stem="coach_advice_turn",
+        issues=["JOS-001"],
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "baselined",
+                "command": "maestro test coach.yaml",
+                "artifact": "artifacts/result.xml",
+                "debt_ref": "JOS-001",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root, id="JOS-001", journey_id="coach_advice_turn", evidence_status="baselined")
+    (root / "artifacts/red.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(
+        root,
+        id="onboarding_first_value",
+        title="Onboarding first value",
+        _stem="onboarding_first_value",
+        issues=["JOS-002"],
+        priority={
+            "trust_blast_radius": 4,
+            "release_blocker_weight": 4,
+            "user_frequency": 4,
+            "evidence_gap": 2,
+            "route_centrality": 4,
+            "compliance_risk": 2,
+            "learning_value": 4,
+            "proof_cost": 3,
+            "rationale": "Lower priority red issue must still route before baselined work.",
+        },
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test onboarding.yaml",
+                "artifact": "artifacts/red.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_B,
+            }
+        ],
+    )
+    _issue(root, id="JOS-002", journey_id="onboarding_first_value", status="regressed", evidence_status="red")
+    journey_os_generate.write(root)
+    today = (root / ".planning/journeys/TODAY.md").read_text(encoding="utf-8")
+
+    assert "| JOS-002 | P0 | regressed | onboarding_first_value |" in today
+    assert "| JOS-001 |" not in today
 
 def test_issue_status_tracks_referenced_record_evidence(tmp_path: Path) -> None:
     root = _root(tmp_path)
@@ -364,3 +461,370 @@ def test_generated_views_are_required_and_current(tmp_path: Path) -> None:
     journey_os_generate.write(root)
     (root / ".planning/journeys/JOURNEYS.md").write_text("stale\n", encoding="utf-8")
     assert any("stale generated" in error for error in _errors(root))
+
+def test_generated_mermaid_views_are_required_and_current(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    (root / ".planning/journeys/diagrams/system_map.mmd").unlink()
+    assert any("missing generated" in error for error in _errors(root))
+
+    journey_os_generate.write(root)
+    (root / ".planning/journeys/diagrams/money_truth_spine.mmd").write_text("stale\n", encoding="utf-8")
+    assert any("stale generated" in error for error in _errors(root))
+
+    journey_os_generate.write(root)
+    (root / ".planning/journeys/diagrams/orphan.mmd").write_text("flowchart TD\n", encoding="utf-8")
+    assert any("orphan generated" in error for error in _errors(root))
+
+def test_schema_files_are_executed(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+    schema_path = root / ".planning/journeys/journey.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema["required"].append("schema_only_field")
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    assert any("schema_only_field" in error for error in _errors(root))
+
+def test_green_runtime_xml_artifact_cannot_report_failures(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/result.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("green but JUnit artifact reports failures" in error for error in _errors(root))
+
+def test_green_runtime_xml_artifact_cannot_be_vacuous(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/result.xml").write_text("<testsuite/>", encoding="utf-8")
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("zero executed tests" in error for error in _errors(root))
+
+def test_baselined_runtime_xml_artifact_cannot_be_vacuous(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/result.xml").write_text("<testsuite/>", encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "baselined",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/result.xml",
+                "debt_ref": "JOS-TEST",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root, evidence_status="baselined")
+    journey_os_generate.write(root)
+
+    assert any("zero executed tests" in error for error in _errors(root))
+
+def test_runtime_evidence_requires_verified_provenance(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(
+        root,
+        evidence=[{"kind": "runtime", "status": "green", "command": "maestro test flow.yaml", "artifact": "artifacts/result.xml"}],
+    )
+    _issue(root)
+    journey_os_generate.write(root)
+
+    errors = _errors(root)
+    assert any("requires verified_at" in error for error in errors)
+    assert any("requires verified_commit" in error for error in errors)
+
+def test_runtime_evidence_requires_full_sha(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/result.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": "abc123",
+            }
+        ],
+    )
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("full SHA" in error for error in _errors(root))
+
+def test_red_runtime_xml_artifact_requires_failure(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/result.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root, evidence_status="red")
+    journey_os_generate.write(root)
+
+    assert any("red but JUnit artifact reports no failures" in error for error in _errors(root))
+
+def test_green_text_artifact_cannot_contain_failure_marker(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    artifact = root / ".planning/journeys/evidence/money_truth_spine/20260626T120000Z/result.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("[Failed] Assertion is false\n", encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": str(artifact.relative_to(root)),
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("text artifact contains failure markers" in error for error in _errors(root))
+
+def test_green_text_artifact_needs_success_marker(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    artifact = root / ".planning/journeys/evidence/money_truth_spine/20260626T120000Z/result.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("Assert that id: money_screen is visible... COMPLETED\n", encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": str(artifact.relative_to(root)),
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("needs an explicit success marker" in error for error in _errors(root))
+
+def test_runtime_evidence_rejects_arbitrary_artifact_type(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    source_artifact = root / "apps/mobile/lib/routes/route_metadata.dart"
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": str(source_artifact.relative_to(root)),
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root)
+    journey_os_generate.write(root)
+
+    assert any("runtime evidence must use a parseable" in error for error in _errors(root))
+
+def test_red_text_artifact_requires_failure_marker(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    artifact = root / ".planning/journeys/evidence/money_truth_spine/20260626T120000Z/result.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("No structured failure marker\n", encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": str(artifact.relative_to(root)),
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            }
+        ],
+    )
+    _issue(root, evidence_status="red")
+    journey_os_generate.write(root)
+
+    assert any("text artifact has no failure marker" in error for error in _errors(root))
+
+def test_green_issue_rejects_latest_red_evidence(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/green.xml").write_text(GOOD_XML, encoding="utf-8")
+    (root / "artifacts/red.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/green.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            },
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/red.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_B,
+            },
+        ],
+    )
+    _issue(root, status="verified", evidence_status="green")
+    journey_os_generate.write(root)
+
+    assert any("latest evidence" in error for error in _errors(root))
+
+def test_green_issue_rejects_latest_baselined_evidence(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/green.xml").write_text(GOOD_XML, encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/green.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            },
+            {
+                "kind": "runtime",
+                "status": "baselined",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/result.xml",
+                "debt_ref": "JOS-TEST",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_B,
+            },
+        ],
+    )
+    _issue(root, status="verified", evidence_status="green")
+    journey_os_generate.write(root)
+
+    assert any("latest evidence" in error and "baselined" in error for error in _errors(root))
+
+def test_live_proven_rejects_latest_red_runtime_evidence(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/green.xml").write_text(GOOD_XML, encoding="utf-8")
+    (root / "artifacts/red.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(
+        root,
+        status="live_proven",
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/green.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_A,
+            },
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/red.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_B,
+            },
+        ],
+    )
+    _issue(root, evidence_status="red")
+    journey_os_generate.write(root)
+
+    assert any("latest runtime evidence" in error for error in _errors(root))
+
+def test_latest_evidence_tiebreak_uses_append_order(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/green.xml").write_text(GOOD_XML, encoding="utf-8")
+    (root / "artifacts/red.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/green.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_A,
+            },
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/red.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_B,
+            },
+        ],
+    )
+    _issue(root, status="regressed", evidence_status="red")
+    journey_os_generate.write(root)
+    board = (root / ".planning/journeys/BOARD.md").read_text(encoding="utf-8")
+
+    assert "red / runtime / 2026-06-27T00:00:00Z / bbbbbbbb" in board
+    assert not any("latest evidence" in error for error in _errors(root))
+
+def test_latest_evidence_append_order_beats_older_timestamp(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    (root / "artifacts/green.xml").write_text(GOOD_XML, encoding="utf-8")
+    (root / "artifacts/red.xml").write_text(FAILING_XML, encoding="utf-8")
+    _record(
+        root,
+        evidence=[
+            {
+                "kind": "runtime",
+                "status": "green",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/green.xml",
+                "verified_at": "2026-06-27T00:00:00Z",
+                "verified_commit": SHA_A,
+            },
+            {
+                "kind": "runtime",
+                "status": "red",
+                "command": "maestro test flow.yaml",
+                "artifact": "artifacts/red.xml",
+                "verified_at": "2026-06-26T00:00:00Z",
+                "verified_commit": SHA_B,
+            },
+        ],
+    )
+    _issue(root, status="regressed", evidence_status="red")
+    journey_os_generate.write(root)
+    board = (root / ".planning/journeys/BOARD.md").read_text(encoding="utf-8")
+
+    assert "red / runtime / 2026-06-26T00:00:00Z / bbbbbbbb" in board
+    assert not any("latest evidence" in error for error in _errors(root))

--- a/tools/checks/tests/test_mint_rules_guard.py
+++ b/tools/checks/tests/test_mint_rules_guard.py
@@ -15,6 +15,7 @@ VALID_RULES = """# Mint rules
 - Read `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json`.
 - Run `python3 tools/checks/active_context_guard.py`.
 - Run `python3 tools/checks/journey_os_check.py`.
+- Run `python3 tools/checks/workflow_contract_guard.py`.
 - Write the phase `SPEC.md` before implementation.
 - Save Engram after decisions, discoveries, conventions, and bug fixes.
 
@@ -39,6 +40,7 @@ Read `AGENTS.md`, `CLAUDE.md`, `docs/MINT_AGENT_WORKFLOW.md`,
 `.planning/ACTIVE_CONTEXT.md`, and `.planning/ACTIVE_CONTEXT.json`.
 Run `python3 tools/checks/active_context_guard.py` before product work.
 Run `python3 tools/checks/journey_os_check.py` before Journey OS work.
+Run `python3 tools/checks/workflow_contract_guard.py` before workflow changes.
 """
 
 VALID_DICTIONARY_LINT = """from __future__ import annotations

--- a/tools/checks/tests/test_workflow_contract_guard.py
+++ b/tools/checks/tests/test_workflow_contract_guard.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "tools/checks/workflow_contract_guard.py"
+
+SESSION_COMMANDS = (
+    "python3 tools/checks/active_context_guard.py",
+    "python3 tools/checks/phase_contract_guard.py",
+    "python3 tools/checks/mint_rules_guard.py",
+    "python3 tools/checks/journey_os_check.py",
+    "python3 tools/checks/workflow_contract_guard.py",
+)
+CI_EXTRA = (
+    "python3 tools/checks/agent_reference_guard.py",
+    "python3 tools/checks/claude_hooks_guard.py",
+    "python3 tools/checks/mermaid_render_guard.py",
+    "python3 tools/checks/verify_phase_acceptance.py",
+)
+CI_TESTS = (
+    "tools/checks/tests/test_active_context_guard.py",
+    "tools/checks/tests/test_phase_contract_guard.py",
+    "tools/checks/tests/test_mint_rules_guard.py",
+    "tools/checks/tests/test_agent_reference_guard.py",
+    "tools/checks/tests/test_claude_hooks_guard.py",
+    "tools/checks/tests/test_journey_os_check.py",
+    "tools/checks/tests/test_workflow_contract_guard.py",
+    "tools/checks/tests/test_verify_phase_acceptance.py",
+)
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_fixture(root: Path) -> None:
+    (root / ".claude").mkdir()
+    (root / ".github/workflows").mkdir(parents=True)
+    commands = "\n".join(SESSION_COMMANDS)
+    (root / "AGENTS.md").write_text(commands, encoding="utf-8")
+    (root / "rules.md").write_text(commands, encoding="utf-8")
+    (root / ".claude/AGENT_BOOTSTRAP.md").write_text(commands, encoding="utf-8")
+    lefthook_lines = ["pre-commit:", "  commands:"]
+    for command in SESSION_COMMANDS:
+        name = Path(command.split()[-1]).stem.replace("_", "-")
+        lefthook_lines += [f"    {name}:", f"      run: {command}"]
+    (root / "lefthook.yml").write_text("\n".join(lefthook_lines) + "\n", encoding="utf-8")
+    workflow_lines = [
+        "name: AI Workflow Guards",
+        "on: pull_request",
+        "jobs:",
+        "  guards:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+    ]
+    for command in SESSION_COMMANDS + CI_EXTRA:
+        workflow_lines += ["      - name: guard", f"        run: {command}"]
+    workflow_lines += ["      - name: Guard tests", "        run: >"]
+    workflow_lines += [f"          python3 -m pytest {' '.join(CI_TESTS)} -q"]
+    (root / ".github/workflows/ai-workflow-guards.yml").write_text(
+        "\n".join(workflow_lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_workflow_contract_guard_passes_for_complete_wiring(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 0
+    assert "OK workflow_contract_guard" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_skips_phase_acceptance(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8")
+        + "\necho 'Skipping generic phase acceptance for old milestone'\n",
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "verify_phase_acceptance.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_landing_hook_drops_journey_os(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    lefthook = tmp_path / "lefthook.yml"
+    lefthook.write_text(
+        lefthook.read_text(encoding="utf-8").replace(
+            "      run: python3 tools/checks/journey_os_check.py\n",
+            "      # python3 tools/checks/journey_os_check.py\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_command_is_comment_only(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "        run: python3 tools/checks/journey_os_check.py\n",
+            "        run: |\n          # python3 tools/checks/journey_os_check.py\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_command_is_echoed(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "        run: python3 tools/checks/journey_os_check.py\n",
+            "        run: echo noop # python3 tools/checks/journey_os_check.py\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_command_is_in_false_branch(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "        run: python3 tools/checks/journey_os_check.py\n",
+            "        run: if false; then python3 tools/checks/journey_os_check.py; fi\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_command_is_in_multiline_false_branch(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "        run: python3 tools/checks/journey_os_check.py\n",
+            "        run: |\n          if false; then\n            python3 tools/checks/journey_os_check.py\n          fi\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr
+
+
+def test_workflow_contract_guard_fails_when_ci_command_is_printed_prose(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    workflow = tmp_path / ".github/workflows/ai-workflow-guards.yml"
+    workflow.write_text(
+        workflow.read_text(encoding="utf-8").replace(
+            "        run: python3 tools/checks/journey_os_check.py\n",
+            "        run: |\n          printf '%s\\n' 'python3 tools/checks/journey_os_check.py is documented here'\n",
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 1
+    assert "journey_os_check.py" in proc.stderr

--- a/tools/checks/workflow_contract_guard.py
+++ b/tools/checks/workflow_contract_guard.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Validate that Mint's human workflow and automated guards stay wired."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only on incomplete local envs.
+    yaml = None
+
+AGENTS = Path("AGENTS.md")
+RULES = Path("rules.md")
+BOOTSTRAP = Path(".claude/AGENT_BOOTSTRAP.md")
+LEFTHOOK = Path("lefthook.yml")
+WORKFLOW = Path(".github/workflows/ai-workflow-guards.yml")
+
+SESSION_COMMANDS = (
+    "python3 tools/checks/active_context_guard.py",
+    "python3 tools/checks/phase_contract_guard.py",
+    "python3 tools/checks/mint_rules_guard.py",
+    "python3 tools/checks/journey_os_check.py",
+    "python3 tools/checks/workflow_contract_guard.py",
+)
+
+CI_COMMANDS = SESSION_COMMANDS + (
+    "python3 tools/checks/agent_reference_guard.py",
+    "python3 tools/checks/claude_hooks_guard.py",
+    "python3 tools/checks/mermaid_render_guard.py",
+    "python3 tools/checks/verify_phase_acceptance.py",
+)
+
+CI_TESTS = (
+    "tools/checks/tests/test_active_context_guard.py",
+    "tools/checks/tests/test_phase_contract_guard.py",
+    "tools/checks/tests/test_mint_rules_guard.py",
+    "tools/checks/tests/test_agent_reference_guard.py",
+    "tools/checks/tests/test_claude_hooks_guard.py",
+    "tools/checks/tests/test_journey_os_check.py",
+    "tools/checks/tests/test_workflow_contract_guard.py",
+    "tools/checks/tests/test_verify_phase_acceptance.py",
+)
+
+
+def _read(root: Path, rel: Path) -> str:
+    return (root / rel).read_text(encoding="utf-8", errors="ignore")
+
+
+def _require_all(errors: list[str], root: Path, rel: Path, needles: tuple[str, ...]) -> None:
+    try:
+        text = _read(root, rel)
+    except OSError as exc:
+        errors.append(f"unable to read {rel}: {exc}")
+        return
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        errors.append(f"{rel} missing required workflow command(s): {', '.join(missing)}")
+
+
+def _yaml_doc(errors: list[str], root: Path, rel: Path) -> object:
+    if yaml is None:
+        errors.append("python package pyyaml is required for workflow contract validation")
+        return None
+    try:
+        return yaml.safe_load(_read(root, rel))
+    except OSError as exc:
+        errors.append(f"unable to read {rel}: {exc}")
+    except yaml.YAMLError as exc:
+        errors.append(f"{rel} is not valid YAML: {exc}")
+    return None
+
+
+def _executable_lines(text: str) -> list[str]:
+    lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if stripped:
+            lines.append(line)
+    return lines
+
+
+def _run_texts(runs: list[str]) -> str:
+    executable_lines = []
+    for text in runs:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            executable_lines.append(line)
+    return "\n".join(executable_lines)
+
+
+def _invokes_command(executable: str, command: str) -> bool:
+    pattern = re.compile(
+        r"^\s*"
+        r"(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*"
+        r"(?:timeout\s+\d+\s+)?"
+        + re.escape(command)
+        + r"(?:\s|$)",
+        re.MULTILINE,
+    )
+    return bool(pattern.search(executable))
+
+
+def _invokes_pytest_target(executable: str, target: str) -> bool:
+    pattern = re.compile(
+        r"^\s*"
+        r"(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*"
+        r"python3\s+-m\s+pytest\b[^\n;&|]*"
+        + re.escape(target)
+        + r"(?:\s|$)",
+        re.MULTILINE,
+    )
+    return bool(pattern.search(executable))
+
+
+def _require_executed_commands(errors: list[str], rel: Path, runs: list[str], needles: tuple[str, ...]) -> None:
+    first_lines = [
+        lines[0]
+        for run in runs
+        if (lines := _executable_lines(run))
+    ]
+    missing = [
+        needle
+        for needle in needles
+        if not any(_invokes_command(line, needle) for line in first_lines)
+    ]
+    if missing:
+        errors.append(f"{rel} missing required executable workflow command(s): {', '.join(missing)}")
+
+
+def _require_pytest_targets(errors: list[str], rel: Path, runs: list[str], targets: tuple[str, ...]) -> None:
+    executable = _run_texts(runs)
+    missing = [target for target in targets if not _invokes_pytest_target(executable, target)]
+    if missing:
+        errors.append(f"{rel} missing required pytest target(s): {', '.join(missing)}")
+
+
+def _lefthook_runs(errors: list[str], root: Path) -> list[str]:
+    data = _yaml_doc(errors, root, LEFTHOOK)
+    if not isinstance(data, dict):
+        errors.append(f"{LEFTHOOK} must be a YAML mapping")
+        return []
+    pre_commit = data.get("pre-commit")
+    commands = pre_commit.get("commands") if isinstance(pre_commit, dict) else None
+    if not isinstance(commands, dict):
+        errors.append(f"{LEFTHOOK} must define pre-commit.commands")
+        return []
+    runs = [
+        command.get("run")
+        for command in commands.values()
+        if isinstance(command, dict) and isinstance(command.get("run"), str)
+    ]
+    if not runs:
+        errors.append(f"{LEFTHOOK} must define executable pre-commit command run fields")
+    return runs
+
+
+def _workflow_runs(errors: list[str], root: Path) -> list[str]:
+    data = _yaml_doc(errors, root, WORKFLOW)
+    if not isinstance(data, dict):
+        errors.append(f"{WORKFLOW} must be a YAML mapping")
+        return []
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        errors.append(f"{WORKFLOW} must define jobs")
+        return []
+    runs: list[str] = []
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict) and isinstance(step.get("run"), str):
+                runs.append(step["run"])
+    if not runs:
+        errors.append(f"{WORKFLOW} must define executable step run fields")
+    return runs
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    for rel in (AGENTS, RULES, BOOTSTRAP):
+        _require_all(errors, root, rel, SESSION_COMMANDS)
+    lefthook_runs = _lefthook_runs(errors, root)
+    workflow_runs = _workflow_runs(errors, root)
+    _require_executed_commands(errors, LEFTHOOK, lefthook_runs, SESSION_COMMANDS)
+    _require_executed_commands(errors, WORKFLOW, workflow_runs, CI_COMMANDS)
+    _require_pytest_targets(errors, WORKFLOW, workflow_runs, CI_TESTS)
+
+    try:
+        workflow = _read(root, WORKFLOW)
+    except OSError:
+        workflow = ""
+    if "Skipping generic phase acceptance" in workflow:
+        errors.append(f"{WORKFLOW} must run verify_phase_acceptance.py for the active SPEC, not skip by milestone name")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    errors = check(args.root.resolve())
+    if not errors:
+        print("OK workflow_contract_guard: workflow guard wiring is coherent.", file=sys.stderr)
+        return 0
+    print("FAIL workflow_contract_guard: workflow guard wiring drift detected.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Harden Journey OS evidence truth: runtime proofs now require UTC verification time, full commit SHA, non-vacuous JUnit, flow-level pass markers for green text logs, append-order latest evidence, and exact issue/latest status alignment.
- Add generated Journey OS cockpit/views: TODAY.md, richer BOARD/JOURNEYS, per-journey Mermaid, and system_map.mmd with routes/surfaces/APIs/issues.
- Add workflow and Mermaid guards wired into CI/lefthook so AGENTS/rules/bootstrap/hooks/CI stay coherent and generated diagrams render.

## Test Plan
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/agent_reference_guard.py
- python3 tools/checks/claude_hooks_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/mermaid_render_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- python3 -m pytest tools/checks/tests/test_active_context_guard.py tools/checks/tests/test_phase_contract_guard.py tools/checks/tests/test_mint_rules_guard.py tools/checks/tests/test_agent_reference_guard.py tools/checks/tests/test_claude_hooks_guard.py tools/checks/tests/test_journey_os_check.py tools/checks/tests/test_workflow_contract_guard.py tools/checks/tests/test_verify_phase_acceptance.py -q
- git diff --check && git diff --cached --check

## Audit
- Expert QA/code review iterated blockers until closed.
- Claude CLI Opus safe-mode final blocker check: no blocking findings, score 10/10.

No product code changes under apps/ or services/.