### PR TITLE
Fix native Apple account fallback

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show unawaited;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
@@ -125,8 +126,31 @@ AuthError _authErrorFromException(Object error) {
     return AuthError.registrationUnavailable;
   }
 
+  final platformText = error is PlatformException
+      ? [
+          error.code,
+          error.message,
+          error.details,
+        ].whereType<Object>().join(' ').toLowerCase()
+      : lower;
+  final nativeAppleAuthorizationFailure =
+      platformText.contains('authenticationservices.authorizationerror') ||
+          platformText.contains('asauthorizationerror') ||
+          platformText.contains('com.apple.authenticationservices');
+  final nativeAppleCancellation = nativeAppleAuthorizationFailure &&
+      (platformText.contains('error 1001') ||
+          platformText.contains('canceled') ||
+          platformText.contains('cancelled'));
+
+  if (nativeAppleCancellation) {
+    return AuthError.genericError;
+  }
+
   if (lower.contains('signinwithappleauthorizationexception') ||
-      lower.contains('authorizationerrorcode')) {
+      lower.contains('authorizationerrorcode') ||
+      // Native iOS/TestFlight failures may arrive as a PlatformException from
+      // AuthenticationServices instead of the typed sign_in_with_apple error.
+      nativeAppleAuthorizationFailure) {
     return AuthError.serviceUnavailable;
   }
 

--- a/apps/mobile/lib/services/apple_sign_in_service.dart
+++ b/apps/mobile/lib/services/apple_sign_in_service.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 import 'package:mint_mobile/services/api_service.dart';
@@ -25,8 +26,25 @@ class AppleSignInService {
   }
 
   static bool isCancellation(Object error) {
-    return error is SignInWithAppleAuthorizationException &&
-        error.code == AuthorizationErrorCode.canceled;
+    if (error is SignInWithAppleAuthorizationException) {
+      return error.code == AuthorizationErrorCode.canceled;
+    }
+    if (error is PlatformException) {
+      final raw = [
+        error.code,
+        error.message,
+        error.details,
+      ].whereType<Object>().join(' ').toLowerCase();
+      final isAppleAuthorizationFailure =
+          raw.contains('authenticationservices.authorizationerror') ||
+              raw.contains('asauthorizationerror') ||
+              raw.contains('com.apple.authenticationservices');
+      return isAppleAuthorizationFailure &&
+          (raw.contains('error 1001') ||
+              raw.contains('canceled') ||
+              raw.contains('cancelled'));
+    }
+    return false;
   }
 
   /// Check if Apple Sign-In is available on this device.

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -701,7 +701,8 @@ void main() {
       expect(message, isNot(contains('Apple Sign-In')));
     });
 
-    test('localizeAuthException maps deleted Apple subject to register guidance',
+    test(
+        'localizeAuthException maps deleted Apple subject to register guidance',
         () async {
       final l10n = await S.delegate.load(const Locale('fr'));
 
@@ -712,6 +713,56 @@ void main() {
 
       expect(message, l10n.authErrorRegistration);
       expect(message, isNot(l10n.authErrorGeneric));
+    });
+
+    test('localizeAuthException maps native Apple platform failures', () async {
+      final l10n = await S.delegate.load(const Locale('fr'));
+
+      final message = localizeAuthException(
+        PlatformException(
+          code: 'authorization_error',
+          message:
+              'The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1000.)',
+        ),
+        l10n,
+      );
+
+      expect(message, l10n.authErrorService);
+      expect(message, isNot(l10n.authErrorGeneric));
+    });
+
+    test('localizeAuthException maps native Apple details failures', () async {
+      final l10n = await S.delegate.load(const Locale('fr'));
+
+      final message = localizeAuthException(
+        PlatformException(
+          code: 'authorization_error',
+          message: 'Authorization failed',
+          details:
+              'Underlying error: com.apple.AuthenticationServices.AuthorizationError error 1000.',
+        ),
+        l10n,
+      );
+
+      expect(message, l10n.authErrorService);
+      expect(message, isNot(l10n.authErrorGeneric));
+    });
+
+    test('localizeAuthException does not map native Apple cancellation service',
+        () async {
+      final l10n = await S.delegate.load(const Locale('fr'));
+
+      final message = localizeAuthException(
+        PlatformException(
+          code: 'authorization_error',
+          message:
+              'The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)',
+        ),
+        l10n,
+      );
+
+      expect(message, l10n.authErrorGeneric);
+      expect(message, isNot(l10n.authErrorService));
     });
 
     // ── Listener notification pattern ──

--- a/apps/mobile/test/screens/register_account_entry_test.dart
+++ b/apps/mobile/test/screens/register_account_entry_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -270,6 +271,40 @@ void main() {
     }
   });
 
+  testWidgets('native Apple platform failure does not show generic auth copy',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    AppleSignInService.signInOverride = () async {
+      throw PlatformException(
+        code: 'authorization_error',
+        message:
+            'The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1000.)',
+      );
+    };
+    try {
+      await tester.pumpWidget(_testApp());
+      await tester.pump();
+
+      await _acceptRequiredConsentsAndTapApple(tester);
+
+      expect(
+        find.text(
+          'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.email_outlined), findsOneWidget);
+      expect(
+        find.text(
+          'Action impossible pour le moment. Réessaie dans quelques instants.',
+        ),
+        findsNothing,
+      );
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
   testWidgets('Apple cancellation does not show service unavailable guidance',
       (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
@@ -277,6 +312,41 @@ void main() {
       throw const SignInWithAppleAuthorizationException(
         code: AuthorizationErrorCode.canceled,
         message: 'User canceled Apple Sign-In',
+      );
+    };
+    try {
+      await tester.pumpWidget(_testApp());
+      await tester.pump();
+
+      await _acceptRequiredConsentsAndTapApple(tester);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.',
+        ),
+        findsNothing,
+      );
+      expect(
+        find.text(
+          'Action impossible pour le moment. Réessaie dans quelques instants.',
+        ),
+        findsNothing,
+      );
+      expect(find.byIcon(Icons.email_outlined), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('native Apple platform cancellation stays silent',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    AppleSignInService.signInOverride = () async {
+      throw PlatformException(
+        code: 'authorization_error',
+        message:
+            'The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)',
       );
     };
     try {


### PR DESCRIPTION
## Summary
- Map native iOS AuthenticationServices Apple failures to the account-service guidance instead of generic copy.
- Keep native Apple cancellation silent, including AuthorizationError 1001.
- Add provider and RegisterScreen regression coverage for message/details-shaped PlatformException payloads.

## Evidence
- Railway staging: no recent POST /api/v1/auth/apple/verify calls; staging /api/v1/auth/register works for a real email-domain test user.
- Claude Opus audit found the cancellation-1001 risk; patch was updated to keep cancellation silent.

## Verification
- cd apps/mobile && flutter test test/screens/register_account_entry_test.dart test/providers/auth_provider_test.dart test/services/apple_sign_in_service_test.dart
- cd apps/mobile && flutter analyze lib/providers/auth_provider.dart lib/services/apple_sign_in_service.dart test/providers/auth_provider_test.dart test/screens/register_account_entry_test.dart test/services/apple_sign_in_service_test.dart
- ./tools/mint-routes check
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/verify_phase_acceptance.py