### PR TITLE
Add Mint2 navigation spine guard

### DIFF
--- a/.github/workflows/ai-workflow-guards.yml
+++ b/.github/workflows/ai-workflow-guards.yml
@@ -40,6 +40,8 @@ jobs:
         run: python3 tools/checks/claude_hooks_guard.py
       - name: Journey OS guard
         run: python3 tools/checks/journey_os_check.py
+      - name: Mint 2 navigation spine guard
+        run: python3 tools/checks/mint2_navigation_spine_guard.py
       - name: Workflow contract guard
         run: python3 tools/checks/workflow_contract_guard.py
       - name: Mermaid render guard
@@ -62,6 +64,7 @@ jobs:
           tools/checks/tests/test_claude_hooks_guard.py
           tools/checks/tests/test_journey_os_check.py
           tools/checks/tests/test_journey_os_runtime_replay.py
+          tools/checks/tests/test_mint2_navigation_spine_guard.py
           tools/checks/tests/test_maestro_locator_audit.py
           tools/checks/tests/test_mermaid_render_guard.py
           tools/checks/tests/test_workflow_contract_guard.py

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -121,6 +121,7 @@ ALLOW = {
     "tools/simulator/flows/maestro-perfect-set/_fragment_cold_launch_to_aujourdhui.yaml",
     "tools/simulator/flows/maestro-perfect-set/flow_hardgate_expat_us.yaml",
     "tools/simulator/flows/maestro-perfect-set/flow_hero_marge_fiscale_3a.yaml",
+    "tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml",
     "tools/simulator/flows/maestro-perfect-set/flow_row22_profile_dossier_production_profile.yaml",
     "tools/simulator/flows/regression/bug__P004__overlay_populated_on_open.yaml",
     "tools/simulator/flows/regression/bug__S005__landing_anonymous_cta_to_home.yaml",
@@ -133,6 +134,7 @@ ALLOW = {
     "tools/checks/journey_os_generate.py",
     "tools/checks/maestro_locator_audit.py",
     "tools/checks/mermaid_render_guard.py",
+    "tools/checks/mint2_navigation_spine_guard.py",
     "tools/checks/mint_rules_guard.py",
     "tools/checks/workflow_contract_guard.py",
     "tools/checks/tests/test_active_context_guard.py",
@@ -141,6 +143,7 @@ ALLOW = {
     "tools/checks/tests/test_journey_os_runtime_replay.py",
     "tools/checks/tests/test_maestro_locator_audit.py",
     "tools/checks/tests/test_mermaid_render_guard.py",
+    "tools/checks/tests/test_mint2_navigation_spine_guard.py",
     "tools/checks/tests/test_mint_rules_guard.py",
     "tools/checks/tests/test_workflow_contract_guard.py",
 }

--- a/tools/checks/mint2_navigation_spine_guard.py
+++ b/tools/checks/mint2_navigation_spine_guard.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Validate the executable Mint 2.0 navigation spine.
+
+This guard intentionally derives facts from runtime-facing source files. It
+protects the active Mint 2.0 first-value path from drifting across app.dart,
+route metadata, and the Maestro replay flow.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROUTE_METADATA = Path("apps/mobile/lib/routes/route_metadata.dart")
+APP = Path("apps/mobile/lib/app.dart")
+MINT2_FLOW = Path(
+    "tools/simulator/flows/maestro-perfect-set/"
+    "flow_mint2_first_experience_rente_capital_entry.yaml"
+)
+REGISTER_FLOW = Path(
+    "tools/simulator/flows/maestro-perfect-set/"
+    "flow_jos001_account_lifecycle_seeded_delete.yaml"
+)
+ACCOUNT_WALL_TITLE = "Cr\u00e9er ton compte"
+
+SPINE_DESTINATIONS = {
+    "/onb": {"scope": "public", "category": "destination", "requiresAuth": "false"},
+    "/rente-vs-capital": {
+        "scope": "onboarding",
+        "category": "destination",
+        "requiresAuth": "false",
+    },
+    "/coach/chat": {"scope": "public", "category": "destination", "requiresAuth": "false"},
+}
+RVC_ALIASES = {
+    "/arbitrage/rente-vs-capital": "/rente-vs-capital",
+    "/simulator/rente-capital": "/rente-vs-capital",
+}
+ONBOARDING_COMPAT_ALIASES = {
+    "/start": "/onb",
+    "/anonymous/chat": "/onb",
+    "/onboarding/quick": "/coach/chat",
+    "/onboarding/quick-start": "/coach/chat",
+    "/onboarding/premier-eclairage": "/coach/chat",
+    "/onboarding/intent": "/coach/chat",
+    "/onboarding/promise": "/coach/chat",
+    "/onboarding/plan": "/coach/chat",
+    "/onboarding/smart": "/coach/chat",
+    "/onboarding/minimal": "/coach/chat",
+}
+
+
+def _read(root: Path, rel: Path) -> str:
+    return (root / rel).read_text(encoding="utf-8", errors="ignore")
+
+
+def _route_field(body: str, name: str) -> str:
+    quoted = re.search(rf"\b{name}:\s*'([^']*)'", body)
+    if quoted:
+        return quoted.group(1)
+    quoted = re.search(rf'\b{name}:\s*"([^"]*)"', body)
+    if quoted:
+        return quoted.group(1)
+    enum_or_bool = re.search(
+        rf"\b{name}:\s*(Route(?:Category|Owner)\.[A-Za-z0-9_]+|true|false)",
+        body,
+    )
+    if enum_or_bool:
+        return enum_or_bool.group(1).split(".")[-1]
+    return ""
+
+
+def _route_target_from_description(description: str) -> str:
+    match = re.search(
+        r"(?:redirects?\s+(?:to\s+)?|->\s*)(/[A-Za-z0-9_/:.-]+)",
+        description,
+        re.IGNORECASE,
+    )
+    return match.group(1).rstrip(".,;") if match else ""
+
+
+def _route_metadata(root: Path) -> dict[str, dict[str, str]]:
+    lines = _read(root, ROUTE_METADATA).splitlines()
+    meta: dict[str, dict[str, str]] = {}
+    for index, line in enumerate(lines):
+        match = re.match(r"\s*'(?P<key>[^']+)':\s*RouteMeta\((?P<tail>.*)$", line)
+        if not match:
+            continue
+        route = match.group("key")
+        body_lines = [match.group("tail")]
+        if ")," not in match.group("tail"):
+            for next_line in lines[index + 1 :]:
+                body_lines.append(next_line)
+                if next_line.strip().startswith("),"):
+                    break
+        body = "\n".join(body_lines)
+        meta[route] = {
+            "path": _route_field(body, "path") or route,
+            "category": _route_field(body, "category"),
+            "owner": _route_field(body, "owner"),
+            "requiresAuth": _route_field(body, "requiresAuth"),
+            "description": _route_field(body, "description"),
+        }
+    return meta
+
+
+def _find_call_blocks(source: str, call_name: str) -> list[str]:
+    blocks: list[str] = []
+    index = 0
+    needle = f"{call_name}("
+    while True:
+        start = source.find(needle, index)
+        if start == -1:
+            return blocks
+        pos = start + len(call_name)
+        depth = 0
+        quote: str | None = None
+        escaped = False
+        for cursor in range(pos, len(source)):
+            char = source[cursor]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                continue
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(source[start : cursor + 1])
+                    index = cursor + 1
+                    break
+        else:
+            return blocks
+
+
+def _app_routes(root: Path) -> dict[str, dict[str, str]]:
+    routes: dict[str, dict[str, str]] = {}
+    for block in _find_call_blocks(_read(root, APP), "ScopedGoRoute"):
+        path = _route_field(block, "path")
+        if not path:
+            continue
+        scope_match = re.search(r"\bscope:\s*RouteScope\.([A-Za-z0-9_]+)", block)
+        redirect_match = re.search(r"=>\s*['\"]([^'\"]+)['\"]", block)
+        if redirect_match is None:
+            redirect_match = re.search(r"\breturn\s+['\"]([^'\"]+)['\"]\s*;", block)
+        routes[path] = {
+            "scope": scope_match.group(1) if scope_match else "authenticated",
+            "redirect": redirect_match.group(1) if redirect_match else "",
+        }
+    return routes
+
+
+def _check_route(
+    errors: list[str],
+    metadata: dict[str, dict[str, str]],
+    app_routes: dict[str, dict[str, str]],
+    route: str,
+    expected: dict[str, str],
+) -> None:
+    meta = metadata.get(route)
+    app = app_routes.get(route)
+    if not meta:
+        errors.append(f"{route} is missing from route_metadata.dart")
+        return
+    if not app:
+        errors.append(f"{route} is missing from app.dart ScopedGoRoute")
+        return
+    for field, value in expected.items():
+        if field == "scope":
+            actual = app.get("scope")
+            if actual != value:
+                errors.append(f"{route} must use RouteScope.{value}; found {actual or '<missing>'}")
+        else:
+            actual = meta.get(field)
+            if actual != value:
+                label = "not require auth" if field == "requiresAuth" and value == "false" else f"set {field}={value}"
+                errors.append(f"{route} must {label}; found {actual or '<missing>'}")
+
+
+def _check_alias(
+    errors: list[str],
+    metadata: dict[str, dict[str, str]],
+    app_routes: dict[str, dict[str, str]],
+    route: str,
+    target: str,
+) -> None:
+    meta = metadata.get(route)
+    app = app_routes.get(route)
+    if not meta:
+        errors.append(f"{route} alias is missing from route_metadata.dart")
+        return
+    if not app:
+        errors.append(f"{route} alias is missing from app.dart")
+        return
+    if meta.get("category") != "alias":
+        errors.append(f"{route} must be a route_metadata alias; found {meta.get('category') or '<missing>'}")
+    if meta.get("requiresAuth") != "false" and target in {"/onb", "/rente-vs-capital", "/coach/chat"}:
+        errors.append(f"{route} must not require auth before reaching {target}")
+    described_target = _route_target_from_description(meta.get("description", ""))
+    if described_target != target:
+        errors.append(f"{route} metadata must document redirect -> {target}; found {described_target or '<missing>'}")
+    if app.get("redirect") != target:
+        errors.append(f"{route} app redirect must target {target}; found {app.get('redirect') or '<missing>'}")
+
+
+def _check_maestro_flow(errors: list[str], root: Path) -> None:
+    flow_path = root / MINT2_FLOW
+    if not flow_path.exists():
+        errors.append(f"missing Mint 2.0 runtime flow: {MINT2_FLOW}")
+        return
+    text = flow_path.read_text(encoding="utf-8", errors="ignore")
+    required_fragments = {
+        'clearState: true': "must clear app state",
+        'id: "mint2-axis-lpp_rente_capital"': "must assert the live LPP axis",
+        'id: "rente_vs_capital_screen"': "must assert rente_vs_capital_screen",
+        ACCOUNT_WALL_TITLE: "must assert the account gate is absent after route",
+    }
+    for fragment, reason in required_fragments.items():
+        if fragment not in text:
+            errors.append(f"{MINT2_FLOW} {reason}")
+
+
+def _check_account_wall_positive_control(errors: list[str], root: Path) -> None:
+    flow_path = root / REGISTER_FLOW
+    if not flow_path.exists():
+        errors.append(f"missing account wall positive-control flow: {REGISTER_FLOW}")
+        return
+    text = flow_path.read_text(encoding="utf-8", errors="ignore")
+    if ACCOUNT_WALL_TITLE not in text:
+        errors.append(
+            f"{REGISTER_FLOW} must positively assert {ACCOUNT_WALL_TITLE!r}"
+        )
+
+
+def check(root: Path) -> list[str]:
+    root = root.resolve()
+    errors: list[str] = []
+    try:
+        metadata = _route_metadata(root)
+        app_routes = _app_routes(root)
+    except OSError as exc:
+        return [f"unable to read navigation source: {exc}"]
+
+    for route, expected in SPINE_DESTINATIONS.items():
+        _check_route(errors, metadata, app_routes, route, expected)
+    for route, target in RVC_ALIASES.items():
+        _check_alias(errors, metadata, app_routes, route, target)
+        if app_routes.get(route, {}).get("scope") != "onboarding":
+            errors.append(f"{route} must stay in RouteScope.onboarding")
+    for route, target in ONBOARDING_COMPAT_ALIASES.items():
+        _check_alias(errors, metadata, app_routes, route, target)
+
+    _check_maestro_flow(errors, root)
+    _check_account_wall_positive_control(errors, root)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    errors = check(args.root)
+    if not errors:
+        print("OK mint2_navigation_spine_guard: Mint 2.0 navigation spine is coherent.")
+        return 0
+    print("FAIL mint2_navigation_spine_guard: Mint 2.0 navigation spine drift detected.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_mint2_navigation_spine_guard.py
+++ b/tools/checks/tests/test_mint2_navigation_spine_guard.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.checks import mint2_navigation_spine_guard
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "tools/checks/mint2_navigation_spine_guard.py"
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_fixture(root: Path) -> None:
+    (root / "apps/mobile/lib/routes").mkdir(parents=True)
+    (root / "tools/simulator/flows/maestro-perfect-set").mkdir(parents=True)
+
+    (root / "apps/mobile/lib/routes/route_metadata.dart").write_text(
+        """
+const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
+  '/onb': RouteMeta(path: '/onb', category: RouteCategory.destination, owner: RouteOwner.anonymous, requiresAuth: false),
+  '/rente-vs-capital': RouteMeta(path: '/rente-vs-capital', category: RouteCategory.destination, owner: RouteOwner.retraite, requiresAuth: false),
+  '/arbitrage/rente-vs-capital': RouteMeta(path: '/arbitrage/rente-vs-capital', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /rente-vs-capital'),
+  '/simulator/rente-capital': RouteMeta(path: '/simulator/rente-capital', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /rente-vs-capital'),
+  '/coach/chat': RouteMeta(path: '/coach/chat', category: RouteCategory.destination, owner: RouteOwner.coach, requiresAuth: false),
+  '/start': RouteMeta(path: '/start', category: RouteCategory.alias, owner: RouteOwner.anonymous, requiresAuth: false, description: 'Legacy redirect -> /onb'),
+  '/anonymous/chat': RouteMeta(path: '/anonymous/chat', category: RouteCategory.alias, owner: RouteOwner.anonymous, requiresAuth: false, description: 'Legacy redirect -> /onb'),
+  '/onboarding/quick': RouteMeta(path: '/onboarding/quick', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/quick-start': RouteMeta(path: '/onboarding/quick-start', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/premier-eclairage': RouteMeta(path: '/onboarding/premier-eclairage', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/intent': RouteMeta(path: '/onboarding/intent', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/promise': RouteMeta(path: '/onboarding/promise', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/plan': RouteMeta(path: '/onboarding/plan', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/smart': RouteMeta(path: '/onboarding/smart', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+  '/onboarding/minimal': RouteMeta(path: '/onboarding/minimal', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: false, description: 'Legacy redirect -> /coach/chat'),
+};
+""",
+        encoding="utf-8",
+    )
+    (root / "apps/mobile/lib/app.dart").write_text(
+        """
+final router = [
+  ScopedGoRoute(path: '/onb', scope: RouteScope.public, builder: (_, __) => Screen()),
+  ScopedGoRoute(path: '/rente-vs-capital', scope: RouteScope.onboarding, builder: (_, __) => Screen()),
+  ScopedGoRoute(path: '/arbitrage/rente-vs-capital', scope: RouteScope.onboarding, redirect: (_, __) => '/rente-vs-capital'),
+  ScopedGoRoute(path: '/simulator/rente-capital', scope: RouteScope.onboarding, redirect: (_, __) => '/rente-vs-capital'),
+  ScopedGoRoute(path: '/coach/chat', scope: RouteScope.public, builder: (_, __) => Screen()),
+  ScopedGoRoute(path: '/start', scope: RouteScope.public, redirect: (_, __) => '/onb'),
+  ScopedGoRoute(path: '/anonymous/chat', scope: RouteScope.public, redirect: (_, __) => '/onb'),
+  ScopedGoRoute(path: '/onboarding/quick', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/quick-start', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/premier-eclairage', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/intent', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/promise', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/plan', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/smart', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+  ScopedGoRoute(path: '/onboarding/minimal', scope: RouteScope.onboarding, redirect: (_, __) => '/coach/chat'),
+];
+""",
+        encoding="utf-8",
+    )
+    flow = (
+        "tools/simulator/flows/maestro-perfect-set/"
+        "flow_mint2_first_experience_rente_capital_entry.yaml"
+    )
+    register_flow = (
+        "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    (root / flow).write_text(
+        """
+appId: ch.mint.app
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "mint2-axis-lpp_rente_capital"
+- assertVisible:
+    id: "rente_vs_capital_screen"
+- assertNotVisible:
+    text: "Cr\u00e9er ton compte"
+""",
+        encoding="utf-8",
+    )
+    (root / register_flow).write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+""",
+        encoding="utf-8",
+    )
+
+
+def test_navigation_spine_guard_passes_for_coherent_fixture(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+
+    assert mint2_navigation_spine_guard.check(tmp_path) == []
+    proc = _run(tmp_path)
+
+    assert proc.returncode == 0
+    assert "OK mint2_navigation_spine_guard" in proc.stdout
+
+
+def test_navigation_spine_guard_fails_when_rvc_requires_auth(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    metadata = tmp_path / "apps/mobile/lib/routes/route_metadata.dart"
+    metadata.write_text(
+        metadata.read_text(encoding="utf-8").replace(
+            "'/rente-vs-capital', category: RouteCategory.destination, owner: RouteOwner.retraite, requiresAuth: false",
+            "'/rente-vs-capital', category: RouteCategory.destination, owner: RouteOwner.retraite, requiresAuth: true",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any("/rente-vs-capital must not require auth" in error for error in errors)
+
+
+def test_navigation_spine_guard_fails_when_live_alias_targets_account_gate(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    app = tmp_path / "apps/mobile/lib/app.dart"
+    app.write_text(
+        app.read_text(encoding="utf-8").replace(
+            "ScopedGoRoute(path: '/arbitrage/rente-vs-capital', scope: RouteScope.onboarding, redirect: (_, __) => '/rente-vs-capital')",
+            "ScopedGoRoute(path: '/arbitrage/rente-vs-capital', scope: RouteScope.onboarding, redirect: (_, __) => '/auth/register')",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "/arbitrage/rente-vs-capital app redirect must target /rente-vs-capital"
+        in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_maestro_flow_loses_live_route_probe(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_mint2_first_experience_rente_capital_entry.yaml"
+    )
+    flow.write_text(flow.read_text(encoding="utf-8").replace("rente_vs_capital_screen", "account_gate"), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any("must assert rente_vs_capital_screen" in error for error in errors)
+
+
+def test_navigation_spine_guard_fails_without_account_wall_positive_control(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text("appId: ch.mint.app\n---\n- launchApp\n", encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any("must positively assert" in error for error in errors)

--- a/tools/checks/tests/test_workflow_contract_guard.py
+++ b/tools/checks/tests/test_workflow_contract_guard.py
@@ -17,6 +17,7 @@ SESSION_COMMANDS = (
 CI_EXTRA = (
     "python3 tools/checks/agent_reference_guard.py",
     "python3 tools/checks/claude_hooks_guard.py",
+    "python3 tools/checks/mint2_navigation_spine_guard.py",
     "python3 tools/checks/mermaid_render_guard.py",
     "python3 tools/checks/maestro_locator_audit.py",
     "bash tools/simulator/journey_os_runtime_replay.sh --dry-run",
@@ -31,6 +32,7 @@ CI_TESTS = (
     "tools/checks/tests/test_claude_hooks_guard.py",
     "tools/checks/tests/test_journey_os_check.py",
     "tools/checks/tests/test_journey_os_runtime_replay.py",
+    "tools/checks/tests/test_mint2_navigation_spine_guard.py",
     "tools/checks/tests/test_maestro_locator_audit.py",
     "tools/checks/tests/test_mermaid_render_guard.py",
     "tools/checks/tests/test_workflow_contract_guard.py",

--- a/tools/checks/workflow_contract_guard.py
+++ b/tools/checks/workflow_contract_guard.py
@@ -33,6 +33,7 @@ SESSION_COMMANDS = (
 CI_COMMANDS = SESSION_COMMANDS + (
     "python3 tools/checks/agent_reference_guard.py",
     "python3 tools/checks/claude_hooks_guard.py",
+    "python3 tools/checks/mint2_navigation_spine_guard.py",
     "python3 tools/checks/mermaid_render_guard.py",
     "python3 tools/checks/maestro_locator_audit.py",
     RUNTIME_REPLAY_DRY_RUN,
@@ -48,6 +49,7 @@ CI_TESTS = (
     "tools/checks/tests/test_claude_hooks_guard.py",
     "tools/checks/tests/test_journey_os_check.py",
     "tools/checks/tests/test_journey_os_runtime_replay.py",
+    "tools/checks/tests/test_mint2_navigation_spine_guard.py",
     "tools/checks/tests/test_maestro_locator_audit.py",
     "tools/checks/tests/test_mermaid_render_guard.py",
     "tools/checks/tests/test_workflow_contract_guard.py",

--- a/tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml
@@ -79,5 +79,7 @@ tags:
 - assertNotVisible:
     text: "NoSuchMethodError"
 - assertNotVisible:
+    text: "Créer ton compte"
+- assertNotVisible:
     text: "CHF/mois"
 - takeScreenshot: "04-rvc-route-state"


### PR DESCRIPTION
## Summary
- Add a CI-wired Mint 2.0 navigation spine guard for the first-value route contract.
- Lock /onb, /rente-vs-capital, /coach/chat, RvC aliases, and legacy onboarding aliases against auth-gate drift.
- Extend the existing Mint2 Maestro flow with an explicit absence check for the account wall, backed by the existing JOS-001 positive-control flow for the same account title.

## Verification
- python3 tools/checks/mint2_navigation_spine_guard.py
- python3 -m pytest tools/checks/tests/test_mint2_navigation_spine_guard.py tools/checks/tests/test_workflow_contract_guard.py tools/checks/tests/test_journey_os_check.py -q -> 94 passed
- python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/journey_os_check.py && python3 tools/checks/workflow_contract_guard.py && python3 tools/checks/mint2_navigation_spine_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- ./tools/mint-routes check -> 145 routes parity OK
- bash tools/simulator/maestro_env.sh check-syntax tools/simulator/flows/maestro-perfect-set/flow_mint2_first_experience_rente_capital_entry.yaml
- cd apps/mobile && flutter analyze -> No issues found
- cd apps/mobile && flutter test test/architecture/route_guard_snapshot_test.dart test/architecture/route_reachability_test.dart test/architecture/route_cycle_test.dart test/architecture/route_scope_leak_test.dart test/routes/route_metadata_test.dart test/navigation/account_lifecycle_public_entry_redirect_test.dart test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart -> 60 passed
- iPhone 13 mini simulator: flow_mint2_first_experience_rente_capital_entry -> 1/1 Flow Passed in 16s; JUnit artifact /tmp/mint-jos008-navigation-spine-gate-20260629T152639Z/result.xml

## Audit
- Claude Opus plan audit recommended the reduced /onb + alias-target-scope subset instead of broader Mermaid/ScreenRegistry/Journey checks.
- Claude Opus post-implementation audit reported no blocking must-fix and requested a positive control for the account-wall title; this PR includes that positive-control requirement in the guard.
