### PR TITLE
Fix rente capital coach token budget

### DIFF
--- a/services/backend/app/api/v1/endpoints/coach_chat.py
+++ b/services/backend/app/api/v1/endpoints/coach_chat.py
@@ -3448,6 +3448,52 @@ def _recover_rente_capital_fallback(
     return recovered
 
 
+def _rente_capital_deterministic_loop_result(
+    reasoning_output: ReasoningOutput | None,
+) -> dict | None:
+    """Return the vetted rente/capital answer without spending an LLM turn."""
+    if reasoning_output is None:
+        return None
+    if reasoning_output.fact_tag != "rente_capital_next_lever":
+        return None
+    lpp_amount = (reasoning_output.supporting_data or {}).get(
+        "avoir_lpp_actuel_CHF"
+    )
+    if lpp_amount is None:
+        return None
+    try:
+        numeric_lpp_amount = float(lpp_amount)
+        if not math.isfinite(numeric_lpp_amount) or numeric_lpp_amount <= 0:
+            return None
+    except (TypeError, ValueError):
+        return None
+    recovered = _recover_rente_capital_fallback(
+        {
+            "answer": FALLBACK_TEMPLATED_TEXT,
+            "tool_calls": [],
+            "citation_chips": None,
+            "sources": [],
+            "disclaimers": [],
+            "tokens_used": 0,
+            "degraded": False,
+            "model_used": "deterministic-rente-capital",
+        },
+        reasoning_output,
+    )
+    recovered["tokens_used"] = 0
+    recovered["degraded"] = False
+    recovered["model_used"] = "deterministic-rente-capital"
+    if _is_generic_data_fallback(recovered.get("answer")):
+        return None
+    if not recovered.get("tool_calls"):
+        return None
+    if not recovered.get("sources"):
+        return None
+    if not recovered.get("disclaimers"):
+        return None
+    return recovered
+
+
 def _fmt_pct(value) -> str:
     """Format a ratio (0-1) or percentage (0-100) as %."""
     if value is None:
@@ -5558,6 +5604,13 @@ async def coach_chat(
             effective_model,
         )
 
+    deterministic_loop_result = (
+        None
+        if safe_history
+        else _rente_capital_deterministic_loop_result(reasoning_output)
+    )
+    deterministic_reasoning_used = deterministic_loop_result is not None
+
     # ------------------------------------------------------------------
     # Step 4: Agent loop — tool_use -> execute -> re-call LLM
     # Internal tools (retrieve_memories) are executed and their results
@@ -5996,37 +6049,48 @@ async def coach_chat(
         increment_and_get_previous(key)
         return await _run_narrator_with_gate(pack=pack)
 
-    try:
-        loop_result = await _run_narrator_with_gate_and_cap()
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Agent loop total timeout (%ds) for user %s",
-            AGENT_LOOP_DEADLINE_SECONDS,
-            _user.id if _user else "anonymous",
+    if deterministic_loop_result is not None:
+        logger.info(
+            "coach_chat deterministic reasoning shortcut fact=%s user=%s",
+            reasoning_output.fact_tag,
+            (str(_user.id)[:8] + "...") if _user else "anonymous",
         )
-        loop_result = {
-            "answer": "Je n'ai pas pu terminer ma recherche dans le temps imparti. "
-            "Repose ta question, je serai plus rapide.",
-            "tool_calls": [],
-            "citation_chips": None,
-            "sources": [],
-            "disclaimers": [],
-            "tokens_used": 0,
-            "degraded": True,
-            "model_used": PRIMARY_MODEL_DEFAULT,
-        }
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid request parameters")
-    except ImportError:
-        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
-    except Exception as exc:
-        logger.error("Coach chat agent loop failed: %s", type(exc).__name__)
-        raise HTTPException(
-            status_code=502,
-            detail="LLM API call failed. Please verify your API key and try again.",
-        )
+        loop_result = deterministic_loop_result
+    else:
+        try:
+            loop_result = await _run_narrator_with_gate_and_cap()
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Agent loop total timeout (%ds) for user %s",
+                AGENT_LOOP_DEADLINE_SECONDS,
+                _user.id if _user else "anonymous",
+            )
+            loop_result = {
+                "answer": "Je n'ai pas pu terminer ma recherche dans le temps imparti. "
+                "Repose ta question, je serai plus rapide.",
+                "tool_calls": [],
+                "citation_chips": None,
+                "sources": [],
+                "disclaimers": [],
+                "tokens_used": 0,
+                "degraded": True,
+                "model_used": PRIMARY_MODEL_DEFAULT,
+            }
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid request parameters")
+        except ImportError:
+            raise HTTPException(
+                status_code=503, detail="Service temporarily unavailable"
+            )
+        except Exception as exc:
+            logger.error("Coach chat agent loop failed: %s", type(exc).__name__)
+            raise HTTPException(
+                status_code=502,
+                detail="LLM API call failed. Please verify your API key and try again.",
+            )
 
-    loop_result = _recover_rente_capital_fallback(loop_result, reasoning_output)
+    if not deterministic_reasoning_used:
+        loop_result = _recover_rente_capital_fallback(loop_result, reasoning_output)
 
     # ------------------------------------------------------------------
     # Step 5: Production monitoring
@@ -6091,6 +6155,10 @@ async def coach_chat(
         system_prompt_used=True,
         response_meta={
             "degraded": bool(loop_result.get("degraded", False)),
+            "deterministic_reasoning": deterministic_reasoning_used,
+            "reasoning_fact": (
+                reasoning_output.fact_tag if deterministic_reasoning_used else None
+            ),
             "model_used": loop_result.get("model_used", PRIMARY_MODEL_DEFAULT),
             "budget_tier": budget_tier,
         },

--- a/services/backend/tests/test_coach_chat_endpoint.py
+++ b/services/backend/tests/test_coach_chat_endpoint.py
@@ -813,14 +813,173 @@ class TestCoachChatRenteCapitalFallbackFloor:
         assert payload["disclaimers"]
         assert payload["sources"][0]["source_kind"] == "legal_reference"
 
-    def test_rente_capital_real_answer_is_not_recovered(self, client_with_auth):
-        answer = "Réponse déjà utile sans fallback."
-        loop = AsyncMock(return_value=self._loop_result(answer=answer))
+    def test_rente_capital_next_lever_short_circuits_before_llm(
+        self, client_with_auth
+    ):
+        loop = AsyncMock(
+            return_value=self._loop_result(answer="LLM should not be called")
+        )
 
         with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
             response = client_with_auth.post(
                 "/api/v1/coach/chat",
                 json=self._rente_capital_body(),
+            )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert loop.await_count == 0
+        assert payload["tokensUsed"] == 0
+        assert "94'000" in payload["message"]
+        assert payload["toolCalls"][0]["name"] == "route_to_screen"
+        assert payload["toolCalls"][0]["input"]["intent"] == "retirement_choice"
+        assert payload["sources"]
+        assert len(payload["sources"]) == 4
+        assert payload["sources"][0]["source_kind"] == "legal_reference"
+        assert payload["disclaimers"]
+        assert len(payload["disclaimers"]) == 1
+        assert payload["responseMeta"]["deterministic_reasoning"] is True
+        assert payload["responseMeta"]["reasoning_fact"] == "rente_capital_next_lever"
+        assert payload["responseMeta"]["model_used"] == "deterministic-rente-capital"
+
+    def test_rente_capital_without_lpp_keeps_llm_path(self, client_with_auth):
+        answer = "Il me manque ton avoir LPP pour comparer rente et capital."
+        loop = AsyncMock(return_value=self._loop_result(answer=answer))
+        body = {
+            **_VALID_BODY,
+            "message": (
+                "Je dois choisir rente ou capital pour ma LPP. "
+                "Quel est le prochain levier concret ?"
+            ),
+            "profileContext": {
+                "age": 49,
+                "canton": "VS",
+                "monthly_income": 7600,
+                "civil_status": "married",
+            },
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        assert loop.await_count == 1
+        assert response.json()["message"] == answer
+
+    def test_rente_capital_zero_lpp_keeps_llm_path(self, client_with_auth):
+        answer = "Il me manque un avoir LPP positif pour comparer rente et capital."
+        loop = AsyncMock(return_value=self._loop_result(answer=answer))
+        body = {
+            **_VALID_BODY,
+            "message": (
+                "Je dois choisir rente ou capital pour ma LPP. "
+                "Quel est le prochain levier concret ?"
+            ),
+            "profileContext": {
+                "age": 49,
+                "canton": "VS",
+                "lpp_capital": 0,
+                "monthly_income": 7600,
+                "civil_status": "married",
+            },
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        assert loop.await_count == 1
+        assert response.json()["message"] == answer
+
+    def test_rente_capital_followup_keeps_llm_path(self, client_with_auth):
+        answer = "Pour ce cas de suivi, je précise la fiscalité VS."
+        loop = AsyncMock(return_value=self._loop_result(answer=answer))
+        body = {
+            **self._rente_capital_body(),
+            "conversationHistory": [
+                {
+                    "role": "assistant",
+                    "content": "On a ouvert la comparaison rente vs capital.",
+                }
+            ],
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post("/api/v1/coach/chat", json=body)
+
+        assert response.status_code == 200
+        assert loop.await_count == 1
+        assert response.json()["message"] == answer
+
+    def test_rente_capital_shortcut_requires_complete_trust_artifacts(self):
+        from app.api.v1.endpoints.coach_chat import (
+            _rente_capital_deterministic_loop_result,
+        )
+        from app.services.coach.citation_parser import FALLBACK_TEMPLATED_TEXT
+        from app.services.coach.structured_reasoning import ReasoningOutput
+
+        def output(*, lpp=94_000, sources=None, disclaimer="Disclaimer") -> ReasoningOutput:
+            return ReasoningOutput(
+                fact_tag="rente_capital_next_lever",
+                fact_label="Rente vs capital",
+                confidence=0.7,
+                suggested_action="Comparer rente et capital.",
+                intent_tag="retirement_choice",
+                reasoning_trace="test",
+                supporting_data={"avoir_lpp_actuel_CHF": lpp, "canton": "VS"},
+                sources=(
+                    ["LIFD art. 22", "LIFD art. 38"]
+                    if sources is None
+                    else sources
+                ),
+                disclaimer=disclaimer,
+            )
+
+        assert _rente_capital_deterministic_loop_result(output(lpp=0)) is None
+        assert _rente_capital_deterministic_loop_result(output(lpp=-1)) is None
+        assert _rente_capital_deterministic_loop_result(output(lpp=float("inf"))) is None
+        assert _rente_capital_deterministic_loop_result(output(lpp=float("nan"))) is None
+        assert _rente_capital_deterministic_loop_result(output(sources=[])) is None
+        assert (
+            _rente_capital_deterministic_loop_result(output(disclaimer="")) is None
+        )
+        with patch(
+            "app.api.v1.endpoints.coach_chat._recover_rente_capital_fallback",
+            return_value={
+                "answer": FALLBACK_TEMPLATED_TEXT,
+                "tool_calls": [{"name": "route_to_screen", "input": {}}],
+                "sources": [{"source_kind": "legal_reference"}],
+                "disclaimers": ["Disclaimer"],
+            },
+        ):
+            assert _rente_capital_deterministic_loop_result(output()) is None
+        with patch(
+            "app.api.v1.endpoints.coach_chat._recover_rente_capital_fallback",
+            return_value={
+                "answer": "Réponse déterministe complète.",
+                "tool_calls": [],
+                "sources": [{"source_kind": "legal_reference"}],
+                "disclaimers": ["Disclaimer"],
+            },
+        ):
+            assert _rente_capital_deterministic_loop_result(output()) is None
+
+    def test_non_rente_capital_real_answer_is_not_recovered(self, client_with_auth):
+        answer = "Réponse déjà utile sans fallback."
+        loop = AsyncMock(return_value=self._loop_result(answer=answer))
+        body = {
+            **_VALID_BODY,
+            "message": "Comment optimiser mon 3a ?",
+            "profileContext": {
+                "annual_3a_contribution": 1000,
+                "tax_saving_potential": 2000,
+            },
+        }
+
+        with patch("app.api.v1.endpoints.coach_chat._run_agent_loop", loop):
+            response = client_with_auth.post(
+                "/api/v1/coach/chat",
+                json=body,
             )
 
         assert response.status_code == 200


### PR DESCRIPTION
Fixes the remaining staging runtime issue on the rente/capital coach flow: the endpoint served the deterministic fallback only after spending ~50k tokens in the agent loop.\n\nScope:\n- Short-circuit first-turn explicit rente/capital LPP questions with positive finite LPP capital to the vetted deterministic answer.\n- Preserve follow-up turns and incomplete profile cases on the normal LLM path.\n- Require trust artifacts before shortcut: route_to_screen, legal sources, disclaimers, non-generic answer.\n- Keep common post-loop metrics/SLO/response construction; expose responseMeta.deterministic_reasoning.\n\nValidation:\n- ruff check coach_chat.py + test_coach_chat_endpoint.py\n- 105 targeted backend tests\n- Full backend: 7907 passed, 85 skipped, 3 xfailed, 1 warning\n- Guards: active_context, phase_contract, mint_rules, journey_os, workflow_contract, verify_phase_acceptance\n- Opus audit final: no critical blocking finding; non-blocking items addressed for no-history followups, finite LPP, idempotency.