### PR TITLE
Fix coach back fallback by auth lifecycle

### DIFF
--- a/apps/mobile/lib/screens/coach/coach_chat_screen.dart
+++ b/apps/mobile/lib/screens/coach/coach_chat_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+import 'package:mint_mobile/services/navigation/mint_nav.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -2256,7 +2257,12 @@ class _CoachChatScreenState extends State<CoachChatScreen> {
               CoachAppBar(
                 isEmbeddedInTab: widget.isEmbeddedInTab,
                 hasUserMessages: _messages.any((m) => m.isUser),
-                onBack: () => safePop(context),
+                onBack: () => safePop(
+                  context,
+                  fallbackRoute: MintNav.coachFallbackRouteFor(
+                    context.read<AuthProvider>().authLifecycle,
+                  ),
+                ),
                 onHistory: () async {
                   final router = GoRouter.of(context);
                   await _autoSaveConversation();

--- a/apps/mobile/lib/services/navigation/mint_nav.dart
+++ b/apps/mobile/lib/services/navigation/mint_nav.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 
 /// Shell-aware navigation helper replacing safePop.
 ///
@@ -12,6 +13,12 @@ class MintNav {
 
   static const shellFallbackRoute = '/home';
   static const onboardingFallbackRoute = '/onb';
+
+  static String coachFallbackRouteFor(AuthLifecycleState lifecycle) {
+    return lifecycle.allowsMainNavigation
+        ? shellFallbackRoute
+        : onboardingFallbackRoute;
+  }
 
   /// Navigate back. If stack is empty, go to the caller-owned [fallbackRoute].
   static void back(

--- a/apps/mobile/test/architecture/navigation_push_doctrine_test.dart
+++ b/apps/mobile/test/architecture/navigation_push_doctrine_test.dart
@@ -194,6 +194,32 @@ Navigator.of(context).pop();
     );
   });
 
+  test('standalone coach back uses lifecycle-aware fallback on empty stack',
+      () {
+    final source =
+        File('lib/screens/coach/coach_chat_screen.dart').readAsStringSync();
+    final backPattern = RegExp(
+      r'onBack:\s*\(\)\s*=>\s*safePop\(\s*context\s*,\s*'
+      r'fallbackRoute:\s*MintNav\.coachFallbackRouteFor\(\s*'
+      r'context\.read<AuthProvider>\(\)\.authLifecycle\s*,?\s*\)\s*,?\s*\)',
+      multiLine: true,
+    );
+
+    expect(
+      source,
+      contains(
+        "import 'package:mint_mobile/services/navigation/mint_nav.dart';",
+      ),
+    );
+    expect(
+      backPattern.hasMatch(_stripComments(source)),
+      isTrue,
+      reason: 'Standalone /coach/chat is shared by guests and accounts. '
+          'With an empty stack, back must use allowsMainNavigation: false '
+          'lifecycles go to /onb, true lifecycles preserve /home.',
+    );
+  });
+
   testWidgets('go to coach branch keeps shell selection coherent and query',
       (tester) async {
     String? capturedTopic;

--- a/apps/mobile/test/screens/coach/coach_chat_test.dart
+++ b/apps/mobile/test/screens/coach/coach_chat_test.dart
@@ -9,6 +9,7 @@ import 'package:mint_mobile/providers/mint_state_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/data/budget/budget_local_store.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart';
 import 'package:mint_mobile/models/budget_snapshot.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
@@ -39,6 +40,15 @@ import '../../semantics_test_helpers.dart';
 // ────────────────────────────────────────────────────────────
 //  COACH CHAT SCREEN TESTS — Phase 4 / BYOK + RAG wiring
 // ────────────────────────────────────────────────────────────
+
+class _LifecycleAuthProvider extends AuthProvider {
+  _LifecycleAuthProvider(this._lifecycle);
+
+  final AuthLifecycleState _lifecycle;
+
+  @override
+  AuthLifecycleState get authLifecycle => _lifecycle;
+}
 
 void main() {
   // FIX-P1-7: Register orchestrator (no longer auto-imported by coach_llm_service).
@@ -197,6 +207,72 @@ void main() {
           contextBuilder: contextBuilder,
           conversationId: conversationId,
         ),
+      ),
+    );
+  }
+
+  Widget buildRoutedCoachWidget({
+    required AuthProvider authProvider,
+    CoachProfileProvider? profileProviderOverride,
+    String initialLocation = '/coach/chat',
+  }) {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: '/source',
+          builder: (context, __) => Scaffold(
+            body: Column(
+              children: [
+                const Text('source route'),
+                TextButton(
+                  onPressed: () => context.push('/coach/chat'),
+                  child: const Text('open coach'),
+                ),
+              ],
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/coach/chat',
+          builder: (_, __) => CoachChatScreen(
+            contextBuilder: emptyContextBuilder,
+          ),
+        ),
+        GoRoute(
+          path: '/home',
+          builder: (_, __) => const Scaffold(
+            body: Text('home route'),
+          ),
+        ),
+        GoRoute(
+          path: '/onb',
+          builder: (_, __) => const Scaffold(
+            body: Text('onboarding route'),
+          ),
+        ),
+      ],
+    );
+
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(
+          value: profileProviderOverride ?? CoachProfileProvider(),
+        ),
+        ChangeNotifierProvider(create: (_) => ByokProvider()),
+        ChangeNotifierProvider.value(value: MintStateProvider()),
+        ChangeNotifierProvider<AuthProvider>.value(value: authProvider),
+      ],
+      child: MaterialApp.router(
+        locale: const Locale('fr'),
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        routerConfig: router,
       ),
     );
   }
@@ -771,6 +847,73 @@ void main() {
       await tester.pumpWidget(buildTestWidget(withProfile: true));
       await tester.pump(const Duration(milliseconds: 100));
       expect(find.byIcon(Icons.arrow_back_ios_new_rounded), findsOneWidget);
+    });
+
+    testWidgets('standalone back returns explicit guests to the shell',
+        (tester) async {
+      usePhoneViewport(tester);
+      final authProvider = _LifecycleAuthProvider(
+        AuthLifecycleState.guestEmpty(installId: 'install-1'),
+      );
+
+      await tester.pumpWidget(buildRoutedCoachWidget(
+        authProvider: authProvider,
+      ));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('home route'), findsOneWidget);
+      expect(find.text('onboarding route'), findsNothing);
+    });
+
+    testWidgets('standalone back returns fresh visitors to onboarding',
+        (tester) async {
+      usePhoneViewport(tester);
+      final authProvider = _LifecycleAuthProvider(
+        AuthLifecycleState.freshVisitor(),
+      );
+
+      await tester.pumpWidget(buildRoutedCoachWidget(
+        authProvider: authProvider,
+      ));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('onboarding route'), findsOneWidget);
+      expect(find.text('home route'), findsNothing);
+    });
+
+    testWidgets('standalone back pops existing stack before fallback',
+        (tester) async {
+      usePhoneViewport(tester);
+      final authProvider = _LifecycleAuthProvider(
+        AuthLifecycleState.freshVisitor(),
+      );
+
+      await tester.pumpWidget(buildRoutedCoachWidget(
+        authProvider: authProvider,
+        initialLocation: '/source',
+      ));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text('open coach'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(CoachChatScreen), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('source route'), findsOneWidget);
+      expect(find.text('onboarding route'), findsNothing);
+      expect(find.text('home route'), findsNothing);
     });
 
     testWidgets('shows suggested action chips', (tester) async {

--- a/apps/mobile/test/services/navigation/mint_nav_test.dart
+++ b/apps/mobile/test/services/navigation/mint_nav_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/models/auth_lifecycle_state.dart';
 import 'package:mint_mobile/services/navigation/mint_nav.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 
@@ -104,6 +105,49 @@ GoRouter _safePopRouter() {
 }
 
 void main() {
+  group('coachFallbackRouteFor', () {
+    test('fresh or incomplete lifecycles return to onboarding', () {
+      expect(
+        MintNav.coachFallbackRouteFor(AuthLifecycleState.freshVisitor()),
+        MintNav.onboardingFallbackRoute,
+      );
+      expect(
+        MintNav.coachFallbackRouteFor(
+          AuthLifecycleState.signedInProfileMissing(
+            userId: 'user-1',
+            cloudSyncEnabled: false,
+          ),
+        ),
+        MintNav.onboardingFallbackRoute,
+      );
+      expect(
+        MintNav.coachFallbackRouteFor(AuthLifecycleState.sessionExpired()),
+        MintNav.onboardingFallbackRoute,
+      );
+    });
+
+    test('main-navigation lifecycles return to the shell', () {
+      expect(
+        MintNav.coachFallbackRouteFor(
+          AuthLifecycleState.guestEmpty(installId: 'install-1'),
+        ),
+        MintNav.shellFallbackRoute,
+      );
+      expect(
+        MintNav.coachFallbackRouteFor(
+          AuthLifecycleState.syncOffAccount(userId: 'user-1'),
+        ),
+        MintNav.shellFallbackRoute,
+      );
+      expect(
+        MintNav.coachFallbackRouteFor(
+          AuthLifecycleState.cloudSyncOnAccount(userId: 'user-1'),
+        ),
+        MintNav.shellFallbackRoute,
+      );
+    });
+  });
+
   testWidgets('empty stack defaults to shell fallback route', (tester) async {
     final router = _router(
       initialLocation: '/source',

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -86,6 +86,7 @@ ALLOW = {
     "apps/mobile/test/screens/register_account_entry_test.dart",
     "apps/mobile/test/screens/data_block_enrichment_screen_test.dart",
     "apps/mobile/test/screens/debug/debug_mint2_account_claim_screen_test.dart",
+    "apps/mobile/test/screens/coach/coach_chat_test.dart",
     "apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_route_scope_test.dart",
     "apps/mobile/test/screens/onboarding/mvp_wedge/mint2_first_experience_signal_axes_test.dart",
     "apps/mobile/test/services/api_service_test.dart",

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -386,6 +386,22 @@ def test_jos006_coach_cta_stack_contract_scope_is_in_scope(tmp_path: Path) -> No
     assert not any("outside Journey OS whitelist" in error for error in errors)
 
 
+def test_coach_chat_widget_regression_scope_is_in_scope(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    _record(root)
+    _issue(root)
+    journey_os_generate.write(root)
+
+    errors = _errors(
+        root,
+        [
+            "apps/mobile/test/screens/coach/coach_chat_test.dart",
+        ],
+    )
+
+    assert not any("outside Journey OS whitelist" in error for error in errors)
+
+
 def test_jos004_runtime_flow_completes_first_experience_before_coach() -> None:
     flow = (
         journey_os_check.REPO_ROOT


### PR DESCRIPTION
## Summary
- Route standalone Coach back fallback through auth lifecycle: /onb when main navigation is not allowed, /home for guest/account states.
- Add widget coverage for empty-stack guest, empty-stack fresh visitor, and non-empty-stack pop behavior.
- Extend Journey OS whitelist for the coach widget regression test with guard coverage.

## Verification
- flutter analyze
- flutter test test/services/navigation/mint_nav_test.dart test/architecture/navigation_push_doctrine_test.dart test/screens/coach/coach_chat_test.dart --name 'coachFallbackRouteFor|standalone coach back|standalone back' -r expanded
- ./tools/mint-routes check
- python3 tools/checks/mint2_navigation_spine_guard.py
- python3 tools/checks/journey_os_check.py
- python3 -m pytest tools/checks/tests/test_journey_os_check.py -q
- python3 tools/checks/verify_phase_acceptance.py
- Opus review: no blocking findings
