### PR TITLE
Fix Apple account backend failure guidance

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -126,6 +126,12 @@ AuthError _authErrorFromException(Object error) {
     return AuthError.registrationUnavailable;
   }
 
+  if (lower.contains('apple identity') ||
+      lower.contains('apple sign-in audience') ||
+      lower.contains('apple sign-in verification failed')) {
+    return AuthError.serviceUnavailable;
+  }
+
   final platformText = error is PlatformException
       ? [
           error.code,

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -748,6 +748,31 @@ void main() {
       expect(message, isNot(l10n.authErrorGeneric));
     });
 
+    test('localizeAuthException maps backend Apple verification failures',
+        () async {
+      final l10n = await S.delegate.load(const Locale('fr'));
+
+      for (final detail in [
+        'Apple identity verification unavailable',
+        'Apple Sign-In audience not configured',
+        'Invalid Apple identity token',
+        'Apple identity token expired',
+        'Invalid Apple identity token nonce',
+      ]) {
+        final message = localizeAuthException(
+          ApiException(detail, statusCode: 503),
+          l10n,
+        );
+
+        expect(
+          message,
+          l10n.authErrorService,
+          reason: detail,
+        );
+        expect(message, isNot(l10n.authErrorGeneric), reason: detail);
+      }
+    });
+
     test('localizeAuthException does not map native Apple cancellation service',
         () async {
       final l10n = await S.delegate.load(const Locale('fr'));

--- a/apps/mobile/test/screens/register_account_entry_test.dart
+++ b/apps/mobile/test/screens/register_account_entry_test.dart
@@ -305,6 +305,39 @@ void main() {
     }
   });
 
+  testWidgets('backend Apple verification failure does not show generic copy',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    AppleSignInService.signInOverride = () async {
+      throw const ApiException(
+        'Apple identity verification unavailable',
+        statusCode: 503,
+      );
+    };
+    try {
+      await tester.pumpWidget(_testApp());
+      await tester.pump();
+
+      await _acceptRequiredConsentsAndTapApple(tester);
+
+      expect(
+        find.text(
+          'Le service de compte n’est pas disponible sur cet environnement. Utilise le mode local.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.email_outlined), findsOneWidget);
+      expect(
+        find.text(
+          'Action impossible pour le moment. Réessaie dans quelques instants.',
+        ),
+        findsNothing,
+      );
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
   testWidgets('Apple cancellation does not show service unavailable guidance',
       (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;


### PR DESCRIPTION
## Summary
- Map backend Apple verification failures to the actionable account-service guidance instead of the generic auth error.
- Keep the email account path visible when Apple/backend verification fails on registration.
- Add provider + register-screen regressions for Apple identity/audience/token backend failures.

## Diagnostic
- Railway CLI is installed at `/opt/homebrew/bin/railway`, but local Railway auth currently returns `Unauthorized. Please run railway login again.`.
- TestFlight staging has uploaded builds after #785, but the screenshot's generic copy is still reachable for backend Apple verification details such as `Apple identity verification unavailable`.

## Verification
- `flutter test test/providers/auth_provider_test.dart --plain-name 'localizeAuthException maps backend Apple verification failures'`
- `flutter test test/screens/register_account_entry_test.dart --plain-name 'backend Apple verification failure does not show generic copy'`
- `flutter test test/providers/auth_provider_test.dart test/screens/register_account_entry_test.dart` (86 passed)
- `flutter analyze`
- `git diff --check`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/journey_os_check.py`
- `python3 tools/checks/workflow_contract_guard.py`
- `python3 tools/checks/verify_phase_acceptance.py`

## Notes
- This does not claim physical Apple Sign-In success without a fresh device/TestFlight run.
- Next route-architecture work remains the leaf-preserving Coach handoff after #795.