### PR TITLE
Fix Apple account creation response shape

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -765,14 +765,18 @@ class AuthProvider extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final accessToken = response['accessToken'] as String?;
+      final accessToken =
+          (response['accessToken'] ?? response['access_token']) as String?;
       if (accessToken == null || accessToken.isEmpty) {
         throw Exception('Missing access token in Apple Sign-In response');
       }
-      final userId = response['userId']?.toString() ?? '';
+      final userId =
+          (response['userId'] ?? response['user_id'])?.toString() ?? '';
       final userEmail = response['email']?.toString() ?? '';
-      final displayName = response['displayName'] as String?;
-      final refreshToken = response['refreshToken'] as String?;
+      final displayName =
+          (response['displayName'] ?? response['display_name']) as String?;
+      final refreshToken =
+          (response['refreshToken'] ?? response['refresh_token']) as String?;
 
       // Apple Sign-In with "Hide My Email" may return an empty userId
       // or email. saveToken now throws ArgumentError on empty values

--- a/apps/mobile/lib/services/apple_sign_in_service.dart
+++ b/apps/mobile/lib/services/apple_sign_in_service.dart
@@ -25,6 +25,31 @@ class AppleSignInService {
     _signInOverride = null;
   }
 
+  @visibleForTesting
+  static Map<String, dynamic> normalizeVerifyResponseForTest(
+    Map<String, dynamic> response,
+  ) =>
+      _normalizeVerifyResponse(response);
+
+  static Map<String, dynamic> _normalizeVerifyResponse(
+    Map<String, dynamic> response,
+  ) {
+    final accessToken = response['accessToken'] ?? response['access_token'];
+    final tokenType = response['tokenType'] ?? response['token_type'];
+    final userId = response['userId'] ?? response['user_id'];
+    final displayName = response['displayName'] ?? response['display_name'];
+    final refreshToken = response['refreshToken'] ?? response['refresh_token'];
+
+    return {
+      ...response,
+      if (accessToken != null) 'accessToken': accessToken,
+      if (tokenType != null) 'tokenType': tokenType,
+      if (userId != null) 'userId': userId,
+      if (displayName != null) 'displayName': displayName,
+      if (refreshToken != null) 'refreshToken': refreshToken,
+    };
+  }
+
   static bool isCancellation(Object error) {
     if (error is SignInWithAppleAuthorizationException) {
       return error.code == AuthorizationErrorCode.canceled;
@@ -108,14 +133,16 @@ class AppleSignInService {
       nonce: rawNonce,
     );
 
-    final accessToken = response['accessToken'] as String?;
+    final normalizedResponse = _normalizeVerifyResponse(response);
+    final accessToken = normalizedResponse['accessToken'] as String?;
     if (accessToken == null) {
       throw Exception('Backend returned no access token for Apple Sign-In');
     }
 
-    // Do NOT persist the token here — return the raw response so
-    // AuthProvider.completeAppleSignIn() owns the single state mutation.
-    return response;
+    // Do NOT persist the token here — return a response shape that
+    // AuthProvider.completeAppleSignIn() can consume as the single state
+    // mutation point.
+    return normalizedResponse;
   }
 
   /// Generate a cryptographically secure random nonce (32 characters).

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -12,6 +12,7 @@ import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/auth_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/account_handoff_service.dart';
+import 'package:mint_mobile/services/apple_sign_in_service.dart';
 import 'package:mint_mobile/services/coach/conversation_store.dart';
 import 'package:mint_mobile/services/coach_llm_service.dart';
 import 'package:mint_mobile/services/feature_flags.dart';
@@ -1285,6 +1286,42 @@ void main() {
         expect(claimedConversations.single.id, 'apple-guest-thread');
       },
     );
+
+    test(
+      'completeAppleSignIn accepts snake_case Apple verify response',
+      () async {
+        final ok = await provider.completeAppleSignIn({
+          'access_token': 'apple-jwt',
+          'refresh_token': 'apple-refresh',
+          'user_id': 'apple-user',
+          'email': 'apple@example.ch',
+          'display_name': 'Apple User',
+        }, claimAnonymousConversations: true);
+
+        expect(ok, isTrue);
+        expect(provider.userId, 'apple-user');
+        expect(provider.email, 'apple@example.ch');
+        expect(provider.displayName, 'Apple User');
+      },
+    );
+
+    test('Apple verify response normalizer accepts snake_case', () {
+      final normalized = AppleSignInService.normalizeVerifyResponseForTest({
+        'access_token': 'apple-jwt',
+        'token_type': 'bearer',
+        'user_id': 'apple-user',
+        'email': 'apple@example.ch',
+        'display_name': 'Apple User',
+        'refresh_token': 'apple-refresh',
+      });
+
+      expect(normalized['accessToken'], 'apple-jwt');
+      expect(normalized['tokenType'], 'bearer');
+      expect(normalized['userId'], 'apple-user');
+      expect(normalized['email'], 'apple@example.ch');
+      expect(normalized['displayName'], 'Apple User');
+      expect(normalized['refreshToken'], 'apple-refresh');
+    });
 
     // ── requiresEmailVerification starts false ──
 


### PR DESCRIPTION
## Summary
- accept snake_case Apple verify responses in AuthProvider
- normalize Apple verify response aliases before session completion
- add regression coverage for snake_case Apple account creation

## Root cause
The backend auth endpoints return snake_case token fields on live staging. The Apple client path only accepted camelCase, so a successful verify response could be treated as missing accessToken and surfaced as the generic account-creation failure.

## Verification
- flutter test test/providers/auth_provider_test.dart test/screens/register_account_entry_test.dart test/services/auth_service_test.dart
- flutter analyze
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/verify_phase_acceptance.py
- git diff --check

## Notes
- Railway CLI is installed at /opt/homebrew/bin/railway, version 4.59.0, but the local OAuth token is expired and railway status requires railway login.
- Claude Opus audit was attempted twice and produced no usable verdict before timeout/interruption.