### PR TITLE
Strengthen account register runtime gate

### DIFF
--- a/tools/checks/mint2_navigation_spine_guard.py
+++ b/tools/checks/mint2_navigation_spine_guard.py
@@ -23,6 +23,26 @@ REGISTER_FLOW = Path(
     "flow_jos001_account_lifecycle_seeded_delete.yaml"
 )
 ACCOUNT_WALL_TITLE = "Cr\u00e9er ton compte"
+EMAIL_FALLBACK_CTA = "Cr\u00e9er avec e-mail"
+REGISTER_EMAIL_FIELD_RE = re.compile(
+    r"visible:\s*(?:\{\s*id:\s*['\"]auth_register_email_field['\"]\s*\}|"
+    r"id:\s*['\"]auth_register_email_field['\"])"
+)
+REGISTER_EMAIL_TAP_RE = re.compile(
+    r"tapOn:\s*(?:\{\s*id:\s*['\"]auth_register_email_field['\"]\s*\}|"
+    r"id:\s*['\"]auth_register_email_field['\"])"
+)
+EMAIL_FALLBACK_ASSERT_RE = re.compile(
+    rf"assertNotVisible:\s*(?:['\"]{re.escape(EMAIL_FALLBACK_CTA)}['\"]|"
+    rf"text:\s*['\"]{re.escape(EMAIL_FALLBACK_CTA)}['\"])"
+)
+EMAIL_FALLBACK_TAP_RE = re.compile(
+    rf"tapOn:\s*(?:['\"]{re.escape(EMAIL_FALLBACK_CTA)}['\"]|"
+    rf"text:\s*['\"]{re.escape(EMAIL_FALLBACK_CTA)}['\"])"
+)
+EMAIL_FALLBACK_VISIBLE_RE = re.compile(
+    rf"visible:\s*['\"]{re.escape(EMAIL_FALLBACK_CTA)}['\"]"
+)
 
 SPINE_DESTINATIONS = {
     "/onb": {"scope": "public", "category": "destination", "requiresAuth": "false"},
@@ -243,6 +263,40 @@ def _check_account_wall_positive_control(errors: list[str], root: Path) -> None:
     if ACCOUNT_WALL_TITLE not in text:
         errors.append(
             f"{REGISTER_FLOW} must positively assert {ACCOUNT_WALL_TITLE!r}"
+        )
+    email_field = REGISTER_EMAIL_FIELD_RE.search(text)
+    email_tap = REGISTER_EMAIL_TAP_RE.search(text)
+    fallback_assert = EMAIL_FALLBACK_ASSERT_RE.search(text)
+    if fallback_assert is None:
+        errors.append(
+            f"{REGISTER_FLOW} must reject the hidden email fallback CTA "
+            f"{EMAIL_FALLBACK_CTA!r}"
+        )
+    if email_field is None:
+        errors.append(
+            f"{REGISTER_FLOW} must assert direct register email field visibility"
+        )
+    if email_tap is None:
+        errors.append(
+            f"{REGISTER_FLOW} must tap the direct register email field by id"
+        )
+    if (
+        email_field is not None
+        and fallback_assert is not None
+        and email_field.start() > fallback_assert.start()
+    ):
+        errors.append(
+            f"{REGISTER_FLOW} must assert direct email field before rejecting the fallback CTA"
+        )
+    if EMAIL_FALLBACK_TAP_RE.search(text) is not None:
+        errors.append(
+            f"{REGISTER_FLOW} must not tap the hidden email fallback CTA "
+            f"{EMAIL_FALLBACK_CTA!r}"
+        )
+    if EMAIL_FALLBACK_VISIBLE_RE.search(text) is not None:
+        errors.append(
+            f"{REGISTER_FLOW} must not branch on hidden email fallback CTA "
+            f"{EMAIL_FALLBACK_CTA!r}"
         )
 
 

--- a/tools/checks/tests/test_journey_os_runtime_replay.py
+++ b/tools/checks/tests/test_journey_os_runtime_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -56,6 +57,36 @@ def test_account_lifecycle_dry_run_is_separate_from_authenticated_set() -> None:
     assert proc.returncode == 0
     assert "account_lifecycle_delete" in proc.stdout
     assert "coach_advice_turn" not in proc.stdout
+
+
+def test_account_lifecycle_register_gate_rejects_hidden_email_regression() -> None:
+    flow = (
+        ROOT
+        / "tools/simulator/flows/maestro-perfect-set/flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    text = flow.read_text(encoding="utf-8")
+
+    email_field = re.search(
+        r"visible:\s*\{\s*id:\s*['\"]auth_register_email_field['\"]\s*\}",
+        text,
+    )
+    fallback_assert = re.search(
+        r"assertNotVisible:\s*['\"]Créer avec e-mail['\"]",
+        text,
+    )
+    fallback_when = re.search(r"visible:\s*['\"]Créer avec e-mail['\"]", text)
+    fallback_tap = re.search(r"tapOn:\s*['\"]Créer avec e-mail['\"]", text)
+    email_tap = re.search(
+        r"tapOn:\s*\n\s*id:\s*['\"]auth_register_email_field['\"]",
+        text,
+    )
+
+    assert email_field is not None
+    assert fallback_assert is not None
+    assert email_field.start() < fallback_assert.start()
+    assert email_tap is not None
+    assert fallback_when is None
+    assert fallback_tap is None
 
 
 def test_requires_auth_classifier_reports_runtime_set_auth_need() -> None:

--- a/tools/checks/tests/test_mint2_navigation_spine_guard.py
+++ b/tools/checks/tests/test_mint2_navigation_spine_guard.py
@@ -98,6 +98,12 @@ appId: ch.mint.app
 - extendedWaitUntil:
     visible: "Cr\u00e9er ton compte"
     timeout: 12000
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+- tapOn:
+    id: "auth_register_email_field"
 """,
         encoding="utf-8",
     )
@@ -111,6 +117,10 @@ def test_navigation_spine_guard_passes_for_coherent_fixture(tmp_path: Path) -> N
 
     assert proc.returncode == 0
     assert "OK mint2_navigation_spine_guard" in proc.stdout
+
+
+def test_navigation_spine_guard_passes_for_repo_flow() -> None:
+    assert mint2_navigation_spine_guard.check(REPO_ROOT) == []
 
 
 def test_navigation_spine_guard_fails_when_rvc_requires_auth(tmp_path: Path) -> None:
@@ -184,3 +194,237 @@ def test_navigation_spine_guard_fails_without_account_wall_positive_control(
     errors = mint2_navigation_spine_guard.check(tmp_path)
 
     assert any("must positively assert" in error for error in errors)
+
+
+def test_navigation_spine_guard_fails_without_direct_email_entry_control(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- runFlow:
+    when:
+      visible: "Cr\u00e9er avec e-mail"
+    commands:
+      - tapOn: "Cr\u00e9er avec e-mail"
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must reject the hidden email fallback CTA" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_if_fallback_cta_is_tapped(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+- tapOn: "Cr\u00e9er avec e-mail"
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must not tap the hidden email fallback CTA" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_if_block_form_fallback_cta_is_tapped(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+- tapOn:
+    text: "Cr\u00e9er avec e-mail"
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must not tap the hidden email fallback CTA" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_if_fallback_cta_is_branch_condition(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- runFlow:
+    when:
+      visible: "Cr\u00e9er avec e-mail"
+    commands:
+      - waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+- tapOn:
+    id: "auth_register_email_field"
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must not branch on hidden email fallback CTA" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_without_direct_email_field_probe(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must assert direct register email field visibility" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_without_direct_email_field_tap(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must tap the direct register email field by id" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_negative_assert_runs_too_early(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    register_flow = (
+        tmp_path
+        / "tools/simulator/flows/maestro-perfect-set/"
+        "flow_jos001_account_lifecycle_seeded_delete.yaml"
+    )
+    register_flow.write_text(
+        """
+appId: ch.mint.app
+---
+- extendedWaitUntil:
+    visible: "Cr\u00e9er ton compte"
+    timeout: 12000
+- assertNotVisible: "Cr\u00e9er avec e-mail"
+- extendedWaitUntil:
+    visible: { id: "auth_register_email_field" }
+    timeout: 8000
+""",
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must assert direct email field before rejecting" in error
+        for error in errors
+    )

--- a/tools/simulator/flows/maestro-perfect-set/flow_jos001_account_lifecycle_seeded_delete.yaml
+++ b/tools/simulator/flows/maestro-perfect-set/flow_jos001_account_lifecycle_seeded_delete.yaml
@@ -49,16 +49,12 @@ tags:
     timeout: 12000
 - waitForAnimationToEnd:
     timeout: 3000
-- runFlow:
-    when:
-      visible: "Créer avec e-mail"
-    commands:
-      - tapOn: "Créer avec e-mail"
 - extendedWaitUntil:
     visible: { id: "auth_register_email_field" }
     timeout: 8000
+- assertNotVisible: "Créer avec e-mail"
 - tapOn:
-    point: "185, 466"
+    id: "auth_register_email_field"
 - inputText: ${MINT_E2E_EMAIL}
 - waitForAnimationToEnd:
     timeout: 2000


### PR DESCRIPTION
## Summary
- tighten the JOS-001 account lifecycle Maestro flow so the register wall must expose `auth_register_email_field` directly
- fail if the old `Créer avec e-mail` fallback CTA appears, is used as a branch condition, or is tapped
- extend `mint2_navigation_spine_guard.py` plus guard tests so this TestFlight regression cannot silently return

## Stop The Bleeding scope
- No product code change.
- This PR turns the current account-entry behavior into a deterministic runtime contract.
- Dynamic PR-size note: 331 changed lines, mostly guard fixtures/tests; splitting would weaken reviewability because the flow and guard must land together.

## Verification
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/journey_os_check.py && python3 tools/checks/workflow_contract_guard.py && python3 tools/checks/verify_phase_acceptance.py`
- `python3 -m pytest tools/checks/tests/test_journey_os_check.py tools/checks/tests/test_journey_os_runtime_replay.py tools/checks/tests/test_mint2_navigation_spine_guard.py -q` -> 108 passed
- `./tools/mint-routes check && python3 tools/checks/screen_registry_parity.py && python3 tools/checks/screen_registry_three_way_parity.py && python3 tools/checks/mint2_navigation_spine_guard.py`
- `cd apps/mobile && flutter analyze test/screens/register_account_entry_test.dart && flutter test test/screens/auth_screens_smoke_test.dart test/screens/register_account_entry_test.dart --reporter compact` -> all tests passed
- `bash tools/simulator/journey_os_runtime_replay.sh --dry-run --set account_lifecycle`
- `bash tools/simulator/journey_os_runtime_replay.sh --requires-auth --set account_lifecycle` -> `true`

## Runtime caveat
Full `account_lifecycle` replay was not run locally because `MINT_E2E_EMAIL` and `MINT_E2E_PASSWORD` are not present in this shell. The replay is correctly classified as authenticated.

## Claude Opus audit
Ran `MINT_CLAUDE_MODEL=opus tools/claude_review.sh` repeatedly on the scoped diff. Opus found no blocking code findings. Non-blocking issues around assertion order, fallback block syntax, direct email tap, and repo-flow guard coverage were integrated before this PR.
