### PR TITLE
Fix Apple account error floor

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -94,11 +94,21 @@ String localizeAuthError(AuthError error, S l) {
 /// Translate an exception-like auth failure into localized UI copy.
 ///
 /// Use this in UI `catch` blocks instead of displaying `error.toString()`.
-String localizeAuthException(Object error, S l) {
-  return localizeAuthError(_authErrorFromException(error), l);
+String localizeAuthException(
+  Object error,
+  S l, {
+  bool appleContext = false,
+}) {
+  return localizeAuthError(
+    _authErrorFromException(error, appleContext: appleContext),
+    l,
+  );
 }
 
-AuthError _authErrorFromException(Object error) {
+AuthError _authErrorFromException(
+  Object error, {
+  bool appleContext = false,
+}) {
   final raw = error.toString().replaceAll('Exception: ', '').trim();
   final lower = raw.toLowerCase();
 
@@ -176,7 +186,7 @@ AuthError _authErrorFromException(Object error) {
     return AuthError.emailNotVerified;
   }
 
-  return AuthError.genericError;
+  return appleContext ? AuthError.serviceUnavailable : AuthError.genericError;
 }
 
 /// Provider for managing authentication state
@@ -825,7 +835,7 @@ class AuthProvider extends ChangeNotifier {
       notifyListeners();
       return true;
     } catch (e) {
-      _error = _toUserFriendlyAuthError(e);
+      _error = _toUserFriendlyAuthError(e, appleContext: true);
       _isLoading = false;
       notifyListeners();
       return false;
@@ -1394,7 +1404,10 @@ class AuthProvider extends ChangeNotifier {
     return generated;
   }
 
-  AuthError _toUserFriendlyAuthError(Object error) {
-    return _authErrorFromException(error);
+  AuthError _toUserFriendlyAuthError(
+    Object error, {
+    bool appleContext = false,
+  }) {
+    return _authErrorFromException(error, appleContext: appleContext);
   }
 }

--- a/apps/mobile/lib/screens/auth/register_screen.dart
+++ b/apps/mobile/lib/screens/auth/register_screen.dart
@@ -161,7 +161,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
         if (!mounted) return;
         setState(() {
           _appleSignInError = authProvider.error == null
-              ? S.of(context)!.authErrorGeneric
+              ? S.of(context)!.authErrorService
               : null;
           _showEmailForm = true;
         });
@@ -175,7 +175,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
       if (AppleSignInService.isCancellation(e)) return;
       if (mounted) {
         setState(() {
-          _appleSignInError = localizeAuthException(e, S.of(context)!);
+          _appleSignInError =
+              localizeAuthException(e, S.of(context)!, appleContext: true);
           _showEmailForm = true;
         });
       }

--- a/apps/mobile/test/providers/auth_provider_test.dart
+++ b/apps/mobile/test/providers/auth_provider_test.dart
@@ -689,17 +689,27 @@ void main() {
       },
     );
 
-    test('localizeAuthException hides raw technical exception text', () async {
+    test('localizeAuthException maps unknown Apple failures to service copy',
+        () async {
       final l10n = await S.delegate.load(const Locale('fr'));
 
-      final message = localizeAuthException(
+      for (final error in [
         Exception('Apple Sign-In returned no identity token'),
-        l10n,
-      );
+        Exception('Backend returned no access token for Apple Sign-In'),
+        const ApiException('Internal Server Error', statusCode: 500),
+      ]) {
+        final message = localizeAuthException(
+          error,
+          l10n,
+          appleContext: true,
+        );
 
-      expect(message, l10n.authErrorGeneric);
-      expect(message, isNot(contains('identity token')));
-      expect(message, isNot(contains('Apple Sign-In')));
+        expect(message, l10n.authErrorService, reason: error.toString());
+        expect(message, isNot(contains('identity token')));
+        expect(message, isNot(contains('access token')));
+        expect(message, isNot(contains('Apple Sign-In')));
+        expect(message, isNot(contains('Internal Server Error')));
+      }
     });
 
     test(
@@ -1302,6 +1312,20 @@ void main() {
         expect(provider.userId, 'apple-user');
         expect(provider.email, 'apple@example.ch');
         expect(provider.displayName, 'Apple User');
+      },
+    );
+
+    test(
+      'completeAppleSignIn maps malformed Apple response to service copy',
+      () async {
+        final ok = await provider.completeAppleSignIn({
+          'userId': 'apple-user',
+          'email': 'apple@example.ch',
+        }, claimAnonymousConversations: true);
+
+        expect(ok, isFalse);
+        expect(provider.error, AuthError.serviceUnavailable);
+        expect(provider.error, isNot(AuthError.genericError));
       },
     );
 


### PR DESCRIPTION
## Summary
- keep Apple account creation failures out of the generic auth banner
- add Apple-context auth error mapping for native/backend unknown failures
- cover malformed Apple verify responses and backend 5xx detail fallback

## Verification
- flutter test test/providers/auth_provider_test.dart
- flutter test test/screens/register_account_entry_test.dart
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- ./tools/mint-routes check
- python3 tools/checks/mint2_navigation_spine_guard.py
- python3 tools/checks/screen_registry_parity.py
- python3 tools/checks/screen_registry_three_way_parity.py
- git diff --check

## Audit
- Claude Opus static audit: NO BLOCKER

## Railway
- Railway CLI found at /opt/homebrew/bin/railway and linked to staging service; local OAuth refresh token is expired, so runtime logs require a fresh railway login.