### PR TITLE
Lock Mint2 Journey OS route spine

### DIFF
--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -178,6 +178,8 @@ ALLOW = {
     "services/backend/tests/test_rag_orchestrator_empty_text_no_fallback.py",
     "services/backend/tests/test_structured_reasoning.py",
     "tools/contracts/regen_screen_registry_contract.py",
+    "tools/simulator/mint2_quality_gate.sh",
+    "tools/simulator/test_mint2_quality_gate.py",
     "tools/contracts/screen_registry.json",
     "tools/simulator/flows/maestro-perfect-set/flow_row24_privacy_control_runtime.yaml",
     "tools/simulator/flows/maestro-perfect-set/flow_jos001_account_lifecycle_seeded_delete.yaml",

--- a/tools/checks/mint2_navigation_spine_guard.py
+++ b/tools/checks/mint2_navigation_spine_guard.py
@@ -8,6 +8,7 @@ route metadata, and the Maestro replay flow.
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -21,6 +22,12 @@ MINT2_FLOW = Path(
 REGISTER_FLOW = Path(
     "tools/simulator/flows/maestro-perfect-set/"
     "flow_jos001_account_lifecycle_seeded_delete.yaml"
+)
+JOURNEY_RECORD = Path(".planning/journeys/records/onboarding_first_value.json")
+JOURNEY_ISSUE = Path(".planning/journeys/issues/JOS-005.json")
+JOURNEY_DIAGRAMS = (
+    Path(".planning/journeys/diagrams/onboarding_first_value.mmd"),
+    Path(".planning/journeys/diagrams/onboarding_first_value_sequence.mmd"),
 )
 ACCOUNT_WALL_TITLE = "Cr\u00e9er ton compte"
 EMAIL_FALLBACK_CTA = "Cr\u00e9er avec e-mail"
@@ -69,6 +76,17 @@ ONBOARDING_COMPAT_ALIASES = {
     "/onboarding/plan": "/coach/chat",
     "/onboarding/smart": "/coach/chat",
     "/onboarding/minimal": "/coach/chat",
+}
+EXPECTED_JOURNEY_ROUTES = [
+    "/onb",
+    "/retraite/rente-vs-capital",
+    "/coach/chat",
+    "/home",
+]
+EXPECTED_JOURNEY_BUILD_DEFINES = {
+    "MINT_DISABLE_BETA_MODAL=true",
+    "MINT_E2E_MINT2_FIRST_EXPERIENCE=true",
+    "MINT_E2E_PROOF_ANCHORS=true",
 }
 
 
@@ -300,6 +318,103 @@ def _check_account_wall_positive_control(errors: list[str], root: Path) -> None:
         )
 
 
+def _read_json(
+    errors: list[str],
+    root: Path,
+    rel: Path,
+) -> dict[str, object] | None:
+    path = root / rel
+    if not path.exists():
+        errors.append(f"missing Journey OS contract file: {rel}")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{rel} must be valid JSON: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{rel} must contain a JSON object")
+        return None
+    return data
+
+
+def _check_journey_os_contract(errors: list[str], root: Path) -> None:
+    record = _read_json(errors, root, JOURNEY_RECORD)
+    issue = _read_json(errors, root, JOURNEY_ISSUE)
+    if record is None or issue is None:
+        return
+
+    if record.get("id") != "onboarding_first_value":
+        errors.append(
+            f"{JOURNEY_RECORD} must describe onboarding_first_value; "
+            f"found {record.get('id') or '<missing>'}"
+        )
+    routes = record.get("route_paths")
+    if routes != EXPECTED_JOURNEY_ROUTES:
+        errors.append(
+            "onboarding_first_value route_paths must be "
+            f"{EXPECTED_JOURNEY_ROUTES}; found {routes!r}"
+        )
+
+    runtime = record.get("runtime_replay")
+    if not isinstance(runtime, dict):
+        errors.append("onboarding_first_value runtime_replay must be an object")
+        runtime = {}
+    expected_flow = MINT2_FLOW.as_posix()
+    if runtime.get("flow") != expected_flow:
+        errors.append(
+            "onboarding_first_value runtime_replay.flow must be "
+            f"{expected_flow}; found {runtime.get('flow') or '<missing>'}"
+        )
+    if runtime.get("requires_auth") is not False:
+        errors.append(
+            "onboarding_first_value runtime_replay.requires_auth must be false"
+        )
+    sets = runtime.get("sets")
+    if not isinstance(sets, list) or "core" not in sets:
+        errors.append("onboarding_first_value runtime_replay.sets must include core")
+    build_defines = runtime.get("build_defines")
+    if not isinstance(build_defines, list):
+        errors.append("onboarding_first_value runtime_replay.build_defines must be a list")
+        build_defines_set: set[str] = set()
+    else:
+        build_defines_set = {str(item) for item in build_defines}
+    missing_defines = sorted(EXPECTED_JOURNEY_BUILD_DEFINES - build_defines_set)
+    if missing_defines:
+        errors.append(
+            "onboarding_first_value runtime_replay.build_defines missing "
+            f"{missing_defines}"
+        )
+
+    if "JOS-005" not in set(map(str, record.get("issues", []))):
+        errors.append("onboarding_first_value issues must include JOS-005")
+    if issue.get("journey_id") != "onboarding_first_value":
+        errors.append(
+            f"{JOURNEY_ISSUE} must point to onboarding_first_value; "
+            f"found {issue.get('journey_id') or '<missing>'}"
+        )
+
+    forbidden_aliases = set(RVC_ALIASES)
+    for rel in JOURNEY_DIAGRAMS:
+        path = root / rel
+        if not path.exists():
+            errors.append(f"missing Journey OS Mermaid diagram: {rel}")
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for route in EXPECTED_JOURNEY_ROUTES:
+            if route not in text:
+                errors.append(f"{rel.name} must include {route}")
+        for alias in sorted(forbidden_aliases):
+            alias_pattern = re.compile(
+                rf"(?<![A-Za-z0-9_-]){re.escape(alias)}(?![A-Za-z0-9_/-])"
+            )
+            if alias_pattern.search(text):
+                errors.append(
+                    f"{rel.name} must not promote legacy alias {alias}; "
+                    "use /retraite/rente-vs-capital in the Journey OS spine"
+                )
+
+
 def check(root: Path) -> list[str]:
     root = root.resolve()
     errors: list[str] = []
@@ -320,6 +435,7 @@ def check(root: Path) -> list[str]:
 
     _check_maestro_flow(errors, root)
     _check_account_wall_positive_control(errors, root)
+    _check_journey_os_contract(errors, root)
     return errors
 
 

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -360,6 +360,8 @@ def test_jos005_first_value_hotfix_scope_is_in_scope(tmp_path: Path) -> None:
             "services/backend/tests/test_coach_tools.py",
             "tools/contracts/regen_screen_registry_contract.py",
             "tools/contracts/screen_registry.json",
+            "tools/simulator/mint2_quality_gate.sh",
+            "tools/simulator/test_mint2_quality_gate.py",
         ],
     )
 

--- a/tools/checks/tests/test_mint2_navigation_spine_guard.py
+++ b/tools/checks/tests/test_mint2_navigation_spine_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -21,6 +22,9 @@ def _run(root: Path) -> subprocess.CompletedProcess[str]:
 def _write_fixture(root: Path) -> None:
     (root / "apps/mobile/lib/routes").mkdir(parents=True)
     (root / "tools/simulator/flows/maestro-perfect-set").mkdir(parents=True)
+    (root / ".planning/journeys/records").mkdir(parents=True)
+    (root / ".planning/journeys/issues").mkdir(parents=True)
+    (root / ".planning/journeys/diagrams").mkdir(parents=True)
 
     (root / "apps/mobile/lib/routes/route_metadata.dart").write_text(
         """
@@ -107,6 +111,84 @@ appId: ch.mint.app
 """,
         encoding="utf-8",
     )
+    (root / ".planning/journeys/records/onboarding_first_value.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "id": "onboarding_first_value",
+                "title": "Onboarding first value",
+                "status": "partial",
+                "runtime_replay": {
+                    "flow": flow,
+                    "sets": ["core"],
+                    "requires_auth": False,
+                    "build_defines": [
+                        "MINT_DISABLE_BETA_MODAL=true",
+                        "MINT_E2E_MINT2_FIRST_EXPERIENCE=true",
+                        "MINT_E2E_PROOF_ANCHORS=true",
+                    ],
+                },
+                "route_paths": [
+                    "/onb",
+                    "/retraite/rente-vs-capital",
+                    "/coach/chat",
+                    "/home",
+                ],
+                "issues": ["JOS-005"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / ".planning/journeys/issues/JOS-005.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "id": "JOS-005",
+                "journey_id": "onboarding_first_value",
+                "status": "verified",
+                "evidence_status": "green",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / ".planning/journeys/diagrams/onboarding_first_value.mmd").write_text(
+        """
+%% Generated from .planning/journeys/records/onboarding_first_value.json
+flowchart TD
+  route_onb["/onb"]
+  route_retraite_rente_vs_capital["/retraite/rente-vs-capital"]
+  route_coach_chat["/coach/chat"]
+  route_home["/home"]
+  issue_JOS_005["JOS-005 verified/green"]
+""",
+        encoding="utf-8",
+    )
+    (
+        root / ".planning/journeys/diagrams/onboarding_first_value_sequence.mmd"
+    ).write_text(
+        f"""
+%% Generated from .planning/journeys/records/onboarding_first_value.json
+sequenceDiagram
+  Journey->>Routes: /onb, /retraite/rente-vs-capital, /coach/chat, /home
+  Journey->>Evidence: replay core / no-auth / MINT iPhone 13 mini RvC / {flow}
+  Evidence-->>Journey: issues JOS-005
+""",
+        encoding="utf-8",
+    )
+    (root / ".planning/journeys/diagrams/route_topology.mmd").write_text(
+        """
+flowchart LR
+  route__onb["/onb<br/>destination/anonymous<br/>public"]
+  route__retraite_rente_vs_capital["/retraite/rente-vs-capital<br/>destination/retraite<br/>public"]
+  route__rente_vs_capital["/rente-vs-capital<br/>alias/system<br/>public"]
+  route__arbitrage_rente_vs_capital["/arbitrage/rente-vs-capital<br/>alias/system<br/>public"]
+  route__simulator_rente_capital["/simulator/rente-capital<br/>alias/system<br/>public"]
+  route__rente_vs_capital -. redirects .-> route__retraite_rente_vs_capital
+  route__arbitrage_rente_vs_capital -. redirects .-> route__retraite_rente_vs_capital
+  route__simulator_rente_capital -. redirects .-> route__retraite_rente_vs_capital
+""",
+        encoding="utf-8",
+    )
 
 
 def test_navigation_spine_guard_passes_for_coherent_fixture(tmp_path: Path) -> None:
@@ -121,6 +203,171 @@ def test_navigation_spine_guard_passes_for_coherent_fixture(tmp_path: Path) -> N
 
 def test_navigation_spine_guard_passes_for_repo_flow() -> None:
     assert mint2_navigation_spine_guard.check(REPO_ROOT) == []
+
+
+def test_navigation_spine_guard_fails_when_journey_os_uses_legacy_rvc_alias(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    record = tmp_path / ".planning/journeys/records/onboarding_first_value.json"
+    data = json.loads(record.read_text(encoding="utf-8"))
+    data["route_paths"] = [
+        "/onb",
+        "/rente-vs-capital",
+        "/coach/chat",
+        "/home",
+    ]
+    record.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value route_paths must be" in error for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_os_points_to_wrong_flow(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    record = tmp_path / ".planning/journeys/records/onboarding_first_value.json"
+    data = json.loads(record.read_text(encoding="utf-8"))
+    data["runtime_replay"]["flow"] = (
+        "tools/simulator/flows/maestro-perfect-set/legacy_route.yaml"
+    )
+    record.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value runtime_replay.flow must be" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_os_requires_auth(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    record = tmp_path / ".planning/journeys/records/onboarding_first_value.json"
+    data = json.loads(record.read_text(encoding="utf-8"))
+    data["runtime_replay"]["requires_auth"] = True
+    record.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value runtime_replay.requires_auth must be false"
+        in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_os_loses_core_set(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    record = tmp_path / ".planning/journeys/records/onboarding_first_value.json"
+    data = json.loads(record.read_text(encoding="utf-8"))
+    data["runtime_replay"]["sets"] = ["top"]
+    record.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value runtime_replay.sets must include core" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_os_loses_e2e_defines(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    record = tmp_path / ".planning/journeys/records/onboarding_first_value.json"
+    data = json.loads(record.read_text(encoding="utf-8"))
+    data["runtime_replay"]["build_defines"] = ["MINT_DISABLE_BETA_MODAL=true"]
+    record.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value runtime_replay.build_defines missing" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_allows_honest_jos005_regression_state(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    issue = tmp_path / ".planning/journeys/issues/JOS-005.json"
+    data = json.loads(issue.read_text(encoding="utf-8"))
+    data["status"] = "regressed"
+    data["evidence_status"] = "red"
+    issue.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert errors == []
+
+
+def test_navigation_spine_guard_fails_when_jos005_points_elsewhere(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    issue = tmp_path / ".planning/journeys/issues/JOS-005.json"
+    data = json.loads(issue.read_text(encoding="utf-8"))
+    data["journey_id"] = "another_journey"
+    issue.write_text(json.dumps(data), encoding="utf-8")
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "JOS-005.json must point to onboarding_first_value" in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_mermaid_omits_route(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    diagram = tmp_path / ".planning/journeys/diagrams/onboarding_first_value.mmd"
+    diagram.write_text(
+        diagram.read_text(encoding="utf-8").replace(
+            'route_retraite_rente_vs_capital["/retraite/rente-vs-capital"]',
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "onboarding_first_value.mmd must include /retraite/rente-vs-capital"
+        in error
+        for error in errors
+    )
+
+
+def test_navigation_spine_guard_fails_when_journey_mermaid_promotes_alias(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    diagram = tmp_path / ".planning/journeys/diagrams/onboarding_first_value.mmd"
+    diagram.write_text(
+        diagram.read_text(encoding="utf-8")
+        + '\n  route_legacy["/rente-vs-capital"]\n',
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "must not promote legacy alias /rente-vs-capital" in error
+        for error in errors
+    )
 
 
 def test_navigation_spine_guard_fails_when_rvc_requires_auth(tmp_path: Path) -> None:

--- a/tools/simulator/mint2_quality_gate.sh
+++ b/tools/simulator/mint2_quality_gate.sh
@@ -59,7 +59,8 @@ if [ "$DRY_RUN" -eq 1 ]; then
 
 Build:
   xattr -cr apps/mobile/build/ios
-  rm -rf apps/mobile/build/ios/Debug-iphonesimulator/App.framework
+  mv apps/mobile/build/ios/Debug-iphonesimulator/App.framework \
+    ${TMPDIR:-/tmp}/mint-stale-App.framework-<run-id>-<pid>
 
   CODE_SIGNING_ALLOWED=NO flutter build ios --simulator --no-codesign \\
     --dart-define=API_BASE_URL=$API_BASE_URL \\
@@ -194,9 +195,10 @@ scrub_ios_build_xattrs() {
     fi
   fi
   if [ -d "$app_framework" ]; then
-    log "removing stale generated App.framework before simulator build"
+    local stale_app_framework="${TMPDIR:-/tmp}/mint-stale-App.framework-$RUN_ID-$$"
+    log "moving stale generated App.framework before simulator build"
     /usr/bin/codesign --remove-signature "$app_framework" 2>/dev/null || true
-    rm -rf "$app_framework"
+    mv "$app_framework" "$stale_app_framework"
   fi
 }
 
@@ -246,7 +248,7 @@ DEVICE_UDID="$(resolve_device_udid)"
 log "booting only $DEVICE_NAME ($DEVICE_UDID)"
 xcrun simctl shutdown all >/dev/null 2>&1 || true
 xcrun simctl boot "$DEVICE_UDID"
-open -a Simulator
+open -a Simulator || true
 xcrun simctl bootstatus "$DEVICE_UDID" -b
 
 log "resetting simulator keychain"

--- a/tools/simulator/test_mint2_quality_gate.py
+++ b/tools/simulator/test_mint2_quality_gate.py
@@ -65,6 +65,19 @@ def test_mint2_quality_gate_combines_layout_and_committed_maestro_flows():
         assert fragment in src, f"quality gate missing: {fragment}"
 
 
+def test_mint2_quality_gate_does_not_delete_stale_app_framework():
+    src = _read_gate()
+
+    assert "rm -rf apps/mobile/build/ios/Debug-iphonesimulator/App.framework" not in src
+    assert 'rm -rf "$app_framework"' not in src
+
+
+def test_mint2_quality_gate_simulator_app_open_is_non_blocking():
+    src = _read_gate()
+
+    assert "open -a Simulator || true" in src
+
+
 def test_mint2_quality_gate_dry_run_lists_contract():
     result = subprocess.run(
         ["bash", str(GATE), "--dry-run"],


### PR DESCRIPTION
## Summary
- lock `mint2_navigation_spine_guard` to the Journey OS `onboarding_first_value` contract and Mermaid spine
- require the canonical route path `/onb -> /retraite/rente-vs-capital -> /coach/chat -> /home` plus the exact no-auth runtime replay flow
- make the local Mint2 quality gate non-destructive for stale `App.framework` cleanup and tolerant of Simulator.app open timeouts

## Verification
- `python3 -m pytest tools/checks/tests/test_mint2_navigation_spine_guard.py tools/simulator/test_mint2_quality_gate.py tools/checks/tests/test_journey_os_check.py -q`
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/journey_os_check.py`
- `python3 tools/checks/workflow_contract_guard.py`
- `python3 tools/checks/verify_phase_acceptance.py`
- `python3 tools/checks/mint2_navigation_spine_guard.py`
- `bash tools/simulator/mint2_quality_gate.sh --dry-run`
- `bash tools/simulator/mint2_quality_gate.sh` PASS, evidence `.planning/runtime-evidence/mint2-quality-gate-20260630T070144Z`

## Review
- Opus audit reviewed the gate. Follow-up applied: the navigation guard no longer requires `JOS-005` to be green, so honest red/regressed Journey OS evidence can still be committed; `journey_os_check` owns evidence-state policy.