### PR TITLE
Make Journey OS replay cleanup non-destructive

### DIFF
--- a/tools/checks/tests/test_journey_os_runtime_replay.py
+++ b/tools/checks/tests/test_journey_os_runtime_replay.py
@@ -193,6 +193,41 @@ def test_replay_script_does_not_expand_empty_auth_env_array() -> None:
     assert '"${maestro_env[@]}" \\' not in text
 
 
+def test_replay_script_does_not_delete_stale_app_framework() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'rm -rf "$app_framework"' not in text
+    assert 'codesign --remove-signature "$app_framework"' not in text
+    assert 'local mobile_build_dir="$ROOT/apps/mobile/build"' in text
+    assert 'local ios_build_dir="$mobile_build_dir/ios"' in text
+    assert 'local stale_stamp="${STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"' in text
+    assert '[[ ! "$stale_stamp" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]' in text
+    assert 'local stale_dir="$mobile_build_dir/.mint-stale-app-frameworks/ios"' in text
+    assert 'local stale_dir="$ios_build_dir/.mint-stale-app-frameworks"' not in text
+    assert 'mkdir -p "$stale_dir"' in text
+    assert 'mktemp -d "$stale_dir/app-framework-$stale_stamp-XXXXXX"' in text
+    assert 'local stale_app_framework="$stale_parent/App.framework"' in text
+    assert 'stale_app_framework="$stale_dir/app-framework-$stale_stamp-$$"' not in text
+    assert "failed to create stale App.framework destination" in text
+    assert 'mv "$app_framework" "$stale_app_framework"' in text
+    assert "failed to move stale App.framework" in text
+
+
+def test_replay_stale_app_framework_directory_is_gitignored() -> None:
+    proc = subprocess.run(
+        [
+            "git",
+            "check-ignore",
+            "apps/mobile/build/.mint-stale-app-frameworks/ios/app-framework-20260630T000000Z-ABCDEF/App.framework",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_replay_script_requires_clean_worktree_for_real_evidence() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 

--- a/tools/simulator/journey_os_runtime_replay.sh
+++ b/tools/simulator/journey_os_runtime_replay.sh
@@ -200,7 +200,8 @@ clear_extended_attributes() {
 }
 
 scrub_ios_build_xattrs() {
-  local ios_build_dir="$ROOT/apps/mobile/build/ios"
+  local mobile_build_dir="$ROOT/apps/mobile/build"
+  local ios_build_dir="$mobile_build_dir/ios"
   local app_framework="$ios_build_dir/Debug-iphonesimulator/App.framework"
   local flutter_root=""
   local flutter_xcframework=""
@@ -212,8 +213,23 @@ scrub_ios_build_xattrs() {
   flutter_xcframework="$flutter_root/bin/cache/artifacts/engine/ios/Flutter.xcframework"
   clear_extended_attributes "$flutter_xcframework"
   if [[ -d "$app_framework" ]]; then
-    /usr/bin/codesign --remove-signature "$app_framework" 2>/dev/null || true
-    rm -rf "$app_framework"
+    local stale_stamp="${STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+    if [[ ! "$stale_stamp" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+      echo "invalid stale App.framework stamp: $stale_stamp" >&2
+      exit 1
+    fi
+    local stale_dir="$mobile_build_dir/.mint-stale-app-frameworks/ios"
+    mkdir -p "$stale_dir"
+    local stale_parent=""
+    stale_parent="$(mktemp -d "$stale_dir/app-framework-$stale_stamp-XXXXXX")" || {
+      echo "failed to create stale App.framework destination under $stale_dir" >&2
+      exit 1
+    }
+    local stale_app_framework="$stale_parent/App.framework"
+    mv "$app_framework" "$stale_app_framework" || {
+      echo "failed to move stale App.framework to $stale_app_framework" >&2
+      exit 1
+    }
   fi
 }
 


### PR DESCRIPTION
## Summary
- replace the Journey OS replay `rm -rf \"$app_framework\"` cleanup with a non-destructive move-aside under `apps/mobile/build/.mint-stale-app-frameworks/ios`
- validate the replay stamp before using it in a filesystem path
- use `mktemp -d` for collision-safe quarantine directories and fail explicitly on move/setup errors
- add tests that lock the non-destructive contract and gitignored quarantine path

## Verification
- `python3 -m pytest tools/checks/tests/test_journey_os_runtime_replay.py -q` -> 21 passed
- `bash tools/simulator/journey_os_runtime_replay.sh --dry-run --set top` -> lists `coach_advice_turn`
- `git diff --check --cached`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/journey_os_check.py && python3 tools/checks/workflow_contract_guard.py`
- Claude Opus audit: no blocking findings

## Residual
- Opus noted unbounded accumulation of quarantined `App.framework` copies. This PR intentionally does not add pruning because this session is operating under a no-destructive-cleanup rule. The copies remain under Flutter `build/` and are disposable via normal build cleanup outside this runtime proof path.