### PR TITLE
Map Journey OS route scopes from runtime

### DIFF
--- a/.planning/journeys/diagrams/route_topology.mmd
+++ b/.planning/journeys/diagrams/route_topology.mmd
@@ -4,25 +4,26 @@ flowchart LR
   classDef alias fill:#f5f5f5,stroke:#616161,color:#212121,stroke-dasharray: 4 3;
   classDef auth fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;
   classDef public fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;
-  route__achievements["/achievements<br/>alias/system<br/>auth"]
+  classDef onboarding fill:#ede7f6,stroke:#4527a0,color:#1a0f4f;
+  route__achievements["/achievements<br/>alias/system<br/>authenticated"]
   class route__achievements alias
   class route__achievements auth
-  route__advisor["/advisor<br/>alias/system<br/>auth"]
+  route__advisor["/advisor<br/>alias/system<br/>authenticated"]
   class route__advisor alias
   class route__advisor auth
-  route__advisor_plan_30_days["/advisor/plan-30-days<br/>alias/system<br/>auth"]
+  route__advisor_plan_30_days["/advisor/plan-30-days<br/>alias/system<br/>authenticated"]
   class route__advisor_plan_30_days alias
   class route__advisor_plan_30_days auth
-  route__advisor_wizard["/advisor/wizard<br/>alias/system<br/>auth"]
+  route__advisor_wizard["/advisor/wizard<br/>alias/system<br/>authenticated"]
   class route__advisor_wizard alias
   class route__advisor_wizard auth
   route__anonymous_chat["/anonymous/chat<br/>alias/anonymous<br/>public"]
   class route__anonymous_chat alias
   class route__anonymous_chat public
-  route__arbitrage_rente_vs_capital["/arbitrage/rente-vs-capital<br/>alias/system<br/>public"]
+  route__arbitrage_rente_vs_capital["/arbitrage/rente-vs-capital<br/>alias/system<br/>onboarding"]
   class route__arbitrage_rente_vs_capital alias
-  class route__arbitrage_rente_vs_capital public
-  route__ask_mint["/ask-mint<br/>alias/system<br/>auth"]
+  class route__arbitrage_rente_vs_capital onboarding
+  route__ask_mint["/ask-mint<br/>alias/system<br/>authenticated"]
   class route__ask_mint alias
   class route__ask_mint auth
   route__auth_forgot_password["/auth/forgot-password<br/>flow/auth<br/>public"]
@@ -34,91 +35,91 @@ flowchart LR
   route__auth_register["/auth/register<br/>flow/auth<br/>public"]
   class route__auth_register route
   class route__auth_register public
-  route__budget["/budget<br/>destination/budget<br/>auth<br/>flag enableBudget"]
+  route__budget["/budget<br/>destination/budget<br/>authenticated<br/>flag enableBudget"]
   class route__budget route
   class route__budget auth
-  route__coach_agir["/coach/agir<br/>alias/coach<br/>auth"]
+  route__coach_agir["/coach/agir<br/>alias/coach<br/>authenticated"]
   class route__coach_agir alias
   class route__coach_agir auth
   route__coach_chat["/coach/chat<br/>destination/coach<br/>public<br/>flag enableCoachChat"]
   class route__coach_chat route
   class route__coach_chat public
-  route__coach_checkin["/coach/checkin<br/>alias/coach<br/>auth"]
+  route__coach_checkin["/coach/checkin<br/>alias/coach<br/>authenticated"]
   class route__coach_checkin alias
   class route__coach_checkin auth
-  route__coach_refresh["/coach/refresh<br/>alias/coach<br/>auth"]
+  route__coach_refresh["/coach/refresh<br/>alias/coach<br/>authenticated"]
   class route__coach_refresh alias
   class route__coach_refresh auth
-  route__home["/home<br/>destination/system<br/>auth"]
+  route__home["/home<br/>destination/system<br/>authenticated"]
   class route__home route
   class route__home auth
-  route__mon_argent["/mon-argent<br/>destination/system<br/>auth"]
+  route__mon_argent["/mon-argent<br/>destination/system<br/>authenticated"]
   class route__mon_argent route
   class route__mon_argent auth
   route__onb["/onb<br/>destination/anonymous<br/>public"]
   class route__onb route
   class route__onb public
-  route__onboarding_intent["/onboarding/intent<br/>alias/system<br/>public"]
+  route__onboarding_intent["/onboarding/intent<br/>alias/system<br/>onboarding"]
   class route__onboarding_intent alias
-  class route__onboarding_intent public
-  route__onboarding_minimal["/onboarding/minimal<br/>alias/system<br/>public"]
+  class route__onboarding_intent onboarding
+  route__onboarding_minimal["/onboarding/minimal<br/>alias/system<br/>onboarding"]
   class route__onboarding_minimal alias
-  class route__onboarding_minimal public
-  route__onboarding_plan["/onboarding/plan<br/>alias/system<br/>public"]
+  class route__onboarding_minimal onboarding
+  route__onboarding_plan["/onboarding/plan<br/>alias/system<br/>onboarding"]
   class route__onboarding_plan alias
-  class route__onboarding_plan public
-  route__onboarding_premier_eclairage["/onboarding/premier-eclairage<br/>alias/system<br/>public"]
+  class route__onboarding_plan onboarding
+  route__onboarding_premier_eclairage["/onboarding/premier-eclairage<br/>alias/system<br/>onboarding"]
   class route__onboarding_premier_eclairage alias
-  class route__onboarding_premier_eclairage public
-  route__onboarding_promise["/onboarding/promise<br/>alias/system<br/>public"]
+  class route__onboarding_premier_eclairage onboarding
+  route__onboarding_promise["/onboarding/promise<br/>alias/system<br/>onboarding"]
   class route__onboarding_promise alias
-  class route__onboarding_promise public
-  route__onboarding_quick["/onboarding/quick<br/>alias/system<br/>public"]
+  class route__onboarding_promise onboarding
+  route__onboarding_quick["/onboarding/quick<br/>alias/system<br/>onboarding"]
   class route__onboarding_quick alias
-  class route__onboarding_quick public
-  route__onboarding_quick_start["/onboarding/quick-start<br/>alias/system<br/>public"]
+  class route__onboarding_quick onboarding
+  route__onboarding_quick_start["/onboarding/quick-start<br/>alias/system<br/>onboarding"]
   class route__onboarding_quick_start alias
-  class route__onboarding_quick_start public
-  route__onboarding_smart["/onboarding/smart<br/>alias/system<br/>public"]
+  class route__onboarding_quick_start onboarding
+  route__onboarding_smart["/onboarding/smart<br/>alias/system<br/>onboarding"]
   class route__onboarding_smart alias
-  class route__onboarding_smart public
-  route__portfolio["/portfolio<br/>alias/system<br/>auth"]
+  class route__onboarding_smart onboarding
+  route__portfolio["/portfolio<br/>alias/system<br/>authenticated"]
   class route__portfolio alias
   class route__portfolio auth
-  route__profile_privacy["/profile/privacy<br/>destination/system<br/>auth"]
+  route__profile_privacy["/profile/privacy<br/>destination/system<br/>authenticated"]
   class route__profile_privacy route
   class route__profile_privacy auth
-  route__profile_privacy_control["/profile/privacy-control<br/>destination/system<br/>auth"]
+  route__profile_privacy_control["/profile/privacy-control<br/>destination/system<br/>authenticated"]
   class route__profile_privacy_control route
   class route__profile_privacy_control auth
-  route__rapport["/rapport<br/>destination/system<br/>auth"]
+  route__rapport["/rapport<br/>destination/system<br/>authenticated"]
   class route__rapport route
   class route__rapport auth
-  route__rente_vs_capital["/rente-vs-capital<br/>alias/system<br/>public"]
+  route__rente_vs_capital["/rente-vs-capital<br/>alias/system<br/>onboarding"]
   class route__rente_vs_capital alias
-  class route__rente_vs_capital public
-  route__report["/report<br/>alias/system<br/>auth"]
+  class route__rente_vs_capital onboarding
+  route__report["/report<br/>alias/system<br/>authenticated"]
   class route__report alias
   class route__report auth
-  route__report_v2["/report/v2<br/>alias/system<br/>auth"]
+  route__report_v2["/report/v2<br/>alias/system<br/>authenticated"]
   class route__report_v2 alias
   class route__report_v2 auth
-  route__retraite_rente_vs_capital["/retraite/rente-vs-capital<br/>destination/retraite<br/>public<br/>flag enableExplorerRetraite"]
+  route__retraite_rente_vs_capital["/retraite/rente-vs-capital<br/>destination/retraite<br/>onboarding<br/>flag enableExplorerRetraite"]
   class route__retraite_rente_vs_capital route
-  class route__retraite_rente_vs_capital public
-  route__score_reveal["/score-reveal<br/>alias/system<br/>auth"]
+  class route__retraite_rente_vs_capital onboarding
+  route__score_reveal["/score-reveal<br/>alias/system<br/>authenticated"]
   class route__score_reveal alias
   class route__score_reveal auth
-  route__settings_confidentialite["/settings/confidentialite<br/>destination/system<br/>auth"]
+  route__settings_confidentialite["/settings/confidentialite<br/>destination/system<br/>authenticated"]
   class route__settings_confidentialite route
   class route__settings_confidentialite auth
-  route__simulator_rente_capital["/simulator/rente-capital<br/>alias/system<br/>public"]
+  route__simulator_rente_capital["/simulator/rente-capital<br/>alias/system<br/>onboarding"]
   class route__simulator_rente_capital alias
-  class route__simulator_rente_capital public
+  class route__simulator_rente_capital onboarding
   route__start["/start<br/>alias/anonymous<br/>public"]
   class route__start alias
   class route__start public
-  route__tools["/tools<br/>alias/system<br/>auth"]
+  route__tools["/tools<br/>alias/system<br/>authenticated"]
   class route__tools alias
   class route__tools auth
   route__achievements -. redirects .-> route__home

--- a/tools/checks/journey_os_generate.py
+++ b/tools/checks/journey_os_generate.py
@@ -18,6 +18,7 @@ DIAGRAMS = JOURNEYS / "diagrams"
 SYSTEM_MAP = DIAGRAMS / "system_map.mmd"
 ROUTE_TOPOLOGY = DIAGRAMS / "route_topology.mmd"
 JOURNEY_STATE = DIAGRAMS / "journey_state.mmd"
+APP = Path("apps/mobile/lib/app.dart")
 PRIORITY_POSITIVE = {"trust_blast_radius", "release_blocker_weight", "user_frequency", "evidence_gap", "route_centrality", "compliance_risk", "learning_value"}
 EVIDENCE_STATUS_RANK = {"red": 0, "missing": 1, "baselined": 2, "green": 3}
 
@@ -310,8 +311,216 @@ def _route_target(meta: dict[str, str]) -> str:
     match = re.search(r"(?:redirects?\s+(?:to\s+)?|->\s*)(/[A-Za-z0-9_/:.-]+)", description, re.IGNORECASE)
     return match.group(1).rstrip(".,;") if match else ""
 
+def _strip_dart_comments(source: str) -> str:
+    cleaned: list[str] = []
+    index = 0
+    quote: str | None = None
+    escaped = False
+    while index < len(source):
+        char = source[index]
+        nxt = source[index + 1] if index + 1 < len(source) else ""
+        if quote:
+            cleaned.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            cleaned.append(char)
+            index += 1
+            continue
+        if char == "/" and nxt == "/":
+            cleaned.extend("  ")
+            index += 2
+            while index < len(source) and source[index] != "\n":
+                cleaned.append(" ")
+                index += 1
+            continue
+        if char == "/" and nxt == "*":
+            cleaned.extend("  ")
+            index += 2
+            while index < len(source):
+                if index + 1 < len(source) and source[index] == "*" and source[index + 1] == "/":
+                    cleaned.extend("  ")
+                    index += 2
+                    break
+                cleaned.append("\n" if source[index] == "\n" else " ")
+                index += 1
+            continue
+        cleaned.append(char)
+        index += 1
+    return "".join(cleaned)
+
+def _find_call_spans(source: str, call_name: str) -> list[tuple[int, int, str]]:
+    spans: list[tuple[int, int, str]] = []
+    index = 0
+    needle = f"{call_name}("
+    while True:
+        start = source.find(needle, index)
+        if start == -1:
+            return spans
+        pos = start + len(call_name)
+        depth = 0
+        quote: str | None = None
+        escaped = False
+        for cursor in range(pos, len(source)):
+            char = source[cursor]
+            if quote:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == quote:
+                    quote = None
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                continue
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    spans.append((start, cursor + 1, source[start : cursor + 1]))
+                    index = start + len(needle)
+                    break
+        else:
+            return spans
+
+def _join_route(parent: str, route: str) -> str:
+    if route.startswith("/"):
+        return route
+    if not parent:
+        return route
+    return f"{parent.rstrip('/')}/{route.lstrip('/')}"
+
+def _top_level_arg(block: str, name: str) -> str:
+    open_paren = block.find("(")
+    if open_paren == -1 or not block.endswith(")"):
+        return ""
+    body = block[open_paren + 1 : -1]
+    quote: str | None = None
+    escaped = False
+    depth = 0
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char in "([{":
+            depth += 1
+            index += 1
+            continue
+        if char in ")]}":
+            depth = max(0, depth - 1)
+            index += 1
+            continue
+        if depth == 0:
+            match = re.match(rf"\b{re.escape(name)}\s*:\s*", body[index:])
+            if match:
+                value_start = index + match.end()
+                value_end = _top_level_value_end(body, value_start)
+                return body[value_start:value_end].strip()
+        index += 1
+    return ""
+
+def _top_level_value_end(body: str, start: int) -> int:
+    quote: str | None = None
+    escaped = False
+    depth = 0
+    for index in range(start, len(body)):
+        char = body[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in "([{":
+            depth += 1
+            continue
+        if char in ")]}":
+            depth = max(0, depth - 1)
+            continue
+        if char == "," and depth == 0:
+            return index
+    return len(body)
+
+def _route_arg(block: str, name: str) -> str:
+    value = _top_level_arg(block, name)
+    if not value:
+        return ""
+    quoted = re.match(r"""(['"])(.*?)\1$""", value, re.DOTALL)
+    if quoted:
+        return quoted.group(2)
+    enum_or_bool = re.match(r"(Route(?:Scope|Category|Owner)\.[A-Za-z0-9_]+|true|false)\b", value)
+    if enum_or_bool:
+        return enum_or_bool.group(1).split(".")[-1]
+    return ""
+
+def _route_scopes(root: Path) -> dict[str, str]:
+    path = root / APP
+    try:
+        source = _strip_dart_comments(path.read_text(encoding="utf-8", errors="ignore"))
+    except OSError:
+        return {}
+    scopes: dict[str, str] = {}
+    resolved: list[tuple[int, int, str]] = []
+    for start, end, block in _find_call_spans(source, "ScopedGoRoute"):
+        route_arg = _route_arg(block, "path")
+        if not route_arg:
+            continue
+        parent = ""
+        for parent_start, parent_end, parent_route in reversed(resolved):
+            if parent_start < start and end <= parent_end:
+                parent = parent_route
+                break
+        route = _join_route(parent, route_arg)
+        scopes[route] = _route_arg(block, "scope") or "authenticated"
+        resolved.append((start, end, route))
+    return scopes
+
+def _route_access_label(meta: dict[str, str], scope: str) -> str:
+    if scope:
+        return scope
+    auth = meta.get("requiresAuth", "unknown")
+    if auth == "true":
+        return "authenticated"
+    if auth == "false":
+        return "public"
+    return "auth unknown"
+
+def _route_access_class(label: str) -> str:
+    if label == "authenticated":
+        return "auth"
+    if label in {"public", "onboarding"}:
+        return label
+    return "route"
+
 def route_topology(root: Path, records: list[dict[str, Any]]) -> str:
     meta = _route_metadata(root)
+    scopes = _route_scopes(root)
     included = {
         str(route)
         for rec in records
@@ -330,20 +539,20 @@ def route_topology(root: Path, records: list[dict[str, Any]]) -> str:
         "  classDef alias fill:#f5f5f5,stroke:#616161,color:#212121,stroke-dasharray: 4 3;",
         "  classDef auth fill:#fff8e1,stroke:#ff8f00,color:#5f3b00;",
         "  classDef public fill:#e8f5e9,stroke:#1b5e20,color:#0b3d1a;",
+        "  classDef onboarding fill:#ede7f6,stroke:#4527a0,color:#1a0f4f;",
     ]
     for route in sorted(included):
         item = meta.get(route, {})
         node = "route__" + _node(route)
         category = item.get("category", "unknown")
         owner = item.get("owner", "unknown")
-        auth = item.get("requiresAuth", "unknown")
+        access_label = _route_access_label(item, scopes.get(route, ""))
         flag = item.get("killFlag", "")
-        auth_label = "auth" if auth == "true" else "public" if auth == "false" else "auth unknown"
         flag_label = f"<br/>flag {flag}" if flag else ""
         lines += [
-            f'  {node}["{_label(route)}<br/>{_label(category)}/{_label(owner)}<br/>{auth_label}{flag_label}"]',
+            f'  {node}["{_label(route)}<br/>{_label(category)}/{_label(owner)}<br/>{_label(access_label)}{flag_label}"]',
             f"  class {node} {'alias' if category == 'alias' else 'route'}",
-            f"  class {node} {'auth' if auth == 'true' else 'public' if auth == 'false' else 'route'}",
+            f"  class {node} {_route_access_class(access_label)}",
         ]
     for route in sorted(included):
         target = _route_target(meta.get(route, {}))

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -37,7 +37,7 @@ def _root(tmp_path: Path) -> Path:
         "# Fixture SPEC\n",
         encoding="utf-8",
     )
-    routes = ["/budget", "/mon-argent", "/rapport", "/coach/chat", "/profile/bilan"]
+    routes = ["/budget", "/mon-argent", "/rapport", "/coach/chat", "/profile", "/profile/bilan"]
     (tmp_path / "apps/mobile/lib/routes/route_metadata.dart").write_text(
         "\n".join(
             [
@@ -50,6 +50,29 @@ def _root(tmp_path: Path) -> Path:
                 ],
                 "  '/legacy/budget': RouteMeta(path: '/legacy/budget', category: RouteCategory.alias, owner: RouteOwner.system, requiresAuth: true, description: 'Legacy redirect -> /budget'),",
                 "};",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "apps/mobile/lib/app.dart").write_text(
+        "\n".join(
+            [
+                "final routes = [",
+                "  ScopedGoRoute(path: '/budget', builder: (_, __) => Screen()),",
+                "  ScopedGoRoute(path: '/coach/chat', scope: RouteScope.public, builder: (_, __) => Screen()),",
+                "  ScopedGoRoute(path: '/legacy/budget', scope: RouteScope.onboarding, redirect: (_, __) => '/budget'),",
+                "  ScopedGoRoute(",
+                "    path: '/profile',",
+                "    routes: [",
+                "      ScopedGoRoute(",
+                "        path: 'bilan',",
+                "        // scope: RouteScope.authenticated must not override the runtime arg below.",
+                "        scope: RouteScope.public,",
+                "        builder: (_, __) => Screen(),",
+                "      ),",
+                "    ],",
+                "  ),",
+                "];",
             ]
         ),
         encoding="utf-8",
@@ -93,7 +116,7 @@ def _record(root: Path, **updates: object) -> None:
             "requires_auth": False,
             "order": 10,
         },
-        "route_paths": ["/budget", "/mon-argent", "/rapport", "/coach/chat"],
+        "route_paths": ["/budget", "/mon-argent", "/rapport", "/coach/chat", "/profile", "/profile/bilan"],
         "surfaces": ["BudgetSnapshot", "DataSpineSnapshot"],
         "external_apis": [],
         "issues": ["JOS-001"],
@@ -676,6 +699,16 @@ def test_issue_registry_and_generated_board(tmp_path: Path) -> None:
     assert "flowchart LR" in route_topology
     assert "route__budget" in route_topology
     assert "route__legacy_budget" in route_topology
+    assert 'route__coach_chat["/coach/chat<br/>destination/system<br/>public"]' in route_topology
+    assert 'route__mon_argent["/mon-argent<br/>destination/system<br/>authenticated"]' in route_topology
+    assert 'route__profile["/profile<br/>destination/system<br/>authenticated"]' in route_topology
+    assert 'route__profile_bilan["/profile/bilan<br/>destination/system<br/>public"]' in route_topology
+    assert 'route__legacy_budget["/legacy/budget<br/>alias/system<br/>onboarding"]' in route_topology
+    assert "class route__coach_chat public" in route_topology
+    assert "class route__mon_argent auth" in route_topology
+    assert "class route__profile auth" in route_topology
+    assert "class route__profile_bilan public" in route_topology
+    assert "class route__legacy_budget onboarding" in route_topology
     assert "route__legacy_budget -. redirects .-> route__budget" in route_topology
 
 def test_external_apis_must_match_canonical_openapi(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Generate Journey OS route_topology.mmd from runtime ScopedGoRoute RouteScope values in apps/mobile/lib/app.dart.
- Compose nested route paths like /profile/privacy from relative child paths.
- Add tests for runtime scope precedence, metadata fallback, nested child routes, comment decoys, and parent scope isolation.

## Verification
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/mint2_navigation_spine_guard.py
- python3 -m pytest tools/checks/tests/test_mint2_navigation_spine_guard.py tools/checks/tests/test_journey_os_runtime_replay.py tools/checks/tests/test_journey_os_check.py
- git diff --check
- Claude Opus audit: no blocking findings after fixing nested child scope leak.

## Notes
- Tooling/docs artifact only; no product runtime code changed.
- This makes the Mermaid route map reflect the runtime route scopes instead of stale metadata when both exist.