### PR TITLE
Guard Mint2 route fallbacks from coach dead ends

### DIFF
--- a/apps/mobile/lib/services/navigation/screen_registry.dart
+++ b/apps/mobile/lib/services/navigation/screen_registry.dart
@@ -395,7 +395,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age'],
     optionalFields: ['canton', 'avoirLpp', 'rachatMaximum'],
-    fallbackRoute: '/coach/chat?topic=retraite',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
     customGate: gateRenteVsCapital,
@@ -407,7 +407,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age', 'canton'],
     optionalFields: ['avoirLpp', 'rachatMaximum', 'civilStatus'],
-    fallbackRoute: '/coach/chat?topic=retraite',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -420,7 +420,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age', 'canton'],
     optionalFields: ['avoirLpp', 'rachatMaximum'],
-    fallbackRoute: '/coach/chat?topic=retraite',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -431,7 +431,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'canton'],
     optionalFields: ['age', 'employmentStatus'],
-    fallbackRoute: '/coach/chat?topic=3a',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -442,7 +442,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['age', 'canton'],
     optionalFields: ['salaireBrut'],
-    fallbackRoute: '/coach/chat?topic=3a',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -463,7 +463,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age', 'canton'],
     optionalFields: ['rachatMaximum', 'avoirLpp'],
-    fallbackRoute: '/coach/chat?topic=rachatLpp',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -488,7 +488,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age', 'canton'],
     optionalFields: ['avoirLpp'],
-    fallbackRoute: '/coach/chat?topic=epl',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );
@@ -542,7 +542,7 @@ class MintScreenRegistry extends ScreenRegistry {
     behavior: ScreenBehavior.decisionCanvas,
     requiredFields: ['salaireBrut', 'age', 'canton'],
     optionalFields: ['avoirLpp', 'epargne3a'],
-    fallbackRoute: '/coach/chat?topic=decaissement',
+    fallbackRoute: '/onb',
     preferFromChat: true,
     prefillFromProfile: true,
   );

--- a/apps/mobile/test/services/navigation/screen_registry_test.dart
+++ b/apps/mobile/test/services/navigation/screen_registry_test.dart
@@ -533,6 +533,24 @@ void main() {
           ]));
     });
 
+    test('chat-routable blocked decisions do not fallback to coach chat', () {
+      final violations = MintScreenRegistry.chatRoutable()
+          .where((entry) =>
+              (entry.behavior == ScreenBehavior.decisionCanvas ||
+                  entry.behavior == ScreenBehavior.roadmapFlow) &&
+              entry.requiredFields.isNotEmpty &&
+              (entry.fallbackRoute?.startsWith('/coach/chat') ?? false))
+          .map((entry) => '${entry.intentTag} -> ${entry.fallbackRoute}')
+          .toList();
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'A blocked decision must route to capture, not strand the user '
+            'in Coach with no next action.',
+      );
+    });
+
     test('all C surfaces are routable from chat', () {
       final roadmap =
           MintScreenRegistry.findByBehavior(ScreenBehavior.roadmapFlow);

--- a/tools/checks/mint2_navigation_spine_guard.py
+++ b/tools/checks/mint2_navigation_spine_guard.py
@@ -103,12 +103,19 @@ def _route_field(body: str, name: str) -> str:
     if quoted:
         return quoted.group(1)
     enum_or_bool = re.search(
-        rf"\b{name}:\s*(Route(?:Category|Owner)\.[A-Za-z0-9_]+|true|false)",
+        rf"\b{name}:\s*([A-Za-z0-9_]+\.[A-Za-z0-9_]+|true|false)",
         body,
     )
     if enum_or_bool:
         return enum_or_bool.group(1).split(".")[-1]
     return ""
+
+
+def _list_field_items(body: str, name: str) -> list[str]:
+    match = re.search(rf"\b{name}:\s*\[([^\]]*)\]", body, re.DOTALL)
+    if match is None:
+        return []
+    return re.findall(r"['\"]([^'\"]+)['\"]", match.group(1))
 
 
 def _route_target_from_description(description: str) -> str:
@@ -460,6 +467,23 @@ def _check_screen_registry_contract(errors: list[str], root: Path) -> None:
         errors.append(
             f"{SCREEN_REGISTRY} must have exactly one primary ScreenEntry route for /onb; found {len(onb_routes)}"
         )
+    for block in screen_entries:
+        behavior = _route_field(block, "behavior")
+        fallback = _route_field(block, "fallbackRoute").split("?", 1)[0]
+        prefer_from_chat = _route_field(block, "preferFromChat")
+        required_fields = _list_field_items(block, "requiredFields")
+        if (
+            prefer_from_chat == "true"
+            and behavior in {"decisionCanvas", "roadmapFlow"}
+            and fallback == "/coach/chat"
+            and required_fields
+        ):
+            intent = _route_field(block, "intentTag") or "<missing-intent>"
+            route = _route_field(block, "route") or "<missing-route>"
+            errors.append(
+                f"{SCREEN_REGISTRY} {intent} ({route}) must not fallback to /coach/chat "
+                "when required fields are missing; use /onb or a scoped capture route"
+            )
 
 
 def check(root: Path) -> list[str]:

--- a/tools/checks/tests/test_mint2_navigation_spine_guard.py
+++ b/tools/checks/tests/test_mint2_navigation_spine_guard.py
@@ -523,6 +523,37 @@ def test_navigation_spine_guard_fails_when_registry_uses_stale_onboarding_fallba
     )
 
 
+def test_navigation_spine_guard_fails_when_blocked_decision_falls_back_to_coach(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    registry = tmp_path / "apps/mobile/lib/services/navigation/screen_registry.dart"
+    registry.write_text(
+        registry.read_text(encoding="utf-8").replace(
+            "  static const ScreenEntry _onboardingQuick = ScreenEntry(",
+            """
+  static const ScreenEntry _retirementChoice = ScreenEntry(
+    route: '/retraite/rente-vs-capital',
+    intentTag: 'retirement_choice',
+    behavior: ScreenBehavior.decisionCanvas,
+    requiredFields: ['salaireBrut'],
+    fallbackRoute: '/coach/chat?topic=retraite',
+    preferFromChat: true,
+  );
+  static const ScreenEntry _onboardingQuick = ScreenEntry(""",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = mint2_navigation_spine_guard.check(tmp_path)
+
+    assert any(
+        "retirement_choice (/retraite/rente-vs-capital) must not fallback to /coach/chat"
+        in error
+        for error in errors
+    )
+
+
 def test_navigation_spine_guard_fails_when_onboarding_quick_entry_uses_legacy_alias(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a Mint2 navigation guard that rejects chat-routable blocked decision surfaces falling back to `/coach/chat`
- route key decision fallbacks to `/onb` instead of Coach dead ends while scoped capture routes are not available yet
- add Flutter coverage for the same ScreenRegistry invariant

## Verification
- `python3 tools/checks/mint2_navigation_spine_guard.py`
- `python3 -m pytest tools/checks/tests/test_mint2_navigation_spine_guard.py -q`
- `cd apps/mobile && flutter test test/services/navigation/screen_registry_test.dart test/services/navigation/route_planner_test.dart`
- `python3 tools/checks/active_context_guard.py && python3 tools/checks/phase_contract_guard.py && python3 tools/checks/mint_rules_guard.py && python3 tools/checks/workflow_contract_guard.py`
- `python3 tools/checks/journey_os_check.py`
- `python3 tools/checks/mint2_vz_route_contract_guard.py && python3 tools/checks/screen_registry_parity.py && python3 tools/checks/route_registry_parity.py`
- `git diff --check`
- `cd apps/mobile && flutter analyze lib/services/navigation/screen_registry.dart test/services/navigation/screen_registry_test.dart`

## Audit context
Claude Opus audit identified the current navigation P0 as blocked decision surfaces falling back to Coach instead of a capture route. This PR turns that into an executable guard and fixes the chat-routable fallbacks.
