### PR TITLE
Route landing CTA through start contract

### DIFF
--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -90,7 +90,7 @@ class _LandingScreenState extends State<LandingScreen>
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context)!;
-    void openOnboarding() => context.go('/onb');
+    void openOnboarding() => context.go('/start');
 
     Widget ctaReveal(Widget child) {
       return AnimatedBuilder(

--- a/tools/checks/journey_os_check.py
+++ b/tools/checks/journey_os_check.py
@@ -62,6 +62,7 @@ ALLOW = {
     "apps/mobile/lib/routes/coach_chat_entry_payload.dart",
     "apps/mobile/lib/routes/route_metadata.dart",
     "apps/mobile/lib/screens/auth/register_screen.dart",
+    "apps/mobile/lib/screens/landing_screen.dart",
     "apps/mobile/lib/screens/profile/financial_summary_screen.dart",
     "apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart",
     "apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart",

--- a/tools/checks/tests/test_journey_os_check.py
+++ b/tools/checks/tests/test_journey_os_check.py
@@ -371,6 +371,7 @@ def test_jos005_first_value_hotfix_scope_is_in_scope(tmp_path: Path) -> None:
             "apps/mobile/lib/app.dart",
             "apps/mobile/lib/providers/auth_provider.dart",
             "apps/mobile/lib/routes/route_metadata.dart",
+            "apps/mobile/lib/screens/landing_screen.dart",
             "apps/mobile/lib/screens/debug/debug_mint2_account_claim_screen.dart",
             "apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart",
             "apps/mobile/lib/services/coach/_valid_routes_generated.dart",


### PR DESCRIPTION
## What
- Route LandingScreen onboarding CTA through the canonical `/start` contract instead of direct `/onb`.
- Add `landing_screen.dart` to the Journey OS in-scope guard because the active route contract test explicitly locks this Mint2 entry surface.

## Why
The first-run routing policy belongs in `/start`; direct `/onb` navigation lets landing bypass the route contract and contributed to the chaotic first-run path seen in TestFlight.

## Verification
- `python3 tools/checks/active_context_guard.py`
- `python3 tools/checks/phase_contract_guard.py`
- `python3 tools/checks/mint_rules_guard.py`
- `python3 tools/checks/workflow_contract_guard.py`
- `python3 tools/checks/journey_os_check.py`
- `python3 tools/checks/mint2_navigation_spine_guard.py`
- `python3 tools/checks/route_registry_parity.py`
- `python3 tools/checks/screen_registry_parity.py`
- `python3 -m pytest tools/checks/tests/test_journey_os_check.py -q -k "jos005_first_value_hotfix_scope or changed_file_outside_whitelist"`
- `cd apps/mobile && flutter analyze lib/screens/landing_screen.dart test/architecture/start_route_contract_test.dart`
- `cd apps/mobile && flutter test test/architecture/start_route_contract_test.dart test/screens/register_account_entry_test.dart test/screens/login_apple_recreate_opt_in_test.dart test/services/api_service_test.dart test/providers/auth_provider_test.dart test/screens/profile/financial_summary_screen_test.dart --reporter expanded`
- `python3 -m pytest services/backend/tests/test_auth_apple.py services/backend/tests/test_auth.py -q -k "apple or register or profile or date_of_birth"`