### PR TITLE
Route onboarding intents to first-value tools

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -1136,6 +1136,7 @@ final _router = GoRouter(
     // ── FISCALITE ────────────────────────────────────────────
     ScopedGoRoute(
       path: '/pilier-3a',
+      scope: RouteScope.onboarding,
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const Simulator3aScreen(),
     ),
@@ -1176,6 +1177,7 @@ final _router = GoRouter(
     // ── IMMOBILIER ───────────────────────────────────────────
     ScopedGoRoute(
       path: '/hypotheque',
+      scope: RouteScope.onboarding,
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const AffordabilityScreen(),
     ),

--- a/apps/mobile/lib/routes/route_metadata.dart
+++ b/apps/mobile/lib/routes/route_metadata.dart
@@ -453,7 +453,7 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     path: '/pilier-3a',
     category: RouteCategory.destination,
     owner: RouteOwner.fiscalite,
-    requiresAuth: true,
+    requiresAuth: false,
     killFlag: 'enableExplorerFiscalite',
   ),
   '/simulator/3a': RouteMeta(
@@ -502,7 +502,7 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     path: '/hypotheque',
     category: RouteCategory.destination,
     owner: RouteOwner.logement,
-    requiresAuth: true,
+    requiresAuth: false,
     killFlag: 'enableExplorerLogement',
   ),
   '/mortgage/affordability': RouteMeta(

--- a/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart
@@ -1481,9 +1481,9 @@ class _BifurcationStepState extends State<_BifurcationStep> {
 
   String _continueRouteFor(OnboardingIntent? intent) => switch (intent) {
         OnboardingIntent.retraite => '/retraite/rente-vs-capital',
-        OnboardingIntent.achat => '/coach/chat?topic=logement',
-        OnboardingIntent.impots => '/coach/chat?topic=fiscalite',
-        OnboardingIntent.explorer || null => '/coach/chat?topic=onboarding',
+        OnboardingIntent.achat => '/hypotheque',
+        OnboardingIntent.impots => '/pilier-3a',
+        OnboardingIntent.explorer || null => '/explore',
       };
 
   Future<void> _sealAndGo({

--- a/apps/mobile/test/architecture/route_guard_snapshot.golden.txt
+++ b/apps/mobile/test/architecture/route_guard_snapshot.golden.txt
@@ -87,7 +87,7 @@
 /fiscal | authenticated
 /household | authenticated
 /household/accept | authenticated
-/hypotheque | authenticated
+/hypotheque | onboarding
 /independants/3a | authenticated
 /independants/avs | authenticated
 /independants/dividende-salaire | authenticated
@@ -124,7 +124,7 @@
 /open-banking | authenticated
 /open-banking/consents | authenticated
 /open-banking/transactions | authenticated
-/pilier-3a | authenticated
+/pilier-3a | onboarding
 /portfolio | authenticated
 /profile | authenticated
 /rachat-lpp | authenticated

--- a/apps/mobile/test/architecture/route_guard_snapshot_test.dart
+++ b/apps/mobile/test/architecture/route_guard_snapshot_test.dart
@@ -202,7 +202,7 @@ void main() {
       }
     });
 
-    test('Rente vs capital first-value routes stay before account creation',
+    test('first-value tool routes stay before account creation',
         () {
       final scopes = Map<String, String>.fromEntries(routeScopes);
 
@@ -210,6 +210,8 @@ void main() {
       expect(scopes['/rente-vs-capital'], 'onboarding');
       expect(scopes['/arbitrage/rente-vs-capital'], 'onboarding');
       expect(scopes['/simulator/rente-capital'], 'onboarding');
+      expect(scopes['/hypotheque'], 'onboarding');
+      expect(scopes['/pilier-3a'], 'onboarding');
     });
 
     test('onboarding fallback route is registered in production router', () {

--- a/apps/mobile/test/routes/route_metadata_test.dart
+++ b/apps/mobile/test/routes/route_metadata_test.dart
@@ -162,6 +162,21 @@ void main() {
       expect(meta.killFlag, 'enableExplorerRetraite');
     });
 
+    test('/hypotheque and /pilier-3a are onboarding first-value tools', () {
+      final hypotheque = kRouteRegistry['/hypotheque'];
+      final pilier3a = kRouteRegistry['/pilier-3a'];
+
+      expect(hypotheque, isNotNull);
+      expect(hypotheque!.category, RouteCategory.destination);
+      expect(hypotheque.owner, RouteOwner.logement);
+      expect(hypotheque.requiresAuth, isFalse);
+
+      expect(pilier3a, isNotNull);
+      expect(pilier3a!.category, RouteCategory.destination);
+      expect(pilier3a.owner, RouteOwner.fiscalite);
+      expect(pilier3a.requiresAuth, isFalse);
+    });
+
     test('/rente-vs-capital is a legacy alias to canonical RVC route', () {
       final meta = kRouteRegistry['/rente-vs-capital'];
       expect(meta, isNotNull);

--- a/apps/mobile/test/screens/onboarding/mvp_wedge_storyboard_test.dart
+++ b/apps/mobile/test/screens/onboarding/mvp_wedge_storyboard_test.dart
@@ -147,6 +147,18 @@ Future<void> _pumpShell(
             : const Scaffold(body: Text('rente-vs-capital-landed')),
       ),
       GoRoute(
+        path: '/hypotheque',
+        builder: (_, __) => const Scaffold(body: Text('hypotheque-landed')),
+      ),
+      GoRoute(
+        path: '/pilier-3a',
+        builder: (_, __) => const Scaffold(body: Text('pilier-3a-landed')),
+      ),
+      GoRoute(
+        path: '/explore',
+        builder: (_, __) => const Scaffold(body: Text('explore-landed')),
+      ),
+      GoRoute(
         path: '/auth/register',
         builder: (_, __) => const Scaffold(body: Text('register-landed')),
       ),
@@ -909,12 +921,12 @@ void main() {
     expect(find.text('rvc_age=2026'), findsNothing);
   });
 
-  testWidgets('T8 Continuer: non-retirement intents keep focused chat topics',
+  testWidgets('T8 Continuer: non-retirement intents open real tools',
       (tester) async {
     const cases = [
-      (ValueKey('onboarding-intent-achat'), 'coach-chat-landed:logement'),
-      (ValueKey('onboarding-intent-impots'), 'coach-chat-landed:fiscalite'),
-      (ValueKey('onboarding-intent-explorer'), 'coach-chat-landed:onboarding'),
+      (ValueKey('onboarding-intent-achat'), 'hypotheque-landed'),
+      (ValueKey('onboarding-intent-impots'), 'pilier-3a-landed'),
+      (ValueKey('onboarding-intent-explorer'), 'explore-landed'),
     ];
 
     for (final (intentKey, expectedLanding) in cases) {
@@ -931,6 +943,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(expectedLanding), findsOneWidget);
+      expect(find.textContaining('coach-chat-landed'), findsNothing);
       expect(find.text('rente-vs-capital-landed'), findsNothing);
       expect(fake.mergedCalls.single['q_wants_deeper'], isTrue);
     }


### PR DESCRIPTION
## Summary
- Route onboarding achat to /hypotheque, impots to /pilier-3a, explorer to /explore instead of coach topic dead-ends.
- Mark /hypotheque and /pilier-3a as onboarding-scope routes and public first-value tools.
- Extend route/storyboard tests so non-retirement intents prove they land on real tools, not chat placeholders.

## Verification
- flutter test test/screens/onboarding/mvp_wedge_storyboard_test.dart test/architecture/route_guard_snapshot_test.dart test/routes/route_metadata_test.dart --reporter expanded
- flutter analyze lib/screens/onboarding/mvp_wedge/onboarding_shell_screen.dart lib/app.dart lib/routes/route_metadata.dart test/screens/onboarding/mvp_wedge_storyboard_test.dart test/architecture/route_guard_snapshot_test.dart test/routes/route_metadata_test.dart
- ./tools/mint-routes check
- python3 tools/checks/route_registry_parity.py
- python3 tools/checks/active_context_guard.py
- python3 tools/checks/phase_contract_guard.py
- python3 tools/checks/mint_rules_guard.py
- python3 tools/checks/journey_os_check.py
- python3 tools/checks/workflow_contract_guard.py
- python3 tools/checks/verify_phase_acceptance.py
- flutter build ios --simulator --debug --dart-define=API_BASE_URL=https://mint-staging.up.railway.app/api/v1 --dart-define=MINT_DISABLE_BETA_MODAL=true --dart-define=MINT_E2E_PROOF_ANCHORS=true --dart-define=MINT_E2E_ARCHETYPE=julien_swiss
- maestro test tools/simulator/flows/maestro-perfect-set/flow_3a_calculator.yaml --output .planning/walker/maestro-flows/3a-calculator/20260701-005010/result.xml --format junit

## Audit
- Based on the completed Opus product audit: first concrete PR should stop terminal onboarding intents from landing in focused chat dead-ends.
- Opus diff review could not run because local Claude CLI session limit is active until 5:50 Europe/Zurich.