### PR TITLE
[codex] Goal-aware confidence prompt ranking

### DIFF
--- a/apps/mobile/lib/services/financial_core/confidence_scorer.dart
+++ b/apps/mobile/lib/services/financial_core/confidence_scorer.dart
@@ -30,12 +30,14 @@ class EnrichmentPrompt {
   final int impact; // percentage points of confidence gained
   final String category; // 'lpp', 'avs', '3a', 'patrimoine', 'foreign_pension'
   final String action; // short description of what to do
+  final String? fieldPath; // ledger/profile field improved by this prompt
 
   const EnrichmentPrompt({
     required this.label,
     required this.impact,
     required this.category,
     required this.action,
+    this.fieldPath,
   });
 }
 
@@ -856,6 +858,7 @@ class ConfidenceScorer {
               ? (prompts['freshnessStale'] ?? 'Donn\u00e9e datant de {months} mois')
                   .replaceAll('{months}', '$monthsOld')
               : prompts['freshnessConfirm'] ?? 'Confirme que cette valeur est toujours actuelle',
+          fieldPath: fieldPath,
         ));
       }
     }
@@ -875,6 +878,7 @@ class ConfidenceScorer {
           impact: (entry.value * (1.0 - (_accuracyWeights[source] ?? 0.25))).round().clamp(1, 15),
           category: 'accuracy',
           action: upgradeAction,
+          fieldPath: fieldPath,
         ));
       }
     }
@@ -897,8 +901,9 @@ class ConfidenceScorer {
       ));
     }
 
-    // Sort by impact descending
-    axisPrompts.sort((a, b) => b.impact.compareTo(a.impact));
+    axisPrompts.sort(
+      (a, b) => _compareGoalAwarePrompts(profile.goalA.type, a, b),
+    );
 
     return EnhancedConfidence(
       completeness: completeness,
@@ -916,6 +921,64 @@ class ConfidenceScorer {
   static double _pow(double base, double exponent) {
     if (base <= 0 || !base.isFinite) return 0;
     return math.exp(exponent * math.log(base));
+  }
+
+  static int _compareGoalAwarePrompts(
+    GoalAType goalType,
+    EnrichmentPrompt a,
+    EnrichmentPrompt b,
+  ) {
+    final scoreOrder = _goalAwarePromptScore(goalType, b)
+        .compareTo(_goalAwarePromptScore(goalType, a));
+    if (scoreOrder != 0) return scoreOrder;
+    final impactOrder = b.impact.compareTo(a.impact);
+    if (impactOrder != 0) return impactOrder;
+    return a.label.compareTo(b.label);
+  }
+
+  static int _goalAwarePromptScore(
+    GoalAType goalType,
+    EnrichmentPrompt prompt,
+  ) {
+    return prompt.impact + _goalFieldBoost(goalType, prompt.fieldPath);
+  }
+
+  static int _goalFieldBoost(GoalAType goalType, String? fieldPath) {
+    if (fieldPath == null) return 0;
+    return switch (goalType) {
+      // Home purchase: liquid assets and salary unlock affordability first;
+      // canton drives tax; LPP can support purchase but is not the first ask.
+      GoalAType.achatImmo => switch (fieldPath) {
+          'patrimoine.epargneLiquide' => 12,
+          'salaireBrutMensuel' => 6,
+          'canton' => 4,
+          'prevoyance.avoirLppTotal' => 2,
+          _ => 0,
+        },
+      // Retirement: pension capital/years/3a/conversion rate drive the first
+      // lucidity gap before broader wealth data.
+      GoalAType.retraite => switch (fieldPath) {
+          'prevoyance.avoirLppTotal' => 8,
+          'prevoyance.anneesContribuees' => 5,
+          'prevoyance.totalEpargne3a' => 5,
+          'prevoyance.tauxConversion' => 4,
+          _ => 0,
+        },
+      // Independence: runway and voluntary pension data matter before salary.
+      GoalAType.independance => switch (fieldPath) {
+          'patrimoine.epargneLiquide' => 7,
+          'prevoyance.totalEpargne3a' => 5,
+          'salaireBrutMensuel' => 3,
+          _ => 0,
+        },
+      // Debt-free: repayment capacity and liquid buffer are the first signals.
+      GoalAType.debtFree => switch (fieldPath) {
+          'salaireBrutMensuel' => 5,
+          'patrimoine.epargneLiquide' => 5,
+          _ => 0,
+        },
+      GoalAType.custom => 0,
+    };
   }
 
   // ── COUP-03: Partner estimate confidence degradation ──────────

--- a/apps/mobile/lib/services/financial_core/confidence_scorer.dart
+++ b/apps/mobile/lib/services/financial_core/confidence_scorer.dart
@@ -152,6 +152,7 @@ class ConfidenceScorer {
         impact: _wSalaire,
         category: 'income',
         action: 'Renseigne ton salaire brut mensuel',
+        fieldPath: 'salaireBrutMensuel',
       ));
     }
 
@@ -178,6 +179,7 @@ class ConfidenceScorer {
         impact: 7,
         category: 'objectif_retraite',
         action: 'A quel age souhaites-tu prendre ta retraite ? (58-70)',
+        fieldPath: 'goalA.targetRetirementAge',
       ));
     }
 
@@ -189,7 +191,7 @@ class ConfidenceScorer {
     // since ~50% of Swiss residents are in couples (BFS, 2024).
     final isExplicitlySingle = !isCoupled &&
         (profile.etatCivil == CoachCivilStatus.divorce ||
-         profile.etatCivil == CoachCivilStatus.veuf);
+            profile.etatCivil == CoachCivilStatus.veuf);
     if (isExplicitlySingle) {
       total += _wMenage;
     } else if (!isCoupled) {
@@ -200,6 +202,7 @@ class ConfidenceScorer {
         impact: 10,
         category: 'menage',
         action: 'Celibataire, en couple, marie·e ? Impact sur AVS et impots.',
+        fieldPath: 'etatCivil',
       ));
     } else if (profile.conjoint == null) {
       // Coupled but no partner data at all
@@ -207,7 +210,9 @@ class ConfidenceScorer {
         label: 'Ajoute les infos de ton\u00b7ta partenaire',
         impact: _wMenage,
         category: 'menage',
-        action: 'Revenu et age de ton\u00b7ta partenaire pour des projections couple',
+        action:
+            'Revenu et age de ton\u00b7ta partenaire pour des projections couple',
+        fieldPath: 'conjoint',
       ));
     } else {
       final hasRevenu = profile.conjoint!.salaireBrutMensuel != null &&
@@ -222,6 +227,7 @@ class ConfidenceScorer {
           impact: 7,
           category: 'menage',
           action: 'Ajoute le revenu et l\'age de ton\u00b7ta partenaire',
+          fieldPath: 'conjoint',
         ));
       } else {
         prompts.add(const EnrichmentPrompt(
@@ -229,6 +235,7 @@ class ConfidenceScorer {
           impact: _wMenage,
           category: 'menage',
           action: 'Revenu et age pour des projections couple fiables',
+          fieldPath: 'conjoint',
         ));
       }
     }
@@ -245,6 +252,7 @@ class ConfidenceScorer {
         impact: 7,
         category: 'lpp',
         action: 'Ajoute ton certificat de prevoyance (solde exact)',
+        fieldPath: 'prevoyance.avoirLppTotal',
       ));
       assumptions.add('LPP estime depuis le salaire — peut varier de +-30%');
     } else if (isIndepSansLpp) {
@@ -257,6 +265,7 @@ class ConfidenceScorer {
         impact: _wLpp,
         category: 'lpp',
         action: 'Ajoute ton certificat de prevoyance (solde exact)',
+        fieldPath: 'prevoyance.avoirLppTotal',
       ));
     }
 
@@ -265,7 +274,10 @@ class ConfidenceScorer {
       total += _wTauxConversion; // Not applicable
     } else {
       final tauxConv = profile.prevoyance.tauxConversion;
-      if ((tauxConv - reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal)).abs() > 0.0001) {
+      if ((tauxConv -
+                  reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal))
+              .abs() >
+          0.0001) {
         total += _wTauxConversion;
       } else {
         total += 1;
@@ -274,6 +286,7 @@ class ConfidenceScorer {
           impact: 4,
           category: 'lpp',
           action: 'Lis ton certificat de prevoyance (taux enveloppe)',
+          fieldPath: 'prevoyance.tauxConversion',
         ));
         assumptions.add(
             'Taux de conversion LPP: minimum legal 6.8% (reel souvent 5-6%)');
@@ -291,6 +304,7 @@ class ConfidenceScorer {
         impact: 7,
         category: 'avs',
         action: 'Gratuit sur inforegister.ch — annees effectives',
+        fieldPath: 'prevoyance.anneesContribuees',
       ));
       assumptions.add('Annees AVS estimees depuis l\'age — lacunes possibles');
     }
@@ -306,6 +320,7 @@ class ConfidenceScorer {
         impact: 7,
         category: '3a',
         action: 'Saisis tes soldes 3e pilier (chaque compte)',
+        fieldPath: 'prevoyance.totalEpargne3a',
       ));
     }
 
@@ -320,6 +335,7 @@ class ConfidenceScorer {
         impact: 6,
         category: 'patrimoine',
         action: 'Epargne, investissements, immobilier',
+        fieldPath: 'patrimoine.epargneLiquide',
       ));
     }
 
@@ -329,7 +345,9 @@ class ConfidenceScorer {
         label: 'Ajoute ta commune',
         impact: 4,
         category: 'fiscalite',
-        action: 'Le coefficient communal impacte ton taux d\'imposition de 60% a 130%',
+        action:
+            'Le coefficient communal impacte ton taux d\'imposition de 60% a 130%',
+        fieldPath: 'commune',
       ));
     }
     final ds = profile.dataSources;
@@ -338,7 +356,9 @@ class ConfidenceScorer {
         label: 'Scanne ta declaration fiscale',
         impact: 8,
         category: 'fiscalite',
-        action: 'Taux marginal reel + revenu imposable + fortune (LIFD art. 38)',
+        action:
+            'Taux marginal reel + revenu imposable + fortune (LIFD art. 38)',
+        fieldPath: 'tauxMarginal',
       ));
     }
 
@@ -350,6 +370,7 @@ class ConfidenceScorer {
         impact: _wForeignPension,
         category: 'foreign_pension',
         action: 'As-tu des droits a une retraite dans ton pays d\'origine?',
+        fieldPath: 'foreignPension',
       ));
       assumptions.add('Pension etrangere non modelisee');
     } else {
@@ -375,7 +396,11 @@ class ConfidenceScorer {
         total -= 5; // AVS extrait missing: extra -5
       }
       if (!isIndepSansLpp &&
-          (profile.prevoyance.tauxConversion - reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal)).abs() < 0.0001) {
+          (profile.prevoyance.tauxConversion -
+                      reg('lpp.conversion_rate_min',
+                          lppTauxConversionMinDecimal))
+                  .abs() <
+              0.0001) {
         total -= 3; // Default taux: extra -3
       }
 
@@ -387,6 +412,7 @@ class ConfidenceScorer {
         action: urgencyLabel == 'URGENT'
             ? 'Chaque mois compte — confirme tes donnees de prevoyance'
             : 'Affine tes projections pour une vision claire',
+        fieldPath: 'prevoyance',
       ));
     }
 
@@ -396,18 +422,21 @@ class ConfidenceScorer {
     // Compute Bayesian enrichment for EVI-ranked prompts
     final bayesianResult = BayesianProfileEnricher.enrich(profile);
 
-    // Re-rank prompts using Bayesian EVI ordering:
-    // Map each existing prompt's category to the Bayesian EVI ranking
+    // Re-rank visible prompts by goal-aware effective impact, with Bayesian
+    // EVI as a tie-breaker. This keeps the rendered Data Quest order tied to
+    // the user's life goal without discarding uncertainty information.
     final eviOrder = <String, double>{};
     for (final eviPrompt in bayesianResult.rankedPrompts) {
       eviOrder[eviPrompt.category] = eviPrompt.evi;
     }
-    prompts.sort((a, b) {
-      final eviA = eviOrder[a.category] ?? 0;
-      final eviB = eviOrder[b.category] ?? 0;
-      if (eviA != eviB) return eviB.compareTo(eviA); // EVI descending
-      return b.impact.compareTo(a.impact); // fallback: impact
-    });
+    prompts.sort(
+      (a, b) => _compareGoalAwarePromptsWithEvi(
+        profile.goalA.type,
+        eviOrder,
+        a,
+        b,
+      ),
+    );
 
     // Determine level
     final level = total >= 70
@@ -415,11 +444,6 @@ class ConfidenceScorer {
         : total >= 40
             ? 'medium'
             : 'low';
-
-    // NOTE: Prompts are emitted in component-check order, NOT sorted by impact.
-    // The EVI bridge (ContextInjectorService) and LowConfidenceCard sort their
-    // own copies when needed. Sorting here would change widget layout order
-    // and cause test viewport overflow in 800×600 test surfaces.
 
     return ProjectionConfidence(
       score: total,
@@ -439,9 +463,7 @@ class ConfidenceScorer {
     final blocs = <String, BlockScore>{};
 
     // --- Salaire ---
-    final salaire = profile.salaireBrutMensuel > 0
-        ? _wSalaire.toDouble()
-        : 0.0;
+    final salaire = profile.salaireBrutMensuel > 0 ? _wSalaire.toDouble() : 0.0;
     blocs['revenu'] = BlockScore(
       score: salaire,
       maxScore: _wSalaire.toDouble(),
@@ -459,9 +481,8 @@ class ConfidenceScorer {
     );
 
     // --- Archetype ---
-    final archetype = _hasArchetypeSignals(profile)
-        ? _wArchetype.toDouble()
-        : 0.0;
+    final archetype =
+        _hasArchetypeSignals(profile) ? _wArchetype.toDouble() : 0.0;
     blocs['archetype'] = BlockScore(
       score: archetype,
       maxScore: _wArchetype.toDouble(),
@@ -470,7 +491,8 @@ class ConfidenceScorer {
 
     // --- Objectif retraite ---
     final hasExplicitRetirement = profile.targetRetirementAge != null;
-    final objectifScore = hasExplicitRetirement ? _wObjectifRetraite.toDouble() : 3.0;
+    final objectifScore =
+        hasExplicitRetirement ? _wObjectifRetraite.toDouble() : 3.0;
     blocs['objectifRetraite'] = BlockScore(
       score: objectifScore,
       maxScore: _wObjectifRetraite.toDouble(),
@@ -485,7 +507,7 @@ class ConfidenceScorer {
     // mirroring the logic in score().
     final isExplicitlySingle = !isCoupled &&
         (profile.etatCivil == CoachCivilStatus.divorce ||
-         profile.etatCivil == CoachCivilStatus.veuf);
+            profile.etatCivil == CoachCivilStatus.veuf);
     double menageScore;
     String menageStatus;
     if (isExplicitlySingle) {
@@ -547,7 +569,10 @@ class ConfidenceScorer {
     if (isIndepSansLpp) {
       tauxScore = _wTauxConversion.toDouble();
       tauxStatus = 'complete';
-    } else if ((profile.prevoyance.tauxConversion - reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal)).abs() > 0.0001) {
+    } else if ((profile.prevoyance.tauxConversion -
+                reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal))
+            .abs() >
+        0.0001) {
       tauxScore = _wTauxConversion.toDouble();
       tauxStatus = 'complete';
     } else {
@@ -648,7 +673,11 @@ class ConfidenceScorer {
         );
       }
       if (!isIndepSansLpp &&
-          (profile.prevoyance.tauxConversion - reg('lpp.conversion_rate_min', lppTauxConversionMinDecimal)).abs() < 0.0001) {
+          (profile.prevoyance.tauxConversion -
+                      reg('lpp.conversion_rate_min',
+                          lppTauxConversionMinDecimal))
+                  .abs() <
+              0.0001) {
         final taux = blocs['taux_conversion']!;
         blocs['taux_conversion'] = BlockScore(
           score: (taux.score - 3).clamp(0, taux.maxScore),
@@ -663,7 +692,8 @@ class ConfidenceScorer {
 
   /// Combined call: returns both bloc scores AND projection confidence
   /// in a single profile traversal (avoids double scoring).
-  static ({Map<String, BlockScore> blocs, ProjectionConfidence confidence}) scoreWithBlocs(CoachProfile profile) {
+  static ({Map<String, BlockScore> blocs, ProjectionConfidence confidence})
+      scoreWithBlocs(CoachProfile profile) {
     return (
       blocs: scoreAsBlocs(profile),
       confidence: score(profile),
@@ -698,8 +728,8 @@ class ConfidenceScorer {
   /// Covers the same fields as V2 scorer for symmetric axes.
   static const Map<String, int> _trackedFields = {
     'salaireBrutMensuel': _wSalaire,
-    'age': 4,          // split from _wAgeCanton (8 → 4+4)
-    'canton': 4,       // split from _wAgeCanton (8 → 4+4)
+    'age': 4, // split from _wAgeCanton (8 → 4+4)
+    'canton': 4, // split from _wAgeCanton (8 → 4+4)
     'etatCivil': _wMenage,
     'prevoyance.avoirLppTotal': _wLpp,
     'prevoyance.tauxConversion': _wTauxConversion,
@@ -747,14 +777,16 @@ class ConfidenceScorer {
   /// Default French prompt templates (used when no [promptLabels] provided).
   static const Map<String, String> _defaultPromptLabels = {
     'freshnessPrefix': 'Actualise\u00a0: ',
-    'freshnessStale': 'Donn\u00e9e datant de {months} mois \u2014 rescanne ton certificat',
+    'freshnessStale':
+        'Donn\u00e9e datant de {months} mois \u2014 rescanne ton certificat',
     'freshnessConfirm': 'Confirme que cette valeur est toujours actuelle',
     'accuracyPrefix': 'Confirme\u00a0: ',
     'accuracyEstimated': 'Saisis ta valeur r\u00e9elle',
     'accuracyCertificate': 'Scanne ton certificat pour confirmer',
   };
 
-  static EnhancedConfidence scoreEnhanced(CoachProfile profile, {
+  static EnhancedConfidence scoreEnhanced(
+    CoachProfile profile, {
     DateTime? now,
     Map<String, String>? labels,
     Map<String, String>? promptLabels,
@@ -826,7 +858,7 @@ class ConfidenceScorer {
     const educationBonus = 0.0;
     final understanding =
         (literacyBase * 0.50 + sessionBonus * 0.30 + educationBonus * 0.20)
-        .clamp(0.0, 100.0);
+            .clamp(0.0, 100.0);
 
     // ── Combined: geometric mean of 4 axes ──────────────────
     // Adding small epsilon (1.0) to avoid zero-multiplication collapse.
@@ -855,9 +887,11 @@ class ConfidenceScorer {
           impact: (entry.value * (1.0 - decay)).round().clamp(1, 15),
           category: 'freshness',
           action: monthsOld > 0
-              ? (prompts['freshnessStale'] ?? 'Donn\u00e9e datant de {months} mois')
+              ? (prompts['freshnessStale'] ??
+                      'Donn\u00e9e datant de {months} mois')
                   .replaceAll('{months}', '$monthsOld')
-              : prompts['freshnessConfirm'] ?? 'Confirme que cette valeur est toujours actuelle',
+              : prompts['freshnessConfirm'] ??
+                  'Confirme que cette valeur est toujours actuelle',
           fieldPath: fieldPath,
         ));
       }
@@ -866,16 +900,20 @@ class ConfidenceScorer {
     // Accuracy prompts: flag estimated fields
     for (final entry in _trackedFields.entries) {
       final fieldPath = entry.key;
-      final source = profile.dataSources[fieldPath] ?? ProfileDataSource.estimated;
+      final source =
+          profile.dataSources[fieldPath] ?? ProfileDataSource.estimated;
       if (source == ProfileDataSource.estimated ||
           source == ProfileDataSource.userInput) {
         final upgradeAction = source == ProfileDataSource.estimated
             ? prompts['accuracyEstimated'] ?? 'Saisis ta valeur r\u00e9elle'
-            : prompts['accuracyCertificate'] ?? 'Scanne ton certificat pour confirmer';
+            : prompts['accuracyCertificate'] ??
+                'Scanne ton certificat pour confirmer';
         final label = fieldLabels[fieldPath] ?? fieldPath;
         axisPrompts.add(EnrichmentPrompt(
           label: '${prompts['accuracyPrefix'] ?? 'Confirme\u00a0: '}$label',
-          impact: (entry.value * (1.0 - (_accuracyWeights[source] ?? 0.25))).round().clamp(1, 15),
+          impact: (entry.value * (1.0 - (_accuracyWeights[source] ?? 0.25)))
+              .round()
+              .clamp(1, 15),
           category: 'accuracy',
           action: upgradeAction,
           fieldPath: fieldPath,
@@ -889,7 +927,8 @@ class ConfidenceScorer {
         label: 'Explore les fiches \u00e9ducatives',
         impact: 10,
         category: 'understanding',
-        action: 'Lis les fiches sur tes th\u00e8mes cl\u00e9s (LPP, AVS, fiscalit\u00e9)',
+        action:
+            'Lis les fiches sur tes th\u00e8mes cl\u00e9s (LPP, AVS, fiscalit\u00e9)',
       ));
     }
     if (sessionCount < 3) {
@@ -897,7 +936,8 @@ class ConfidenceScorer {
         label: 'Pose une question au coach',
         impact: 5,
         category: 'understanding',
-        action: 'Chaque interaction affine ta compr\u00e9hension financi\u00e8re',
+        action:
+            'Chaque interaction affine ta compr\u00e9hension financi\u00e8re',
       ));
     }
 
@@ -936,6 +976,23 @@ class ConfidenceScorer {
     return a.label.compareTo(b.label);
   }
 
+  static int _compareGoalAwarePromptsWithEvi(
+    GoalAType goalType,
+    Map<String, double> eviOrder,
+    EnrichmentPrompt a,
+    EnrichmentPrompt b,
+  ) {
+    final scoreOrder = _goalAwarePromptScore(goalType, b)
+        .compareTo(_goalAwarePromptScore(goalType, a));
+    if (scoreOrder != 0) return scoreOrder;
+    final eviCompare =
+        (eviOrder[b.category] ?? 0).compareTo(eviOrder[a.category] ?? 0);
+    if (eviCompare != 0) return eviCompare;
+    final impactOrder = b.impact.compareTo(a.impact);
+    if (impactOrder != 0) return impactOrder;
+    return a.label.compareTo(b.label);
+  }
+
   static int _goalAwarePromptScore(
     GoalAType goalType,
     EnrichmentPrompt prompt,
@@ -949,7 +1006,7 @@ class ConfidenceScorer {
       // Home purchase: liquid assets and salary unlock affordability first;
       // canton drives tax; LPP can support purchase but is not the first ask.
       GoalAType.achatImmo => switch (fieldPath) {
-          'patrimoine.epargneLiquide' => 12,
+          'patrimoine.epargneLiquide' => 16,
           'salaireBrutMensuel' => 6,
           'canton' => 4,
           'prevoyance.avoirLppTotal' => 2,
@@ -999,9 +1056,7 @@ class ConfidenceScorer {
     // partnerConfidence 0.25 at best → scale to 0-25 range
     final partnerScore = partnerConfidence * 100; // 0-25 range
     final blended = math.sqrt(base.score * math.max(partnerScore, 1.0));
-    final level = blended >= 70
-        ? 'high'
-        : (blended >= 40 ? 'medium' : 'low');
+    final level = blended >= 70 ? 'high' : (blended >= 40 ? 'medium' : 'low');
 
     return ProjectionConfidence(
       score: blended.clamp(0, 100),
@@ -1118,8 +1173,7 @@ class EnhancedConfidence {
         ? (scoreRaw <= 1.0 ? scoreRaw * 100.0 : scoreRaw)
         : (() {
             // Geometric mean fallback if score absent.
-            final product =
-                completeness * accuracy * freshness * understanding;
+            final product = completeness * accuracy * freshness * understanding;
             if (product <= 0) return 0.0;
             return math.pow(product, 0.25).toDouble();
           })();

--- a/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
+++ b/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
@@ -88,6 +88,46 @@ void main() {
       }
     });
 
+    test('visible prompts prioritize liquid assets for home purchase', () {
+      final profile = _buildProfile(
+        age: 35,
+        salary: 5000,
+        canton: 'GE',
+        goalAType: GoalAType.achatImmo,
+      );
+      final confidence = ConfidenceScorer.score(profile);
+      final patrimoineIndex = confidence.prompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'patrimoine.epargneLiquide',
+      );
+      final lppIndex = confidence.prompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'prevoyance.avoirLppTotal',
+      );
+
+      expect(patrimoineIndex, greaterThan(-1));
+      expect(lppIndex, greaterThan(-1));
+      expect(patrimoineIndex, lessThan(lppIndex));
+    });
+
+    test('visible prompts prioritize pension data for retirement', () {
+      final profile = _buildProfile(
+        age: 35,
+        salary: 5000,
+        canton: 'GE',
+        goalAType: GoalAType.retraite,
+      );
+      final confidence = ConfidenceScorer.score(profile);
+      final lppIndex = confidence.prompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'prevoyance.avoirLppTotal',
+      );
+      final patrimoineIndex = confidence.prompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'patrimoine.epargneLiquide',
+      );
+
+      expect(lppIndex, greaterThan(-1));
+      expect(patrimoineIndex, greaterThan(-1));
+      expect(lppIndex, lessThan(patrimoineIndex));
+    });
+
     test('assumptions list populated for missing data', () {
       final profile = _buildProfile(
         age: 35,
@@ -131,7 +171,8 @@ void main() {
       final now = DateTime(2026, 3, 9);
       final result = ConfidenceScorer.scoreEnhanced(profile, now: now);
       expect(result.completeness, greaterThanOrEqualTo(70));
-      expect(result.accuracy, greaterThan(60)); // mix of certificate + userInput
+      expect(
+          result.accuracy, greaterThan(60)); // mix of certificate + userInput
       expect(result.combined, greaterThan(0));
       expect(result.combined, lessThanOrEqualTo(100));
     });
@@ -160,7 +201,8 @@ void main() {
           'etatCivil': now.subtract(const Duration(days: 30)),
           'prevoyance.avoirLppTotal': now.subtract(const Duration(days: 60)),
           'prevoyance.tauxConversion': now.subtract(const Duration(days: 60)),
-          'prevoyance.anneesContribuees': now.subtract(const Duration(days: 90)),
+          'prevoyance.anneesContribuees':
+              now.subtract(const Duration(days: 90)),
           'prevoyance.totalEpargne3a': now.subtract(const Duration(days: 30)),
           'patrimoine.epargneLiquide': now.subtract(const Duration(days: 15)),
         },
@@ -217,7 +259,12 @@ void main() {
       );
       final result = ConfidenceScorer.scoreEnhanced(profile);
       // Combined should be between min and max of the 4 axes
-      final axes = [result.completeness, result.accuracy, result.freshness, result.understanding];
+      final axes = [
+        result.completeness,
+        result.accuracy,
+        result.freshness,
+        result.understanding
+      ];
       final minAxis = axes.reduce((a, b) => a < b ? a : b);
       final maxAxis = axes.reduce((a, b) => a > b ? a : b);
       expect(result.combined, greaterThanOrEqualTo(minAxis - 1));
@@ -346,11 +393,17 @@ void main() {
     test('understanding axis included in combined geometric mean', () {
       // Same profile, different literacy → different combined
       final beginner = _buildProfile(
-        age: 45, salary: 8000, canton: 'ZH', avoirLpp: 300000,
+        age: 45,
+        salary: 8000,
+        canton: 'ZH',
+        avoirLpp: 300000,
         financialLiteracyLevel: FinancialLiteracyLevel.beginner,
       );
       final advanced = _buildProfile(
-        age: 45, salary: 8000, canton: 'ZH', avoirLpp: 300000,
+        age: 45,
+        salary: 8000,
+        canton: 'ZH',
+        avoirLpp: 300000,
         financialLiteracyLevel: FinancialLiteracyLevel.advanced,
         checkInsCount: 15,
       );
@@ -569,19 +622,21 @@ void main() {
     test('returns all expected bloc keys', () {
       final profile = _buildProfile(age: 45, salary: 8000, canton: 'VD');
       final blocs = ConfidenceScorer.scoreAsBlocs(profile);
-      expect(blocs.keys, containsAll([
-        'revenu',
-        'age_canton',
-        'archetype',
-        'objectifRetraite',
-        'compositionMenage',
-        'lpp',
-        'taux_conversion',
-        'avs',
-        '3a',
-        'patrimoine',
-        'foreign_pension',
-      ]));
+      expect(
+          blocs.keys,
+          containsAll([
+            'revenu',
+            'age_canton',
+            'archetype',
+            'objectifRetraite',
+            'compositionMenage',
+            'lpp',
+            'taux_conversion',
+            'avs',
+            '3a',
+            'patrimoine',
+            'foreign_pension',
+          ]));
     });
 
     test('total maxScore sums to 115 (100 core + 15 fiscalite)', () {
@@ -606,7 +661,8 @@ void main() {
         expect(
           entry.value.score,
           lessThanOrEqualTo(entry.value.maxScore),
-          reason: '${entry.key}: score ${entry.value.score} > max ${entry.value.maxScore}',
+          reason:
+              '${entry.key}: score ${entry.value.score} > max ${entry.value.maxScore}',
         );
       }
     });
@@ -635,7 +691,8 @@ void main() {
       expect(blocs['objectifRetraite']!.score, 3.0); // default partial score
     });
 
-    test('compositionMenage is partial for default celibataire (unconfirmed)', () {
+    test('compositionMenage is partial for default celibataire (unconfirmed)',
+        () {
       final profile = _buildProfile(age: 45, salary: 8000, canton: 'VD');
       final blocs = ConfidenceScorer.scoreAsBlocs(profile);
       // Default celibataire (not confirmed) → partial with 5 points
@@ -696,7 +753,8 @@ CoachProfile _buildProfile({
   CoachCivilStatus etatCivil = CoachCivilStatus.celibataire,
   Map<String, ProfileDataSource> dataSources = const {},
   Map<String, DateTime> dataTimestamps = const {},
-  FinancialLiteracyLevel financialLiteracyLevel = FinancialLiteracyLevel.beginner,
+  FinancialLiteracyLevel financialLiteracyLevel =
+      FinancialLiteracyLevel.beginner,
   int checkInsCount = 0,
   int? targetRetirementAge,
   GoalAType goalAType = GoalAType.retraite,

--- a/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
+++ b/apps/mobile/test/services/financial_core/confidence_scorer_test.dart
@@ -245,11 +245,12 @@ void main() {
       expect(categories, contains('freshness'));
     });
 
-    test('axisPrompts sorted by impact descending', () {
+    test('axisPrompts sorted by impact descending when goal is custom', () {
       final profile = _buildProfile(
         age: 35,
         salary: 5000,
         canton: 'GE',
+        goalAType: GoalAType.custom,
       );
       final result = ConfidenceScorer.scoreEnhanced(profile);
       for (int i = 0; i < result.axisPrompts.length - 1; i++) {
@@ -258,6 +259,46 @@ void main() {
           greaterThanOrEqualTo(result.axisPrompts[i + 1].impact),
         );
       }
+    });
+
+    test('axisPrompts use goal-aware ranking for home purchase', () {
+      final profile = _buildProfile(
+        age: 35,
+        salary: 5000,
+        canton: 'GE',
+        goalAType: GoalAType.achatImmo,
+      );
+      final result = ConfidenceScorer.scoreEnhanced(profile);
+      final patrimoineIndex = result.axisPrompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'patrimoine.epargneLiquide',
+      );
+      final lppIndex = result.axisPrompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'prevoyance.avoirLppTotal',
+      );
+
+      expect(patrimoineIndex, greaterThan(-1));
+      expect(lppIndex, greaterThan(-1));
+      expect(patrimoineIndex, lessThan(lppIndex));
+    });
+
+    test('axisPrompts keep retirement focus on pension data', () {
+      final profile = _buildProfile(
+        age: 35,
+        salary: 5000,
+        canton: 'GE',
+        goalAType: GoalAType.retraite,
+      );
+      final result = ConfidenceScorer.scoreEnhanced(profile);
+      final lppIndex = result.axisPrompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'prevoyance.avoirLppTotal',
+      );
+      final patrimoineIndex = result.axisPrompts.indexWhere(
+        (prompt) => prompt.fieldPath == 'patrimoine.epargneLiquide',
+      );
+
+      expect(lppIndex, greaterThan(-1));
+      expect(patrimoineIndex, greaterThan(-1));
+      expect(lppIndex, lessThan(patrimoineIndex));
     });
 
     // ── Phase 2: Understanding axis (V3) ──────────────────────
@@ -658,6 +699,7 @@ CoachProfile _buildProfile({
   FinancialLiteracyLevel financialLiteracyLevel = FinancialLiteracyLevel.beginner,
   int checkInsCount = 0,
   int? targetRetirementAge,
+  GoalAType goalAType = GoalAType.retraite,
 }) {
   final checkIns = List.generate(
     checkInsCount,
@@ -693,9 +735,9 @@ CoachProfile _buildProfile({
     ),
     depenses: const DepensesProfile(),
     goalA: GoalA(
-      type: GoalAType.retraite,
+      type: goalAType,
       targetDate: DateTime(2050),
-      label: 'Retraite',
+      label: 'Test goal',
     ),
   );
 }

--- a/docs/codex/DATA_QUEST.md
+++ b/docs/codex/DATA_QUEST.md
@@ -131,16 +131,17 @@ No screen writes SharedPreferences / `ProfileModel.data` directly.
 | Q-2 | `DataQuest`/`Case` orchestrator does not exist | new `apps/mobile/lib/services/data_quest/data_quest_service.dart` implementing §2–§5 |
 | Q-3 | `/data-block/:type` has no delta/before-after UI, no reconfirm | extend `data_block_enrichment_screen.dart` with `AskMode.reconfirm` widget (§3) |
 | Q-4 | Backend `suggest_actions` is hardcoded, not the ranker | wire `suggest_actions` → `enhanced_confidence_service.rank_enrichment_prompts()` |
-| Q-5 | Goal-aware prompt ranking is live for mobile `ConfidenceScorer.scoreEnhanced()` axis prompts: each prompt carries its `fieldPath`, and sorting uses goal-aware effective impact without changing displayed impact points | Keep `confidence_scorer_test.dart` coverage for `GoalAType.achatImmo` vs `GoalAType.retraite`, and keep `tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py` so the scorer cannot silently fall back to generic impact-only ordering. Backend/global `EnhancedConfidenceService.rank_enrichment_prompts()` remains generic unless a later phase makes it goal-aware too. |
+| Q-5 | Goal-aware prompt ranking is live for mobile `ConfidenceScorer.score()` visible prompts and `scoreEnhanced()` axis prompts: prompts carry `fieldPath`, and sorting uses goal-aware effective impact without changing displayed impact points | Keep `confidence_scorer_test.dart` coverage for `GoalAType.achatImmo` vs `GoalAType.retraite` on both visible prompts and enhanced axis prompts, and keep `tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py` so the scorer cannot silently fall back to generic impact-only ordering. Backend/global `EnhancedConfidenceService.rank_enrichment_prompts()` remains generic unless a later phase makes it goal-aware too. |
 | Q-6 | No `Case` registry mapping events→guardQuests | new `data_quest/case_registry.dart`; seed with `transmit_property`, `divorce`, `retirement` |
 
 ## 8. Acceptance criteria (Codex/CI must verify)
 
 - **DQ-1** A screen with all `reads[]` fresh triggers **zero** Asks (planQuest returns []).
 - **DQ-2** A screen missing k fields surfaces exactly k Asks; mobile
-  confidence enrichment prompts use `ConfidenceScorer` impact plus `GoalAType`
-  ordering, while DataQuest case asks remain ordered by the case registry until
-  a later phase connects those rankers. It is never a blocking wall
+  confidence enrichment prompts rendered from `ConfidenceScorer.score().prompts`
+  use impact plus `GoalAType` ordering, while DataQuest case asks remain
+  ordered by the case registry until a later phase connects those rankers.
+  It is never a blocking wall
   (partialState renders).
 - **DQ-3** A field with `needsRefresh==true` produces an `AskMode.reconfirm` (1-tap), never a blank field.
 - **DQ-4** Every write goes through `CoachProfileProvider` (grep: no other writer of `wizard_answers_v2`).

--- a/docs/codex/DATA_QUEST.md
+++ b/docs/codex/DATA_QUEST.md
@@ -131,13 +131,17 @@ No screen writes SharedPreferences / `ProfileModel.data` directly.
 | Q-2 | `DataQuest`/`Case` orchestrator does not exist | new `apps/mobile/lib/services/data_quest/data_quest_service.dart` implementing §2–§5 |
 | Q-3 | `/data-block/:type` has no delta/before-after UI, no reconfirm | extend `data_block_enrichment_screen.dart` with `AskMode.reconfirm` widget (§3) |
 | Q-4 | Backend `suggest_actions` is hardcoded, not the ranker | wire `suggest_actions` → `enhanced_confidence_service.rank_enrichment_prompts()` |
-| Q-5 | Goal-aware ranking absent (ranker is generic) | add `impactOf(key, prompts, goal)` weighting in `confidence_scorer.dart` |
+| Q-5 | Goal-aware prompt ranking is live for mobile `ConfidenceScorer.scoreEnhanced()` axis prompts: each prompt carries its `fieldPath`, and sorting uses goal-aware effective impact without changing displayed impact points | Keep `confidence_scorer_test.dart` coverage for `GoalAType.achatImmo` vs `GoalAType.retraite`, and keep `tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py` so the scorer cannot silently fall back to generic impact-only ordering. Backend/global `EnhancedConfidenceService.rank_enrichment_prompts()` remains generic unless a later phase makes it goal-aware too. |
 | Q-6 | No `Case` registry mapping events→guardQuests | new `data_quest/case_registry.dart`; seed with `transmit_property`, `divorce`, `retirement` |
 
 ## 8. Acceptance criteria (Codex/CI must verify)
 
 - **DQ-1** A screen with all `reads[]` fresh triggers **zero** Asks (planQuest returns []).
-- **DQ-2** A screen missing k fields surfaces exactly k Asks, ordered by `ConfidenceScorer` impact; never a blocking wall (partialState renders).
+- **DQ-2** A screen missing k fields surfaces exactly k Asks; mobile
+  confidence enrichment prompts use `ConfidenceScorer` impact plus `GoalAType`
+  ordering, while DataQuest case asks remain ordered by the case registry until
+  a later phase connects those rankers. It is never a blocking wall
+  (partialState renders).
 - **DQ-3** A field with `needsRefresh==true` produces an `AskMode.reconfirm` (1-tap), never a blank field.
 - **DQ-4** Every write goes through `CoachProfileProvider` (grep: no other writer of `wizard_answers_v2`).
 - **DQ-5** `transmit_property` Case runs the retirement-affordability guardQuest before rendering any gift result.

--- a/tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py
+++ b/tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DATA_QUEST = ROOT / "docs/codex/DATA_QUEST.md"
+CONFIDENCE_SCORER = (
+    ROOT / "apps/mobile/lib/services/financial_core/confidence_scorer.dart"
+)
+
+
+def test_data_quest_doc_matches_live_goal_aware_confidence_ranking() -> None:
+    doc = DATA_QUEST.read_text(encoding="utf-8")
+    scorer = CONFIDENCE_SCORER.read_text(encoding="utf-8")
+
+    assert "Goal-aware ranking absent" not in doc
+    assert "ranker is generic" not in doc
+    assert "final String? fieldPath" in scorer
+    assert "_goalAwarePromptScore" in scorer
+    assert "GoalAType.achatImmo" in scorer
+    assert "GoalAType.retraite" in scorer

--- a/tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py
+++ b/tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py
@@ -15,6 +15,8 @@ def test_data_quest_doc_matches_live_goal_aware_confidence_ranking() -> None:
     assert "Goal-aware ranking absent" not in doc
     assert "ranker is generic" not in doc
     assert "final String? fieldPath" in scorer
+    assert "_compareGoalAwarePromptsWithEvi" in scorer
     assert "_goalAwarePromptScore" in scorer
+    assert "ConfidenceScorer.score().prompts" in doc
     assert "GoalAType.achatImmo" in scorer
     assert "GoalAType.retraite" in scorer


### PR DESCRIPTION
## Scope
- Make `ConfidenceScorer.scoreEnhanced()` rank enrichment prompts by `GoalAType` while keeping displayed impact points unchanged.
- Add `fieldPath` to prompts so the ranker can prioritize the exact ledger/profile variable needed for the active goal.
- Update `DATA_QUEST.md` so the executable spec matches the live mobile behavior.

## TDD red proof
- `flutter test test/services/financial_core/confidence_scorer_test.dart --plain-name "axisPrompts" --reporter expanded` failed before implementation because `EnrichmentPrompt.fieldPath` did not exist.
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q` failed before implementation because `DATA_QUEST.md` still said goal-aware ranking was absent.

## Green QA
- `flutter analyze lib/services/financial_core/confidence_scorer.dart test/services/financial_core/confidence_scorer_test.dart`
- `flutter test test/services/financial_core/confidence_scorer_test.dart --reporter expanded`
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q`
- `git diff --check`

## External audit
Claude CLI reviewed the diff. Addressed findings:
- Tests no longer assert fragile localized labels; they assert `fieldPath` order.
- Goal boost rationale is documented next to each boost table.

Residual notes:
- This PR intentionally covers the P0 contrast: achat immobilier vs retraite. `independance` and `debtFree` boost rows are low-risk follow-up coverage.
- The Python guard is included under `tools/checks/tests/`; CI coverage depends on the repo test matrix picking up that path.
