### PR TITLE
[codex] Allow first-value route before account

### DIFF
--- a/apps/mobile/lib/app.dart
+++ b/apps/mobile/lib/app.dart
@@ -563,14 +563,15 @@ final _router = GoRouter(
 
     ScopedGoRoute(
       path: '/rente-vs-capital',
+      scope: RouteScope.onboarding,
       parentNavigatorKey: _rootNavigatorKey,
       builder: (context, state) => const RenteVsCapitalScreen(),
     ),
-    ScopedGoRoute(path: '/arbitrage/rente-vs-capital', redirect: (_, state) {
+    ScopedGoRoute(path: '/arbitrage/rente-vs-capital', scope: RouteScope.onboarding, redirect: (_, state) {
       MintBreadcrumbs.legacyRedirectHit(from: state.uri.path, to: '/rente-vs-capital');
       return '/rente-vs-capital';
     }),
-    ScopedGoRoute(path: '/simulator/rente-capital', redirect: (_, state) {
+    ScopedGoRoute(path: '/simulator/rente-capital', scope: RouteScope.onboarding, redirect: (_, state) {
       MintBreadcrumbs.legacyRedirectHit(from: state.uri.path, to: '/rente-vs-capital');
       return '/rente-vs-capital';
     }),

--- a/apps/mobile/lib/routes/route_metadata.dart
+++ b/apps/mobile/lib/routes/route_metadata.dart
@@ -2,8 +2,11 @@
 //  RouteMeta + kRouteRegistry — Phase 32 MAP-01 (D-01 locked v4)
 // ────────────────────────────────────────────────────────────
 //
-// Source of truth for the 147 mobile routes declared in
-// `apps/mobile/lib/app.dart`. Consumed by:
+// Source of truth for the 148 non-admin mobile routes declared in
+// `apps/mobile/lib/app.dart`. Dev-only `/admin/routes` is intentionally
+// absent from this registry; see
+// `tools/checks/route_registry_parity-KNOWN-MISSES.md` Category 7.
+// Consumed by:
 //
 //   - `tools/mint-routes` CLI (Python, Plan 32-02 Wave 2)
 //   - `/admin/routes` Flutter schema viewer (Plan 32-03 Wave 3)
@@ -74,8 +77,8 @@ class RouteMeta {
 }
 
 /// Source-of-truth map: one entry per `GoRoute`/`ScopedGoRoute` declared
-/// in `apps/mobile/lib/app.dart`. Exactly **147 entries** as of Wave 0
-/// reconciliation (app.dart SHA b7a88cc8, see
+/// in `apps/mobile/lib/app.dart`. Exactly **148 non-admin entries** as of Wave
+/// 0 reconciliation (app.dart SHA b7a88cc8, see
 /// `.planning/phases/32-cartographier/32-00-RECONCILE-REPORT.md`).
 ///
 /// **Maintenance contract (D-04, D-12):** adding or removing a `GoRoute`
@@ -279,21 +282,21 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     path: '/rente-vs-capital',
     category: RouteCategory.destination,
     owner: RouteOwner.retraite,
-    requiresAuth: true,
+    requiresAuth: false,
     killFlag: 'enableExplorerRetraite',
   ),
   '/arbitrage/rente-vs-capital': RouteMeta(
     path: '/arbitrage/rente-vs-capital',
     category: RouteCategory.alias,
     owner: RouteOwner.system,
-    requiresAuth: true,
+    requiresAuth: false,
     description: 'Legacy redirect -> /rente-vs-capital',
   ),
   '/simulator/rente-capital': RouteMeta(
     path: '/simulator/rente-capital',
     category: RouteCategory.alias,
     owner: RouteOwner.system,
-    requiresAuth: true,
+    requiresAuth: false,
     description: 'Legacy redirect -> /rente-vs-capital',
   ),
   '/rachat-lpp': RouteMeta(

--- a/apps/mobile/test/architecture/route_guard_snapshot.golden.txt
+++ b/apps/mobile/test/architecture/route_guard_snapshot.golden.txt
@@ -11,6 +11,7 @@
 /3a-retroactif | authenticated
 /about | public
 /achievements | authenticated
+/admin/routes | authenticated
 /advisor | authenticated
 /advisor/plan-30-days | authenticated
 /advisor/wizard | authenticated
@@ -20,7 +21,7 @@
 /arbitrage/calendrier-retraits | authenticated
 /arbitrage/location-vs-propriete | authenticated
 /arbitrage/rachat-vs-marche | authenticated
-/arbitrage/rente-vs-capital | authenticated
+/arbitrage/rente-vs-capital | onboarding
 /ask-mint | authenticated
 /assurances/coverage | authenticated
 /assurances/lamal | authenticated
@@ -31,6 +32,7 @@
 /auth/verify-email | public
 /bank-import | authenticated
 /budget | authenticated
+/budget/setup | authenticated
 /cantonal-benchmark | authenticated
 /check/debt | authenticated
 /coach/agir | authenticated
@@ -122,7 +124,7 @@
 /profile | authenticated
 /rachat-lpp | authenticated
 /rapport | authenticated
-/rente-vs-capital | authenticated
+/rente-vs-capital | onboarding
 /report | authenticated
 /report/v2 | authenticated
 /retirement | authenticated
@@ -143,7 +145,7 @@
 /simulator/disability-gap | authenticated
 /simulator/job-comparison | authenticated
 /simulator/leasing | authenticated
-/simulator/rente-capital | authenticated
+/simulator/rente-capital | onboarding
 /succession | authenticated
 /timeline | authenticated
 /tools | authenticated

--- a/apps/mobile/test/architecture/route_guard_snapshot_test.dart
+++ b/apps/mobile/test/architecture/route_guard_snapshot_test.dart
@@ -210,5 +210,28 @@ void main() {
         reason: '/onboarding/intent must be marked as onboarding',
       );
     });
+
+    test('JOS-005 first-value routes are reachable before account creation',
+        () {
+      const firstValueRoutes = [
+        '/rente-vs-capital',
+        '/arbitrage/rente-vs-capital',
+        '/simulator/rente-capital',
+      ];
+
+      for (final path in firstValueRoutes) {
+        final route = routeScopes.firstWhere(
+          (entry) => entry.key == path,
+          orElse: () => const MapEntry('', ''),
+        );
+
+        expect(
+          route.value,
+          'onboarding',
+          reason: 'Selecting the LPP rente-vs-capital first-value axis must '
+              'reach $path before permanent account creation.',
+        );
+      }
+    });
   });
 }

--- a/apps/mobile/test/routes/route_metadata_test.dart
+++ b/apps/mobile/test/routes/route_metadata_test.dart
@@ -1,7 +1,7 @@
 // Phase 32 MAP-01 — RouteMeta schema + enum integrity + kRouteRegistry.
 //
 // Baseline contract (from .planning/phases/32-cartographier/32-00-RECONCILE-REPORT.md):
-// - kRouteRegistry.length == 147
+// - kRouteRegistry.length == 148
 // - RouteOwner enum has 15 values (11 flag-groups + auth/admin/system/explore)
 // - RouteCategory enum has 4 values (destination, flow, tool, alias)
 // - Owner ambiguity rule (D-01 v4): /explore/retraite -> owner=explore (first-segment-wins)
@@ -101,8 +101,8 @@ void main() {
   });
 
   group('kRouteRegistry (MAP-01)', () {
-    test('has exactly 147 entries', () {
-      expect(kRouteRegistry.length, 147);
+    test('has exactly 148 entries', () {
+      expect(kRouteRegistry.length, 148);
     });
 
     test('every entry path matches its key', () {
@@ -144,6 +144,32 @@ void main() {
       final meta = kRouteRegistry['/retraite'];
       expect(meta, isNotNull);
       expect(meta!.owner, RouteOwner.retraite);
+    });
+
+    test('/rente-vs-capital is a first-value route before account creation',
+        () {
+      final meta = kRouteRegistry['/rente-vs-capital'];
+      expect(meta, isNotNull);
+      expect(meta!.owner, RouteOwner.retraite);
+      expect(meta.category, RouteCategory.destination);
+      expect(meta.requiresAuth, isFalse);
+      expect(meta.killFlag, 'enableExplorerRetraite');
+    });
+
+    test('/rente-vs-capital aliases do not reintroduce auth gating', () {
+      const aliases = [
+        '/arbitrage/rente-vs-capital',
+        '/simulator/rente-capital',
+      ];
+
+      for (final path in aliases) {
+        final meta = kRouteRegistry[path];
+        expect(meta, isNotNull);
+        expect(meta!.path, path);
+        expect(meta.category, RouteCategory.alias);
+        expect(meta.owner, RouteOwner.system);
+        expect(meta.requiresAuth, isFalse);
+      }
     });
 
     test('/coach/chat owner=coach (first-segment rule)', () {

--- a/apps/mobile/test/screens/arbitrage_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/arbitrage_screens_smoke_test.dart
@@ -58,6 +58,15 @@ void main() {
       expect(find.byType(Scaffold), findsOneWidget);
     });
 
+    testWidgets('renders before account creation with no profile',
+        (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('displays i18n app bar title', (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();


### PR DESCRIPTION
## Scope
- Make `/rente-vs-capital` reachable before permanent account creation by marking it `RouteScope.onboarding`.
- Keep both legacy aliases (`/arbitrage/rente-vs-capital`, `/simulator/rente-capital`) onboarding too, so deep links do not hit the auth wall before redirecting.
- Align route metadata, route snapshot golden, and widget smoke coverage.

## TDD red proof
- Added `JOS-005 first-value route is reachable before account creation`; before the route change it failed with actual scope `authenticated` instead of `onboarding`.

## Green QA
- `flutter test test/architecture/route_guard_snapshot_test.dart test/routes/route_metadata_test.dart test/screens/arbitrage_screens_smoke_test.dart --reporter expanded`
- `flutter analyze lib/app.dart lib/routes/route_metadata.dart test/architecture/route_guard_snapshot_test.dart test/routes/route_metadata_test.dart test/screens/arbitrage_screens_smoke_test.dart`
- `./tools/mint-routes reconcile`
- `git diff --check`

## External audit
Claude CLI found two real blockers and both were fixed:
- legacy alias routes were still authenticated; now both aliases are onboarding and `requiresAuth: false`.
- `RenteVsCapitalScreen` lacked an explicit no-profile proof; `arbitrage_screens_smoke_test.dart` now covers rendering before account creation with no profile and no widget exception.

Claude also flagged `/admin/routes` missing from `kRouteRegistry`; this is intentionally NOT changed. The repo contract documents `/admin/routes` as an admin-only compile-conditional known miss in `tools/checks/route_registry_parity-KNOWN-MISSES.md` Category 7, and `./tools/mint-routes reconcile` confirms the exemption. `route_metadata.dart` now states this explicitly.
