### PR TITLE
[codex] Collect canonical revenue facts inline

### DIFF
--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -47,11 +47,30 @@ class DataBlockEnrichmentScreen extends StatefulWidget {
 
 class _DataBlockEnrichmentScreenState
     extends State<DataBlockEnrichmentScreen> {
+  static const _swissCantonCodes =
+      ' AG AI AR BE BL BS FR GE GL GR JU LU NE NW OW SG SH SO SZ TG TI UR VD VS ZG ZH ';
+
   bool _showCoachMode = false;
+  final TextEditingController _cantonController = TextEditingController();
+  final TextEditingController _salaryController = TextEditingController();
+  final TextEditingController _birthYearController = TextEditingController();
+  bool _revenueInputsSeeded = false;
+  bool _hasPensionFund = false;
+  bool _hasPensionFundTouched = false;
+  bool _isSavingRevenue = false;
+  String? _revenueError;
 
   /// Cached cross-validation alerts to avoid recomputing on every build.
   List<ValidationAlert>? _cachedAlerts;
   CoachProfile? _cachedAlertsProfile;
+
+  @override
+  void dispose() {
+    _cantonController.dispose();
+    _salaryController.dispose();
+    _birthYearController.dispose();
+    super.dispose();
+  }
 
   List<ValidationAlert> _getAlertsForBlock(
       CoachProfile profile, String blockType) {
@@ -67,6 +86,9 @@ class _DataBlockEnrichmentScreenState
   Widget build(BuildContext context) {
     final profile = context.watch<CoachProfileProvider>().profile;
     final canonicalBlockType = _canonicalBlockType(widget.blockType);
+    if (canonicalBlockType == 'revenu') {
+      _seedRevenueInputs(profile);
+    }
     final isKnownBlock =
         DataBlockEnrichmentScreen._supportedBlockTypes.contains(canonicalBlockType);
     final blocs = profile != null
@@ -132,8 +154,14 @@ class _DataBlockEnrichmentScreenState
               ],
 
               // ── Enrichment prompts for this block ────────────────
-              if (profile != null) ...[
+              if (profile != null && canonicalBlockType != 'revenu') ...[
                 MintEntrance(delay: const Duration(milliseconds: 200), child: _buildPrompts(profile, canonicalBlockType, bloc)),
+              ],
+              if (canonicalBlockType == 'revenu') ...[
+                MintEntrance(
+                  delay: const Duration(milliseconds: 200),
+                  child: _buildRevenueCollector(l),
+                ),
               ],
 
               // ── Cross-validation alerts ────────────────────────────
@@ -144,36 +172,37 @@ class _DataBlockEnrichmentScreenState
               const SizedBox(height: 32),
 
               // ── CTA ──────────────────────────────────────────────
-              Semantics(
-                button: true,
-                label: meta.ctaLabel,
-                child: SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  onPressed: () {
-                    HapticFeedback.lightImpact();
-                    // Navigate to the appropriate enrichment flow
-                    final route = _enrichmentRoute(canonicalBlockType);
-                    if (route != null) {
-                      context.push(route);
-                    } else {
-                      safePop(context);
-                    }
-                  },
-                  style: FilledButton.styleFrom(
-                    backgroundColor: MintColors.primary,
-                    foregroundColor: MintColors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 18),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
+              if (canonicalBlockType != 'revenu')
+                Semantics(
+                  button: true,
+                  label: meta.ctaLabel,
+                  child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () {
+                      HapticFeedback.lightImpact();
+                      // Navigate to the appropriate enrichment flow
+                      final route = _enrichmentRoute(canonicalBlockType);
+                      if (route != null) {
+                        context.push(route);
+                      } else {
+                        safePop(context);
+                      }
+                    },
+                    style: FilledButton.styleFrom(
+                      backgroundColor: MintColors.primary,
+                      foregroundColor: MintColors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 18),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    child: Text(
+                      meta.ctaLabel,
+                      style: MintTextStyles.titleMedium().copyWith(fontWeight: FontWeight.w600),
                     ),
                   ),
-                  child: Text(
-                    meta.ctaLabel,
-                    style: MintTextStyles.titleMedium().copyWith(fontWeight: FontWeight.w600),
-                  ),
-                ),
-              )),
+                )),
               const SizedBox(height: 16),
 
               // ── Disclaimer ───────────────────────────────────────
@@ -189,6 +218,170 @@ class _DataBlockEnrichmentScreenState
       ))),
     );
   }
+
+  void _seedRevenueInputs(CoachProfile? profile) {
+    if (_revenueInputsSeeded || profile == null) return;
+    _revenueInputsSeeded = true;
+    if (profile.canton.isNotEmpty) _cantonController.text = profile.canton;
+    if (profile.revenuBrutAnnuel > 0) {
+      _salaryController.text = '${profile.revenuBrutAnnuel.round()}';
+    }
+    if (profile.birthYear >= 1900) _birthYearController.text = '${profile.birthYear}';
+    _hasPensionFund = (profile.prevoyance.avoirLppTotal ?? 0) > 0 ||
+        profile.prevoyance.isLppFromCertificate;
+  }
+
+  Widget _buildRevenueCollector(S l) {
+    return MintSurface(
+      padding: const EdgeInsets.all(18),
+      radius: 12,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildRevenueTextField(
+            key: const Key('salary_input'),
+            semanticsIdentifier: 'salary_input',
+            controller: _salaryController,
+            label: l.renteVsCapitalSalary,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+          ),
+          const SizedBox(height: 14),
+          _buildRevenueTextField(
+            key: const Key('canton_picker'),
+            semanticsIdentifier: 'canton_picker',
+            controller: _cantonController,
+            label: l.affordabilityCanton,
+            textCapitalization: TextCapitalization.characters,
+            inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z]')), LengthLimitingTextInputFormatter(2)],
+          ),
+          const SizedBox(height: 14),
+          _buildRevenueTextField(
+            key: const Key('birth_year_input'),
+            semanticsIdentifier: 'birth_year_input',
+            controller: _birthYearController,
+            label: l.landingBirthYear,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly, LengthLimitingTextInputFormatter(4)],
+          ),
+          const SizedBox(height: 8),
+          Semantics(
+            identifier: 'has_pension_fund_switch',
+            child: SwitchListTile.adaptive(
+              key: const Key('has_pension_fund_switch'),
+              contentPadding: EdgeInsets.zero,
+              activeThumbColor: MintColors.primary,
+              title: Text(
+                l.eduThemeLppQuestion,
+                style: MintTextStyles.bodyMedium(color: MintColors.textPrimary),
+              ),
+              value: _hasPensionFund,
+              onChanged: (value) => setState(() {
+                _hasPensionFund = value;
+                _hasPensionFundTouched = true;
+              }),
+            ),
+          ),
+          if (_revenueError != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _revenueError!,
+              style: MintTextStyles.labelMedium(color: MintColors.error),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Semantics(
+            identifier: 'salary_save_cta',
+            button: true,
+            label: l.financialSummaryEnregistrer,
+            child: FilledButton(
+              key: const Key('salary_save_cta'),
+              onPressed: _isSavingRevenue ? null : _saveRevenueFacts,
+              style: FilledButton.styleFrom(
+                backgroundColor: MintColors.primary,
+                foregroundColor: MintColors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: Text(
+                l.financialSummaryEnregistrer,
+                style: MintTextStyles.titleMedium()
+                    .copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRevenueTextField({
+    required Key key,
+    required TextEditingController controller,
+    required String label,
+    required String semanticsIdentifier,
+    TextInputType? keyboardType,
+    TextCapitalization textCapitalization = TextCapitalization.none,
+    List<TextInputFormatter>? inputFormatters,
+  }) {
+    return Semantics(
+      identifier: semanticsIdentifier,
+      child: TextField(
+        key: key,
+        controller: controller,
+        keyboardType: keyboardType,
+        textCapitalization: textCapitalization,
+        inputFormatters: inputFormatters,
+        decoration: InputDecoration(
+          labelText: label,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _saveRevenueFacts() async {
+    final l = S.of(context)!;
+    final canton = _cantonController.text.trim().toUpperCase();
+    final salary = int.tryParse(_digitsOnly(_salaryController.text));
+    final birthText = _birthYearController.text.trim();
+    final birthYear = birthText.isEmpty ? null : int.tryParse(birthText);
+    final currentYear = DateTime.now().year;
+
+    if (!_swissCantonCodes.contains(' $canton ') ||
+        salary == null ||
+        salary <= 0 ||
+        (birthText.isNotEmpty &&
+            (birthYear == null ||
+                birthYear < 1900 ||
+                birthYear > currentYear))) {
+      setState(() => _revenueError = l.authErrorInvalid);
+      return;
+    }
+
+    setState(() {
+      _isSavingRevenue = true;
+      _revenueError = null;
+    });
+
+    final answers = <String, dynamic>{
+      'q_gross_salary_annual': salary,
+      'q_canton': canton,
+      if (birthYear != null) 'q_birth_year': birthYear,
+      if (_hasPensionFundTouched) 'q_has_pension_fund': _hasPensionFund,
+    };
+
+    await context.read<CoachProfileProvider>().mergeAnswers(answers);
+    if (!mounted) return;
+    HapticFeedback.lightImpact();
+    setState(() => _isSavingRevenue = false);
+  }
+
+  String _digitsOnly(String value) => value.replaceAll(RegExp(r'[^0-9]'), '');
 
   Widget _buildPrompts(CoachProfile profile, String type, BlockScore? bloc) {
     final confidence = ConfidenceScorer.score(profile);
@@ -362,20 +555,6 @@ class _DataBlockEnrichmentScreenState
     };
     final categories = mapping[blockType] ?? [];
     return categories.contains(category);
-  }
-
-  String _coachPromptForBlock(String type) {
-    return switch (type) {
-      '3a' => 'Je veux comprendre mon 3e pilier : combien de comptes ouvrir, chez quel provider, et comment maximiser mon avantage fiscal.',
-      'lpp' => 'Explique-moi mon 2e pilier LPP : mon avoir actuel, la lacune de rachat, et ce que je peux faire pour améliorer ma situation.',
-      'avs' => 'Parle-moi de ma rente AVS : est-ce que j\'ai des lacunes de cotisation et comment les combler ?',
-      'patrimoine' => 'Je veux faire le point sur mon patrimoine global et comprendre comment le structurer.',
-      'fiscalite' => 'Aide-moi a comprendre ma situation fiscale et les leviers d\'optimisation possibles.',
-      'revenu' => 'Je veux comprendre l\'impact de mon revenu sur ma prevoyance et mes impots.',
-      'objectifRetraite' => 'Quel serait l\'impact si je partais a la retraite plus tot ou plus tard ?',
-      'compositionMenage' => 'Comment la situation de couple influence mes projections de retraite ?',
-      _ => 'Aide-moi a completer mon profil financier.',
-    };
   }
 
   String? _enrichmentRoute(String type) {

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -351,6 +351,7 @@ class _DataBlockEnrichmentScreenState
     final birthText = _birthYearController.text.trim();
     final birthYear = birthText.isEmpty ? null : int.tryParse(birthText);
     final currentYear = DateTime.now().year;
+    final youngestSupportedBirthYear = currentYear - 18;
 
     if (!_swissCantonCodes.contains(' $canton ') ||
         salary == null ||
@@ -358,7 +359,7 @@ class _DataBlockEnrichmentScreenState
         (birthText.isNotEmpty &&
             (birthYear == null ||
                 birthYear < 1900 ||
-                birthYear > currentYear))) {
+                birthYear > youngestSupportedBirthYear))) {
       setState(() => _revenueError = l.authErrorInvalid);
       return;
     }

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -1,31 +1,92 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/providers/slm_provider.dart';
 import 'package:mint_mobile/screens/onboarding/data_block_enrichment_screen.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-Widget _wrap(Widget child) {
+Widget _wrap(Widget child, {CoachProfileProvider? coachProfileProvider}) {
   return MultiProvider(
     providers: [
-      ChangeNotifierProvider(create: (_) => CoachProfileProvider()),
+      ChangeNotifierProvider(
+        create: (_) => coachProfileProvider ?? CoachProfileProvider(),
+      ),
       ChangeNotifierProvider(create: (_) => SlmProvider()),
     ],
-    child: MaterialApp(
-  locale: const Locale('fr'),
-  localizationsDelegates: const [
-    S.delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-  ],
-  supportedLocales: S.supportedLocales,home: child),
+    child: MaterialApp(locale: const Locale('fr'), localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ], supportedLocales: S.supportedLocales, home: child),
   );
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('revenue block captures canonical first salary facts only',
+      (tester) async {
+    final provider = CoachProfileProvider();
+
+    await tester.pumpWidget(_wrap(
+      const DataBlockEnrichmentScreen(blockType: 'revenu'),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('canton_picker')), 'ge');
+    await tester.enterText(find.byKey(const Key('salary_input')), '96000');
+    await tester.enterText(find.byKey(const Key('birth_year_input')), '2001');
+    await tester.tap(find.byKey(const Key('has_pension_fund_switch')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('salary_save_cta')));
+    await tester.pumpAndSettle();
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect((answers['q_gross_salary_annual'] as num).toDouble(), 96000);
+    expect(answers['q_canton'], 'GE');
+    expect(answers['q_birth_year'], 2001);
+    expect(answers['q_has_pension_fund'], true);
+    expect(answers.containsKey('q_net_income_period_chf'), isFalse);
+    expect(answers.containsKey('q_monthly_gross_salary_chf'), isFalse);
+
+    expect(provider.profile?.revenuBrutAnnuel, 96000);
+    expect(provider.profile?.canton, 'GE');
+    expect(provider.profile?.birthYear, 2001);
+  });
+
+  testWidgets('revenue block seeds pension switch from existing profile',
+      (tester) async {
+    final provider = CoachProfileProvider()
+      ..updateFromAnswers({
+        'q_gross_salary_annual': 96000,
+        'q_canton': 'GE',
+        'q_birth_year': 1990,
+        'q_has_pension_fund': true,
+      });
+
+    await tester.pumpWidget(_wrap(
+      const DataBlockEnrichmentScreen(blockType: 'revenu'),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(const Key('has_pension_fund_switch'));
+    expect(tester.widget<SwitchListTile>(tile).value, true);
+  });
+
   testWidgets('maps pension alias to LPP block metadata', (tester) async {
     await tester.pumpWidget(
       _wrap(const DataBlockEnrichmentScreen(blockType: 'pension')),

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -87,6 +87,33 @@ void main() {
     expect(tester.widget<SwitchListTile>(tile).value, true);
   });
 
+  testWidgets('revenue block rejects underage birth year', (tester) async {
+    final provider = CoachProfileProvider();
+    final underageBirthYear = DateTime.now().year - 17;
+
+    await tester.pumpWidget(_wrap(
+      const DataBlockEnrichmentScreen(blockType: 'revenu'),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('canton_picker')), 'GE');
+    await tester.enterText(find.byKey(const Key('salary_input')), '96000');
+    await tester.enterText(
+      find.byKey(const Key('birth_year_input')),
+      '$underageBirthYear',
+    );
+
+    await tester.tap(find.byKey(const Key('salary_save_cta')));
+    await tester.pumpAndSettle();
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers.containsKey('q_gross_salary_annual'), isFalse);
+    expect(answers.containsKey('q_canton'), isFalse);
+    expect(answers.containsKey('q_birth_year'), isFalse);
+    expect(provider.profile, isNull);
+  });
+
   testWidgets('maps pension alias to LPP block metadata', (tester) async {
     await tester.pumpWidget(
       _wrap(const DataBlockEnrichmentScreen(blockType: 'pension')),


### PR DESCRIPTION
## What
- Adds an inline revenue collector on `/data-block/revenu` for first salary facts.
- Persists only canonical Data Ledger keys via `CoachProfileProvider.mergeAnswers`: `q_gross_salary_annual`, `q_canton`, optional `q_birth_year`, optional touched `q_has_pension_fund`.
- Keeps income chronology clean: does not write `q_net_income_period_chf` or `q_monthly_gross_salary_chf`.

## QA
- Red/green widget coverage for canonical revenue persistence and no duplicate income keys.
- `flutter analyze lib/screens/onboarding/data_block_enrichment_screen.dart test/screens/data_block_enrichment_screen_test.dart`
- `flutter test test/screens/data_block_enrichment_screen_test.dart --reporter expanded`
- `git diff --check`
- MCP ARB parity: OK across fr/en/de/es/it/pt.
- Claude CLI external audit: no unresolved CRITICAL/HIGH blockers; previous pension-switch overwrite risk resolved by seeding from profile and writing only if touched.

## Runtime Gate
- Runtime proof is blocked in this clean base because `apps/mobile/.maestro/` and `apps/mobile/test/patrol/` are absent, and iOS `Info.plist` has no `CFBundleURLTypes` for `mint://` deep links.
- Claude audit notes `MAESTRO_FLOWS.md` must be updated before authoring flows: use `salary_save_cta`, canton code `GE`, and register `birth_year_input` / `has_pension_fund_switch` / `salary_save_cta`.

## Notes
- Scope is intentionally narrow: one data block, one canonical write path, two files.
- Diff: 2 files, 297 insertions, 57 deletions.
