### PR TITLE
[codex] Register iOS mint deep links

### DIFF
--- a/apps/mobile/ios/Runner/Info.plist
+++ b/apps/mobile/ios/Runner/Info.plist
@@ -18,6 +18,17 @@
 	<string>MINT</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ch.mint.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mint</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>

--- a/apps/mobile/test/runtime/ios_url_scheme_contract_test.dart
+++ b/apps/mobile/test/runtime/ios_url_scheme_contract_test.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('iOS registers the mint custom URL scheme for Maestro openLink', () {
+    final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+    expect(plist, contains('<key>CFBundleURLTypes</key>'));
+    expect(plist, contains('<key>CFBundleURLSchemes</key>'));
+    expect(plist, contains('<string>mint</string>'));
+  });
+}


### PR DESCRIPTION
## What
- Registers the `mint` custom URL scheme in iOS `Info.plist`.
- Adds a narrow runtime contract test so Maestro `openLink: mint:///...` cannot silently regress on iOS.

## Why
- #831 could not honestly claim Maestro runtime proof from the clean base because iOS had no `CFBundleURLTypes` for `mint://`.
- This PR extracts only the proven runtime-entry piece from the larger gisement; no Android work, no startup-route bridge, no product UI changes.

## QA
- `flutter analyze ios/Runner/Info.plist test/runtime/ios_url_scheme_contract_test.dart`
- `flutter test test/runtime/ios_url_scheme_contract_test.dart --reporter expanded`
- `plutil -lint apps/mobile/ios/Runner/Info.plist`
- `./tools/mint-routes reconcile`
- `git diff --check`
- MCP ARB parity: OK across fr/en/de/es/it/pt.
- Claude CLI final audit: PASS, no CRITICAL/HIGH blockers.

## Runtime Proof
- Simulator: iPhone 17 Pro `B03E429D-0422-4357-B754-536637D979F9`.
- `flutter build ios --simulator --debug` -> PASS.
- `xcrun simctl install ... Runner.app` -> PASS.
- Cold deep link: `xcrun simctl openurl ... mint:///data-block/revenu` -> PASS.
- `xcodebuildmcp` snapshot after deep link showed the revenue data-block with `Ton salaire brut est la base de toutes les projections`, `Ce bloc est complet`, and `Préciser mon revenu`.

## Notes
- Custom URL schemes require no Apple Associated Domains entitlement or provisioning profile change.
- Deep-link inputs remain untrusted; future state-changing links must still be guarded by route/auth logic.
- Diff: 2 files, 24 insertions.
