### PR TITLE
[codex] Expose mortgage ledger prefill ids

### DIFF
--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -282,21 +282,25 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                 // SECTION 2 — LE RESULTAT : consequence financiere
                 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                MintResultHeroCard(
-                  eyebrow: result.premierEclairagePositif
-                      ? l.affordabilityParameters
-                      : l.affordabilityInsightEquityTitle,
-                  primaryValue: result.premierEclairagePositif
-                      ? 'CHF\u00a0${formatChf(result.prixMaxAccessible)}'
-                      : 'CHF\u00a0${formatChf(result.manqueFondsPropres)}',
-                  primaryLabel: result.premierEclairagePositif
-                      ? l.affordabilityCalculationDetail
-                      : l.affordabilityExceeded,
-                  narrative: result.premierEclairageTexte,
-                  accentColor: result.premierEclairagePositif
-                      ? MintColors.success
-                      : MintColors.error,
-                  tone: MintSurfaceTone.porcelaine,
+                Semantics(
+                  identifier: 'mortgage_afford_result',
+                  child: MintResultHeroCard(
+                    key: const Key('mortgage_afford_result'),
+                    eyebrow: result.premierEclairagePositif
+                        ? l.affordabilityParameters
+                        : l.affordabilityInsightEquityTitle,
+                    primaryValue: result.premierEclairagePositif
+                        ? 'CHF\u00a0${formatChf(result.prixMaxAccessible)}'
+                        : 'CHF\u00a0${formatChf(result.manqueFondsPropres)}',
+                    primaryLabel: result.premierEclairagePositif
+                        ? l.affordabilityCalculationDetail
+                        : l.affordabilityExceeded,
+                    narrative: result.premierEclairageTexte,
+                    accentColor: result.premierEclairagePositif
+                        ? MintColors.success
+                        : MintColors.error,
+                    tone: MintSurfaceTone.porcelaine,
+                  ),
                 ),
                 const SizedBox(height: MintSpacing.xl),
 
@@ -417,38 +421,50 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                       const SizedBox(height: MintSpacing.lg),
 
                       // Revenu brut annuel
-                      _buildAmountFieldWithBadge(
-                        label: l.affordabilityGrossIncome,
-                        value: _revenuBrut,
-                        fieldKey: 'revenu_brut',
-                        onChanged: (v) {
-                          setState(() { _hasUserInteracted = true; _revenuBrut = v; });
-                          WidgetsBinding.instance.addPostFrameCallback((_) => _writeBackResult());
-                        },
-                        min: 50000,
-                        max: 300000,
+                      Semantics(
+                        identifier: 'mortgage_income_amount',
+                        child: _buildAmountFieldWithBadge(
+                          key: const Key('mortgage_income_amount'),
+                          label: l.affordabilityGrossIncome,
+                          value: _revenuBrut,
+                          fieldKey: 'revenu_brut',
+                          onChanged: (v) {
+                            setState(() { _hasUserInteracted = true; _revenuBrut = v; });
+                            WidgetsBinding.instance.addPostFrameCallback((_) => _writeBackResult());
+                          },
+                          min: 50000,
+                          max: 300000,
+                        ),
                       ),
                       const SizedBox(height: MintSpacing.md),
 
                       // Prix d'achat
-                      MintAmountField(
-                        label: l.affordabilityTargetPrice,
-                        value: _prixAchat,
-                        formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                        onChanged: (v) => setState(() { _hasUserInteracted = true; _prixAchat = v; }),
-                        min: 200000,
-                        max: 3000000,
+                      Semantics(
+                        identifier: 'mortgage_price_amount',
+                        child: MintAmountField(
+                          key: const Key('mortgage_price_amount'),
+                          label: l.affordabilityTargetPrice,
+                          value: _prixAchat,
+                          formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
+                          onChanged: (v) => setState(() { _hasUserInteracted = true; _prixAchat = v; }),
+                          min: 200000,
+                          max: 3000000,
+                        ),
                       ),
                       const SizedBox(height: MintSpacing.md),
 
                       // Epargne disponible
-                      MintAmountField(
-                        label: l.affordabilityAvailableSavings,
-                        value: _epargneDispo,
-                        formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                        onChanged: (v) => setState(() { _hasUserInteracted = true; _epargneDispo = v; }),
-                        min: 0,
-                        max: 500000,
+                      Semantics(
+                        identifier: 'mortgage_savings_amount',
+                        child: MintAmountField(
+                          key: const Key('mortgage_savings_amount'),
+                          label: l.affordabilityAvailableSavings,
+                          value: _epargneDispo,
+                          formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
+                          onChanged: (v) => setState(() { _hasUserInteracted = true; _epargneDispo = v; }),
+                          min: 0,
+                          max: 500000,
+                        ),
                       ),
 
                       // Progressive disclosure: 3a + LPP behind toggle
@@ -480,22 +496,30 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
                       ),
                       if (_showAdvancedParams) ...[
                         const SizedBox(height: MintSpacing.md),
-                        MintAmountField(
-                          label: l.affordabilityPillar3a,
-                          value: _avoir3a,
-                          formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                          onChanged: (v) => setState(() { _hasUserInteracted = true; _avoir3a = v; }),
-                          min: 0,
-                          max: 300000,
+                        Semantics(
+                          identifier: 'mortgage_pillar3a_amount',
+                          child: MintAmountField(
+                            key: const Key('mortgage_pillar3a_amount'),
+                            label: l.affordabilityPillar3a,
+                            value: _avoir3a,
+                            formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
+                            onChanged: (v) => setState(() { _hasUserInteracted = true; _avoir3a = v; }),
+                            min: 0,
+                            max: 300000,
+                          ),
                         ),
                         const SizedBox(height: MintSpacing.md),
-                        _buildAmountFieldWithBadge(
-                          label: l.affordabilityPillarLpp,
-                          value: _avoirLpp,
-                          fieldKey: 'avoir_lpp',
-                          onChanged: (v) => setState(() { _hasUserInteracted = true; _avoirLpp = v; }),
-                          min: 0,
-                          max: 500000,
+                        Semantics(
+                          identifier: 'mortgage_lpp_amount',
+                          child: _buildAmountFieldWithBadge(
+                            key: const Key('mortgage_lpp_amount'),
+                            label: l.affordabilityPillarLpp,
+                            value: _avoirLpp,
+                            fieldKey: 'avoir_lpp',
+                            onChanged: (v) => setState(() { _hasUserInteracted = true; _avoirLpp = v; }),
+                            min: 0,
+                            max: 500000,
+                          ),
                         ),
                       ],
                     ],
@@ -548,6 +572,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   /// Builds a MintAmountField with an optional SmartDefaultIndicator badge
   /// shown above the field when the field key is in _prefilledFields.
   Widget _buildAmountFieldWithBadge({
+    Key? key,
     required String label,
     required double value,
     required String fieldKey,
@@ -557,6 +582,7 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   }) {
     final isPrefilled = _prefilledFields.contains(fieldKey);
     return Column(
+      key: key,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (isPrefilled) ...[

--- a/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 // Screens under test
 import 'package:mint_mobile/screens/mortgage/affordability_screen.dart';
@@ -9,6 +10,7 @@ import 'package:mint_mobile/screens/mortgage/amortization_screen.dart';
 import 'package:mint_mobile/screens/mortgage/epl_combined_screen.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 
 // =============================================================================
@@ -31,8 +33,8 @@ void main() {
   // ===========================================================================
 
   group('AffordabilityScreen', () {
-    Widget buildScreen() {
-      return const MaterialApp(
+    Widget buildScreen({CoachProfileProvider? coachProvider}) {
+      const app = MaterialApp(
         locale: Locale('fr'),
         localizationsDelegates: [
           S.delegate,
@@ -42,6 +44,16 @@ void main() {
         ],
         supportedLocales: S.supportedLocales,
         home: AffordabilityScreen(),
+      );
+      if (coachProvider != null) {
+        return ChangeNotifierProvider<CoachProfileProvider>.value(
+          value: coachProvider,
+          child: app,
+        );
+      }
+      return ChangeNotifierProvider<CoachProfileProvider>(
+        create: (_) => CoachProfileProvider(),
+        child: app,
       );
     }
 
@@ -137,6 +149,38 @@ void main() {
       await tester.pump();
 
       expect(find.byType(DropdownButton<String>), findsOneWidget);
+    });
+
+    testWidgets('uses canonical ledger facts and exposes runtime result id',
+        (tester) async {
+      final coachProvider = CoachProfileProvider()
+        ..updateFromAnswers({
+          'q_gross_salary_annual': 96000,
+          'q_canton': 'GE',
+          'q_birth_year': 2001,
+          'q_has_pension_fund': false,
+        });
+
+      await tester.pumpWidget(buildScreen(coachProvider: coachProvider));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('mortgage_afford_result')), findsOneWidget);
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('mortgage_income_amount')),
+        300,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('mortgage_income_amount')), findsOneWidget);
+      expect(find.text('Estime'), findsWidgets);
+      expect(find.textContaining("96'000"), findsWidgets);
+      expect(find.text('GE'), findsWidgets);
+
+      await tester.tap(find.text('Estime').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Depuis ton profil MINT'), findsOneWidget);
     });
 
     testWidgets('displays detail section after scrolling', (tester) async {


### PR DESCRIPTION
## Summary
- Exposes stable runtime identifiers on the mortgage affordability result and core input controls.
- Adds a widget contract proving `/hypotheque` reuses canonical ledger facts (`q_gross_salary_annual`, `q_canton`) instead of asking for duplicate revenue data.
- Asserts the estimated source sheet still explains that reused values come from the MINT profile.

## QA
- `flutter test test/screens/mortgage_screens_smoke_test.dart --reporter expanded` — 53 tests passed
- `flutter analyze lib/screens/mortgage/affordability_screen.dart test/screens/mortgage_screens_smoke_test.dart` — no issues
- `./tools/mint-routes reconcile` — 141 routes parity OK
- `git diff --check origin/claude/mint-swiss-coach-eu33i7...HEAD` — no whitespace errors
- MCP `validate_arb_parity` — 6821 keys in each fr/en/de/es/it/pt

## Runtime note
This PR is intentionally small and does not add a new navigation route or financial formula. It prepares `/hypotheque` for Maestro/Patrol runtime proof by exposing stable identifiers. Full seeded simulator proof depends on the iOS deep-link and revenue data-block branches being merged or validated together.
