### PR TITLE
[codex] Prove revenue data block feeds mortgage

### DIFF
--- a/apps/mobile/.maestro/f2_datablock_to_mortgage.yaml
+++ b/apps/mobile/.maestro/f2_datablock_to_mortgage.yaml
@@ -40,3 +40,16 @@ appId: ch.mint.app
 - openLink: "mint:///hypotheque"
 - assertVisible:
     id: "mortgage_afford_result"
+- scrollUntilVisible:
+    element:
+      id: "mortgage_income_amount"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- assertVisible:
+    id: "mortgage_income_amount"
+- assertVisible:
+    text: ".*CHF.*96'000.*"
+- assertVisible:
+    text: ".*Canton.*GE.*"

--- a/apps/mobile/.maestro/f2_datablock_to_mortgage.yaml
+++ b/apps/mobile/.maestro/f2_datablock_to_mortgage.yaml
@@ -1,0 +1,42 @@
+appId: ch.mint.app
+---
+# F-2: the user fills the revenue data block, saves canonical ledger facts,
+# then /hypotheque consumes those facts without asking for salary/canton again.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///data-block/revenu"
+- assertVisible:
+    text: "Revenu"
+- tapOn:
+    id: "salary_input"
+- inputText: "96000"
+- tapOn:
+    id: "canton_picker"
+- inputText: "GE"
+- tapOn:
+    id: "birth_year_input"
+- inputText: "2001"
+- tapOn:
+    text: "Revenu"
+- tapOn:
+    id: "has_pension_fund_switch"
+- scrollUntilVisible:
+    element:
+      id: "salary_save_cta"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- tapOn:
+    id: "salary_save_cta"
+- assertVisible:
+    text: "12 / 12 pts"
+- assertVisible:
+    text: "Complet"
+- openLink: "mint:///hypotheque"
+- assertVisible:
+    id: "mortgage_afford_result"


### PR DESCRIPTION
## Summary
- Add an executable Maestro F-2 flow for the real revenue data-block path.
- The flow fills salary, canton, birth year and LPP through the UI, saves the canonical ledger facts, then opens /hypotheque.
- This intentionally avoids startup seeds or storage injection, so the proof covers chronology and no duplicate salary/canton collection.

## QA
- `MAESTRO_CLI_NO_ANALYTICS=true maestro test --device B03E429D-0422-4357-B754-536637D979F9 apps/mobile/.maestro/f2_datablock_to_mortgage.yaml`
- `cd apps/mobile && flutter analyze lib/screens/onboarding/data_block_enrichment_screen.dart lib/screens/mortgage/affordability_screen.dart test/screens/data_block_enrichment_screen_test.dart test/screens/mortgage_screens_smoke_test.dart test/runtime/ios_url_scheme_contract_test.dart`
- `cd apps/mobile && flutter test test/screens/data_block_enrichment_screen_test.dart test/screens/mortgage_screens_smoke_test.dart test/runtime/ios_url_scheme_contract_test.dart --reporter expanded`
- `./tools/mint-routes reconcile`
- `git diff --check`
- MCP `validate_arb_parity`: ARB parity OK, 6821 keys in fr/en/de/es/it/pt

## Workflow Gaps Noted
- This clean base has no `docs/MINT_AGENT_WORKFLOW.md`, `.planning/ACTIVE_CONTEXT.*`, or active guard scripts found for `active_context_guard.py`, `phase_contract_guard.py`, `mint_rules_guard.py`, `verify_phase_acceptance.py`.
- No `.planning/runtime-evidence/` convention exists in this base, so runtime evidence is recorded in this PR and the executable Maestro artifact itself.