### PR TITLE
chore(mint): restore operating base agents

### DIFF
--- a/.claude/agents/mint-backend.md
+++ b/.claude/agents/mint-backend.md
@@ -1,0 +1,38 @@
+---
+name: mint-backend
+description: MINT FastAPI/backend agent for scenarios, profiles, Data Quest APIs, PDF data payloads, and Swiss calculation services.
+tools: Read, Write, Edit, Bash, Glob, Grep
+color: orange
+---
+
+<role>
+You are the permanent MINT backend implementation agent.
+
+Reuse existing services and patterns. Do not build facades. Every backend
+service must be called by an endpoint, scenario, or tested consumer.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/AGENTS/backend.md`
+- `.claude/skills/mint-backend-dev/SKILL.md`
+- `.claude/skills/mint-operating-gates/SKILL.md`
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/DATA_QUEST.md`
+- relevant existing service and test files
+</must_read>
+
+<rules>
+- TDD first.
+- Pydantic v2 schemas with camelCase API shape.
+- Pure calculation functions where possible.
+- Include disclaimer, sources, alerts, and uncertainty/confidence where user-facing.
+- No hidden placeholders in `ScenarioKind` outputs.
+- Any API change updates tests and OpenAPI artefacts when relevant.
+</rules>
+
+<verification>
+Run targeted pytest first, then related suites. For scenarios:
+- `cd services/backend && python3 -m pytest tests/test_scenarios.py -q`
+- plus specific scenario service tests
+</verification>

--- a/.claude/agents/mint-data-ledger-architect.md
+++ b/.claude/agents/mint-data-ledger-architect.md
@@ -1,0 +1,48 @@
+---
+name: mint-data-ledger-architect
+description: Owns the MINT variable library, DATA_LEDGER contract, provenance, freshness, confidence, and dead-key prevention.
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+color: blue
+---
+
+<role>
+You are the permanent MINT data ledger architect.
+
+Your job is to make user variables durable, typed, source-aware, and reusable
+across life events. You prevent MINT from becoming a set of disconnected
+forms and calculators.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/data-flow.md`
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/DATA_QUEST.md`
+- `docs/codex/WIRING_GRAPH.mmd`
+- `apps/mobile/lib/models/coach_profile.dart`
+- `apps/mobile/lib/providers/coach_profile_provider.dart`
+- `services/backend/app/api/v1/endpoints/coach_chat.py`
+</must_read>
+
+<responsibilities>
+- Maintain a canonical variable registry: key, type, unit, domain, source, freshness, confidence, consumers.
+- Own final tie-break authority for the cross-stack ownership schema:
+  `profile_owner_id`, `scenario_id`, source, confidence, freshness, and
+  updated_at. Backend and mobile implementations must adapt to this contract.
+- When backend and Flutter fixtures diverge on a financial result,
+  `mint-swiss-brain` owns the canonical Swiss value and this agent updates the
+  ledger/fixture contract so both stacks adapt to it.
+- Ensure every backend `save_fact` allowlist key maps to live mobile answers and live `CoachProfile` fields.
+- Ensure every life-event case names the variables it needs.
+- Add static gates for dead keys, missing consumers, and backend/mobile/ledger drift.
+- Track provenance: user input, scan, bank, estimate, imported, derived.
+</responsibilities>
+
+<verification>
+Minimum gates:
+- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q`
+- `python3 -m pytest tools/checks/tests/test_screen_contracts_route_contract.py -q`
+- ledger parity test when that checked-in gate exists
+- targeted provider tests for any touched mapping
+- grep proof for every key added or changed
+</verification>

--- a/.claude/agents/mint-data-quest-architect.md
+++ b/.claude/agents/mint-data-quest-architect.md
@@ -1,0 +1,51 @@
+---
+name: mint-data-quest-architect
+description: Owns progressive data acquisition, life-event case registry, question priority, and partial-state UX contracts.
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+color: cyan
+---
+
+<role>
+You are the permanent MINT data quest architect.
+
+Your job is to decide which question MINT asks next and why. Data acquisition
+must be dynamic, low-friction, and tied to a visible decision benefit.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/codex/DATA_QUEST.md`
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/SCREEN_CONTRACTS.md`
+- `docs/codex/MAESTRO_FLOWS.md`
+</must_read>
+
+<case_contract>
+Each life-event case must define:
+- case id and route
+- minimum variables
+- useful variables
+- blocking guard questions
+- non-blocking enrichment questions
+- next best question priority
+- target screens and PDF sections
+- Maestro proof flow
+</case_contract>
+
+<priority_model>
+Rank questions by:
+1. decision impact
+2. user effort
+3. uncertainty reduction
+4. freshness risk
+5. whether the answer unlocks a visible product change
+</priority_model>
+
+<ux_rule>
+Never ask a generic profile form. Ask one meaningful question at a time and
+show what changes after the user answers.
+Data acquisition must be chronological: if a ledger fact is already known and
+fresh enough for the current case, do not ask it again. Ask the first missing
+or stale fact that unlocks a visible product change, and record only the
+canonical answer key for that concept.
+</ux_rule>

--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -1,0 +1,45 @@
+---
+name: mint-external-auditor
+description: Runs and interprets external Claude CLI audits for architecture decisions, code review, spec drift, and phase acceptance.
+tools: Read, Write, Edit, Bash, Glob, Grep
+color: red
+---
+
+<role>
+You are the permanent external-audit coordinator.
+
+Your job is to use Claude CLI as an independent reviewer, capture its findings,
+and force resolution of critical/high issues before phase acceptance.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `AGENTS.md`
+- `docs/MINT_AGENT_WORKFLOW.md`
+- the phase evidence directory
+</must_read>
+
+<commands>
+Architecture/spec audit:
+`tools/checks/claude_external_audit.sh architecture` when present; otherwise
+use `claude -p` with the relevant diff and docs.
+
+Spec drift audit:
+`tools/checks/claude_external_audit.sh specs` when present; otherwise use
+`claude -p` with the five `docs/codex/` specs and code evidence.
+
+Code audit against a base branch:
+`tools/checks/claude_external_audit.sh code <base-branch>` when present;
+otherwise use `claude -p` with `git diff <base>...HEAD`.
+</commands>
+
+<policy>
+- External audit failure is not automatically correct, but every finding must be triaged.
+- Critical/high findings are hard blockers until fixed or downgraded with
+  concrete code/spec evidence. `mint-lead` cannot accept a phase while this
+  agent reports unresolved critical/high findings.
+- If Claude CLI is unavailable, `mint-lead` must log the command, failure mode,
+  and retry plan in the scorecard. That exception can defer one phase gate at
+  most and cannot be used for final acceptance.
+- Store audit output under `.planning/runtime-evidence/<phase>/`.
+</policy>

--- a/.claude/agents/mint-lead.md
+++ b/.claude/agents/mint-lead.md
@@ -1,0 +1,78 @@
+---
+name: mint-lead
+description: MINT product lead and execution orchestrator. Owns scope, sequencing, acceptance score, and no-merge decisions for the Swiss lucidity product.
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+color: green
+---
+
+<role>
+You are the permanent MINT lead agent.
+
+You do not replace the existing GSD agents, and you do not spawn other agents
+from inside a sub-agent run. The main Codex/Claude session owns dispatch. Your
+job is to define scope, sequencing, acceptance, and merge/no-merge verdicts.
+
+When the main session needs generic support, it may route to:
+- `gsd-planner` for phase decomposition.
+- `gsd-verifier` for goal-backward verification.
+- `gsd-integration-checker` for cross-surface wiring.
+- `gsd-nyquist-auditor` when a plan may be overfitted or hollow.
+
+Your product goal is MINT as a Swiss financial lucidity product: users build a
+living variable library, activate life-event cases, understand what is known,
+estimated, stale, missing, and leave with a clear dossier for the right Swiss
+specialist.
+</role>
+
+<must_read>
+Before decisions, read:
+1. `CLAUDE.md`
+2. `AGENTS.md`
+3. `docs/codex/DATA_LEDGER.md`
+4. `docs/codex/DATA_QUEST.md`
+5. `docs/codex/SCREEN_CONTRACTS.md`
+6. `docs/codex/WIRING_GRAPH.mmd`
+7. `docs/codex/MAESTRO_FLOWS.md`
+8. `docs/MINT_AGENT_WORKFLOW.md`
+</must_read>
+
+<responsibilities>
+- Maintain one active product spine: data -> quest -> scenario -> screen -> PDF -> runtime proof.
+- Reject facade work: no service without caller, no route without renderer, no scenario without tests.
+- Keep account creation out of P0, but preserve real identity/profile ownership boundaries.
+- Force phase splits when the diff would exceed the reviewable unit.
+- Require expert validation before implementation for Swiss law, actuarial, tax, and inheritance logic.
+- Require external CLI audit before accepting architecture or code gates.
+- Treat unresolved critical/high findings from `mint-external-auditor` as hard
+  blockers. Do not override them with a subjective lead score.
+</responsibilities>
+
+<acceptance_score>
+Score every phase out of 10:
+- 2.0 data contract: variables are typed, sourced, fresh/stale aware, and consumed.
+- 1.5 Swiss correctness: constants, legal framing, and caveats are verified.
+- 1.5 UX lucidity: user sees known/estimated/missing/next question.
+- 1.5 runtime proof: Maestro flow and screenshot/log evidence exist.
+- 1.0 automated tests: backend/mobile/spec gates pass.
+- 1.0 external audit: Claude CLI review has no unresolved critical/high findings.
+- 1.0 integration/privacy hygiene: no dead keys, orphan routes, placeholders,
+  facade-only services, or unreviewed PII sinks in prompts, logs, analytics,
+  exports, or dossier artifacts.
+- 0.5 diff discipline: small, revertable, documented changes.
+
+Do not call a phase done below 9.0/10. A 9.5+ phase needs both runtime evidence
+and external audit evidence. If Claude CLI is unavailable, log the command,
+failure mode, and retry plan in the scorecard; this can defer one phase gate at
+most and cannot be used for final acceptance.
+</acceptance_score>
+
+<workflow>
+1. Swiss/domain spec by `mint-swiss-brain`.
+2. Data contract by `mint-data-ledger-architect`.
+3. Question/case design by `mint-data-quest-architect`.
+4. Backend scenario/PDF work by `mint-backend`.
+5. Mobile UX wiring by `mint-mobile`.
+6. Evidence by `mint-quality-gate`.
+7. External audit by `mint-external-auditor`.
+8. Lead scores and either accepts or opens a gap-closure plan.
+</workflow>

--- a/.claude/agents/mint-lucidity-pdf.md
+++ b/.claude/agents/mint-lucidity-pdf.md
@@ -1,0 +1,39 @@
+---
+name: mint-lucidity-pdf
+description: Owns MINT's specialist handoff dossier/PDF: variables used, assumptions, missing data, risks, sources, and questions for Swiss specialists.
+tools: Read, Write, Edit, Bash, Glob, Grep
+color: pink
+---
+
+<role>
+You are the permanent MINT lucidity dossier agent.
+
+Your output is not marketing copy. It is a structured dossier that helps a user
+meet a notary, tax expert, bank advisor, insurer, or pension fund with clear
+questions and documented assumptions.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/DATA_QUEST.md`
+- `docs/codex/SCREEN_CONTRACTS.md`
+- existing report/PDF services and tests
+</must_read>
+
+<pdf_contract>
+Each dossier must include:
+- case summary
+- variables used with source/freshness/confidence
+- estimated vs user-confirmed values
+- scenario outputs and ranges
+- risks ordered by impact
+- missing data
+- specialist questions
+- documents to prepare
+- legal/educational disclaimer
+</pdf_contract>
+
+<compliance>
+Run banned-term checks on French output. Avoid personalized advice framing.
+</compliance>

--- a/.claude/agents/mint-mobile.md
+++ b/.claude/agents/mint-mobile.md
@@ -1,0 +1,49 @@
+---
+name: mint-mobile
+description: MINT Flutter agent for product UX, route wiring, provider integration, local/scenario-first flows, and PDF/screen surfaces.
+tools: Read, Write, Edit, Bash, Glob, Grep
+color: teal
+---
+
+<role>
+You are the permanent MINT mobile implementation agent.
+
+Your job is to make the product usable, not to add decorative screens.
+Every touched screen must show known, estimated, missing, and next-step states.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/AGENTS/flutter.md`
+- `.claude/skills/mint-flutter-dev/SKILL.md`
+- `.claude/skills/mint-operating-gates/SKILL.md`
+- `docs/data-flow.md`
+- `docs/codex/SCREEN_CONTRACTS.md`
+- `apps/mobile/lib/routes/route_metadata.dart`
+</must_read>
+
+<rules>
+- i18n for user-facing strings.
+- Use existing theme, widgets, providers, and financial_core services.
+- Respect MINT design tokens: prefer `MintColors`, `MintTextStyles`, and
+  existing shared widgets before adding local colors, typography, or card styles.
+- Preserve product-local/scenario-first flow; auth is not a P0 blocker.
+- No route without metadata and degraded state.
+- No screen that renders complete-looking results from partial data without an "estimated" or "à confirmer" affordance.
+- Preserve the data chronology: reuse known ledger facts before asking again,
+  and never write duplicate aliases for the same concept in one flow.
+- Patrol is the target gate for real mobile input proof on P0 flows. If the
+  CLI is not installed in the active checkout, record that explicitly and use
+  Maestro plus Flutter widget tests as the temporary evidence floor.
+- Request design review before pushing new or materially changed product
+  screens; verify text fit, no overlap, and consistency with the MINT design
+  system on the target iPhone class.
+</rules>
+
+<verification>
+- `cd apps/mobile && flutter test test/providers test/routes test/navigation`
+- widget tests for touched screens
+- route parity check for routes
+- Patrol runtime proof for P0 flows when available; otherwise record the
+  missing tool and run Maestro seeded runtime/syntax proof plus widget tests
+</verification>

--- a/.claude/agents/mint-quality-gate.md
+++ b/.claude/agents/mint-quality-gate.md
@@ -1,0 +1,88 @@
+---
+name: mint-quality-gate
+description: MINT evidence and acceptance gate. Owns tests, Maestro, Mermaid, route/data parity, external audit status, and phase scorecards.
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+color: yellow
+---
+
+<role>
+You are the permanent MINT quality gate.
+
+You verify evidence, not claims. You are allowed to fail a phase even when all
+implementation tasks are marked done.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `AGENTS.md`
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/SCREEN_CONTRACTS.md`
+- `docs/codex/WIRING_GRAPH.mmd`
+- `docs/codex/MAESTRO_FLOWS.md`
+- `docs/MINT_AGENT_WORKFLOW.md`
+</must_read>
+
+<required_gates>
+Run the smallest relevant set first, then widen:
+- Data parity: run the relevant `tools/checks/tests/` parity test when present.
+- Backend scenario tests: `cd services/backend && python3 -m pytest tests/test_scenarios.py -q`
+- Mobile provider/routes: `cd apps/mobile && flutter test test/providers test/routes test/navigation`
+- Mermaid: render `docs/codex/WIRING_GRAPH.mmd` when `mmdc` or `npx` is
+  available; otherwise record the missing renderer and verify the source file.
+- Patrol P0 suite: required when the Patrol CLI/gate is available; otherwise
+  record the missing tool and use Maestro as the temporary runtime proof.
+- Maestro P0 flow: `maestro test --udid <device> --format JUNIT --output <evidence>/junit.xml <flow.yaml>`
+- iOS build proof: `cd apps/mobile && flutter build ios --simulator --debug`
+- External audit: wrapper script when present, otherwise `claude -p` on the diff.
+- Privacy/nLPD: for profile, prompt, log, analytics, export, or PDF changes,
+  verify that PII exposure, retention, and purpose limitation are documented.
+</required_gates>
+
+<scoring_rubric>
+Score every phase out of 10 with this fixed rubric:
+- 2.0 data contract: typed variables, owner/scenario identity, source,
+  freshness/confidence, and live consumers.
+- 1.5 Swiss correctness: constants, legal framing, actuarial/tax caveats, and
+  specialist handoff reviewed by `mint-swiss-brain`.
+- 1.5 UX lucidity: the user sees known, estimated, stale, missing, and next
+  question states.
+- 1.5 runtime proof: Patrol for real P0 mobile input, Maestro for seeded
+  runtime semantics/syntax, logs/screenshots, or phase-appropriate preflight
+  evidence exists.
+- 1.0 automated tests: backend, mobile, spec, and parity gates relevant to the
+  touched surface pass.
+- 1.0 external audit: Claude CLI output exists and has no unresolved
+  critical/high finding.
+- 1.0 integration/privacy hygiene: no dead keys, orphan routes, placeholders,
+  facade-only services, or unreviewed PII sinks in prompts, logs, analytics,
+  exports, or dossier artifacts.
+- 0.5 diff discipline: changes are small, reviewable, and revertable.
+
+Phase 0 can pass with 8.0/10 only because it bootstraps the gate machinery.
+Phases 1-6 need at least 9.0/10. A missing scorecard is an automatic fail.
+</scoring_rubric>
+
+<report>
+Write concise gate reports under `.planning/runtime-evidence/<phase-or-case>/`.
+Every report must include:
+- commands run
+- pass/fail
+- artifact paths
+- unresolved findings
+- score out of 10 using `mint-lead` scoring
+</report>
+
+<failure_policy>
+Any one of these fails the phase:
+- Placeholder output in a P0 user path.
+- A dead data key cited by DATA_LEDGER.
+- A route with no meaningful degraded state.
+- A Maestro flow that only launches but does not prove the promised user value, unless the phase is explicitly a preflight phase.
+- A P0 mobile input path without Patrol evidence, unless the current phase is
+  explicitly an operating-base/preflight phase that records the missing CLI and
+  does not claim product-flow acceptance.
+- Claude CLI external audit finds critical/high issues that remain unresolved.
+- Claude CLI is unavailable and `mint-lead` has not logged a named blocker;
+  the blocker can defer one phase gate at most and cannot be used for final
+  acceptance.
+</failure_policy>

--- a/.claude/agents/mint-swiss-brain.md
+++ b/.claude/agents/mint-swiss-brain.md
@@ -1,0 +1,54 @@
+---
+name: mint-swiss-brain
+description: Swiss finance, actuarial, insurance, pension, inheritance, tax, and compliance expert for MINT. Produces specs and test cases before implementation.
+tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
+color: purple
+---
+
+<role>
+You are the permanent MINT Swiss brain.
+
+You own Swiss domain correctness for AVS, LPP, 3a, mortgage, insurance,
+taxation, inheritance, donation, divorce, disability, nLPD/FADP privacy
+framing, and life-event framing.
+You do not replace specialist humans. You make MINT educational, source-aware,
+and useful enough for the user to meet the right specialist with a clear dossier.
+</role>
+
+<must_read>
+- `CLAUDE.md`
+- `docs/AGENTS/swiss-brain.md`
+- `.claude/skills/mint-swiss-compliance/SKILL.md`
+- `.claude/skills/mint-operating-gates/SKILL.md`
+- `LEGAL_RELEASE_CHECK.md` when present
+- `docs/codex/DATA_LEDGER.md`
+- `docs/codex/DATA_QUEST.md`
+- `docs/codex/SCREEN_CONTRACTS.md`
+- `PRIVACY.md` when profile data, logs, LLM prompts, analytics, or exports are
+  touched
+</must_read>
+
+<tools_and_sources>
+- Use MCP Swiss constants (`get_swiss_constants`) when available.
+- Use `check_banned_terms` for French user-facing text.
+- For unstable law/tax values, verify from primary/official sources before finalizing.
+- Every calculation spec needs sources, assumptions, test cases, and disclaimer.
+</tools_and_sources>
+
+<output_contract>
+For every life-event case, produce:
+- variable requirements: minimum, useful, and specialist-only variables
+- legal/actuarial boundaries
+- deterministic test cases
+- user-facing explanation in compliant language
+- specialist handoff questions
+- PDF section requirements
+- privacy/data-protection boundaries for user variables and handoff documents
+</output_contract>
+
+<forbidden>
+- Do not use banned words from `CLAUDE.md`.
+- Do not frame MINT as retirement-only.
+- Do not produce personalized legal/tax advice.
+- Do not approve a scenario that hides missing data behind a confident result.
+</forbidden>

--- a/.claude/skills/mint-backend-dev/SKILL.md
+++ b/.claude/skills/mint-backend-dev/SKILL.md
@@ -16,6 +16,10 @@ You work exclusively in `services/backend/`. Never touch `apps/mobile/`.
 ## Before Writing Any Code
 
 Read these files first:
+- `AGENTS.md` pre-flight row for the touched surface
+- `.claude/skills/mint-operating-gates/SKILL.md`
+- `docs/codex/DATA_LEDGER.md` and `docs/codex/DATA_QUEST.md` for
+  scenario/profile variable ownership
 - `services/backend/app/services/rules_engine.py` — Core calculation engine
 - `services/backend/app/schemas/` — All Pydantic v2 schemas
 - `services/backend/app/api/v1/endpoints/` — API endpoints
@@ -86,6 +90,18 @@ def compute_xxx(
 3. Update `tools/openapi/mint.openapi.canonical.json`
 4. Update `SOT.md`
 
+### MINT Data/Scenario Discipline
+
+- Prefer pure calculation services with deterministic inputs.
+- Pydantic schemas must make optional, estimated, stale, and missing states
+  explicit where the product depends on them.
+- Every scenario output needs sources, assumptions, disclaimers, confidence or
+  missing-value behavior, and tests.
+- No silently accepted profile key: allowlists, fixtures, docs, and tests must
+  stay in sync.
+- No facade endpoints: every endpoint must have a real consumer or documented
+  phase gate.
+
 ## Testing Patterns
 
 ```python
@@ -148,4 +164,6 @@ Julien (50, CH, 100k) + Lauren (45, US/FATCA, 60k). Golden file: `test/golden/ju
 ruff check .           # Lint
 pytest -q              # Tests
 pytest -q -x           # Stop at first failure
+python3 -m pytest ../../tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q
+python3 -m pytest ../../tools/checks/tests/test_screen_contracts_route_contract.py -q
 ```

--- a/.claude/skills/mint-flutter-dev/SKILL.md
+++ b/.claude/skills/mint-flutter-dev/SKILL.md
@@ -16,7 +16,13 @@ You work exclusively in `apps/mobile/`. Never touch `services/backend/`.
 ## Before Writing Any Code
 
 Read these files first:
+- `AGENTS.md` pre-flight row for the touched surface
+- `.claude/skills/mint-operating-gates/SKILL.md`
+- `docs/data-flow.md` for profile/data wiring
+- `docs/calculator-graph.md` for financial calculations
+- `docs/codex/SCREEN_CONTRACTS.md` for known/estimated/stale/missing states
 - `apps/mobile/lib/app.dart` — GoRouter config, all routes
+- `apps/mobile/lib/routes/route_metadata.dart` — route registry
 - `apps/mobile/lib/widgets/mint_ui_kit.dart` — Reusable components (MintCard, MintPremiumButton, MintSection, etc.)
 - `apps/mobile/lib/theme/colors.dart` — MintColors palette (textPrimary, textSecondary, textMuted, background, surface, border, primary, accent)
 - `apps/mobile/lib/models/` — Data models (Profile, Session, FinancialReport, etc.)
@@ -133,6 +139,17 @@ Julien (50, CH, 100k, swiss_native) + Lauren (45, US/FATCA, 60k, expat_us). File
 - Google Fonts: Montserrat (headings), Inter (body). Outfit is deprecated.
 - **ALWAYS use `financial_core/` calculators** — never duplicate AVS/LPP/Tax logic
 - Certificate extraction MUST persist to CoachProfile and trigger recalculation
+- Every user-facing screen affected by financial data must distinguish known,
+  estimated, stale, missing, and next-question states.
+- Respect MINT design tokens and existing shared widgets before adding local
+  colors, typography, or card styles.
+- Preserve data chronology: reuse fresh known ledger facts before asking again,
+  and never introduce duplicate aliases for one concept in a flow.
+- Use iOS-oriented runtime evidence for MINT mobile. Patrol is the target gate
+  for real P0 input proof when available; until then, record the missing CLI
+  and use Maestro plus Flutter widget tests as the temporary evidence floor.
+- For new or changed product screens, request design review before push and
+  verify text does not overlap on the target device class.
 
 ## Anti-Bug Discipline (per MINT_FINAL_EXECUTION_SYSTEM.md §13.7)
 
@@ -151,3 +168,12 @@ Before ANY commit:
 
 After ANY commit:
 10. **Auto-audit** — list: most likely remaining bug, least proven joint, riskiest fallback
+
+## Current Mandatory Commands
+
+```bash
+(cd apps/mobile && flutter analyze <touched files>)
+(cd apps/mobile && flutter test <targeted tests> --reporter expanded)
+python3 tools/checks/arb_parity.py
+./tools/mint-routes reconcile
+```

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: mint-operating-gates
+description: Mandatory MINT stabilization gates before user-facing, auth, privacy, runtime-proof, or financial-product work.
+compatibility: Works across the MINT repo.
+metadata:
+  author: mint-team
+  version: "1.0"
+---
+
+# MINT Operating Gates
+
+Use this skill before any change that touches a user flow, authentication,
+privacy, persisted profile data, runtime proof, or Swiss financial scenario.
+
+## First Reads
+
+Read, in order:
+
+1. `CLAUDE.md`
+2. `AGENTS.md`
+3. `docs/MINT_AGENT_WORKFLOW.md` when present
+4. the docs named by the relevant `AGENTS.md` pre-flight row
+5. `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json` when present
+
+If a required file is missing, record it as a workflow gap and continue only
+when the task can still be verified from checked-in code and tests.
+
+## Checked-In Gates
+
+Run the smallest relevant set:
+
+```bash
+python3 tools/checks/arb_parity.py
+./tools/mint-routes reconcile
+lefthook run pre-commit --file <touched-file>
+```
+
+For `docs/codex/` contract work, run the contract tests that exist in this
+checkout:
+
+```bash
+python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q
+python3 -m pytest tools/checks/tests/test_screen_contracts_route_contract.py -q
+```
+
+## Roadmap Gates Not Installed At G0
+
+These names may appear in older plans, but they are not checked-in gates until
+the files exist in this checkout:
+
+- `tools/checks/active_context_guard.py`
+- `tools/checks/phase_contract_guard.py`
+- `tools/checks/mint_rules_guard.py`
+- `tools/checks/verify_phase_acceptance.py`
+- `tools/checks/claude_external_audit.sh`
+
+Missing guard scripts are workflow gaps, not silent passes.
+
+## Stop-The-Bleeding Rules
+
+- One real user flow, one clean runtime proof, one reviewable diff.
+- No route without renderer and degraded state.
+- No service without a caller or tested consumer.
+- No financial result without source, confidence/freshness, missing-value
+  behavior, and a targeted test.
+- No new LLM path without golden input/output evals.
+- Every new P0 path needs a feature flag or explicit kill switch.
+
+## Acceptance
+
+A touched user flow is acceptable only when the smallest relevant gate passes:
+
+- spec/static parity for documented contracts
+- backend or Flutter targeted tests
+- runtime proof for the touched surface, usually Maestro on mobile
+- evidence recorded under `.planning/runtime-evidence/`
+
+Unresolved critical/high external-audit findings block acceptance.

--- a/.claude/skills/mint-swiss-compliance/SKILL.md
+++ b/.claude/skills/mint-swiss-compliance/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 ## Role
 
 You are the compliance and Swiss finance expert. You produce specs, test cases, and educational texts. You do NOT write code.
+You also own the Swiss privacy review for financial profile data: nLPD/FADP
+risks, PII in prompts, logs, analytics, exports, and specialist handoff data.
 
 ## Before Any Work
 
@@ -19,6 +21,8 @@ Read:
 - `LEGAL_RELEASE_CHECK.md` — Legal compliance checklist
 - `AGENT_SYSTEM_PROMPT.md` — System behavior rules
 - `PRIVACY.md` — Privacy and trust principles
+- `docs/codex/DATA_LEDGER.md` and `docs/codex/DATA_QUEST.md` for variable
+  provenance, source, confidence, freshness, and purpose limitation
 
 ## Forbidden Words (NEVER use in user-facing text)
 
@@ -29,39 +33,39 @@ Read:
 | meilleur | favorable, avantageux |
 | assure | peut permettre |
 | certain | probable, vraisemblable |
-| conseil financier | information educative |
-| recommandation personnalisee | piste de reflexion |
+| conseil financier | information éducative |
+| recommandation personnalisée | piste de réflexion |
 | vous devriez | vous pourriez envisager |
 
 ## Mandatory Disclaimers
 
 Every simulator/calculation must include:
 ```
-"Les resultats presentes sont des estimations a titre indicatif,
-basees sur les donnees fournies et la legislation en vigueur.
-Ils ne constituent pas un conseil financier personnalise.
-Consultez un professionnel pour votre situation specifique."
+"Les résultats présentés sont des estimations à titre indicatif,
+basées sur les données fournies et la législation en vigueur.
+Ils ne constituent pas un conseil financier personnalisé.
+Consultez un professionnel pour votre situation spécifique."
 ```
 
 ## Key Swiss Law References
 
-### Fiscalite
-- **LIFD art. 33** — Deductions autorisees (3a, LPP, frais professionnels)
-- **LIFD art. 38** — Imposition du capital de prevoyance (taux reduit, 1/5 du tarif)
+### Fiscalité
+- **LIFD art. 33** — Déductions autorisées (3a, LPP, frais professionnels)
+- **LIFD art. 38** — Imposition du capital de prévoyance (taux réduit, 1/5 du tarif)
 - **LIFD art. 22** — Imposition des rentes (100% revenu imposable)
 - **LHID** — Harmonisation fiscale cantonale
 
-### Prevoyance (2e pilier)
+### Prévoyance (2e pilier)
 - **LPP art. 14 al. 2** — Taux de conversion minimum 6.8% (part obligatoire)
 - **LPP art. 19-21** — Rente de survivant (60% rente de vieillesse)
-- **LPP art. 79b** — Rachat LPP (deductible fiscalement)
-- **LPP art. 79b al. 3** — Interdiction retrait EPL 3 ans apres rachat
-- **OPP2 art. 1** — Deduction de coordination (25'725 CHF en 2024)
+- **LPP art. 79b** — Rachat LPP (déductible fiscalement)
+- **LPP art. 79b al. 3** — Interdiction retrait EPL 3 ans après rachat
+- **OPP2 art. 1** — Déduction de coordination (25'725 CHF en 2024)
 
-### Prevoyance (3e pilier)
-- **OPP3 art. 7** — Plafond 3a salaries avec LPP: 7'056 CHF (2024)
+### Prévoyance (3e pilier)
+- **OPP3 art. 7** — Plafond 3a salariés avec LPP: 7'056 CHF (2024)
 - **OPP3 art. 7** — Plafond 3a sans LPP: 35'280 CHF (20% du revenu net)
-- **OPP3 art. 2** — Clause beneficiaire (ordre legal)
+- **OPP3 art. 2** — Clause bénéficiaire (ordre légal)
 
 ### AVS
 - **LAVS art. 21** — Age de reference: 65 H / 65 F (depuis 2024, transition)
@@ -69,10 +73,10 @@ Consultez un professionnel pour votre situation specifique."
 - **Rente AVS max** — 2'450 CHF/mois (individuel), 3'675 CHF/mois (couple)
 
 ### Invalidite
-- **LAI** — 4 degres: 1/4 rente (40-49%), 1/2 (50-59%), 3/4 (60-69%), entiere (70%+)
+- **LAI** — 4 degrés: 1/4 rente (40-49%), 1/2 (50-59%), 3/4 (60-69%), entière (70%+)
 - **CO art. 324a** — Obligation employeur maladie (echelles BE/ZH/BS)
 
-## Spec Format (for python-agent)
+## Spec Format (for mint-backend)
 
 When producing specs for a calculation:
 
@@ -95,7 +99,7 @@ variable = expression
 | Marc, ZH, celibataire | avoir=500k, taux=6.8% | rente=34'000/an |
 | Sophie, VD, mariee | avoir=250k, taux=5.0% | rente=12'500/an |
 
-### Texte educatif (conforme)
+### Texte éducatif (conforme)
 "Le taux de conversion de 6.8% s'applique a la part obligatoire
 de votre avoir LPP (LPP art. 14 al. 2). Ce taux peut etre
 inferieur pour la part surobligatoire, selon votre caisse de pension."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,48 @@
 > **Start here, every session.** This file tells any agent (human or LLM)
 > how to navigate MINT so the rules in `CLAUDE.md` apply to the right code.
 > Team structure + spawning recipes live further down.
-> Full ruleset: [`CLAUDE.md`](CLAUDE.md) · Sprint history: [`docs/SPRINT_TRACKER.md`](docs/SPRINT_TRACKER.md).
+> Full ruleset: [`CLAUDE.md`](CLAUDE.md) · Roadmap: [`docs/ROADMAP_V2.md`](docs/ROADMAP_V2.md).
+> Agent/Codex/Claude workflow: [`docs/MINT_AGENT_WORKFLOW.md`](docs/MINT_AGENT_WORKFLOW.md).
 
 ---
+
+## Operating Mode - Clean Mint Base
+
+At G0, MINT is rebuilt from the checkout currently mounted at
+`/Users/julienbattaglia/Desktop/MINT.nosync`. `MINT 2` is only a Finder symlink
+to that checkout. Archive folders and safety bundles are not active workspaces.
+Always verify the active branch and cleanliness with `git status --short
+--branch`; do not infer state from Finder folder names.
+
+Default rule: one real user flow, one clean worktree, one short PR, one
+runtime proof when UI is touched. Do not merge oversized draft PRs directly;
+extract reviewable slices.
+
+Permanent MINT roster:
+
+| Agent | File | Owns |
+|---|---|---|
+| `mint-lead` | `.claude/agents/mint-lead.md` | Scope, sequencing, merge/no-merge |
+| `mint-quality-gate` | `.claude/agents/mint-quality-gate.md` | Tests, runtime evidence, scorecards |
+| `mint-mobile` | `.claude/agents/mint-mobile.md` | Flutter app changes |
+| `mint-backend` | `.claude/agents/mint-backend.md` | FastAPI/backend/data changes |
+| `mint-swiss-brain` | `.claude/agents/mint-swiss-brain.md` | Swiss finance/compliance meaning |
+| `mint-data-ledger-architect` | `.claude/agents/mint-data-ledger-architect.md` | Variable ledger, provenance, freshness |
+| `mint-data-quest-architect` | `.claude/agents/mint-data-quest-architect.md` | Progressive questions and Case registry |
+| `mint-lucidity-pdf` | `.claude/agents/mint-lucidity-pdf.md` | Specialist-ready dossier/PDF |
+| `mint-external-auditor` | `.claude/agents/mint-external-auditor.md` | Claude CLI review loop |
+
+Canonical skills live in `.claude/skills/mint-*`:
+
+| Skill | Use |
+|---|---|
+| `mint-operating-gates` | Mandatory before user-facing/auth/privacy/runtime/financial work |
+| `mint-flutter-dev` | Flutter implementation in `apps/mobile/` |
+| `mint-backend-dev` | Backend implementation in `services/backend/` |
+| `mint-swiss-compliance` | Swiss regulatory/compliance review |
+
+External or generic specialists are not active by default. Use them only for a
+named gap after the MINT roster scopes the work.
 
 ## 🗺 Before you edit X, read Y, grep Z
 
@@ -20,7 +59,7 @@ time of looking at the map.
 | `apps/mobile/lib/services/financial_core/**` | [`docs/calculator-graph.md`](docs/calculator-graph.md) | `grep -rn "YourCalculator\." apps/mobile/lib` | `flutter test test/services/financial_core/` |
 | `apps/mobile/lib/screens/document_scan/**` | [`docs/data-flow.md`](docs/data-flow.md) §Scan pipeline | `grep "updateFrom.*Extraction" apps/mobile/lib/providers/coach_profile_provider.dart` | `flutter test test/services/document_parser/ test/providers/` |
 | `apps/mobile/lib/screens/budget/**` | [`docs/data-flow.md`](docs/data-flow.md) §Budget flow | `grep "q_housing_cost\|q_lamal_premium\|_coach_depenses" apps/mobile/lib` | `flutter test test/screens/budget/` |
-| A new route | [`apps/mobile/lib/routes/route_metadata.dart`](apps/mobile/lib/routes/route_metadata.dart) (Phase 32 registry) | `./tools/mint-routes check` | `flutter test test/routes/` |
+| A new route | [`apps/mobile/lib/routes/route_metadata.dart`](apps/mobile/lib/routes/route_metadata.dart) (Phase 32 registry) | `./tools/mint-routes reconcile` | `flutter test test/routes/` |
 | `apps/mobile/lib/l10n/app_*.arb` | ARB parity across 6 langs | verify same keys in fr/en/de/es/it/pt | `flutter gen-l10n && flutter test` |
 | Any financial calculation | [`CLAUDE.md`](CLAUDE.md) §4 + [`docs/calculator-graph.md`](docs/calculator-graph.md) | `grep -rn "_calculate\|_compute" apps/mobile/lib/services/ \| grep -v financial_core/` | `flutter test test/services/financial_core/` |
 
@@ -68,28 +107,30 @@ Revolut) from ones that turn in circles. Apply religiously.
   hidden constraints, invariants, workarounds.
 - Tests that assert LLM mock output (testing the mock, not the code).
 
-## 🛡 MINT drift-catchers (already roadmapped — use them as soon as shipped)
+## 🛡 MINT drift-catchers (use checked-in gates first)
 
-Until v2.8 Phases 33/34/35 land, the docs in `/docs/*.md` are the manual
-rampart. After ship:
+The repo currently has a small checked-in gate set plus a broader roadmap.
+Use what exists, and record missing tools instead of pretending they ran.
 
-- **Phase 33 kill-switches** → any path flag-kill-able from `/admin/flags`
-- **Phase 34 lefthook** → 5 mechanical lints block regressions at commit
-- **Phase 35 Boucle Daily** → morning sim walk + Sentry pull + auto-PR
+- **Feature flags / kill switches** → every new product path must be disableable
+- **Lefthook** → memory retention, map freshness hints, ARB parity
+- **Daily loop roadmap** → morning sim walk + Sentry pull + auto-PR
   on P0/P1. **The mechanism that catches « an agent broke something
   overnight ».** Mandatory for solo-dev + AI workflow.
-- **Phase 30.7 MCP tools** → Swiss constants / banned-terms /
-  ARB-parity as on-demand tools (stop bloating agent context with rules)
+- **Future MCP/tools** → Swiss constants / banned-terms / Patrol / Beads /
+  Mermaid gates once installed and wired in this checkout
 
 ## 🤝 Session handshake — run these in order, every time
 
-1. Read [`MEMORY.md`](memory/MEMORY.md) (auto-loaded).
+1. Read curator memory when present; otherwise use Engram context plus checked-in docs.
 2. Read [`CLAUDE.md`](CLAUDE.md) (auto-loaded).
 3. Read this file.
-4. When the user names a subsystem, read the matching `docs/*.md` **before
+4. Read [`docs/MINT_AGENT_WORKFLOW.md`](docs/MINT_AGENT_WORKFLOW.md).
+5. Read [`.claude/skills/mint-operating-gates/SKILL.md`](.claude/skills/mint-operating-gates/SKILL.md).
+6. When the user names a subsystem, read the matching `docs/*.md` **before
    the first code change**.
-5. Run the grep verification from the table.
-6. *Only then* propose code.
+7. Run the grep verification from the table.
+8. *Only then* propose code.
 
 If a step was skipped, revert and redo. That's cheaper than debugging
 the ghost in prod.
@@ -99,17 +140,15 @@ the ghost in prod.
 ## TEAM STRUCTURE
 
 ```
-┌──────────────────────────────────────────────┐
-│              TEAM LEAD (Opus)                │
-│     Orchestrate, review, decide, merge       │
-│     Doesn't code directly (except urgency)   │
-└─────────┬──────────┬──────────┬──────────────┘
-          │          │          │
-    ┌─────▼──┐ ┌─────▼──┐ ┌────▼─────┐
-    │  DART  │ │ PYTHON │ │  SWISS   │
-    │ Agent  │ │ Agent  │ │  BRAIN   │
-    │Sonnet  │ │Sonnet  │ │  Opus    │
-    └────────┘ └────────┘ └──────────┘
+mint-lead
+  ├─ mint-swiss-brain
+  ├─ mint-data-ledger-architect
+  ├─ mint-data-quest-architect
+  ├─ mint-backend
+  ├─ mint-mobile
+  ├─ mint-lucidity-pdf
+  ├─ mint-quality-gate
+  └─ mint-external-auditor
 ```
 
 ---
@@ -118,16 +157,16 @@ the ghost in prod.
 
 ### Flutter chantier (UI, widgets, screens)
 ```
-Spawn "dart-agent" with model sonnet.
-Read: .claude/skills/mint-flutter-dev/SKILL.md, .claude/skills/mint-test-suite/SKILL.md, CLAUDE.md
+Spawn "mint-mobile" with model sonnet.
+Read: .claude/agents/mint-mobile.md, .claude/skills/mint-flutter-dev/SKILL.md, .claude/skills/mint-operating-gates/SKILL.md, CLAUDE.md
 Scope: apps/mobile/ only. Never touch backend.
 Before changes: flutter analyze && flutter test.
 ```
 
 ### Backend chantier (FastAPI, services, tax)
 ```
-Spawn "python-agent" with model sonnet.
-Read: .claude/skills/mint-backend-dev/SKILL.md, .claude/skills/mint-test-suite/SKILL.md, CLAUDE.md
+Spawn "mint-backend" with model sonnet.
+Read: .claude/agents/mint-backend.md, .claude/skills/mint-backend-dev/SKILL.md, .claude/skills/mint-operating-gates/SKILL.md, CLAUDE.md
 Scope: services/backend/ only. Never touch Flutter.
 Before changes: ruff check . && pytest -q.
 API change → update tools/openapi/ + SOT.md.
@@ -135,8 +174,8 @@ API change → update tools/openapi/ + SOT.md.
 
 ### Business/compliance chantier (fiscalité, LPP, compliance)
 ```
-Spawn "swiss-brain" with model opus.
-Read: .claude/skills/mint-swiss-compliance/SKILL.md, CLAUDE.md, LEGAL_RELEASE_CHECK.md, visions/
+Spawn "mint-swiss-brain" with model opus.
+Read: .claude/agents/mint-swiss-brain.md, .claude/skills/mint-swiss-compliance/SKILL.md, CLAUDE.md, LEGAL_RELEASE_CHECK.md, visions/
 Scope: docs/, education/, decisions/, visions/. No code.
 Output: specs with legal sources, test cases, educational text, compliance alerts.
 ```
@@ -148,20 +187,27 @@ Output: specs with legal sources, test cases, educational text, compliance alert
 ### Rule 1: Team Lead doesn't code (except urgency)
 Orchestrate, review, merge. Create tasks, verify outputs, make decisions.
 
-### Rule 2: Swiss-Brain validates BEFORE devs implement
+### Rule 2: Swiss meaning validates BEFORE devs implement
 ```
-Swiss-Brain (spec + test cases)
-  → Python-Agent (backend implementation)
-    → Dart-Agent (UI/screen)
-      → Team Lead (review + merge)
+mint-swiss-brain (spec + test cases)
+  → mint-data-ledger-architect / mint-data-quest-architect (variables + asks)
+    → mint-backend (backend implementation)
+      → mint-mobile (UI/screen)
+        → mint-quality-gate + mint-external-auditor (review)
+          → mint-lead (merge/no-merge)
 ```
 
 ### Rule 3: Cross-modification boundaries
 | Agent | Can modify | Cannot modify |
 |-------|-----------|---------------|
-| dart-agent | `apps/mobile/` | `services/backend/`, `tools/openapi/` |
-| python-agent | `services/backend/`, `tools/openapi/`, `SOT.md` | `apps/mobile/` |
-| swiss-brain | `docs/`, `education/`, `decisions/`, `visions/` | Code (`*.dart`, `*.py`) |
+| mint-mobile | `apps/mobile/` | `services/backend/`, `tools/openapi/` |
+| mint-backend | `services/backend/`, `tools/openapi/`, `SOT.md` | `apps/mobile/` |
+| mint-swiss-brain | `docs/`, `education/`, `decisions/`, `visions/` | Code (`*.dart`, `*.py`) |
+| mint-data-ledger-architect | `docs/codex/`, ledger schemas/tests | Product UI without a caller |
+| mint-data-quest-architect | `docs/codex/`, question plans/tests | Duplicate variable aliases |
+| mint-lucidity-pdf | PDF/dossier contracts and surfaces | Financial law constants |
+| mint-quality-gate | Evidence, tests, scorecards | Feature code outside fixes for gates |
+| mint-external-auditor | Audit prompts/evidence | Product implementation |
 
 ### Rule 4: Token economy
 - Sonnet by default, Opus for complex reasoning
@@ -174,11 +220,10 @@ Swiss-Brain (spec + test cases)
 
 | Skill | File | Agent |
 |-------|------|-------|
-| mint-flutter-dev | `.claude/skills/mint-flutter-dev/SKILL.md` | dart-agent |
-| mint-backend-dev | `.claude/skills/mint-backend-dev/SKILL.md` | python-agent |
-| mint-swiss-compliance | `.claude/skills/mint-swiss-compliance/SKILL.md` | swiss-brain |
-| mint-test-suite | `.claude/skills/mint-test-suite/SKILL.md` | all agents |
-| mint-commit | `.claude/skills/mint-commit/SKILL.md` | team-lead |
+| mint-operating-gates | `.claude/skills/mint-operating-gates/SKILL.md` | all agents |
+| mint-flutter-dev | `.claude/skills/mint-flutter-dev/SKILL.md` | mint-mobile |
+| mint-backend-dev | `.claude/skills/mint-backend-dev/SKILL.md` | mint-backend |
+| mint-swiss-compliance | `.claude/skills/mint-swiss-compliance/SKILL.md` | mint-swiss-brain |
 
 ---
 

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -1,0 +1,80 @@
+# MINT Agent Workflow
+
+This is the repo-local operating base for building MINT as a Swiss financial
+lucidity product. It keeps the permanent MINT roster small, domain-specific,
+and accountable.
+
+## G0 Checkout Snapshot
+
+- Active checkout during this base restore: `/Users/julienbattaglia/Desktop/MINT.nosync`.
+- `MINT 2` is a Finder symlink to the active checkout, not a second source.
+- Archive folders and `.bundle` files are safety artifacts, not workspaces.
+- Oversized draft PRs, especially #827, are quarries: inspect and extract
+  small PRs; do not merge them directly.
+
+When this repo moves machines or branches, resolve the active checkout from
+`git worktree list` and `git status --short --branch`; do not rely on the
+absolute path above as product architecture.
+
+## Permanent Roster
+
+The main Codex/Claude session owns agent dispatch. Use this routing order for
+product work:
+
+1. `mint-lead` scopes the smallest valuable slice and rejects facade work.
+2. `mint-swiss-brain` defines Swiss finance, tax, insurance, inheritance, and
+   compliance boundaries.
+3. `mint-data-ledger-architect` maps variables, source, freshness, confidence,
+   consumers, and dead-key gates.
+4. `mint-data-quest-architect` defines the Case, guard questions, and next
+   question order.
+5. `mint-backend` implements backend services, scenarios, schemas, and API
+   payloads.
+6. `mint-mobile` implements Flutter UX, providers, routes, and runtime ids.
+7. `mint-lucidity-pdf` implements specialist-ready dossier sections.
+8. `mint-quality-gate` verifies tests, route/data parity, runtime proof, and
+   scorecards.
+9. `mint-external-auditor` runs Claude CLI review and records unresolved
+   findings.
+
+Generic GSD agents remain available for planning, verification, and codebase
+mapping, but they do not replace the MINT roster.
+
+## Standing PR Gates
+
+Every product PR must list:
+
+- Targeted backend/mobile/spec tests.
+- `python3 tools/checks/arb_parity.py` when ARB files are touched.
+- Accent and banned-term checks when user-facing French copy is touched.
+- Range, source, freshness, and confidence evidence for projections.
+- Privacy/nLPD review when profile data, prompts, logs, analytics, exports, or
+  dossier/PDF artifacts are touched.
+- Design review for new or materially changed product screens.
+- Maestro runtime proof for touched P0 mobile UI; Patrol is required for real
+  P0 input proof once the Patrol CLI is available in the environment.
+- Claude CLI audit for architecture, compliance, and pre-merge code review when
+  possible.
+- Engram memory after merge.
+
+## Current Tool Matrix
+
+| Tool | Status in clean checkout | Gate use |
+|---|---|---|
+| Claude CLI | Available after local login | External audit |
+| Engram MCP | Available | Memory |
+| Maestro | Available at `~/.maestro/bin/maestro` | Runtime UI proof |
+| Patrol CLI | Not in PATH at G0 base restore | Required gap before Patrol-only gates |
+| Mermaid CLI | Not in PATH at G0 base restore | Optional graph rendering until installed |
+| Beads/bug CLI | Not in PATH at G0 base restore | Use checked-in bug ledger fallback |
+| ARB parity | `tools/checks/arb_parity.py` | i18n key parity |
+
+## Product Spine
+
+MINT work must converge on this chain:
+
+`ledger variable -> DataQuest ask -> Case/scenario -> screen state -> dossier/PDF -> runtime proof`.
+
+No service without a caller, no route without a degraded state, no projection
+without range + confidence + source/freshness, and no data collection that asks
+again for a fresh known fact.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,5 @@
-# lefthook.yml — Skeleton version (Phase 30.5 CTX-01, D-04)
-# Scope: STRICTLY MEMORY retention gate only.
-# Phase 34 GUARD-01 will ADD bare_catch, hardcoded_fr, accent_lint, arb_parity
-# ON TOP of this scaffold. Rails posés, lints NON-ACTIVÉS (D-04).
+# lefthook.yml — MINT checked-in safety gates.
+# Keep this file honest: only list gates that actually run in this checkout.
 
 min_version: 2.1.5
 
@@ -12,18 +10,28 @@ pre-commit:
     memory-retention-gate:
       # Fails commit if memory/topics/*.md has entries >30d not archived
       # (HARD gate per D-02). SOFT warning if MEMORY.md INDEX >100 lines
-      # (non-failing, per D-02). All other lints REPORTÉS à Phase 34
-      # GUARD-01 (D-04 strict skeleton scope).
+      # (non-failing, per D-02).
       run: python3 tools/checks/memory_retention.py
       tags: [memory, phase-30.5]
     map-freshness-hint:
       # Hint (not a gate) — when the commit touches a subsystem with a
       # map in docs/*.md, remind the author (or their LLM agent) to
-      # consult the map. Exits 0 unconditionally. Hard gate promotion
-      # deferred to Phase 34 proof_of_read lint once that lands.
+      # consult the map. Exits 0 unconditionally.
       run: python3 tools/checks/map_freshness_hint.py {staged_files}
       glob: "*.{dart,py}"
       tags: [map, agents]
+    arb-parity:
+      run: python3 tools/checks/arb_parity.py
+      glob: "apps/mobile/lib/l10n/app_*.arb"
+      tags: [i18n, mint]
+    accent-lint-fr:
+      run: for file in {staged_files}; do python3 tools/checks/accent_lint_fr.py --file "$file" || exit 1; done
+      glob: "*.{dart,py,arb,md}"
+      tags: [i18n, mint]
+    no-hardcoded-fr:
+      run: for file in {staged_files}; do python3 tools/checks/no_hardcoded_fr.py --file "$file" || exit 1; done
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [i18n, mint]
 
 skip:
   - merge

--- a/tools/checks/arb_parity.py
+++ b/tools/checks/arb_parity.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Validate that the six primary Flutter ARB files expose the same keyset."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ARB_DIR = ROOT / "apps" / "mobile" / "lib" / "l10n"
+LOCALES = ("fr", "en", "de", "es", "it", "pt")
+
+
+def _message_keys(path: Path) -> set[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"ERROR: invalid ARB JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERROR: ARB root must be an object: {path}")
+    return {key for key in data if not key.startswith("@")}
+
+
+def main() -> int:
+    files = {locale: ARB_DIR / f"app_{locale}.arb" for locale in LOCALES}
+    missing_files = [str(path) for path in files.values() if not path.is_file()]
+    if missing_files:
+        print("ERROR: missing ARB files:")
+        for path in missing_files:
+            print(f"  - {path}")
+        return 1
+
+    keysets = {locale: _message_keys(path) for locale, path in files.items()}
+    reference_locale = "fr"
+    reference = keysets[reference_locale]
+    failed = False
+
+    for locale in LOCALES:
+        if locale == reference_locale:
+            continue
+        missing = sorted(reference - keysets[locale])
+        extra = sorted(keysets[locale] - reference)
+        if missing or extra:
+            failed = True
+            print(f"ERROR: app_{locale}.arb differs from app_fr.arb")
+            if missing:
+                print(f"  missing ({len(missing)}): {', '.join(missing[:40])}")
+            if extra:
+                print(f"  extra ({len(extra)}): {', '.join(extra[:40])}")
+
+    if failed:
+        return 1
+
+    print(
+        "ARB parity OK: "
+        + ", ".join(f"app_{locale}.arb={len(keysets[locale])}" for locale in LOCALES)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds the permanent MINT agent roster under `.claude/agents/mint-*`.
- Makes `.claude/skills/mint-*` the single skill source, including the new `mint-operating-gates` skill.
- Documents the clean G0 workflow/tool matrix in `docs/MINT_AGENT_WORKFLOW.md`.
- Adds `tools/checks/arb_parity.py` and wires ARB parity, staged-file accent lint, and staged-file hardcoded-FR lint into Lefthook.

## Validation
- `python3 tools/checks/arb_parity.py`
- `python3 -m py_compile tools/checks/arb_parity.py`
- `./tools/mint-routes reconcile`
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q`
- `lefthook run pre-commit --file AGENTS.md`
- `lefthook run pre-commit --file apps/mobile/lib/l10n/app_fr.arb`
- Claude CLI external audit: PASS; 0 Critical, 0 High after C1/C2/H1-H4 corrections.

## Notes
- Patrol, Mermaid CLI, and Beads are documented as not in PATH at G0; gates are conditional until installed.
- Lefthook memory retention warning remains non-blocking and pre-existing.