### PR TITLE
Infra-G1: add gitleaks secret scanning gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,42 @@ jobs:
             exit 1
           fi
 
+  # ─── Secret scanning ─────────────────────────────────────────
+  # Scans the commits introduced by the PR/push. The local pre-commit hook
+  # catches staged secrets before they enter history; this CI job catches
+  # bypasses and direct pushes without scanning all historical commits.
+  secret-scan:
+    name: Gitleaks secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan introduced commits
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LOG_OPTS="origin/${{ github.base_ref }}..HEAD"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+            if [[ -z "$BASE_SHA" ]] || [[ "${BASE_SHA//0/}" == "" ]]; then
+              LOG_OPTS="-1"
+            else
+              LOG_OPTS="${BASE_SHA}..${HEAD_SHA}"
+            fi
+          fi
+          echo "Running gitleaks with log opts: ${LOG_OPTS}"
+          docker run --rm \
+            -v "$PWD:/repo" \
+            -w /repo \
+            -e GIT_CONFIG_COUNT=1 \
+            -e GIT_CONFIG_KEY_0=safe.directory \
+            -e GIT_CONFIG_VALUE_0=/repo \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 \
+            git --redact --config .gitleaks.toml --log-opts="${LOG_OPTS}" .
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -537,7 +573,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, secret-scan, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -545,6 +581,7 @@ jobs:
         run: |
           # Skip check if job was skipped (no relevant changes)
           backend="${{ needs.backend.result }}"
+          secret_scan="${{ needs.secret-scan.result }}"
           flutter="${{ needs.flutter.result }}"
           readability="${{ needs.readability.result }}"
           wcag="${{ needs.wcag-aa-all-touched.result }}"
@@ -562,8 +599,8 @@ jobs:
           [[ "$contract_tests" == "skipped" ]] && contract_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$backend" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — backend=$backend flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "MINT gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Non-secret placeholders in the backend example environment file."
+condition = "AND"
+regexTarget = "line"
+paths = [
+  '''^services/backend/\.env\.example$''',
+]
+regexes = [
+  '''^DATABASE_URL=postgresql://mint:mint@localhost:5432/mint$''',
+  '''^JWT_SECRET_KEY=change-me-in-production$''',
+]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,12 @@ pre-commit:
       # (non-failing, per D-02).
       run: python3 tools/checks/memory_retention.py
       tags: [memory, phase-30.5]
+    gitleaks-secret-scan:
+      run: >-
+        command -v gitleaks >/dev/null ||
+        { echo "gitleaks is required for MINT secret scanning. Install with: brew install gitleaks"; exit 1; };
+        gitleaks git --pre-commit --staged --redact --config .gitleaks.toml --verbose
+      tags: [security, secrets, mint]
     map-freshness-hint:
       # Hint (not a gate) — when the commit touches a subsystem with a
       # map in docs/*.md, remind the author (or their LLM agent) to

--- a/tools/checks/tests/test_gitleaks_gate_contract.py
+++ b/tools/checks/tests/test_gitleaks_gate_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+GITLEAKS_CONFIG = ROOT / ".gitleaks.toml"
+LEFTHOOK = ROOT / "lefthook.yml"
+CI = ROOT / ".github/workflows/ci.yml"
+
+
+def test_gitleaks_config_extends_default_rules() -> None:
+    config = GITLEAKS_CONFIG.read_text(encoding="utf-8")
+
+    assert "[extend]" in config
+    assert "useDefault = true" in config
+    assert "[[allowlists]]" in config
+
+
+def test_lefthook_runs_gitleaks_pre_commit_gate() -> None:
+    lefthook = LEFTHOOK.read_text(encoding="utf-8")
+
+    assert "gitleaks-secret-scan:" in lefthook
+    assert "command -v gitleaks" in lefthook
+    assert "gitleaks git" in lefthook
+    assert "--pre-commit" in lefthook
+    assert "--staged" in lefthook
+    assert "--redact" in lefthook
+    assert "--config .gitleaks.toml" in lefthook
+
+
+def test_ci_runs_gitleaks_and_blocks_ci_gate() -> None:
+    ci = CI.read_text(encoding="utf-8")
+
+    assert "secret-scan:" in ci
+    assert "Gitleaks secret scan" in ci
+    assert "ghcr.io/gitleaks/gitleaks" in ci
+    assert "GIT_CONFIG_KEY_0=safe.directory" in ci
+    assert "GIT_CONFIG_VALUE_0=/repo" in ci
+    assert "--config .gitleaks.toml" in ci
+    assert "secret_scan=\"${{ needs.secret-scan.result }}\"" in ci
+    assert '[[ "$secret_scan" == "skipped" ]]' not in ci
+    assert "secret-scan" in ci.split("ci-gate:", maxsplit=1)[1]


### PR DESCRIPTION
## Summary
- Add `.gitleaks.toml` extending default gitleaks rules with a tightly scoped example-env allowlist.
- Add `gitleaks-secret-scan` to `lefthook.yml` pre-commit, scanning staged changes with redacted output.
- Add a CI `secret-scan` job using `ghcr.io/gitleaks/gitleaks:v8.30.1`, wired into `ci-gate`, with Docker `safe.directory` hardening.
- Add a repo contract test proving config/hook/CI wiring and preventing `secret-scan` skipped results from being silently promoted to success.

## Local verification
- `python3 -m pytest tools/checks/tests/test_gitleaks_gate_contract.py -q` -> 3 passed
- `python3 -m pytest tools/checks/tests tests/checks -q --tb=short` -> 32 passed
- `actionlint .github/workflows/ci.yml` -> pass
- `gitleaks git --redact --config .gitleaks.toml --log-opts=-1 .` -> no leaks
- `lefthook run pre-commit --file gitleaks_canary.txt` with a staged fake full RSA private-key block -> blocked by `private-key` rule
- `git diff --check origin/claude/mint-swiss-coach-eu33i7...HEAD` -> pass

## External audit
- `CLAUDE_AUDIT_MODEL=sonnet CLAUDE_AUDIT_EFFORT=high tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> PASS, no P0/P1.
- Addressed Claude P2-3 by making a skipped `secret-scan` fail instead of being normalized to success.
- Remaining P2 notes are accepted for this slice: first-push multi-commit branch pushes fall back to HEAD-only scanning, and the gitleaks Docker image is tag-pinned rather than digest-pinned.
