### PR TITLE
Infra-G3: banned UI terms gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,24 @@ jobs:
       - name: Run repo contract tests
         run: python3 -m pytest tools/checks/tests/ -q
 
+  # ─── LSFin UI copy gate ─────────────────────────────────────
+  # Blocks core banned promise terms from CLAUDE.md /
+  # LEGAL_RELEASE_CHECK.md in Dart UI string literals. The scanner is
+  # lexical but not raw grep: it skips comments/tests/imports/internal guard
+  # dictionaries and allows explicit Swiss legal terms such as "salaire
+  # assuré" plus negative disclaimers such as "ne constitue pas un conseil
+  # financier".
+  banned-ui-terms:
+    name: Banned UI terms
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan Dart UI strings
+        run: python3 tools/checks/banned_ui_terms.py
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -597,7 +615,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, banned-ui-terms, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -606,6 +624,7 @@ jobs:
           # Skip check if job was skipped (no relevant changes)
           contracts="${{ needs.contracts-drift.result }}"
           repo_contracts="${{ needs.repo-contract-tests.result }}"
+          banned_terms="${{ needs.banned-ui-terms.result }}"
           backend="${{ needs.backend.result }}"
           secret_scan="${{ needs.secret-scan.result }}"
           flutter="${{ needs.flutter.result }}"
@@ -618,6 +637,7 @@ jobs:
           cache_gi="${{ needs.cache-gitignore-check.result }}"
           [[ "$contracts" == "skipped" ]] && contracts="success"
           [[ "$repo_contracts" == "skipped" ]] && repo_contracts="success"
+          [[ "$banned_terms" == "skipped" ]] && banned_terms="success"
           [[ "$backend" == "skipped" ]] && backend="success"
           [[ "$secret_scan" == "skipped" ]] && secret_scan="success"
           [[ "$flutter" == "skipped" ]] && flutter="success"
@@ -628,8 +648,8 @@ jobs:
           [[ "$cli_tests" == "skipped" ]] && cli_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts banned_terms=$banned_terms backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ tools/agent-drift/spikes/A7_headless_result.txt
 # Phase 31 walker.sh runtime output (timestamped screenshots, logs, sentry-event JSON dumps)
 .planning/walker/
 .cache/
+.hypothesis/

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -10290,7 +10290,7 @@
   "jargonReplacementRateTooltip": "Le taux de remplacement mesure la part de ton revenu actuel que tu conserveras à la retraite. Exemple : 65 % signifie que tu toucheras 65 % de ton salaire actuel.",
   "jargonLppTooltip": "La LPP (Loi sur la prévoyance professionnelle) est le 2e pilier. Ton employeur et toi cotisez ensemble pour ta retraite.",
   "jargon3aTooltip": "Le pilier 3a est une épargne retraite volontaire avec avantage fiscal. Le plafond est de 7 258 CHF/an (salarié avec LPP).",
-  "jargonAvsTooltip": "L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.",
+  "jargonAvsTooltip": "L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle sert de revenu de base à la retraite.",
   "jargonRamdTooltip": "Le RAMD détermine le montant de ta rente AVS. Il est calculé à partir de tes revenus soumis à cotisation.",
   "confidenceDetailsTooltip": "Basé sur : âge, revenu, canton, statut civil, nationalité, LPP et 3a déclarés. Plus tu fournis de données, plus la projection est fiable.",
   "replacementRateContextGood": "C’est un bon niveau — au-dessus de 80 %.",

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -36858,7 +36858,7 @@ abstract class S {
   /// No description provided for @jargonAvsTooltip.
   ///
   /// In fr, this message translates to:
-  /// **'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.'**
+  /// **'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle sert de revenu de base à la retraite.'**
   String get jargonAvsTooltip;
 
   /// No description provided for @jargonRamdTooltip.

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -20947,7 +20947,7 @@ class SFr extends S {
 
   @override
   String get jargonAvsTooltip =>
-      'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle garantit un revenu de base à la retraite.';
+      'L’AVS (assurance-vieillesse et survivants) est le 1er pilier. Elle sert de revenu de base à la retraite.';
 
   @override
   String get jargonRamdTooltip =>

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -38,6 +38,10 @@ pre-commit:
       run: for file in {staged_files}; do python3 tools/checks/no_hardcoded_fr.py --file "$file" || exit 1; done
       glob: "apps/mobile/lib/**/*.dart"
       tags: [i18n, mint]
+    banned-ui-terms:
+      run: for file in {staged_files}; do python3 tools/checks/banned_ui_terms.py --file "$file" || exit 1; done
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [compliance, mint]
 
 skip:
   - merge

--- a/tools/checks/banned_ui_terms.py
+++ b/tools/checks/banned_ui_terms.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Block LSFin-banned vocabulary in Dart UI string literals.
+
+This is deliberately narrower than a raw grep. MINT's Dart tree contains
+legitimate Swiss legal terms such as "salaire assuré" and compliance guard
+fixtures that must mention banned words in order to block them. This gate scans
+string literals under apps/mobile/lib, skips comments/tests/import URIs/internal
+guard dictionaries, and reports only user-facing promise-language violations.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+from pathlib import Path
+from typing import NamedTuple
+
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_SCOPE = ("apps/mobile/lib",)
+
+
+class PolicyTerm(NamedTuple):
+    raw: str
+    active: bool = True
+
+    @property
+    def normalized(self) -> str:
+        return _normalize(self.raw)
+
+
+# Core terms are from CLAUDE.md / LEGAL_RELEASE_CHECK.md. The English terms are
+# tracked here for audit visibility; fully semantic option-ranking checks remain
+# outside this lexical gate.
+POLICY_TERMS = (
+    PolicyTerm("garanti"),
+    PolicyTerm("optimal"),
+    PolicyTerm("meilleur"),
+    PolicyTerm("certain"),
+    PolicyTerm("assuré"),
+    PolicyTerm("sans risque"),
+    PolicyTerm("parfait"),
+    PolicyTerm("conseil financier"),
+    PolicyTerm("tu vas gagner"),
+    PolicyTerm("recommandation personnalisée"),
+    PolicyTerm("vous devriez"),
+    PolicyTerm("top X% des Suisses"),
+    PolicyTerm("better", active=False),
+    PolicyTerm("recommended", active=False),
+)
+
+INTERNAL_POLICY_FILES = {
+    "apps/mobile/lib/services/agent/autonomous_agent_service.dart",
+    "apps/mobile/lib/services/coach/context_injector_service.dart",
+    "apps/mobile/lib/services/coach/compliance_guard.dart",
+    "apps/mobile/lib/services/llm/response_quality_monitor.dart",
+}
+
+NON_UI_PATH_PREFIXES = (
+    "apps/mobile/lib/services/document_parser/",
+)
+
+EXCLUDED_PATH_PARTS = (
+    "/.dart_tool/",
+    "/build/",
+    "/.git/",
+    "/test/",
+    "/tests/",
+)
+
+NON_UI_GUARD_MARKERS = (
+    "aucun terme banni",
+    "banned terms",
+    "complianceguard",
+    "jamais de termes",
+    "jamais :",
+    "ne donnes jamais",
+    "ne dis jamais",
+    "tu ne dis jamais",
+    "tu ne donnes jamais",
+    "termes bannis",
+    "termes interdits",
+)
+
+NEGATED_PROMISE_PATTERNS = (
+    re.compile(r"\bpas\s+de\b.{0,80}\bgaranti(?:e|s|es)?\b"),
+    re.compile(r"\bpas\b.{0,40}\bgaranti(?:e|s|es)?\b"),
+    re.compile(r"\bnon\s+garanti(?:e|s|es)?\b"),
+    re.compile(r"\bnot\s+guaranteed\b"),
+    re.compile(r"\bno\s+guaranteed\b"),
+    re.compile(r"\bresultats?\s+non\s+assures?\b"),
+)
+
+SWISS_INSURANCE_PATTERNS = (
+    re.compile(r"\b(?:salaire|gain|capital|montant|revenu)\s+assure\b"),
+    re.compile(r"\bassure(?:e|·e|\\u00b7e)?\s+lpp\b"),
+    re.compile(r"\bavs/assure\b"),
+    re.compile(r"\brente\s+assuree\b"),
+    re.compile(r"\bsomme\s+assuree\b"),
+    re.compile(r"\bpartie\b.{0,40}\bnon\s+assuree\b"),
+)
+
+ASSURE_VERB_PATTERNS = (
+    re.compile(r"\bassure-toi\b"),
+)
+
+NEGATED_ADVICE_PATTERNS = (
+    re.compile(r"\bne\s+constitu(?:e|ent)\s+pas\s+un\s+conseil\s+financier\b"),
+    re.compile(r"\bpas\s+un\s+conseil\s+financier\b"),
+    re.compile(r"\bdoes\s+not\s+constitute\b.{0,40}\bfinancial\s+advice\b"),
+)
+
+CERTAIN_INDEFINITE_PATTERNS = (
+    re.compile(r"\b(?:un|une|d'un|d une)\s+certain\b"),
+)
+
+PARFAIT_ACK_PATTERNS = (
+    re.compile(r"^parfait\s*,"),
+)
+
+NEGATED_RANKING_PATTERNS = (
+    re.compile(r"\baucune\s+option\b.{0,80}\bmeilleur(?:e|s|es)?\b"),
+)
+
+TERM_PATTERN_SOURCES = {
+    "garanti": r"garanti(?:e|s|es)?|garantit|garantissent",
+    "optimal": r"optimal(?:e|es|s)?|optimaux",
+    "meilleur": r"meilleur(?:e|s|es)?",
+    "sans risque": r"sans\s+risques?",
+    "parfait": r"parfait(?:e|s|es)?",
+}
+
+
+class DartString(NamedTuple):
+    line: int
+    text: str
+    source_line: str
+
+
+class Violation(NamedTuple):
+    path: Path
+    line: int
+    term: str
+    text: str
+
+
+def _normalize(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value)
+    ascii_text = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return re.sub(r"\s+", " ", ascii_text.casefold()).strip()
+
+
+def _word_pattern(term: PolicyTerm) -> re.Pattern[str]:
+    escaped = TERM_PATTERN_SOURCES.get(term.raw)
+    if escaped is None:
+        escaped = re.escape(term.normalized).replace(r"\ ", r"\s+")
+    return re.compile(rf"(?<![a-z0-9_])(?:{escaped})(?![a-z0-9_])")
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _is_scoped_dart_file(path: Path, root: Path) -> bool:
+    rel = "/" + _relative(path, root) + "/"
+    if path.suffix != ".dart":
+        return False
+    if not rel.startswith("/apps/mobile/lib/"):
+        return False
+    return not any(part in rel for part in EXCLUDED_PATH_PARTS)
+
+
+def _collect_paths(root: Path, scope: tuple[str, ...]) -> list[Path]:
+    paths: list[Path] = []
+    for raw_scope in scope:
+        scope_root = root / raw_scope
+        if not scope_root.exists():
+            continue
+        for path in scope_root.rglob("*.dart"):
+            if _is_scoped_dart_file(path, root):
+                paths.append(path)
+    return sorted(paths)
+
+
+def _line_is_import_like(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith(("import ", "export ", "part "))
+
+
+def _extract_dart_strings(source: str) -> list[DartString]:
+    out: list[DartString] = []
+    lines = source.splitlines()
+    i = 0
+    line = 1
+    length = len(source)
+
+    while i < length:
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < length else ""
+
+        if ch == "\n":
+            line += 1
+            i += 1
+            continue
+
+        if ch == "/" and nxt == "/":
+            i += 2
+            while i < length and source[i] != "\n":
+                i += 1
+            continue
+
+        if ch == "/" and nxt == "*":
+            i += 2
+            while i < length - 1 and not (source[i] == "*" and source[i + 1] == "/"):
+                if source[i] == "\n":
+                    line += 1
+                i += 1
+            i += 2
+            continue
+
+        raw_prefix = ch in {"r", "R"} and nxt in {"'", '"'}
+        if ch in {"'", '"'} or raw_prefix:
+            quote = nxt if raw_prefix else ch
+            start = i + 1 if raw_prefix else i
+            start_line = line
+            i = start + 1
+            triple = source.startswith(quote * 3, start)
+            if triple:
+                i = start + 3
+            literal: list[str] = []
+            escaped = False
+            while i < length:
+                if source[i] == "\n":
+                    line += 1
+                    literal.append(source[i])
+                    i += 1
+                    escaped = False
+                    continue
+                if not raw_prefix and escaped:
+                    literal.append(source[i])
+                    escaped = False
+                    i += 1
+                    continue
+                if not raw_prefix and source[i] == "\\":
+                    literal.append(source[i])
+                    escaped = True
+                    i += 1
+                    continue
+                if not raw_prefix and source[i] == "$":
+                    if i + 1 < length and source[i + 1] == "{":
+                        i += 2
+                        depth = 1
+                        while i < length and depth > 0:
+                            if source[i] == "\n":
+                                line += 1
+                            elif source[i] == "{":
+                                depth += 1
+                            elif source[i] == "}":
+                                depth -= 1
+                            i += 1
+                        literal.append("${}")
+                        continue
+                    if i + 1 < length and re.match(r"[A-Za-z_]", source[i + 1]):
+                        i += 2
+                        while i < length and re.match(r"[A-Za-z0-9_.]", source[i]):
+                            i += 1
+                        literal.append("$")
+                        continue
+                if triple and source.startswith(quote * 3, i):
+                    i += 3
+                    break
+                if not triple and source[i] == quote:
+                    i += 1
+                    break
+                literal.append(source[i])
+                i += 1
+
+            source_line = lines[start_line - 1] if start_line <= len(lines) else ""
+            if not _line_is_import_like(source_line):
+                out.append(DartString(start_line, "".join(literal), source_line))
+            continue
+
+        i += 1
+
+    return out
+
+
+def _literal_is_non_ui_guard(text: str, source_line: str) -> bool:
+    normalized = _normalize(f"{source_line} {text}")
+    return any(marker in normalized for marker in NON_UI_GUARD_MARKERS)
+
+
+def _literal_is_machine_token(text: str) -> bool:
+    compact = text.strip()
+    if not compact:
+        return True
+    normalized = _normalize(compact)
+    for term in POLICY_TERMS:
+        if term.active and _word_pattern(term).search(normalized):
+            return False
+    if len(compact) <= 80 and re.fullmatch(r"[A-Za-z0-9_.:/@-]+", compact):
+        return True
+    return False
+
+
+def _literal_is_policy_list_item(text: str, source_line: str) -> bool:
+    stripped = source_line.strip()
+    if not re.fullmatch(r"""['"][^'"]+['"],?""", stripped):
+        return False
+    normalized = _normalize(text)
+    return any(normalized == term.normalized for term in POLICY_TERMS)
+
+
+def _term_allowed(term: PolicyTerm, normalized_text: str) -> bool:
+    if term.raw == "garanti":
+        return any(pattern.search(normalized_text) for pattern in NEGATED_PROMISE_PATTERNS)
+    if term.raw == "assuré":
+        return any(pattern.search(normalized_text) for pattern in SWISS_INSURANCE_PATTERNS) or any(
+            pattern.search(normalized_text) for pattern in ASSURE_VERB_PATTERNS
+        )
+    if term.raw == "certain":
+        return any(pattern.search(normalized_text) for pattern in CERTAIN_INDEFINITE_PATTERNS)
+    if term.raw == "meilleur":
+        return any(pattern.search(normalized_text) for pattern in NEGATED_RANKING_PATTERNS)
+    if term.raw == "conseil financier":
+        return any(pattern.search(normalized_text) for pattern in NEGATED_ADVICE_PATTERNS)
+    if term.raw == "parfait":
+        return any(pattern.search(normalized_text) for pattern in PARFAIT_ACK_PATTERNS)
+    return False
+
+
+def scan_file(path: Path, root: Path) -> list[Violation]:
+    rel = _relative(path, root)
+    if rel in INTERNAL_POLICY_FILES:
+        return []
+    if any(rel.startswith(prefix) for prefix in NON_UI_PATH_PREFIXES):
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    violations: list[Violation] = []
+    for literal in _extract_dart_strings(source):
+        if _literal_is_machine_token(literal.text):
+            continue
+        if _literal_is_non_ui_guard(literal.text, literal.source_line):
+            continue
+        if _literal_is_policy_list_item(literal.text, literal.source_line):
+            continue
+        normalized = _normalize(literal.text)
+        for term in POLICY_TERMS:
+            if not term.active:
+                continue
+            if not _word_pattern(term).search(normalized):
+                continue
+            if _term_allowed(term, normalized):
+                continue
+            violations.append(
+                Violation(
+                    path=path,
+                    line=literal.line,
+                    term=term.raw,
+                    text=" ".join(literal.text.split())[:180],
+                )
+            )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan apps/mobile/lib/**/*.dart UI strings for MINT banned terms."
+    )
+    parser.add_argument("--root", default=str(REPO), help="Repository root")
+    parser.add_argument("--file", help="Check one staged file; non-scope files are skipped")
+    parser.add_argument(
+        "--scope",
+        nargs="*",
+        default=list(DEFAULT_SCOPE),
+        help="Scope directories relative to --root",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if args.file:
+        path = Path(args.file)
+        if not path.is_absolute():
+            path = root / path
+        paths = [path] if _is_scoped_dart_file(path, root) else []
+    else:
+        paths = _collect_paths(root, tuple(args.scope))
+
+    violations: list[Violation] = []
+    for path in paths:
+        violations.extend(scan_file(path, root))
+
+    if violations:
+        print("::error::banned_ui_terms gate failed:")
+        for violation in violations:
+            rel = _relative(violation.path, root)
+            print(
+                f"{rel}:{violation.line}: banned term '{violation.term}' in UI string: "
+                f"{violation.text}"
+            )
+        return 1
+
+    print(f"OK banned_ui_terms: scanned {len(paths)} Dart file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/no_hardcoded_fr.py
+++ b/tools/checks/no_hardcoded_fr.py
@@ -53,6 +53,11 @@ EXCLUDE_SUBSTRINGS = (
 )
 
 
+def _is_excluded(path: Path) -> bool:
+    rel = "/" + path.as_posix() + "/"
+    return any(ex in rel for ex in EXCLUDE_SUBSTRINGS)
+
+
 def _line_is_exempt(line: str) -> bool:
     return any(marker in line for marker in IGNORE_MARKERS)
 
@@ -87,8 +92,7 @@ def _collect_paths(scope: list[str]) -> list[Path]:
                 continue
             if p.suffix not in TEXT_EXTS:
                 continue
-            rel = "/" + p.as_posix() + "/"
-            if any(ex in rel for ex in EXCLUDE_SUBSTRINGS):
+            if _is_excluded(p):
                 continue
             paths.append(p)
     return paths
@@ -116,7 +120,7 @@ def main() -> int:
         if not target.exists():
             print(f"no_hardcoded_fr: file not found: {target}", file=sys.stderr)
             return 1
-        paths = [target]
+        paths = [] if _is_excluded(target) or target.suffix not in TEXT_EXTS else [target]
     else:
         paths = _collect_paths(args.scope)
 

--- a/tools/checks/tests/test_banned_ui_terms_gate.py
+++ b/tools/checks/tests/test_banned_ui_terms_gate.py
@@ -1,0 +1,209 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/banned_ui_terms.py"
+CI = ROOT / ".github/workflows/ci.yml"
+LEFTHOOK = ROOT / "lefthook.yml"
+
+
+def _write_dart(root: Path, relative_path: str, source: str) -> Path:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_checker_module():
+    spec = importlib.util.spec_from_file_location("banned_ui_terms", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ui_promise_string_with_banned_terms_fails(tmp_path: Path) -> None:
+    _write_dart(
+        tmp_path,
+        "apps/mobile/lib/screens/promise_screen.dart",
+        """
+        import 'package:flutter/widgets.dart';
+
+        Widget build(BuildContext context) {
+          return const Text('Plan parfait, rendement garanti et sans risque.');
+        }
+        """,
+    )
+
+    result = _run_checker("--root", str(tmp_path))
+
+    assert result.returncode == 1
+    diagnostics = result.stdout + result.stderr
+    assert "promise_screen.dart:5" in diagnostics
+    assert "parfait" in diagnostics
+    assert "garanti" in diagnostics
+    assert "sans risque" in diagnostics
+
+
+def test_comments_and_internal_guard_prompts_are_not_ui_violations(
+    tmp_path: Path,
+) -> None:
+    _write_dart(
+        tmp_path,
+        "apps/mobile/lib/services/coach_prompt.dart",
+        """
+        // Exemple interdit documenté: rendement garanti.
+        /* Autre documentation: sans risque. */
+        const promptRule =
+            'Tu NE dis JAMAIS : garanti, certain, assuré, sans risque.';
+        """,
+    )
+
+    result = _run_checker("--root", str(tmp_path))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_single_word_banned_ui_label_fails(tmp_path: Path) -> None:
+    _write_dart(
+        tmp_path,
+        "apps/mobile/lib/widgets/promise_chip.dart",
+        """
+        import 'package:flutter/widgets.dart';
+
+        Widget build(BuildContext context) => const Text('Garanti');
+        """,
+    )
+
+    result = _run_checker("--root", str(tmp_path))
+
+    assert result.returncode == 1
+    assert "promise_chip.dart:4" in result.stdout + result.stderr
+    assert "garanti" in result.stdout + result.stderr
+
+
+def test_common_french_inflections_of_banned_terms_fail(tmp_path: Path) -> None:
+    _write_dart(
+        tmp_path,
+        "apps/mobile/lib/widgets/inflected_promises.dart",
+        """
+        import 'package:flutter/widgets.dart';
+
+        Widget build(BuildContext context) {
+          return const Column(children: [
+            Text('Performance garantie.'),
+            Text('La meilleure option.'),
+            Text('Solution optimale.'),
+            Text('Choix optimaux.'),
+            Text('Placement sans risques.'),
+            Text('Solution parfaite.'),
+          ]);
+        }
+        """,
+    )
+
+    result = _run_checker("--root", str(tmp_path))
+
+    assert result.returncode == 1
+    diagnostics = result.stdout + result.stderr
+    for term in ("garanti", "meilleur", "optimal", "sans risque", "parfait"):
+        assert term in diagnostics
+
+
+def test_swiss_insurance_terms_and_negated_disclaimers_pass(tmp_path: Path) -> None:
+    _write_dart(
+        tmp_path,
+        "apps/mobile/lib/screens/legal_terms_screen.dart",
+        """
+        import 'package:flutter/widgets.dart';
+
+        Widget build(BuildContext context) {
+          return const Column(children: [
+            Text('Salaire assuré'),
+            Text('Gain assuré retenu'),
+            Text('Plan 1e détecté. Pas de taux de conversion garanti.'),
+            Text('Pas de rente garantie ici.'),
+            Text('Ne constitue pas un conseil financier personnalisé.'),
+            Text('Outil éducatif, pas un conseil financier.'),
+            Text('Assure-toi d’être connecté en WiFi.'),
+            Text('Libère dans ${meilleur.moisJusquaLiberation} mois.'),
+            Text('Parfait, c’est noté.'),
+            Text('Aucune option n’est universellement meilleure.'),
+          ]);
+        }
+        """,
+    )
+
+    result = _run_checker("--root", str(tmp_path))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_adversarial_test_paths_are_skipped_for_single_file(tmp_path: Path) -> None:
+    test_file = _write_dart(
+        tmp_path,
+        "apps/mobile/test/compliance/adversarial_banned_terms_test.dart",
+        "const badFixture = 'rendement garanti et sans risque';\n",
+    )
+
+    result = _run_checker("--root", str(tmp_path), "--file", str(test_file))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_current_repo_ui_strings_are_clean_under_gate() -> None:
+    result = _run_checker()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_gate_policy_covers_claude_and_legal_banned_terms() -> None:
+    module = _load_checker_module()
+
+    policy_terms = {term.raw for term in module.POLICY_TERMS}
+    for term in (
+        "garanti",
+        "optimal",
+        "meilleur",
+        "certain",
+        "assuré",
+        "sans risque",
+        "parfait",
+        "conseil financier",
+        "better",
+        "recommended",
+    ):
+        assert term in policy_terms
+
+
+def test_lefthook_runs_banned_ui_terms_pre_commit_gate() -> None:
+    lefthook = LEFTHOOK.read_text(encoding="utf-8")
+
+    assert "banned-ui-terms:" in lefthook
+    assert "tools/checks/banned_ui_terms.py --file" in lefthook
+    assert 'glob: "apps/mobile/lib/**/*.dart"' in lefthook
+
+
+def test_ci_runs_banned_ui_terms_and_blocks_ci_gate() -> None:
+    ci = CI.read_text(encoding="utf-8")
+    gate = ci.split("ci-gate:", maxsplit=1)[1]
+
+    assert "banned-ui-terms:" in ci
+    assert "Banned UI terms" in ci
+    assert "python3 tools/checks/banned_ui_terms.py" in ci
+    assert "banned-ui-terms" in gate
+    assert 'banned_terms="${{ needs.banned-ui-terms.result }}"' in gate
+    assert '"$banned_terms" != "success"' in gate

--- a/tools/checks/tests/test_no_hardcoded_fr_contract.py
+++ b/tools/checks/tests/test_no_hardcoded_fr_contract.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/no_hardcoded_fr.py"
+
+
+def test_file_mode_respects_l10n_generated_exclusion() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--file",
+            "apps/mobile/lib/l10n/app_localizations.dart",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Add deterministic `tools/checks/banned_ui_terms.py` for Dart UI string literals under `apps/mobile/lib/**/*.dart`.
- Wire the gate into Lefthook pre-commit and GitHub CI `ci-gate`.
- Add adversarial contract tests for single-word labels, French inflections, negated disclaimers, Swiss insurance terms, prompt/internal exclusions, and CI/Lefthook wiring.
- Fix `no_hardcoded_fr.py --file` so its documented `lib/l10n/` exclusion also works in pre-commit file mode.
- Replace one French AVS tooltip wording from `garantit` to `sert de` in source/generated l10n.
- Ignore local `.hypothesis/` artifacts.

## Local QA
- `python3 tools/checks/arb_parity.py`
- `python3 -m pytest tools/checks/tests/ -q` → 23 passed
- `python3 tools/checks/banned_ui_terms.py` → scanned 675 Dart files
- `actionlint .github/workflows/ci.yml`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- `flutter analyze --no-fatal-warnings --no-fatal-infos` → exit 0; existing warnings only
- `flutter test test/l10n_regional/regional_localizations_test.dart --reporter compact` → passed
- `lefthook run pre-commit --file ...` → passed
- `gitleaks git --redact --config .gitleaks.toml --log-opts=-1 .` → no leaks
- Claude CLI Opus external audit: initial two blockers fixed; final focused re-audit PASS

## Stack
Base: #843 / `codex/mint-infra-g2-ci-baseline-20260707`
