### PR TITLE
Infra G4: add financial core drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,34 @@ jobs:
       - name: Scan Dart UI strings
         run: python3 tools/checks/banned_ui_terms.py
 
+  # ─── Financial core drift gate ───────────────────────────────
+  # Blocks newly added financial helper definitions and formula lines outside
+  # apps/mobile/lib/services/financial_core/. Historical drift is handled by
+  # migration PRs; this gate prevents new debt in every PR.
+  financial-core-gate:
+    name: Financial core gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan introduced financial calculations
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+            if [[ -z "$BASE_REF" ]] || [[ "${BASE_REF//0/}" == "" ]]; then
+              BASE_REF="HEAD^"
+            fi
+          fi
+          python3 tools/checks/financial_core_gate.py --base-ref "$BASE_REF"
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -615,7 +643,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, banned-ui-terms, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, banned-ui-terms, financial-core-gate, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -625,6 +653,7 @@ jobs:
           contracts="${{ needs.contracts-drift.result }}"
           repo_contracts="${{ needs.repo-contract-tests.result }}"
           banned_terms="${{ needs.banned-ui-terms.result }}"
+          financial_core="${{ needs.financial-core-gate.result }}"
           backend="${{ needs.backend.result }}"
           secret_scan="${{ needs.secret-scan.result }}"
           flutter="${{ needs.flutter.result }}"
@@ -638,6 +667,7 @@ jobs:
           [[ "$contracts" == "skipped" ]] && contracts="success"
           [[ "$repo_contracts" == "skipped" ]] && repo_contracts="success"
           [[ "$banned_terms" == "skipped" ]] && banned_terms="success"
+          [[ "$financial_core" == "skipped" ]] && financial_core="success"
           [[ "$backend" == "skipped" ]] && backend="success"
           [[ "$secret_scan" == "skipped" ]] && secret_scan="success"
           [[ "$flutter" == "skipped" ]] && flutter="success"
@@ -648,8 +678,8 @@ jobs:
           [[ "$cli_tests" == "skipped" ]] && cli_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts banned_terms=$banned_terms backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts banned_terms=$banned_terms financial_core=$financial_core backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,6 +42,10 @@ pre-commit:
       run: for file in {staged_files}; do python3 tools/checks/banned_ui_terms.py --file "$file" || exit 1; done
       glob: "apps/mobile/lib/**/*.dart"
       tags: [compliance, mint]
+    financial-core-gate:
+      run: python3 tools/checks/financial_core_gate.py --staged
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [financial-core, mint]
 
 skip:
   - merge

--- a/tools/checks/financial_core_gate.py
+++ b/tools/checks/financial_core_gate.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Block newly introduced financial calculation drift outside financial_core."""
+from __future__ import annotations
+import argparse
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+REPO = Path(__file__).resolve().parents[2]
+APP_LIB = "apps/mobile/lib/"
+CORE_SEGMENT = "/services/financial_core/"
+EXCLUDED = ("/.dart_tool/", "/build/", "/.git/", "/l10n/", "/test/", "/tests/")
+FINANCIAL_TOKENS = set(
+    "3a affordability assurance avs benefice budget capital chf cotisation contribution debt decaissement dette dividende "
+    "dividend donation epargne epl fiscal fitness fortune franchise fri heritage hoirie hypothecaire hypotheque imputed "
+    "income interet lamal leasing loyer lpp mortgage patrimoine pension pilier pillar prevoyance prime rachat rent rente "
+    "resilience retrait revenu salary salaire savings score successoral tax tenue usufruit withdrawal".split()
+)
+CALC_RE = re.compile(
+    r"^\s*(?:static\s+)?(?:(?:Future|Stream|List|Map|Set|Iterable|double|int|num|bool|String|void)(?:<[^>{}]+>)?\s+)?"
+    r"(?P<name>_?(?:calculate|calculer|compute|estimate|project|simulate)[A-Za-z0-9_]*)\s*\("
+)
+ASSIGN_RE = re.compile(r"^\s*(?:final|var|const|double|int|num)\s+[A-Za-z_][A-Za-z0-9_]*\s*=")
+RETURN_RE = re.compile(r"^\s*return\s+")
+ARITH_RE = re.compile(
+    r"[A-Za-z0-9_\]\)]\s*[\*/]\s*[A-Za-z0-9_\(]|[A-Za-z0-9_\]\)]\s+[\+\-]\s+[A-Za-z0-9_\(]|"
+    r"\b\d+(?:\.\d+)?\s*[\*/]\s*[A-Za-z_\(]|[A-Za-z_\)]\s*[\*/]\s*\d+(?:\.\d+)?"
+)
+
+def _normalize(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch)).casefold()
+
+def _clean_path(path: str) -> str:
+    return path.removeprefix("a/").removeprefix("b/").replace("\\", "/")
+
+def _is_scoped(path: str) -> bool:
+    rel = _clean_path(path)
+    wrapped = f"/{rel}/"
+    return rel.startswith(APP_LIB) and rel.endswith(".dart") and not rel.endswith(".g.dart") and CORE_SEGMENT not in wrapped and not any(
+        part in wrapped for part in EXCLUDED
+    )
+
+def _has_financial_context(path: str, text: str) -> bool:
+    haystack = _normalize(f"{path} {text}")
+    return any(re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", haystack) for token in FINANCIAL_TOKENS)
+
+def _code_without_strings(line: str) -> str:
+    out: list[str] = []
+    quote = None
+    escaped = False
+    for index, ch in enumerate(line):
+        nxt = line[index + 1] if index + 1 < len(line) else ""
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch in {"'", '"'}:
+            quote = ch
+            out.append(" ")
+        elif ch == "/" and nxt == "/":
+            return "".join(out)
+        else:
+            out.append(ch)
+    return "".join(out)
+
+def _added_lines(diff_text: str) -> list[tuple[str, int, str]]:
+    out: list[tuple[str, int, str]] = []
+    path: str | None = None
+    lineno: int | None = None
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git "):
+            path = None
+            lineno = None
+        elif raw.startswith("+++ "):
+            marker = raw[4:].strip()
+            path = None if marker == "/dev/null" else _clean_path(marker)
+        elif raw.startswith("@@ "):
+            match = re.search(r"\+(\d+)(?:,\d+)?", raw)
+            lineno = int(match.group(1)) if match else None
+        elif lineno is None:
+            continue
+        elif raw.startswith("+") and not raw.startswith("+++"):
+            if path and _is_scoped(path):
+                out.append((path, lineno, raw[1:]))
+            lineno += 1
+        elif not (raw.startswith("-") and not raw.startswith("---")):
+            lineno += 1
+    return out
+
+def _violation(path: str, text: str) -> str | None:
+    code = _code_without_strings(text).strip()
+    if not code:
+        return None
+    match = CALC_RE.match(code)
+    if match and _has_financial_context("", code):
+        return f"new calculation helper '{match.group('name')}' outside financial_core/"
+    if (ASSIGN_RE.match(code) or RETURN_RE.match(code)) and ARITH_RE.search(code) and _has_financial_context("", code):
+        return "new financial formula outside financial_core/"
+    return None
+
+def _git_diff(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-ext-diff", *args, "--", "apps/mobile/lib"],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+def _read_diff(args: argparse.Namespace) -> str:
+    if args.diff_file:
+        return Path(args.diff_file).read_text(encoding="utf-8")
+    if args.staged:
+        return _git_diff(["--cached"])
+    return _git_diff([f"{args.base_ref}...HEAD"] if args.base_ref else ["HEAD"])
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff-file")
+    parser.add_argument("--staged", action="store_true")
+    parser.add_argument("--base-ref")
+    args = parser.parse_args()
+    if sum(bool(v) for v in (args.diff_file, args.staged, args.base_ref)) > 1:
+        parser.error("use only one of --diff-file, --staged, or --base-ref")
+    lines = _added_lines(_read_diff(args))
+    failures = [(p, n, d, t.strip()) for p, n, t in lines for d in [_violation(p, t)] if d]
+    if failures:
+        print("::error::financial_core_gate failed:")
+        for path, lineno, detail, text in failures:
+            print(f"{path}:{lineno}: {detail}: {text}")
+        return 1
+    print(f"OK financial_core_gate: scanned {len(lines)} added Dart line(s), no new calculation drift")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_financial_core_gate.py
+++ b/tools/checks/tests/test_financial_core_gate.py
@@ -1,0 +1,115 @@
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/financial_core_gate.py"
+def _diff(path: str, added: list[str], start: int = 1) -> str:
+    body = "\n".join(f"+{line}" for line in added)
+    return f"""diff --git a/{path} b/{path}
+--- a/{path}
++++ b/{path}
+@@ -0,0 +{start},{len(added)} @@
+{body}
+"""
+def _run(tmp_path: Path, diff: str) -> subprocess.CompletedProcess[str]:
+    path = tmp_path / "changes.diff"
+    path.write_text(diff, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--diff-file", str(path)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+@pytest.mark.parametrize(
+    ("diff", "needle"),
+    [
+        (
+            _diff(
+                "apps/mobile/lib/services/tax_projection_service.dart",
+                [
+                    "class TaxProjectionService {",
+                    "  static double _calculateTaxSavings(double income, double pillar3a) {",
+                    "    return income * 0.12 + pillar3a * 0.25;",
+                    "  }",
+                    "}",
+                ],
+            ),
+            "_calculateTaxSavings",
+        ),
+        (
+            _diff(
+                "apps/mobile/lib/services/mortgage_hint_service.dart",
+                [
+                    "    final affordability = revenuAnnuel * 0.33 - interetsHypotheque;",
+                    "    return affordability;",
+                ],
+                start=11,
+            ),
+            "affordability",
+        ),
+    ],
+)
+def test_new_financial_calculation_outside_financial_core_fails(
+    tmp_path: Path, diff: str, needle: str
+) -> None:
+    result = _run(tmp_path, diff)
+    assert result.returncode == 1
+    diagnostics = result.stdout + result.stderr
+    assert needle in diagnostics
+    assert "financial_core/" in diagnostics
+
+@pytest.mark.parametrize(
+    "diff",
+    [
+        _diff(
+            "apps/mobile/lib/services/financial_core/tax_calculator.dart",
+            ["static double _calculateTaxSavings(double income) => income * 0.12;"],
+        ),
+        _diff(
+            "apps/mobile/lib/services/coach_summary_service.dart",
+            ["final estimate = TaxCalculator.calculate(income: profile.salaireBrutAnnuel);"],
+        ),
+        _diff(
+            "apps/mobile/lib/services/navigation_state_service.dart",
+            ["String _computeRouteLabel(String routeName) => routeName.trim();"],
+        ),
+        _diff(
+            "apps/mobile/lib/l10n/app_localizations_fr.dart",
+            ["String monthlyAmount(Object amount) => 'Total fixe : $amount CHF / mois';"],
+        ),
+        _diff(
+            "apps/mobile/lib/services/coach_copy_service.dart",
+            ["return 'Ton loyer est de 1200 CHF / mois';"],
+        ),
+        _diff(
+            "apps/mobile/lib/services/tax_screen_state_service.dart",
+            ["final width = index * 2.0;"],
+        ),
+        _diff(
+            "apps/mobile/lib/screens/tax_screen.dart",
+            ["void _calculate() {", "  setState(() {});", "}"],
+        ),
+        _diff(
+            "apps/mobile/lib/app.dart",
+            ["String avsGuidePath() => '/scan/avs-guide';"],
+        ),
+    ],
+)
+def test_allowed_diffs_pass(tmp_path: Path, diff: str) -> None:
+    result = _run(tmp_path, diff)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+def test_financial_core_gate_is_wired_into_ci_gate_and_lefthook() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    gate = ci.split("ci-gate:", maxsplit=1)[1]
+    lefthook = (ROOT / "lefthook.yml").read_text(encoding="utf-8")
+    assert "financial-core-gate:" in ci
+    assert "tools/checks/financial_core_gate.py --base-ref" in ci
+    assert "financial-core-gate" in gate
+    assert 'financial_core="${{ needs.financial-core-gate.result }}"' in gate
+    assert '"$financial_core" != "success"' in gate
+    assert "financial-core-gate:" in lefthook
+    assert "tools/checks/financial_core_gate.py --staged" in lefthook


### PR DESCRIPTION
## Summary
- add a diff-aware `financial_core_gate.py` to block newly introduced financial helper definitions and formula lines outside `apps/mobile/lib/services/financial_core/`
- wire the gate into Lefthook pre-commit and GitHub CI / CI Gate
- add contract tests for real financial drift, allowed `financial_core` reuse, l10n/string false positives, path-token false positives, generic UI `_calculate()` false positives, and CI/Lefthook wiring

## Verification
- `python3 -m pytest tools/checks/tests/ -q`
- `python3 tools/checks/financial_core_gate.py --staged`
- `python3 tools/checks/financial_core_gate.py --base-ref codex/mint-infra-g3-banned-ui-terms-20260707`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `gitleaks git --redact --config .gitleaks.toml --log-opts=-1 .`
- `lefthook run pre-commit`
- Claude CLI Opus audit: initial NOT PASS fixed; final PASS

## Notes
This is a new-debt guard, not a migration of historical non-core calculation debt. Historical migrations should remain separate small PRs.