### PR TITLE
Infra-G6: wire QA tool roadmap contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
       - name: Install pytest
         run: pip install pytest
       - name: Run repo contract tests
-        run: python3 -m pytest tools/checks/tests/ -q
+        run: |
+          python3 -m pytest tools/checks/tests/ -q
+          python3 -m pytest tests/checks/test_test_roadmap_contract.py -q
 
   # ─── LSFin UI copy gate ─────────────────────────────────────
   # Blocks core banned promise terms from CLAUDE.md /
@@ -407,11 +409,11 @@ jobs:
   #   - screens:  test/screens/ + test/golden/ + test/auth/ + test/modules/
   #               + test/journeys/ + test/accessibility/ + test/i18n/                                  (~55 files)
   #
-  # NOTE: test/patrol/ is intentionally excluded — requires emulator infrastructure.
+  # NOTE: Patrol is intentionally excluded — requires emulator infrastructure.
   # NOTE: test/golden_screenshots/ is intentionally excluded — pixel diffs are
   #       cross-platform fragile (Mac baselines fail on Linux CI). Run locally
   #       before each release. See test/golden_screenshots/README.md.
-  # See .github/workflows/patrol.md for manual gate policy.
+  # See .github/workflows/patrol.md for the current manual-gap policy.
   #
   # `flutter analyze` runs only in the services shard to avoid redundant work.
   # All shards exclude test/_archive/ (legacy suite).

--- a/.github/workflows/patrol.md
+++ b/.github/workflows/patrol.md
@@ -1,54 +1,44 @@
-# Patrol Integration Tests — Manual Gate Policy
+# Patrol Integration Tests — Manual Gap Policy
 
 ## Status
 
-Patrol integration tests are **NOT** included in CI. They require emulator infrastructure
-(iOS 17 simulator + Android API 34 emulator) that is not available on GitHub Actions
-ubuntu runners.
+Patrol integration tests are NOT included in CI. They require emulator
+infrastructure that is not available on GitHub Actions ubuntu runners, and this
+checkout does not yet install Patrol.
 
-## Test Location
+## Current Repo State
 
-```
-apps/mobile/test/patrol/
-  onboarding_patrol_test.dart   — Full onboarding flow (7 steps)
-  document_patrol_test.dart     — Document capture flow (7 steps, screenshots)
-```
+- `apps/mobile/pubspec.yaml` has `integration_test`, but no `patrol:`
+  dependency.
+- `patrol` is not expected on the default PATH.
+- No committed Patrol suite is present yet. The reserved future location is
+  `apps/mobile/test/patrol/`.
+- Existing executable mobile runtime proof is Maestro-first until Patrol is
+  added.
 
 ## When to Run
 
-Patrol tests are a **manual gate** required before promotion PRs:
+Patrol is a manual gap until the dependency, test suite, and runner exist.
+After that, it becomes the required proof for native input surfaces:
 
-| PR Type              | Patrol Required | Who Runs       |
-|----------------------|-----------------|----------------|
-| feature/* -> dev     | No              | —              |
-| dev -> staging       | Yes             | Developer      |
-| staging -> main      | Yes             | Developer      |
+| Surface | Patrol status |
+|---|---|
+| Pure Flutter logic/widget | Not required; use Flutter tests |
+| Black-box route and data reuse | Use Maestro when identifiers/deep links exist |
+| Native pickers, permissions, camera, biometrics | Required after Patrol is installed |
+| Promotion PR with native input changed | Blocked until Patrol proof or explicit deferral |
 
-## How to Run
+## Future Command Shape
 
-### Prerequisites
-
-- macOS with Xcode 15+ (iOS 17 simulator)
-- Android Studio with API 34 emulator image
-- Flutter 3.27.4+ with patrol_cli installed
-
-### Commands
+Once Patrol is added to `pubspec.yaml` and the suite exists, use a real device
+or simulator command shaped like:
 
 ```bash
-cd apps/mobile
-
-# iOS (iPhone 15 simulator)
-flutter test test/patrol/ --device-id "iPhone 15"
-
-# Android (Pixel 7 API 34 emulator)
-flutter test test/patrol/ --device-id "emulator-5554"
+cd apps/mobile && patrol test --target test/patrol/<flow>_test.dart
 ```
 
-### Expected Results
-
-- All 7 onboarding steps complete without crash
-- All 7 document capture steps complete with screenshots captured
-- No unhandled exceptions in console output
+Record every run under `.planning/runtime-evidence/` with branch, commit,
+device, command, logs, screenshots, and pass/fail summary.
 
 ## Future: CI Integration
 
@@ -58,7 +48,7 @@ When GitHub Actions macOS runners with iOS simulator support are configured
 1. Create `.github/workflows/patrol.yml` with macOS runner
 2. Configure iOS 17 simulator boot
 3. Add Android API 34 emulator via `reactivecircus/android-emulator-runner`
-4. Move `test/patrol/` into the new workflow
+4. Run the committed Patrol suite from the mobile package
 5. Remove this manual gate policy document
 
 ## Why Not CI Today

--- a/TEST_ROADMAP.md
+++ b/TEST_ROADMAP.md
@@ -3,6 +3,58 @@
 ## Objectif
 Valider que l'application s'adapte correctement à des profils financiers radicalement différents, en vérifiant la logique métier, la compliance (Safe Mode) et les recommandations.
 
+## Infra-G6 QA Tool Split
+
+G6 turns this roadmap into an executable QA contract: every tool must have a
+clear owner, execution mode, evidence artifact, and current repo status.
+
+### Tool Roles
+
+| Tool | Role | Use when | Current gate |
+|---|---|---|---|
+| Flutter tests | Deterministic logic, rendering, and contract checks | Any backend/mobile/doc contract change | CI |
+| Maestro = black-box agent loop | Drive the installed app through accessibility ids and deep links like an external user/agent | P0 route proof, data reuse proof, no-facade checks | Manual/local until runner wiring |
+| Patrol = white-box native input proof | Drive Flutter/native input where black-box taps are fragile, including native pickers, permissions, camera, and biometric flows | P0 native input proof and future biometric proof | Manual gap until Patrol is added to pubspec and CI runner support exists |
+
+### Current executable state
+
+- CI runs repo contracts, backend tests, Flutter shards, route parity,
+  financial_core, banned UI terms, WCAG, PII, and gitleaks.
+- Maestro is present locally at `~/.maestro/bin/maestro`; real flows live under
+  `apps/mobile/.maestro/`. Current smoke command:
+  `cd apps/mobile && ~/.maestro/bin/maestro test .maestro/`.
+- Patrol CLI is not installed in PATH in this checkout, `apps/mobile/pubspec.yaml`
+  has no `patrol:` dependency, and no committed Patrol suite exists yet under
+  `apps/mobile/test/patrol/`.
+- Patrol remains manual: GitHub Actions ubuntu runners have no iOS simulator support.
+- This is a manual gap until Patrol is added to pubspec and CI runner support exists.
+- Flutter integration coverage currently contains `persona_lea_test.dart` and
+  `persona_marc_test.dart`; the other personas below are target coverage, not
+  committed executable tests.
+
+### Promotion gates
+
+| Change type | Required proof |
+|---|---|
+| Pure docs/spec/contract | Targeted pytest contract plus `lefthook run pre-commit` |
+| Flutter logic or widget | Targeted Flutter test plus relevant CI shard |
+| P0 route/screen | Maestro proof when identifiers/deep links exist |
+| P0 native input, camera, permissions, biometrics | Patrol proof once the Patrol dependency and runner exist |
+| Promotion to staging/main | CI green plus any manual runtime proof recorded in evidence |
+
+### Evidence artifacts
+
+Runtime proof belongs under `.planning/runtime-evidence/` with command, device,
+branch, commit, screenshots/log path, and pass/fail summary. The directory may
+be absent on a clean branch until a runtime proof is actually produced.
+
+### Interaction Registry - walker assertions
+
+Interaction Registry is reserved for a future blocking walker that checks
+route nodes, payloads, provenance-aware back behavior, and test references.
+It is not implemented in G6. Until that registry exists, G6 only requires this
+roadmap contract and the existing route/data/widget gates.
+
 ## 1. Persona "Léa" (Starter / Student)
 *   **Profil** : 22 ans, Étudiante/Stage, Revenu < 4k, Célibataire, Locataire.
 *   **Situation** : Pas de 3a, pas de dettes, épargne faible.
@@ -91,8 +143,6 @@ Valider que l'application s'adapte correctement à des profils financiers radica
 ---
 
 ## Stratégie d'Exécution
-Pour chaque persona, nous allons créer un **Test d'Intégration Flutter** (`integration_test/`) qui :
-1.  Lance l'app.
-2.  Remplit le Wizard avec les réponses spécifiques.
-3.  Vérifie l'écran de Rapport généré (Textes, Scores).
-4.  Navigue vers `/tools` et vérifie l'état des verrous (Safe Mode).
+Les personas ci-dessus définissent la couverture cible. Un persona devient
+accepté seulement quand il a une preuve exécutable nommée dans ce fichier:
+test Flutter, flow Maestro, ou future preuve Patrol selon la surface touchée.

--- a/tests/checks/test_test_roadmap_contract.py
+++ b/tests/checks/test_test_roadmap_contract.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ROADMAP = ROOT / "TEST_ROADMAP.md"
+PATROL_POLICY = ROOT / ".github" / "workflows" / "patrol.md"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+MAESTRO_DIR = ROOT / "apps" / "mobile" / ".maestro"
+PUBSPEC = ROOT / "apps" / "mobile" / "pubspec.yaml"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_test_roadmap_contract_is_ci_wired() -> None:
+    ci = _text(CI)
+
+    assert "tests/checks/test_test_roadmap_contract.py" in ci
+
+
+def test_test_roadmap_documents_g6_tool_split() -> None:
+    roadmap = _text(ROADMAP)
+
+    required_phrases = (
+        "Infra-G6 QA Tool Split",
+        "Maestro = black-box agent loop",
+        "Patrol = white-box native input proof",
+        "Current executable state",
+        "Promotion gates",
+        "Evidence artifacts",
+        ".planning/runtime-evidence/",
+        "Interaction Registry - walker assertions",
+        "not implemented in G6",
+    )
+
+    for phrase in required_phrases:
+        assert phrase in roadmap
+
+
+def test_test_roadmap_matches_current_maestro_and_patrol_reality() -> None:
+    roadmap = _text(ROADMAP)
+
+    assert MAESTRO_DIR.exists()
+    assert any(MAESTRO_DIR.glob("*.yaml"))
+    assert "~/.maestro/bin/maestro" in roadmap
+    assert "apps/mobile/.maestro/" in roadmap
+
+    pubspec = _text(PUBSPEC)
+    assert "patrol:" not in pubspec
+    assert "patrol_cli" not in pubspec
+    assert "Patrol CLI is not installed in PATH" in roadmap
+    assert "apps/mobile/test/patrol/" in roadmap
+    assert "manual gap until Patrol is added to pubspec and CI runner support exists" in roadmap
+
+
+def test_docs_do_not_prescribe_stale_patrol_or_persona_claims() -> None:
+    combined = "\n".join((_text(ROADMAP), _text(PATROL_POLICY)))
+    obsolete_claims = (
+        "nous allons créer un **Test d'Intégration Flutter** (`integration_test/`)",
+        "Pour chaque persona, nous allons créer",
+        "flutter test test/patrol/",
+        "onboarding_patrol_test.dart",
+        "document_patrol_test.dart",
+    )
+
+    for claim in obsolete_claims:
+        assert claim not in combined
+
+
+def test_patrol_policy_is_consistent_with_roadmap_manual_gate() -> None:
+    roadmap = _text(ROADMAP)
+    policy = _text(PATROL_POLICY)
+
+    assert "NOT included in CI" in policy
+    assert "manual gap" in policy.lower()
+    assert "Patrol remains manual" in roadmap
+    assert "GitHub Actions ubuntu runners have no iOS simulator support" in roadmap


### PR DESCRIPTION
## Summary
- Wire a CI repo contract for TEST_ROADMAP tool split and Patrol/Maestro reality.
- Document Maestro as black-box agent proof and Patrol as future white-box native proof.
- Reconcile Patrol policy with current repo state: no Patrol dependency, no committed Patrol suite, manual gap until runner/dependency exist.

## Test Plan
- python3 -m pytest tests/checks/test_test_roadmap_contract.py -q
- python3 -m pytest tools/checks/tests/ tests/checks/test_test_roadmap_contract.py -q
- actionlint .github/workflows/ci.yml
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check
- lefthook run pre-commit
- python3 tools/checks/no_chiffre_choc.py
- Claude Opus audit: PASS