### PR TITLE
Infra-G7: memory and hosting governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           python3 -m pytest tools/checks/tests/ -q
           python3 -m pytest tests/checks/test_test_roadmap_contract.py -q
+          python3 -m pytest tests/checks/test_governance_docs_contract.py -q
 
   # ─── LSFin UI copy gate ─────────────────────────────────────
   # Blocks core banned promise terms from CLAUDE.md /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,16 @@
 ## 🚨 TOP — 5 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
 
 1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md).
-2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`, `decouvrir → découvrir`, `securite → sécurité`, `premier éclairage` (jamais `premier eclairage`). ASCII « e » à la place de « é » = bug. Lint : `tools/checks/accent_lint_fr.py`.
+2. **Accents 100% FR mandatory** — écrire `créer`, `éclairage`, `découvrir`, `sécurité`, `premier éclairage`. ASCII « e » à la place de « é » = bug. Lint : `tools/checks/accent_lint_fr.py`.
 3. **MINT ≠ retirement app** — 18 life events equally weighted (housing, family, tax, career, debt…). Never frame screens/prompts as « retraite-first ». Target : 18-99. Pivot 2026-04-12 : lucidité, pas protection.
 4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`.
 5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. Run `flutter gen-l10n`.
+
+---
+
+## 0. MEMORY HIERARCHY
+
+- **Hiérarchie mémoire** — repo (git history + `decisions/` ADR + checked-in docs/code) = source de vérité ; Engram = index de rappel, jamais source primaire. Conflit → le repo gagne.
 
 ---
 
@@ -115,7 +121,7 @@ cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 ## 🚨 BOTTOM — 5 RULES CRITIQUES (duplicated intentionally, Liu 2024)
 
 1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur ». Use « pourrait », « envisager ».
-2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`. ASCII = bug.
+2. **Accents 100% FR mandatory** — écrire `créer` et `éclairage`. ASCII = bug.
 3. **MINT ≠ retirement app** — 18 life events equally weighted. Frame generically, pas « retraite-first ».
 4. **Financial_core reuse mandatory** — `lib/services/financial_core/`. Never re-implement `_calculate*()`.
 5. **i18n required** — `AppLocalizations.of(context)!.key`. 6 ARB files. Run `flutter gen-l10n`.

--- a/decisions/ADR-20260707-hosting-migration.md
+++ b/decisions/ADR-20260707-hosting-migration.md
@@ -1,0 +1,72 @@
+# ADR-20260707 — Hosting Migration Triggers
+
+Status: Proposed
+Date: 2026-07-07
+
+## Contexte
+
+MINT currently uses Railway in the deployment architecture, while the product
+direction is Swiss financial lucidity with progressively richer personal data.
+This ADR defines a target hosting boundary without pretending the current
+backend is already stateless.
+
+Current persistence exceptions in the backend:
+
+- `services/backend/app/models/snapshot.py:27` stores `gross_income`.
+- `services/backend/app/models/coach_insight.py:45` stores `coach_insight.summary`.
+- `services/backend/app/models/earmark.py:89` stores `amount_hint`.
+- `services/backend/app/models/billing.py:86` stores `amount_cents`.
+
+## Décision
+
+Railway target = stateless compute only.
+
+The target policy is no new raw identifiable financial amount persisted server-side
+on Railway. Railway may run stateless API compute, orchestration, and transient
+processing, but identifiable financial state should move to a Swiss hosting
+posture before production use of server-side personal finance storage expands.
+
+Migration to a Swiss host is triggered by either condition:
+
+- server-side storage of identifiable financial data beyond the current
+  explicitly named exceptions;
+- regulatory requirement, including a FINMA or legal/compliance requirement
+  that hosting or data residency must be Swiss-controlled.
+
+Target Swiss hosting candidates: Infomaniak or Exoscale.
+
+## Alternatives considérées
+
+- Keep Railway as full application and data host indefinitely.
+- Move immediately to Swiss hosting before the product data model stabilizes.
+- Keep raw identifiable financial state local-first and use Railway only for
+  stateless compute until a migration trigger is reached.
+
+## Conséquences
+
+- New backend features must not add raw identifiable financial amount
+  persistence casually; if they do, this ADR requires an explicit review.
+- Existing persistence exceptions remain visible and must be reduced or migrated
+  before claiming a stateless Railway posture.
+- Engram and agent memory are not compliance evidence; checked-in ADRs, code,
+  deployment configuration, and PR history are authoritative.
+
+## Plan de migration
+
+1. Inventory server-side financial fields before each production-readiness gate.
+2. Block new raw identifiable financial amount fields unless an ADR updates this
+   policy.
+3. If a trigger fires, choose Infomaniak or Exoscale, migrate storage first,
+   then move compute or networking as needed.
+4. Update the DPA, deployment workflows, secrets, and runtime proof after the
+   migration.
+
+## Liens
+
+- `docs/DPA_TECHNICAL_ANNEX.md`
+- `docs/CICD_ARCHITECTURE.md`
+- `.github/workflows/deploy-backend.yml`
+- `services/backend/app/models/snapshot.py`
+- `services/backend/app/models/coach_insight.py`
+- `services/backend/app/models/earmark.py`
+- `services/backend/app/models/billing.py`

--- a/tests/checks/test_governance_docs_contract.py
+++ b/tests/checks/test_governance_docs_contract.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+CLAUDE = ROOT / "CLAUDE.md"
+HOSTING_ADR = ROOT / "decisions" / "ADR-20260707-hosting-migration.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_governance_contract_is_ci_wired() -> None:
+    ci = _text(CI)
+
+    assert "tests/checks/test_governance_docs_contract.py" in ci
+
+
+def test_claude_md_declares_memory_hierarchy() -> None:
+    claude = _text(CLAUDE)
+
+    assert "Hiérarchie mémoire" in claude
+    assert "Engram = index de rappel, jamais source primaire" in claude
+    assert "le repo gagne" in claude
+    assert "AGENTS_LOG" not in claude
+    assert "docs/archive/" not in claude
+
+
+def test_hosting_adr_exists_and_follows_template() -> None:
+    adr = _text(HOSTING_ADR)
+
+    for heading in (
+        "## Contexte",
+        "## Décision",
+        "## Alternatives considérées",
+        "## Conséquences",
+        "## Plan de migration",
+        "## Liens",
+    ):
+        assert heading in adr
+
+
+def test_hosting_adr_states_stateless_target_with_current_exceptions() -> None:
+    adr = _text(HOSTING_ADR)
+
+    required_phrases = (
+        "Railway target = stateless compute only",
+        "no new raw identifiable financial amount persisted server-side",
+        "Current persistence exceptions",
+        "gross_income",
+        "coach_insight",
+        "amount_hint",
+        "amount_cents",
+        "Infomaniak",
+        "Exoscale",
+        "FINMA",
+        "server-side storage of identifiable financial data",
+        "regulatory requirement",
+    )
+
+    for phrase in required_phrases:
+        assert phrase in adr
+
+    assert "no raw financial amount persisted server-side" not in adr
+
+
+def test_hosting_adr_marked_proposed() -> None:
+    adr = _text(HOSTING_ADR)
+
+    assert "Status: Proposed" in adr


### PR DESCRIPTION
## Summary
- Add repo-vs-Engram memory hierarchy to CLAUDE.md with repo as source of truth.
- Add Proposed hosting migration ADR with Railway stateless target, current persistence exceptions, and CH migration triggers.
- Wire governance docs contract into CI repo-contract tests.

## Test Plan
- python3 -m pytest tests/checks/test_governance_docs_contract.py -q
- python3 -m pytest tools/checks/tests/ tests/checks/test_test_roadmap_contract.py tests/checks/test_governance_docs_contract.py -q
- actionlint .github/workflows/ci.yml
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
- python3 tools/checks/accent_lint_fr.py --file CLAUDE.md
- python3 tools/checks/accent_lint_fr.py --file decisions/ADR-20260707-hosting-migration.md
- python3 tools/checks/no_chiffre_choc.py
- lefthook run pre-commit
- Claude Opus audit: PASS