### PR TITLE
Infra G8: instruction hygiene contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
           python3 -m pytest tools/checks/tests/ -q
           python3 -m pytest tests/checks/test_test_roadmap_contract.py -q
           python3 -m pytest tests/checks/test_governance_docs_contract.py -q
+          python3 -m pytest tests/checks/test_instruction_hygiene_contract.py -q
 
   # ─── LSFin UI copy gate ─────────────────────────────────────
   # Blocks core banned promise terms from CLAUDE.md /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@
 
 ## 🚨 TOP — 5 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
 
-1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md).
-2. **Accents 100% FR mandatory** — écrire `créer`, `éclairage`, `découvrir`, `sécurité`, `premier éclairage`. ASCII « e » à la place de « é » = bug. Lint : `tools/checks/accent_lint_fr.py`.
+1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md). enforced by hook/CI: banned-ui-terms.
+2. **Accents 100% FR mandatory** — écrire `créer`, `éclairage`, `découvrir`, `sécurité`, `premier éclairage`. ASCII « e » à la place de « é » = bug. enforced by hook/CI: accent-lint-fr.
 3. **MINT ≠ retirement app** — 18 life events equally weighted (housing, family, tax, career, debt…). Never frame screens/prompts as « retraite-first ». Target : 18-99. Pivot 2026-04-12 : lucidité, pas protection.
-4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`.
-5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. Run `flutter gen-l10n`.
+4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`. enforced by hook/CI: financial-core-gate.
+5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. enforced by hook/CI: no-hardcoded-fr, arb-parity.
 
 ---
 
@@ -65,7 +65,7 @@ cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 ### NEVER #1 — Hardcode user-facing strings
 - ❌ NEVER: `Text('Bonjour')`
 - ✅ INSTEAD: `Text(AppLocalizations.of(context)!.greetingMorning)`
-- ⚠️ WHY: i18n drift 6 langues, ARB parity breaks, l10n CI fails, blocs MintShell audit.
+- ⚠️ WHY: i18n drift 6 langues, ARB parity breaks, l10n CI fails, blocs MintShell audit. enforced by hook/CI: no-hardcoded-fr, arb-parity.
 
 ### NEVER #2 — Hardcode colors
 - ❌ NEVER: `Color(0xFF003B2F)`
@@ -75,7 +75,7 @@ cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 ### NEVER #3 — Duplicate calculation logic
 - ❌ NEVER: `double _calculateRente(profile) { ... }` dans un service file
 - ✅ INSTEAD: `AvsCalculator.computeMonthlyRente(profile)` depuis `lib/services/financial_core/`
-- ⚠️ WHY: single source of truth, testé contre Julien+Lauren golden, backend parity garantie.
+- ⚠️ WHY: single source of truth, testé contre Julien+Lauren golden, backend parity garantie. enforced by hook/CI: financial-core-gate.
 
 ### NEVER #4 — Frame MINT as retirement app
 - ❌ NEVER: « Préparez votre retraite avec MINT » en hero copy
@@ -85,7 +85,7 @@ cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 ### NEVER #5 — Use banned terms
 - ❌ NEVER: « rendement garanti », « l'optimal », « sans risque », « meilleur choix »
 - ✅ INSTEAD: « scénarios (Bas/Moyen/Haut) », « pourrait », « envisager », « adapté »
-- ⚠️ WHY: LSFin compliance, FINMA, disclaimer required sur chaque projection. `ComplianceGuard` enforce.
+- ⚠️ WHY: LSFin compliance, FINMA, disclaimer required sur chaque projection. `ComplianceGuard` enforce. enforced by hook/CI: banned-ui-terms.
 
 ### NEVER #6 — Code without reading existing code
 - ❌ NEVER: écrire un nouveau widget sans grep pour un existant
@@ -120,8 +120,8 @@ cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 
 ## 🚨 BOTTOM — 5 RULES CRITIQUES (duplicated intentionally, Liu 2024)
 
-1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur ». Use « pourrait », « envisager ».
-2. **Accents 100% FR mandatory** — écrire `créer` et `éclairage`. ASCII = bug.
+1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur ». Use « pourrait », « envisager ». enforced by hook/CI: banned-ui-terms.
+2. **Accents 100% FR mandatory** — écrire `créer` et `éclairage`. ASCII = bug. enforced by hook/CI: accent-lint-fr.
 3. **MINT ≠ retirement app** — 18 life events equally weighted. Frame generically, pas « retraite-first ».
-4. **Financial_core reuse mandatory** — `lib/services/financial_core/`. Never re-implement `_calculate*()`.
-5. **i18n required** — `AppLocalizations.of(context)!.key`. 6 ARB files. Run `flutter gen-l10n`.
+4. **Financial_core reuse mandatory** — `lib/services/financial_core/`. Never re-implement `_calculate*()`. enforced by hook/CI: financial-core-gate.
+5. **i18n required** — `AppLocalizations.of(context)!.key`. 6 ARB files. enforced by hook/CI: no-hardcoded-fr, arb-parity.

--- a/rules.md
+++ b/rules.md
@@ -4,7 +4,7 @@ Objectif: coder vite (“vibe coding”) sans casser la cohérence.
 
 ## 0) Hiérarchie de vérité
 1. rules.md — Non-negotiable technical + ethical rules
-2. .claude/CLAUDE.md — Project context, constants, compliance, anti-patterns
+2. CLAUDE.md — Project context, constants, compliance, anti-patterns
 3. AGENTS.md — Team workflow, roles, sprint tracker
 4. .claude/skills/ — Agent-specific conventions and patterns
 5. LEGAL_RELEASE_CHECK.md — Wording compliance checklist
@@ -12,10 +12,13 @@ Objectif: coder vite (“vibe coding”) sans casser la cohérence.
 7. docs/ (evolution specs) — ONBOARDING_ARBITRAGE_ENGINE, COACH_VIVANT_ROADMAP, DATA_ACQUISITION
 8. decisions/ (ADR) — Architecture decisions
 9. SOT.md + OpenAPI — Data contracts
-10. Code — Implementation follows documents
+10. Code — executable implementation reality in the repo
 
-Si le code contredit 1–9: corriger le code OU écrire une ADR.
-docs/ evolution specs sit below visions/ but above ADRs.
+The repo source of truth includes git history, decisions/ ADRs, checked-in
+docs, SOT/OpenAPI, and code. On a contract/spec conflict, reconcile
+SOT/OpenAPI/ADR ↔ code in the same patch; if the decision changes architecture
+or product meaning, write an ADR. If an evolution spec is obsolete against
+verified code, fix the spec before coding against a fiction.
 
 ## 1) Commandes standards
 

--- a/tests/checks/test_instruction_hygiene_contract.py
+++ b/tests/checks/test_instruction_hygiene_contract.py
@@ -1,0 +1,81 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CLAUDE = ROOT / "CLAUDE.md"
+RULES = ROOT / "rules.md"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+INSTRUCTION_PATTERNS = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "rules.md",
+    ".claude/agents/*.md",
+    ".claude/skills/*/SKILL.md",
+    ".claude/prompts/*.md",
+    ".claude/AGENT*.md",
+    ".claude/*WORKFLOW*.md",
+)
+
+VOLATILE_PATTERNS = (
+    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?"),
+    re.compile(r"\bGenerated\s+(?:at|on)\s+\d{4}-\d{2}-\d{2}", re.IGNORECASE),
+    re.compile(r"\bLast\s+updated\s*:\s*\d{4}-\d{2}-\d{2}", re.IGNORECASE),
+)
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _instruction_files() -> list[Path]:
+    files: set[Path] = set()
+    for pattern in INSTRUCTION_PATTERNS:
+        files.update(ROOT.glob(pattern))
+    return sorted(path for path in files if path.is_file())
+
+
+def test_instruction_hygiene_contract_is_ci_wired() -> None:
+    ci = _text(CI)
+
+    assert "tests/checks/test_instruction_hygiene_contract.py" in ci
+
+
+def test_active_instruction_files_have_no_volatile_timestamps() -> None:
+    offenders: list[str] = []
+
+    for path in _instruction_files():
+        for lineno, line in enumerate(_text(path).splitlines(), start=1):
+            if any(pattern.search(line) for pattern in VOLATILE_PATTERNS):
+                offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {line.strip()}")
+
+    assert offenders == []
+
+
+def test_rules_md_points_to_root_claude_md() -> None:
+    rules = _text(RULES)
+
+    assert ".claude/CLAUDE.md" not in rules
+    assert "CLAUDE.md — Project context" in rules
+
+
+def test_rules_md_uses_repo_reality_reconciliation() -> None:
+    rules = _text(RULES)
+
+    assert "Implementation follows documents" not in rules
+    assert "repo source of truth" in rules
+    assert "reconcile" in rules
+    assert "SOT/OpenAPI/ADR" in rules
+
+
+def test_claude_md_points_repeated_rules_to_enforced_gates() -> None:
+    claude = _text(CLAUDE)
+
+    for gate in (
+        "enforced by hook/CI: banned-ui-terms",
+        "enforced by hook/CI: accent-lint-fr",
+        "enforced by hook/CI: financial-core-gate",
+        "enforced by hook/CI: no-hardcoded-fr, arb-parity",
+    ):
+        assert gate in claude


### PR DESCRIPTION
## Summary
- add a CI-wired instruction hygiene contract for active MINT instruction files
- fix rules.md source-of-truth hierarchy to point to root CLAUDE.md and repo-reality reconciliation
- add hook/CI enforcement pointers to load-bearing CLAUDE.md rules without deleting the duplicated prompt guards

## Verification
- python3 -m pytest tests/checks/test_instruction_hygiene_contract.py -q
- python3 -m pytest tools/checks/tests/ tests/checks/test_test_roadmap_contract.py tests/checks/test_governance_docs_contract.py tests/checks/test_instruction_hygiene_contract.py -q
- actionlint .github/workflows/ci.yml
- python3 tools/checks/accent_lint_fr.py --file CLAUDE.md
- python3 tools/checks/accent_lint_fr.py --file rules.md
- python3 tools/checks/claude_md_bracket.py --file CLAUDE.md
- python3 tools/checks/no_chiffre_choc.py
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check
- lefthook run pre-commit
- Claude Opus audit: PASS