### PR TITLE
Infra-G9: add no-bypass persistence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,34 @@ jobs:
           fi
           python3 tools/checks/financial_core_gate.py --base-ref "$BASE_REF"
 
+  # ─── DATA_LEDGER §8.3: persistence bypass gate ─────────────
+  # Blocks newly introduced SharedPreferences domain-key writes outside the
+  # provider/report persistence path. Historical debt is handled by migration
+  # PRs; this job prevents new bypasses.
+  no-bypass-persistence:
+    name: No bypass persistence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan introduced ledger persistence bypasses
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+            if [[ -z "$BASE_REF" ]] || [[ "${BASE_REF//0/}" == "" ]]; then
+              BASE_REF="HEAD^"
+            fi
+          fi
+          python3 tools/checks/no_bypass_persistence.py --base-ref "$BASE_REF"
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -633,7 +661,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, banned-ui-terms, financial-core-gate, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, contracts-drift, secret-scan, repo-contract-tests, banned-ui-terms, financial-core-gate, no-bypass-persistence, backend, flutter, readability, wcag-aa-all-touched, pii-log-gate, route-registry-parity, mint-routes-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -644,6 +672,7 @@ jobs:
           repo_contracts="${{ needs.repo-contract-tests.result }}"
           banned_terms="${{ needs.banned-ui-terms.result }}"
           financial_core="${{ needs.financial-core-gate.result }}"
+          no_bypass="${{ needs.no-bypass-persistence.result }}"
           backend="${{ needs.backend.result }}"
           secret_scan="${{ needs.secret-scan.result }}"
           flutter="${{ needs.flutter.result }}"
@@ -658,6 +687,7 @@ jobs:
           [[ "$repo_contracts" == "skipped" ]] && repo_contracts="success"
           [[ "$banned_terms" == "skipped" ]] && banned_terms="success"
           [[ "$financial_core" == "skipped" ]] && financial_core="success"
+          [[ "$no_bypass" == "skipped" ]] && no_bypass="success"
           [[ "$backend" == "skipped" ]] && backend="success"
           [[ "$secret_scan" == "skipped" ]] && secret_scan="success"
           [[ "$flutter" == "skipped" ]] && flutter="success"
@@ -668,8 +698,8 @@ jobs:
           [[ "$cli_tests" == "skipped" ]] && cli_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts banned_terms=$banned_terms financial_core=$financial_core backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$contracts" != "success" ]] || [[ "$repo_contracts" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$no_bypass" != "success" ]] || [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$pii" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — contracts=$contracts repo_contracts=$repo_contracts banned_terms=$banned_terms financial_core=$financial_core no_bypass=$no_bypass backend=$backend secret_scan=$secret_scan flutter=$flutter readability=$readability wcag=$wcag pii=$pii parity=$parity cli_tests=$cli_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -46,6 +46,10 @@ pre-commit:
       run: python3 tools/checks/financial_core_gate.py --staged
       glob: "apps/mobile/lib/**/*.dart"
       tags: [financial-core, mint]
+    no-bypass-persistence:
+      run: python3 tools/checks/no_bypass_persistence.py --staged
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [persistence, ledger, mint]
 
 skip:
   - merge

--- a/tools/checks/no_bypass_persistence.py
+++ b/tools/checks/no_bypass_persistence.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""DATA_LEDGER.md §8.3 new-debt gate for ledger persistence bypasses."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+APP_LIB = "apps/mobile/lib/"
+ALLOWED = {
+    "apps/mobile/lib/services/report_persistence_service.dart",
+    "apps/mobile/lib/providers/coach_profile_provider.dart",
+}
+BUDGET_CACHE = "apps/mobile/lib/data/budget/budget_local_store.dart"
+DOMAIN = set(
+    "birthYear dateOfBirth canton commune householdType employmentStatus goal targetRetirementAge gender "
+    "incomeNetMonthly incomeNetYearly incomeGrossMonthly incomeGrossYearly employmentRate annualBonus "
+    "selfEmployedNetIncome lppInsuredSalary avoirLpp avoirLppObligatoire avoirLppSurobligatoire "
+    "lppBuybackMax has2ndPillar hasVoluntaryLpp pillar3aAnnual pillar3aBalance savingsMonthly "
+    "totalSavings wealthEstimate hasDebt totalDebt spouseBirthYear spouseIncomeNetMonthly "
+    "spouseAvsContributionYears hasAvsGaps avsContributionYears"
+    .split()
+)
+PREFIXES = (
+    "q_",
+    "_coach_",
+    "fp:",
+    "prevoyance.",
+    "patrimoine.",
+    "dettes.",
+    "depenses.",
+    "conjoint.",
+    "goalA",
+    "goalsB",
+    "plannedContributions",
+    "checkIns",
+)
+SETTER = re.compile(r"\.set(?:String|Double|Int|Bool|StringList)\s*\(\s*(?P<q>['\"])(?P<key>[^'\"]+)(?P=q)")
+
+
+def _clean(path: str) -> str:
+    return path.removeprefix("a/").removeprefix("b/").replace("\\", "/")
+
+
+def _scoped(path: str) -> bool:
+    rel = _clean(path)
+    wrapped = f"/{rel}/"
+    return rel.startswith(APP_LIB) and rel.endswith(".dart") and not rel.endswith(".g.dart") and "/test/" not in wrapped and "/tests/" not in wrapped
+
+
+def _added(diff: str) -> list[tuple[str, int, str]]:
+    out: list[tuple[str, int, str]] = []
+    path: str | None = None
+    line: int | None = None
+    for raw in diff.splitlines():
+        if raw.startswith("diff --git "):
+            path = None
+        elif raw.startswith("+++ "):
+            marker = raw[4:].strip()
+            path = None if marker == "/dev/null" else _clean(marker)
+        elif raw.startswith("@@ "):
+            match = re.search(r"\+(\d+)", raw)
+            line = int(match.group(1)) if match else None
+        elif line is None:
+            continue
+        elif raw.startswith("+") and not raw.startswith("+++"):
+            if path and _scoped(path):
+                out.append((path, line, raw[1:]))
+            line += 1
+        elif not (raw.startswith("-") and not raw.startswith("---")):
+            line += 1
+    return out
+
+
+def _domain_key(key: str) -> bool:
+    return key == "wizard_answers_v2" or key in DOMAIN or key.startswith(PREFIXES)
+
+
+def _violation(path: str, text: str) -> str | None:
+    if path not in ALLOWED and "SharedPreferences.getInstance()" in text and "/screens/" in f"/{path}/" and "simulator" in path.lower():
+        return "simulator screen must use CoachProfileProvider.updateProfile(), not SharedPreferences"
+    match = SETTER.search(text)
+    if not match:
+        return None
+    key = match.group("key")
+    if path == BUDGET_CACHE:
+        return "budget_local_store.dart is a cache and must not write wizard_answers_v2" if key == "wizard_answers_v2" else None
+    if path in ALLOWED or not _domain_key(key):
+        return None
+    return f"domain key '{key}' persisted outside CoachProfileProvider/report_persistence_service; use mergeAnswers/applySaveFact/updateProfile"
+
+
+def _git_diff(args: list[str]) -> str:
+    result = subprocess.run(["git", "diff", "--unified=0", "--no-ext-diff", *args, "--", APP_LIB], cwd=REPO, text=True, capture_output=True, check=False)
+    if result.returncode:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def _read(args: argparse.Namespace) -> str:
+    if args.diff_file:
+        return Path(args.diff_file).read_text(encoding="utf-8")
+    if args.staged:
+        return _git_diff(["--cached"])
+    return _git_diff([f"{args.base_ref}...HEAD"] if args.base_ref else ["HEAD"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff-file")
+    parser.add_argument("--staged", action="store_true")
+    parser.add_argument("--base-ref")
+    args = parser.parse_args()
+    if sum(bool(v) for v in (args.diff_file, args.staged, args.base_ref)) > 1:
+        parser.error("use only one of --diff-file, --staged, or --base-ref")
+    failures = [(p, n, d, t.strip()) for p, n, t in _added(_read(args)) for d in [_violation(p, t)] if d]
+    if failures:
+        print("::error::no_bypass_persistence failed:")
+        for path, line, detail, text in failures:
+            print(f"{path}:{line}: {detail}: {text}")
+        return 1
+    print("OK no_bypass_persistence: no ledger persistence bypass in added Dart lines")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_no_bypass_persistence_gate.py
+++ b/tools/checks/tests/test_no_bypass_persistence_gate.py
@@ -1,0 +1,75 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/no_bypass_persistence.py"
+
+
+def _diff(path: str, added: list[str], start: int = 1) -> str:
+    body = "\n".join(f"+{line}" for line in added)
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -0,0 +{start},{len(added)} @@\n{body}\n"
+
+
+def _run(tmp_path: Path, diff: str) -> subprocess.CompletedProcess[str]:
+    diff_path = tmp_path / "changes.diff"
+    diff_path.write_text(diff, encoding="utf-8")
+    return subprocess.run([sys.executable, str(SCRIPT), "--diff-file", str(diff_path)], cwd=ROOT, text=True, capture_output=True, check=False)
+
+
+@pytest.mark.parametrize(
+    ("path", "added", "needle"),
+    [
+        (
+            "apps/mobile/lib/screens/simulator_3a_screen.dart",
+            ["final prefs = await SharedPreferences.getInstance();", "await prefs.setString('wizard_answers_v2', encoded);"],
+            "wizard_answers_v2",
+        ),
+        (
+            "apps/mobile/lib/services/salary_cache_service.dart",
+            ["final prefs = await SharedPreferences.getInstance();", "await prefs.setDouble('q_gross_salary_annual', salary);"],
+            "q_gross_salary_annual",
+        ),
+        (
+            "apps/mobile/lib/screens/simulator_compound_screen.dart",
+            ["final prefs = await SharedPreferences.getInstance();"],
+            "updateProfile",
+        ),
+        (
+            "apps/mobile/lib/data/budget/budget_local_store.dart",
+            ["await prefs.setString('wizard_answers_v2', encoded);"],
+            "budget_local_store",
+        ),
+    ],
+)
+def test_persistence_bypasses_fail(tmp_path: Path, path: str, added: list[str], needle: str) -> None:
+    result = _run(tmp_path, _diff(path, added))
+    assert result.returncode == 1
+    assert needle in result.stdout
+
+
+def test_allowed_persistence_paths_and_non_domain_keys_pass(tmp_path: Path) -> None:
+    diff = "".join(
+        [
+            _diff("apps/mobile/lib/services/report_persistence_service.dart", ["await prefs.setString('wizard_answers_v2', encoded);"]),
+            _diff("apps/mobile/lib/providers/coach_profile_provider.dart", ["await prefs.setString('q_canton', canton);"]),
+            _diff("apps/mobile/lib/data/budget/budget_local_store.dart", ["await prefs.setString('_budget_inputs_v1', encoded);"]),
+            _diff("apps/mobile/lib/services/analytics_service.dart", ["await prefs.setString('_analytics_session_id', sessionId);"]),
+        ]
+    )
+    result = _run(tmp_path, diff)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_no_bypass_persistence_gate_is_wired_into_ci_and_lefthook() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    gate = ci.split("ci-gate:", maxsplit=1)[1]
+    lefthook = (ROOT / "lefthook.yml").read_text(encoding="utf-8")
+    assert "no-bypass-persistence:" in ci
+    assert "tools/checks/no_bypass_persistence.py --base-ref" in ci
+    assert 'no_bypass="${{ needs.no-bypass-persistence.result }}"' in gate
+    assert '"$no_bypass" != "success"' in gate
+    assert "no-bypass-persistence:" in lefthook
+    assert "tools/checks/no_bypass_persistence.py --staged" in lefthook


### PR DESCRIPTION
## Summary
- adds `tools/checks/no_bypass_persistence.py` implementing DATA_LEDGER §8.3 as a new-debt diff gate
- wires the gate into Lefthook and CI Gate
- adds repo contract tests for domain-key writes, simulator SharedPreferences bypasses, budget cache limits, and wiring

## Verification
- `python3 -m pytest tools/checks/tests/test_no_bypass_persistence_gate.py -q` -> 6 passed
- `python3 -m pytest tools/checks/tests/ -q` -> 43 passed
- `python3 tools/checks/no_bypass_persistence.py --base-ref codex/mint-infra-g8-instruction-hygiene-20260707` -> OK
- `python3 tools/checks/no_bypass_persistence.py --staged` -> OK
- `lefthook run pre-commit` -> OK, memory retention warning only

## Notes
This is intentionally a new-debt gate. The live repo has historical SharedPreferences bypass debt, so a full blocking scan would turn this infra slice into a migration PR.