### PR TITLE
G3: specify stale data reconfirmation before code

### DIFF
--- a/.planning/phases/G3/scorecard.md
+++ b/.planning/phases/G3/scorecard.md
@@ -1,0 +1,31 @@
+# G3 Scorecard — stale data reconfirm
+
+Status: blocked before code until infra gates are available on the product branch.
+
+## Dependencies
+
+- #851 `no_bypass_persistence`: required for DATA_QUEST DQ-4 / DATA_LEDGER I-3 proof.
+- #852 `hardcoded_rate_gate`: required before any financial scenario code touches rates.
+
+## Current PR
+
+This PR only creates the mandatory Swiss Brain spec before code:
+
+- `.planning/phases/G3/swiss-brain-spec.md`
+
+## Code Gate
+
+Do not add product code to G3 until the implementation PR can run:
+
+- `python3 tools/checks/no_bypass_persistence.py --base-ref <base>`
+- `python3 tools/checks/hardcoded_rate_gate.py --base-ref <base>`
+- `cd apps/mobile && flutter test test/services/biography/ test/screens/data_block_enrichment_screen_test.dart`
+- `cd apps/mobile && flutter analyze`
+
+## First Implementation Slice
+
+Target one vertical only:
+
+- route: `/data-block/revenu`
+- fields: `q_gross_salary_annual`, `q_canton`, `q_birth_year`
+- behavior: stale known value → one reconfirm card; fresh known value → no Ask; missing value → existing collect flow.

--- a/.planning/phases/G3/scorecard.md
+++ b/.planning/phases/G3/scorecard.md
@@ -1,6 +1,6 @@
 # G3 Scorecard — stale data reconfirm
 
-Status: blocked before code until infra gates are available on the product branch.
+Status: revised spec has Claude CLI GO. Product code may start only from a base that includes #851/#852 gates.
 
 ## Dependencies
 
@@ -12,6 +12,21 @@ Status: blocked before code until infra gates are available on the product branc
 This PR only creates the mandatory Swiss Brain spec before code:
 
 - `.planning/phases/G3/swiss-brain-spec.md`
+- `.planning/runtime-evidence/G3/claude-audit-20260708.md`
+
+## External Audit Findings
+
+Claude CLI returned NO-GO on 2026-07-08. Resolved in this revision:
+
+- Confirming a stale value would have been a facade because `mergeAnswers()` does not advance/persist `dataTimestamps`.
+- Freshness classification must use field paths (`salaireBrutMensuel`, `canton`), not raw `q_*` wizard keys.
+- `q_birth_year` is static identity data: collect if missing, never stale/reconfirm.
+- Proposed freshness i18n keys did not exist and must be added explicitly.
+
+Claude CLI re-audit returned GO after those fixes, with two implementation constraints:
+
+- evaluate/reuse `BiographyRefreshDetector.detectStaleFields()` before adding UI ask planning;
+- prove timestamp advancement survives reload from persisted `_coach_data_timestamps`, not just in-memory state.
 
 ## Code Gate
 
@@ -27,5 +42,13 @@ Do not add product code to G3 until the implementation PR can run:
 Target one vertical only:
 
 - route: `/data-block/revenu`
-- fields: `q_gross_salary_annual`, `q_canton`, `q_birth_year`
-- behavior: stale known value → one reconfirm card; fresh known value → no Ask; missing value → existing collect flow.
+- stale/reconfirm fields: `q_gross_salary_annual` → `salaireBrutMensuel`, `q_canton` → `canton`
+- collect-only static field: `q_birth_year` → `age`
+- behavior: stale known salary/canton → one reconfirm card; fresh known value → no Ask; missing value → existing collect flow.
+
+## Required Anti-Facade Proof Before Code Acceptance
+
+- Confirming a stale salary advances the field-path timestamp.
+- Re-running the classifier after confirm returns no stale ask.
+- Reloading answers in a new provider/profile instance preserves the advanced `_coach_data_timestamps` entry.
+- The implementation either reuses `BiographyRefreshDetector.detectStaleFields()` or documents why a UI-only adapter cannot reuse its coach-nudge text without duplicating decay math.

--- a/.planning/phases/G3/swiss-brain-spec.md
+++ b/.planning/phases/G3/swiss-brain-spec.md
@@ -1,0 +1,83 @@
+# G3 — Swiss Brain Spec: reconfirmer les données périmées
+
+Status: Spec before code. No product code in this PR.
+Base produit: PR #841 (`codex/mint-g2-ledger-docs-20260707`).
+Infra required before code: PR #851 (`no_bypass_persistence`) and PR #852 (`hardcoded_rate_gate`) green and available on the product branch or invoked in the G3 scorecard.
+
+## Product Intent
+
+G3 makes Mint ask for less while understanding more.
+
+When a known user fact is stale, Mint must not erase it or ask a blank question again. It must show the known value, explain why it matters, and offer a one-tap confirmation or a focused correction.
+
+First vertical: `/data-block/revenu`, because stale salary and canton directly affect tax, 3a, housing capacity, and budget ranges.
+
+## Repo Reality
+
+- `DATA_LEDGER.md:299` says to reuse `data_block_enrichment_screen.dart`, `rank_enrichment_prompts()`, and `freshness_decay_service.dart`.
+- `DATA_LEDGER.md:303-313` says `FreshnessDecayService.weight()` accepts a `BiographyFact`, not a field path. G3 therefore needs an adapter, not a second decay model.
+- `DATA_LEDGER.md:320-321` defines stale data as `weightForField(path, profile, now) < 0.60`; stale fields are reconfirmed and fresh fields are skipped.
+- `DATA_LEDGER.md:432` requires any write to keep `dataSources` and `dataTimestamps` populated.
+- `DATA_QUEST.md:72-83` defines `AskMode.reconfirm`: prior value visible, one-tap confirm, focused correction path.
+- `DATA_QUEST.md:146-147` requires `AskMode.reconfirm` for stale fields and forbids bypassing `CoachProfileProvider`.
+- `freshness_decay_service.dart:64-92` already owns decay and `needsRefresh`.
+- `coach_profile_provider.dart:54-76` already has timestamp stamping/persistence helpers.
+- `coach_profile_provider.dart:500-520` makes `mergeAnswers()` the write path for incremental updates.
+- `coach_profile_provider.dart:1030-1036` exposes `updateProfile()` for whole-profile writes.
+- `data_block_enrichment_screen.dart:86-165` already renders `/data-block/:type` and the revenue collector.
+
+## Swiss Meaning
+
+Stale salary, canton, household, LPP, 3a, and mortgage data can materially change the educational range shown by Mint. Mint must present this as an uncertainty and a data-quality issue, not as advice.
+
+Allowed wording pattern:
+
+> On avait noté {label}: {prior}. Cette donnée date de {age}. Toujours juste ?
+
+Buttons:
+
+- Confirmer
+- Mettre à jour
+
+Avoid promises and ranking language. Do not use banned terms from `CLAUDE.md`.
+
+## G3 Scope
+
+Implement only the smallest real product slice:
+
+1. Add `AskMode.collect` / `AskMode.reconfirm` model in a Data Quest service.
+2. Add a field freshness adapter using the existing decay model.
+3. For `/data-block/revenu`, classify `q_gross_salary_annual`, `q_canton`, and `q_birth_year` as missing, fresh, or stale.
+4. Render at most one reconfirm card above the revenue collector.
+5. Confirm action writes the same value through `CoachProfileProvider.mergeAnswers()` and updates `dataTimestamps`.
+6. Correction action focuses the existing field input; it does not open a duplicate form.
+
+Out of scope:
+
+- Full Case registry.
+- Backend profile field metadata.
+- New tax calculation.
+- New login/account behavior.
+- PDF.
+
+## Required Tests
+
+- Unit: annual field with timestamp older than 36 months returns stale.
+- Unit: fresh annual field produces no Ask.
+- Unit: missing salary produces `AskMode.collect`; stale salary produces `AskMode.reconfirm`.
+- Widget: `/data-block/revenu` with stale salary shows one reconfirm card with prior value.
+- Widget: confirming stale salary calls provider write path and advances timestamp.
+- Regression: no direct `SharedPreferences` write outside provider/report persistence.
+
+## Required Commands
+
+- `python3 tools/checks/no_bypass_persistence.py --base-ref <base>`
+- `python3 tools/checks/hardcoded_rate_gate.py --base-ref <base>`
+- `python3 -m pytest tools/checks/tests/ -q`
+- `cd apps/mobile && flutter test test/services/biography/ test/screens/data_block_enrichment_screen_test.dart`
+- `cd apps/mobile && flutter analyze`
+- Maestro runtime proof for `mint:///data-block/revenu` after UI code lands.
+
+## Acceptance
+
+G3 is accepted only if a stale known value is reconfirmed in one tap, a fresh known value is not asked again, and every write remains inside the ledger path.

--- a/.planning/phases/G3/swiss-brain-spec.md
+++ b/.planning/phases/G3/swiss-brain-spec.md
@@ -3,6 +3,7 @@
 Status: Spec before code. No product code in this PR.
 Base produit: PR #841 (`codex/mint-g2-ledger-docs-20260707`).
 Infra required before code: PR #851 (`no_bypass_persistence`) and PR #852 (`hardcoded_rate_gate`) green and available on the product branch or invoked in the G3 scorecard.
+External audit: Claude CLI 2026-07-08 returned NO-GO on the first draft; this revision resolves the four blockers in `.planning/runtime-evidence/G3/claude-audit-20260708.md`.
 
 ## Product Intent
 
@@ -21,10 +22,13 @@ First vertical: `/data-block/revenu`, because stale salary and canton directly a
 - `DATA_QUEST.md:72-83` defines `AskMode.reconfirm`: prior value visible, one-tap confirm, focused correction path.
 - `DATA_QUEST.md:146-147` requires `AskMode.reconfirm` for stale fields and forbids bypassing `CoachProfileProvider`.
 - `freshness_decay_service.dart:64-92` already owns decay and `needsRefresh`.
-- `coach_profile_provider.dart:54-76` already has timestamp stamping/persistence helpers.
+- `coach_profile_provider.dart:54-76` already has timestamp stamping/persistence helpers, but `mergeAnswers()` does not currently stamp `dataTimestamps`.
 - `coach_profile_provider.dart:500-520` makes `mergeAnswers()` the write path for incremental updates.
 - `coach_profile_provider.dart:1030-1036` exposes `updateProfile()` for whole-profile writes.
 - `data_block_enrichment_screen.dart:86-165` already renders `/data-block/:type` and the revenue collector.
+- `CoachProfile.dataTimestamps` are field-path keyed (`salaireBrutMensuel`, `canton`, `age`), not wizard-key keyed (`q_*`). Any classifier must map keys explicitly.
+- The ARB files do not currently contain the proposed `freshnessConfirm` / `freshnessStale` keys; G3 must add real l10n keys instead of reusing nonexistent ones.
+- `BiographyRefreshDetector.detectStaleFields()` already detects stale `BiographyFact`s using `FreshnessDecayService.needsRefresh`; G3 must reuse that detection where practical, or explicitly justify a pure adapter limited to converting `CoachProfile.dataTimestamps` into the same `BiographyFact` shape. Do not create a third staleness model.
 
 ## Swiss Meaning
 
@@ -47,10 +51,26 @@ Implement only the smallest real product slice:
 
 1. Add `AskMode.collect` / `AskMode.reconfirm` model in a Data Quest service.
 2. Add a field freshness adapter using the existing decay model.
-3. For `/data-block/revenu`, classify `q_gross_salary_annual`, `q_canton`, and `q_birth_year` as missing, fresh, or stale.
-4. Render at most one reconfirm card above the revenue collector.
-5. Confirm action writes the same value through `CoachProfileProvider.mergeAnswers()` and updates `dataTimestamps`.
-6. Correction action focuses the existing field input; it does not open a duplicate form.
+3. For `/data-block/revenu`, classify only salary and canton as missing, fresh, or stale:
+   - `q_gross_salary_annual` → field path `salaireBrutMensuel`
+   - `q_canton` → field path `canton`
+4. Treat birth year as a static identity fact:
+   - `q_birth_year` → field path `age`
+   - collect it when missing in the existing revenue collector
+   - never emit a stale/reconfirm ask for it
+5. Render at most one reconfirm card above the revenue collector.
+6. Confirm action must close the loop: it writes through a provider method that advances and persists the field-path timestamp, so the ask disappears immediately and stays gone after reload.
+7. Correction action focuses the existing field input; it does not open a duplicate form.
+
+## Required Implementation Corrections From Claude Audit
+
+1. **No facade confirm.** Add a provider write path that advances freshness for the confirmed field path. Acceptable shapes:
+   - preferred small blast radius: `CoachProfileProvider.confirmFreshness({required String answerKey, required String fieldPath, required dynamic value})`, internally reusing `ReportPersistenceService.loadAnswers()`, `_stampTimestamps()`, `_persistTimestamps()`, `CoachProfile.fromWizardAnswers()`, and `ReportPersistenceService.saveAnswers()`;
+   - broader alternative only if justified: extend `mergeAnswers()` to stamp touched field paths, with regression tests for chat/budget/save_fact callers.
+2. **Field path mapping is explicit.** `DataQuest` must classify freshness on field paths, not on `q_*` answer keys. Missing-state may inspect wizard answers/user-provided evidence, but freshness uses `salaireBrutMensuel` and `canton`.
+3. **Birth year is static.** It can be collected if absent, but it never decays and never produces a reconfirm card.
+4. **Real i18n.** Add ARB keys across `fr/en/de/es/it/pt` for the reconfirm title/body and buttons. Do not hardcode copy and do not reference nonexistent `freshnessConfirm` / `freshnessStale`.
+5. **No duplicate stale detector.** `BiographyRefreshDetector` is the existing stale-fact detector, but its current nudge text is hardcoded and coach-oriented. The implementation may reuse its `detectStaleFields()` logic after converting `CoachProfile` timestamps into `BiographyFact`s, or keep a tiny adapter around `FreshnessDecayService.weightForField()` with a code comment explaining why UI `Ask` planning cannot reuse the detector text. It must not add another decay model.
 
 Out of scope:
 
@@ -65,6 +85,9 @@ Out of scope:
 - Unit: annual field with timestamp older than 36 months returns stale.
 - Unit: fresh annual field produces no Ask.
 - Unit: missing salary produces `AskMode.collect`; stale salary produces `AskMode.reconfirm`.
+- Unit: birth year/static path never produces `AskMode.reconfirm`.
+- Unit: after confirming a stale value, re-running classification returns fresh/no Ask.
+- Unit: confirmed timestamp survives reload via `_coach_data_timestamps` in a new provider/profile instance, not just in memory.
 - Widget: `/data-block/revenu` with stale salary shows one reconfirm card with prior value.
 - Widget: confirming stale salary calls provider write path and advances timestamp.
 - Regression: no direct `SharedPreferences` write outside provider/report persistence.
@@ -80,4 +103,4 @@ Out of scope:
 
 ## Acceptance
 
-G3 is accepted only if a stale known value is reconfirmed in one tap, a fresh known value is not asked again, and every write remains inside the ledger path.
+G3 is accepted only if a stale known salary or canton value is reconfirmed in one tap, a fresh known value is not asked again, birth year is never stale-asked, and every write remains inside the ledger path.

--- a/.planning/runtime-evidence/G3/claude-audit-20260708.md
+++ b/.planning/runtime-evidence/G3/claude-audit-20260708.md
@@ -1,0 +1,33 @@
+# G3 Claude CLI Audit — 2026-07-08
+
+Command:
+
+```bash
+claude -p --model opus --effort max < /tmp/mint_g3_audit_prompt.txt
+```
+
+Verdict: **NO-GO as written**.
+
+Claude agreed the G3 direction is the right next product slice after the infra gates, but found four blockers in the first spec draft:
+
+1. Confirming a stale value through `mergeAnswers()` would be a facade because the method does not advance or persist `dataTimestamps`; the same stale card would reappear.
+2. Freshness must be evaluated on field paths (`salaireBrutMensuel`, `canton`, `age`), not raw wizard keys (`q_*`).
+3. Birth year is static identity data and must never decay into a stale reconfirm ask.
+4. The proposed `freshnessConfirm` / `freshnessStale` i18n reuse claim is false; real ARB keys must be added.
+
+Required implementation shape from the audit:
+
+- Add a small provider method, preferably `confirmFreshness(...)`, that writes through the provider and persists the advanced field-path timestamp.
+- Add only a minimal `DataQuest` model/service for `collect` and `reconfirm`; no Case registry in this slice.
+- Classify missing values from answer presence/user-provided evidence, but classify staleness from field-path timestamps.
+- Render exactly one reconfirm card above the existing revenue collector.
+- Keep the first implementation to salary and canton stale checks; birth year remains collect-only if missing.
+
+Required anti-facade tests:
+
+- annual stale field becomes `AskMode.reconfirm`;
+- fresh annual field produces no ask;
+- static birth-year path never produces a reconfirm ask;
+- after confirm, the classifier returns no ask for that field;
+- the advanced timestamp survives reload through `_coach_data_timestamps`;
+- the `/data-block/revenu` widget shows one stale card and removes it after confirm.

--- a/.planning/runtime-evidence/G3/claude-reaudit-20260708.md
+++ b/.planning/runtime-evidence/G3/claude-reaudit-20260708.md
@@ -1,0 +1,32 @@
+# G3 Claude CLI Re-Audit — 2026-07-08
+
+Command:
+
+```bash
+claude -p --model opus --effort max < /tmp/mint_g3_reaudit_prompt.txt
+```
+
+Verdict: **GO** to implement the first code slice, conditioned on branching from a base that includes #851/#852.
+
+Claude verified that the four previous blockers are resolved at spec level:
+
+1. The spec no longer treats plain `mergeAnswers()` as a sufficient confirm path; it requires a provider method that advances and persists field-path timestamps.
+2. The spec maps `q_gross_salary_annual` to `salaireBrutMensuel` and `q_canton` to `canton`, with freshness classification on field paths.
+3. Birth year is collect-only/static and never produces a stale reconfirm ask.
+4. The false i18n reuse claim was removed; G3 requires real ARB keys.
+
+Remaining implementation constraints:
+
+- `BiographyRefreshDetector.detectStaleFields()` already exists. The implementation must reuse it where practical or justify a tiny adapter that converts `CoachProfile.dataTimestamps` to the same `BiographyFact` freshness shape without creating a new decay model.
+- `confirmFreshness` must persist the advanced timestamp into `_coach_data_timestamps`; an in-memory-only update is not sufficient.
+- If `mergeAnswers()` is broadened instead of adding a dedicated confirm method, chat/budget/save_fact regression tests are mandatory. The preferred slice keeps the blast radius to a dedicated `confirmFreshness` method.
+
+Blocking tests for implementation:
+
+- stale annual field -> `AskMode.reconfirm`;
+- fresh annual field -> no ask;
+- missing salary -> `AskMode.collect`;
+- static birth-year/`age` path never emits reconfirm;
+- after confirm, classifier returns no ask;
+- a new provider/profile reloading persisted answers still sees the advanced timestamp;
+- `/data-block/revenu` shows exactly one reconfirm card and removes it after confirm.

--- a/docs/codex/DATA_QUEST.md
+++ b/docs/codex/DATA_QUEST.md
@@ -22,7 +22,7 @@ When any surface needs data it does not have, MINT asks **only the missing or st
 | Write path | `CoachProfileProvider.mergeAnswers()` (`:502`) / `applySaveFact()` (`:542`) / `updateProfile()` (`:969`) — the ONLY mutators |
 | Coach write allow­list | `_SAVE_FACT_ALLOWED_KEYS` (35 keys, `coach_chat.py:924`); mobile map `_mapFactKeyToAnswers` (`coach_profile_provider.dart:557`) |
 | Field→screen mapping | `ScreenRegistry` + `ReadinessGate` (behaviors A–E) + `routes/route_metadata.dart` |
-| Freshness i18n | keys already present: `freshnessConfirm`, `freshnessStale`, `freshnessPrefix` (`confidence_scorer.dart:747-749`) |
+| Freshness i18n | target behavior exists in copy only; checked-in ARB keys for stale reconfirm cards must be added by the slice that implements them. Do not reuse nonexistent `freshnessConfirm` / `freshnessStale` keys. |
 
 ## 2. The `DataQuest` object (new — the orchestrator this doc specifies)
 
@@ -78,9 +78,9 @@ When `FreshnessDecayService.needsRefresh(fact, now)` is true, the Ask is a **1-t
    [ Oui, toujours ]   [ Mettre à jour ]   [ Rescanner ]
 ```
 
-- **Oui** → `CoachProfileProvider.updateProfile(key: same value)` → resets `updatedAt=now` (freshness back to 1.0). No re-entry.
+- **Oui** → provider write path that confirms the same value and advances the field-path timestamp (`dataTimestamps[path]=now`, persisted in `_coach_data_timestamps`) so freshness returns to 1.0. No re-entry.
 - **Mettre à jour** → collect flow for that one key.
-- Use existing i18n keys `freshnessConfirm` / `freshnessStale` (`confidence_scorer.dart:747`).
+- Use real ARB keys added by the implementation slice for the reconfirm title/body/buttons; hardcoded copy is not acceptable.
 
 ## 4. Heavy events get a conversational quest, not a form wall
 


### PR DESCRIPTION
## Summary
- adds the mandatory Swiss Brain spec for G3 before product code
- defines the first vertical: `/data-block/revenu` stale salary/canton/birth-year reconfirmation
- records #851 and #852 as required infra dependencies before code
- adds a G3 scorecard with required commands and first implementation slice

## Verification
- `python3 tools/checks/accent_lint_fr.py --file .planning/phases/G3/swiss-brain-spec.md` -> OK
- `python3 tools/checks/accent_lint_fr.py --file .planning/phases/G3/scorecard.md` -> OK
- `python3 tools/checks/no_chiffre_choc.py` -> OK
- `lefthook run pre-commit` -> OK, `codex-spec-reality` 9 passed, memory warning only

## Blocking note
No product code in this PR. G3 implementation should start only when the product branch can run the #851/#852 gates or when those gates are integrated into its base.