### PR TITLE
G6: modernize first job screen

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11187,5 +11187,28 @@
   "firstJobG5DataCta": "Daten ergänzen",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "3a öffnen",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Lohnabrechnungs-Röntgen. Brutto: {gross}, netto: {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Lohnabrechnung verstehen",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Tippe auf jede Zeile, um sie zu verstehen",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Bruttolohn",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Nettolohn",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "Dein echter Lohn: {amount} (inklusive Arbeitgeberbeiträge)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Bildungstool — keine Finanzberatung (FIDLEG).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11187,5 +11187,28 @@
   "firstJobG5DataCta": "Complete data",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "Open 3a",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Payslip x-ray. Gross: {gross}, net: {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Payslip x-ray",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Tap each line to understand it",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Gross salary",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Net salary",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "Your real salary: {amount} (including employer contributions)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Educational tool — not financial advice (FinSA).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11187,5 +11187,28 @@
   "firstJobG5DataCta": "Completar datos",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "Abrir 3a",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Radiografía de nómina. Bruto: {gross}, neto: {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Radiografía de tu nómina",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Toca cada línea para entenderla",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Salario bruto",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Salario neto",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "Tu salario real: {amount} (incluidas las cotizaciones del empleador)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Herramienta educativa — no constituye asesoramiento financiero (LSFin).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11976,5 +11976,28 @@
   "firstJobG5DataCta": "Compléter les données",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "Voir le 3a",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Radiographie fiche de paie. Brut : {gross}, net : {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Radiographie de ta fiche de paie",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Tape sur chaque ligne pour comprendre",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Salaire brut",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Salaire net",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "Ton vrai salaire : {amount} (cotisations employeur incluses)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Outil éducatif — ne constitue pas un conseil financier (LSFin).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11187,5 +11187,28 @@
   "firstJobG5DataCta": "Completare i dati",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "Aprire 3a",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Radiografia della busta paga. Lordo: {gross}, netto: {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Radiografia della busta paga",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Tocca ogni riga per capirla",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Salario lordo",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Salario netto",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "Il tuo salario reale: {amount} (con contributi del datore di lavoro)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Strumento educativo — non costituisce consulenza finanziaria (LSFin).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40556,6 +40556,48 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Voir le 3a'**
   String get firstJobG5Pillar3aCta;
+
+  /// Accessibility label for the payslip x-ray widget.
+  ///
+  /// In fr, this message translates to:
+  /// **'Radiographie fiche de paie. Brut : {gross}, net : {net}.'**
+  String payslipXraySemantics(String gross, String net);
+
+  /// Payslip x-ray widget title.
+  ///
+  /// In fr, this message translates to:
+  /// **'Radiographie de ta fiche de paie'**
+  String get payslipXrayTitle;
+
+  /// Payslip x-ray widget subtitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Tape sur chaque ligne pour comprendre'**
+  String get payslipXraySubtitle;
+
+  /// Payslip x-ray gross salary label.
+  ///
+  /// In fr, this message translates to:
+  /// **'Salaire brut'**
+  String get payslipXrayGrossSalary;
+
+  /// Payslip x-ray net salary label.
+  ///
+  /// In fr, this message translates to:
+  /// **'Salaire net'**
+  String get payslipXrayNetSalary;
+
+  /// Payslip x-ray employer total cost insight.
+  ///
+  /// In fr, this message translates to:
+  /// **'Ton vrai salaire : {amount} (cotisations employeur incluses)'**
+  String payslipXrayEmployerCost(String amount);
+
+  /// Payslip x-ray educational disclaimer.
+  ///
+  /// In fr, this message translates to:
+  /// **'Outil éducatif — ne constitue pas un conseil financier (LSFin).'**
+  String get payslipXrayDisclaimer;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23171,4 +23171,30 @@ class SDe extends S {
 
   @override
   String get firstJobG5Pillar3aCta => '3a öffnen';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Lohnabrechnungs-Röntgen. Brutto: $gross, netto: $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Lohnabrechnung verstehen';
+
+  @override
+  String get payslipXraySubtitle => 'Tippe auf jede Zeile, um sie zu verstehen';
+
+  @override
+  String get payslipXrayGrossSalary => 'Bruttolohn';
+
+  @override
+  String get payslipXrayNetSalary => 'Nettolohn';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'Dein echter Lohn: $amount (inklusive Arbeitgeberbeiträge)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Bildungstool — keine Finanzberatung (FIDLEG).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -23004,4 +23004,30 @@ class SEn extends S {
 
   @override
   String get firstJobG5Pillar3aCta => 'Open 3a';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Payslip x-ray. Gross: $gross, net: $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Payslip x-ray';
+
+  @override
+  String get payslipXraySubtitle => 'Tap each line to understand it';
+
+  @override
+  String get payslipXrayGrossSalary => 'Gross salary';
+
+  @override
+  String get payslipXrayNetSalary => 'Net salary';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'Your real salary: $amount (including employer contributions)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Educational tool — not financial advice (FinSA).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23115,4 +23115,30 @@ class SEs extends S {
 
   @override
   String get firstJobG5Pillar3aCta => 'Abrir 3a';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Radiografía de nómina. Bruto: $gross, neto: $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Radiografía de tu nómina';
+
+  @override
+  String get payslipXraySubtitle => 'Toca cada línea para entenderla';
+
+  @override
+  String get payslipXrayGrossSalary => 'Salario bruto';
+
+  @override
+  String get payslipXrayNetSalary => 'Salario neto';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'Tu salario real: $amount (incluidas las cotizaciones del empleador)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Herramienta educativa — no constituye asesoramiento financiero (LSFin).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23116,4 +23116,30 @@ class SFr extends S {
 
   @override
   String get firstJobG5Pillar3aCta => 'Voir le 3a';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Radiographie fiche de paie. Brut : $gross, net : $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Radiographie de ta fiche de paie';
+
+  @override
+  String get payslipXraySubtitle => 'Tape sur chaque ligne pour comprendre';
+
+  @override
+  String get payslipXrayGrossSalary => 'Salaire brut';
+
+  @override
+  String get payslipXrayNetSalary => 'Salaire net';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'Ton vrai salaire : $amount (cotisations employeur incluses)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Outil éducatif — ne constitue pas un conseil financier (LSFin).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23177,4 +23177,30 @@ class SIt extends S {
 
   @override
   String get firstJobG5Pillar3aCta => 'Aprire 3a';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Radiografia della busta paga. Lordo: $gross, netto: $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Radiografia della busta paga';
+
+  @override
+  String get payslipXraySubtitle => 'Tocca ogni riga per capirla';
+
+  @override
+  String get payslipXrayGrossSalary => 'Salario lordo';
+
+  @override
+  String get payslipXrayNetSalary => 'Salario netto';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'Il tuo salario reale: $amount (con contributi del datore di lavoro)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Strumento educativo — non costituisce consulenza finanziaria (LSFin).';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23123,4 +23123,30 @@ class SPt extends S {
 
   @override
   String get firstJobG5Pillar3aCta => 'Abrir 3a';
+
+  @override
+  String payslipXraySemantics(String gross, String net) {
+    return 'Raio X do recibo de salário. Bruto: $gross, líquido: $net.';
+  }
+
+  @override
+  String get payslipXrayTitle => 'Raio X do teu recibo de salário';
+
+  @override
+  String get payslipXraySubtitle => 'Toca em cada linha para entender';
+
+  @override
+  String get payslipXrayGrossSalary => 'Salário bruto';
+
+  @override
+  String get payslipXrayNetSalary => 'Salário líquido';
+
+  @override
+  String payslipXrayEmployerCost(String amount) {
+    return 'O teu salário real: $amount (incluindo contribuições do empregador)';
+  }
+
+  @override
+  String get payslipXrayDisclaimer =>
+      'Ferramenta educativa — não constitui aconselhamento financeiro (LSFin).';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11187,5 +11187,28 @@
   "firstJobG5DataCta": "Completar dados",
   "@firstJobG5DataCta": { "description": "G5 CTA to complete salary data block." },
   "firstJobG5Pillar3aCta": "Abrir 3a",
-  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." }
+  "@firstJobG5Pillar3aCta": { "description": "G5 CTA to open pillar 3a screen." },
+  "payslipXraySemantics": "Raio X do recibo de salário. Bruto: {gross}, líquido: {net}.",
+  "@payslipXraySemantics": {
+    "description": "Accessibility label for the payslip x-ray widget.",
+    "placeholders": {
+      "gross": { "type": "String" },
+      "net": { "type": "String" }
+    }
+  },
+  "payslipXrayTitle": "Raio X do teu recibo de salário",
+  "@payslipXrayTitle": { "description": "Payslip x-ray widget title." },
+  "payslipXraySubtitle": "Toca em cada linha para entender",
+  "@payslipXraySubtitle": { "description": "Payslip x-ray widget subtitle." },
+  "payslipXrayGrossSalary": "Salário bruto",
+  "@payslipXrayGrossSalary": { "description": "Payslip x-ray gross salary label." },
+  "payslipXrayNetSalary": "Salário líquido",
+  "@payslipXrayNetSalary": { "description": "Payslip x-ray net salary label." },
+  "payslipXrayEmployerCost": "O teu salário real: {amount} (incluindo contribuições do empregador)",
+  "@payslipXrayEmployerCost": {
+    "description": "Payslip x-ray employer total cost insight.",
+    "placeholders": { "amount": { "type": "String" } }
+  },
+  "payslipXrayDisclaimer": "Ferramenta educativa — não constitui aconselhamento financeiro (LSFin).",
+  "@payslipXrayDisclaimer": { "description": "Payslip x-ray educational disclaimer." }
 }

--- a/apps/mobile/lib/screens/first_job_screen.dart
+++ b/apps/mobile/lib/screens/first_job_screen.dart
@@ -1,7 +1,5 @@
-import 'dart:math' show pow;
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/models/screen_return.dart';
@@ -14,12 +12,7 @@ import 'package:mint_mobile/services/first_job_service.dart';
 import 'package:mint_mobile/services/data_quest/first_salary_tax_3a_summary_service.dart';
 import 'package:mint_mobile/widgets/educational/salary_breakdown_widget.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
-import 'package:mint_mobile/widgets/coach/first_salary_film_widget.dart';
-import 'package:mint_mobile/widgets/coach/budget_503020_widget.dart';
-import 'package:mint_mobile/widgets/coach/career_timelapse_widget.dart';
 import 'package:mint_mobile/widgets/coach/payslip_xray_widget.dart';
-import 'package:mint_mobile/widgets/coach/job_change_checklist_widget.dart';
-import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_narrative_card.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
@@ -205,18 +198,14 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
                             const SizedBox(height: MintSpacing.md + 4),
                             MintEntrance(
                                 delay: const Duration(milliseconds: 100),
-                                child: _buildHeader()),
-                            const SizedBox(height: MintSpacing.md + 4),
-                            MintEntrance(
-                                delay: const Duration(milliseconds: 200),
                                 child: _buildSalaireSlider()),
                             const SizedBox(height: MintSpacing.md + 4),
                             MintEntrance(
-                                delay: const Duration(milliseconds: 300),
+                                delay: const Duration(milliseconds: 200),
                                 child: _buildAgeSlider()),
                             const SizedBox(height: MintSpacing.md + 4),
                             MintEntrance(
-                                delay: const Duration(milliseconds: 400),
+                                delay: const Duration(milliseconds: 300),
                                 child: _buildCantonAndActivity()),
                             const SizedBox(height: MintSpacing.lg),
                             MintEntrance(
@@ -248,47 +237,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
                               const SizedBox(height: MintSpacing.lg),
                               _buildChecklist(),
                               const SizedBox(height: MintSpacing.lg),
-                              Builder(
-                                builder: (ctx) {
-                                  final l = S.of(ctx)!;
-                                  return JobChangeChecklistWidget(
-                                    items: [
-                                      ChecklistItem(
-                                        deadline: l.firstJobChecklistDeadline1,
-                                        emoji: '\u{1F4C4}',
-                                        action: l.firstJobChecklistAction1,
-                                        legalRef: 'LPP art. 3 — libre passage',
-                                        consequence:
-                                            l.firstJobChecklistConsequence1,
-                                      ),
-                                      ChecklistItem(
-                                        deadline: l.firstJobChecklistDeadline2,
-                                        emoji: '\u{1F3E6}',
-                                        action: l.firstJobChecklistAction2,
-                                        legalRef: 'OLP art. 3',
-                                        consequence:
-                                            l.firstJobChecklistConsequence2,
-                                      ),
-                                      ChecklistItem(
-                                        deadline: l.firstJobChecklistDeadline3,
-                                        emoji: '\u{1F6E1}\u{FE0F}',
-                                        action: l.firstJobChecklistAction3,
-                                        legalRef: 'LAMal art. 3',
-                                      ),
-                                      ChecklistItem(
-                                        deadline: l.firstJobChecklistDeadline4,
-                                        emoji: '\u{1F3E6}',
-                                        action: l.firstJobChecklistAction4,
-                                        legalRef: 'OPP3 art. 1',
-                                      ),
-                                    ],
-                                  );
-                                },
-                              ),
-                              const SizedBox(height: MintSpacing.lg),
                               _buildEducation(),
-                              const SizedBox(height: MintSpacing.lg),
-                              _buildMintAnalysisSection(),
                               const SizedBox(height: MintSpacing.lg),
                             ],
                             MintEntrance(
@@ -537,7 +486,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     final deductions = <PayslipLine>[
       PayslipLine(
         label: l.firstJobPayslipAvsLabel,
-        emoji: '\u{1F6E1}\u{FE0F}',
+        icon: Icons.security_outlined,
         amount: r.avsAiApg,
         percentage: _percentOfGross(r.avsAiApg),
         explanation: l.firstJobPayslipAvsExplanation,
@@ -546,7 +495,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
       if (r.lppEmploye > 0)
         PayslipLine(
           label: l.firstJobPayslipLppLabel,
-          emoji: '\u{1F3E6}',
+          icon: Icons.account_balance_outlined,
           amount: r.lppEmploye,
           percentage: _percentOfGross(r.lppEmploye),
           explanation: l.firstJobPayslipLppExplanation,
@@ -555,7 +504,7 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
       if (monthlyTax > 0)
         PayslipLine(
           label: l.firstJobPayslipImpotLabel,
-          emoji: '\u{1F3DB}\u{FE0F}',
+          icon: Icons.receipt_long_outlined,
           amount: monthlyTax,
           percentage: _percentOfGross(monthlyTax),
           explanation: l.firstJobPayslipImpotExplanation,
@@ -575,28 +524,6 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
     final gross = _result?.brut ?? 0;
     if (gross <= 0) return 0;
     return amount / gross * 100;
-  }
-
-  Widget _buildHeader() {
-    return MintSurface(
-      tone: MintSurfaceTone.blanc,
-      padding: const EdgeInsets.all(MintSpacing.md),
-      radius: 16,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Icon(Icons.celebration_outlined,
-              color: MintColors.info, size: 20),
-          const SizedBox(width: MintSpacing.sm + 4),
-          Expanded(
-            child: Text(
-              S.of(context)!.firstJobHeaderDesc,
-              style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 
   // ── Sliders ────────────────────────────────────────────────
@@ -1188,214 +1115,6 @@ class _FirstJobScreenState extends State<FirstJobScreen> {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  // ── Analyse MINT ───────────────────────────────────────────
-
-  Widget _buildMintAnalysisSection() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildSectionHeader(),
-        const SizedBox(height: MintSpacing.sm + 4),
-        _buildScenarioChips(),
-        const SizedBox(height: MintSpacing.md),
-        FirstSalaryFilmWidget(grossMonthly: _salaire),
-        const SizedBox(height: MintSpacing.md + 4),
-        _buildBudget503020(),
-        const SizedBox(height: MintSpacing.md + 4),
-        _buildCareerTimeLapse(),
-      ],
-    );
-  }
-
-  /// Future Value of annuity: annual * ((1+r)^n - 1) / r
-  static double _fvAnnuity(double annual, int years, {double r = 0.04}) {
-    if (years <= 0) return 0;
-    return annual * ((pow(1 + r, years) - 1) / r);
-  }
-
-  Widget _buildBudget503020() {
-    final l10n = S.of(context)!;
-    final net = _result?.netEstime ?? _salaire * 0.85;
-    final annualSavings = net * 0.20 * 12;
-    final years = (avsAgeReferenceHomme - _age).clamp(0, 45);
-    final fv = _fvAnnuity(annualSavings, years);
-    return Budget503020Widget(
-      netSalary: net,
-      categories: [
-        BudgetCategory(
-          label: l10n.firstJobBudgetBesoins,
-          emoji: '\u{1F3E0}',
-          percent: 50,
-          amount: net * 0.50,
-          examples: [
-            l10n.firstJobBudgetLoyer,
-            'LAMal',
-            l10n.firstJobBudgetTransport,
-            l10n.firstJobBudgetAlimentation,
-          ],
-        ),
-        BudgetCategory(
-          label: l10n.firstJobBudgetEnvies,
-          emoji: '\u2728',
-          percent: 30,
-          amount: net * 0.30,
-          examples: [
-            l10n.firstJobBudgetLoisirs,
-            l10n.firstJobBudgetRestaurants,
-            l10n.firstJobBudgetVoyages,
-            l10n.firstJobBudgetShopping,
-          ],
-        ),
-        BudgetCategory(
-          label: l10n.firstJobBudgetEpargne,
-          emoji: '\u{1F3E6}',
-          percent: 20,
-          amount: net * 0.20,
-          examples: [
-            l10n.firstJobBudgetPilier3a,
-            l10n.firstJobBudgetEpargneCourt,
-            l10n.firstJobBudgetFondsUrgence,
-          ],
-        ),
-      ],
-      premierEclairage: l10n.firstJobBudgetPremierEclairage(
-        '${(annualSavings.round() ~/ 1000)}\'000',
-        '~${(fv.round() ~/ 1000)}\'000',
-      ),
-    );
-  }
-
-  Widget _buildCareerTimeLapse() {
-    const monthly3a = pilier3aPlafondAvecLpp / 12;
-    const annual3a = monthly3a * 12;
-
-    final candidateAges = [22, 25, 30, 35].where((a) => a <= _age + 5).toList();
-    final scenarioAges = candidateAges.isEmpty ? [_age] : candidateAges;
-    final scenarios = scenarioAges
-        .map((a) => TimeLapseScenario(
-              startAge: a,
-              capitalAt65:
-                  _fvAnnuity(annual3a, (avsAgeReferenceHomme - a).clamp(0, 45)),
-            ))
-        .toList();
-
-    return CareerTimeLapseWidget(
-      scenarios: scenarios,
-      monthly3aContribution: monthly3a,
-      initialAge: _age,
-    );
-  }
-
-  Widget _buildSectionHeader() {
-    return Row(
-      children: [
-        Expanded(
-          child: Text(
-            S.of(context)!.firstJobAnalysisHeader,
-            style: MintTextStyles.titleMedium(color: MintColors.textPrimary)
-                .copyWith(fontWeight: FontWeight.w800),
-          ),
-        ),
-        Container(
-          padding: const EdgeInsets.symmetric(
-              horizontal: MintSpacing.sm + 2, vertical: MintSpacing.xs),
-          decoration: BoxDecoration(
-            color: _seededFromProfile
-                ? MintColors.success.withValues(alpha: 0.1)
-                : MintColors.warning.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-              color: _seededFromProfile
-                  ? MintColors.success.withValues(alpha: 0.15)
-                  : MintColors.warning.withValues(alpha: 0.15),
-            ),
-          ),
-          child: Text(
-            _seededFromProfile
-                ? '\u{1F4CD} ${S.of(context)!.firstJobProfileBadge}'
-                : '\u{1F4A1} ${S.of(context)!.firstJobIllustrativeBadge}',
-            style: MintTextStyles.labelSmall(
-              color:
-                  _seededFromProfile ? MintColors.success : MintColors.warning,
-            ).copyWith(fontWeight: FontWeight.w700),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildScenarioChips() {
-    final l10n = S.of(context)!;
-    const median = 6500.0;
-    final profileVal = _seededFromProfile
-        ? context.read<CoachProfileProvider>().profile?.salaireBrutMensuel ??
-            5000.0
-        : 5000.0;
-    final boosted = (profileVal * 1.20).clamp(2000.0, 15000.0);
-
-    final scenarios = [
-      (
-        label: _seededFromProfile
-            ? '\u{1F4CD} ${l10n.firstJobScenarioMySalary}'
-            : '\u{1F4CD} ${l10n.firstJobScenarioDefault}',
-        value: profileVal.clamp(2000.0, 15000.0),
-        active: (_salaire - profileVal.clamp(2000.0, 15000.0)).abs() < 50,
-      ),
-      (
-        label: '\u{1F1E8}\u{1F1ED} ${l10n.firstJobScenarioMedianCH}',
-        value: median,
-        active: (_salaire - median).abs() < 50,
-      ),
-      (
-        label: '\u2728 ${l10n.firstJobScenarioBoosted}',
-        value: boosted,
-        active: (_salaire - boosted).abs() < 50,
-      ),
-    ];
-
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: scenarios.map((s) {
-          return Padding(
-            padding: const EdgeInsets.only(right: MintSpacing.sm),
-            child: Semantics(
-              label: l10n.firstJobScenarioSemantics(s.label),
-              button: true,
-              child: GestureDetector(
-                onTap: () {
-                  HapticFeedback.lightImpact();
-                  setState(() => _salaire = s.value);
-                  _calculate();
-                },
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: MintSpacing.sm + 6, vertical: MintSpacing.sm),
-                  decoration: BoxDecoration(
-                    color: s.active ? MintColors.primary : MintColors.white,
-                    borderRadius: BorderRadius.circular(24),
-                    border: Border.all(
-                      color: s.active ? MintColors.primary : MintColors.border,
-                      width: s.active ? 2 : 1,
-                    ),
-                  ),
-                  child: Text(
-                    '${s.label}  CHF ${FirstJobService.formatChf(s.value)}',
-                    style: MintTextStyles.labelSmall(
-                      color:
-                          s.active ? MintColors.white : MintColors.textPrimary,
-                    ).copyWith(fontWeight: FontWeight.w600),
-                  ),
-                ),
-              ),
-            ),
-          );
-        }).toList(),
       ),
     );
   }

--- a/apps/mobile/lib/widgets/coach/payslip_xray_widget.dart
+++ b/apps/mobile/lib/widgets/coach/payslip_xray_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/utils/chf_formatter.dart';
@@ -17,7 +18,7 @@ import 'package:mint_mobile/utils/chf_formatter.dart';
 /// Single deduction line on the payslip.
 class PayslipLine {
   final String label;
-  final String emoji;
+  final IconData icon;
   final double amount;
   final double percentage;
   final String explanation;
@@ -25,7 +26,7 @@ class PayslipLine {
 
   const PayslipLine({
     required this.label,
-    required this.emoji,
+    required this.icon,
     required this.amount,
     required this.percentage,
     required this.explanation,
@@ -56,10 +57,12 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
     return Semantics(
-      label: 'Radiographie fiche de paie. '
-          'Brut\u00a0: ${formatChfWithPrefix(widget.grossSalary)}, '
-          'Net\u00a0: ${formatChfWithPrefix(widget.netSalary)}.',
+      label: l.payslipXraySemantics(
+        formatChfWithPrefix(widget.grossSalary),
+        formatChfWithPrefix(widget.netSalary),
+      ),
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.all(20),
@@ -72,18 +75,18 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Radiographie de ta fiche de paie',
+              l.payslipXrayTitle,
               style: MintTextStyles.titleMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 4),
             Text(
-              'Tape sur chaque ligne pour comprendre',
+              l.payslipXraySubtitle,
               style: MintTextStyles.labelMedium(color: MintColors.textMuted),
             ),
             const SizedBox(height: 16),
 
             // ── Gross ──
-            _buildHeaderLine('Salaire brut', widget.grossSalary, true),
+            _buildHeaderLine(l.payslipXrayGrossSalary, widget.grossSalary, true),
             const Divider(height: 16),
 
             // ── Deductions ──
@@ -93,7 +96,7 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
             const Divider(height: 16),
 
             // ── Net ──
-            _buildHeaderLine('Salaire net', widget.netSalary, false),
+            _buildHeaderLine(l.payslipXrayNetSalary, widget.netSalary, false),
 
             // ── Employer hidden cost ──
             if (widget.employerHiddenCost != null) ...[
@@ -110,14 +113,13 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
                 ),
                 child: Row(
                   children: [
-                    const Text('\ud83d\udca1',
-                        style: TextStyle(fontSize: 16)),
+                    const Icon(Icons.lightbulb_outline, size: 16, color: MintColors.primary),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
-                        'Ton vrai salaire\u00a0: '
-                        '${formatChfWithPrefix(widget.employerHiddenCost!)} '
-                        '(cotisations employeur incluses)',
+                        l.payslipXrayEmployerCost(
+                          formatChfWithPrefix(widget.employerHiddenCost!),
+                        ),
                         style: MintTextStyles.labelMedium(color: MintColors.primary).copyWith(fontWeight: FontWeight.w600),
                       ),
                     ),
@@ -128,7 +130,7 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
 
             const SizedBox(height: 12),
             Text(
-              'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+              l.payslipXrayDisclaimer,
               style: MintTextStyles.micro(color: MintColors.textMuted),
             ),
           ],
@@ -176,7 +178,7 @@ class _PayslipXRayWidgetState extends State<PayslipXRayWidget> {
           children: [
             Row(
               children: [
-                Text(line.emoji, style: const TextStyle(fontSize: 16)),
+                Icon(line.icon, size: 16, color: MintColors.textMuted),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(

--- a/apps/mobile/test/navigation_route_integrity_test.dart
+++ b/apps/mobile/test/navigation_route_integrity_test.dart
@@ -1,18 +1,37 @@
 /// FIX-191: Verify that every context.push/context.go target in screens
 /// corresponds to a real GoRoute path in app.dart.
 library;
+
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
+
+bool _routeMatches(Set<String> definedRoutes, String basePath) {
+  if (definedRoutes.contains(basePath)) return true;
+
+  for (final definedRoute in definedRoutes) {
+    if (!definedRoute.contains(':')) {
+      if (basePath.startsWith('$definedRoute/')) return true;
+      continue;
+    }
+
+    final pattern = definedRoute
+        .split('/')
+        .map((segment) =>
+            segment.startsWith(':') ? r'[^/]+' : RegExp.escape(segment))
+        .join('/');
+    if (RegExp('^$pattern\$').hasMatch(basePath)) return true;
+  }
+
+  return false;
+}
 
 void main() {
   test('FIX-191: all static context.push targets match a GoRoute path', () {
     // 1. Extract all GoRoute paths from app.dart
     final appDart = File('lib/app.dart').readAsStringSync();
     final routePattern = RegExp(r"path:\s*'(/[^']*)'");
-    final definedRoutes = routePattern
-        .allMatches(appDart)
-        .map((m) => m.group(1)!)
-        .toSet();
+    final definedRoutes =
+        routePattern.allMatches(appDart).map((m) => m.group(1)!).toSet();
 
     // 2. Extract all STATIC route targets from screens, widgets, services, data
     // Scans: context.push/go, route: '/...' fields, and redirect patterns
@@ -35,12 +54,15 @@ void main() {
         final contentLines = content.split('\n');
         for (final match in pushPattern.allMatches(content)) {
           // Skip matches inside comments
-          final lineIdx = content.substring(0, match.start).split('\n').length - 1;
-          if (lineIdx < contentLines.length && contentLines[lineIdx].trimLeft().startsWith('//')) continue;
+          final lineIdx =
+              content.substring(0, match.start).split('\n').length - 1;
+          if (lineIdx < contentLines.length &&
+              contentLines[lineIdx].trimLeft().startsWith('//')) {
+            continue;
+          }
           final route = match.group(2)!;
           final basePath = route.split('?').first;
-          final hasMatch = definedRoutes.contains(basePath) ||
-              definedRoutes.any((r) => basePath.startsWith('$r/'));
+          final hasMatch = _routeMatches(definedRoutes, basePath);
           if (!hasMatch) {
             brokenRoutes.add('${file.path.split('lib/').last}: $route');
           }
@@ -49,12 +71,15 @@ void main() {
         final lines = content.split('\n');
         for (final match in routeFieldPattern.allMatches(content)) {
           // Skip matches inside comments
-          final lineIdx = content.substring(0, match.start).split('\n').length - 1;
-          if (lineIdx < lines.length && lines[lineIdx].trimLeft().startsWith('//')) continue;
+          final lineIdx =
+              content.substring(0, match.start).split('\n').length - 1;
+          if (lineIdx < lines.length &&
+              lines[lineIdx].trimLeft().startsWith('//')) {
+            continue;
+          }
           final route = match.group(1)!;
           final basePath = route.split('?').first;
-          final hasMatch = definedRoutes.contains(basePath) ||
-              definedRoutes.any((r) => basePath.startsWith('$r/'));
+          final hasMatch = _routeMatches(definedRoutes, basePath);
           if (!hasMatch) {
             brokenRoutes.add('${file.path.split('lib/').last}: $route (field)');
           }

--- a/apps/mobile/test/screens/first_job_screen_g5_test.dart
+++ b/apps/mobile/test/screens/first_job_screen_g5_test.dart
@@ -4,6 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/first_job_screen.dart';
+import 'package:mint_mobile/widgets/coach/budget_503020_widget.dart';
+import 'package:mint_mobile/widgets/coach/career_timelapse_widget.dart';
+import 'package:mint_mobile/widgets/coach/first_salary_film_widget.dart';
+import 'package:mint_mobile/widgets/coach/job_change_checklist_widget.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -75,5 +79,33 @@ void main() {
         find.byKey(const Key('first_salary_tax_3a_summary')), findsOneWidget);
     expect(
         find.byKey(const Key('first_salary_tax_3a_data_cta')), findsOneWidget);
+  });
+
+  testWidgets('does not render legacy analysis widgets in first-job path',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 8000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final provider = CoachProfileProvider()
+      ..updateFromAnswers({
+        'q_gross_salary_annual': 96000,
+        'q_canton': 'GE',
+        'q_birth_year': 2001,
+      });
+
+    await tester.pumpWidget(_wrap(const FirstJobScreen(), provider));
+    await tester.pump();
+
+    expect(
+        find.byKey(const Key('first_salary_tax_3a_summary')), findsOneWidget);
+    expect(find.byKey(const Key('first_salary_tax_3a_room')), findsOneWidget);
+    expect(find.byType(FirstSalaryFilmWidget), findsNothing);
+    expect(find.byType(Budget503020Widget), findsNothing);
+    expect(find.byType(CareerTimeLapseWidget), findsNothing);
+    expect(find.byType(JobChangeChecklistWidget), findsNothing);
   });
 }

--- a/apps/mobile/test/widgets/coach/payslip_xray_widget_test.dart
+++ b/apps/mobile/test/widgets/coach/payslip_xray_widget_test.dart
@@ -8,7 +8,7 @@ void main() {
   final lines = [
     const PayslipLine(
       label: 'AVS / AI / APG',
-      emoji: '\ud83e\uddf1',
+      icon: Icons.security_outlined,
       amount: 291.5,
       percentage: 5.3,
       explanation: 'Rente vieillesse.',
@@ -16,7 +16,7 @@ void main() {
     ),
     const PayslipLine(
       label: 'LPP',
-      emoji: '\ud83c\udfe6',
+      icon: Icons.account_balance_outlined,
       amount: 193.0,
       percentage: 3.5,
       explanation: '2e pilier.',
@@ -24,7 +24,7 @@ void main() {
     ),
     const PayslipLine(
       label: 'AC',
-      emoji: '\ud83e\ude82',
+      icon: Icons.work_outline,
       amount: 60.5,
       percentage: 1.1,
       explanation: 'Assurance-ch\u00f4mage.',


### PR DESCRIPTION
## Summary
- Modernizes `/first-job` around the canonical G5 first_salary_tax_3a block.
- Removes legacy analysis/checklist/time-lapse rendering from the First Job path.
- Localizes Payslip X-Ray copy and replaces visible emoji/acronym badges with neutral Material icons.
- Adds tests proving the G5 block renders and legacy widgets stay absent.

## QA
- `git diff --check`
- `python3 tools/checks/arb_parity.py`
- `python3 tools/checks/no_hardcoded_fr.py --file apps/mobile/lib/screens/first_job_screen.dart`
- `python3 tools/checks/no_hardcoded_fr.py --file apps/mobile/lib/widgets/coach/payslip_xray_widget.dart`
- `python3 tools/checks/banned_ui_terms.py --file apps/mobile/lib/screens/first_job_screen.dart`
- `python3 tools/checks/banned_ui_terms.py --file apps/mobile/lib/widgets/coach/payslip_xray_widget.dart`
- `python3 tools/checks/hardcoded_rate_gate.py --base-ref HEAD`
- `python3 tools/checks/financial_core_gate.py --base-ref HEAD`
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/screens/first_job_screen.dart lib/widgets/coach/payslip_xray_widget.dart test/screens/first_job_screen_g5_test.dart test/widgets/coach/payslip_xray_widget_test.dart`
- `flutter test test/screens/first_job_screen_g5_test.dart test/widgets/coach/payslip_xray_widget_test.dart test/screens/life_event_screens_additional_smoke_test.dart --reporter expanded`
- `flutter build ios --simulator --debug`
- `xcrun simctl install B03E429D-0422-4357-B754-536637D979F9 build/ios/iphonesimulator/Runner.app`
- `~/.maestro/bin/maestro --platform ios --udid B03E429D-0422-4357-B754-536637D979F9 test apps/mobile/.maestro/g5_first_job_tax_3a.yaml`
- Claude Opus final audit: GO; no P0/P1 remaining.