### PR TITLE
G8: add save fact ledger parity gate

### DIFF
--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -39,6 +39,7 @@ For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:
 
 ```bash
+python3 -m pytest tools/checks/tests/test_ledger_parity.py -q
 python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q
 python3 -m pytest tools/checks/tests/test_screen_contracts_route_contract.py -q
 ```

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -191,7 +191,7 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 G1 found **18 ineffective backend-writable keys** at `095eeaa32`: 11 had no mobile mapper case, and 7 mapped to wizard keys that `CoachProfile.fromWizardAnswers()` did not read. G2 repairs the mobile path and turns the contract into a hard parity gate: backend allowlist == coach tool enum == 35 mobile mapper cases == 0 mapped-but-unread targets.
 
-**Gate:** `tools/checks/tests/test_codex_spec_reality_contract.py::test_data_ledger_save_fact_parity_is_repaired` asserts no backend-writable key can be added, renamed, or mapped to a dead wizard key without failing CI.
+**Gate:** `tools/checks/tests/test_ledger_parity.py` asserts no backend-writable key can be added, renamed, omitted from the ledger, or mapped to a dead wizard key without failing CI. The broader `test_codex_spec_reality_contract.py` keeps cross-spec reality checks, but ledger parity lives in the dedicated gate.
 
 | decision | repaired mapping |
 |---|---|
@@ -403,11 +403,12 @@ The doc must give the per-route reads/writes/emptyState/partialState/errorState/
 
 Each gate names exact symbols/modules so it is mechanically buildable.
 
-### 8.1 Allowlist parity (I-7) — new test `test_ledger_parity.py`
+### 8.1 Allowlist parity (I-7) — implemented test `test_ledger_parity.py`
 
 - **8.1a** `assert len(_SAVE_FACT_ALLOWED_KEYS) == 35` (import from `app.api.v1.endpoints.coach_chat`).
-- **8.1b** Parse the mobile switch: extract the set of `case '<key>':` labels in `_mapFactKeyToAnswers` (`coach_profile_provider.dart`, between `Map<String, dynamic> _mapFactKeyToAnswers` and its closing `default:`). `assert mapped_keys == _SAVE_FACT_ALLOWED_KEYS`. **On the frozen baseline `mapped_keys` has 24 entries; this assertion is RED until §3.8 T-1 lands and is the gate that proves T-1 done.**
+- **8.1b** Parse the mobile switch: extract the set of `case '<key>':` labels in `_mapFactKeyToAnswers` (`coach_profile_provider.dart`, between `Map<String, dynamic> _mapFactKeyToAnswers` and its closing `default:`). `assert mapped_keys == _SAVE_FACT_ALLOWED_KEYS`.
 - **8.1c** Parse §3 of this file: the set of `key` cells (excluding §4). `assert ledger_keys == _SAVE_FACT_ALLOWED_KEYS`.
+- **8.1d** Parse the wizard keys returned by each mobile mapper case. Every returned `q_*` / `_coach_*` target must be read by `CoachProfile.fromWizardAnswers`, and every wizard key declared in §3 must be a subset of that fact's actual mapper targets.
 - **Do NOT reuse `test_allowlist_count_is_exactly_eight`** — that test targets the DIFFERENT purpose-tagging allowlist `ALLOWED_FACT_KEYS` (`services/backend/app/services/privacy/fact_key_allowlist.py`, **8** entries), not `_SAVE_FACT_ALLOWED_KEYS`. Keep it as-is for its own purpose.
 
 ### 8.2 No extra-as-data (I-1/I-2) — lint `no_domain_from_extra`

--- a/tools/checks/tests/test_ledger_parity.py
+++ b/tools/checks/tests/test_ledger_parity.py
@@ -1,0 +1,121 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DATA_LEDGER = ROOT / "docs/codex/DATA_LEDGER.md"
+COACH_CHAT = ROOT / "services/backend/app/api/v1/endpoints/coach_chat.py"
+COACH_TOOLS = ROOT / "services/backend/app/services/coach/coach_tools.py"
+COACH_PROFILE_PROVIDER = (
+    ROOT / "apps/mobile/lib/providers/coach_profile_provider.dart"
+)
+COACH_PROFILE = ROOT / "apps/mobile/lib/models/coach_profile.dart"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _backend_allowlist() -> set[str]:
+    source = _read(COACH_CHAT)
+    match = re.search(
+        r"_SAVE_FACT_ALLOWED_KEYS: set\[str\] = \{(?P<body>.*?)\n\}",
+        source,
+        re.DOTALL,
+    )
+    assert match is not None
+    return set(re.findall(r'"([A-Za-z0-9]+)"', match.group("body")))
+
+
+def _coach_tool_enum() -> set[str]:
+    source = _read(COACH_TOOLS)
+    save_fact = source.split('"name": "save_fact"', 1)[1]
+    match = re.search(r'"enum": \[(?P<body>.*?)\]', save_fact, re.DOTALL)
+    assert match is not None
+    return set(re.findall(r'"([A-Za-z0-9]+)"', match.group("body")))
+
+
+def _mapper_cases_to_wizard_keys() -> dict[str, set[str]]:
+    source = _read(COACH_PROFILE_PROVIDER)
+    mapper = source.split(
+        "Map<String, dynamic> _mapFactKeyToAnswers", 1
+    )[1].split("static bool? _asBool", 1)[0]
+    case_matches = list(re.finditer(r"case '([^']+)':", mapper))
+    cases: dict[str, set[str]] = {}
+
+    for index, match in enumerate(case_matches):
+        fact_key = match.group(1)
+        start = match.end()
+        end = (
+            case_matches[index + 1].start()
+            if index + 1 < len(case_matches)
+            else mapper.find("default:", start)
+        )
+        block = mapper[start:end]
+        cases[fact_key] = set(
+            re.findall(r"'((?:q|_coach)_[^']+)'\s*:", block)
+        )
+
+    return cases
+
+
+def _wizard_keys_read_by_profile() -> set[str]:
+    source = _read(COACH_PROFILE)
+    from_wizard = source.split("factory CoachProfile.fromWizardAnswers", 1)[1]
+    from_wizard = from_wizard.split("\n  static ", 1)[0]
+    return set(re.findall(r"answers\['([^']+)'\]", from_wizard))
+
+
+def _ledger_rows() -> dict[str, set[str]]:
+    text = _read(DATA_LEDGER)
+    section = text.split("## 3. Ledger", 1)[1].split("## 4.", 1)[0]
+    rows: dict[str, set[str]] = {}
+
+    for fact_key, wizard_cell in re.findall(
+        r"^\| `([A-Za-z0-9]+)` \| ([^|]+) \|",
+        section,
+        re.MULTILINE,
+    ):
+        rows[fact_key] = set(
+            re.findall(r"`((?:q|_coach)_[^`= ()]+)", wizard_cell)
+        )
+
+    return rows
+
+
+def test_save_fact_allowlist_sets_match_the_ledger_contract() -> None:
+    backend_keys = _backend_allowlist()
+    tool_keys = _coach_tool_enum()
+    mapper_keys = set(_mapper_cases_to_wizard_keys())
+    ledger_keys = set(_ledger_rows())
+
+    assert backend_keys == tool_keys
+    assert backend_keys == mapper_keys
+    assert backend_keys == ledger_keys
+    assert len(backend_keys) == 35
+
+
+def test_save_fact_mapper_targets_are_hydrated_by_coach_profile() -> None:
+    read_keys = _wizard_keys_read_by_profile()
+    dead_targets = {
+        fact_key: sorted(wizard_keys - read_keys)
+        for fact_key, wizard_keys in _mapper_cases_to_wizard_keys().items()
+        if wizard_keys - read_keys
+    }
+
+    assert dead_targets == {}
+
+
+def test_data_ledger_wizard_keys_match_the_mobile_mapper() -> None:
+    mapper = _mapper_cases_to_wizard_keys()
+    ledger = _ledger_rows()
+    mismatches = {
+        fact_key: {
+            "ledger": sorted(ledger_keys),
+            "mapper": sorted(mapper.get(fact_key, set())),
+        }
+        for fact_key, ledger_keys in ledger.items()
+        if not ledger_keys <= mapper.get(fact_key, set())
+    }
+
+    assert mismatches == {}


### PR DESCRIPTION
## Scope
- Add dedicated `tools/checks/tests/test_ledger_parity.py` for DATA_LEDGER §8.1.
- Prove `_SAVE_FACT_ALLOWED_KEYS` parity across backend allowlist, coach tool enum, mobile `_mapFactKeyToAnswers`, and DATA_LEDGER §3 rows.
- Prove mapped `q_*` / `_coach_*` targets are hydrated by `CoachProfile.fromWizardAnswers`.
- Wire the new gate into `.claude/skills/mint-operating-gates/SKILL.md` and update DATA_LEDGER wording.

## QA
- `python3 -m pytest tools/checks/tests/test_ledger_parity.py -q` → 3 passed
- `python3 -m pytest tools/checks/tests/test_ledger_parity.py tools/checks/tests/test_codex_spec_reality_contract.py tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q` → 12 passed
- `python3 -m pytest tools/checks/tests -q` → 55 passed
- `cd apps/mobile && flutter test test/providers/coach_profile_provider_save_fact_test.dart --reporter expanded` → 8 passed
- pre-commit lefthook on commit → 55 gate tests, gitleaks, hardcoded-rate gate passed

## External audit
Claude Opus verdict: GO. No blocking findings. One non-blocking hardening note was applied: the test now bounds `fromWizardAnswers` parsing before the next static helper.

## Notes
No product behavior code changed. This PR turns an already repaired save_fact/Data Ledger contract into an explicit regression gate.