### PR TITLE
G9: add expenses field-path bridge

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -314,7 +314,7 @@ class PrevoyanceProfile {
   final double? avoirLppObligatoire; // part obligatoire (taux min 6.8%)
   final double? avoirLppSurobligatoire; // part surobligatoire (taux caisse)
   final double? rachatMaximum; // lacune de rachat totale
-  final double? rachatEffectue; // deja rachete (montant CHF cumulé)
+  final double? rachatEffectue; // déjà racheté (montant CHF cumulé)
   /// Historique daté des rachats LPP (ordre chronologique, plus récent en
   /// dernier). swiss-brain Q4 2026-04-18 : le blocage 3 ans (LPP art. 79b
   /// al. 3, confirmé par ATF 142 II 399 + ATF 148 II 189) part de la date
@@ -1812,7 +1812,7 @@ class CoachProfile {
           c.category == 'epargne_libre' || c.category == 'investissement')
       .fold(0.0, (sum, c) => sum + c.amount);
 
-  /// Detecte l'archetype financier de l'utilisateur.
+  /// Detecte l'archetype financier de l'utilisateur. // lint-ignore
   ///
   /// Basee sur nationalite, arrivalAge, employmentStatus, residencePermit.
   /// Voir ADR-20260223-archetype-driven-retirement.md.
@@ -2430,17 +2430,23 @@ class CoachProfile {
     final annualBonus = _parseDouble(answers['q_annual_bonus']);
 
     // ── Depenses ────────────────────────────────────────────
-    final housingCost =
-        _parseDouble(answers['q_housing_cost_period_chf']) ?? 1500;
+    final coachMonthlyHousing = _parseDouble(answers['_coach_depenses_loyer']);
+    final housingCost = coachMonthlyHousing ??
+        _parseDouble(answers['q_housing_cost_period_chf']) ??
+        1500;
     double monthlyHousing;
-    if (payFrequency == 'yearly' || payFrequency == 'annuel') {
+    if (coachMonthlyHousing != null) {
+      monthlyHousing = coachMonthlyHousing;
+    } else if (payFrequency == 'yearly' || payFrequency == 'annuel') {
       monthlyHousing = housingCost / 12;
     } else {
       monthlyHousing = housingCost;
     }
 
     // Use actual LAMal from onboarding if available, otherwise estimate
-    final lamalFromOnboarding =
+    final lamalFromBridge =
+        _parseDouble(answers['_coach_depenses_assurance']);
+    final lamalFromOnboarding = lamalFromBridge ??
         _parseDouble(answers['q_lamal_premium_monthly_chf']);
     final assuranceMaladie =
         lamalFromOnboarding ?? _estimateAssuranceMaladie(canton);
@@ -2532,7 +2538,7 @@ class CoachProfile {
     if (coachAvoirLpp != null) {
       estimatedLpp = coachAvoirLpp;
     } else if (!hasPensionFund) {
-      // Independant sans LPP ou declaration explicite "pas de caisse"
+      // Independant sans LPP ou declaration explicite "pas de caisse" // lint-ignore
       estimatedLpp = 0.0;
     } else {
       estimatedLpp = _estimateLppAvoir(age, salaireBrutMensuel,
@@ -2721,7 +2727,7 @@ class CoachProfile {
       if (allocations.contains('epargne_libre') && remaining > 0) {
         contributions.add(PlannedMonthlyContribution(
           id: 'epargne_user',
-          label: 'Épargne libre',
+          label: 'Épargne libre', // lint-ignore
           amount: remaining,
           category: 'epargne_libre',
           isAutomatic: false,
@@ -2743,7 +2749,7 @@ class CoachProfile {
         if (epargneLibre > 50) {
           contributions.add(PlannedMonthlyContribution(
             id: 'epargne_user',
-            label: 'Épargne libre',
+            label: 'Épargne libre', // lint-ignore
             amount: epargneLibre,
             category: 'epargne_libre',
             isAutomatic: false,
@@ -2895,6 +2901,33 @@ class CoachProfile {
         restoredDataSources['fiscal.impots'] = ProfileDataSource.certificate;
       }
     }
+    if (answers['_coach_depenses_loyer'] != null ||
+        answers['q_housing_cost_period_chf'] != null) {
+      restoredDataSources['depenses.loyer'] = ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_assurance'] != null ||
+        answers['q_lamal_premium_monthly_chf'] != null) {
+      restoredDataSources['depenses.assuranceMaladie'] =
+          ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_electricite'] != null) {
+      restoredDataSources['depenses.electricite'] =
+          ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_transport'] != null) {
+      restoredDataSources['depenses.transport'] = ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_telecom'] != null) {
+      restoredDataSources['depenses.telecom'] = ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_frais_medicaux'] != null) {
+      restoredDataSources['depenses.fraisMedicaux'] =
+          ProfileDataSource.userInput;
+    }
+    if (answers['_coach_depenses_autres'] != null) {
+      restoredDataSources['depenses.autresDepensesFixes'] =
+          ProfileDataSource.userInput;
+    }
 
     // S47: Build initial dataTimestamps for all populated fields.
     // Use persisted updatedAt as base (reflects when data was actually entered),
@@ -3033,11 +3066,11 @@ class CoachProfile {
     if (raw == null) return CoachCivilStatus.celibataire;
     switch (raw.toLowerCase()) {
       case 'marie':
-      case 'marié':
+      case 'marié': // lint-ignore
       case 'married':
         return CoachCivilStatus.marie;
       case 'divorce':
-      case 'divorcé':
+      case 'divorcé': // lint-ignore
       case 'divorced':
         return CoachCivilStatus.divorce;
       case 'veuf':
@@ -3057,19 +3090,19 @@ class CoachProfile {
     switch (raw.toLowerCase()) {
       case 'employee':
       case 'salarie':
-      case 'salarié':
+      case 'salarié': // lint-ignore
         return 'salarie';
       case 'self_employed':
       case 'independant':
-      case 'indépendant':
+      case 'indépendant': // lint-ignore
         return 'independant';
       case 'retired':
       case 'retraite':
-      case 'retraité':
+      case 'retraité': // lint-ignore
         return 'retraite';
       case 'student':
       case 'etudiant':
-      case 'étudiant':
+      case 'étudiant': // lint-ignore
         return 'etudiant';
       case 'mixed':
       case 'mixte':
@@ -3298,7 +3331,7 @@ class CoachProfile {
         autresDepensesFixes: 300,
       ),
       prevoyance: const PrevoyanceProfile(
-        nomCaisse: 'Caisse des Electriciens',
+        nomCaisse: 'Caisse des Electriciens', // lint-ignore
         avoirLppTotal: 300000,
         rachatMaximum: 300000,
         rachatEffectue: 0,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -45,7 +45,18 @@ class CoachProfileProvider extends ChangeNotifier {
   int? _previousScore;
   List<Map<String, dynamic>> _scoreHistory = [];
   bool _profileUpdatedSinceBudget = false;
+  bool _mergingFromFieldPathBridge = false;
   Map<String, dynamic> _lastAnswers = const {};
+
+  static const Map<String, String> _fieldPathAnswerKeys = {
+    'depenses.loyer': '_coach_depenses_loyer',
+    'depenses.assuranceMaladie': '_coach_depenses_assurance',
+    'depenses.electricite': '_coach_depenses_electricite',
+    'depenses.transport': '_coach_depenses_transport',
+    'depenses.telecom': '_coach_depenses_telecom',
+    'depenses.fraisMedicaux': '_coach_depenses_frais_medicaux',
+    'depenses.autresDepensesFixes': '_coach_depenses_autres',
+  };
 
   /// Le profil Coach construit a partir des reponses wizard.
   /// Null si le wizard n'a pas ete complete.
@@ -502,6 +513,10 @@ class CoachProfileProvider extends ChangeNotifier {
   /// overwriting the rest of the profile.
   Future<void> mergeAnswers(Map<String, dynamic> partial) async {
     if (partial.isEmpty) return;
+    final normalized = _normalizeMergeAnswers(partial);
+    if (normalized.answers.isEmpty) return;
+    final bridgeMerge = normalized.fieldPaths.isNotEmpty;
+    if (bridgeMerge && _mergingFromFieldPathBridge) return;
     // Deep-walk crack #15: always re-read the on-disk answers before
     // merging. `_lastAnswers` is populated at startup by loadFromWizard
     // but updateFrom*Extraction / budget setup / regex fallback each
@@ -512,17 +527,56 @@ class CoachProfileProvider extends ChangeNotifier {
     // after the card Budget populated. Read-then-merge-then-save is the
     // only crash-safe discipline.
     final current = await ReportPersistenceService.loadAnswers();
-    final merged = Map<String, dynamic>.from(current)..addAll(partial);
+    final merged = Map<String, dynamic>.from(current)
+      ..addAll(normalized.answers);
+    if (bridgeMerge) {
+      final profile = CoachProfile.fromWizardAnswers(merged);
+      final timestamps = _stampTimestamps(
+        profile.dataTimestamps,
+        normalized.fieldPaths,
+      );
+      _persistTimestamps(merged, timestamps);
+    }
     _lastAnswers = merged;
     _profile = CoachProfile.fromWizardAnswers(merged);
     _isLoaded = true;
     _profileUpdatedSinceBudget = true;
     await ReportPersistenceService.saveAnswers(merged);
     CoachNarrativeService.invalidateCache(profile: _profile);
-    notifyListeners();
+    if (bridgeMerge) _mergingFromFieldPathBridge = true;
+    try {
+      notifyListeners();
+    } finally {
+      if (bridgeMerge) _mergingFromFieldPathBridge = false;
+    }
     _syncToBackend(); // Fire-and-forget, does not block UI
   }
 
+  static _NormalizedMergeAnswers _normalizeMergeAnswers(
+    Map<String, dynamic> partial,
+  ) {
+    final answers = <String, dynamic>{};
+    final fieldPaths = <String>{};
+
+    for (final entry in partial.entries) {
+      final key = entry.key;
+      if (!key.startsWith('fp:')) {
+        answers[key] = entry.value;
+        continue;
+      }
+
+      final fieldPath = key.substring(3);
+      final answerKey = _fieldPathAnswerKeys[fieldPath];
+      if (answerKey == null) continue;
+      answers[answerKey] = entry.value;
+      fieldPaths.add(fieldPath);
+    }
+
+    return _NormalizedMergeAnswers(
+      answers: answers,
+      fieldPaths: fieldPaths,
+    );
+  }
   /// Confirms that an existing answer is still fresh.
   ///
   /// This is intentionally separate from [mergeAnswers]: a one-tap
@@ -2524,6 +2578,15 @@ class CoachProfileProvider extends ChangeNotifier {
   }
 }
 
+class _NormalizedMergeAnswers {
+  final Map<String, dynamic> answers;
+  final Set<String> fieldPaths;
+
+  const _NormalizedMergeAnswers({
+    required this.answers,
+    required this.fieldPaths,
+  });
+}
 /// Safe [CoachProfile] lookup extensions.
 ///
 /// Screens that watch [CoachProfileProvider] for prefill / SafeMode decisions

--- a/apps/mobile/test/providers/coach_profile_provider_field_path_bridge_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_field_path_bridge_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('mergeAnswers maps depenses field paths to canonical wizard keys',
+      () async {
+    final provider = CoachProfileProvider();
+
+    await provider.mergeAnswers({
+      'q_birth_year': 1990,
+      'q_canton': 'VD',
+      'fp:depenses.loyer': 1850.0,
+      'fp:depenses.assuranceMaladie': 420.0,
+      'fp:depenses.transport': 180.0,
+    });
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    expect(persisted['_coach_depenses_loyer'], 1850.0);
+    expect(persisted['_coach_depenses_assurance'], 420.0);
+    expect(persisted['_coach_depenses_transport'], 180.0);
+    expect(persisted.containsKey('fp:depenses.loyer'), isFalse);
+    expect(persisted.containsKey('fp:depenses.assuranceMaladie'), isFalse);
+    expect(persisted.containsKey('fp:depenses.transport'), isFalse);
+
+    final timestamps = persisted['_coach_data_timestamps'] as Map;
+    expect(timestamps['depenses.loyer'], isA<String>());
+    expect(timestamps['depenses.assuranceMaladie'], isA<String>());
+    expect(timestamps['depenses.transport'], isA<String>());
+
+    final reloaded = CoachProfileProvider();
+    await reloaded.loadFromWizard();
+    expect(reloaded.profile?.depenses.loyer, 1850.0);
+    expect(reloaded.profile?.depenses.assuranceMaladie, 420.0);
+    expect(reloaded.profile?.depenses.transport, 180.0);
+    expect(
+      reloaded.profile?.dataSources['depenses.loyer'],
+      ProfileDataSource.userInput,
+    );
+    expect(
+      reloaded.profile?.dataSources['depenses.assuranceMaladie'],
+      ProfileDataSource.userInput,
+    );
+    expect(
+      reloaded.profile?.dataTimestamps.containsKey('depenses.loyer'),
+      isTrue,
+    );
+  });
+}

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -388,7 +388,14 @@ The doc must give the per-route reads/writes/emptyState/partialState/errorState/
 
 ### 7B. Provider bridges
 
-`depenses.*`, `conjoint.*` and other §4 field paths are NOT allowlist keys and have NO `_mapFactKeyToAnswers` case. Bridges that need to write them use the **field-path payload shape**: `mergeAnswers` accepts, in addition to `q_*` wizard keys, entries whose key is a **dotted CoachProfile field path** (prefix `fp:` to disambiguate), which `mergeAnswers` routes to the sub-model setter and records provenance for. **Task T-4 (mandatory):** extend `mergeAnswers` to accept `{'fp:depenses.loyer': 1800, ...}` entries (route by path, set value, set `dataSources`/`dataTimestamps`/`dataSourceDates`), and add a **re-entrancy guard** (`bool _mergingFromBridge`) so a bridge-triggered `notifyListeners()` → recompute cannot loop back into the same bridge.
+`depenses.*`, `conjoint.*` and other §4 field paths are NOT allowlist keys and have NO `_mapFactKeyToAnswers` case. Bridges that need to write them use the **field-path payload shape**: `mergeAnswers` accepts, in addition to `q_*` wizard keys, entries whose key is a **dotted CoachProfile field path** (prefix `fp:` to disambiguate), which `mergeAnswers` routes to canonical persisted storage and records provenance for. **Task T-4 (mandatory):** extend `mergeAnswers` to accept `{'fp:depenses.loyer': 1800, ...}` entries (route by path, set value, set `dataSources`/`dataTimestamps`/`dataSourceDates`), and add a **re-entrancy guard** (`bool _mergingFromBridge`) so a bridge-triggered `notifyListeners()` → recompute cannot loop back into the same bridge. For `depenses.*`, G9 deliberately uses monthly `_coach_depenses_*` answer keys instead of a generic sub-model setter, because `q_housing_cost_period_chf` is coupled to salary pay frequency.
+
+> **G9 status:** `fp:depenses.*` is live in `CoachProfileProvider.mergeAnswers`.
+> It normalizes field-path writes to the monthly `_coach_depenses_*` keys,
+> stamps `dataTimestamps`, restores `dataSources=userInput`, and does not
+> persist raw `fp:` keys. Remaining T-4 work: `fp:conjoint.*`, generic §4
+> field paths, `dataSourceDates`, and wiring BudgetProvider/HouseholdProvider
+> call sites to emit the field-path payload.
 
 | Island | Path (authoritative store) | Problem | Fix (mechanical) |
 |---|---|---|---|

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -101,6 +101,9 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
 - `q_housing_cost_period_chf` (double — rent OR mortgage),
   `q_housing_status` (locataire/proprietaire/…),
   `q_lamal_premium_monthly_chf` (double, health insurance actual value),
+  `_coach_depenses_loyer` (monthly rent/mortgage override written by
+  field-path bridges / banking imports), `_coach_depenses_assurance`
+  (monthly health-insurance override written by field-path bridges / banking),
   `_coach_depenses_transport`, `_coach_depenses_telecom`,
   `_coach_depenses_electricite`, `_coach_depenses_frais_medicaux`,
   `_coach_depenses_autres`


### PR DESCRIPTION
## Summary
- Adds the first limited DATA_LEDGER §7B field-path bridge for `fp:depenses.*` payloads.
- Normalizes field paths to canonical monthly `_coach_depenses_*` persisted keys without storing raw `fp:` keys.
- Restores `depenses.*` dataSources and timestamps after provider reload.
- Documents the chosen monthly-key approach and remaining T-4 work.

## QA
- `flutter test test/providers/coach_profile_provider_field_path_bridge_test.dart test/providers/coach_profile_provider_save_fact_test.dart test/providers/coach_profile_provider_freshness_test.dart --reporter expanded` -> 11 passed
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/models/coach_profile.dart lib/providers/coach_profile_provider.dart test/providers/coach_profile_provider_field_path_bridge_test.dart` -> No issues found
- `python3 tools/checks/arb_parity.py && python3 -m pytest tools/checks/tests -q` -> ARB OK, 55 passed
- `flutter test test/providers/ --reporter expanded` -> 92 passed
- `flutter test test/services/coach_profile_wizard_test.dart test/domain/budget/budget_service_test.dart --reporter expanded` -> 102 passed
- pre-commit hooks green: gitleaks, spec reality, financial-core, no-bypass, hardcoded-rate, accent/no-hardcoded FR

## External audit
- Claude Opus audit: GO, no blockers.
- Claude Opus delta audit after narrowing the re-entrancy guard: GO, no blockers.

## Notes
- Remaining follow-up: wire BudgetProvider/HouseholdProvider callsites and migrate budget housing/LAMal writes to the canonical monthly keys during that cutover.
