### PR TITLE
G10: Cut budget expenses to canonical ledger keys

### DIFF
--- a/apps/mobile/lib/data/budget/budget_local_store.dart
+++ b/apps/mobile/lib/data/budget/budget_local_store.dart
@@ -42,14 +42,17 @@ class BudgetLocalStore {
           orElse: () => PayFrequency.monthly,
         ),
         netIncome: (map['q_net_income_period_chf'] as num?)?.toDouble() ?? 0.0,
-        housingCost:
-            (map['q_housing_cost_period_chf'] as num?)?.toDouble() ?? 0.0,
+        housingCost: (map['_coach_depenses_loyer'] as num?)?.toDouble() ??
+            (map['q_housing_cost_period_chf'] as num?)?.toDouble() ??
+            0.0,
         debtPayments:
             (map['q_debt_payments_period_chf'] as num?)?.toDouble() ?? 0.0,
         taxProvision:
             (map['q_tax_provision_monthly_chf'] as num?)?.toDouble() ?? 0.0,
         healthInsurance:
-            (map['q_lamal_premium_monthly_chf'] as num?)?.toDouble() ?? 0.0,
+            (map['_coach_depenses_assurance'] as num?)?.toDouble() ??
+                (map['q_lamal_premium_monthly_chf'] as num?)?.toDouble() ??
+                0.0,
         otherFixedCosts:
             (map['q_other_fixed_costs_monthly_chf'] as num?)?.toDouble() ?? 0.0,
         style: BudgetStyle.values.firstWhere(

--- a/apps/mobile/lib/domain/budget/budget_inputs.dart
+++ b/apps/mobile/lib/domain/budget/budget_inputs.dart
@@ -85,7 +85,7 @@ class BudgetInputs {
       _ => 'single',
     };
 
-    // Data source tags — propagate "estimé" vs "saisi" from profile
+    // Data source tags: propagate estimated vs user-entered status from profile.
     final healthSource =
         profile.dataSources['depenses.assuranceMaladie'];
     final isHealthFromUser = healthSource == ProfileDataSource.userInput ||
@@ -149,15 +149,17 @@ class BudgetInputs {
     );
     final netIncome =
         (map['q_net_income_period_chf'] as num?)?.toDouble() ?? 0.0;
-    final housingCost =
-        (map['q_housing_cost_period_chf'] as num?)?.toDouble() ?? 0.0;
+    final housingCost = (map['_coach_depenses_loyer'] as num?)?.toDouble() ??
+        (map['q_housing_cost_period_chf'] as num?)?.toDouble() ??
+        0.0;
     final debtPayments =
         (map['q_debt_payments_period_chf'] as num?)?.toDouble() ?? 0.0;
 
     final normalizedMonthlyIncome = _toMonthly(netIncome, payFrequency);
     final taxProvisionRaw =
         (map['q_tax_provision_monthly_chf'] as num?)?.toDouble();
-    final lamalRaw = (map['q_lamal_premium_monthly_chf'] as num?)?.toDouble();
+    final lamalRaw = (map['_coach_depenses_assurance'] as num?)?.toDouble() ??
+        (map['q_lamal_premium_monthly_chf'] as num?)?.toDouble();
     final otherFixedRaw =
         (map['q_other_fixed_costs_monthly_chf'] as num?)?.toDouble();
 
@@ -211,10 +213,10 @@ class BudgetInputs {
     return {
       'q_pay_frequency': payFrequency.name,
       'q_net_income_period_chf': netIncome,
-      'q_housing_cost_period_chf': housingCost,
+      '_coach_depenses_loyer': housingCost,
       'q_debt_payments_period_chf': debtPayments,
       'q_tax_provision_monthly_chf': taxProvision,
-      'q_lamal_premium_monthly_chf': healthInsurance,
+      '_coach_depenses_assurance': healthInsurance,
       'q_other_fixed_costs_monthly_chf': otherFixedCosts,
       'meta_tax_estimated': isTaxEstimated,
       'meta_health_estimated': isHealthEstimated,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -58,6 +58,11 @@ class CoachProfileProvider extends ChangeNotifier {
     'depenses.autresDepensesFixes': '_coach_depenses_autres',
   };
 
+  static const Map<String, List<String>> _qualityKeyAliases = {
+    'q_housing_cost_period_chf': ['_coach_depenses_loyer'],
+    'q_lamal_premium_monthly_chf': ['_coach_depenses_assurance'],
+  };
+
   /// Le profil Coach construit a partir des reponses wizard.
   /// Null si le wizard n'a pas ete complete.
   CoachProfile? get profile => _profile;
@@ -331,9 +336,17 @@ class CoachProfileProvider extends ChangeNotifier {
     return true;
   }
 
+  bool _isQualityKeyAnswered(String key) {
+    if (_isAnswered(_lastAnswers[key])) return true;
+    for (final alias in _qualityKeyAliases[key] ?? const <String>[]) {
+      if (_isAnswered(_lastAnswers[alias])) return true;
+    }
+    return false;
+  }
+
   int get onboardingAnsweredSignals {
     if (_profile == null) return 0;
-    return _qualityKeys.where((k) => _isAnswered(_lastAnswers[k])).length;
+    return _qualityKeys.where(_isQualityKeyAnswered).length;
   }
 
   int get onboardingTotalSignals {
@@ -2310,10 +2323,10 @@ class CoachProfileProvider extends ChangeNotifier {
       if (investissements != null) {
         answers['q_investments_total'] = investissements;
       }
-      // Persist depenses — use canonical wizard keys where they exist
-      if (loyer != null) answers['q_housing_cost_period_chf'] = loyer;
+      // Persist depenses to canonical ledger keys.
+      if (loyer != null) answers['_coach_depenses_loyer'] = loyer;
       if (assuranceMaladie != null) {
-        answers['q_lamal_premium_monthly_chf'] = assuranceMaladie;
+        answers['_coach_depenses_assurance'] = assuranceMaladie;
       }
       if (electricite != null) {
         answers['_coach_depenses_electricite'] = electricite;

--- a/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
+++ b/apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
@@ -301,8 +301,9 @@ class FinancialReportScreenV2 extends StatelessWidget {
   Widget _buildBudgetSection(
       BuildContext context, Map<String, dynamic> answers) {
     final income = WizardService.getMonthlyIncome(answers);
-    final housing =
-        (answers['q_housing_cost_period_chf'] as num?)?.toDouble() ?? 0;
+    final housing = (answers['_coach_depenses_loyer'] as num?)?.toDouble() ??
+        (answers['q_housing_cost_period_chf'] as num?)?.toDouble() ??
+        0;
     final debt =
         (answers['q_debt_payments_period_chf'] as num?)?.toDouble() ?? 0;
     final civilStatus = answers['q_civil_status'] as String? ?? 'single';
@@ -321,8 +322,9 @@ class FinancialReportScreenV2 extends StatelessWidget {
                 isSourceTaxed: false,
               ),
             );
-    final healthInsurance = (answers['q_lamal_premium_monthly_chf'] as num?)
-            ?.toDouble() ??
+    final healthInsurance =
+        (answers['_coach_depenses_assurance'] as num?)?.toDouble() ??
+        (answers['q_lamal_premium_monthly_chf'] as num?)?.toDouble() ??
         _estimateLamalMonthly(canton, answers['q_household_type'] as String?);
     final otherFixed =
         (answers['q_other_fixed_costs_monthly_chf'] as num?)?.toDouble() ?? 0;

--- a/apps/mobile/lib/screens/budget/budget_setup_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_setup_screen.dart
@@ -157,32 +157,31 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
     setState(() => _saving = true);
     final provider = context.read<CoachProfileProvider>();
     final answers = <String, dynamic>{
-      'q_housing_cost_period_chf': housing,
-      'q_pay_frequency': 'monthly',
-      'q_lamal_premium_monthly_chf': lamal,
+      'fp:depenses.loyer': housing,
+      'fp:depenses.assuranceMaladie': lamal,
     };
     final transport = _parseAmount(_transport.text);
-    if (transport != null) answers['_coach_depenses_transport'] = transport;
+    if (transport != null) answers['fp:depenses.transport'] = transport;
     final telecom = _parseAmount(_telecom.text);
-    if (telecom != null) answers['_coach_depenses_telecom'] = telecom;
+    if (telecom != null) answers['fp:depenses.telecom'] = telecom;
     final electricity = _parseAmount(_electricity.text);
     if (electricity != null) {
-      answers['_coach_depenses_electricite'] = electricity;
+      answers['fp:depenses.electricite'] = electricity;
     }
     final medical = _parseAmount(_medical.text);
     if (medical != null) {
-      answers['_coach_depenses_frais_medicaux'] = medical;
+      answers['fp:depenses.fraisMedicaux'] = medical;
     }
     final other = _parseAmount(_other.text);
-    if (other != null) answers['_coach_depenses_autres'] = other;
+    if (other != null) answers['fp:depenses.autresDepensesFixes'] = other;
 
     await provider.mergeAnswers(answers);
     if (!mounted) return;
-    // Refresh BudgetProvider so the Mon argent « Ton budget ce mois »
+    // Refresh BudgetProvider so the money dashboard monthly-budget
     // card re-derives inputs from the updated CoachProfile.depenses and
-    // swaps from the empty "Définis ton budget" state to the computed
-    // plan (revenu / charges fixes / reste). Without this the user
-    // enters their charges and the card still shows « Commencer » —
+    // swaps from the empty setup state to the computed
+    // plan (income / fixed charges / remaining). Without this the user
+    // enters their charges and the card still shows the start action:
     // silent failure, identical to the save_fact bug.
     final updated = provider.profile;
     if (updated != null) {

--- a/apps/mobile/test/domain/budget/budget_service_test.dart
+++ b/apps/mobile/test/domain/budget/budget_service_test.dart
@@ -692,6 +692,27 @@ void main() {
       expect(inputs.style, BudgetStyle.envelopes3);
     });
 
+    test('fromMap prefers canonical monthly expense keys over legacy q keys',
+        () {
+      final map = {
+        'q_pay_frequency': 'monthly',
+        'q_net_income_period_chf': 5000.0,
+        'q_housing_cost_period_chf': 999.0,
+        '_coach_depenses_loyer': 1800.0,
+        'q_debt_payments_period_chf': 0.0,
+        'q_lamal_premium_monthly_chf': 111.0,
+        '_coach_depenses_assurance': 420.0,
+        'q_canton': 'VD',
+        'q_civil_status': 'single',
+      };
+
+      final inputs = BudgetInputs.fromMap(map);
+
+      expect(inputs.housingCost, 1800.0);
+      expect(inputs.healthInsurance, 420.0);
+      expect(inputs.isHealthEstimated, isFalse);
+    });
+
     test('toMap roundtrip preserves core values', () {
       const inputs = BudgetInputs(
         payFrequency: PayFrequency.monthly,
@@ -710,10 +731,12 @@ void main() {
       final map = inputs.toMap();
       expect(map['q_pay_frequency'], 'monthly');
       expect(map['q_net_income_period_chf'], 5000);
-      expect(map['q_housing_cost_period_chf'], 1500);
+      expect(map['_coach_depenses_loyer'], 1500);
+      expect(map.containsKey('q_housing_cost_period_chf'), isFalse);
       expect(map['q_debt_payments_period_chf'], 200);
       expect(map['q_tax_provision_monthly_chf'], 300);
-      expect(map['q_lamal_premium_monthly_chf'], 400);
+      expect(map['_coach_depenses_assurance'], 400);
+      expect(map.containsKey('q_lamal_premium_monthly_chf'), isFalse);
       expect(map['q_other_fixed_costs_monthly_chf'], 100);
       expect(map['meta_tax_estimated'], isTrue);
       expect(map['meta_health_estimated'], isFalse);

--- a/apps/mobile/test/providers/coach_profile_provider_field_path_bridge_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_field_path_bridge_test.dart
@@ -56,4 +56,45 @@ void main() {
       isTrue,
     );
   });
+
+  test('canonical depenses keys count toward onboarding signals', () {
+    final provider = CoachProfileProvider();
+
+    provider.updateFromAnswers({
+      'q_birth_year': 1990,
+      'q_canton': 'VD',
+      '_coach_depenses_loyer': 1850.0,
+      '_coach_depenses_assurance': 420.0,
+    });
+
+    expect(provider.onboardingAnsweredSignals, 4);
+  });
+
+  test('updateInline persists loyer and LAMal to canonical depenses keys',
+      () async {
+    final provider = CoachProfileProvider();
+    provider.updateFromAnswers({
+      'q_birth_year': 1990,
+      'q_canton': 'VD',
+      '_coach_depenses_loyer': 1850.0,
+      '_coach_depenses_assurance': 420.0,
+    });
+    await ReportPersistenceService.saveAnswers({
+      'q_birth_year': 1990,
+      'q_canton': 'VD',
+      '_coach_depenses_loyer': 1850.0,
+      '_coach_depenses_assurance': 420.0,
+    });
+
+    await provider.updateInline(
+      loyer: 2100.0,
+      assuranceMaladie: 390.0,
+    );
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    expect(persisted['_coach_depenses_loyer'], 2100.0);
+    expect(persisted['_coach_depenses_assurance'], 390.0);
+    expect(persisted.containsKey('q_housing_cost_period_chf'), isFalse);
+    expect(persisted.containsKey('q_lamal_premium_monthly_chf'), isFalse);
+  });
 }

--- a/apps/mobile/test/screens/advisor_banking_smoke_test.dart
+++ b/apps/mobile/test/screens/advisor_banking_smoke_test.dart
@@ -140,6 +140,31 @@ void main() {
       // Thematic cards replaced circles — check for a thematic card title
       expect(find.textContaining('Ton Budget'), findsOneWidget);
     });
+
+    testWidgets('budget card reads canonical monthly expense keys',
+        (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+
+      final answers = Map<String, dynamic>.from(testAnswersV2)
+        ..remove('q_housing_cost_period_chf')
+        ..remove('q_lamal_premium_monthly_chf')
+        ..['q_tax_provision_monthly_chf'] = 0.0
+        ..['q_debt_payments_period_chf'] = 0.0
+        ..['q_other_fixed_costs_monthly_chf'] = 0.0
+        ..['_coach_depenses_loyer'] = 2100.0
+        ..['_coach_depenses_assurance'] = 390.0;
+
+      await tester.pumpWidget(
+        buildWithProfileProvider(
+          FinancialReportScreenV2(wizardAnswers: answers),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text("CHF\u00a03'510"), findsOneWidget);
+    });
   });
 
   // ===========================================================================

--- a/apps/mobile/test/screens/budget_screen_smoke_test.dart
+++ b/apps/mobile/test/screens/budget_screen_smoke_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart'; // Ensure correct imports
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/screens/budget/budget_screen.dart';
+import 'package:mint_mobile/screens/budget/budget_setup_screen.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -10,6 +14,7 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 
 void main() {
   setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
     SharedPreferences.setMockInitialValues({});
   });
 
@@ -89,5 +94,44 @@ void main() {
 
     // Available 0 => Variables 0 => Stop Rule Warning
     expect(find.textContaining('Stop Rule Triggered'), findsOneWidget);
+  });
+
+  testWidgets('BudgetSetupScreen saves canonical depenses keys',
+      (tester) async {
+    final coachProvider = CoachProfileProvider();
+    final budgetProvider = BudgetProvider();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('fr'),
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: MultiProvider(
+          providers: [
+            ChangeNotifierProvider.value(value: coachProvider),
+            ChangeNotifierProvider.value(value: budgetProvider),
+          ],
+          child: const BudgetSetupScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), '2100');
+    await tester.enterText(find.byType(TextField).at(1), '390');
+    await tester.tap(find.byType(FilledButton));
+    await tester.pumpAndSettle();
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers['_coach_depenses_loyer'], 2100.0);
+    expect(answers['_coach_depenses_assurance'], 390.0);
+    expect(answers.containsKey('q_housing_cost_period_chf'), isFalse);
+    expect(answers.containsKey('q_lamal_premium_monthly_chf'), isFalse);
+    expect(coachProvider.profile?.depenses.loyer, 2100.0);
   });
 }

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -67,7 +67,7 @@ mirrors to SharedPreferences. **This is the only legal write path.**
 | 3 | **Scan confirmation** | `extraction_review_screen.dart:659` → `updateFrom{Lpp,Avs,Tax,Salary}Extraction` | `_coach_avoir_lpp*`, `_coach_salaire_assure`, `_coach_rachat_maximum`, `_coach_taux_conversion*`, `_coach_avs_*`, `_coach_tax_*` + `_coach_<type>_source = 'document_scan'` | Post-scan flow |
 | 4 | **Coach chat inline picker** | `coach_chat_screen.dart` → `coachProvider.mergeAnswers()` | Arbitrary `q_*` single field | User taps inline picker in conversation |
 | 5 | **Dart regex fact fallback** | `lib/services/chat/fact_extraction_fallback.dart` → `applySaveFact` → `mergeAnswers` | `q_birth_year`, `q_net_income_period_chf`, `q_pay_frequency`, `q_gross_salary_annual`, `_coach_avoir_lpp`, `q_3a_total` (restricted to 1st-person matches) | Every coach chat send |
-| 6 | **Budget setup form** | `budget_setup_screen.dart` → `coachProvider.mergeAnswers` + `budgetProvider.refreshFromProfile` | `q_housing_cost_period_chf`, `q_lamal_premium_monthly_chf`, `q_pay_frequency='monthly'`, `_coach_depenses_{transport,telecom,electricite,frais_medicaux,autres}` | Tap « Enregistrer » |
+| 6 | **Budget setup form** | `budget_setup_screen.dart` → `coachProvider.mergeAnswers` + `budgetProvider.refreshFromProfile` | `fp:depenses.*` payload, normalized by `mergeAnswers` to `_coach_depenses_{loyer,assurance,electricite,transport,telecom,frais_medicaux,autres}` | Tap « Enregistrer » |
 | 7 | **Annual refresh** (scheduled) | `updateFromRefresh` (CoachProfileProvider) | Updates `_coach_updated_at` + tax + salary | Annual trigger (currently orphaned, cf façade audit) |
 
 **Legend.** Keys prefixed `q_*` come from wizard-style answers
@@ -98,12 +98,15 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
   `q_partner_birth_year`, `q_partner_employment_status`
 
 **Housing & fixed charges**
-- `q_housing_cost_period_chf` (double — rent OR mortgage),
+- `q_housing_cost_period_chf` (double — legacy wizard rent OR mortgage;
+  canonical budget consumers read it only as fallback),
   `q_housing_status` (locataire/proprietaire/…),
-  `q_lamal_premium_monthly_chf` (double, health insurance actual value),
-  `_coach_depenses_loyer` (monthly rent/mortgage override written by
-  field-path bridges / banking imports), `_coach_depenses_assurance`
-  (monthly health-insurance override written by field-path bridges / banking),
+  `q_lamal_premium_monthly_chf` (double, legacy health insurance actual
+  value; canonical budget consumers read it only as fallback),
+  `_coach_depenses_loyer` (canonical monthly rent/mortgage value written by
+  field-path bridges, budget setup and banking imports),
+  `_coach_depenses_assurance` (canonical monthly health-insurance value
+  written by field-path bridges, budget setup and banking imports),
   `_coach_depenses_transport`, `_coach_depenses_telecom`,
   `_coach_depenses_electricite`, `_coach_depenses_frais_medicaux`,
   `_coach_depenses_autres`
@@ -269,16 +272,15 @@ BudgetSetupScreen (new, P0-MVP-3)
   ↓ tap Enregistrer
   ↓
 coachProvider.mergeAnswers({
-  q_housing_cost_period_chf: …,
-  q_pay_frequency: 'monthly',
-  q_lamal_premium_monthly_chf: …,
-  _coach_depenses_transport: …,          (optional)
-  _coach_depenses_telecom: …,             (optional)
-  _coach_depenses_electricite: …,         (optional)
-  _coach_depenses_frais_medicaux: …,      (optional)
-  _coach_depenses_autres: …,              (optional)
+  fp:depenses.loyer: …,
+  fp:depenses.assuranceMaladie: …,
+  fp:depenses.transport: …,              (optional)
+  fp:depenses.telecom: …,                (optional)
+  fp:depenses.electricite: …,            (optional)
+  fp:depenses.fraisMedicaux: …,          (optional)
+  fp:depenses.autresDepensesFixes: …,    (optional)
 })
-  ↓ answers written via ReportPersistenceService
+  ↓ answers written via ReportPersistenceService as _coach_depenses_* only
   ↓
 budgetProvider.refreshFromProfile(updatedProfile)
   ↓ BudgetInputs.fromCoachProfile(profile) re-derives


### PR DESCRIPTION
## Summary
- Cut BudgetSetupScreen writes from legacy q_* expenses to fp:depenses.* bridge payloads.
- Read canonical _coach_depenses_loyer / _coach_depenses_assurance first in BudgetInputs, BudgetLocalStore, and FinancialReportScreenV2, with legacy q_* read fallback only.
- Keep onboarding quality signals and updateInline aligned with canonical depenses keys.
- Update docs/data-flow.md to distinguish legacy wizard keys from canonical budget consumers.

## QA
- Red-first regressions confirmed failures before implementation: report canonical read, onboarding signal aliases, updateInline canonical writes.
- cd apps/mobile && flutter test test/screens/advisor_banking_smoke_test.dart test/providers/coach_profile_provider_field_path_bridge_test.dart --reporter expanded
- cd apps/mobile && flutter test test/domain/budget/budget_service_test.dart test/screens/budget_screen_smoke_test.dart test/screens/advisor_banking_smoke_test.dart test/providers/coach_profile_provider_field_path_bridge_test.dart test/providers/coach_profile_provider_save_fact_test.dart test/providers/mint_state_provider_test.dart --reporter expanded
- cd apps/mobile && flutter test test/domain/budget/budget_service_test.dart --reporter expanded
- python3 tools/checks/arb_parity.py
- python3 tools/checks/accent_lint_fr.py --file apps/mobile/lib/screens/budget/budget_setup_screen.dart --file apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart --file docs/data-flow.md
- python3 tools/checks/no_hardcoded_fr.py --file apps/mobile/lib/domain/budget/budget_inputs.dart --file apps/mobile/lib/screens/budget/budget_setup_screen.dart --file apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart
- python3 -m pytest tools/checks/tests -q
- git diff --check
- cd apps/mobile && flutter analyze --no-fatal-infos --no-fatal-warnings (exit 0; 128 pre-existing warnings/infos)
- pre-commit hooks: PASS on commit 58b347741
- Claude Opus CLI audit: GO; output saved locally at .planning/runtime-evidence/g10-budget-expense-cutover/claude-opus-audit.txt

## Notes
- Claude noted the historical wizard still writes legacy q_housing_cost_period_chf / q_lamal_premium_monthly_chf. This PR keeps that out of scope and documents that only canonical budget consumers treat q_* as fallback.
- Patrol CLI remains unavailable in PATH in this environment; this slice is unit/widget/provider proof, not a Patrol runtime gate.