### PR TITLE
G11: canonicalize wizard fixed expenses

### DIFF
--- a/apps/mobile/lib/models/wizard_question.dart
+++ b/apps/mobile/lib/models/wizard_question.dart
@@ -63,7 +63,25 @@ class WizardQuestion {
 
   bool shouldShow(Map<String, dynamic> answers) {
     if (condition == null) return true;
-    return condition!(answers);
+    return condition!(_withCanonicalAliases(answers));
+  }
+
+  static const _canonicalAliases = {
+    'q_housing_cost_period_chf': '_coach_depenses_loyer',
+    'q_lamal_premium_monthly_chf': '_coach_depenses_assurance',
+  };
+
+  static Map<String, dynamic> _withCanonicalAliases(
+    Map<String, dynamic> answers,
+  ) {
+    final normalized = Map<String, dynamic>.from(answers);
+    for (final entry in _canonicalAliases.entries) {
+      final canonicalValue = answers[entry.value];
+      if (canonicalValue != null) {
+        normalized[entry.key] = canonicalValue;
+      }
+    }
+    return normalized;
   }
 }
 

--- a/apps/mobile/lib/services/report_persistence_service.dart
+++ b/apps/mobile/lib/services/report_persistence_service.dart
@@ -13,7 +13,8 @@ class ReportPersistenceService {
   /// SEC-10: Sensitive financial keys are stored in encrypted storage.
   static Future<void> saveAnswers(Map<String, dynamic> answers) async {
     final prefs = await SharedPreferences.getInstance();
-    final cleaned = await SecureWizardStore.secureSensitiveKeys(answers);
+    final normalized = _normalizeFixedChargeKeys(answers);
+    final cleaned = await SecureWizardStore.secureSensitiveKeys(normalized);
     final jsonString = json.encode(cleaned);
     await prefs.setString(_wizardKey, jsonString);
   }
@@ -28,12 +29,32 @@ class ReportPersistenceService {
 
     try {
       final answers = Map<String, dynamic>.from(json.decode(jsonString));
-      return await SecureWizardStore.restoreSensitiveKeys(answers);
+      final restored = await SecureWizardStore.restoreSensitiveKeys(answers);
+      return _normalizeFixedChargeKeys(restored);
     } catch (e, stack) {
       dev.log('Failed to decode wizard answers',
           error: e, stackTrace: stack, name: 'Persistence');
       return {};
     }
+  }
+
+  static Map<String, dynamic> _normalizeFixedChargeKeys(
+    Map<String, dynamic> answers,
+  ) {
+    final normalized = Map<String, dynamic>.from(answers);
+
+    void moveLegacy(String legacyKey, String canonicalKey) {
+      final canonicalValue = normalized[canonicalKey];
+      final legacyValue = normalized[legacyKey];
+      if (canonicalValue == null && legacyValue != null) {
+        normalized[canonicalKey] = legacyValue;
+      }
+      normalized.remove(legacyKey);
+    }
+
+    moveLegacy('q_housing_cost_period_chf', '_coach_depenses_loyer');
+    moveLegacy('q_lamal_premium_monthly_chf', '_coach_depenses_assurance');
+    return normalized;
   }
 
   /// Marque le wizard comme complété (pour ne pas le relancer au reboot)
@@ -63,7 +84,7 @@ class ReportPersistenceService {
       'mini_onboarding_cohort_metrics_v1';
   static const String _selectedIntentKey = 'selected_onboarding_intent_v1';
 
-  // ── Premier Eclairage persistence keys (D-09) ──
+  // ── Premier Éclairage persistence keys (D-09) ──
   static const String _hasSeenPremierEclairageKey =
       'has_seen_premier_eclairage_v1';
   static const String _premierEclairageSnapshotKey =
@@ -83,13 +104,13 @@ class ReportPersistenceService {
     return prefs.getBool(_miniOnboardingKey) ?? false;
   }
 
-  /// Persiste l'intent choisi sur l'écran d'intent (onboarding V2).
+  /// Persists the selected onboarding intent.
   static Future<void> setSelectedOnboardingIntent(String intent) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_selectedIntentKey, intent);
   }
 
-  /// Retourne l'intent choisi lors de l'onboarding, ou null.
+  /// Returns the selected onboarding intent, or null.
   static Future<String?> getSelectedOnboardingIntent() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString(_selectedIntentKey);
@@ -108,13 +129,13 @@ class ReportPersistenceService {
     return variant;
   }
 
-  /// Indique si l'exposition a l'experience onboarding a deja ete trackee.
+  /// Returns whether onboarding exposure has already been tracked.
   static Future<bool> isMiniOnboardingExposureTracked() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_miniOnboardingExposureTrackedKey) ?? false;
   }
 
-  /// Marque l'exposition a l'experience onboarding comme trackee.
+  /// Marks onboarding exposure as tracked.
   static Future<void> setMiniOnboardingExposureTracked(bool tracked) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_miniOnboardingExposureTrackedKey, tracked);
@@ -206,10 +227,10 @@ class ReportPersistenceService {
   }
 
   // ═══════════════════════════════════════════════════════════
-  //  PREMIER ECLAIRAGE PERSISTENCE (D-09)
+  //  PREMIER ÉCLAIRAGE PERSISTENCE (D-09)
   // ═══════════════════════════════════════════════════════════
 
-  /// Saves a premier eclairage snapshot to SharedPreferences.
+  /// Saves a premier éclairage snapshot to SharedPreferences.
   ///
   /// [data] MUST contain only display fields:
   ///   value (formatted string), title, subtitle, colorKey, suggestedRoute.
@@ -220,7 +241,7 @@ class ReportPersistenceService {
     await prefs.setString(_premierEclairageSnapshotKey, json.encode(data));
   }
 
-  /// Loads the premier eclairage snapshot. Returns null if not set or on error.
+  /// Loads the premier éclairage snapshot. Returns null if not set or on error.
   static Future<Map<String, dynamic>?> loadPremierEclairageSnapshot() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_premierEclairageSnapshotKey);
@@ -232,13 +253,13 @@ class ReportPersistenceService {
     }
   }
 
-  /// Returns true if the user has already seen their premier eclairage card.
+  /// Returns true if the user has already seen their premier éclairage card.
   static Future<bool> hasSeenPremierEclairage() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_hasSeenPremierEclairageKey) ?? false;
   }
 
-  /// Marks the premier eclairage card as seen (one-shot flag per D-09).
+  /// Marks the premier éclairage card as seen (one-shot flag per D-09).
   static Future<void> markPremierEclairageSeen() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_hasSeenPremierEclairageKey, true);
@@ -471,7 +492,7 @@ class ReportPersistenceService {
     // Charger l'historique existant
     List<Map<String, dynamic>> history = await loadScoreHistory();
 
-    // Remplacer l'entree du mois en cours si elle existe deja
+    // Replace the current month entry when it already exists.
     final existingIndex =
         history.indexWhere((entry) => entry['month'] == monthKey);
     if (existingIndex >= 0) {
@@ -677,8 +698,8 @@ class ReportPersistenceService {
   /// Efface uniquement l'historique coach:
   /// - check-ins mensuels
   /// - score du mois + historique des scores
-  /// - progression "simulateurs explorés"
-  /// - activite utilisateur (life events, tips dismissed/snoozed)
+  /// - explored simulator progress
+  /// - user activity (life events, tips dismissed/snoozed)
   static Future<void> clearCoachHistory() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_checkInsKey);

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -26,6 +26,11 @@ class SecureWizardStore {
     'q_partner_salary',
     'q_patrimoine_liquide',
     'q_dettes_total',
+    // Kept for backward restore of pre-canonicalization secure entries.
+    'q_housing_cost_period_chf',
+    'q_lamal_premium_monthly_chf',
+    '_coach_depenses_loyer',
+    '_coach_depenses_assurance',
   };
 
   /// Whether a key should be stored in secure storage.

--- a/apps/mobile/lib/services/wizard_service.dart
+++ b/apps/mobile/lib/services/wizard_service.dart
@@ -5,6 +5,16 @@ import 'package:mint_mobile/models/profile.dart';
 import 'package:mint_mobile/data/wizard_questions.dart';
 
 class WizardService {
+  static const _questionAnswerAliases = {
+    'q_housing_cost_period_chf': ['_coach_depenses_loyer'],
+    'q_lamal_premium_monthly_chf': ['_coach_depenses_assurance'],
+  };
+
+  static const _answerQuestionAliases = {
+    '_coach_depenses_loyer': 'q_housing_cost_period_chf',
+    '_coach_depenses_assurance': 'q_lamal_premium_monthly_chf',
+  };
+
   /// Filtre les questions selon le profil utilisateur
   static List<WizardQuestion> getQuestionsForUser(
     Profile? profile,
@@ -29,7 +39,7 @@ class WizardService {
     Profile? profile,
     Map<String, dynamic> answers,
   ) {
-    if (question.condition != null && !question.condition!(answers)) {
+    if (!question.shouldShow(answers)) {
       return false;
     }
     return true;
@@ -74,14 +84,6 @@ class WizardService {
     if (answers['q_has_consumer_credit'] == 'yes') {
       totalDebt += (answers['q_credit_monthly'] as num?)?.toDouble() ?? 0.0;
     }
-
-    // Ajout: dette périodique du budget aussi ?
-    // Le prompt dit "q_debt_payments_period_chf: double (0 OK)"
-    // Si on a cette réponse, on devrait l'ajouter, mais attention aux doublons avec leasing/credit_monthly existants.
-    // Le prompt dit "Offline, read-only...".
-    // Si l'utilisateur remplit le budget wizard, il remplit q_debt_payments_period_chf.
-    // Si c'est le wizard classic, il remplit q_leasing/q_credit.
-    // Pour l'instant, je garde l'existant + le nouveau si présent (en assumant qu'ils sont exclusifs ou complémentaires).
 
     if (answers.containsKey('q_debt_payments_period_chf')) {
       // Normaliser la dette périodique en mensuel
@@ -183,12 +185,13 @@ class WizardService {
     final summary = <String, String>{};
 
     for (final entry in answers.entries) {
+      final questionId = _answerQuestionAliases[entry.key] ?? entry.key;
       final question = questions.firstWhere(
-        (q) => q.id == entry.key,
+        (q) => q.id == questionId,
         orElse: () => questions.first,
       );
 
-      if (question.id == entry.key) {
+      if (question.id == questionId) {
         summary[question.title] = _formatAnswer(entry.value, question, l: l);
       }
     }
@@ -196,9 +199,8 @@ class WizardService {
     return summary;
   }
 
-  static String _formatAnswer(dynamic value, WizardQuestion question,
-      {S? l}) {
-    if (value == null) return l?.wizardAnswerNotProvided ?? 'Non renseigné';
+  static String _formatAnswer(dynamic value, WizardQuestion question, {S? l}) {
+    if (value == null) return l?.wizardAnswerNotProvided ?? '-';
 
     if (question.type == QuestionType.choice) {
       final option = question.options?.firstWhere(
@@ -225,11 +227,17 @@ class WizardService {
   ) {
     final requiredQuestions = allQuestions.where((q) => q.required).toList();
     final answeredRequired = requiredQuestions
-        .where((q) => answers.containsKey(q.id) && answers[q.id] != null)
+        .where((q) => _hasAnswerForQuestion(answers, q.id))
         .length;
 
     if (requiredQuestions.isEmpty) return 100.0;
 
     return (answeredRequired / requiredQuestions.length) * 100;
+  }
+
+  static bool _hasAnswerForQuestion(Map<String, dynamic> answers, String id) {
+    if (answers[id] != null) return true;
+    final aliases = _questionAnswerAliases[id] ?? const <String>[];
+    return aliases.any((alias) => answers[alias] != null);
   }
 }

--- a/apps/mobile/test/services/wizard_expense_canonical_test.dart
+++ b/apps/mobile/test/services/wizard_expense_canonical_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/data/wizard_questions_v2.dart';
+import 'package:mint_mobile/models/wizard_question.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:mint_mobile/services/secure_wizard_store.dart';
+import 'package:mint_mobile/services/wizard_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final mockSecureStorage = <String, String>{};
+
+  setUp(() {
+    mockSecureStorage.clear();
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+      (MethodCall call) async {
+        switch (call.method) {
+          case 'write':
+            final key = call.arguments['key'] as String;
+            final value = call.arguments['value'] as String?;
+            if (value != null) mockSecureStorage[key] = value;
+            return null;
+          case 'read':
+            final key = call.arguments['key'] as String;
+            return mockSecureStorage[key];
+          case 'delete':
+            final key = call.arguments['key'] as String;
+            mockSecureStorage.remove(key);
+            return null;
+          case 'deleteAll':
+            mockSecureStorage.clear();
+            return null;
+          default:
+            return null;
+        }
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+      null,
+    );
+  });
+
+  test('saveAnswers normalizes legacy fixed-charge keys before storage',
+      () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      'q_housing_cost_period_chf': 2100,
+      'q_lamal_premium_monthly_chf': 390,
+    });
+
+    final loaded = await ReportPersistenceService.loadAnswers();
+
+    expect(loaded['_coach_depenses_loyer'], 2100);
+    expect(loaded['_coach_depenses_assurance'], 390);
+    expect(loaded.containsKey('q_housing_cost_period_chf'), isFalse);
+    expect(loaded.containsKey('q_lamal_premium_monthly_chf'), isFalse);
+
+    final prefs = await SharedPreferences.getInstance();
+    final rawAnswers = prefs.getString('wizard_answers_v2');
+    expect(rawAnswers, contains('_coach_depenses_loyer'));
+    expect(rawAnswers, contains('_coach_depenses_assurance'));
+    expect(rawAnswers, isNot(contains('q_housing_cost_period_chf')));
+    expect(rawAnswers, isNot(contains('q_lamal_premium_monthly_chf')));
+    expect(mockSecureStorage['_coach_depenses_loyer'], '2100');
+    expect(mockSecureStorage['_coach_depenses_assurance'], '390');
+    expect(mockSecureStorage.containsKey('q_housing_cost_period_chf'), isFalse);
+    expect(
+      mockSecureStorage.containsKey('q_lamal_premium_monthly_chf'),
+      isFalse,
+    );
+  });
+
+  test('savings allocation condition reads canonical fixed charges first', () {
+    final savingsAllocation = WizardQuestionsV2.questions
+        .firstWhere((q) => q.id == 'q_savings_allocation');
+
+    final shouldShow = savingsAllocation.shouldShow({
+      'q_net_income_period_chf': 5000,
+      '_coach_depenses_loyer': 4500,
+      '_coach_depenses_assurance': 600,
+      'q_debt_payments_period_chf': 0,
+      'q_tax_provision_monthly_chf': 0,
+      'q_other_fixed_costs_monthly_chf': 0,
+    });
+
+    expect(shouldShow, isFalse);
+  });
+
+  test('completion score counts canonical fixed-charge aliases', () {
+    const questions = [
+      WizardQuestion(
+        id: 'q_housing_cost_period_chf',
+        type: QuestionType.number,
+        title: 'Housing cost',
+      ),
+    ];
+
+    final legacyScore = WizardService.calculateCompletionScore(
+      {'q_housing_cost_period_chf': 2100},
+      questions,
+    );
+    final canonicalScore = WizardService.calculateCompletionScore(
+      {'_coach_depenses_loyer': 2100},
+      questions,
+    );
+
+    expect(legacyScore, 100);
+    expect(canonicalScore, legacyScore);
+  });
+
+  test('fixed-charge values are sensitive persistence keys', () {
+    expect(SecureWizardStore.isSensitive('_coach_depenses_loyer'), isTrue);
+    expect(SecureWizardStore.isSensitive('_coach_depenses_assurance'), isTrue);
+    expect(SecureWizardStore.isSensitive('q_housing_cost_period_chf'), isTrue);
+    expect(
+      SecureWizardStore.isSensitive('q_lamal_premium_monthly_chf'),
+      isTrue,
+    );
+  });
+}

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -62,7 +62,7 @@ mirrors to SharedPreferences. **This is the only legal write path.**
 
 | # | Writer | Entry points | Keys written | Lifecycle trigger |
 |---|---|---|---|---|
-| 1 | **Wizard full** | `wizard_service.dart` | `q_firstname`, `q_birth_year`, `q_canton`, `q_net_income_period_chf`, `q_pay_frequency`, `q_housing_cost_period_chf`, … (all `q_*`) | `WizardProvider.complete()` sets `_completed_key` flag |
+| 1 | **Wizard full** | Wizard provider/save flow → `ReportPersistenceService.saveAnswers` | `q_firstname`, `q_birth_year`, `q_canton`, `q_net_income_period_chf`, `q_pay_frequency`, …; legacy fixed-charge IDs are normalized before storage to `_coach_depenses_loyer` / `_coach_depenses_assurance` | `WizardProvider.complete()` sets `_completed_key` flag |
 | 2 | **Mini-onboarding** | `smart_flow_screen.dart` | Subset of `q_*` (3 questions) | `ReportPersistenceService.setMiniOnboardingCompleted(true)` |
 | 3 | **Scan confirmation** | `extraction_review_screen.dart:659` → `updateFrom{Lpp,Avs,Tax,Salary}Extraction` | `_coach_avoir_lpp*`, `_coach_salaire_assure`, `_coach_rachat_maximum`, `_coach_taux_conversion*`, `_coach_avs_*`, `_coach_tax_*` + `_coach_<type>_source = 'document_scan'` | Post-scan flow |
 | 4 | **Coach chat inline picker** | `coach_chat_screen.dart` → `coachProvider.mergeAnswers()` | Arbitrary `q_*` single field | User taps inline picker in conversation |
@@ -99,10 +99,13 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
 
 **Housing & fixed charges**
 - `q_housing_cost_period_chf` (double — legacy wizard rent OR mortgage;
-  canonical budget consumers read it only as fallback),
+  `ReportPersistenceService.saveAnswers` migrates it to
+  `_coach_depenses_loyer` before storage; consumers read it only as fallback),
   `q_housing_status` (locataire/proprietaire/…),
   `q_lamal_premium_monthly_chf` (double, legacy health insurance actual
-  value; canonical budget consumers read it only as fallback),
+  value; `ReportPersistenceService.saveAnswers` migrates it to
+  `_coach_depenses_assurance` before storage; consumers read it only as
+  fallback),
   `_coach_depenses_loyer` (canonical monthly rent/mortgage value written by
   field-path bridges, budget setup and banking imports),
   `_coach_depenses_assurance` (canonical monthly health-insurance value


### PR DESCRIPTION
## Summary
- Normalize legacy wizard fixed-charge keys to canonical ledger keys before persistence.
- Keep canonical expense values readable by wizard conditions and completion scoring.
- Mark canonical/legacy fixed-charge keys sensitive and document the data-flow migration.

## QA
- RED first: canonical expense tests failed before implementation.
- `flutter test test/services/wizard_expense_canonical_test.dart test/wizard_test.dart test/services/report_persistence_service_test.dart test/providers/coach_profile_provider_field_path_bridge_test.dart test/screens/budget_screen_smoke_test.dart test/screens/advisor_banking_smoke_test.dart --reporter expanded` => 99 passed.
- `dart analyze lib/models/wizard_question.dart lib/services/report_persistence_service.dart lib/services/secure_wizard_store.dart lib/services/wizard_service.dart test/services/wizard_expense_canonical_test.dart` => No issues found.
- `lefthook run pre-commit` => PASS, including gitleaks, codex-spec-reality 55 tests, financial-core-gate, no-bypass-persistence, no-hardcoded-fr, banned-ui-terms.
- Claude Opus CLI external audit => GO. Follow-up noted: sensitive-value delete-on-clear is pre-existing and should be handled separately.

## Runtime
- No UI flow changed; Maestro/Patrol runtime not applicable for this data-persistence slice.
