### PR TITLE
G12: Clear stale secure wizard values

### DIFF
--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -43,6 +43,13 @@ class SecureWizardStore {
     }
   }
 
+  /// Delete a sensitive value from encrypted storage.
+  static Future<void> delete(String key) async {
+    if (_sensitiveKeys.contains(key)) {
+      await _storage.delete(key: key);
+    }
+  }
+
   /// Read a sensitive value from encrypted storage.
   ///
   /// On iOS simulator without a valid keychain-access-groups entitlement
@@ -76,10 +83,16 @@ class SecureWizardStore {
   ) async {
     final cleaned = Map<String, dynamic>.from(answers);
     for (final key in _sensitiveKeys) {
-      if (cleaned.containsKey(key) && cleaned[key] != null) {
-        await write(key, cleaned[key].toString());
-        cleaned[key] = '__secure__';
+      if (!cleaned.containsKey(key)) continue;
+
+      final value = cleaned[key];
+      if (value == null) {
+        await delete(key);
+        continue;
       }
+
+      await write(key, value.toString());
+      cleaned[key] = '__secure__';
     }
     return cleaned;
   }

--- a/apps/mobile/test/services/wizard_expense_canonical_test.dart
+++ b/apps/mobile/test/services/wizard_expense_canonical_test.dart
@@ -80,6 +80,60 @@ void main() {
     );
   });
 
+  test('explicit null fixed-charge value deletes stale secure copy', () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      '_coach_depenses_loyer': 2100,
+    });
+
+    expect(mockSecureStorage['_coach_depenses_loyer'], '2100');
+
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      '_coach_depenses_loyer': null,
+    });
+
+    final loaded = await ReportPersistenceService.loadAnswers();
+
+    expect(mockSecureStorage.containsKey('_coach_depenses_loyer'), isFalse);
+    expect(loaded['_coach_depenses_loyer'], isNull);
+  });
+
+  test('explicit null sensitive value deletes stale secure copy', () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      'q_net_income_period_chf': 6400,
+    });
+
+    expect(mockSecureStorage['q_net_income_period_chf'], '6400');
+
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      'q_net_income_period_chf': null,
+    });
+
+    final loaded = await ReportPersistenceService.loadAnswers();
+
+    expect(mockSecureStorage.containsKey('q_net_income_period_chf'), isFalse);
+    expect(loaded['q_net_income_period_chf'], isNull);
+  });
+
+  test('absent sensitive value preserves secure copy for partial saves',
+      () async {
+    await ReportPersistenceService.saveAnswers({
+      'q_canton': 'VD',
+      'q_net_income_period_chf': 6400,
+    });
+
+    await ReportPersistenceService.saveAnswers({'q_canton': 'GE'});
+
+    final loaded = await ReportPersistenceService.loadAnswers();
+
+    expect(mockSecureStorage['q_net_income_period_chf'], '6400');
+    expect(loaded['q_canton'], 'GE');
+    expect(loaded['q_net_income_period_chf'], 6400);
+  });
+
   test('savings allocation condition reads canonical fixed charges first', () {
     final savingsAllocation = WizardQuestionsV2.questions
         .firstWhere((q) => q.id == 'q_savings_allocation');

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -59,6 +59,8 @@ flowchart LR
 Every writer persists via `ReportPersistenceService.saveAnswers(answers)`
 which encrypts sensitive keys via `SecureWizardStore` (Keychain) and
 mirrors to SharedPreferences. **This is the only legal write path.**
+For sensitive keys, an absent key is a partial save and preserves the
+encrypted copy; a key explicitly set to `null` deletes the encrypted copy.
 
 | # | Writer | Entry points | Keys written | Lifecycle trigger |
 |---|---|---|---|---|


### PR DESCRIPTION
## Summary
- Adds individual delete semantics to `SecureWizardStore` for sensitive wizard keys explicitly set to `null`.
- Preserves existing partial-save behavior: absent sensitive keys keep their encrypted copy and restore on load.
- Documents the null-vs-absent contract in `docs/data-flow.md`.

## QA
- RED verified first: `flutter test test/services/wizard_expense_canonical_test.dart --reporter expanded` failed because `_coach_depenses_loyer` remained in secure storage after explicit null.
- `dart analyze lib/services/secure_wizard_store.dart test/services/wizard_expense_canonical_test.dart`
- `flutter test test/services/wizard_expense_canonical_test.dart test/services/report_persistence_service_test.dart test/providers/coach_profile_provider_field_path_bridge_test.dart test/providers/coach_profile_provider_save_fact_test.dart test/services/chat/fact_extraction_fallback_test.dart test/services/coach/report_persistence_premier_eclairage_test.dart test/wizard_test.dart --reporter expanded` (100 passed)
- `lefthook run pre-commit` (all applicable staged hooks green; memory-retention warning only)
- Claude CLI Opus audit: GO, no P0/P1 blockers.

## Notes
- Full `flutter analyze` remains red on 128 pre-existing issues outside the touched files; targeted analysis is green.
- No UI route/screen touched, so Maestro/Patrol runtime evidence is not applicable for this non-UI storage slice.
