### PR TITLE
G13: secure spouse wizard data

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -31,6 +31,16 @@ Spec drift audit:
 Code audit against a base branch:
 `tools/checks/claude_external_audit.sh code <base-branch>` when present;
 otherwise use `claude -p` with `git diff <base>...HEAD`.
+
+Default bounded diff audit:
+`claude -p --model opus --effort high --safe-mode --strict-mcp-config --mcp-config '{"mcpServers":{}}' --disable-slash-commands --no-session-persistence --permission-mode dontAsk --tools Read,Grep,Bash --add-dir <worktree>`
+
+Use `--effort max` only for a named final-release or unresolved P0/P1
+architecture dispute. Repeated re-audits of the same bounded diff should use
+Sonnet high first, then one Opus high final confirmation. This avoids paying
+full startup hooks, MCP servers, memory injection, skill inventory, and max
+reasoning on every tool turn. The currently installed Claude CLI does not expose
+`--max-turns`; keep prompts bounded and cite exact files/functions instead.
 </commands>
 
 <policy>

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -2786,12 +2786,15 @@ class CoachProfile {
     final partnerBirthYear = _parseInt(answers['q_partner_birth_year']);
     final spouseAvsContributionYears =
         _parseInt(answers['q_spouse_avs_contribution_years']);
-    final hasPartnerData = (partnerIncome != null && partnerIncome > 0) ||
-        partnerBirthYear != null ||
-        spouseAvsContributionYears != null ||
-        answers['q_spouse_avs_lacunes_status'] != null ||
-        answers['q_spouse_avs_arrival_year'] != null ||
-        answers['q_spouse_avs_years_abroad'] != null;
+    final isCoupledStatus = etatCivil == CoachCivilStatus.marie ||
+        etatCivil == CoachCivilStatus.concubinage;
+    final hasPartnerData = isCoupledStatus &&
+        ((partnerIncome != null && partnerIncome > 0) ||
+            partnerBirthYear != null ||
+            spouseAvsContributionYears != null ||
+            answers['q_spouse_avs_lacunes_status'] != null ||
+            answers['q_spouse_avs_arrival_year'] != null ||
+            answers['q_spouse_avs_years_abroad'] != null);
     if (hasPartnerData) {
       // Net -> Brut estimation: same social charges rate as main user
       final partnerBrut = partnerIncome != null && partnerIncome > 0
@@ -3065,9 +3068,14 @@ class CoachProfile {
   static CoachCivilStatus _parseCivilStatus(String? raw) {
     if (raw == null) return CoachCivilStatus.celibataire;
     switch (raw.toLowerCase()) {
+      case 'single':
+        return CoachCivilStatus.celibataire;
       case 'marie':
       case 'marié': // lint-ignore
       case 'married':
+      case 'couple':
+      case 'registered_partner':
+      case 'partenariat':
         return CoachCivilStatus.marie;
       case 'divorce':
       case 'divorcé': // lint-ignore
@@ -3078,7 +3086,9 @@ class CoachProfile {
       case 'widowed':
         return CoachCivilStatus.veuf;
       case 'concubinage':
-      case 'partenariat':
+      case 'concubine':
+      case 'family':
+      case 'cohabiting':
         return CoachCivilStatus.concubinage;
       default:
         return CoachCivilStatus.celibataire;

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -13,6 +13,7 @@ import 'package:mint_mobile/services/cap_memory_store.dart';
 import 'package:mint_mobile/services/coach/coach_cache_service.dart';
 import 'package:mint_mobile/services/coach_narrative_service.dart';
 import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:mint_mobile/services/secure_wizard_store.dart';
 import 'package:mint_mobile/services/sentry_breadcrumbs.dart';
 import 'package:mint_mobile/services/snapshot_service.dart';
 import 'package:mint_mobile/services/voice/voice_cursor_contract.dart'
@@ -61,6 +62,11 @@ class CoachProfileProvider extends ChangeNotifier {
   static const Map<String, List<String>> _qualityKeyAliases = {
     'q_housing_cost_period_chf': ['_coach_depenses_loyer'],
     'q_lamal_premium_monthly_chf': ['_coach_depenses_assurance'],
+  };
+
+  static const Set<String> _sensitivePartnerKeysToPurge = {
+    'q_partner_net_income_chf',
+    'q_partner_salary',
   };
 
   /// Le profil Coach construit a partir des reponses wizard.
@@ -542,6 +548,9 @@ class CoachProfileProvider extends ChangeNotifier {
     final current = await ReportPersistenceService.loadAnswers();
     final merged = Map<String, dynamic>.from(current)
       ..addAll(normalized.answers);
+    if (_isNonCoupledCivilStatus(normalized.answers['q_civil_status'])) {
+      _removePartnerAnswers(merged);
+    }
     if (bridgeMerge) {
       final profile = CoachProfile.fromWizardAnswers(merged);
       final timestamps = _stampTimestamps(
@@ -1135,13 +1144,13 @@ class CoachProfileProvider extends ChangeNotifier {
   }
 
   /// Replace the current profile with an updated one and persist via answers.
-  void updateProfile(CoachProfile updated) {
+  Future<void> updateProfile(CoachProfile updated) async {
     final previousStatus = _profile?.etatCivil;
     _profile = updated;
     _profileUpdatedSinceBudget = true;
     notifyListeners();
     // FIX-045: Persist ALL profile fields.
-    _persistFullProfile(updated);
+    await _persistFullProfile(updated);
     // FIX-HIGH-1: Invalidate coach cache on profile change (was never called).
     CoachCacheService.invalidate(InvalidationTrigger.profileUpdate);
     // Also invalidate daily narrative cache so greeting / topTip / scenarios
@@ -1162,18 +1171,14 @@ class CoachProfileProvider extends ChangeNotifier {
         previousStatus != updated.etatCivil &&
         updated.etatCivil != CoachCivilStatus.marie &&
         updated.etatCivil != CoachCivilStatus.concubinage) {
-      // FIX-097: Clear local household state on divorce (AWAITED).
-      // FIX-P0-1: Remove ALL partner/spouse keys to prevent ghost conjoint
-      // on app restart. Without this, fromWizardAnswers() recreates the spouse
-      // from stale SharedPreferences → AVS couple cap 150% applied to a single.
-      // FIX-P0-3: Was fire-and-forget → now awaited to guarantee cleanup before
-      // any subsequent read.
-      _awaitedDivorceCleanup();
+      // Wizard JSON spouse cleanup is handled in _persistFullProfile.
+      // This clears only legacy top-level household caches.
+      await _awaitedDivorceCleanup();
     }
   }
 
-  /// Awaited divorce cleanup — removes all partner/spouse keys from SharedPreferences.
-  /// Previously fire-and-forget (.then/.catchError), which could race with subsequent reads.
+  /// Awaited divorce cleanup — removes legacy top-level household cache keys.
+  /// Canonical wizard-answer cleanup happens in [_persistFullProfile].
   Future<void> _awaitedDivorceCleanup() async {
     try {
       final sp = await SharedPreferences.getInstance();
@@ -1218,9 +1223,13 @@ class CoachProfileProvider extends ChangeNotifier {
     if (profile.targetRetirementAge != null) {
       answers['q_target_retirement_age'] = profile.targetRetirementAge;
     }
+    final coupledStatus = profile.etatCivil == CoachCivilStatus.marie ||
+        profile.etatCivil == CoachCivilStatus.concubinage;
     // FIX-P0-2: Persist conjoint (spouse) data — was previously lost on restart.
     // fromWizardAnswers() reads these keys to rebuild ConjointProfile.
-    if (profile.conjoint != null) {
+    if (!coupledStatus || profile.conjoint == null) {
+      _removePartnerAnswers(answers);
+    } else {
       final c = profile.conjoint!;
       if (c.salaireBrutMensuel != null) {
         // Store as net (reverse the brut→net from fromWizardAnswers)
@@ -1251,6 +1260,41 @@ class CoachProfileProvider extends ChangeNotifier {
       }
     }
     await ReportPersistenceService.saveAnswers(answers);
+  }
+
+  static void _removePartnerAnswers(Map<String, dynamic> answers) {
+    final partnerKeys = answers.keys
+        .where((key) =>
+            key.startsWith('q_partner_') || key.startsWith('q_spouse_'))
+        .toList();
+
+    for (final key in partnerKeys) {
+      if (SecureWizardStore.isSensitive(key)) {
+        answers[key] = null;
+      } else {
+        answers.remove(key);
+      }
+    }
+
+    for (final key in _sensitivePartnerKeysToPurge) {
+      answers[key] = null;
+    }
+  }
+
+  static bool _isNonCoupledCivilStatus(dynamic value) {
+    final status = value
+        ?.toString()
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'[\u00e9\u00e8\u00ea\u00eb]'), 'e');
+    if (status == null || status.isEmpty) return false;
+    return status == 'celibataire' ||
+        status == 'single' ||
+        status == 'divorce' ||
+        status == 'divorced' ||
+        status == 'veuf' ||
+        status == 'veuve' ||
+        status == 'widowed';
   }
 
   /// W15: Create a financial snapshot from the current profile state.

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -23,6 +23,8 @@ class SecureWizardStore {
     'q_net_income_period_chf',
     'q_lpp_avoir',
     'q_3a_capital',
+    'q_partner_net_income_chf',
+    // Legacy spouse salary key kept so old encrypted copies can be purged.
     'q_partner_salary',
     'q_patrimoine_liquide',
     'q_dettes_total',

--- a/apps/mobile/test/providers/coach_profile_provider_save_fact_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_save_fact_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
@@ -9,9 +11,11 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final mockSecureStorage = <String, String>{};
+  final secureReadFailures = <String>{};
 
   setUp(() {
     mockSecureStorage.clear();
+    secureReadFailures.clear();
     SharedPreferences.setMockInitialValues({});
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(
@@ -24,6 +28,7 @@ void main() {
             if (key != null && value != null) mockSecureStorage[key] = value;
             return null;
           case 'read':
+            if (key != null && secureReadFailures.contains(key)) return null;
             return key == null ? null : mockSecureStorage[key];
           case 'delete':
             if (key != null) mockSecureStorage.remove(key);
@@ -109,6 +114,7 @@ void main() {
   test('save_fact spouse keys hydrate conjoint profile', () async {
     final profile = await profileAfterSaveFacts([
       const MapEntry('birthYear', 1980),
+      const MapEntry('householdType', 'married'),
       const MapEntry('spouseIncomeNetMonthly', 5500.0),
       const MapEntry('spouseBirthYear', 1982),
       const MapEntry('spouseAvsContributionYears', 22),
@@ -120,10 +126,127 @@ void main() {
     expect(profile.conjoint!.prevoyance!.anneesContribuees, 22);
   });
 
+  test('save_fact coupled wizard statuses hydrate conjoint profile', () async {
+    const statuses = {
+      'couple': CoachCivilStatus.marie,
+      'concubine': CoachCivilStatus.concubinage,
+      'family': CoachCivilStatus.concubinage,
+      'cohabiting': CoachCivilStatus.concubinage,
+      'registered_partner': CoachCivilStatus.marie,
+    };
+
+    for (final entry in statuses.entries) {
+      SharedPreferences.setMockInitialValues({});
+      mockSecureStorage.clear();
+
+      final profile = await profileAfterSaveFacts([
+        const MapEntry('birthYear', 1980),
+        MapEntry('householdType', entry.key),
+        const MapEntry('spouseBirthYear', 1982),
+      ]);
+
+      expect(profile.etatCivil, entry.value, reason: entry.key);
+      expect(profile.conjoint, isNotNull, reason: entry.key);
+      expect(profile.conjoint!.birthYear, 1982, reason: entry.key);
+    }
+  });
+
+  test('save_fact spouse income is stored only in secure storage', () async {
+    await profileAfterSaveFacts([
+      const MapEntry('birthYear', 1980),
+      const MapEntry('spouseIncomeNetMonthly', 5500.0),
+    ]);
+
+    final prefs = await SharedPreferences.getInstance();
+    final rawAnswers = prefs.getString('wizard_answers_v2');
+
+    expect(rawAnswers, contains('"q_partner_net_income_chf":"__secure__"'));
+    expect(rawAnswers, isNot(contains('5500')));
+    expect(mockSecureStorage['q_partner_net_income_chf'], '5500.0');
+  });
+
+  test('divorce profile update purges stale spouse answers and secure values',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+    expect(
+        await provider.applySaveFact('spouseIncomeNetMonthly', 5500.0), isTrue);
+    expect(await provider.applySaveFact('spouseBirthYear', 1982), isTrue);
+    expect(
+        await provider.applySaveFact('spouseAvsContributionYears', 22), isTrue);
+    mockSecureStorage['q_partner_salary'] = '9999';
+
+    await provider.updateProfile(
+      provider.profile!.copyWith(etatCivil: CoachCivilStatus.divorce),
+    );
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    expect(persisted['q_civil_status'], 'divorce');
+    expect(persisted['q_partner_net_income_chf'], isNull);
+    expect(persisted.containsKey('q_partner_birth_year'), isFalse);
+    expect(persisted.containsKey('q_spouse_avs_contribution_years'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_net_income_chf'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_salary'), isFalse);
+
+    await ReportPersistenceService.setMiniOnboardingCompleted(true);
+    final reloaded = CoachProfileProvider();
+    await reloaded.loadFromWizard();
+
+    expect(reloaded.profile, isNotNull);
+    expect(reloaded.profile!.etatCivil, CoachCivilStatus.divorce);
+    expect(reloaded.profile!.conjoint, isNull);
+  });
+
+  test('save_fact divorce purges stale spouse answers and secure values',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+    expect(await provider.applySaveFact('householdType', 'married'), isTrue);
+    expect(
+        await provider.applySaveFact('spouseIncomeNetMonthly', 5500.0), isTrue);
+    expect(await provider.applySaveFact('spouseBirthYear', 1982), isTrue);
+    expect(
+        await provider.applySaveFact('spouseAvsContributionYears', 22), isTrue);
+    final prefs = await SharedPreferences.getInstance();
+    final rawAnswers = prefs.getString('wizard_answers_v2')!;
+    final answersWithoutSecurePlaceholder =
+        Map<String, dynamic>.from(jsonDecode(rawAnswers) as Map)
+          ..remove('q_partner_net_income_chf');
+    await prefs.setString(
+      'wizard_answers_v2',
+      jsonEncode(answersWithoutSecurePlaceholder),
+    );
+    expect(mockSecureStorage['q_partner_net_income_chf'], '5500.0');
+    secureReadFailures.add('q_partner_net_income_chf');
+    mockSecureStorage['q_partner_salary'] = '9999';
+
+    expect(await provider.applySaveFact('householdType', 'divorced'), isTrue);
+    secureReadFailures.clear();
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    expect(persisted['q_civil_status'], 'divorced');
+    expect(persisted['q_partner_net_income_chf'], isNull);
+    expect(persisted.containsKey('q_partner_birth_year'), isFalse);
+    expect(persisted.containsKey('q_spouse_avs_contribution_years'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_net_income_chf'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_salary'), isFalse);
+    expect(provider.profile!.etatCivil, CoachCivilStatus.divorce);
+    expect(provider.profile!.conjoint, isNull);
+
+    await ReportPersistenceService.setMiniOnboardingCompleted(true);
+    final reloaded = CoachProfileProvider();
+    await reloaded.loadFromWizard();
+
+    expect(reloaded.profile, isNotNull);
+    expect(reloaded.profile!.etatCivil, CoachCivilStatus.divorce);
+    expect(reloaded.profile!.conjoint, isNull);
+  });
+
   test('save_fact spouse identity and AVS keys hydrate without spouse income',
       () async {
     final profile = await profileAfterSaveFacts([
       const MapEntry('birthYear', 1980),
+      const MapEntry('householdType', 'married'),
       const MapEntry('spouseBirthYear', 1982),
       const MapEntry('spouseAvsContributionYears', 22),
     ]);
@@ -153,7 +276,8 @@ void main() {
     }
   });
 
-  test('save_fact self-employed income clears stale gross salary only when safe',
+  test(
+      'save_fact self-employed income clears stale gross salary only when safe',
       () async {
     final independent = await profileAfterSaveFacts([
       const MapEntry('birthYear', 1985),

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -61,7 +61,7 @@ Every product PR must list:
 
 | Tool | Status in clean checkout | Gate use |
 |---|---|---|
-| Claude CLI | Available after local login | External audit |
+| Claude CLI | Available after local login | External audit; use bounded audits (`opus high`, safe mode, strict empty MCP) by default |
 | Engram MCP | Available | Memory |
 | Maestro | Available at `~/.maestro/bin/maestro` | Runtime UI proof |
 | Patrol CLI | Not in PATH at G0 base restore | Required gap before Patrol-only gates |
@@ -78,3 +78,9 @@ MINT work must converge on this chain:
 No service without a caller, no route without a degraded state, no projection
 without range + confidence + source/freshness, and no data collection that asks
 again for a fresh known fact.
+
+Claude CLI audits should be bounded by default: provide the diff, exact
+acceptance criteria, and relevant contract snippets; run Opus at `--effort high`
+with safe mode and empty MCP unless a named final-release/P0 dispute justifies
+`--effort max`. Re-run loops use Sonnet high first, then one Opus high final
+confirmation.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -87,7 +87,9 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
 **Identity**
 - `q_firstname` (str), `q_birth_year` (int), `q_date_of_birth` (ISO str),
   `q_canton` (2-letter, default `ZH`), `q_civil_status`
-  (celibataire/marie/concubinage/divorce/veuf), `q_children` (int),
+  (celibataire/marie/concubinage/divorce/veuf; save_fact aliases:
+  single → celibataire, couple → marie, concubine/family → concubinage),
+  `q_children` (int),
   `q_gender`, `q_commune`
 
 **Income**
@@ -96,7 +98,8 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
   `q_gross_salary_annual` (preferred when known — avoids net↔brut roundtrip),
   `q_employment_status` (salarie/independant/retraite/etc.),
   `q_employment_rate` (%), `q_annual_bonus` (CHF),
-  `q_self_employed_net_income` (CHF/year), `q_partner_net_income_chf`,
+  `q_self_employed_net_income` (CHF/year), `q_partner_net_income_chf`
+  (CHF/month, sensitive; encrypted by `SecureWizardStore`),
   `q_partner_birth_year`, `q_partner_employment_status`
 
 **Housing & fixed charges**


### PR DESCRIPTION
## Summary
- Encrypt `q_partner_net_income_chf` through `SecureWizardStore` instead of clear wizard JSON.
- Purge stale `q_partner_*` / `q_spouse_*` values and secure copies when status becomes non-coupled.
- Align `householdType` aliases with backend contract, including `family` as coupled/two-adult household.
- Document bounded Claude CLI audit defaults to avoid repeated slow max-effort sessions.

## QA
- `flutter test test/providers/coach_profile_provider_save_fact_test.dart test/providers/coach_profile_provider_field_path_bridge_test.dart test/services/wizard_expense_canonical_test.dart test/services/report_persistence_service_test.dart test/wizard_test.dart --reporter expanded` ✅ 80 tests
- `flutter test test/services/chat/fact_extraction_fallback_test.dart test/services/coach/report_persistence_premier_eclairage_test.dart --reporter expanded` ✅ 24 tests
- `flutter analyze lib/models/coach_profile.dart lib/providers/coach_profile_provider.dart lib/services/secure_wizard_store.dart test/providers/coach_profile_provider_save_fact_test.dart lib/screens/mortgage/affordability_screen.dart lib/screens/arbitrage/rente_vs_capital_screen.dart lib/screens/lpp_deep/rachat_echelonne_screen.dart lib/screens/lpp_deep/epl_screen.dart lib/screens/coach/retirement_dashboard_screen.dart lib/screens/simulator_3a_screen.dart lib/screens/pillar_3a_deep/retroactive_3a_screen.dart` ✅
- `lefthook run pre-commit` ✅
- Claude Opus bounded external audit ✅ PASS, no P0/P1

## Known Baseline
- Full `flutter analyze` still fails on 128 pre-existing issues outside this slice; targeted changed/callsite analyze is green.

Stacked on G12.
