### PR TITLE
G15: guard spouse facts by household context

### DIFF
--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -44,6 +44,23 @@ python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract
 python3 -m pytest tools/checks/tests/test_screen_contracts_route_contract.py -q
 ```
 
+For external Claude CLI audits, use the checked-in wrapper, not raw `claude`
+commands:
+
+```bash
+tools/checks/claude_external_audit.sh code <base-ref>
+tools/checks/claude_external_audit.sh specs
+tools/checks/claude_external_audit.sh architecture
+```
+
+The wrapper defaults to Opus high, safe mode, strict empty MCP, disabled slash
+commands, no session persistence, bounded tools, and dynamic-system-prompt
+sections excluded. Repeated re-audits of the same gate should use
+`CLAUDE_AUDIT_MODEL=sonnet` for Sonnet high first, then one Opus high final
+confirmation.
+`--effort max` requires an explicit final-release/P0 exception; do not add
+`--max-turns` because the installed Claude CLI does not expose that flag.
+
 ## Roadmap Gates Not Installed At G0
 
 These names may appear in older plans, but they are not checked-in gates until
@@ -53,7 +70,6 @@ the files exist in this checkout:
 - `tools/checks/phase_contract_guard.py`
 - `tools/checks/mint_rules_guard.py`
 - `tools/checks/verify_phase_acceptance.py`
-- `tools/checks/claude_external_audit.sh`
 
 Missing guard scripts are workflow gaps, not silent passes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ Use what exists, and record missing tools instead of pretending they ran.
 
 - **Feature flags / kill switches** → every new product path must be disableable
 - **Lefthook** → memory retention, map freshness hints, ARB parity
+- **Claude external audits** → always run through
+  `tools/checks/claude_external_audit.sh`; default Opus high is bounded, same
+  gate re-runs use Sonnet high first, and `--effort max` is an explicit
+  final-release/P0 exception only.
 - **Daily loop roadmap** → morning sim walk + Sentry pull + auto-PR
   on P0/P1. **The mechanism that catches « an agent broke something
   overnight ».** Mandatory for solo-dev + AI workflow.

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart' show BuildContext;
 import 'package:provider/provider.dart';
@@ -47,6 +49,8 @@ class CoachProfileProvider extends ChangeNotifier {
   List<Map<String, dynamic>> _scoreHistory = [];
   bool _profileUpdatedSinceBudget = false;
   bool _mergingFromFieldPathBridge = false;
+  Future<void>? _mergeAnswersLock;
+  final Map<String, dynamic> _pendingPartnerAnswers = {};
   Map<String, dynamic> _lastAnswers = const {};
 
   static const Map<String, String> _fieldPathAnswerKeys = {
@@ -532,46 +536,70 @@ class CoachProfileProvider extends ChangeNotifier {
   /// overwriting the rest of the profile.
   Future<void> mergeAnswers(Map<String, dynamic> partial) async {
     if (partial.isEmpty) return;
-    final normalized = _normalizeMergeAnswers(partial);
-    if (normalized.answers.isEmpty) return;
-    final bridgeMerge = normalized.fieldPaths.isNotEmpty;
-    if (bridgeMerge && _mergingFromFieldPathBridge) return;
-    // Deep-walk crack #15: always re-read the on-disk answers before
-    // merging. `_lastAnswers` is populated at startup by loadFromWizard
-    // but updateFrom*Extraction / budget setup / regex fallback each
-    // load+save independently. If mergeAnswers relied on the stale
-    // in-memory copy, a budget setup that ran after a scan would build
-    // `merged` from {} + {q_housing, q_lamal} and overwrite the persisted
-    // `_coach_avoir_lpp` on disk — card Patrimoine would go empty right
-    // after the card Budget populated. Read-then-merge-then-save is the
-    // only crash-safe discipline.
-    final current = await ReportPersistenceService.loadAnswers();
-    final merged = Map<String, dynamic>.from(current)
-      ..addAll(normalized.answers);
-    if (_isNonCoupledCivilStatus(normalized.answers['q_civil_status'])) {
-      _removePartnerAnswers(merged);
+    while (_mergeAnswersLock != null) {
+      await _mergeAnswersLock;
     }
-    if (bridgeMerge) {
-      final profile = CoachProfile.fromWizardAnswers(merged);
-      final timestamps = _stampTimestamps(
-        profile.dataTimestamps,
-        normalized.fieldPaths,
-      );
-      _persistTimestamps(merged, timestamps);
-    }
-    _lastAnswers = merged;
-    _profile = CoachProfile.fromWizardAnswers(merged);
-    _isLoaded = true;
-    _profileUpdatedSinceBudget = true;
-    await ReportPersistenceService.saveAnswers(merged);
-    CoachNarrativeService.invalidateCache(profile: _profile);
-    if (bridgeMerge) _mergingFromFieldPathBridge = true;
+
+    final completer = Completer<void>();
+    _mergeAnswersLock = completer.future;
     try {
-      notifyListeners();
+      final normalized = _normalizeMergeAnswers(partial);
+      if (normalized.answers.isEmpty) return;
+      final bridgeMerge = normalized.fieldPaths.isNotEmpty;
+      if (bridgeMerge && _mergingFromFieldPathBridge) return;
+      // Deep-walk crack #15: always re-read the on-disk answers before
+      // merging. `_lastAnswers` is populated at startup by loadFromWizard
+      // but updateFrom*Extraction / budget setup / regex fallback each
+      // load+save independently. If mergeAnswers relied on the stale
+      // in-memory copy, a budget setup that ran after a scan would build
+      // `merged` from {} + {q_housing, q_lamal} and overwrite the persisted
+      // `_coach_avoir_lpp` on disk — card Patrimoine would go empty right
+      // after the card Budget populated. Read-then-merge-then-save is the
+      // only crash-safe discipline.
+      final current = await ReportPersistenceService.loadAnswers();
+      final merged = Map<String, dynamic>.from(current)
+        ..addAll(normalized.answers);
+      final hasIncomingPartnerAnswers =
+          _containsPartnerAnswers(normalized.answers);
+      if (_isNonCoupledCivilStatus(merged['q_civil_status'])) {
+        _pendingPartnerAnswers.clear();
+        _removePartnerAnswers(merged);
+      } else if (hasIncomingPartnerAnswers &&
+          !_isCoupledCivilStatus(merged['q_civil_status'])) {
+        _pendingPartnerAnswers
+          ..clear()
+          ..addAll(_partnerAnswersOnly(normalized.answers));
+        _removePartnerAnswers(merged);
+      } else if (_pendingPartnerAnswers.isNotEmpty &&
+          _isCoupledCivilStatus(merged['q_civil_status'])) {
+        merged.addAll(_pendingPartnerAnswers);
+        _pendingPartnerAnswers.clear();
+      }
+      if (bridgeMerge) {
+        final profile = CoachProfile.fromWizardAnswers(merged);
+        final timestamps = _stampTimestamps(
+          profile.dataTimestamps,
+          normalized.fieldPaths,
+        );
+        _persistTimestamps(merged, timestamps);
+      }
+      _lastAnswers = merged;
+      _profile = CoachProfile.fromWizardAnswers(merged);
+      _isLoaded = true;
+      _profileUpdatedSinceBudget = true;
+      await ReportPersistenceService.saveAnswers(merged);
+      CoachNarrativeService.invalidateCache(profile: _profile);
+      if (bridgeMerge) _mergingFromFieldPathBridge = true;
+      try {
+        notifyListeners();
+      } finally {
+        if (bridgeMerge) _mergingFromFieldPathBridge = false;
+      }
+      _syncToBackend(); // Fire-and-forget, does not block UI
     } finally {
-      if (bridgeMerge) _mergingFromFieldPathBridge = false;
+      _mergeAnswersLock = null;
+      completer.complete();
     }
-    _syncToBackend(); // Fire-and-forget, does not block UI
   }
 
   static _NormalizedMergeAnswers _normalizeMergeAnswers(
@@ -1281,12 +1309,26 @@ class CoachProfileProvider extends ChangeNotifier {
     }
   }
 
+  static bool _containsPartnerAnswers(Map<String, dynamic> answers) {
+    return answers.keys.any(
+      (key) => key.startsWith('q_partner_') || key.startsWith('q_spouse_'),
+    );
+  }
+
+  static Map<String, dynamic> _partnerAnswersOnly(
+    Map<String, dynamic> answers,
+  ) {
+    return Map.fromEntries(
+      answers.entries.where(
+        (entry) =>
+            entry.key.startsWith('q_partner_') ||
+            entry.key.startsWith('q_spouse_'),
+      ),
+    );
+  }
+
   static bool _isNonCoupledCivilStatus(dynamic value) {
-    final status = value
-        ?.toString()
-        .trim()
-        .toLowerCase()
-        .replaceAll(RegExp(r'[\u00e9\u00e8\u00ea\u00eb]'), 'e');
+    final status = _normalizedCivilStatusToken(value);
     if (status == null || status.isEmpty) return false;
     return status == 'celibataire' ||
         status == 'single' ||
@@ -1295,6 +1337,28 @@ class CoachProfileProvider extends ChangeNotifier {
         status == 'veuf' ||
         status == 'veuve' ||
         status == 'widowed';
+  }
+
+  static bool _isCoupledCivilStatus(dynamic value) {
+    final status = _normalizedCivilStatusToken(value);
+    if (status == null || status.isEmpty) return false;
+    return status == 'marie' ||
+        status == 'married' ||
+        status == 'couple' ||
+        status == 'registered_partner' ||
+        status == 'partenariat' ||
+        status == 'concubinage' ||
+        status == 'concubine' ||
+        status == 'family' ||
+        status == 'cohabiting';
+  }
+
+  static String? _normalizedCivilStatusToken(dynamic value) {
+    return value
+        ?.toString()
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'[\u00e9\u00e8\u00ea\u00eb]'), 'e');
   }
 
   /// W15: Create a financial snapshot from the current profile state.

--- a/apps/mobile/test/providers/coach_profile_provider_save_fact_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_save_fact_test.dart
@@ -154,6 +154,7 @@ void main() {
   test('save_fact spouse income is stored only in secure storage', () async {
     await profileAfterSaveFacts([
       const MapEntry('birthYear', 1980),
+      const MapEntry('householdType', 'married'),
       const MapEntry('spouseIncomeNetMonthly', 5500.0),
     ]);
 
@@ -163,6 +164,119 @@ void main() {
     expect(rawAnswers, contains('"q_partner_net_income_chf":"__secure__"'));
     expect(rawAnswers, isNot(contains('5500')));
     expect(mockSecureStorage['q_partner_net_income_chf'], '5500.0');
+  });
+
+  test('save_fact concurrent household and spouse facts keep spouse data',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+
+    final results = await Future.wait([
+      provider.applySaveFact('householdType', 'married'),
+      provider.applySaveFact('spouseIncomeNetMonthly', 5500.0),
+    ]);
+
+    final prefs = await SharedPreferences.getInstance();
+    final persisted = await ReportPersistenceService.loadAnswers();
+    final rawAnswers = prefs.getString('wizard_answers_v2')!;
+
+    expect(results, everyElement(isTrue));
+    expect(persisted['q_civil_status'], 'married');
+    expect(persisted['q_partner_net_income_chf'], 5500.0);
+    expect(rawAnswers, contains('"q_partner_net_income_chf":"__secure__"'));
+    expect(rawAnswers, isNot(contains('5500')));
+    expect(mockSecureStorage['q_partner_net_income_chf'], '5500.0');
+    expect(provider.profile!.etatCivil, CoachCivilStatus.marie);
+    expect(provider.profile!.conjoint, isNotNull);
+    expect(
+      provider.profile!.conjoint!.salaireBrutMensuel,
+      closeTo(6321.84, 0.01),
+    );
+  });
+
+  test('save_fact spouse before household keeps pending spouse data', () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+
+    final results = await Future.wait([
+      provider.applySaveFact('spouseIncomeNetMonthly', 5500.0),
+      provider.applySaveFact('householdType', 'married'),
+    ]);
+
+    final prefs = await SharedPreferences.getInstance();
+    final persisted = await ReportPersistenceService.loadAnswers();
+    final rawAnswers = prefs.getString('wizard_answers_v2')!;
+
+    expect(results, everyElement(isTrue));
+    expect(persisted['q_civil_status'], 'married');
+    expect(persisted['q_partner_net_income_chf'], 5500.0);
+    expect(rawAnswers, contains('"q_partner_net_income_chf":"__secure__"'));
+    expect(rawAnswers, isNot(contains('5500')));
+    expect(provider.profile!.etatCivil, CoachCivilStatus.marie);
+    expect(provider.profile!.conjoint, isNotNull);
+  });
+
+  test(
+      'save_fact spouse income without coupled status purges stale spouse data',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+
+    final prefs = await SharedPreferences.getInstance();
+    mockSecureStorage['q_partner_net_income_chf'] = '5500.0';
+    mockSecureStorage['q_partner_salary'] = '9999';
+    await prefs.setString(
+      'wizard_answers_v2',
+      jsonEncode({
+        'q_birth_year': 1980,
+        'q_partner_net_income_chf': '__secure__',
+        'q_partner_birth_year': 1982,
+        'q_spouse_avs_contribution_years': 22,
+      }),
+    );
+
+    expect(
+        await provider.applySaveFact('spouseIncomeNetMonthly', 6200.0), isTrue);
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    final rawAnswers = prefs.getString('wizard_answers_v2')!;
+
+    expect(rawAnswers, isNot(contains('6200')));
+    expect(rawAnswers, isNot(contains('5500')));
+    expect(rawAnswers, isNot(contains('__secure__')));
+    expect(persisted['q_partner_net_income_chf'], isNull);
+    expect(persisted.containsKey('q_partner_birth_year'), isFalse);
+    expect(persisted.containsKey('q_spouse_avs_contribution_years'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_net_income_chf'), isFalse);
+    expect(mockSecureStorage.containsKey('q_partner_salary'), isFalse);
+    expect(provider.profile!.etatCivil, CoachCivilStatus.celibataire);
+    expect(provider.profile!.conjoint, isNull);
+  });
+
+  test('save_fact non-coupled persisted status clears pending spouse data',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+    expect(
+        await provider.applySaveFact('spouseIncomeNetMonthly', 5500.0), isTrue);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'wizard_answers_v2',
+      jsonEncode({
+        'q_birth_year': 1980,
+        'q_civil_status': 'divorced',
+      }),
+    );
+
+    expect(await provider.applySaveFact('incomeGrossYearly', 120000.0), isTrue);
+    expect(await provider.applySaveFact('householdType', 'married'), isTrue);
+
+    final persisted = await ReportPersistenceService.loadAnswers();
+    expect(persisted['q_civil_status'], 'married');
+    expect(persisted['q_partner_net_income_chf'], isNull);
+    expect(mockSecureStorage.containsKey('q_partner_net_income_chf'), isFalse);
+    expect(provider.profile!.conjoint?.salaireBrutMensuel, isNull);
   });
 
   test('divorce profile update purges stale spouse answers and secure values',

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -185,6 +185,17 @@ wizard keys.
 **Spouse**: `spouseBirthYear`, `spouseIncomeNetMonthly`,
 `spouseAvsContributionYears`
 
+Spouse `save_fact` keys are retained only when `q_civil_status` is already a
+coupled status (`marie`, `married`, `couple`, `registered_partner`,
+`partenariat`, `concubinage`, `concubine`, `family`, `cohabiting`). If a spouse
+fact arrives before the household status is known, `CoachProfileProvider`
+treats it as orphaned spouse payload and purges `q_partner_*` / `q_spouse_*`
+answers plus encrypted spouse copies. If spouse facts arrive before
+`householdType`, the provider keeps them only as in-memory pending facts; they
+are persisted only if a later same-session merge establishes a coupled
+`householdType`. Data Quest must still collect or emit `householdType` before
+spouse-specific values.
+
 **AVS**: `hasAvsGaps`, `avsContributionYears`
 
 **⚠ Trap.** Adding a new canonical key to the backend whitelist without

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -8,6 +8,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
+AGENTS = ROOT / "AGENTS.md"
+OPERATING_GATES = ROOT / ".claude/skills/mint-operating-gates/SKILL.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
 
 
@@ -118,6 +120,8 @@ def test_specs_and_architecture_prompts_are_wired() -> None:
 def test_auditor_docs_point_to_wrapper_policy() -> None:
     for text in (
         AGENT.read_text(encoding="utf-8"),
+        AGENTS.read_text(encoding="utf-8"),
+        OPERATING_GATES.read_text(encoding="utf-8"),
         WORKFLOW.read_text(encoding="utf-8"),
     ):
         lowered = text.lower()
@@ -125,3 +129,10 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "opus high" in lowered
         assert "Sonnet high" in text
         assert "--effort max" in text
+
+
+def test_operating_gates_do_not_mark_claude_wrapper_missing() -> None:
+    text = OPERATING_GATES.read_text(encoding="utf-8")
+
+    assert "For external Claude CLI audits" in text
+    assert "- `tools/checks/claude_external_audit.sh`" not in text


### PR DESCRIPTION
## Summary
- serialize `CoachProfileProvider.mergeAnswers` so concurrent save_fact writes cannot clobber each other
- keep spouse/partner facts memory-only until a coupled `householdType` exists, and purge stale spouse secure values for non-coupled contexts
- codify bounded Claude external-audit policy in AGENTS/operating gates and contract tests

## QA
- flutter test test/providers/coach_profile_provider_save_fact_test.dart --reporter expanded
- flutter test test/providers --reporter compact
- flutter analyze lib/providers/coach_profile_provider.dart test/providers/coach_profile_provider_save_fact_test.dart
- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q
- python3 tools/checks/arb_parity.py
- ./tools/mint-routes reconcile
- git diff --check
- lefthook run pre-commit
- CLAUDE_AUDIT_MODEL=opus CLAUDE_AUDIT_EFFORT=high tools/checks/claude_external_audit.sh code HEAD -> PASS

## Notes
- Claude PASS returned no P0/P1. Residual P2: Data Quest ordering should get an explicit sequencing test before production reliance.
