### PR TITLE
Tools: bound Claude external audits

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -21,16 +21,27 @@ and force resolution of critical/high issues before phase acceptance.
 
 <commands>
 Architecture/spec audit:
-`tools/checks/claude_external_audit.sh architecture` when present; otherwise
-use `claude -p` with the relevant diff and docs.
+`tools/checks/claude_external_audit.sh architecture`.
 
 Spec drift audit:
-`tools/checks/claude_external_audit.sh specs` when present; otherwise use
-`claude -p` with the five `docs/codex/` specs and code evidence.
+`tools/checks/claude_external_audit.sh specs`.
 
 Code audit against a base branch:
-`tools/checks/claude_external_audit.sh code <base-branch>` when present;
-otherwise use `claude -p` with `git diff <base>...HEAD`.
+`tools/checks/claude_external_audit.sh code <base-branch>`.
+
+The wrapper is the default. It runs Claude CLI with Opus high, safe mode,
+strict empty MCP, disabled slash commands, no session persistence, bounded
+tools, and dynamic-system-prompt sections excluded for cache stability.
+
+Use `--effort max` only for named final-release/P0 disputes. Repeated re-audits of the same bounded diff should use
+Sonnet high first, then one Opus high final confirmation. This avoids paying
+full startup hooks, MCP servers, memory injection, skill inventory, and max
+reasoning on every tool turn.
+
+Do not add `--max-turns`: the installed Claude CLI does not expose it, and the
+wrapper rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not
+use `--bare` by default: it skips OAuth/keychain auth and only works with
+explicit API-key/apiKeyHelper auth.
 </commands>
 
 <policy>

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -61,7 +61,7 @@ Every product PR must list:
 
 | Tool | Status in clean checkout | Gate use |
 |---|---|---|
-| Claude CLI | Available after local login | External audit |
+| Claude CLI | Available after local login | External audit via `tools/checks/claude_external_audit.sh`; use bounded audits (`opus high`, safe mode, strict empty MCP) by default |
 | Engram MCP | Available | Memory |
 | Maestro | Available at `~/.maestro/bin/maestro` | Runtime UI proof |
 | Patrol CLI | Not in PATH at G0 base restore | Required gap before Patrol-only gates |
@@ -78,3 +78,10 @@ MINT work must converge on this chain:
 No service without a caller, no route without a degraded state, no projection
 without range + confidence + source/freshness, and no data collection that asks
 again for a fresh known fact.
+
+Claude CLI audits should be bounded through
+`tools/checks/claude_external_audit.sh`: Opus high by default, strict empty MCP,
+no session persistence, and no `--effort max` except named final-release/P0
+disputes. Re-run loops use Sonnet high first, then one Opus high final; do not
+use `--bare` without explicit API-key auth, and do not add unsupported
+`--max-turns`.

--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/checks/claude_external_audit.sh code <base-ref>
+  tools/checks/claude_external_audit.sh specs
+  tools/checks/claude_external_audit.sh architecture
+
+Env: CLAUDE_AUDIT_MODEL, CLAUDE_AUDIT_EFFORT, CLAUDE_AUDIT_ALLOW_MAX,
+CLAUDE_AUDIT_WORKTREE, CLAUDE_AUDIT_BARE, CLAUDE_AUDIT_SETTINGS,
+CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_DRY_RUN.
+EOF
+}
+die() {
+  echo "claude_external_audit: $*" >&2
+  exit 2
+}
+mode="${1:-}"
+case "$mode" in
+  -h|--help|"")
+    usage
+    exit 0
+    ;;
+  code|specs|architecture)
+    ;;
+  *)
+    usage >&2
+    die "unknown mode '$mode'"
+    ;;
+esac
+[[ -n "${CLAUDE_AUDIT_MAX_TURNS:-}" ]] && die "CLAUDE_AUDIT_MAX_TURNS is not supported by the installed Claude CLI; bound the prompt instead"
+model="${CLAUDE_AUDIT_MODEL:-opus}"
+effort="${CLAUDE_AUDIT_EFFORT:-high}"
+case "$effort" in low|medium|high|xhigh|max) ;; *) die "unsupported effort '$effort'" ;; esac
+if [[ "$effort" == "max" && "${CLAUDE_AUDIT_ALLOW_MAX:-}" != "1" ]]; then
+  die "refusing --effort max without CLAUDE_AUDIT_ALLOW_MAX=1; use high for bounded PR audits"
+fi
+repo_root="$(git rev-parse --show-toplevel)"
+worktree="${CLAUDE_AUDIT_WORKTREE:-$repo_root}"
+prompt_file="$(mktemp "${TMPDIR:-/tmp}/mint-claude-audit.XXXXXX")"
+trap 'rm -f "$prompt_file"' EXIT
+write_header() {
+  local audit_mode="$1"
+  cat >"$prompt_file" <<EOF
+You are the MINT external auditor.
+
+Audit mode: ${audit_mode}
+Repo root: ${repo_root}
+
+Hard rules:
+- Treat checked-in code and tests as source of truth; do not trust docs blindly.
+- Return exactly one verdict: PASS or NO-GO.
+- Findings must be grouped as P0/P1/P2 with file:line evidence when possible.
+- P0/P1 findings must include a concrete reproduction or code path.
+- Ignore speculative rewrites; focus on correctness, privacy, compliance, routing, tests, and facade-without-wiring risks.
+- If evidence is missing, say what command or file would prove it.
+
+EOF
+}
+
+case "$mode" in
+  code)
+    base_ref="${2:-}"
+    [[ -n "$base_ref" ]] || die "code mode requires a base ref"
+    write_header "code"
+    {
+      echo "Base ref: ${base_ref}"
+      echo
+      echo "Current branch/status:"
+      echo '```text'
+      git -C "$repo_root" status --short --branch
+      echo '```'
+      echo
+      echo "Diff stat:"
+      echo '```text'
+      git -C "$repo_root" diff --stat "${base_ref}...HEAD"
+      echo '```'
+      echo
+      echo "Full diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --no-ext-diff --unified=80 "${base_ref}...HEAD"
+      echo '```'
+      echo
+      echo "Staged worktree diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --cached --no-ext-diff --unified=80
+      echo '```'
+      echo
+      echo "Unstaged worktree diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --no-ext-diff --unified=80
+      echo '```'
+    } >>"$prompt_file"
+    ;;
+  specs)
+    write_header "specs"
+    cat >>"$prompt_file" <<'EOF'
+Audit the five executable specs under docs/codex/ against live repo code:
+- DATA_LEDGER.md
+- SCREEN_CONTRACTS.md
+- WIRING_GRAPH.mmd
+- DATA_QUEST.md
+- MAESTRO_FLOWS.md
+
+Start with WIRING_GRAPH.mmd invariants. For each cited file:line, API, route,
+key, and invariant, classify verified / obsolete / false with code evidence.
+EOF
+    ;;
+  architecture)
+    write_header "architecture"
+    cat >>"$prompt_file" <<'EOF'
+Audit the current architecture decision or phase evidence. Read AGENTS.md,
+CLAUDE.md, docs/MINT_AGENT_WORKFLOW.md, and the files referenced by the
+caller. Challenge docs against live code and report unresolved P0/P1 risks.
+EOF
+    ;;
+esac
+
+claude_args=(-p --model "$model" --effort "$effort" --safe-mode
+  --strict-mcp-config --mcp-config '{"mcpServers":{}}'
+  --disable-slash-commands --no-session-persistence
+  --permission-mode dontAsk --tools Read,Grep,Bash --add-dir "$worktree"
+  --exclude-dynamic-system-prompt-sections)
+
+[[ -n "${CLAUDE_AUDIT_MAX_BUDGET_USD:-}" ]] && claude_args+=(--max-budget-usd "$CLAUDE_AUDIT_MAX_BUDGET_USD")
+[[ -n "${CLAUDE_AUDIT_SETTINGS:-}" ]] && claude_args+=(--settings "$CLAUDE_AUDIT_SETTINGS")
+
+if [[ "${CLAUDE_AUDIT_BARE:-}" == "1" ]]; then
+  if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${CLAUDE_AUDIT_SETTINGS:-}" ]]; then
+    die "--bare skips OAuth/keychain; set ANTHROPIC_API_KEY or CLAUDE_AUDIT_SETTINGS with apiKeyHelper"
+  fi
+  claude_args+=(--bare)
+fi
+
+if [[ "${CLAUDE_AUDIT_DRY_RUN:-}" == "1" ]]; then
+  # CI validates this path; live Claude auth/flag drift is checked by reviewers.
+  printf 'claude'
+  printf ' %q' "${claude_args[@]}"
+  printf '\n'
+  echo '--- PROMPT_BEGIN ---'
+  cat "$prompt_file"
+  echo '--- PROMPT_END ---'
+  exit 0
+fi
+
+claude "${claude_args[@]}" <"$prompt_file"

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -1,0 +1,127 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
+AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
+WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
+
+
+def _run(*args: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_wrapper_is_syntax_valid_and_executable() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert os.access(SCRIPT, os.X_OK)
+
+
+def test_wrapper_defaults_are_bounded() -> None:
+    result = _run("code", "HEAD", CLAUDE_AUDIT_DRY_RUN="1")
+
+    assert result.returncode == 0, result.stderr
+    for needle in (
+        "--model opus",
+        "--effort high",
+        "--safe-mode",
+        "--strict-mcp-config",
+        r"\{\"mcpServers\":\{\}\}",
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--permission-mode dontAsk",
+        "--tools Read\\,Grep\\,Bash",
+        "--exclude-dynamic-system-prompt-sections",
+        "--- PROMPT_BEGIN ---",
+        "Staged worktree diff:",
+        "Unstaged worktree diff:",
+    ):
+        assert needle in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("args", "env", "stderr"),
+    (
+        (("code",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "code mode requires a base ref"),
+        (("unknown",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "unknown mode"),
+        (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_EFFORT": "max"},
+            "refusing --effort max",
+        ),
+        (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_MAX_TURNS": "25"},
+            "MAX_TURNS is not supported",
+        ),
+        (
+            ("specs",),
+            {
+                "CLAUDE_AUDIT_DRY_RUN": "1",
+                "CLAUDE_AUDIT_BARE": "1",
+                "ANTHROPIC_API_KEY": "",
+                "CLAUDE_AUDIT_SETTINGS": "",
+            },
+            "--bare skips OAuth/keychain",
+        ),
+    ),
+)
+def test_wrapper_rejects_unsafe_or_invalid_invocations(
+    args: tuple[str, ...],
+    env: dict[str, str],
+    stderr: str,
+) -> None:
+    result = _run(*args, **env)
+
+    assert result.returncode == 2
+    assert stderr in result.stderr
+
+
+def test_specs_and_architecture_prompts_are_wired() -> None:
+    specs = _run("specs", CLAUDE_AUDIT_DRY_RUN="1")
+    architecture = _run("architecture", CLAUDE_AUDIT_DRY_RUN="1")
+
+    assert specs.returncode == 0, specs.stderr
+    assert architecture.returncode == 0, architecture.stderr
+    for spec in (
+        "DATA_LEDGER.md",
+        "SCREEN_CONTRACTS.md",
+        "WIRING_GRAPH.mmd",
+        "DATA_QUEST.md",
+        "MAESTRO_FLOWS.md",
+    ):
+        assert spec in specs.stdout
+    for doc in ("AGENTS.md", "CLAUDE.md", "docs/MINT_AGENT_WORKFLOW.md"):
+        assert doc in architecture.stdout
+
+
+def test_auditor_docs_point_to_wrapper_policy() -> None:
+    for text in (
+        AGENT.read_text(encoding="utf-8"),
+        WORKFLOW.read_text(encoding="utf-8"),
+    ):
+        lowered = text.lower()
+        assert "tools/checks/claude_external_audit.sh" in text
+        assert "opus high" in lowered
+        assert "Sonnet high" in text
+        assert "--effort max" in text


### PR DESCRIPTION
## Summary
- add `tools/checks/claude_external_audit.sh` as the mandatory bounded Claude CLI audit wrapper
- document `mint-external-auditor` defaults: Opus high, safe mode, strict empty MCP, no session persistence, no dynamic prompt sections
- reject fake/slow knobs: `--effort max` requires explicit override and `CLAUDE_AUDIT_MAX_TURNS` is rejected because the installed Claude CLI does not support it
- add contract tests so future edits cannot silently drift back to slow unbounded `claude -p` calls

## Verification
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q`
- `bash -n tools/checks/claude_external_audit.sh`
- `CLAUDE_AUDIT_DRY_RUN=1 tools/checks/claude_external_audit.sh code HEAD`
- `CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_EFFORT=max tools/checks/claude_external_audit.sh code HEAD` exits 2 as expected
- `CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_MAX_TURNS=25 tools/checks/claude_external_audit.sh code HEAD` exits 2 as expected
- `git diff --check`
