### PR TITLE
Docs: sync Claude audit operating gate

### DIFF
--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -35,6 +35,21 @@ python3 tools/checks/arb_parity.py
 lefthook run pre-commit --file <touched-file>
 ```
 
+For external Claude review, use the checked-in wrapper instead of raw
+`claude -p` commands:
+
+```bash
+tools/checks/claude_external_audit.sh code <base-ref>
+tools/checks/claude_external_audit.sh specs
+tools/checks/claude_external_audit.sh architecture
+```
+
+The wrapper is deliberately bounded: Opus high by default, strict empty MCP,
+no session persistence, no dynamic-system-prompt sections, and no `--effort max`
+unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly set for a named final-release
+or unresolved P0/P1 dispute. Repeated same-gate re-audits should use Sonnet high
+first, then one Opus high final.
+
 For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:
 
@@ -52,7 +67,6 @@ the files exist in this checkout:
 - `tools/checks/phase_contract_guard.py`
 - `tools/checks/mint_rules_guard.py`
 - `tools/checks/verify_phase_acceptance.py`
-- `tools/checks/claude_external_audit.sh`
 
 Missing guard scripts are workflow gaps, not silent passes.
 

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
+OPERATING_GATES = ROOT / ".claude/skills/mint-operating-gates/SKILL.md"
 
 
 def _run(*args: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
@@ -119,9 +120,17 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
     for text in (
         AGENT.read_text(encoding="utf-8"),
         WORKFLOW.read_text(encoding="utf-8"),
+        OPERATING_GATES.read_text(encoding="utf-8"),
     ):
         lowered = text.lower()
         assert "tools/checks/claude_external_audit.sh" in text
         assert "opus high" in lowered
         assert "Sonnet high" in text
         assert "--effort max" in text
+
+
+def test_operating_gates_do_not_mark_claude_wrapper_as_missing() -> None:
+    text = OPERATING_GATES.read_text(encoding="utf-8")
+    missing_section = text.split("## Roadmap Gates Not Installed At G0", 1)[1]
+
+    assert "tools/checks/claude_external_audit.sh" not in missing_section


### PR DESCRIPTION
## Summary
- Move `tools/checks/claude_external_audit.sh` from the missing-roadmap list into checked-in MINT operating gates.
- Extend the Claude audit contract test to cover `.claude/skills/mint-operating-gates/SKILL.md` and fail if the wrapper is marked missing again.

## Tests
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q`
- `python3 -m pytest tools/checks/tests tests/checks -q --tb=short`
- `git diff --check`
- `CLAUDE_AUDIT_DRY_RUN=1 tools/checks/claude_external_audit.sh code HEAD | sed -n '1,36p'`
