### PR TITLE
Tools: harden Claude audit wrapper

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -32,6 +32,9 @@ Code audit against a base branch:
 The wrapper is the default. It runs Claude CLI with Opus high, safe mode,
 strict empty MCP, disabled slash commands, no session persistence, bounded
 tools, and dynamic-system-prompt sections excluded for cache stability.
+Code audits also enforce a diff-prompt budget (`CLAUDE_AUDIT_MAX_DIFF_LINES`,
+default 2500). If it trips, split the PR; use `CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1`
+only for a named final-release/P0 dispute.
 
 Use `--effort max` only for named final-release/P0 disputes. Repeated re-audits of the same bounded diff should use
 Sonnet high first, then one Opus high final confirmation. This avoids paying

--- a/.claude/agents/mint-quality-gate.md
+++ b/.claude/agents/mint-quality-gate.md
@@ -33,7 +33,9 @@ Run the smallest relevant set first, then widen:
   record the missing tool and use Maestro as the temporary runtime proof.
 - Maestro P0 flow: `maestro test --udid <device> --format JUNIT --output <evidence>/junit.xml <flow.yaml>`
 - iOS build proof: `cd apps/mobile && flutter build ios --simulator --debug`
-- External audit: wrapper script when present, otherwise `claude -p` on the diff.
+- External audit: `tools/checks/claude_external_audit.sh`; if the wrapper or
+  Claude CLI is unavailable, log the blocker and retry plan instead of running
+  raw `claude -p`.
 - Privacy/nLPD: for profile, prompt, log, analytics, export, or PDF changes,
   verify that PII exposure, retention, and purpose limitation are documented.
 </required_gates>

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -47,8 +47,10 @@ tools/checks/claude_external_audit.sh architecture
 The wrapper is deliberately bounded: Opus high by default, strict empty MCP,
 no session persistence, no dynamic-system-prompt sections, and no `--effort max`
 unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly set for a named final-release
-or unresolved P0/P1 dispute. Repeated same-gate re-audits should use Sonnet high
-first, then one Opus high final.
+or unresolved P0/P1 dispute. Code audits reject large diff prompts by default
+(`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500) so oversized branches are split
+before review. Repeated same-gate re-audits should use Sonnet high first, then
+one Opus high final.
 
 For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -84,4 +84,6 @@ Claude CLI audits should be bounded through
 no session persistence, and no `--effort max` except named final-release/P0
 disputes. Re-run loops use Sonnet high first, then one Opus high final; do not
 use `--bare` without explicit API-key auth, and do not add unsupported
-`--max-turns`.
+`--max-turns`. Code audits refuse large diff prompts by default
+(`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500); split the PR instead of
+overriding except for a named final-release/P0 dispute.

--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -9,7 +9,8 @@ Usage:
 
 Env: CLAUDE_AUDIT_MODEL, CLAUDE_AUDIT_EFFORT, CLAUDE_AUDIT_ALLOW_MAX,
 CLAUDE_AUDIT_WORKTREE, CLAUDE_AUDIT_BARE, CLAUDE_AUDIT_SETTINGS,
-CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_DRY_RUN.
+CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_MAX_DIFF_LINES,
+CLAUDE_AUDIT_ALLOW_LARGE_DIFF, CLAUDE_AUDIT_DRY_RUN.
 EOF
 }
 die() {
@@ -38,8 +39,28 @@ if [[ "$effort" == "max" && "${CLAUDE_AUDIT_ALLOW_MAX:-}" != "1" ]]; then
 fi
 repo_root="$(git rev-parse --show-toplevel)"
 worktree="${CLAUDE_AUDIT_WORKTREE:-$repo_root}"
+max_diff_lines="${CLAUDE_AUDIT_MAX_DIFF_LINES:-2500}"
+case "$max_diff_lines" in ""|*[!0-9]*) die "CLAUDE_AUDIT_MAX_DIFF_LINES must be a non-negative integer" ;; esac
 prompt_file="$(mktemp "${TMPDIR:-/tmp}/mint-claude-audit.XXXXXX")"
 trap 'rm -f "$prompt_file"' EXIT
+
+count_diff_lines() {
+  git -C "$repo_root" diff "$@" | wc -l | tr -d '[:space:]'
+}
+
+enforce_code_diff_budget() {
+  local base_ref="$1"
+  local branch_lines staged_lines unstaged_lines total_lines
+  branch_lines="$(count_diff_lines --no-ext-diff --unified=80 "${base_ref}...HEAD")"
+  staged_lines="$(count_diff_lines --cached --no-ext-diff --unified=80)"
+  unstaged_lines="$(count_diff_lines --no-ext-diff --unified=80)"
+  total_lines=$((branch_lines + staged_lines + unstaged_lines))
+
+  if (( total_lines > max_diff_lines )) && [[ "${CLAUDE_AUDIT_ALLOW_LARGE_DIFF:-}" != "1" ]]; then
+    die "diff prompt is ${total_lines} lines, above CLAUDE_AUDIT_MAX_DIFF_LINES=${max_diff_lines}; split the PR or set CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1 for a named final-release/P0 dispute"
+  fi
+}
+
 write_header() {
   local audit_mode="$1"
   cat >"$prompt_file" <<EOF
@@ -63,9 +84,12 @@ case "$mode" in
   code)
     base_ref="${2:-}"
     [[ -n "$base_ref" ]] || die "code mode requires a base ref"
+    git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null || die "unknown base ref '$base_ref'"
+    enforce_code_diff_budget "$base_ref"
     write_header "code"
     {
       echo "Base ref: ${base_ref}"
+      echo "Diff line budget: ${max_diff_lines} lines (override requires CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1)."
       echo
       echo "Current branch/status:"
       echo '```text'

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -8,6 +8,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
+QUALITY_GATE = ROOT / ".claude/agents/mint-quality-gate.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
 OPERATING_GATES = ROOT / ".claude/skills/mint-operating-gates/SKILL.md"
 
@@ -54,6 +55,7 @@ def test_wrapper_defaults_are_bounded() -> None:
         "--tools Read\\,Grep\\,Bash",
         "--exclude-dynamic-system-prompt-sections",
         "--- PROMPT_BEGIN ---",
+        "Diff line budget: 2500 lines",
         "Staged worktree diff:",
         "Unstaged worktree diff:",
     ):
@@ -65,6 +67,7 @@ def test_wrapper_defaults_are_bounded() -> None:
     (
         (("code",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "code mode requires a base ref"),
         (("unknown",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "unknown mode"),
+        (("code", "no-such-ref-xyz"), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "unknown base ref"),
         (
             ("code", "HEAD"),
             {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_EFFORT": "max"},
@@ -74,6 +77,11 @@ def test_wrapper_defaults_are_bounded() -> None:
             ("code", "HEAD"),
             {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_MAX_TURNS": "25"},
             "MAX_TURNS is not supported",
+        ),
+        (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_MAX_DIFF_LINES": "not-a-number"},
+            "MAX_DIFF_LINES must be a non-negative integer",
         ),
         (
             ("specs",),
@@ -96,6 +104,32 @@ def test_wrapper_rejects_unsafe_or_invalid_invocations(
 
     assert result.returncode == 2
     assert stderr in result.stderr
+
+
+def test_wrapper_rejects_large_code_diff_without_explicit_override() -> None:
+    result = _run(
+        "code",
+        "HEAD~1",
+        CLAUDE_AUDIT_DRY_RUN="1",
+        CLAUDE_AUDIT_MAX_DIFF_LINES="1",
+    )
+
+    assert result.returncode == 2
+    assert "diff prompt is" in result.stderr
+    assert "CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1" in result.stderr
+
+
+def test_wrapper_allows_large_code_diff_only_with_named_override() -> None:
+    result = _run(
+        "code",
+        "HEAD~1",
+        CLAUDE_AUDIT_DRY_RUN="1",
+        CLAUDE_AUDIT_MAX_DIFF_LINES="1",
+        CLAUDE_AUDIT_ALLOW_LARGE_DIFF="1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Diff line budget: 1 lines" in result.stdout
 
 
 def test_specs_and_architecture_prompts_are_wired() -> None:
@@ -127,6 +161,15 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "opus high" in lowered
         assert "Sonnet high" in text
         assert "--effort max" in text
+        assert "CLAUDE_AUDIT_MAX_DIFF_LINES" in text
+
+
+def test_quality_gate_does_not_allow_raw_claude_fallback() -> None:
+    text = QUALITY_GATE.read_text(encoding="utf-8")
+
+    assert "tools/checks/claude_external_audit.sh" in text
+    assert "otherwise `claude -p`" not in text
+    assert "raw `claude -p`" in text
 
 
 def test_operating_gates_do_not_mark_claude_wrapper_as_missing() -> None:

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -26,6 +26,21 @@ def _run(*args: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _run_with_temporary_worktree_diff(
+    *args: str,
+    **env_overrides: str,
+) -> subprocess.CompletedProcess[str]:
+    original = WORKFLOW.read_text(encoding="utf-8")
+    WORKFLOW.write_text(
+        f"{original}\n\n<!-- contract-test-diff: claude audit budget -->\n",
+        encoding="utf-8",
+    )
+    try:
+        return _run(*args, **env_overrides)
+    finally:
+        WORKFLOW.write_text(original, encoding="utf-8")
+
+
 def test_wrapper_is_syntax_valid_and_executable() -> None:
     result = subprocess.run(
         ["bash", "-n", str(SCRIPT)],
@@ -107,9 +122,9 @@ def test_wrapper_rejects_unsafe_or_invalid_invocations(
 
 
 def test_wrapper_rejects_large_code_diff_without_explicit_override() -> None:
-    result = _run(
+    result = _run_with_temporary_worktree_diff(
         "code",
-        "HEAD~1",
+        "HEAD",
         CLAUDE_AUDIT_DRY_RUN="1",
         CLAUDE_AUDIT_MAX_DIFF_LINES="1",
     )
@@ -120,9 +135,9 @@ def test_wrapper_rejects_large_code_diff_without_explicit_override() -> None:
 
 
 def test_wrapper_allows_large_code_diff_only_with_named_override() -> None:
-    result = _run(
+    result = _run_with_temporary_worktree_diff(
         "code",
-        "HEAD~1",
+        "HEAD",
         CLAUDE_AUDIT_DRY_RUN="1",
         CLAUDE_AUDIT_MAX_DIFF_LINES="1",
         CLAUDE_AUDIT_ALLOW_LARGE_DIFF="1",


### PR DESCRIPTION
## Summary
- Add a default 2500-line diff prompt budget to tools/checks/claude_external_audit.sh for code audits.
- Reject raw quality-gate fallback to claude -p; route through the checked-in wrapper or log a blocker/retry plan.
- Document the policy in the permanent auditor, operating gates, and MINT workflow docs.
- Extend contract tests for large diffs, invalid base refs, max-turn rejection, and raw fallback drift.

## Verification
- bash -n tools/checks/claude_external_audit.sh
- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q
- python3 -m pytest tools/checks/tests -q
- lefthook run pre-commit --file .claude/agents/mint-external-auditor.md --file .claude/agents/mint-quality-gate.md --file .claude/skills/mint-operating-gates/SKILL.md --file docs/MINT_AGENT_WORKFLOW.md --file tools/checks/claude_external_audit.sh --file tools/checks/tests/test_claude_external_audit_contract.py
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 → PASS, no P0/P1

## Notes
- Claude flagged fixed prompt overhead as P2; accepted because the guard bounds the variable diff body that caused slow audit loops.
- Lefthook reports a non-blocking retention warning for an existing ~/.claude memory file.