### PR TITLE
Tools: add Claude audit rerun guard

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -29,6 +29,9 @@ Spec drift audit:
 Code audit against a base branch:
 `tools/checks/claude_external_audit.sh code <base-branch>`.
 
+Same-gate rerun after a first finding pass:
+`CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code <base-branch>`.
+
 The wrapper is the default. It runs Claude CLI with Opus high, safe mode,
 strict empty MCP, disabled slash commands, no session persistence, bounded
 tools, and dynamic-system-prompt sections excluded for cache stability.
@@ -37,9 +40,11 @@ default 2500). If it trips, split the PR; use `CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1`
 only for a named final-release/P0 dispute.
 
 Use `--effort max` only for named final-release/P0 disputes. Repeated re-audits of the same bounded diff should use
-Sonnet high first, then one Opus high final confirmation. This avoids paying
-full startup hooks, MCP servers, memory injection, skill inventory, and max
-reasoning on every tool turn.
+Sonnet high first (`CLAUDE_AUDIT_RERUN=1`), then one Opus high final
+confirmation. The wrapper rejects non-Sonnet reruns unless
+`CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly set for a final
+confirmation or P0 dispute. This avoids paying full startup hooks, MCP servers, memory
+injection, skill inventory, and max reasoning on every tool turn.
 
 Do not add `--max-turns`: the installed Claude CLI does not expose it, and the
 wrapper rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -49,8 +49,10 @@ no session persistence, no dynamic-system-prompt sections, and no `--effort max`
 unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly set for a named final-release
 or unresolved P0/P1 dispute. Code audits reject large diff prompts by default
 (`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500) so oversized branches are split
-before review. Repeated same-gate re-audits should use Sonnet high first, then
-one Opus high final.
+before review. Repeated same-gate re-audits should use Sonnet high first via
+`CLAUDE_AUDIT_RERUN=1`, then one Opus high final. The wrapper rejects
+non-Sonnet reruns unless `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly set for a
+final confirmation or P0 dispute.
 
 For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 *.pyc
 *.pyo
 .venv/
+.hypothesis/
 services/backend/.venv/
 
 # Flutter generated

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -84,6 +84,10 @@ Claude CLI audits should be bounded through
 no session persistence, and no `--effort max` except named final-release/P0
 disputes. Re-run loops use Sonnet high first, then one Opus high final; do not
 use `--bare` without explicit API-key auth, and do not add unsupported
-`--max-turns`. Code audits refuse large diff prompts by default
+`--max-turns`. Same-gate re-runs use
+`CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh ...`; the wrapper
+switches the default model to Sonnet and rejects non-Sonnet reruns unless
+`CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is set for a final confirmation/P0 dispute.
+Code audits refuse large diff prompts by default
 (`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500); split the PR instead of
 overriding except for a named final-release/P0 dispute.

--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -10,7 +10,8 @@ Usage:
 Env: CLAUDE_AUDIT_MODEL, CLAUDE_AUDIT_EFFORT, CLAUDE_AUDIT_ALLOW_MAX,
 CLAUDE_AUDIT_WORKTREE, CLAUDE_AUDIT_BARE, CLAUDE_AUDIT_SETTINGS,
 CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_MAX_DIFF_LINES,
-CLAUDE_AUDIT_ALLOW_LARGE_DIFF, CLAUDE_AUDIT_DRY_RUN.
+CLAUDE_AUDIT_ALLOW_LARGE_DIFF, CLAUDE_AUDIT_RERUN,
+CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN, CLAUDE_AUDIT_DRY_RUN.
 EOF
 }
 die() {
@@ -31,11 +32,22 @@ case "$mode" in
     ;;
 esac
 [[ -n "${CLAUDE_AUDIT_MAX_TURNS:-}" ]] && die "CLAUDE_AUDIT_MAX_TURNS is not supported by the installed Claude CLI; bound the prompt instead"
-model="${CLAUDE_AUDIT_MODEL:-opus}"
+rerun="${CLAUDE_AUDIT_RERUN:-0}"
+case "$rerun" in 0|1) ;; *) die "CLAUDE_AUDIT_RERUN must be 0 or 1" ;; esac
+if [[ -n "${CLAUDE_AUDIT_MODEL:-}" ]]; then
+  model="$CLAUDE_AUDIT_MODEL"
+elif [[ "$rerun" == "1" ]]; then
+  model="sonnet"
+else
+  model="opus"
+fi
 effort="${CLAUDE_AUDIT_EFFORT:-high}"
 case "$effort" in low|medium|high|xhigh|max) ;; *) die "unsupported effort '$effort'" ;; esac
 if [[ "$effort" == "max" && "${CLAUDE_AUDIT_ALLOW_MAX:-}" != "1" ]]; then
   die "refusing --effort max without CLAUDE_AUDIT_ALLOW_MAX=1; use high for bounded PR audits"
+fi
+if [[ "$rerun" == "1" && "$model" != *sonnet* && "${CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN:-}" != "1" ]]; then
+  die "CLAUDE_AUDIT_RERUN=1 must use a sonnet model; reserve non-sonnet reruns for final confirmation/P0 disputes with CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1"
 fi
 repo_root="$(git rev-parse --show-toplevel)"
 worktree="${CLAUDE_AUDIT_WORKTREE:-$repo_root}"

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -77,6 +77,14 @@ def test_wrapper_defaults_are_bounded() -> None:
         assert needle in result.stdout
 
 
+def test_rerun_mode_defaults_to_sonnet_high() -> None:
+    result = _run("code", "HEAD", CLAUDE_AUDIT_DRY_RUN="1", CLAUDE_AUDIT_RERUN="1")
+
+    assert result.returncode == 0, result.stderr
+    assert "--model sonnet" in result.stdout
+    assert "--effort high" in result.stdout
+
+
 @pytest.mark.parametrize(
     ("args", "env", "stderr"),
     (
@@ -92,6 +100,29 @@ def test_wrapper_defaults_are_bounded() -> None:
             ("code", "HEAD"),
             {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_MAX_TURNS": "25"},
             "MAX_TURNS is not supported",
+        ),
+        (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_RERUN": "maybe"},
+            "CLAUDE_AUDIT_RERUN must be 0 or 1",
+        ),
+        (
+            ("code", "HEAD"),
+            {
+                "CLAUDE_AUDIT_DRY_RUN": "1",
+                "CLAUDE_AUDIT_RERUN": "1",
+                "CLAUDE_AUDIT_MODEL": "opus",
+            },
+            "CLAUDE_AUDIT_RERUN=1 must use a sonnet model",
+        ),
+        (
+            ("code", "HEAD"),
+            {
+                "CLAUDE_AUDIT_DRY_RUN": "1",
+                "CLAUDE_AUDIT_RERUN": "1",
+                "CLAUDE_AUDIT_MODEL": "haiku",
+            },
+            "CLAUDE_AUDIT_RERUN=1 must use a sonnet model",
         ),
         (
             ("code", "HEAD"),
@@ -119,6 +150,20 @@ def test_wrapper_rejects_unsafe_or_invalid_invocations(
 
     assert result.returncode == 2
     assert stderr in result.stderr
+
+
+def test_rerun_mode_allows_non_sonnet_only_with_explicit_override() -> None:
+    result = _run(
+        "code",
+        "HEAD",
+        CLAUDE_AUDIT_DRY_RUN="1",
+        CLAUDE_AUDIT_RERUN="1",
+        CLAUDE_AUDIT_MODEL="opus",
+        CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN="1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--model opus" in result.stdout
 
 
 def test_wrapper_rejects_large_code_diff_without_explicit_override() -> None:
@@ -175,6 +220,8 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "tools/checks/claude_external_audit.sh" in text
         assert "opus high" in lowered
         assert "Sonnet high" in text
+        assert "CLAUDE_AUDIT_RERUN=1" in text
+        assert "CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1" in text
         assert "--effort max" in text
         assert "CLAUDE_AUDIT_MAX_DIFF_LINES" in text
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE_AUDIT_RERUN=1` to default same-gate audit reruns to Sonnet high.
- Reject non-Sonnet reruns unless `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly set for final confirmation/P0 disputes.
- Document the policy in `mint-external-auditor`, `mint-operating-gates`, and `docs/MINT_AGENT_WORKFLOW.md`.
- Ignore `.hypothesis/` so local pytest/Hypothesis cache does not dirty worktrees.

## Verification
- `bash -n tools/checks/claude_external_audit.sh`
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q` (20 passed)
- `python3 -m pytest tools/checks/tests -q` (39 passed)
- `git diff --check`
- `lefthook run pre-commit --file .gitignore --file tools/checks/claude_external_audit.sh --file tools/checks/tests/test_claude_external_audit_contract.py --file .claude/agents/mint-external-auditor.md --file docs/MINT_AGENT_WORKFLOW.md --file .claude/skills/mint-operating-gates/SKILL.md`
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → PASS, P2 `.hypothesis/` fixed
- `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → PASS, P2 flag naming fixed
- Final `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → PASS, P2 temporary doc marker removed
