### PR TITLE
Tools: add no-bypass persistence gate

### DIFF
--- a/apps/mobile/lib/providers/auth_provider.dart
+++ b/apps/mobile/lib/providers/auth_provider.dart
@@ -127,8 +127,7 @@ class AuthProvider extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       _requiresEmailVerification =
           prefs.getBool('requires_email_verification') ?? false;
-      // Local-mode default: true on fresh install (local-first per UX copy
-      // "Compte optionnel : tes données restent locales par défaut").
+      // Local-mode default: true on fresh install.
       // Explicit register/login flips it to false.
       if (!prefs.containsKey('auth_local_mode')) {
         await prefs.setBool('auth_local_mode', true);
@@ -705,31 +704,31 @@ class AuthProvider extends ChangeNotifier {
       final data = profileData['data'] as Map<String, dynamic>?;
       if (data == null) return;
 
-      final prefs = await SharedPreferences.getInstance();
+      final answers = await ReportPersistenceService.loadAnswers();
+      var changed = false;
       if (data['birthYear'] != null) {
-        await prefs.setInt('q_birth_year', data['birthYear'] as int);
+        answers['q_birth_year'] = data['birthYear'] as int;
+        changed = true;
       }
       if (data['canton'] != null) {
-        await prefs.setString('q_canton', data['canton'] as String);
+        answers['q_canton'] = data['canton'] as String;
+        changed = true;
       }
       if (data['incomeGrossYearly'] != null) {
-        await prefs.setDouble(
-          'q_gross_salary',
-          (data['incomeGrossYearly'] as num).toDouble() / 12,
-        );
+        answers['q_gross_salary_annual'] =
+            (data['incomeGrossYearly'] as num).toDouble();
+        changed = true;
       }
       if (data['incomeNetMonthly'] != null) {
-        await prefs.setDouble(
-          'q_net_income_period_chf',
-          (data['incomeNetMonthly'] as num).toDouble(),
-        );
+        answers['q_net_income_period_chf'] =
+            (data['incomeNetMonthly'] as num).toDouble();
+        changed = true;
       }
       if (data['householdType'] != null) {
-        await prefs.setString(
-          'q_household_type',
-          data['householdType'] as String,
-        );
+        answers['q_household_type'] = data['householdType'] as String;
+        changed = true;
       }
+      if (changed) await ReportPersistenceService.saveAnswers(answers);
     } catch (e) {
       // Hydration is best-effort — never block login flow
       if (kDebugMode) {
@@ -766,7 +765,7 @@ class AuthProvider extends ChangeNotifier {
       return AuthError.networkUnavailable;
     }
 
-    if (lower.contains('existe déjà')) {
+    if (lower.contains('existe déjà')) { // lint-ignore: backend error fragment, not UI copy
       return AuthError.emailAlreadyUsed;
     }
 
@@ -792,7 +791,7 @@ class AuthProvider extends ChangeNotifier {
     if (lower.contains('expir')) {
       return AuthError.linkExpired;
     }
-    if (lower.contains('non vérifié') || lower.contains('not verified')) {
+    if (lower.contains('non vérifié') || lower.contains('not verified')) { // lint-ignore: backend error fragment, not UI copy
       return AuthError.emailNotVerified;
     }
 

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -19,7 +19,9 @@ class SecureWizardStore {
   /// Keys containing sensitive financial PII that must not be stored
   /// in plain SharedPreferences.
   static const _sensitiveKeys = {
+    // Legacy key retained so old secure placeholders do not leak as plain JSON.
     'q_gross_salary',
+    'q_gross_salary_annual',
     'q_net_income_period_chf',
     'q_lpp_avoir',
     'q_3a_capital',
@@ -72,6 +74,7 @@ class SecureWizardStore {
     final cleaned = Map<String, dynamic>.from(answers);
     for (final key in _sensitiveKeys) {
       if (cleaned.containsKey(key) && cleaned[key] != null) {
+        if (cleaned[key] == '__secure__') continue;
         await write(key, cleaned[key].toString());
         cleaned[key] = '__secure__';
       }

--- a/apps/mobile/test/providers/coach_profile_provider_tax_extraction_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_tax_extraction_test.dart
@@ -54,7 +54,7 @@ void main() {
 
     test('persists canonical tax fields and data sources', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 35,
         grossSalary: 120000,
         canton: 'VD',
@@ -140,7 +140,7 @@ void main() {
 
     test('handles missing fields gracefully', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 50,
         grossSalary: 100000,
         canton: 'ZH',
@@ -202,7 +202,7 @@ void main() {
 
     test('ignores fields without profileField mapping', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 40,
         grossSalary: 90000,
         canton: 'GE',
@@ -245,7 +245,7 @@ void main() {
 
     test('ignores non-double values', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 45,
         grossSalary: 110000,
         canton: 'BE',
@@ -273,7 +273,7 @@ void main() {
 
     test('sets updatedAt and source marker in persisted answers', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 55,
         grossSalary: 130000,
         canton: 'TI',
@@ -307,7 +307,7 @@ void main() {
 
     test('notifies listeners after extraction', () async {
       final provider = CoachProfileProvider();
-      provider.updateFromSmartFlow(
+      await provider.updateFromSmartFlow(
         age: 42,
         grossSalary: 95000,
         canton: 'LU',

--- a/apps/mobile/test/services/secure_wizard_store_test.dart
+++ b/apps/mobile/test/services/secure_wizard_store_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/services/secure_wizard_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SecureWizardStore', () {
+    test('treats gross salary ledger keys as sensitive', () {
+      expect(SecureWizardStore.isSensitive('q_gross_salary'), isTrue);
+      expect(SecureWizardStore.isSensitive('q_gross_salary_annual'), isTrue);
+    });
+
+    test('does not treat public profile keys as sensitive', () {
+      expect(SecureWizardStore.isSensitive('q_canton'), isFalse);
+      expect(SecureWizardStore.isSensitive('q_birth_year'), isFalse);
+    });
+
+    test('does not rewrite secure placeholders', () async {
+      final cleaned = await SecureWizardStore.secureSensitiveKeys({
+        'q_gross_salary_annual': '__secure__',
+      });
+
+      expect(cleaned['q_gross_salary_annual'], '__secure__');
+    });
+  });
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -38,6 +38,10 @@ pre-commit:
       run: for file in {staged_files}; do python3 tools/checks/no_hardcoded_fr.py --file "$file" || exit 1; done
       glob: "apps/mobile/lib/**/*.dart"
       tags: [i18n, mint]
+    no-bypass-persistence:
+      run: python3 tools/checks/no_bypass_persistence.py {staged_files}
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [data-ledger, persistence, mint]
 
 skip:
   - merge

--- a/tools/checks/no_bypass_persistence.py
+++ b/tools/checks/no_bypass_persistence.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Reject direct SharedPreferences writes of MINT ledger keys.
+
+Domain answers must be persisted through ReportPersistenceService. Other local
+caches may still use SharedPreferences, but they must not write `q_*`,
+`_coach_*`, `fp:*`, or `wizard_answers_v2` directly.
+
+This is a lexical pre-commit guard, not a whole-program Dart analyzer. It
+catches direct key literals and same-file key constants, which covers the
+historic bypass pattern this gate is meant to stop.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCOPE = [ROOT / "apps/mobile/lib"]
+ALLOWED_WRITERS = {
+    ROOT / "apps/mobile/lib/services/report_persistence_service.dart",
+}
+
+WRITE_CALL = re.compile(r"\.set(?:String|Double|Int|Bool|StringList)\s*\(")
+STRING_LITERAL = re.compile(r"""['"]([^'"]+)['"]""")
+STRING_ASSIGNMENT = re.compile(
+    r"""(?:static\s+)?(?:const|final)\s+String\s+([A-Za-z_]\w*)\s*=\s*['"]([^'"]+)['"]"""
+)
+
+
+def _is_domain_key(value: str) -> bool:
+    return (
+        value == "wizard_answers_v2"
+        or value.startswith("q_")
+        or value.startswith("_coach_")
+        or value.startswith("fp:")
+    )
+
+
+def _collect_paths(inputs: list[str]) -> list[Path]:
+    roots = [Path(item) for item in inputs] if inputs else DEFAULT_SCOPE
+    paths: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file():
+            if root.suffix == ".dart":
+                paths.append(root)
+            continue
+        for path in root.rglob("*.dart"):
+            if "/.dart_tool/" in path.as_posix() or "/build/" in path.as_posix():
+                continue
+            paths.append(path)
+    return sorted({path.resolve() for path in paths})
+
+
+def _constants(text: str) -> dict[str, str]:
+    return {
+        match.group(1): match.group(2)
+        for match in STRING_ASSIGNMENT.finditer(text)
+        if _is_domain_key(match.group(2))
+    }
+
+
+def _call_window(lines: list[str], index: int) -> str:
+    window: list[str] = []
+    for line in lines[index : min(index + 8, len(lines))]:
+        window.append(line)
+        if ");" in line:
+            break
+    return "\n".join(window)
+
+
+def scan_file(path: Path) -> list[str]:
+    if path.resolve() in ALLOWED_WRITERS:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    constants = _constants(text)
+    violations: list[str] = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if not WRITE_CALL.search(line):
+            continue
+        window = _call_window(lines, index)
+        direct_keys = {value for value in STRING_LITERAL.findall(window) if _is_domain_key(value)}
+        constant_keys = {value for name, value in constants.items() if re.search(rf"\b{name}\b", window)}
+        bad = sorted(direct_keys | constant_keys)
+        if bad:
+            try:
+                rel = path.relative_to(ROOT)
+            except ValueError:
+                rel = path
+            violations.append(f"{rel}:{index + 1} writes {', '.join(bad)}")
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Optional Dart files/directories. Defaults to apps/mobile/lib.",
+    )
+    args = parser.parse_args()
+
+    violations: list[str] = []
+    for path in _collect_paths(args.paths):
+        violations.extend(scan_file(path))
+
+    if violations:
+        print(
+            "no_bypass_persistence: domain ledger keys must be persisted through "
+            "ReportPersistenceService only.",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(violation, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_no_bypass_persistence.py
+++ b/tools/checks/tests/test_no_bypass_persistence.py
@@ -1,0 +1,86 @@
+import subprocess
+from pathlib import Path
+from typing import Union
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/no_bypass_persistence.py"
+LEFTHOOK = ROOT / "lefthook.yml"
+
+
+def _run(*paths: Union[Path, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(SCRIPT), *(str(path) for path in paths)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_no_bypass_persistence_script_exists_and_repo_clean() -> None:
+    result = _run()
+
+    assert SCRIPT.exists()
+    assert result.returncode == 0, result.stderr
+
+
+def test_no_bypass_persistence_rejects_direct_domain_key_write(tmp_path: Path) -> None:
+    fixture = tmp_path / "bad_writer.dart"
+    fixture.write_text(
+        """
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<void> writeBad() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('q_birth_year', '1980');
+}
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "q_birth_year" in result.stderr
+    assert "bad_writer.dart:6" in result.stderr
+
+
+def test_no_bypass_persistence_rejects_constant_domain_key_write(tmp_path: Path) -> None:
+    fixture = tmp_path / "constant_bad_writer.dart"
+    fixture.write_text(
+        """
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String wizardKey = 'wizard_answers_v2';
+
+Future<void> writeBad() async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(wizardKey, '{}');
+}
+""",
+        encoding="utf-8",
+    )
+
+    result = _run(fixture)
+
+    assert result.returncode == 1
+    assert "wizard_answers_v2" in result.stderr
+
+
+def test_no_bypass_persistence_allows_caches_and_canonical_writers() -> None:
+    result = _run(
+        ROOT / "apps/mobile/lib/data/budget/budget_local_store.dart",
+        ROOT / "apps/mobile/lib/services/report_persistence_service.dart",
+        ROOT / "apps/mobile/lib/providers/coach_profile_provider.dart",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_lefthook_runs_no_bypass_persistence_for_mobile_dart() -> None:
+    lefthook = LEFTHOOK.read_text(encoding="utf-8")
+
+    assert "no-bypass-persistence:" in lefthook
+    assert "python3 tools/checks/no_bypass_persistence.py {staged_files}" in lefthook
+    assert 'glob: "apps/mobile/lib/**/*.dart"' in lefthook


### PR DESCRIPTION
## Summary
- Add `tools/checks/no_bypass_persistence.py` and Lefthook wiring to block direct SharedPreferences writes of domain ledger keys outside `ReportPersistenceService`.
- Reroute `AuthProvider._hydrateProfileFromBackend` through `ReportPersistenceService.loadAnswers/saveAnswers` instead of raw prefs writes.
- Fix backend gross-income hydration to write canonical `q_gross_salary_annual` and keep it in secure storage.
- Harden `SecureWizardStore` against rewriting the `__secure__` placeholder and add focused tests.

## Verification
- `python3 tools/checks/no_bypass_persistence.py`
- `python3 -m pytest tools/checks/tests/test_no_bypass_persistence.py -q` (5 passed)
- `python3 -m pytest tools/checks/tests -q` (44 passed)
- `python3 tools/checks/no_hardcoded_fr.py --file apps/mobile/lib/providers/auth_provider.dart`
- `python3 tools/checks/accent_lint_fr.py --file apps/mobile/lib/providers/auth_provider.dart`
- `cd apps/mobile && flutter analyze lib/providers/auth_provider.dart lib/services/secure_wizard_store.dart`
- `cd apps/mobile && flutter test test/providers/auth_provider_test.dart test/services/secure_wizard_store_test.dart` (17 passed)
- `lefthook run pre-commit --file apps/mobile/lib/providers/auth_provider.dart --file apps/mobile/lib/services/secure_wizard_store.dart --file apps/mobile/test/services/secure_wizard_store_test.dart --file lefthook.yml --file tools/checks/no_bypass_persistence.py --file tools/checks/tests/test_no_bypass_persistence.py`
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → initial NO-GO fixed; later PASS
- `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → final PASS
