### PR TITLE
tools: add financial core drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,34 @@ jobs:
       - name: Scan Dart UI strings
         run: python3 tools/checks/banned_ui_terms.py
 
+  # ─── Financial calculation drift gate ──────────────────────────
+  # Blocks newly introduced financial calculation helpers/formulas
+  # outside apps/mobile/lib/services/financial_core/. Existing drift is
+  # handled separately; this job prevents making the hole larger.
+  financial-core-gate:
+    name: Financial core gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan introduced financial calculations
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+            if [[ -z "$BASE_REF" ]] || [[ "${BASE_REF//0/}" == "" ]]; then
+              BASE_REF="HEAD^"
+            fi
+          fi
+          python3 tools/checks/financial_core_gate.py --base-ref "$BASE_REF"
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -591,7 +619,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, secret-scan, banned-ui-terms, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, secret-scan, banned-ui-terms, financial-core-gate, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -601,6 +629,7 @@ jobs:
           backend="${{ needs.backend.result }}"
           secret_scan="${{ needs.secret-scan.result }}"
           banned_terms="${{ needs.banned-ui-terms.result }}"
+          financial_core="${{ needs.financial-core-gate.result }}"
           flutter="${{ needs.flutter.result }}"
           readability="${{ needs.readability.result }}"
           wcag="${{ needs.wcag-aa-all-touched.result }}"
@@ -611,6 +640,7 @@ jobs:
           cache_gi="${{ needs.cache-gitignore-check.result }}"
           [[ "$backend" == "skipped" ]] && backend="success"
           [[ "$banned_terms" == "skipped" ]] && banned_terms="success"
+          [[ "$financial_core" == "skipped" ]] && financial_core="success"
           [[ "$flutter" == "skipped" ]] && flutter="success"
           [[ "$readability" == "skipped" ]] && readability="success"
           [[ "$wcag" == "skipped" ]] && wcag="success"
@@ -619,8 +649,8 @@ jobs:
           [[ "$contract_tests" == "skipped" ]] && contract_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — backend=$backend secret_scan=$secret_scan banned_terms=$banned_terms flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — backend=$backend secret_scan=$secret_scan banned_terms=$banned_terms financial_core=$financial_core flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,6 +42,10 @@ pre-commit:
       run: for file in {staged_files}; do python3 tools/checks/banned_ui_terms.py --file "$file" || exit 1; done
       glob: "apps/mobile/lib/**/*.dart"
       tags: [compliance, mint]
+    financial-core-gate:
+      run: python3 tools/checks/financial_core_gate.py --staged
+      glob: "apps/mobile/lib/**/*.dart"
+      tags: [financial-core, mint]
     no-bypass-persistence:
       run: python3 tools/checks/no_bypass_persistence.py {staged_files}
       glob: "apps/mobile/lib/**/*.dart"

--- a/tools/checks/financial_core_gate.py
+++ b/tools/checks/financial_core_gate.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Block newly introduced financial calculations outside financial_core."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+FINANCIAL_TOKENS = set(
+    "3a affordability assurance avs benefice budget capital chf cotisation contribution debt "
+    "decaissement dette dividende dividend donation epargne epl fiscal fitness fortune franchise "
+    "fri heritage hoirie hypothecaire hypotheque imputed income interet lamal leasing loyer lpp "
+    "mortgage patrimoine pension pilier pillar prevoyance prime rachat rent rente resilience "
+    "retrait revenu salary salaire savings score successoral tax tenue usufruit withdrawal".split()
+)
+CALC_RE = re.compile(
+    r"^\s*(?:static\s+)?(?:(?:Future|Stream|List|Map|Set|Iterable|double|int|num|bool|String|void)"
+    r"(?:<[^>{}]+>)?\s+)?(?P<name>_?(?:calculate|calculer|compute|estimate|project|simulate)"
+    r"[A-Za-z0-9_]*)\s*\("
+)
+ASSIGN_RE = re.compile(r"^\s*(?:final|var|const|double|int|num)\s+[A-Za-z_][A-Za-z0-9_]*\s*=")
+RETURN_RE = re.compile(r"^\s*return\s+")
+GETTER_RE = re.compile(r"^\s*(?:double|int|num)\s+get\s+[A-Za-z_][A-Za-z0-9_]*\s*=>")
+ARROW_FN_RE = re.compile(r"^\s*(?:double|int|num)\s+[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)\s*=>")
+ARITH_RE = re.compile(
+    r"[A-Za-z0-9_\]\)]\s*[\*/]\s*[A-Za-z0-9_\(]|"
+    r"[A-Za-z0-9_\]\)]\s+[\+\-]\s+[A-Za-z0-9_\(]|"
+    r"\b\d+(?:\.\d+)?\s*[\*/]\s*[A-Za-z_\(]|"
+    r"[A-Za-z_\)]\s*[\*/]\s*\d+(?:\.\d+)?"
+)
+
+
+def _normalize(value: str) -> str:
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
+    decomposed = unicodedata.normalize("NFKD", value)
+    asciiish = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return re.sub(r"[^A-Za-z0-9]+", " ", asciiish).casefold()
+
+
+def _is_scoped(path: str) -> bool:
+    rel = path.removeprefix("a/").removeprefix("b/").replace("\\", "/")
+    wrapped = f"/{rel}/"
+    return (
+        rel.startswith("apps/mobile/lib/")
+        and rel.endswith(".dart")
+        and not rel.endswith(".g.dart")
+        and "/services/financial_core/" not in wrapped
+        and not any(part in wrapped for part in ("/.dart_tool/", "/build/", "/.git/", "/l10n/", "/test/", "/tests/"))
+    )
+
+
+def _has_financial_context(text: str) -> bool:
+    haystack = _normalize(text)
+    return any(re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", haystack) for token in FINANCIAL_TOKENS)
+
+
+def _code_without_strings(line: str) -> str:
+    out: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for index, ch in enumerate(line):
+        nxt = line[index + 1] if index + 1 < len(line) else ""
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch in {"'", '"'}:
+            quote = ch
+            out.append(" ")
+        elif ch == "/" and nxt == "/":
+            break
+        else:
+            out.append(ch)
+    return "".join(out).strip()
+
+
+def _added_lines(diff_text: str) -> list[tuple[str, int, str]]:
+    path: str | None = None
+    lineno: int | None = None
+    lines: list[tuple[str, int, str]] = []
+    for raw in diff_text.splitlines():
+        if raw.startswith("diff --git "):
+            path = None
+            lineno = None
+        elif raw.startswith("+++ "):
+            marker = raw[4:].strip()
+            path = None if marker == "/dev/null" else marker.removeprefix("a/").removeprefix("b/")
+        elif raw.startswith("@@ "):
+            match = re.search(r"\+(\d+)(?:,\d+)?", raw)
+            lineno = int(match.group(1)) if match else None
+        elif lineno is None:
+            continue
+        elif raw.startswith("+") and not raw.startswith("+++"):
+            if path and _is_scoped(path):
+                lines.append((path, lineno, raw[1:]))
+            lineno += 1
+        elif not (raw.startswith("-") and not raw.startswith("---")):
+            lineno += 1
+    return lines
+
+
+def _violation(text: str) -> str | None:
+    code = _code_without_strings(text)
+    if not code:
+        return None
+    match = CALC_RE.match(code)
+    if match and _has_financial_context(code):
+        return f"new calculation helper '{match.group('name')}' outside financial_core/"
+    if (ASSIGN_RE.match(code) or RETURN_RE.match(code) or GETTER_RE.match(code) or ARROW_FN_RE.match(code)) and ARITH_RE.search(code) and _has_financial_context(code):
+        return "new financial formula outside financial_core/"
+    return None
+
+
+def _git_diff(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-ext-diff", *args, "--", "apps/mobile/lib"],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff-file")
+    parser.add_argument("--staged", action="store_true")
+    parser.add_argument("--base-ref")
+    args = parser.parse_args()
+    if sum(bool(v) for v in (args.diff_file, args.staged, args.base_ref)) > 1:
+        parser.error("use only one of --diff-file, --staged, or --base-ref")
+
+    diff = Path(args.diff_file).read_text(encoding="utf-8") if args.diff_file else _git_diff(["--cached"] if args.staged else ([f"{args.base_ref}...HEAD"] if args.base_ref else ["HEAD"]))
+    failures = [(p, n, detail, t.strip()) for p, n, t in _added_lines(diff) for detail in [_violation(t)] if detail]
+    if not failures:
+        print("OK financial_core_gate: no new calculation drift")
+        return 0
+    print("::error::financial_core_gate failed:")
+    for path, lineno, detail, text in failures:
+        print(f"{path}:{lineno}: {detail}: {text}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_financial_core_gate.py
+++ b/tools/checks/tests/test_financial_core_gate.py
@@ -1,0 +1,93 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/financial_core_gate.py"
+CI = ROOT / ".github/workflows/ci.yml"
+LEFTHOOK = ROOT / "lefthook.yml"
+
+
+def _diff(path: str, added: list[str], start: int = 1) -> str:
+    body = "\n".join(f"+{line}" for line in added)
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -0,0 +{start},{len(added)} @@\n{body}\n"
+
+
+def _run(tmp_path: Path, diff: str) -> subprocess.CompletedProcess[str]:
+    diff_path = tmp_path / "changes.diff"
+    diff_path.write_text(diff, encoding="utf-8")
+    return subprocess.run([sys.executable, str(SCRIPT), "--diff-file", str(diff_path)], cwd=ROOT, text=True, capture_output=True, check=False)
+
+
+@pytest.mark.parametrize(
+    ("diff", "needle"),
+    [
+        (
+            _diff(
+                "apps/mobile/lib/services/tax_projection_service.dart",
+                ["class TaxProjectionService {", "  static double _calculateTaxSavings(double income, double pillar3a) {", "    return income * 0.12 + pillar3a * 0.25;", "  }", "}"],
+            ),
+            "_calculateTaxSavings",
+        ),
+        (
+            _diff(
+                "apps/mobile/lib/services/mortgage_hint_service.dart",
+                ["    final affordability = revenuAnnuel * 0.33 - interetsHypotheque;", "    return affordability;"],
+                start=11,
+            ),
+            "affordability",
+        ),
+        (
+            _diff("apps/mobile/lib/services/risk_service.dart", ["double computeCapacity(double revenuAnnuel, double chargesHypothecaires) => revenuAnnuel * 0.33 - chargesHypothecaires;"]),
+            "computeCapacity",
+        ),
+        (
+            _diff("apps/mobile/lib/services/risk_service.dart", ["double get affordabilityRate => revenu * 0.33;"]),
+            "affordabilityRate",
+        ),
+        (
+            _diff("apps/mobile/lib/services/pillar3a_hint_service.dart", ["double _pillar3aDeduction(double revenu) => revenu * 0.12;"]),
+            "_pillar3aDeduction",
+        ),
+    ],
+)
+def test_new_financial_calculation_outside_financial_core_fails(tmp_path: Path, diff: str, needle: str) -> None:
+    result = _run(tmp_path, diff)
+    diagnostics = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert needle in diagnostics
+    assert "financial_core/" in diagnostics
+
+
+@pytest.mark.parametrize(
+    "diff",
+    [
+        _diff("apps/mobile/lib/services/financial_core/tax_calculator.dart", ["static double _calculateTaxSavings(double income) => income * 0.12;"]),
+        _diff("apps/mobile/lib/services/coach_summary_service.dart", ["final estimate = TaxCalculator.calculate(income: profile.salaireBrutAnnuel);"]),
+        _diff("apps/mobile/lib/services/navigation_state_service.dart", ["String _computeRouteLabel(String routeName) => routeName.trim();"]),
+        _diff("apps/mobile/lib/l10n/app_localizations_fr.dart", ["String monthlyAmount(Object amount) => 'Total fixe : $amount CHF / mois';"]),
+        _diff("apps/mobile/lib/services/coach_copy_service.dart", ["return 'Ton loyer est de 1200 CHF / mois';"]),
+        _diff("apps/mobile/lib/services/tax_screen_state_service.dart", ["final width = index * 2.0;"]),
+        _diff("apps/mobile/lib/screens/tax_screen.dart", ["void _calculate() {", "  setState(() {});", "}"]),
+        _diff("apps/mobile/lib/app.dart", ["String avsGuidePath() => '/scan/avs-guide';"]),
+    ],
+)
+def test_allowed_diffs_pass(tmp_path: Path, diff: str) -> None:
+    result = _run(tmp_path, diff)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_financial_core_gate_is_wired_into_ci_gate_and_lefthook() -> None:
+    ci = CI.read_text(encoding="utf-8")
+    gate = ci.split("ci-gate:", maxsplit=1)[1]
+    lefthook = LEFTHOOK.read_text(encoding="utf-8")
+    assert "financial-core-gate:" in ci
+    assert "tools/checks/financial_core_gate.py --base-ref" in ci
+    assert "financial-core-gate" in gate
+    assert 'financial_core="${{ needs.financial-core-gate.result }}"' in gate
+    assert '"$financial_core" != "success"' in gate
+    assert "financial-core-gate:" in lefthook
+    assert "tools/checks/financial_core_gate.py --staged" in lefthook


### PR DESCRIPTION
Summary
- Add a financial_core drift checker that scans introduced Dart lines under apps/mobile/lib and blocks new financial calculation helpers or formulas outside services/financial_core.
- Wire the gate into GitHub Actions CI Gate and lefthook pre-commit.
- Cover CI and lefthook wiring plus camelCase, getter, and arrow-helper regressions with pytest.

Verification
- python3 -m pytest tools/checks/tests/test_financial_core_gate.py -q : 14 passed
- python3 -m pytest tools/checks/tests -q : 70 passed
- python3 tools/checks/financial_core_gate.py --base-ref origin/claude/mint-swiss-coach-eu33i7 : OK
- lefthook run pre-commit on touched files : passed
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 : PASS, no P0/P1

Notes
- PR is 287 insertions, below the Mint 300 line limit.
- This is an additive drift fence for new code, not a semantic rewrite of existing historical drift.