### PR TITLE
docs: anchor Claude audit latency policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,24 @@ cd services/backend && python3 -m pytest tests/ -q && uvicorn app.main:app --rel
 cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
 ```
 
+### 3.1 EXTERNAL CLAUDE AUDIT (latency policy)
+
+Use the checked-in wrapper, never raw `claude -p`, for external reviews:
+
+```bash
+tools/checks/claude_external_audit.sh code <base-ref>
+tools/checks/claude_external_audit.sh specs
+tools/checks/claude_external_audit.sh architecture
+```
+
+The wrapper is intentionally bounded: Opus high by default, Sonnet high for
+same-gate reruns via `CLAUDE_AUDIT_RERUN=1`, `--safe-mode`,
+`--strict-mcp-config`, empty MCP config, `--no-session-persistence`, and bounded
+tools. Use `--effort max` only for a named final-release/P0 dispute with
+`CLAUDE_AUDIT_ALLOW_MAX=1`. Do not add unsupported `--max-turns`: the installed
+Claude CLI does not expose it, and the wrapper rejects `CLAUDE_AUDIT_MAX_TURNS`
+so agents cannot rely on a fake safety knob.
+
 ## 4. ROLE ROUTING
 
 - **Flutter work** → [docs/AGENTS/flutter.md](docs/AGENTS/flutter.md) (UX rules, design system, navigation, i18n setup, anti-bug discipline).

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -7,6 +7,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
+CLAUDE_MD = ROOT / "CLAUDE.md"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
 QUALITY_GATE = ROOT / ".claude/agents/mint-quality-gate.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
@@ -224,6 +225,23 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1" in text
         assert "--effort max" in text
         assert "CLAUDE_AUDIT_MAX_DIFF_LINES" in text
+
+
+def test_claude_md_anchors_external_audit_latency_policy() -> None:
+    text = CLAUDE_MD.read_text(encoding="utf-8")
+
+    for needle in (
+        "tools/checks/claude_external_audit.sh",
+        "Opus high",
+        "Sonnet high",
+        "CLAUDE_AUDIT_RERUN=1",
+        "--safe-mode",
+        "--strict-mcp-config",
+        "--no-session-persistence",
+        "--effort max",
+        "unsupported `--max-turns`",
+    ):
+        assert needle in text
 
 
 def test_quality_gate_does_not_allow_raw_claude_fallback() -> None:


### PR DESCRIPTION
## Summary\n- Anchor the Claude external audit latency policy in CLAUDE.md so every session sees it first.\n- Add a contract test that fails if CLAUDE.md loses the wrapper/rerun/safe-mode/max-turns policy.\n\n## Verification\n- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q\n- python3 -m pytest tools/checks/tests -q\n- git diff --check\n- lefthook run pre-commit --file CLAUDE.md --file tools/checks/tests/test_claude_external_audit_contract.py\n- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS, no P0/P1/P2 material\n