### PR TITLE
docs: define memory and hosting governance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 > Loaded at every session start. Quickref ~150L.
 > Role-scoped detail : [docs/AGENTS/flutter.md](docs/AGENTS/flutter.md) · [docs/AGENTS/backend.md](docs/AGENTS/backend.md) · [docs/AGENTS/swiss-brain.md](docs/AGENTS/swiss-brain.md).
 > Conflict resolution : `rules.md` (tier 1) > this file (tier 2) > `.claude/skills/*` (tier 3).
+> Memory hierarchy : repo git/ADR/AGENTS_LOG is the source of truth. Engram is a recall index, not a primary source. If memory conflicts with the checked-in repo, the repo wins.
 
 ## 🚨 TOP — 5 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
 

--- a/decisions/ADR-hosting-migration.md
+++ b/decisions/ADR-hosting-migration.md
@@ -1,0 +1,107 @@
+# ADR — Hosting Migration Boundary
+
+Status: Proposed
+Date: 2026-07-09
+
+## Context
+
+MINT is a Swiss financial lucidity product that progressively collects salary,
+tax, pension, insurance, mortgage, inheritance, and family variables. Railway is
+currently part of the backend deployment architecture, but the target product
+posture cannot treat a generic cloud host as a long-term home for raw,
+identifiable financial state without an explicit decision.
+
+This ADR defines the hosting boundary without pretending the current backend is
+already stateless.
+
+## Decision
+
+Railway target = stateless compute only.
+
+Policy: no new raw identifiable financial amount persisted server-side on Railway.
+Railway may run API compute, orchestration, transient document processing,
+health checks, and non-identifying operational telemetry. Any expansion of
+server-side identifiable financial storage needs an ADR and privacy/compliance
+review before merge.
+
+Swiss hosting candidates for the storage migration are Infomaniak and Exoscale.
+
+## Current Exceptions
+
+Existing backend persistence means MINT cannot claim Railway is stateless today.
+The current exceptions that drove this ADR are:
+
+- `services/backend/app/models/snapshot.py:27` stores `gross_income`.
+- `services/backend/app/models/profile_model.py:37` stores the full profile as JSON.
+  Active write paths include `services/backend/app/api/v1/endpoints/profiles.py:120`
+  on create and `services/backend/app/api/v1/endpoints/profiles.py:268` on update.
+- `services/backend/app/models/scenario.py:20` and
+  `services/backend/app/models/scenario.py:21` store scenario `inputs` and
+  `outputs`.
+- `services/backend/app/models/external_data_source.py:26` stores
+  `cached_response` for external sources. This is a registered schema with no checked-in writer
+  found at this ADR date, so it is treated as dormant storage risk rather than
+  an active write path.
+- `services/backend/app/models/document_memory.py:65` and
+  `services/backend/app/models/document_memory.py:67` keep plaintext
+  `evidence_text` and `vision_raw` nullable during the encryption migration
+  window.
+- `services/backend/app/models/coach_insight.py:45` stores `summary`, which may
+  contain raw user financial facts.
+- `services/backend/app/models/earmark.py:89` stores `amount_hint`.
+- `services/backend/app/models/billing.py:86` stores `amount_cents`.
+- `services/backend/app/models/snapshot.py:35` stores `tax_saving_potential`,
+  a derived identifiable financial amount.
+
+These exceptions are not permission to add more. They are inventory items to
+reduce, encrypt, localize, or migrate before a production stateless-Railway
+claim.
+
+## Migration Triggers
+
+Migration to a Swiss storage posture is already a production-readiness requirement
+because server-side identifiable financial data exists today. Further migration
+or hosting escalation is triggered by either condition:
+
+- server-side storage of identifiable financial data expands beyond the current
+  named exceptions;
+- a regulatory requirement, including FINMA, nLPD, contractual, DPA, or legal
+  counsel guidance, requires Swiss-controlled hosting or data residency.
+
+## Alternatives Considered
+
+- Keep Railway as full compute and data host indefinitely.
+- Move all compute and storage immediately to Swiss hosting before the data
+  model stabilizes.
+- Keep Railway for stateless compute, block new raw identifiable financial
+  amount persistence, and migrate storage when the trigger is reached.
+
+## Consequences
+
+- Backend PRs adding profile, document, pension, mortgage, inheritance, tax, or
+  insurance persistence must check this ADR.
+- CI and review should treat new raw identifiable financial amount fields on
+  Railway as a governance event, not a casual model change.
+- Engram, local agent memory, and chat transcripts are not compliance evidence.
+  Checked-in ADRs, code, deployment config, PRs, and test results are the
+  evidence.
+
+## Migration Plan
+
+1. Inventory server-side financial fields at each production-readiness gate.
+2. Block or ADR-review new raw identifiable financial amount persistence.
+3. If a trigger fires, choose Infomaniak or Exoscale for the first Swiss storage
+   target.
+4. Migrate storage before expanding compute, networking, DPA, secrets, and
+   runtime proof.
+5. Update `docs/DPA_TECHNICAL_ANNEX.md`, `docs/CICD_ARCHITECTURE.md`, secrets,
+   deployment workflows, and mobile/backend runtime proof after migration.
+
+## Evidence Links
+
+- `docs/DPA_TECHNICAL_ANNEX.md`
+- `docs/CICD_ARCHITECTURE.md`
+- `services/backend/app/models/snapshot.py`
+- `services/backend/app/models/coach_insight.py`
+- `services/backend/app/models/earmark.py`
+- `services/backend/app/models/billing.py`

--- a/rules.md
+++ b/rules.md
@@ -4,17 +4,20 @@ Objectif: coder vite (“vibe coding”) sans casser la cohérence.
 
 ## 0) Hiérarchie de vérité
 1. rules.md — Non-negotiable technical + ethical rules
-2. .claude/CLAUDE.md — Project context, constants, compliance, anti-patterns
-3. AGENTS.md — Team workflow, roles, sprint tracker
-4. .claude/skills/ — Agent-specific conventions and patterns
-5. LEGAL_RELEASE_CHECK.md — Wording compliance checklist
-6. visions/ — Product vision + limits
-7. docs/ (evolution specs) — ONBOARDING_ARBITRAGE_ENGINE, COACH_VIVANT_ROADMAP, DATA_ACQUISITION
-8. decisions/ (ADR) — Architecture decisions
-9. SOT.md + OpenAPI — Data contracts
-10. Code — Implementation follows documents
+2. Code/repo reality — authoritative implementation evidence
+3. CLAUDE.md — Project context, constants, compliance, anti-patterns
+4. AGENTS.md — Team workflow, roles, sprint tracker
+5. .claude/skills/ — Agent-specific conventions and patterns
+6. LEGAL_RELEASE_CHECK.md — Wording compliance checklist
+7. visions/ — Product vision + limits
+8. docs/ (evolution specs) — ONBOARDING_ARBITRAGE_ENGINE, COACH_VIVANT_ROADMAP, DATA_ACQUISITION
+9. decisions/ (ADR) — Architecture decisions
+10. SOT.md + OpenAPI — Data contracts
 
-Si le code contredit 1–9: corriger le code OU écrire une ADR.
+Docs are executable specs, not gospel. Challenge them against the live repo. If
+docs and implementation diverge, reconcile with code, SOT/OpenAPI, and ADRs:
+fix the implementation, update the spec, or write a new ADR/test that names the
+accepted divergence. Engram is never source of truth; it is only a recall index.
 docs/ evolution specs sit below visions/ but above ADRs.
 
 ## 1) Commandes standards

--- a/tools/checks/tests/test_governance_docs_contract.py
+++ b/tools/checks/tests/test_governance_docs_contract.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CLAUDE = ROOT / "CLAUDE.md"
+RULES = ROOT / "rules.md"
+HOSTING_ADR = ROOT / "decisions" / "ADR-hosting-migration.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_claude_md_declares_repo_memory_hierarchy() -> None:
+    claude = _text(CLAUDE)
+
+    for phrase in (
+        "Memory hierarchy",
+        "repo git/ADR/AGENTS_LOG is the source of truth",
+        "Engram is a recall index",
+        "not a primary source",
+        "the repo wins",
+    ):
+        assert phrase in claude
+
+
+def test_rules_md_uses_repo_reality_reconciliation() -> None:
+    rules = _text(RULES)
+
+    assert ".claude/CLAUDE.md" not in rules
+    assert "Code — Implementation follows documents" not in rules
+    for phrase in (
+        "CLAUDE.md — Project context",
+        "Code/repo reality — authoritative implementation evidence",
+        "reconcile with code, SOT/OpenAPI, and ADRs",
+        "Engram is never source of truth",
+    ):
+        assert phrase in rules
+
+
+def test_hosting_adr_exists_and_follows_template() -> None:
+    adr = _text(HOSTING_ADR)
+
+    for heading in (
+        "## Context",
+        "## Decision",
+        "## Current Exceptions",
+        "## Migration Triggers",
+        "## Alternatives Considered",
+        "## Consequences",
+        "## Migration Plan",
+        "## Evidence Links",
+    ):
+        assert heading in adr
+
+
+def test_hosting_adr_states_stateless_railway_target_without_hiding_exceptions() -> None:
+    adr = _text(HOSTING_ADR)
+
+    required_phrases = (
+        "Railway target = stateless compute only",
+        "no new raw identifiable financial amount persisted server-side on Railway",
+        "Existing backend persistence means MINT cannot claim Railway is stateless today",
+        "services/backend/app/models/snapshot.py:27",
+        "gross_income",
+        "services/backend/app/models/profile_model.py:37",
+        "full profile as JSON",
+        "services/backend/app/api/v1/endpoints/profiles.py:120",
+        "services/backend/app/api/v1/endpoints/profiles.py:268",
+        "services/backend/app/models/scenario.py:20",
+        "services/backend/app/models/scenario.py:21",
+        "inputs",
+        "outputs",
+        "services/backend/app/models/external_data_source.py:26",
+        "cached_response",
+        "registered schema with no checked-in writer",
+        "services/backend/app/models/document_memory.py:65",
+        "services/backend/app/models/document_memory.py:67",
+        "evidence_text",
+        "vision_raw",
+        "services/backend/app/models/coach_insight.py:45",
+        "summary",
+        "services/backend/app/models/earmark.py:89",
+        "amount_hint",
+        "services/backend/app/models/billing.py:86",
+        "amount_cents",
+        "services/backend/app/models/snapshot.py:35",
+        "tax_saving_potential",
+        "already a production-readiness requirement",
+        "Infomaniak",
+        "Exoscale",
+        "FINMA",
+        "server-side storage of identifiable financial data",
+        "regulatory requirement",
+    )
+
+    for phrase in required_phrases:
+        assert phrase in adr
+
+
+def test_hosting_adr_is_proposed_until_exceptions_are_removed_or_migrated() -> None:
+    adr = _text(HOSTING_ADR)
+
+    assert "Status: Proposed" in adr
+    assert "Accepted" not in adr.splitlines()[:8]


### PR DESCRIPTION
## Summary\n- Add repo-vs-memory hierarchy to CLAUDE.md and rules.md: Engram is recall only, repo/code/ADR evidence wins.\n- Add ADR-hosting-migration.md defining Railway as stateless-compute target and Swiss storage migration readiness boundary.\n- Add governance contract tests for memory hierarchy and hosting ADR claims.\n\n## Key correction from audit\nThe first Claude audit found the old four-field hosting inventory was incomplete. This PR now inventories the active backend stores: profile JSON, scenario inputs/outputs, document memory plaintext migration window, coach insights, earmarks, snapshots, billing amounts, plus dormant external_data_source cached_response schema.\n\n## Verification\n- python3 -m pytest tools/checks/tests/test_governance_docs_contract.py -q => 5 passed\n- python3 -m pytest tools/checks/tests -q => 77 passed\n- git diff --cached --check\n- lefthook run pre-commit --file CLAUDE.md --file rules.md --file decisions/ADR-hosting-migration.md --file tools/checks/tests/test_governance_docs_contract.py\n- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => NO-GO P1 incomplete inventory, fixed\n- CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS\n- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS final Opus/high\n