### PR TITLE
test: add instruction hygiene contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@
 
 ## 🚨 TOP — 5 RULES CRITIQUES (repeat at BOTTOM — Liu 2024 lost-in-the-middle mitigation)
 
-1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md).
-2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`, `decouvrir → découvrir`, `securite → sécurité`, `premier éclairage` (jamais `premier eclairage`). ASCII « e » à la place de « é » = bug. Lint : `tools/checks/accent_lint_fr.py`.
+1. **Banned terms (LSFin)** — NEVER « garanti », « optimal », « meilleur », « certain », « assuré », « sans risque », « parfait ». Use « pourrait », « envisager », « adapté ». Full list → [swiss-brain.md §1](docs/AGENTS/swiss-brain.md). Mechanical UI scan enforced by hook/CI: banned-ui-terms.
+2. **Accents 100% FR mandatory** — `creer → créer`, `eclairage → éclairage`, `decouvrir → découvrir`, `securite → sécurité`, `premier éclairage` (jamais `premier eclairage`). ASCII « e » à la place de « é » = bug. Mechanical scan enforced by hook/CI: accent-lint-fr.
 3. **MINT ≠ retirement app** — 18 life events equally weighted (housing, family, tax, career, debt…). Never frame screens/prompts as « retraite-first ». Target : 18-99. Pivot 2026-04-12 : lucidité, pas protection.
-4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`.
-5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. Run `flutter gen-l10n`.
+4. **Financial_core reuse mandatory** — `lib/services/financial_core/` est SOURCE OF TRUTH. Never re-implement `_calculate*()` dans services. ADR : `decisions/ADR-20260223-unified-financial-engine.md`. Mechanical scan enforced by hook/CI: financial-core-gate.
+5. **i18n required** — Toutes strings user-facing via `AppLocalizations.of(context)!.key`. Never `Text('Bonjour')`. 6 ARB files (fr/en/de/es/it/pt) sous `lib/l10n/`. Mechanical scan enforced by hook/CI: no-hardcoded-fr, arb-parity.
 
 ---
 

--- a/rules.md
+++ b/rules.md
@@ -18,6 +18,7 @@ Docs are executable specs, not gospel. Challenge them against the live repo. If
 docs and implementation diverge, reconcile with code, SOT/OpenAPI, and ADRs:
 fix the implementation, update the spec, or write a new ADR/test that names the
 accepted divergence. Engram is never source of truth; it is only a recall index.
+Checked-in hooks/CI, not memory, enforce mechanical rules.
 docs/ evolution specs sit below visions/ but above ADRs.
 
 ## 1) Commandes standards

--- a/tools/checks/tests/test_instruction_hygiene_contract.py
+++ b/tools/checks/tests/test_instruction_hygiene_contract.py
@@ -1,0 +1,86 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CLAUDE = ROOT / "CLAUDE.md"
+RULES = ROOT / "rules.md"
+LEFTHOOK = ROOT / "lefthook.yml"
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+INSTRUCTION_PATTERNS = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "rules.md",
+    ".claude/agents/*.md",
+    ".claude/skills/*/SKILL.md",
+    ".claude/prompts/*.md",
+)
+
+VOLATILE_PATTERNS = (
+    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?"),
+    re.compile(r"\bGenerated\s+(?:at|on)\s+\d{4}-\d{2}-\d{2}", re.IGNORECASE),
+    re.compile(r"\bLast\s+updated\s*:\s*\d{4}-\d{2}-\d{2}", re.IGNORECASE),
+)
+
+GATES = {
+    "banned-ui-terms": "tools/checks/banned_ui_terms.py",
+    "accent-lint-fr": "tools/checks/accent_lint_fr.py",
+    "financial-core-gate": "tools/checks/financial_core_gate.py",
+    "no-hardcoded-fr": "tools/checks/no_hardcoded_fr.py",
+    "arb-parity": "tools/checks/arb_parity.py",
+}
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _instruction_files() -> list[Path]:
+    files: set[Path] = set()
+    for pattern in INSTRUCTION_PATTERNS:
+        files.update(ROOT.glob(pattern))
+    return sorted(path for path in files if path.is_file())
+
+
+def test_active_instruction_files_have_no_volatile_timestamps() -> None:
+    offenders: list[str] = []
+
+    for path in _instruction_files():
+        for lineno, line in enumerate(_text(path).splitlines(), start=1):
+            if any(pattern.search(line) for pattern in VOLATILE_PATTERNS):
+                offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {line.strip()}")
+
+    assert offenders == []
+
+
+def test_claude_md_marks_mechanical_rules_as_enforced_by_hooks_or_ci() -> None:
+    claude = _text(CLAUDE)
+
+    for gate in (
+        "enforced by hook/CI: banned-ui-terms",
+        "enforced by hook/CI: accent-lint-fr",
+        "enforced by hook/CI: financial-core-gate",
+        "enforced by hook/CI: no-hardcoded-fr, arb-parity",
+    ):
+        assert gate in claude
+
+
+def test_claude_md_gate_labels_are_backed_by_checked_in_hooks_or_ci() -> None:
+    lefthook = _text(LEFTHOOK)
+    ci = _text(CI)
+
+    for label, script in GATES.items():
+        assert f"{label}:" in lefthook
+        assert script in lefthook
+
+    for label in ("banned-ui-terms", "financial-core-gate"):
+        assert f"{label}:" in ci
+
+
+def test_rules_md_points_to_repo_claude_and_checked_in_gates() -> None:
+    rules = _text(RULES)
+
+    assert ".claude/CLAUDE.md" not in rules
+    assert "CLAUDE.md — Project context" in rules
+    assert "Checked-in hooks/CI, not memory, enforce mechanical rules" in rules


### PR DESCRIPTION
## Summary\n- Add an instruction hygiene contract that blocks volatile generated timestamps in active instruction files.\n- Mark CLAUDE.md mechanical rules as enforced by checked-in hooks/CI labels.\n- Strengthen the contract so CLAUDE.md labels must map to real lefthook/CI wiring, not just prose.\n\n## Verification\n- python3 -m pytest tools/checks/tests/test_instruction_hygiene_contract.py -q => 4 passed\n- python3 -m pytest tools/checks/tests -q => 81 passed\n- git diff --cached --check\n- lefthook run pre-commit --file CLAUDE.md --file rules.md --file tools/checks/tests/test_instruction_hygiene_contract.py\n- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS, P2 suggested stronger hook/CI backing test\n- CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS, no P0/P1/P2\n- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS final Opus/high\n\n## Known follow-up\n- accent-lint-fr, no-hardcoded-fr, and arb-parity are currently lefthook-only. The wording says hook/CI as inclusive OR, but adding CI backstops is the next hardening slice.\n