### PR TITLE
ci: isolate Claude audit setting sources

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -34,7 +34,8 @@ Same-gate rerun after a first finding pass:
 
 The wrapper is the default. It runs Claude CLI with Opus high, safe mode,
 strict empty MCP, disabled slash commands, no session persistence, bounded
-tools, and dynamic-system-prompt sections excluded for cache stability.
+tools, `--setting-sources user`, and dynamic-system-prompt sections excluded for
+cache stability.
 Code audits also enforce a diff-prompt budget (`CLAUDE_AUDIT_MAX_DIFF_LINES`,
 default 2500). If it trips, split the PR; use `CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1`
 only for a named final-release/P0 dispute.
@@ -49,7 +50,9 @@ injection, skill inventory, and max reasoning on every tool turn.
 Do not add `--max-turns`: the installed Claude CLI does not expose it, and the
 wrapper rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not
 use `--bare` by default: it skips OAuth/keychain auth and only works with
-explicit API-key/apiKeyHelper auth.
+explicit API-key/apiKeyHelper auth. Do not use project/local setting sources by
+default: they can reload repo hooks. The wrapper rejects them unless
+`CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1` is set for a named debug run.
 </commands>
 
 <policy>

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -45,9 +45,12 @@ tools/checks/claude_external_audit.sh architecture
 ```
 
 The wrapper is deliberately bounded: Opus high by default, strict empty MCP,
-no session persistence, no dynamic-system-prompt sections, and no `--effort max`
-unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly set for a named final-release
-or unresolved P0/P1 dispute. Code audits reject large diff prompts by default
+no session persistence, `--setting-sources user`, no dynamic-system-prompt
+sections, and no `--effort max` unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly
+set for a named final-release or unresolved P0/P1 dispute. Project/local setting
+sources are rejected by default because they can load repo hooks; override only
+with `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1` for a named debug run. Code audits
+reject large diff prompts by default
 (`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500) so oversized branches are split
 before review. Repeated same-gate re-audits should use Sonnet high first via
 `CLAUDE_AUDIT_RERUN=1`, then one Opus high final. The wrapper rejects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,10 @@ tools/checks/claude_external_audit.sh architecture
 
 The wrapper is intentionally bounded: Opus high by default, Sonnet high for
 same-gate reruns via `CLAUDE_AUDIT_RERUN=1`, `--safe-mode`,
-`--strict-mcp-config`, empty MCP config, `--no-session-persistence`, and bounded
-tools. Use `--effort max` only for a named final-release/P0 dispute with
+`--strict-mcp-config`, empty MCP config, `--setting-sources user`,
+`--no-session-persistence`, and bounded tools. Project/local setting sources are
+rejected by default because `.claude/settings*.json` can load repo hooks. Use
+`--effort max` only for a named final-release/P0 dispute with
 `CLAUDE_AUDIT_ALLOW_MAX=1`. Do not add unsupported `--max-turns`: the installed
 Claude CLI does not expose it, and the wrapper rejects `CLAUDE_AUDIT_MAX_TURNS`
 so agents cannot rely on a fake safety knob.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -61,7 +61,7 @@ Every product PR must list:
 
 | Tool | Status in clean checkout | Gate use |
 |---|---|---|
-| Claude CLI | Available after local login | External audit via `tools/checks/claude_external_audit.sh`; use bounded audits (`opus high`, safe mode, strict empty MCP) by default |
+| Claude CLI | Available after local login | External audit via `tools/checks/claude_external_audit.sh`; use bounded audits (`opus high`, safe mode, strict empty MCP, `--setting-sources user`) by default |
 | Engram MCP | Available | Memory |
 | Maestro | Available at `~/.maestro/bin/maestro` | Runtime UI proof |
 | Patrol CLI | Not in PATH at G0 base restore | Required gap before Patrol-only gates |
@@ -84,7 +84,10 @@ Claude CLI audits should be bounded through
 no session persistence, and no `--effort max` except named final-release/P0
 disputes. Re-run loops use Sonnet high first, then one Opus high final; do not
 use `--bare` without explicit API-key auth, and do not add unsupported
-`--max-turns`. Same-gate re-runs use
+`--max-turns`. The wrapper also forces `--setting-sources user` by default and
+rejects project/local setting sources unless `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1`
+is explicitly set for a named debug run, because project/local settings can
+reload repo hooks. Same-gate re-runs use
 `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh ...`; the wrapper
 switches the default model to Sonnet and rejects non-Sonnet reruns unless
 `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is set for a final confirmation/P0 dispute.

--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -9,6 +9,7 @@ Usage:
 
 Env: CLAUDE_AUDIT_MODEL, CLAUDE_AUDIT_EFFORT, CLAUDE_AUDIT_ALLOW_MAX,
 CLAUDE_AUDIT_WORKTREE, CLAUDE_AUDIT_BARE, CLAUDE_AUDIT_SETTINGS,
+CLAUDE_AUDIT_SETTING_SOURCES, CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS,
 CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_MAX_DIFF_LINES,
 CLAUDE_AUDIT_ALLOW_LARGE_DIFF, CLAUDE_AUDIT_RERUN,
 CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN, CLAUDE_AUDIT_DRY_RUN.
@@ -53,6 +54,25 @@ repo_root="$(git rev-parse --show-toplevel)"
 worktree="${CLAUDE_AUDIT_WORKTREE:-$repo_root}"
 max_diff_lines="${CLAUDE_AUDIT_MAX_DIFF_LINES:-2500}"
 case "$max_diff_lines" in ""|*[!0-9]*) die "CLAUDE_AUDIT_MAX_DIFF_LINES must be a non-negative integer" ;; esac
+setting_sources="${CLAUDE_AUDIT_SETTING_SOURCES:-user}"
+case "${CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS:-0}" in
+  0|1) ;;
+  *) die "CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS must be 0 or 1" ;;
+esac
+IFS=',' read -r -a setting_source_parts <<< "$setting_sources"
+for setting_source in "${setting_source_parts[@]}"; do
+  case "$setting_source" in
+    user) ;;
+    project|local)
+      if [[ "${CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS:-0}" != "1" ]]; then
+        die "project/local settings can load repo hooks; keep CLAUDE_AUDIT_SETTING_SOURCES=user or set CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1 for a named debug run"
+      fi
+      ;;
+    *)
+      die "CLAUDE_AUDIT_SETTING_SOURCES must be a comma-separated list of user,project,local"
+      ;;
+  esac
+done
 prompt_file="$(mktemp "${TMPDIR:-/tmp}/mint-claude-audit.XXXXXX")"
 trap 'rm -f "$prompt_file"' EXIT
 
@@ -156,6 +176,7 @@ esac
 claude_args=(-p --model "$model" --effort "$effort" --safe-mode
   --strict-mcp-config --mcp-config '{"mcpServers":{}}'
   --disable-slash-commands --no-session-persistence
+  --setting-sources "$setting_sources"
   --permission-mode dontAsk --tools Read,Grep,Bash --add-dir "$worktree"
   --exclude-dynamic-system-prompt-sections)
 

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -67,6 +67,7 @@ def test_wrapper_defaults_are_bounded() -> None:
         r"\{\"mcpServers\":\{\}\}",
         "--disable-slash-commands",
         "--no-session-persistence",
+        "--setting-sources user",
         "--permission-mode dontAsk",
         "--tools Read\\,Grep\\,Bash",
         "--exclude-dynamic-system-prompt-sections",
@@ -131,6 +132,16 @@ def test_rerun_mode_defaults_to_sonnet_high() -> None:
             "MAX_DIFF_LINES must be a non-negative integer",
         ),
         (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_SETTING_SOURCES": "project"},
+            "project/local settings can load repo hooks",
+        ),
+        (
+            ("code", "HEAD"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_SETTING_SOURCES": "local"},
+            "project/local settings can load repo hooks",
+        ),
+        (
             ("specs",),
             {
                 "CLAUDE_AUDIT_DRY_RUN": "1",
@@ -165,6 +176,19 @@ def test_rerun_mode_allows_non_sonnet_only_with_explicit_override() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "--model opus" in result.stdout
+
+
+def test_project_setting_sources_require_explicit_override() -> None:
+    result = _run(
+        "code",
+        "HEAD",
+        CLAUDE_AUDIT_DRY_RUN="1",
+        CLAUDE_AUDIT_SETTING_SOURCES="project,local",
+        CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS="1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--setting-sources project\\,local" in result.stdout
 
 
 def test_wrapper_rejects_large_code_diff_without_explicit_override() -> None:
@@ -223,6 +247,8 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "Sonnet high" in text
         assert "CLAUDE_AUDIT_RERUN=1" in text
         assert "CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1" in text
+        assert "--setting-sources user" in text
+        assert "CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1" in text
         assert "--effort max" in text
         assert "CLAUDE_AUDIT_MAX_DIFF_LINES" in text
 
@@ -237,6 +263,7 @@ def test_claude_md_anchors_external_audit_latency_policy() -> None:
         "CLAUDE_AUDIT_RERUN=1",
         "--safe-mode",
         "--strict-mcp-config",
+        "--setting-sources user",
         "--no-session-persistence",
         "--effort max",
         "unsupported `--max-turns`",


### PR DESCRIPTION
## Summary
- force the Claude external-audit wrapper to default to `--setting-sources user`
- reject project/local setting sources unless explicitly allowed for a named debug run
- anchor the setting-source policy in CLAUDE.md, MINT_AGENT_WORKFLOW, operating gates, and mint-external-auditor docs

## QA
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q`
- `python3 -m pytest tools/checks/tests -q`
- `lefthook run pre-commit --file tools/checks/claude_external_audit.sh --file tools/checks/tests/test_claude_external_audit_contract.py --file CLAUDE.md --file docs/MINT_AGENT_WORKFLOW.md --file .claude/skills/mint-operating-gates/SKILL.md --file .claude/agents/mint-external-auditor.md`
- `tools/checks/claude_external_audit.sh code HEAD` → PASS
