### PR TITLE
test: scope french accent lint

### DIFF
--- a/tools/checks/accent_lint_fr.py
+++ b/tools/checks/accent_lint_fr.py
@@ -52,11 +52,31 @@ EXCLUDE_SUBSTRINGS = (
     "/docs/archive/",
     "/.planning/archives/",
 )
+ROUTE_OR_URL_LITERAL_RE = re.compile(
+    r"""(?P<quote>['"])(?:[a-z][a-z0-9+.-]*:)?/{1,3}[^'"\s]*(?P=quote)""",
+    re.IGNORECASE,
+)
+NON_FRENCH_GENERATED_L10N_RE = re.compile(
+    r"^app_localizations_(?!fr\b)[a-z]{2}\.dart$"
+)
+
+
+def _line_for_lint(path: Path, line: str) -> str:
+    lint_line = line
+    if path.suffix == ".md":
+        lint_line = re.sub(r"`[^`]*`", "", lint_line)
+    if path.suffix == ".dart":
+        lint_line = ROUTE_OR_URL_LITERAL_RE.sub("", lint_line)
+    return lint_line
 
 
 def scan_file(path: Path) -> list[tuple[int, str, str]]:
     """Return list of (lineno, snippet, pattern->correction) violations."""
     if path.name == "accent_lint_fr.py":
+        return []
+    if path.suffix == ".arb" and path.name != "app_fr.arb":
+        return []
+    if NON_FRENCH_GENERATED_L10N_RE.match(path.name):
         return []
     try:
         text = path.read_text(encoding="utf-8", errors="ignore")
@@ -64,9 +84,7 @@ def scan_file(path: Path) -> list[tuple[int, str, str]]:
         return []
     out: list[tuple[int, str, str]] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
-        lint_line = line
-        if path.suffix == ".md":
-            lint_line = re.sub(r"`[^`]*`", "", line)
+        lint_line = _line_for_lint(path, line)
         for pat, correct in PATTERNS:
             if re.search(pat, lint_line, re.IGNORECASE):
                 snippet = line.strip()[:140]

--- a/tools/checks/tests/test_accent_lint_fr_contract.py
+++ b/tools/checks/tests/test_accent_lint_fr_contract.py
@@ -29,3 +29,71 @@ def test_markdown_plain_french_copy_is_still_linted(tmp_path: Path) -> None:
 
     assert len(violations) == 1
     assert "éclairage" in violations[0][2]
+
+
+def test_dart_route_literals_are_not_french_copy(tmp_path: Path) -> None:
+    dart = tmp_path / "app.dart"
+    dart.write_text(
+        "GoRoute(path: '/onboarding/premier-ecl" "airage', builder: _build);\n",
+        encoding="utf-8",
+    )
+
+    assert accent_lint_fr.scan_file(dart) == []
+
+
+def test_dart_plain_ui_copy_is_still_linted(tmp_path: Path) -> None:
+    dart = tmp_path / "screen.dart"
+    dart.write_text(
+        "const Text('Ce premier ecl" "airage doit être accentué');\n",
+        encoding="utf-8",
+    )
+
+    violations = accent_lint_fr.scan_file(dart)
+
+    assert len(violations) == 1
+    assert "éclairage" in violations[0][2]
+
+
+def test_non_french_arb_is_not_scanned_as_french_copy(tmp_path: Path) -> None:
+    arb = tmp_path / "app_de.arb"
+    arb.write_text(
+        '{"lamalFranchiseIntro": "Verschiebe die Reg' "ler, um zu vergleichen." "}\n",
+        encoding="utf-8",
+    )
+
+    assert accent_lint_fr.scan_file(arb) == []
+
+
+def test_french_arb_is_still_linted(tmp_path: Path) -> None:
+    arb = tmp_path / "app_fr.arb"
+    arb.write_text('{"title": "Ce premier ecl' 'airage compte."}\n', encoding="utf-8")
+
+    violations = accent_lint_fr.scan_file(arb)
+
+    assert len(violations) == 1
+    assert "éclairage" in violations[0][2]
+
+
+def test_non_french_generated_l10n_dart_is_not_scanned_as_french_copy(
+    tmp_path: Path,
+) -> None:
+    dart = tmp_path / "app_localizations_de.dart"
+    dart.write_text(
+        "String get title => 'Verschiebe die Reg" "ler, um zu vergleichen.';\n",
+        encoding="utf-8",
+    )
+
+    assert accent_lint_fr.scan_file(dart) == []
+
+
+def test_french_generated_l10n_dart_is_still_linted(tmp_path: Path) -> None:
+    dart = tmp_path / "app_localizations_fr.dart"
+    dart.write_text(
+        "String get title => 'Ce premier ecl" "airage compte.';\n",
+        encoding="utf-8",
+    )
+
+    violations = accent_lint_fr.scan_file(dart)
+
+    assert len(violations) == 1
+    assert "éclairage" in violations[0][2]


### PR DESCRIPTION
## Summary
- Keep French accent lint strict for UI copy.
- Ignore Dart route/URL literals and non-French generated/localization files so slugs and translated text do not false-positive.

## QA
- python3 -m pytest tools/checks/tests/test_accent_lint_fr_contract.py -q
- python3 -m py_compile tools/checks/accent_lint_fr.py
- lefthook pre-commit via git commit

## Stack
1. This PR
2. codex/mint-scan-recovery-l10n-20260709
3. codex/mint-scan-dead-road-recovery-split-20260709