### PR TITLE
docs: anchor Claude audit wrapper in agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,21 @@ Canonical skills live in `.claude/skills/mint-*`:
 External or generic specialists are not active by default. Use them only for a
 named gap after the MINT roster scopes the work.
 
+### External Claude Audit
+
+Run external reviews through `tools/checks/claude_external_audit.sh`, never raw
+`claude -p`. The wrapper is the operating contract: Opus high for first-pass
+bounded reviews, Sonnet high for same-gate reruns with `CLAUDE_AUDIT_RERUN=1`,
+strict empty MCP, `--setting-sources user`, no session persistence, and a code
+diff budget via `CLAUDE_AUDIT_MAX_DIFF_LINES`. Use `--effort max` only for a
+named final-release/P0 dispute with `CLAUDE_AUDIT_ALLOW_MAX=1`.
+
+If a rerun needs Opus for final confirmation or a P0 dispute, set
+`CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1`. If a named debug run must load
+project/local settings, set `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1`. Do not add
+a max-turn cap; this Claude CLI does not expose `--max-turns`, and the wrapper
+rejects `CLAUDE_AUDIT_MAX_TURNS` so agents cannot rely on a fake safety knob.
+
 ## 🗺 Before you edit X, read Y, grep Z
 
 Pre-flight for any code change. If the agent can't state which row applies

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -8,6 +8,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = ROOT / "tools/checks/claude_external_audit.sh"
 CLAUDE_MD = ROOT / "CLAUDE.md"
+AGENTS_MD = ROOT / "AGENTS.md"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
 QUALITY_GATE = ROOT / ".claude/agents/mint-quality-gate.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
@@ -238,6 +239,7 @@ def test_specs_and_architecture_prompts_are_wired() -> None:
 def test_auditor_docs_point_to_wrapper_policy() -> None:
     for text in (
         AGENT.read_text(encoding="utf-8"),
+        AGENTS_MD.read_text(encoding="utf-8"),
         WORKFLOW.read_text(encoding="utf-8"),
         OPERATING_GATES.read_text(encoding="utf-8"),
     ):


### PR DESCRIPTION
## Summary
- Add the Claude external-audit wrapper policy directly to AGENTS.md.
- Extend the existing Claude audit contract test so AGENTS.md is enforced with the same policy anchors as the auditor agent, workflow doc, and operating-gates skill.

## Verification
- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q
- CLAUDE_AUDIT_DRY_RUN=1 tools/checks/claude_external_audit.sh code HEAD
- CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code HEAD
- CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_EFFORT=max tools/checks/claude_external_audit.sh code HEAD (expected refusal)
- CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_MAX_TURNS=25 tools/checks/claude_external_audit.sh code HEAD (expected refusal)
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS
- CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS
