### PR TITLE
test(mobile): stabilize scan Maestro assertions

### DIFF
--- a/apps/mobile/.maestro/r1_scan_review.yaml
+++ b/apps/mobile/.maestro/r1_scan_review.yaml
@@ -11,4 +11,4 @@ appId: ch.mint.app
 - tapOn:
     id: "scan_review_recovery_cta"
 - assertVisible:
-    text: "Prendre une photo"
+    id: "document_scan_capture_cta"

--- a/apps/mobile/.maestro/r2_scan_impact.yaml
+++ b/apps/mobile/.maestro/r2_scan_impact.yaml
@@ -11,4 +11,4 @@ appId: ch.mint.app
 - tapOn:
     id: "scan_impact_recovery_cta"
 - assertVisible:
-    text: "MINT"
+    id: "home_route"

--- a/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
+++ b/apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart
@@ -39,6 +39,14 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
   final Set<String> _collapsedMonths = {};
   bool _initialCollapseSet = false;
 
+  Widget _homeRoute(Widget child) {
+    return Semantics(
+      container: true,
+      identifier: 'home_route',
+      child: child,
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -79,20 +87,20 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
     final l10n = S.of(context)!;
 
     if (provider.isLoading) {
-      return const Scaffold(
+      return _homeRoute(const Scaffold(
         backgroundColor: MintColors.warmWhite,
         body: Center(
           child: CircularProgressIndicator(
             color: MintColors.success,
           ),
         ),
-      );
+      ));
     }
 
     if (provider.isEmpty) {
       // Wave B-minimal B1-fix (2026-04-18): Cap du jour banner surfaces
       // even when the timeline is empty so CapEngine's fallback card
-      // ("Parle-moi de toi") is visible on first open.
+      // (fallback coach invite) is visible on first open.
       //
       // Deep-walk 2026-04-21 crack #11: the tension-empty card below
       // used to always render, repeating "Commence par parler au coach"
@@ -102,7 +110,7 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
       // redundant copy disappears.
       final hasAnyProfileFact =
           context.watch<CoachProfileProvider>().profile != null;
-      return Scaffold(
+      return _homeRoute(Scaffold(
         backgroundColor: MintColors.warmWhite,
         body: SafeArea(
           child: Column(
@@ -155,13 +163,13 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
             ],
           ),
         ),
-      );
+      ));
     }
 
     // Set initial collapse state once provider has data.
     _ensureInitialCollapse(provider);
 
-    return Scaffold(
+    return _homeRoute(Scaffold(
       backgroundColor: MintColors.warmWhite,
       body: SafeArea(
         child: CustomScrollView(
@@ -219,7 +227,7 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
               ),
             ),
 
-            // ── Divider: "Ton histoire" ────────────────────────
+            // ── Timeline divider ────────────────────────────────
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.only(top: 24, bottom: 12),
@@ -333,6 +341,6 @@ class _AujourdhuiScreenState extends State<AujourdhuiScreen> {
           ],
         ),
       ),
-    );
+    ));
   }
 }

--- a/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
+++ b/apps/mobile/lib/screens/document_scan/document_scan_screen.dart
@@ -275,17 +275,26 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
       children: [
         Semantics(
           button: true,
+          identifier: 'document_scan_capture_cta',
           label: S.of(context)!.documentScanTakePhoto,
-          child: SizedBox(
-            width: double.infinity,
-            height: 56,
-            child: FilledButton.icon(
-              onPressed: _isProcessing
-                  ? null
-                  : () {
-                      HapticFeedback.lightImpact();
-                      _onCameraPressed();
-                    },
+          onTap: _isProcessing
+              ? null
+              : () {
+                  HapticFeedback.lightImpact();
+                  _onCameraPressed();
+                },
+          child: ExcludeSemantics(
+            child: SizedBox(
+              width: double.infinity,
+              height: 56,
+              child: FilledButton.icon(
+                key: const Key('document_scan_capture_cta'),
+                onPressed: _isProcessing
+                    ? null
+                    : () {
+                        HapticFeedback.lightImpact();
+                        _onCameraPressed();
+                      },
             icon: const Icon(
               kIsWeb ? Icons.upload_file_outlined : Icons.camera_alt_outlined,
               size: 22,
@@ -307,6 +316,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
             ),
           ),
         ),
+          ),
         ),
         const SizedBox(height: 12),
         Semantics(
@@ -644,7 +654,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
       // slice, which blocked iterating on Apple Silicon simulators). Backend
       // Claude Vision is the single source of OCR — it already ran above;
       // if it produced nothing, the user sees the OCR recovery sheet.
-      final String extractedText = '';
+      const String extractedText = '';
 
       if (extractedText.trim().length < 12) {
         if (!mounted) return;
@@ -1221,9 +1231,7 @@ class _DocumentScanScreenState extends State<DocumentScanScreen> {
         return SalaryCertificateParser.parse(text);
       case DocumentType.threeAAttestation:
       case DocumentType.mortgageAttestation:
-        throw UnsupportedError(
-          'Type non supporte pour le moment: ${_selectedType.label}',
-        );
+        throw UnsupportedError(S.of(context)!.docScanPdfTypeUnsupported);
     }
   }
 

--- a/apps/mobile/lib/screens/landing_screen.dart
+++ b/apps/mobile/lib/screens/landing_screen.dart
@@ -80,12 +80,20 @@ class _LandingScreenState extends State<LandingScreen>
     super.dispose();
   }
 
+  Widget _homeRoute(Widget child) {
+    return Semantics(
+      container: true,
+      identifier: 'home_route',
+      child: child,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = S.of(context)!;
     final textTheme = Theme.of(context).textTheme;
 
-    return Scaffold(
+    return _homeRoute(Scaffold(
       backgroundColor: MintColors.warmWhite,
       body: SafeArea(
         child: Center(
@@ -206,6 +214,6 @@ class _LandingScreenState extends State<LandingScreen>
           ),
         ),
       ),
-    );
+    ));
   }
 }

--- a/apps/mobile/test/screens/document_scan/document_scan_screen_test.dart
+++ b/apps/mobile/test/screens/document_scan/document_scan_screen_test.dart
@@ -47,15 +47,40 @@ Widget _buildWrapped() {
 void main() {
   testWidgets('DocumentScanScreen builds and surfaces capture buttons',
       (tester) async {
-    await tester.pumpWidget(_buildWrapped());
-    await tester.pump();
+    final semantics = tester.ensureSemantics();
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    try {
+      await tester.pumpWidget(_buildWrapped());
+      await tester.pump();
 
-    // The screen renders without throwing. We don't assert the exact label
-    // string — i18n lookups in fr exercise the live ARB. Phase 28-04 will
-    // add the polished reject bubble UI; here we just verify the screen
-    // composes cleanly with the new classifier wiring.
-    expect(find.byType(DocumentScanScreen), findsOneWidget);
-    expect(tester.takeException(), isNull);
+      final captureCta = find.byKey(const Key('document_scan_capture_cta'));
+      final scrollable = find.byType(Scrollable);
+      if (scrollable.evaluate().isNotEmpty) {
+        await tester.scrollUntilVisible(
+          captureCta,
+          200,
+          scrollable: scrollable.first,
+        );
+        await tester.pumpAndSettle();
+      }
+
+      // The screen renders without throwing. We don't assert the exact label
+      // string — i18n lookups in fr exercise the live ARB. Phase 28-04 will
+      // add the polished reject bubble UI; here we just verify the screen
+      // composes cleanly with the new classifier wiring.
+      expect(find.byType(DocumentScanScreen), findsOneWidget);
+      expect(
+        find.bySemanticsIdentifier('document_scan_capture_cta'),
+        findsOneWidget,
+      );
+      expect(captureCta, findsOneWidget);
+      expect(tester.takeException(), isNull);
+    } finally {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      semantics.dispose();
+    }
   });
 
   testWidgets('Phase 28-03 i18n keys for pre-reject + scanner error resolve',

--- a/apps/mobile/test/screens/home_route_semantics_test.dart
+++ b/apps/mobile/test/screens/home_route_semantics_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/providers/mint_state_provider.dart';
+import 'package:mint_mobile/providers/timeline_provider.dart';
+import 'package:mint_mobile/screens/aujourdhui/aujourdhui_screen.dart';
+import 'package:mint_mobile/screens/landing_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _wrapHome(Widget child) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider(create: (_) => CoachProfileProvider()),
+      ChangeNotifierProvider(create: (_) => MintStateProvider()),
+      ChangeNotifierProvider(create: (_) => TimelineProvider()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('fr'),
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: S.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('LandingScreen exposes the stable home route id', (tester) async {
+    final semantics = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(_wrapHome(const LandingScreen()));
+      await tester.pump();
+
+      expect(find.bySemanticsIdentifier('home_route'), findsOneWidget);
+    } finally {
+      semantics.dispose();
+    }
+  });
+
+  testWidgets('AujourdhuiScreen exposes the stable home route id',
+      (tester) async {
+    final semantics = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(_wrapHome(const AujourdhuiScreen()));
+      await tester.pump();
+
+      expect(find.bySemanticsIdentifier('home_route'), findsOneWidget);
+    } finally {
+      semantics.dispose();
+    }
+  });
+}

--- a/docs/codex/MAESTRO_FLOWS.md
+++ b/docs/codex/MAESTRO_FLOWS.md
@@ -180,7 +180,7 @@ appId: ch.mint.app
 - assertNotVisible: { text: "Document non disponible" }   # the blank trap
 - assertVisible: { id: "scan_review_recovery_cta" }        # recovery exists
 - tapOn: { id: "scan_review_recovery_cta" }
-- assertVisible: { text: "Prendre une photo" } # lands back on /scan, not stuck
+- assertVisible: { id: "document_scan_capture_cta" }       # lands back on /scan
 ```
 **G1 repair status:** checked-in flow exists; the blank trap is covered by `apps/mobile/test/routing/scan_flow_repair_test.dart`. Runtime acceptance still requires running this Maestro flow against the app.
 
@@ -194,7 +194,7 @@ appId: ch.mint.app
 - assertNotVisible: { text: "Document non disponible" }   # the blank trap
 - assertVisible: { id: "scan_impact_recovery_cta" }        # recovery exists
 - tapOn: { id: "scan_impact_recovery_cta" }
-- assertVisible: { text: "MINT" }             # lands on /home, not stuck
+- assertVisible: { id: "home_route" }                      # lands on /home
 ```
 **G1 repair status:** checked-in flow exists; the blank trap is covered by `apps/mobile/test/routing/scan_flow_repair_test.dart`. Runtime acceptance still requires running this Maestro flow against the app.
 
@@ -269,4 +269,4 @@ appId: ch.mint.app
 
 ---
 
-Grounding notes (verified at `095eeaa32`): `/scan/review` and `/scan/impact` still hit the `Document non disponible` trap; `/tools` and `/portfolio` now preserve query; only F-2 exists under `.maestro`; iOS has the `mint` scheme; Android still needs the `mint` intent-filter.
+Grounding notes: `/scan/review` and `/scan/impact` recovery flows are now checked in as R-1/R-2 with stable ids; `/tools` and `/portfolio` preserve query; F-2 plus R-1/R-2 exist under `.maestro`; iOS has the `mint` scheme; Android still needs the `mint` intent-filter.


### PR DESCRIPTION
## Summary
- Replace volatile text assertions in scan Maestro recovery flows with stable semantics ids.
- Add `document_scan_capture_cta` and `home_route` semantics anchors.
- Add targeted Flutter widget coverage for scan CTA and home-route semantics.
- Update `docs/codex/MAESTRO_FLOWS.md` to match checked-in stable ids.

## Verification
- `flutter analyze lib/screens/document_scan/document_scan_screen.dart lib/screens/landing_screen.dart lib/screens/aujourdhui/aujourdhui_screen.dart test/screens/document_scan/document_scan_screen_test.dart test/screens/home_route_semantics_test.dart`
- `flutter test test/screens/document_scan/document_scan_screen_test.dart`
- `flutter test test/screens/home_route_semantics_test.dart`
- `python3 tools/checks/no_hardcoded_fr.py --file apps/mobile/lib/screens/document_scan/document_scan_screen.dart --file apps/mobile/lib/screens/landing_screen.dart --file apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart`
- `python3 tools/checks/accent_lint_fr.py --file apps/mobile/lib/screens/document_scan/document_scan_screen.dart --file apps/mobile/lib/screens/landing_screen.dart --file apps/mobile/lib/screens/aujourdhui/aujourdhui_screen.dart`
- `python3 -m pytest tools/checks/tests/test_codex_spec_reality_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q`
- `flutter build ios --simulator --debug`
- `~/.maestro/bin/maestro test .maestro/r1_scan_review.yaml .maestro/r2_scan_impact.yaml` -> 2/2 flows passed on iPhone 17 Pro.
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> PASS; final rerun with `CLAUDE_AUDIT_RERUN=1` -> PASS.

## Known Gap
- Patrol CLI is still not available in PATH in this environment, so no Patrol run was possible for this slice.