### PR TITLE
ci: add hardcoded financial rate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,33 @@ jobs:
           fi
           python3 tools/checks/financial_core_gate.py --base-ref "$BASE_REF"
 
+  # ─── Hardcoded financial rate drift gate ──────────────────────
+  # Blocks newly introduced Swiss financial rates outside the
+  # checked-in regulatory registry and financial_core calculators.
+  hardcoded-rate-gate:
+    name: Hardcoded financial rate gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan introduced hardcoded financial rates
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+            if [[ -z "$BASE_REF" ]] || [[ "${BASE_REF//0/}" == "" ]]; then
+              BASE_REF="HEAD^"
+            fi
+          fi
+          python3 tools/checks/hardcoded_rate_gate.py --base-ref "$BASE_REF"
+
   # ─── Phase 10 Plan 10-03 / ACCESS-06: onboarding readability gate ───
   # Pure-Dart Kandel–Moles French readability check on the onboarding
   # surfaces (intent screen + landing v2 + intent chips). Fails the build
@@ -713,7 +740,7 @@ jobs:
   # ─── Gate: all checks must pass ──────────────────────────────
   ci-gate:
     name: CI Gate
-    needs: [changes, secret-scan, banned-ui-terms, arb-parity, accent-lint-fr, no-hardcoded-fr, financial-core-gate, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
+    needs: [changes, secret-scan, banned-ui-terms, arb-parity, accent-lint-fr, no-hardcoded-fr, financial-core-gate, hardcoded-rate-gate, backend, flutter, readability, wcag-aa-all-touched, route-registry-parity, mint-routes-tests, repository-contract-tests, admin-build-sanity, cache-gitignore-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -727,6 +754,7 @@ jobs:
           accent_lint="${{ needs.accent-lint-fr.result }}"
           no_hardcoded_fr="${{ needs.no-hardcoded-fr.result }}"
           financial_core="${{ needs.financial-core-gate.result }}"
+          hardcoded_rates="${{ needs.hardcoded-rate-gate.result }}"
           flutter="${{ needs.flutter.result }}"
           readability="${{ needs.readability.result }}"
           wcag="${{ needs.wcag-aa-all-touched.result }}"
@@ -741,6 +769,7 @@ jobs:
           [[ "$accent_lint" == "skipped" ]] && accent_lint="success"
           [[ "$no_hardcoded_fr" == "skipped" ]] && no_hardcoded_fr="success"
           [[ "$financial_core" == "skipped" ]] && financial_core="success"
+          [[ "$hardcoded_rates" == "skipped" ]] && hardcoded_rates="success"
           [[ "$flutter" == "skipped" ]] && flutter="success"
           [[ "$readability" == "skipped" ]] && readability="success"
           [[ "$wcag" == "skipped" ]] && wcag="success"
@@ -749,8 +778,8 @@ jobs:
           [[ "$contract_tests" == "skipped" ]] && contract_tests="success"
           [[ "$admin_sanity" == "skipped" ]] && admin_sanity="success"
           [[ "$cache_gi" == "skipped" ]] && cache_gi="success"
-          if [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$arb_parity" != "success" ]] || [[ "$accent_lint" != "success" ]] || [[ "$no_hardcoded_fr" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
-            echo "CI failed — backend=$backend secret_scan=$secret_scan banned_terms=$banned_terms arb_parity=$arb_parity accent_lint=$accent_lint no_hardcoded_fr=$no_hardcoded_fr financial_core=$financial_core flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
+          if [[ "$backend" != "success" ]] || [[ "$secret_scan" != "success" ]] || [[ "$banned_terms" != "success" ]] || [[ "$arb_parity" != "success" ]] || [[ "$accent_lint" != "success" ]] || [[ "$no_hardcoded_fr" != "success" ]] || [[ "$financial_core" != "success" ]] || [[ "$hardcoded_rates" != "success" ]] || [[ "$flutter" != "success" ]] || [[ "$readability" != "success" ]] || [[ "$wcag" != "success" ]] || [[ "$parity" != "success" ]] || [[ "$cli_tests" != "success" ]] || [[ "$contract_tests" != "success" ]] || [[ "$admin_sanity" != "success" ]] || [[ "$cache_gi" != "success" ]]; then
+            echo "CI failed — backend=$backend secret_scan=$secret_scan banned_terms=$banned_terms arb_parity=$arb_parity accent_lint=$accent_lint no_hardcoded_fr=$no_hardcoded_fr financial_core=$financial_core hardcoded_rates=$hardcoded_rates flutter=$flutter readability=$readability wcag=$wcag parity=$parity cli_tests=$cli_tests contract_tests=$contract_tests admin_sanity=$admin_sanity cache_gi=$cache_gi"
             exit 1
           fi
           echo "All checks passed"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -46,6 +46,10 @@ pre-commit:
       run: python3 tools/checks/financial_core_gate.py --staged
       glob: "apps/mobile/lib/**/*.dart"
       tags: [financial-core, mint]
+    hardcoded-rate-gate:
+      run: python3 tools/checks/hardcoded_rate_gate.py --staged
+      glob: "{apps/mobile/lib/**/*.dart,services/backend/app/**/*.py}"
+      tags: [financial-core, swiss-rates, mint]
     no-bypass-persistence:
       run: python3 tools/checks/no_bypass_persistence.py {staged_files}
       glob: "apps/mobile/lib/**/*.dart"

--- a/tools/checks/hardcoded_rate_gate.py
+++ b/tools/checks/hardcoded_rate_gate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""New-debt gate for hardcoded Swiss financial rates."""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCOPES = ("apps/mobile/lib/", "services/backend/app/")
+ALLOWED = ("/apps/mobile/lib/services/financial_core/", "/services/backend/app/services/regulatory/registry.py")
+EXCLUDED = ("/test/", "/tests/", "/l10n/", "/.dart_tool/", "/build/")
+TOKENS = set(
+    "3a affordability amortissement assurance avs benefice budget capital chf cotisation debt dette dividende donation "
+    "epargne epl fiscal fortune fri heritage hoirie hypothecaire hypotheque imputed income interet lamal leasing loyer "
+    "lpp mortgage patrimoine pension pilier pillar prevoyance prime rachat rate rent rente revenu salary salaire tax taux "
+    "usufruit withdrawal".split()
+)
+DECIMAL_RATE = re.compile(r"(?<![A-Za-z0-9_])0\.(?=\d*[1-9])\d+\b")
+DECIMAL_FORMULA = re.compile(r"(?:\d?\.\d+\s*[*\/]|[*\/]\s*\d?\.\d+)")
+ASSIGN = re.compile(r"\b(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*[A-Za-z_][A-Za-z0-9_\[\]]*)?\s*=\s*-?\d*\.\d+")
+RATE_NAME_TOKENS = {"rate", "taux", "tax", "interest", "interet", "cotisation"}
+TECHNICAL_RATE_TOKENS = {"frame", "refresh", "sample", "bit", "baud", "fps", "limit"}
+TECHNICAL_DECIMAL_TOKENS = {"alpha", "animation", "opacity", "tween", "curve", "duration"}
+
+
+def _norm(value: str) -> str:
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
+    decomposed = unicodedata.normalize("NFKD", value)
+    asciiish = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return re.sub(r"[^A-Za-z0-9]+", " ", asciiish).casefold()
+
+
+def _clean(path: str) -> str:
+    return path.removeprefix("a/").removeprefix("b/").replace("\\", "/")
+
+
+def _scoped(path: str) -> bool:
+    rel = _clean(path)
+    wrapped = f"/{rel}/"
+    return rel.startswith(SCOPES) and (rel.endswith(".dart") or rel.endswith(".py")) and not rel.endswith(".g.dart") and not any(part in wrapped for part in EXCLUDED)
+
+
+def _allowed(path: str) -> bool:
+    wrapped = f"/{_clean(path)}"
+    return any(part in wrapped for part in ALLOWED)
+
+
+def _code(line: str) -> str:
+    if line.strip().startswith(('"""', "'''")):
+        return ""
+    out: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for index, ch in enumerate(line):
+        nxt = line[index + 1] if index + 1 < len(line) else ""
+        if quote:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+        elif ch in {"'", '"'}:
+            quote = ch
+            out.append(" ")
+        elif ch == "/" and nxt == "/" or ch == "#":
+            return "".join(out)
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _financial(path: str, code: str) -> bool:
+    haystack = _norm(f"{path} {code}")
+    return any(re.search(rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])", haystack) for token in TOKENS)
+
+
+def _rate_name(name: str) -> bool:
+    tokens = set(_norm(name).split())
+    if tokens & TECHNICAL_RATE_TOKENS:
+        return False
+    if "conversion" in tokens:
+        return bool(tokens & {"rate", "taux"})
+    return bool(tokens & RATE_NAME_TOKENS)
+
+
+def _technical_decimal(code: str) -> bool:
+    return bool(set(_norm(code).split()) & TECHNICAL_DECIMAL_TOKENS)
+
+
+def _added(diff: str) -> list[tuple[str, int, str]]:
+    out: list[tuple[str, int, str]] = []
+    path: str | None = None
+    line: int | None = None
+    for raw in diff.splitlines():
+        if raw.startswith("diff --git "):
+            path = None
+        elif raw.startswith("+++ "):
+            marker = raw[4:].strip()
+            path = None if marker == "/dev/null" else _clean(marker)
+        elif raw.startswith("@@ "):
+            match = re.search(r"\+(\d+)", raw)
+            line = int(match.group(1)) if match else None
+        elif line is None:
+            continue
+        elif raw.startswith("+") and not raw.startswith("+++"):
+            if path and _scoped(path):
+                out.append((path, line, raw[1:]))
+            line += 1
+        elif not (raw.startswith("-") and not raw.startswith("---")):
+            line += 1
+    return out
+
+
+def _violation(path: str, text: str) -> str | None:
+    if _allowed(path):
+        return None
+    code = _code(text).strip()
+    if not code:
+        return None
+    if any(_rate_name(match.group("name")) for match in ASSIGN.finditer(code)):
+        return "new hardcoded financial rate outside registry.py/financial_core"
+    if DECIMAL_RATE.search(code) and DECIMAL_FORMULA.search(code) and _financial(path, code) and not _technical_decimal(code):
+        return "new hardcoded decimal financial rate outside registry.py/financial_core"
+    return None
+
+
+def _git_diff(args: list[str]) -> str:
+    result = subprocess.run(["git", "diff", "--unified=0", "--no-ext-diff", *args, "--", *SCOPES], cwd=REPO, text=True, capture_output=True, check=False)
+    if result.returncode:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def _read(args: argparse.Namespace) -> str:
+    if args.diff_file:
+        return Path(args.diff_file).read_text(encoding="utf-8")
+    if args.staged:
+        return _git_diff(["--cached"])
+    return _git_diff([f"{args.base_ref}...HEAD"] if args.base_ref else ["HEAD"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--diff-file")
+    parser.add_argument("--staged", action="store_true")
+    parser.add_argument("--base-ref")
+    args = parser.parse_args()
+    if sum(bool(v) for v in (args.diff_file, args.staged, args.base_ref)) > 1:
+        parser.error("use only one of --diff-file, --staged, or --base-ref")
+    failures = [(p, n, d, t.strip()) for p, n, t in _added(_read(args)) for d in [_violation(p, t)] if d]
+    if failures:
+        print("::error::hardcoded_rate_gate failed:")
+        print("Use regulatory registry.py or apps/mobile/lib/services/financial_core/ for financial constants.")
+        for path, line, detail, text in failures:
+            print(f"{path}:{line}: {detail}: {text}")
+        return 1
+    print("OK hardcoded_rate_gate: no hardcoded financial rates in added Python/Dart lines")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_hardcoded_rate_gate.py
+++ b/tools/checks/tests/test_hardcoded_rate_gate.py
@@ -1,0 +1,70 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/hardcoded_rate_gate.py"
+
+
+def _diff(path: str, added: list[str], start: int = 1) -> str:
+    body = "\n".join(f"+{line}" for line in added)
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -0,0 +{start},{len(added)} @@\n{body}\n"
+
+
+def _run(tmp_path: Path, diff: str) -> subprocess.CompletedProcess[str]:
+    diff_path = tmp_path / "changes.diff"
+    diff_path.write_text(diff, encoding="utf-8")
+    return subprocess.run([sys.executable, str(SCRIPT), "--diff-file", str(diff_path)], cwd=ROOT, text=True, capture_output=True, check=False)
+
+
+@pytest.mark.parametrize(
+    ("path", "added", "needle"),
+    [
+        ("services/backend/app/services/tax_projection_service.py", ["def estimate_tax_saving(income: float) -> float:", "    rate = 0.12", "    return income * rate"], "registry.py"),
+        ("apps/mobile/lib/services/mortgage_hint_service.dart", ["double estimateInterest(double balance) {", "  return balance * 0.035;", "}"], "financial_core"),
+    ],
+)
+def test_new_hardcoded_financial_rates_fail(tmp_path: Path, path: str, added: list[str], needle: str) -> None:
+    result = _run(tmp_path, _diff(path, added))
+    assert result.returncode == 1
+    assert needle in result.stdout
+
+
+def test_allowed_registry_financial_core_non_financial_and_tests_pass(tmp_path: Path) -> None:
+    diff = "".join(
+        [
+            _diff("services/backend/app/services/regulatory/registry.py", ["MORTGAGE_REFERENCE_RATE = 0.035"]),
+            _diff("apps/mobile/lib/services/financial_core/tax_calculator.dart", ["const baseRate = 0.068;"]),
+            _diff("apps/mobile/lib/widgets/layout_grid.dart", ["final opacity = animation.value * 0.08;"]),
+            _diff("apps/mobile/lib/widgets/retirement/budget_gauge_widget.dart", ["Divider(color: MintColors.border.withValues(alpha: 0.5)),"]),
+            _diff("apps/mobile/lib/screens/budget/budget_screen.dart", ["final refreshRate = 120;"]),
+            _diff("apps/mobile/lib/services/mortgage_service.dart", ["final anim = animation.value * 0.5;"]),
+            _diff("services/backend/app/services/display.py", ["conversionMultiplier = 1000"]),
+            _diff("services/backend/app/services/network.py", ["rateLimit = 5", "rateLimit = 5.0", "interestPeriod = 12", "taxRate = 0", "rateIndex = 0"]),
+            _diff("services/backend/app/tests/test_projection.py", ["assert result.rate == 0.12"]),
+            _diff("services/backend/app/services/tax_projection_service.py", ['"""Reference tax rate is 0.035 per annum"""']),
+            _diff("apps/mobile/test/services/tax_projection_test.dart", ["expect(result.rate, 0.12);"]),
+        ]
+    )
+    result = _run(tmp_path, diff)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_hardcoded_rate_gate_is_wired_into_ci_and_lefthook() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    gate = ci.split("ci-gate:", maxsplit=1)[1]
+    lefthook = (ROOT / "lefthook.yml").read_text(encoding="utf-8")
+    assert "hardcoded-rate-gate:" in ci
+    assert "tools/checks/hardcoded_rate_gate.py --base-ref" in ci
+    assert 'hardcoded_rates="${{ needs.hardcoded-rate-gate.result }}"' in gate
+    assert '"$hardcoded_rates" != "success"' in gate
+    assert "hardcoded-rate-gate:" in lefthook
+    assert "tools/checks/hardcoded_rate_gate.py --staged" in lefthook
+
+
+def test_git_diff_modes_do_not_crash() -> None:
+    for arg in ("--staged", "--base-ref=HEAD"):
+        result = subprocess.run([sys.executable, str(SCRIPT), arg], cwd=ROOT, text=True, capture_output=True, check=False)
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Add `tools/checks/hardcoded_rate_gate.py` to block newly introduced Swiss financial-rate constants outside `financial_core/` and backend `regulatory/registry.py`.
- Wire the gate into lefthook pre-commit and GitHub CI Gate.
- Add adversarial tests for true positives and false positives: UI opacity decimals, technical `rateLimit`/`refreshRate`, test directories, and allowed registry/core paths.

## Verification
- `python3 -m pytest tools/checks/tests/test_hardcoded_rate_gate.py -q` -> 5 passed
- `python3 -m pytest tools/checks/tests -q` -> 95 passed
- `python3 tools/checks/hardcoded_rate_gate.py --base-ref origin/claude/mint-swiss-coach-eu33i7` -> OK
- `python3 -m py_compile tools/checks/hardcoded_rate_gate.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file("lefthook.yml")'`\n- `lefthook run pre-commit --file .github/workflows/ci.yml --file lefthook.yml --file tools/checks/hardcoded_rate_gate.py --file tools/checks/tests/test_hardcoded_rate_gate.py` -> passed\n- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> NO-GO initially; fixed false positives\n- final `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> PASS, no P0/P1\n\n## Notes\n- Diff kept under the 300-line PR discipline: 4 files, 274 insertions, 3 deletions.\n- The gate is intentionally new-debt only: it scans added diff lines, not historical debt.