### PR TITLE
feat(dataquest): route salary prompt to focused input

### DIFF
--- a/apps/mobile/lib/l10n/app_de.arb
+++ b/apps/mobile/lib/l10n/app_de.arb
@@ -11093,5 +11093,7 @@
   "scanSummaryTaxDeclaration": "Steuererklärung gescannt",
   "scanSummaryAvsExtract": "AHV-Auszug gescannt",
   "scanSummaryMortgageAttestation": "Hypothekenbescheinigung gescannt",
-  "scanSummarySalaryCertificate": "Lohnausweis gescannt"
+  "scanSummarySalaryCertificate": "Lohnausweis gescannt",
+  "lowConfidenceCardTitle": "Nicht genug Daten für eine verlässliche Projektion",
+  "lowConfidenceCardPromptIntro": "Das würde deine Projektionen am stärksten verbessern:"
 }

--- a/apps/mobile/lib/l10n/app_en.arb
+++ b/apps/mobile/lib/l10n/app_en.arb
@@ -11093,5 +11093,7 @@
   "scanSummaryTaxDeclaration": "Tax declaration scanned",
   "scanSummaryAvsExtract": "AVS extract scanned",
   "scanSummaryMortgageAttestation": "Mortgage attestation scanned",
-  "scanSummarySalaryCertificate": "Salary certificate scanned"
+  "scanSummarySalaryCertificate": "Salary certificate scanned",
+  "lowConfidenceCardTitle": "Not enough data for a reliable projection",
+  "lowConfidenceCardPromptIntro": "This would improve your projections the most:"
 }

--- a/apps/mobile/lib/l10n/app_es.arb
+++ b/apps/mobile/lib/l10n/app_es.arb
@@ -11093,5 +11093,7 @@
   "scanSummaryTaxDeclaration": "Declaración fiscal escaneada",
   "scanSummaryAvsExtract": "Extracto AVS escaneado",
   "scanSummaryMortgageAttestation": "Certificado hipotecario escaneado",
-  "scanSummarySalaryCertificate": "Certificado de salario escaneado"
+  "scanSummarySalaryCertificate": "Certificado de salario escaneado",
+  "lowConfidenceCardTitle": "No hay suficientes datos para una proyección fiable",
+  "lowConfidenceCardPromptIntro": "Esto mejoraría más tus proyecciones:"
 }

--- a/apps/mobile/lib/l10n/app_fr.arb
+++ b/apps/mobile/lib/l10n/app_fr.arb
@@ -11890,5 +11890,9 @@
   "scanSummaryMortgageAttestation": "Attestation hypothèque scannée",
   "@scanSummaryMortgageAttestation": { "description": "Persistent event summary when a mortgage attestation is scanned." },
   "scanSummarySalaryCertificate": "Certificat de salaire scanné",
-  "@scanSummarySalaryCertificate": { "description": "Persistent event summary when a salary certificate is scanned." }
+  "@scanSummarySalaryCertificate": { "description": "Persistent event summary when a salary certificate is scanned." },
+  "lowConfidenceCardTitle": "Pas assez de données pour une projection fiable",
+  "@lowConfidenceCardTitle": { "description": "Title for the low projection confidence card." },
+  "lowConfidenceCardPromptIntro": "Voici ce qui améliorerait le plus tes projections :",
+  "@lowConfidenceCardPromptIntro": { "description": "Intro text before the ranked enrichment prompts in the low projection confidence card." }
 }

--- a/apps/mobile/lib/l10n/app_it.arb
+++ b/apps/mobile/lib/l10n/app_it.arb
@@ -11093,5 +11093,7 @@
   "scanSummaryTaxDeclaration": "Dichiarazione fiscale scansionata",
   "scanSummaryAvsExtract": "Estratto AVS scansionato",
   "scanSummaryMortgageAttestation": "Attestato ipoteca scansionato",
-  "scanSummarySalaryCertificate": "Certificato di stipendio scansionato"
+  "scanSummarySalaryCertificate": "Certificato di stipendio scansionato",
+  "lowConfidenceCardTitle": "Dati insufficienti per una proiezione affidabile",
+  "lowConfidenceCardPromptIntro": "Questi dati migliorerebbero di più le tue proiezioni:"
 }

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40418,6 +40418,17 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Certificat de salaire scanné'**
   String get scanSummarySalaryCertificate;
+  /// Title for the low projection confidence card.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pas assez de données pour une projection fiable'**
+  String get lowConfidenceCardTitle;
+
+  /// Intro text before the ranked enrichment prompts in the low projection confidence card.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voici ce qui améliorerait le plus tes projections :'**
+  String get lowConfidenceCardPromptIntro;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/apps/mobile/lib/l10n/app_localizations.dart
+++ b/apps/mobile/lib/l10n/app_localizations.dart
@@ -40418,6 +40418,7 @@ abstract class S {
   /// In fr, this message translates to:
   /// **'Certificat de salaire scanné'**
   String get scanSummarySalaryCertificate;
+
   /// Title for the low projection confidence card.
   ///
   /// In fr, this message translates to:

--- a/apps/mobile/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/lib/l10n/app_localizations_de.dart
@@ -23087,4 +23087,11 @@ class SDe extends S {
 
   @override
   String get scanSummarySalaryCertificate => 'Lohnausweis gescannt';
+  @override
+  String get lowConfidenceCardTitle =>
+      'Nicht genug Daten für eine verlässliche Projektion';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'Das würde deine Projektionen am stärksten verbessern:';
 }

--- a/apps/mobile/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/lib/l10n/app_localizations_en.dart
@@ -22920,4 +22920,11 @@ class SEn extends S {
 
   @override
   String get scanSummarySalaryCertificate => 'Salary certificate scanned';
+  @override
+  String get lowConfidenceCardTitle =>
+      'Not enough data for a reliable projection';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'This would improve your projections the most:';
 }

--- a/apps/mobile/lib/l10n/app_localizations_es.dart
+++ b/apps/mobile/lib/l10n/app_localizations_es.dart
@@ -23031,4 +23031,11 @@ class SEs extends S {
 
   @override
   String get scanSummarySalaryCertificate => 'Certificado de salario escaneado';
+  @override
+  String get lowConfidenceCardTitle =>
+      'No hay suficientes datos para una proyección fiable';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'Esto mejoraría más tus proyecciones:';
 }

--- a/apps/mobile/lib/l10n/app_localizations_fr.dart
+++ b/apps/mobile/lib/l10n/app_localizations_fr.dart
@@ -23032,4 +23032,11 @@ class SFr extends S {
 
   @override
   String get scanSummarySalaryCertificate => 'Certificat de salaire scanné';
+  @override
+  String get lowConfidenceCardTitle =>
+      'Pas assez de données pour une projection fiable';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'Voici ce qui améliorerait le plus tes projections :';
 }

--- a/apps/mobile/lib/l10n/app_localizations_it.dart
+++ b/apps/mobile/lib/l10n/app_localizations_it.dart
@@ -23093,4 +23093,11 @@ class SIt extends S {
   @override
   String get scanSummarySalaryCertificate =>
       'Certificato di stipendio scansionato';
+  @override
+  String get lowConfidenceCardTitle =>
+      'Dati insufficienti per una proiezione affidabile';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'Questi dati migliorerebbero di più le tue proiezioni:';
 }

--- a/apps/mobile/lib/l10n/app_localizations_pt.dart
+++ b/apps/mobile/lib/l10n/app_localizations_pt.dart
@@ -23039,4 +23039,11 @@ class SPt extends S {
   @override
   String get scanSummarySalaryCertificate =>
       'Certificado de salário digitalizado';
+  @override
+  String get lowConfidenceCardTitle =>
+      'Dados insuficientes para uma projeção fiável';
+
+  @override
+  String get lowConfidenceCardPromptIntro =>
+      'Isto melhoraria mais as tuas projeções:';
 }

--- a/apps/mobile/lib/l10n/app_pt.arb
+++ b/apps/mobile/lib/l10n/app_pt.arb
@@ -11093,5 +11093,7 @@
   "scanSummaryTaxDeclaration": "Declaração fiscal digitalizada",
   "scanSummaryAvsExtract": "Extrato AVS digitalizado",
   "scanSummaryMortgageAttestation": "Atestação hipoteca digitalizada",
-  "scanSummarySalaryCertificate": "Certificado de salário digitalizado"
+  "scanSummarySalaryCertificate": "Certificado de salário digitalizado",
+  "lowConfidenceCardTitle": "Dados insuficientes para uma projeção fiável",
+  "lowConfidenceCardPromptIntro": "Isto melhoraria mais as tuas projeções:"
 }

--- a/apps/mobile/lib/widgets/coach/low_confidence_card.dart
+++ b/apps/mobile/lib/widgets/coach/low_confidence_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/services/financial_core/confidence_scorer.dart';
@@ -20,16 +21,16 @@ class LowConfidenceCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = S.of(context)!;
     final confidence = ConfidenceScorer.score(profile);
     final topPrompts = confidence.prompts.take(3).toList();
 
     // Determine the best CTA route from the highest-impact prompt
     final bestRoute = topPrompts.isNotEmpty
-        ? _routeForCategory(topPrompts.first.category) ?? '/scan'
+        ? _routeForPrompt(topPrompts.first) ?? '/scan'
         : '/scan';
-    final bestLabel = topPrompts.isNotEmpty
-        ? topPrompts.first.action
-        : 'Compl\u00e9ter mon profil';
+    final bestLabel =
+        topPrompts.isNotEmpty ? topPrompts.first.action : l.dossierCompleteCta;
 
     return Container(
       width: double.infinity,
@@ -51,9 +52,10 @@ class LowConfidenceCard extends StatelessWidget {
               const SizedBox(width: 10),
               Expanded(
                 child: Text(
-                  'Pas assez de donn\u00e9es pour une projection fiable',
-                  style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
-                      .copyWith(fontWeight: FontWeight.w700),
+                  l.lowConfidenceCardTitle,
+                  style:
+                      MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                          .copyWith(fontWeight: FontWeight.w700),
                 ),
               ),
             ],
@@ -64,8 +66,9 @@ class LowConfidenceCard extends StatelessWidget {
             children: [
               Text(
                 '${confidence.score.round()}/100',
-                style: MintTextStyles.labelSmall(color: MintColors.textSecondary)
-                    .copyWith(fontWeight: FontWeight.w600),
+                style:
+                    MintTextStyles.labelSmall(color: MintColors.textSecondary)
+                        .copyWith(fontWeight: FontWeight.w600),
               ),
               const SizedBox(width: 10),
               Expanded(
@@ -89,14 +92,14 @@ class LowConfidenceCard extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            'Voici ce qui am\u00e9liorerait le plus tes projections\u00a0:',
+            l.lowConfidenceCardPromptIntro,
             style: MintTextStyles.bodySmall(color: MintColors.textSecondary)
                 .copyWith(height: 1.4),
           ),
           const SizedBox(height: 12),
           // EVI-ranked prompts with tappable rows
           ...topPrompts.map((p) {
-            final route = _routeForCategory(p.category);
+            final route = _routeForPrompt(p);
             return Padding(
               padding: const EdgeInsets.only(bottom: 6),
               child: InkWell(
@@ -168,12 +171,20 @@ class LowConfidenceCard extends StatelessWidget {
           ),
           const SizedBox(height: 10),
           Text(
-            'Outil \u00e9ducatif \u2014 ne constitue pas un conseil financier (LSFin).',
+            l.dataBlockDisclaimer,
             style: MintTextStyles.micro(color: MintColors.textMuted),
           ),
         ],
       ),
     );
+  }
+
+  static String? _routeForPrompt(EnrichmentPrompt prompt) {
+    if (prompt.category == 'income' &&
+        prompt.fieldPath == 'salaireBrutMensuel') {
+      return '/data-block/revenu?inputKey=salary';
+    }
+    return _routeForCategory(prompt.category);
   }
 
   /// Map enrichment category to the best data capture route.

--- a/apps/mobile/test/widgets/coach/refonte_widgets_test.dart
+++ b/apps/mobile/test/widgets/coach/refonte_widgets_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/forecaster_service.dart';
@@ -47,6 +48,48 @@ Widget buildSimpleApp({required Widget child}) {
     home: Scaffold(
       body: SingleChildScrollView(child: child),
     ),
+  );
+}
+
+Widget buildRoutedApp({
+  required Widget child,
+  required ValueChanged<Uri> onDataBlockRoute,
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => Scaffold(
+          body: SingleChildScrollView(child: child),
+        ),
+      ),
+      GoRoute(
+        path: '/data-block/:type',
+        builder: (_, state) {
+          onDataBlockRoute(state.uri);
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+      GoRoute(
+        path: '/scan',
+        builder: (_, __) => const Scaffold(body: SizedBox.shrink()),
+      ),
+      GoRoute(
+        path: '/scan/avs-guide',
+        builder: (_, __) => const Scaffold(body: SizedBox.shrink()),
+      ),
+    ],
+  );
+  return MaterialApp.router(
+    routerConfig: router,
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
   );
 }
 
@@ -102,6 +145,36 @@ CoachProfile buildMinimalProfile() {
     canton: 'GE',
     salaireBrutMensuel: 5000,
     employmentStatus: 'salarie',
+    goalA: GoalA(
+      type: GoalAType.retraite,
+      targetDate: DateTime(2055, 12, 31),
+      label: 'Retraite',
+    ),
+  );
+}
+
+/// Creates a profile where the only high-impact visible gap is salary.
+CoachProfile buildProfileMissingSalaryOnly() {
+  return CoachProfile(
+    firstName: 'Nina',
+    birthYear: 1990,
+    canton: 'GE',
+    salaireBrutMensuel: 0,
+    employmentStatus: 'salarie',
+    etatCivil: CoachCivilStatus.divorce,
+    targetRetirementAge: 65,
+    prevoyance: const PrevoyanceProfile(
+      anneesContribuees: 20,
+      avoirLppTotal: 180000,
+      salaireAssure: 76000,
+      tauxConversion: 0.055,
+      nombre3a: 2,
+      totalEpargne3a: 42000,
+      canContribute3a: true,
+    ),
+    patrimoine: const PatrimoineProfile(
+      epargneLiquide: 50000,
+    ),
     goalA: GoalA(
       type: GoalAType.retraite,
       targetDate: DateTime(2055, 12, 31),
@@ -218,7 +291,7 @@ void main() {
     testWidgets('renders with minimal profile', (tester) async {
       final profile = buildMinimalProfile();
       await tester.pumpWidget(
-        buildSimpleApp(child: LowConfidenceCard(profile: profile)),
+        buildLocalizedApp(child: LowConfidenceCard(profile: profile)),
       );
       await tester.pump(const Duration(seconds: 1));
 
@@ -229,12 +302,12 @@ void main() {
         (tester) async {
       final profile = buildMinimalProfile();
       await tester.pumpWidget(
-        buildSimpleApp(child: LowConfidenceCard(profile: profile)),
+        buildLocalizedApp(child: LowConfidenceCard(profile: profile)),
       );
       await tester.pump(const Duration(seconds: 1));
 
       expect(
-        find.textContaining('ne constitue pas un conseil financier'),
+        find.textContaining('constitue pas un conseil financier'),
         findsOneWidget,
       );
     });
@@ -242,7 +315,7 @@ void main() {
     testWidgets('shows info icon and header text', (tester) async {
       final profile = buildMinimalProfile();
       await tester.pumpWidget(
-        buildSimpleApp(child: LowConfidenceCard(profile: profile)),
+        buildLocalizedApp(child: LowConfidenceCard(profile: profile)),
       );
       await tester.pump(const Duration(seconds: 1));
 
@@ -251,6 +324,24 @@ void main() {
         find.textContaining('Pas assez de donn'),
         findsOneWidget,
       );
+    });
+
+    testWidgets('routes salary prompt to targeted revenue inputKey',
+        (tester) async {
+      Uri? capturedRoute;
+      await tester.pumpWidget(
+        buildRoutedApp(
+          child: LowConfidenceCard(profile: buildProfileMissingSalaryOnly()),
+          onDataBlockRoute: (uri) => capturedRoute = uri,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Ajoute ton salaire'));
+      await tester.pumpAndSettle();
+
+      expect(capturedRoute?.path, '/data-block/revenu');
+      expect(capturedRoute?.queryParameters['inputKey'], 'salary');
     });
   });
 


### PR DESCRIPTION
## Summary
- Route the low-confidence salary enrichment prompt to `/data-block/revenu?inputKey=salary` instead of leaving income prompts without a capture route.
- Keep the guard narrow: only `category == income` + `fieldPath == salaireBrutMensuel` maps to the focused revenue collector.
- Localize `LowConfidenceCard` strings and reuse the existing LSFin disclaimer key.

## QA
- RED first: `flutter test test/widgets/coach/refonte_widgets_test.dart --plain-name "routes salary prompt to targeted revenue inputKey"` failed with `capturedRoute == null` before implementation.
- `cd apps/mobile && flutter test test/widgets/coach/refonte_widgets_test.dart` — 16 passed.
- `cd apps/mobile && flutter test test/screens/data_block_enrichment_screen_test.dart` — 10 passed.
- `cd apps/mobile && flutter analyze lib/widgets/coach/low_confidence_card.dart test/widgets/coach/refonte_widgets_test.dart` — no issues.
- `lefthook run pre-commit --file ...` — passed, including ARB parity, no-hardcoded-fr, financial-core-gate, gitleaks.
- `git diff --check` — passed.
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` — PASS. P2 cosmetic only: generated l10n files are non-canonical at the new getter separator to keep `git diff --check` clean in this CRLF-generated file set; CI regenerates `flutter gen-l10n` before analyze/test.

## Notes
- This intentionally does not extend `inputKey` to patrimoine/LPP/household yet. Next logical product slice is a focused `q_cash_total` / liquid-savings collector for mortgage readiness.
