### PR TITLE
chore: bound Claude CLI drift runs

### DIFF
--- a/.claude/get-shit-done/workflows/review.md
+++ b/.claude/get-shit-done/workflows/review.md
@@ -128,7 +128,20 @@ gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-revi
 
 **Claude (separate session):**
 ```bash
-claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" --no-input 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+claude -p \
+  --model sonnet \
+  --effort high \
+  --safe-mode \
+  --strict-mcp-config \
+  --mcp-config '{"mcpServers":{}}' \
+  --disable-slash-commands \
+  --no-session-persistence \
+  --setting-sources user \
+  --permission-mode dontAsk \
+  --tools "" \
+  --exclude-dynamic-system-prompt-sections \
+  < /tmp/gsd-review-prompt-{phase}.md \
+  2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 ```
 
 **Codex:**

--- a/.planning/agent-drift/README.md
+++ b/.planning/agent-drift/README.md
@@ -12,7 +12,7 @@ snapshot is captured pre-refonte and locked.
 2. `python3 tools/agent-drift/dashboard.py ingest` — parse last 7d git log + JSONL transcripts + `context_hits.jsonl` + `golden/results.jsonl` into `drift.db`.
 3. `python3 tools/agent-drift/dashboard.py report` — render `.planning/agent-drift/{today}.md`.
 4. `python3 tools/agent-drift/dashboard.py baseline` — lock baseline J0 snapshot. **Run ONCE pre-refonte** (D-12). Re-running exits 1 unless `.baseline-lock` is deleted.
-5. `python3 tools/agent-drift/dashboard.py golden-run` — run 20 golden prompts via `claude -p` (A7 AVAILABLE from Plan 00 spike).
+5. `python3 tools/agent-drift/dashboard.py golden-run` — run 20 golden prompts via the bounded Claude print command in `tools/agent-drift/golden/run.py`.
 6. `python3 tools/agent-drift/dashboard.py compare-to .planning/agent-drift/baseline-J0.md` — compare current state vs baseline (CTX-05 spike will harden this into a strict >5% regression gate).
 
 ## The 4 metrics (D-11)
@@ -31,7 +31,7 @@ snapshot is captured pre-refonte and locked.
 - `.planning/agent-drift/context_hits.jsonl` — append-only, written by the
   extended `.claude/hooks/gsd-prompt-guard.js` (v1.33.0+).
 - `tools/agent-drift/golden/results.jsonl` — written by the nightly
-  `golden/run.sh` harness (A7 AVAILABLE, uses `claude -p --output-format json`).
+  `golden/run.sh` harness with bounded Claude print settings.
 
 ## Storage
 

--- a/tools/agent-drift/dashboard.py
+++ b/tools/agent-drift/dashboard.py
@@ -10,7 +10,7 @@ Subcommands (positional per D-09):
   baseline    -> [STUB Task 1 — full impl Task 3] capture J0 snapshot
   ingest      -> parse git log + jsonl transcripts + hits log into drift.db
   report      -> render .planning/agent-drift/YYYY-MM-DD.md with 4 metrics
-  golden-run  -> run 20 golden prompts via `claude -p` (A7 AVAILABLE)
+  golden-run  -> run 20 golden prompts via bounded Claude print (A7 AVAILABLE)
   compare-to  -> compare current drift.db vs baseline markdown (CTX-05 spike)
 
 Per D-09: CLI Python + nightly markdown report (NOT mobile route).
@@ -195,7 +195,7 @@ def cmd_report(args: argparse.Namespace) -> int:
 # golden-run
 # ---------------------------------------------------------------------------
 def cmd_golden_run(args: argparse.Namespace) -> int:
-    """Run 20 golden prompts via `claude -p` (A7 AVAILABLE per Plan 00 spike)."""
+    """Run 20 golden prompts via bounded Claude print."""
     if not GOLDEN_RUN_SH.exists():
         print(f"golden-run: missing {GOLDEN_RUN_SH}", file=sys.stderr)
         return 1

--- a/tools/agent-drift/golden/run.py
+++ b/tools/agent-drift/golden/run.py
@@ -2,7 +2,7 @@
 """Golden prompts harness — CTX-02 metric (d) time-to-first-correct-output.
 
 For each of the 20 prompts in prompts.jsonl:
-  1. Invoke `claude -p "<prompt>"` (headless 1-shot)
+  1. Invoke a bounded Claude print session (headless 1-shot)
   2. Capture output
   3. Run domain-specific pass/fail check on the output text
   4. Write result to results.jsonl (consumed by ingest_golden.py)
@@ -17,11 +17,12 @@ Pass criteria per domain:
 Exit 0 always (even if prompts fail — that IS the signal). Exit 1 only on
 infrastructure error (missing CLI, missing prompts file, etc).
 
-Duration: ~10-20 min for 20 prompts at ~30-60s each via `claude -p`.
+Duration: bounded by per-prompt timeout and a minimal Claude session config.
 """
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -31,6 +32,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PROMPTS = REPO_ROOT / "tools" / "agent-drift" / "golden" / "prompts.jsonl"
 RESULTS = REPO_ROOT / "tools" / "agent-drift" / "golden" / "results.jsonl"
+ALLOWED_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+ALLOWED_MODEL_ALIASES = {"haiku", "opus", "sonnet"}
+MINT_GOLDEN_SYSTEM_PROMPT = """You are evaluating MINT agent discipline.
+Answer briefly with what the agent should do; do not edit files.
+Hard rules:
+- MINT is a Swiss financial lucidity app, not a retirement-first app.
+- User-facing text must use AppLocalizations/ARB, not hardcoded French strings.
+- Financial calculations must reuse financial_core calculators.
+- Avoid banned absolute terms such as garanti, optimal, meilleur, certain, assure, sans risque, parfait.
+- Before proposing a new file, widget, provider, service, route, or calculation, say what existing code you would grep/read first.
+"""
 
 FRENCH_CHARS = re.compile(r"[éèêàçùôïÉÈÀÇÙÔÏ]")
 TEXT_WITH_FR = re.compile(r"Text\s*\(\s*['\"][^'\"]*[éèàçùôÉÈÀÇÙÔ][^'\"]*['\"]")
@@ -58,7 +70,7 @@ def is_graceful_refusal(output: str) -> bool:
     """Agent pushed back instead of coding blindly — doctrine-aligned behavior."""
     # Count refusal signals. 1 signal could be incidental; 2+ = clear intent.
     signals = len(REFUSAL_RE.findall(output))
-    return signals >= 1
+    return signals >= 2
 
 
 def check_i18n(output: str) -> tuple[bool, str, str]:
@@ -163,23 +175,89 @@ DOMAIN_CHECKERS = {
 }
 
 
+def build_claude_command() -> list[str]:
+    """Return the bounded Claude command used by the golden harness."""
+    model = os.environ.get("MINT_GOLDEN_CLAUDE_MODEL", "sonnet")
+    effort = os.environ.get("MINT_GOLDEN_CLAUDE_EFFORT", "high")
+    if model not in ALLOWED_MODEL_ALIASES and not model.startswith("claude-"):
+        raise ValueError(
+            "MINT_GOLDEN_CLAUDE_MODEL must be a known alias "
+            f"{sorted(ALLOWED_MODEL_ALIASES)} or a full claude-* model id"
+        )
+    if effort not in ALLOWED_EFFORTS:
+        raise ValueError(
+            f"MINT_GOLDEN_CLAUDE_EFFORT must be one of {sorted(ALLOWED_EFFORTS)}"
+        )
+    if effort == "max" and os.environ.get("MINT_GOLDEN_CLAUDE_ALLOW_MAX") != "1":
+        raise ValueError(
+            "refusing max effort for golden prompts without "
+            "MINT_GOLDEN_CLAUDE_ALLOW_MAX=1"
+        )
+
+    return [
+        "claude",
+        "-p",
+        "--model",
+        model,
+        "--effort",
+        effort,
+        "--safe-mode",
+        "--strict-mcp-config",
+        "--mcp-config",
+        '{"mcpServers":{}}',
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--setting-sources",
+        "user",
+        "--permission-mode",
+        "dontAsk",
+        "--tools",
+        "",
+        "--exclude-dynamic-system-prompt-sections",
+        "--append-system-prompt",
+        MINT_GOLDEN_SYSTEM_PROMPT,
+    ]
+
+
 def run_one(prompt_obj: dict, timeout_sec: int = 120) -> dict:
-    """Run one prompt via `claude -p`. Return result dict."""
+    """Run one prompt through a bounded Claude print session."""
     prompt = prompt_obj["prompt"]
     pid = prompt_obj["id"]
     domain = prompt_obj["domain"]
     run_at = int(time.time())
 
     try:
+        command = build_claude_command()
         proc = subprocess.run(
-            ["claude", "-p"],
+            command,
             input=prompt,
             capture_output=True,
             text=True,
             timeout=timeout_sec,
             check=False,
         )
-        output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+        output = proc.stdout or ""
+        if proc.returncode != 0:
+            error_output = output + ("\n" + proc.stderr if proc.stderr else "")
+            return {
+                "run_at": run_at,
+                "prompt_id": pid,
+                "domain": domain,
+                "turns_to_correct": 999,
+                "passed_lints": "",
+                "failed_lints": "cli_error",
+                "output_excerpt": error_output[:500].replace("\n", " ").strip(),
+            }
+    except ValueError as exc:
+        return {
+            "run_at": run_at,
+            "prompt_id": pid,
+            "domain": domain,
+            "turns_to_correct": 999,
+            "passed_lints": "",
+            "failed_lints": "invalid_cli_config",
+            "output_excerpt": str(exc),
+        }
     except subprocess.TimeoutExpired:
         return {
             "run_at": run_at,
@@ -240,6 +318,11 @@ def run_one(prompt_obj: dict, timeout_sec: int = 120) -> dict:
 def main() -> int:
     if not PROMPTS.exists():
         print(f"missing {PROMPTS}", file=sys.stderr)
+        return 1
+    try:
+        build_claude_command()
+    except ValueError as exc:
+        print(f"golden harness: invalid Claude CLI config: {exc}", file=sys.stderr)
         return 1
 
     prompts = []

--- a/tools/agent-drift/golden/run.sh
+++ b/tools/agent-drift/golden/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Golden prompts harness runner (CTX-02 metric d — time-to-first-correct-output).
 #
-# Delegates to run.py which implements real `claude -p` per-prompt execution
+# Delegates to run.py which implements bounded Claude print per-prompt execution
 # + domain-specific pass/fail checks + JSONL results output.
 #
 # Per D-11: 20 prompts covering 5 domains (i18n, financial_core, retirement,

--- a/tools/agent-drift/tests/test_golden_claude_command.py
+++ b/tools/agent-drift/tests/test_golden_claude_command.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib, subprocess, sys
+from pathlib import Path
+
+import pytest
+
+GOLDEN_DIR = Path(__file__).resolve().parents[3] / "tools" / "agent-drift" / "golden"
+sys.path.insert(0, str(GOLDEN_DIR))
+
+
+def _golden_run():
+    return importlib.import_module("run")
+
+
+def _arg(command: list[str], flag: str) -> str:
+    return command[command.index(flag) + 1]
+
+
+def test_golden_claude_command_is_bounded_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("MINT_GOLDEN_CLAUDE_MODEL", "MINT_GOLDEN_CLAUDE_EFFORT", "MINT_GOLDEN_CLAUDE_ALLOW_MAX"):
+        monkeypatch.delenv(key, raising=False)
+
+    command = _golden_run().build_claude_command()
+
+    assert command[:2] == ["claude", "-p"]
+    assert _arg(command, "--model") == "sonnet"
+    assert _arg(command, "--effort") == "high"
+    assert _arg(command, "--mcp-config") == '{"mcpServers":{}}'
+    assert _arg(command, "--setting-sources") == "user"
+    assert _arg(command, "--permission-mode") == "dontAsk"
+    assert _arg(command, "--tools") == ""
+    for flag in (
+        "--safe-mode",
+        "--strict-mcp-config",
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--exclude-dynamic-system-prompt-sections",
+    ):
+        assert flag in command
+    system_prompt = _arg(command, "--append-system-prompt")
+    assert "Swiss financial lucidity app" in system_prompt
+    assert "financial_core" in system_prompt
+
+
+@pytest.mark.parametrize("model", ["opus", "claude-sonnet-4-5"])
+def test_golden_claude_command_allows_supported_models(
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+) -> None:
+    monkeypatch.setenv("MINT_GOLDEN_CLAUDE_MODEL", model)
+
+    assert _arg(_golden_run().build_claude_command(), "--model") == model
+
+
+@pytest.mark.parametrize(
+    ("env", "match"),
+    [
+        ({"MINT_GOLDEN_CLAUDE_EFFORT": "max"}, "refusing max effort"),
+        ({"MINT_GOLDEN_CLAUDE_MODEL": "opuss"}, "MINT_GOLDEN_CLAUDE_MODEL"),
+    ],
+)
+def test_golden_claude_command_rejects_bad_config(
+    monkeypatch: pytest.MonkeyPatch,
+    env: dict[str, str],
+    match: str,
+) -> None:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.delenv("MINT_GOLDEN_CLAUDE_ALLOW_MAX", raising=False)
+
+    with pytest.raises(ValueError, match=match):
+        _golden_run().build_claude_command()
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr", "expected_failed", "expected_excerpt"),
+    [
+        (2, "", "unknown option --future-flag", "cli_error", "unknown option"),
+        (0, "", "existing widget", "no_read_before_write", None),
+    ],
+)
+def test_run_one_handles_cli_errors_and_success_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    expected_failed: str,
+    expected_excerpt: str | None,
+) -> None:
+    golden_run = _golden_run()
+
+    def fake_run(*args, **kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    monkeypatch.setattr(golden_run.subprocess, "run", fake_run)
+    result = golden_run.run_one(
+        {"id": 1, "domain": "read_before_write", "prompt": "Crée un widget."}
+    )
+
+    assert result["turns_to_correct"] == 999
+    assert result["failed_lints"] == expected_failed
+    if expected_excerpt:
+        assert expected_excerpt in result["output_excerpt"]
+
+
+def test_graceful_refusal_requires_two_signals() -> None:
+    golden_run = _golden_run()
+
+    assert not golden_run.is_graceful_refusal("I cannot do that.")
+    assert golden_run.is_graceful_refusal(
+        "I cannot do that. Before creating it, I would check the existing widget."
+    )

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -11,8 +12,23 @@ CLAUDE_MD = ROOT / "CLAUDE.md"
 AGENTS_MD = ROOT / "AGENTS.md"
 AGENT = ROOT / ".claude/agents/mint-external-auditor.md"
 QUALITY_GATE = ROOT / ".claude/agents/mint-quality-gate.md"
+GSD_REVIEW = ROOT / ".claude/get-shit-done/workflows/review.md"
 WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
 OPERATING_GATES = ROOT / ".claude/skills/mint-operating-gates/SKILL.md"
+RAW_CLAUDE_PRINT_RE = re.compile(
+    r"claude\s+(-p|--print)|"
+    r"\[\s*[\"']claude[\"']\s*,\s*[\"'](-p|--print)[\"']"
+)
+RAW_CLAUDE_PRINT_ALLOWLIST = {
+    ".claude/agents/mint-quality-gate.md",
+    ".claude/get-shit-done/workflows/review.md",
+    ".claude/skills/mint-operating-gates/SKILL.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "tools/agent-drift/golden/run.py",
+    "tools/agent-drift/tests/test_golden_claude_command.py",
+    "tools/checks/tests/test_claude_external_audit_contract.py",
+}
 
 
 def _run(*args: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
@@ -279,6 +295,61 @@ def test_quality_gate_does_not_allow_raw_claude_fallback() -> None:
     assert "tools/checks/claude_external_audit.sh" in text
     assert "otherwise `claude -p`" not in text
     assert "raw `claude -p`" in text
+
+
+def test_raw_claude_print_usage_is_confined_to_known_contracts() -> None:
+    files = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.splitlines()
+
+    offenders: list[str] = []
+    for rel_path in files:
+        if rel_path.startswith(".planning/phases/"):
+            continue
+        if not rel_path.endswith((".md", ".py", ".sh", ".yml", ".yaml", ".txt")):
+            continue
+        text = (ROOT / rel_path).read_text(encoding="utf-8", errors="ignore")
+        if RAW_CLAUDE_PRINT_RE.search(text) and rel_path not in RAW_CLAUDE_PRINT_ALLOWLIST:
+            offenders.append(rel_path)
+
+    assert offenders == []
+
+
+def test_raw_claude_print_allowlist_entries_still_match() -> None:
+    stale_entries = [
+        rel_path
+        for rel_path in RAW_CLAUDE_PRINT_ALLOWLIST
+        if not RAW_CLAUDE_PRINT_RE.search(
+            (ROOT / rel_path).read_text(encoding="utf-8", errors="ignore")
+        )
+    ]
+
+    assert stale_entries == []
+
+
+def test_gsd_review_claude_invocation_is_bounded() -> None:
+    text = GSD_REVIEW.read_text(encoding="utf-8")
+
+    assert "--no-input" not in text
+    for needle in (
+        "--model sonnet",
+        "--effort high",
+        "--safe-mode",
+        "--strict-mcp-config",
+        "--mcp-config",
+        '{"mcpServers":{}}',
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--setting-sources user",
+        "--permission-mode dontAsk",
+        '--tools ""',
+        "--exclude-dynamic-system-prompt-sections",
+    ):
+        assert needle in text
 
 
 def test_operating_gates_do_not_mark_claude_wrapper_as_missing() -> None:


### PR DESCRIPTION
## Summary\n- bound the agent-drift golden Claude runs with model/effort validation, empty MCP, no session persistence, no slash commands, and tools disabled\n- replace the GSD review raw Claude command with a bounded stdin-based invocation\n- add contract tests that prevent raw Claude print usage from spreading outside allowlisted contracts\n\n## QA\n- python3 -m pytest tools/agent-drift/tests/test_golden_claude_command.py tools/checks/tests/test_claude_external_audit_contract.py -q\n- python3 -m pytest tools/agent-drift/tests -q\n- python3 -m pytest tools/checks/tests -q\n- python3 tools/agent-drift/dashboard.py golden-run --dry-run\n- MINT_GOLDEN_CLAUDE_EFFORT=max python3 tools/agent-drift/golden/run.py exits 1 before invoking Claude\n- claude --help confirms --tools "" disables all tools\n- lefthook run pre-commit --file ...\n- CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS\n\n## Notes\n- Final staged diff is 297 insertions, under the repo <300-line slice rule.\n