### PR TITLE
feat(dataquest): collect focused patrimoine savings

### DIFF
--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -197,19 +197,17 @@ class CoachProfileProvider extends ChangeNotifier {
       final isLoggedIn = await AuthService.isLoggedIn();
       if (!isLoggedIn) return;
       final remoteData = await ApiService.get('/profiles/me');
-      if (remoteData is Map<String, dynamic>) {
-        mergeFromRemoteProfile(remoteData);
-        // Also merge financial fields that the basic merge doesn't cover.
-        _mergeFinancialFieldsFromRemote(remoteData);
-        // OBS-05 — save_fact success proxy breadcrumb (D-03 4-level).
-        // factKind is the coarse 'profile_sync' enum; the finer-grained
-        // per-field attribution is deferred to Phase 31-02 (backend can
-        // echo `facts_saved: [...]` in /profiles/me response).
-        MintBreadcrumbs.saveFact(
-          success: true,
-          factKind: 'profile_sync',
-        );
-      }
+      mergeFromRemoteProfile(remoteData);
+      // Also merge financial fields that the basic merge doesn't cover.
+      _mergeFinancialFieldsFromRemote(remoteData);
+      // OBS-05 — save_fact success proxy breadcrumb (D-03 4-level).
+      // factKind is the coarse 'profile_sync' enum; the finer-grained
+      // per-field attribution is deferred to Phase 31-02 (backend can
+      // echo `facts_saved: [...]` in /profiles/me response).
+      MintBreadcrumbs.saveFact(
+        success: true,
+        factKind: 'profile_sync',
+      );
     } catch (e) {
       debugPrint('[CoachProfile] syncFromBackend failed (non-fatal): $e');
       // OBS-05 — save_fact failure proxy breadcrumb. Error code is an
@@ -253,7 +251,7 @@ class CoachProfileProvider extends ChangeNotifier {
     }
     // 3a balance
     final remote3a = (remote['pillar3aBalance'] as num?)?.toDouble();
-    if ((p.totalEpargne3a ?? 0) <= 0 && remote3a != null && remote3a > 0) {
+    if (p.totalEpargne3a <= 0 && remote3a != null && remote3a > 0) {
       partial['_coach_total_3a'] = remote3a;
     }
 
@@ -484,8 +482,8 @@ class CoachProfileProvider extends ChangeNotifier {
     _scoreHistory = await ReportPersistenceService.loadScoreHistory();
   }
 
-  /// Met a jour le profil directement a partir d'un map d'answers.
-  /// Utilise apres la completion du wizard pour eviter un rechargement async.
+  /// Updates the profile directly from an answers map.
+  /// Used after wizard completion to avoid an async reload.
   void updateFromAnswers(Map<String, dynamic> answers) {
     if (answers.isEmpty) return;
     _lastAnswers = answers;
@@ -527,7 +525,7 @@ class CoachProfileProvider extends ChangeNotifier {
   /// Backend `save_fact` persists to `ProfileModel.data` only when `user_id`
   /// is present. Anonymous local-mode users (the default for fresh installs)
   /// never have a `user_id`, so the backend path hits `# Hors-DB path` and
-  /// returns "Fait noté (hors DB)" without persisting — the chat captures
+  /// returns a non-DB acknowledgement without persisting — the chat captures
   /// data in theory but nothing lands in the profile.
   ///
   /// This method closes that gap: when the coach_chat_screen receives a
@@ -616,6 +614,7 @@ class CoachProfileProvider extends ChangeNotifier {
       case 'savingsMonthly':
         return {'q_savings_monthly': value};
       case 'totalSavings':
+        return {'q_cash_total': value};
       case 'wealthEstimate':
         return {'q_epargne_liquide': value};
       default:
@@ -1041,7 +1040,7 @@ class CoachProfileProvider extends ChangeNotifier {
       answers['q_total_3a'] = profile.prevoyance.totalEpargne3a;
     }
     // Patrimoine
-    answers['q_epargne_liquide'] = profile.patrimoine.epargneLiquide;
+    answers['q_cash_total'] = profile.patrimoine.epargneLiquide;
     answers['q_investissements'] = profile.patrimoine.investissements;
     // Housing
     _persistHousingFieldsSync(answers, profile);
@@ -1259,7 +1258,7 @@ class CoachProfileProvider extends ChangeNotifier {
     // a chaque restart et daysSinceUpdate >= 330 ne sera jamais vrai.
     answers['_coach_updated_at'] = DateTime.now().toIso8601String();
 
-    // Persister aussi createdAt si c'est le premier refresh (preserve l'original)
+    // Preserve createdAt on the first refresh.
     if (answers['_coach_created_at'] == null && p.createdAt != p.updatedAt) {
       answers['_coach_created_at'] = p.createdAt.toIso8601String();
     }

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -56,11 +56,15 @@ class _DataBlockEnrichmentScreenState
   final TextEditingController _cantonController = TextEditingController();
   final TextEditingController _salaryController = TextEditingController();
   final TextEditingController _birthYearController = TextEditingController();
+  final TextEditingController _cashController = TextEditingController();
   bool _revenueInputsSeeded = false;
+  bool _patrimoineInputsSeeded = false;
   bool _hasPensionFund = false;
   bool _hasPensionFundTouched = false;
   bool _isSavingRevenue = false;
+  bool _isSavingPatrimoine = false;
   String? _revenueError;
+  String? _patrimoineError;
 
   /// Cached cross-validation alerts to avoid recomputing on every build.
   List<ValidationAlert>? _cachedAlerts;
@@ -71,6 +75,7 @@ class _DataBlockEnrichmentScreenState
     _cantonController.dispose();
     _salaryController.dispose();
     _birthYearController.dispose();
+    _cashController.dispose();
     super.dispose();
   }
 
@@ -90,6 +95,8 @@ class _DataBlockEnrichmentScreenState
     final canonicalBlockType = _canonicalBlockType(widget.blockType);
     if (canonicalBlockType == 'revenu') {
       _seedRevenueInputs(profile);
+    } else if (canonicalBlockType == 'patrimoine') {
+      _seedPatrimoineInputs(profile);
     }
     final isKnownBlock =
         DataBlockEnrichmentScreen._supportedBlockTypes.contains(canonicalBlockType);
@@ -156,7 +163,12 @@ class _DataBlockEnrichmentScreenState
               ],
 
               // ── Enrichment prompts for this block ────────────────
-              if (profile != null && canonicalBlockType != 'revenu') ...[
+              if (_shouldShowPatrimoineCollector(canonicalBlockType)) ...[
+                MintEntrance(
+                  delay: const Duration(milliseconds: 200),
+                  child: _buildPatrimoineCollector(l),
+                ),
+              ] else if (profile != null && canonicalBlockType != 'revenu') ...[
                 MintEntrance(delay: const Duration(milliseconds: 200), child: _buildPrompts(profile, canonicalBlockType, bloc)),
               ],
               if (canonicalBlockType == 'revenu') ...[
@@ -174,7 +186,8 @@ class _DataBlockEnrichmentScreenState
               const SizedBox(height: 32),
 
               // ── CTA ──────────────────────────────────────────────
-              if (canonicalBlockType != 'revenu')
+              if (canonicalBlockType != 'revenu' &&
+                  !_shouldShowPatrimoineCollector(canonicalBlockType))
                 Semantics(
                   button: true,
                   label: meta.ctaLabel,
@@ -231,6 +244,14 @@ class _DataBlockEnrichmentScreenState
     if (profile.birthYear >= 1900) _birthYearController.text = '${profile.birthYear}';
     _hasPensionFund = (profile.prevoyance.avoirLppTotal ?? 0) > 0 ||
         profile.prevoyance.isLppFromCertificate;
+  }
+
+  void _seedPatrimoineInputs(CoachProfile? profile) {
+    if (_patrimoineInputsSeeded || profile == null) return;
+    _patrimoineInputsSeeded = true;
+    if (profile.patrimoine.epargneLiquide > 0) {
+      _cashController.text = '${profile.patrimoine.epargneLiquide.round()}';
+    }
   }
 
   Widget _buildRevenueCollector(S l) {
@@ -414,7 +435,96 @@ class _DataBlockEnrichmentScreenState
     setState(() => _isSavingRevenue = false);
   }
 
+  bool _shouldShowPatrimoineCollector(String canonicalBlockType) {
+    return canonicalBlockType == 'patrimoine' &&
+        _canonicalPatrimoineInputKey(widget.initialInputKey) != null;
+  }
+
+  Widget _buildPatrimoineCollector(S l) {
+    return MintSurface(
+      padding: const EdgeInsets.all(18),
+      radius: 12,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _buildRevenueTextField(
+            key: const Key('savings_input'),
+            semanticsIdentifier: 'savings_input',
+            controller: _cashController,
+            label: l.financialSummaryEditEpargneLiquide,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+          ),
+          if (_patrimoineError != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _patrimoineError!,
+              style: MintTextStyles.labelMedium(color: MintColors.error),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Semantics(
+            identifier: 'patrimoine_save_cta',
+            button: true,
+            label: l.financialSummaryEnregistrer,
+            child: FilledButton(
+              key: const Key('patrimoine_save_cta'),
+              onPressed: _isSavingPatrimoine ? null : _savePatrimoineFacts,
+              style: FilledButton.styleFrom(
+                backgroundColor: MintColors.primary,
+                foregroundColor: MintColors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: Text(
+                l.financialSummaryEnregistrer,
+                style: MintTextStyles.titleMedium()
+                    .copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _savePatrimoineFacts() async {
+    final l = S.of(context)!;
+    final cash = int.tryParse(_digitsOnly(_cashController.text));
+    if (cash == null || cash < 0) {
+      setState(() => _patrimoineError = l.authErrorInvalid);
+      return;
+    }
+    setState(() {
+      _isSavingPatrimoine = true;
+      _patrimoineError = null;
+    });
+    await context.read<CoachProfileProvider>().mergeAnswers({
+      'q_cash_total': cash,
+    });
+    if (!mounted) return;
+    HapticFeedback.lightImpact();
+    setState(() => _isSavingPatrimoine = false);
+  }
+
   String _digitsOnly(String value) => value.replaceAll(RegExp(r'[^0-9]'), '');
+
+  String? _canonicalPatrimoineInputKey(String? inputKey) {
+    if (inputKey == null || inputKey.trim().isEmpty) return null;
+    final token =
+        inputKey.trim().toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+    return switch (token) {
+      'totalsavings' ||
+      'cashtotal' ||
+      'qcashtotal' ||
+      'epargneliquide' ||
+      'savings' =>
+        'q_cash_total',
+      _ => null,
+    };
+  }
 
   String? _canonicalRevenueInputKey(String? inputKey) {
     if (inputKey == null || inputKey.trim().isEmpty) return null;

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const secureStorage =
+      MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(secureStorage, (call) async {
+    if (call.method == 'read') return null;
+    if (call.method == 'readAll') return <String, String>{};
+    return null;
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('updateProfile persists liquid savings on the readable cash key',
+      () async {
+    final provider = CoachProfileProvider();
+    final profile = CoachProfile.defaults().copyWith(
+      patrimoine: const PatrimoineProfile(epargneLiquide: 88000),
+    );
+
+    provider.updateProfile(profile);
+    await Future<void>.delayed(Duration.zero);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_cash_total', 88000));
+    expect(answers.containsKey('q_epargne_liquide'), isFalse);
+    expect(CoachProfile.fromWizardAnswers(answers).patrimoine.epargneLiquide,
+        88000);
+  });
+}

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -162,6 +162,32 @@ void main() {
     expect(provider.profile, isNotNull);
   });
 
+  testWidgets('patrimoine block inputKey collects only liquid savings',
+      (tester) async {
+    final provider = CoachProfileProvider();
+
+    await tester.pumpWidget(_wrap(
+      const DataBlockEnrichmentScreen(
+        blockType: 'patrimoine',
+        initialInputKey: 'totalSavings',
+      ),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('savings_input')), findsOneWidget);
+    expect(find.byKey(const Key('salary_input')), findsNothing);
+
+    await tester.enterText(find.byKey(const Key('savings_input')), '120000');
+    await tester.tap(find.byKey(const Key('patrimoine_save_cta')));
+    await tester.pumpAndSettle();
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_cash_total', 120000));
+    expect(answers.containsKey('q_epargne_liquide'), isFalse);
+    expect(provider.profile?.patrimoine.epargneLiquide, 120000);
+  });
+
   testWidgets('revenue block seeds pension switch from existing profile',
       (tester) async {
     final provider = CoachProfileProvider()

--- a/apps/mobile/test/services/chat/fact_extraction_fallback_test.dart
+++ b/apps/mobile/test/services/chat/fact_extraction_fallback_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/services/chat/fact_extraction_fallback.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -64,6 +65,18 @@ void main() {
       final applied = await FactExtractionFallback.extract(
         "mon 3a est à 15000 CHF", p);
       expect(applied, contains('pillar3aBalance'));
+    });
+
+    test('save_fact totalSavings writes the cash key read by the profile',
+        () async {
+      final p = CoachProfileProvider();
+      final applied = await p.applySaveFact('totalSavings', 120000);
+
+      expect(applied, isTrue);
+      final answers = await ReportPersistenceService.loadAnswers();
+      expect(answers, containsPair('q_cash_total', 120000));
+      expect(answers.containsKey('q_epargne_liquide'), isFalse);
+      expect(p.profile?.patrimoine.epargneLiquide, 120000);
     });
 
     test('IGNORES third-person salary (« ma sœur gagne 7500 »)', () async {

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -160,12 +160,12 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 | key | wizard key | type+unit | domain | sources | fresh | wconf | write | consumers |
 |---|---|---|---|---|---|---|---|---|
 | `savingsMonthly` | `q_savings_monthly` | double CHF/mo | patrimoine | userInput, openBanking | annual | .60 | applySaveFact/mergeAnswers | budget gap, `capSequencePlan`, FRI score |
-| `totalSavings` | `q_epargne_liquide` | double CHF | patrimoine | userInput, certificate, openBanking | annual | .60 | applySaveFact/mergeAnswers | `patrimoine.epargneLiquide`, emergency fund (SafeMode Signal C), liquidity axis |
-| `wealthEstimate` | `q_epargne_liquide` **(key collision — see note)** | double CHF | patrimoine | userInput, estimated | annual | .60 | applySaveFact/mergeAnswers | `totalPatrimoine`, wealth tax, net worth |
+| `totalSavings` | `q_cash_total` | double CHF | patrimoine | userInput, certificate, openBanking | annual | .60 | applySaveFact/mergeAnswers | `patrimoine.epargneLiquide`, emergency fund (SafeMode Signal C), liquidity axis |
+| `wealthEstimate` | `q_epargne_liquide` **(legacy unread key — see note)** | double CHF | patrimoine | userInput, estimated | annual | .60 | applySaveFact/mergeAnswers | `totalPatrimoine`, wealth tax, net worth |
 | `hasDebt` | ⚠ NO MAPPER CASE (§3.8) | bool | dettes | userInput | volatile | .60 | applySaveFact/mergeAnswers | SafeMode Signal A, `isInDebtCrisis` |
 | `totalDebt` | ⚠ NO MAPPER CASE (§3.8) | double CHF | dettes | userInput, certificate | volatile | .60 | applySaveFact/mergeAnswers | `dettes.*`, debt-to-income 0.33, net worth |
 
-> **⚠ `totalSavings` and `wealthEstimate` BOTH map to `q_epargne_liquide` in the real switch** (`case 'totalSavings': case 'wealthEstimate': return {'q_epargne_liquide': value};`). This is a real key collision: the last write wins and clobbers the other concept. The §3.8 repair MUST split these onto distinct wizard keys (`wealthEstimate` → a new `q_wealth_estimate` read by `fromWizardAnswers` into `totalPatrimoine`), or explicitly document and accept the collision. Do not silently preserve the collision without a decision recorded here.
+> **Status:** `totalSavings` now maps to `q_cash_total`, the key actually read by `CoachProfile.fromWizardAnswers()` for `patrimoine.epargneLiquide`. `wealthEstimate` still maps to the legacy unread `q_epargne_liquide`; the remaining §3.8 repair MUST give it a distinct wizard key (`q_wealth_estimate`) and a distinct read into `totalPatrimoine`, or explicitly drop coach-write support. Do not reintroduce the old collision.
 
 ### 3.6 Spouse (couple)
 
@@ -186,15 +186,17 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 **Count check (must match code):** 3.1–3.7 = 9 (identity) + 7 (income) + 7 (LPP) + 2 (3a) + 5 (savings/wealth/debt) + 3 (spouse) + 2 (AVS) = **35 keys** = `len(_SAVE_FACT_ALLOWED_KEYS)`. CI test §8.1 asserts `len == 35`.
 
-### 3.8 REQUIRED REPAIR — 18 backend-writable keys ineffective locally (parity is broken today)
+### 3.8 REQUIRED REPAIR — 17 backend-writable keys still ineffective locally (parity is still broken)
 
 At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handles only **24** of the 35 allowlist keys; the other **11** fall through `default: return const {}`, so `applySaveFact` returns `false` and the coach write is **silently dropped** — a live dead road (`save_fact('hasAvsGaps')` etc. writes nothing to `CoachProfile`).
 
-G1 found a second gap: **7 mapped keys write to wizard keys that `CoachProfile.fromWizardAnswers()` does not read**, so `applySaveFact` returns `true` but the profile still does not reconstruct the intended value. Total local ineffectiveness: **18 backend-writable keys**.
+G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`; total remaining local ineffectiveness is now **17 backend-writable keys**.
 
 **The 11 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`, `hasAvsGaps`, `avsContributionYears`.
 
-**The 7 mapped-but-unread keys:** `commune -> q_commune`, `gender -> q_gender`, `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`, `pillar3aBalance -> q_total_3a`, `totalSavings -> q_epargne_liquide`, `wealthEstimate -> q_epargne_liquide`.
+**The 6 remaining mapped-but-unread keys:** `commune -> q_commune`, `gender -> q_gender`, `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`, `pillar3aBalance -> q_total_3a`, `wealthEstimate -> q_epargne_liquide`.
+
+**Repaired mapped key:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`.
 
 **Task T-0 (mandatory):** repair the 7 mapped-but-unread cases first. Either align the mapper to wizard keys already read by `fromWizardAnswers`, or add explicit `fromWizardAnswers` reads with tests.
 
@@ -205,7 +207,7 @@ G1 found a second gap: **7 mapped keys write to wizard keys that `CoachProfile.f
 | `employmentRate` | `q_employment_rate` | none | add field/read or remove coach-writable status |
 | `annualBonus` | `q_annual_bonus` | none | add field/read or remove coach-writable status |
 | `pillar3aBalance` | `q_total_3a` | `q_3a_total` / `_coach_total_3a` | map to a read key or add alias |
-| `totalSavings` | `q_epargne_liquide` | `q_cash_total` | map to `q_cash_total` |
+| `totalSavings` | `q_cash_total` | `q_cash_total` | ✅ repaired; keep mapping on `q_cash_total` |
 | `wealthEstimate` | `q_epargne_liquide` | none distinct | add `q_wealth_estimate` or explicitly drop coach-write |
 
 **Task T-1 (mandatory):** add a `case` for each of the 11 unmapped keys to `_mapFactKeyToAnswers`, mapping to a wizard key that `fromWizardAnswers` already reads where one exists. Where no wizard key exists yet in `fromWizardAnswers`, add BOTH the mapper case AND the read.
@@ -226,7 +228,7 @@ G1 found a second gap: **7 mapped keys write to wizard keys that `CoachProfile.f
 
 After T-0 and T-1, `_mapFactKeyToAnswers` handles all 35 keys and every mapper target is actually read by `fromWizardAnswers`; the §8.1 parity test passes. Until both tasks land, that test is expected RED and gates the PR.
 
-**Task T-2 (mandatory, from §3.5 note):** resolve the `totalSavings` / `wealthEstimate` → `q_epargne_liquide` collision by giving `wealthEstimate` its own wizard key (`q_wealth_estimate`) and a distinct `fromWizardAnswers` read into `totalPatrimoine`.
+**Task T-2 (mandatory, from §3.5 note):** finish the split by giving `wealthEstimate` its own wizard key (`q_wealth_estimate`) and a distinct `fromWizardAnswers` read into `totalPatrimoine`. `totalSavings` MUST remain on `q_cash_total`.
 
 ---
 


### PR DESCRIPTION
## Summary
- route focused patrimoine data-block prompts for liquid savings into a single `savings_input` collector
- persist `totalSavings` and full-profile liquid savings through `q_cash_total`, the key read by `CoachProfile.fromWizardAnswers`
- update `DATA_LEDGER.md` to mark `totalSavings` repaired while keeping `wealthEstimate` as remaining debt

## QA
- RED first: `flutter test test/providers/coach_profile_provider_test.dart --plain-name 'updateProfile persists liquid savings on the readable cash key'` failed on `q_epargne_liquide`; fixed to `q_cash_total`
- `flutter analyze lib/providers/coach_profile_provider.dart lib/screens/onboarding/data_block_enrichment_screen.dart test/providers/coach_profile_provider_test.dart test/screens/data_block_enrichment_screen_test.dart test/services/chat/fact_extraction_fallback_test.dart`
- `flutter test test/providers/coach_profile_provider_test.dart test/screens/data_block_enrichment_screen_test.dart test/services/chat/fact_extraction_fallback_test.dart`
- `python3 -m pytest tools/checks/tests/test_codex_spec_reality_contract.py -q`
- `lefthook run pre-commit --file apps/mobile/lib/providers/coach_profile_provider.dart --file apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart --file apps/mobile/test/providers/coach_profile_provider_test.dart --file apps/mobile/test/screens/data_block_enrichment_screen_test.dart --file apps/mobile/test/services/chat/fact_extraction_fallback_test.dart --file docs/codex/DATA_LEDGER.md`
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> PASS

## Known remaining debt
- `wealthEstimate -> q_epargne_liquide` remains mapped-but-unread and is documented as the next T-2 split.
- The focused collector still needs an in-app entry point beyond the existing route-contract/deep-link surface.
