### PR TITLE
docs: anchor Claude audit safe-mode policy

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -35,7 +35,9 @@ Same-gate rerun after a first finding pass:
 The wrapper is the default. It runs Claude CLI with Opus high, safe mode,
 strict empty MCP, disabled slash commands, no session persistence, bounded
 tools, `--setting-sources user`, and dynamic-system-prompt sections excluded for
-cache stability.
+cache stability. Safe mode is the no-hooks boot path: it disables hooks, skills,
+plugins, custom agents, auto memory, and CLAUDE.md auto-discovery while keeping
+auth/model/permissions available.
 Code audits also enforce a diff-prompt budget (`CLAUDE_AUDIT_MAX_DIFF_LINES`,
 default 2500). If it trips, split the PR; use `CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1`
 only for a named final-release/P0 dispute.
@@ -47,9 +49,10 @@ confirmation. The wrapper rejects non-Sonnet reruns unless
 confirmation or P0 dispute. This avoids paying full startup hooks, MCP servers, memory
 injection, skill inventory, and max reasoning on every tool turn.
 
-Do not add `--max-turns`: the installed Claude CLI does not expose it, and the
-wrapper rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not
-use `--bare` by default: it skips OAuth/keychain auth and only works with
+Do not replace safe mode with ad hoc minimal settings. Do not add
+`--max-turns`: the installed Claude CLI does not expose it, and the wrapper
+rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not use
+`--bare` by default: it skips OAuth/keychain auth and only works with
 explicit API-key/apiKeyHelper auth. Do not use project/local setting sources by
 default: they can reload repo hooks. The wrapper rejects them unless
 `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1` is set for a named debug run.

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -47,7 +47,11 @@ tools/checks/claude_external_audit.sh architecture
 The wrapper is deliberately bounded: Opus high by default, strict empty MCP,
 no session persistence, `--setting-sources user`, no dynamic-system-prompt
 sections, and no `--effort max` unless `CLAUDE_AUDIT_ALLOW_MAX=1` is explicitly
-set for a named final-release or unresolved P0/P1 dispute. Project/local setting
+set for a named final-release or unresolved P0/P1 dispute. It uses safe mode
+(`--safe-mode`) as the no-hooks boot path, disabling hooks, skills, plugins,
+custom agents, auto memory, and CLAUDE.md auto-discovery while preserving
+auth/model/permissions.
+Project/local setting
 sources are rejected by default because they can load repo hooks; override only
 with `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1` for a named debug run. Code audits
 reject large diff prompts by default

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,11 @@ named gap after the MINT roster scopes the work.
 Run external reviews through `tools/checks/claude_external_audit.sh`, never raw
 `claude -p`. The wrapper is the operating contract: Opus high for first-pass
 bounded reviews, Sonnet high for same-gate reruns with `CLAUDE_AUDIT_RERUN=1`,
-strict empty MCP, `--setting-sources user`, no session persistence, and a code
-diff budget via `CLAUDE_AUDIT_MAX_DIFF_LINES`. Use `--effort max` only for a
+safe mode no-hooks boot, strict empty MCP, `--setting-sources user`, no session
+persistence, and a code diff budget via `CLAUDE_AUDIT_MAX_DIFF_LINES`.
+`--safe-mode` is required because it disables hooks, skills, plugins, custom
+agents, auto memory, and CLAUDE.md auto-discovery while preserving
+auth/model/permissions. Use `--effort max` only for a
 named final-release/P0 dispute with `CLAUDE_AUDIT_ALLOW_MAX=1`.
 
 If a rerun needs Opus for final confirmation or a P0 dispute, set

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,12 @@ tools/checks/claude_external_audit.sh architecture
 The wrapper is intentionally bounded: Opus high by default, Sonnet high for
 same-gate reruns via `CLAUDE_AUDIT_RERUN=1`, `--safe-mode`,
 `--strict-mcp-config`, empty MCP config, `--setting-sources user`,
-`--no-session-persistence`, and bounded tools. Project/local setting sources are
-rejected by default because `.claude/settings*.json` can load repo hooks. Use
-`--effort max` only for a named final-release/P0 dispute with
+`--no-session-persistence`, and bounded tools. `--safe-mode` is the no-hooks
+boot path: it disables hooks, skills, plugins, custom agents, auto memory, and
+CLAUDE.md auto-discovery while keeping auth/model/permissions available.
+Project/local setting sources are rejected by default because
+`.claude/settings*.json` can load repo hooks. Use `--effort max` only for a
+named final-release/P0 dispute with
 `CLAUDE_AUDIT_ALLOW_MAX=1`. Do not add unsupported `--max-turns`: the installed
 Claude CLI does not expose it, and the wrapper rejects `CLAUDE_AUDIT_MAX_TURNS`
 so agents cannot rely on a fake safety knob.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -80,10 +80,13 @@ without range + confidence + source/freshness, and no data collection that asks
 again for a fresh known fact.
 
 Claude CLI audits should be bounded through
-`tools/checks/claude_external_audit.sh`: Opus high by default, strict empty MCP,
-no session persistence, and no `--effort max` except named final-release/P0
-disputes. Re-run loops use Sonnet high first, then one Opus high final; do not
-use `--bare` without explicit API-key auth, and do not add unsupported
+`tools/checks/claude_external_audit.sh`: Opus high by default, `--safe-mode`
+no-hooks boot, strict empty MCP, no session persistence, and no `--effort max`
+except named final-release/P0 disputes. `--safe-mode` is the required latency
+guard because it disables hooks, skills, plugins, custom agents, auto memory,
+and CLAUDE.md auto-discovery without losing auth/model/permissions. Re-run loops
+use Sonnet high first, then one Opus high final; do not use `--bare` without
+explicit API-key auth, and do not add unsupported
 `--max-turns`. The wrapper also forces `--setting-sources user` by default and
 rejects project/local setting sources unless `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1`
 is explicitly set for a named debug run, because project/local settings can

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -265,6 +265,9 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "Sonnet high" in text
         assert "CLAUDE_AUDIT_RERUN=1" in text
         assert "CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1" in text
+        assert "safe mode" in lowered
+        assert "hooks" in lowered
+        assert "plugins" in lowered
         assert "--setting-sources user" in text
         assert "CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1" in text
         assert "--effort max" in text
@@ -280,6 +283,8 @@ def test_claude_md_anchors_external_audit_latency_policy() -> None:
         "Sonnet high",
         "CLAUDE_AUDIT_RERUN=1",
         "--safe-mode",
+        "no-hooks",
+        "hooks, skills, plugins",
         "--strict-mcp-config",
         "--setting-sources user",
         "--no-session-persistence",


### PR DESCRIPTION
## Summary
- Anchors the Claude CLI latency policy in CLAUDE/AGENTS/workflow/agent docs.
- Documents that `--safe-mode` is the no-hooks boot path, disabling hooks, skills, plugins, custom agents, auto memory, and CLAUDE.md auto-discovery while preserving auth/model/permissions.
- Extends the contract test so docs must keep the safe-mode/hooks/plugins rationale.

## Verification
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py tools/agent-drift/tests/test_golden_claude_command.py -q`
- `lefthook run pre-commit --file CLAUDE.md --file AGENTS.md --file docs/MINT_AGENT_WORKFLOW.md --file .claude/agents/mint-external-auditor.md --file .claude/skills/mint-operating-gates/SKILL.md --file tools/checks/tests/test_claude_external_audit_contract.py`
- `CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code HEAD`
- `CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_EFFORT=max tools/checks/claude_external_audit.sh code HEAD` rejects with rc=2 unless `CLAUDE_AUDIT_ALLOW_MAX=1`.
