### PR TITLE
feat(dataquest): wire wealth estimate safely

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -314,7 +314,7 @@ class PrevoyanceProfile {
   final double? avoirLppObligatoire; // part obligatoire (taux min 6.8%)
   final double? avoirLppSurobligatoire; // part surobligatoire (taux caisse)
   final double? rachatMaximum; // lacune de rachat totale
-  final double? rachatEffectue; // deja rachete (montant CHF cumulé)
+  final double? rachatEffectue; // déjà racheté (montant CHF cumulé)
   /// Historique daté des rachats LPP (ordre chronologique, plus récent en
   /// dernier). swiss-brain Q4 2026-04-18 : le blocage 3 ans (LPP art. 79b
   /// al. 3, confirmé par ATF 142 II 399 + ATF 148 II 189) part de la date
@@ -695,6 +695,11 @@ class PatrimoineProfile {
   final double epargneLiquide;
   final double investissements;
   final double? immobilier;
+
+  /// Broad user-supplied wealth estimate. Treat as an aggregate fallback, never
+  /// as an additive asset component. Because users may answer all-in, consumers
+  /// that add explicit LPP/3a values must compare totals with max(), not sum.
+  final double? wealthEstimate;
   final InvestmentCurrency deviseInvestissements;
   final String? plateformeInvestissement; // "Interactive Brokers", etc.
 
@@ -715,6 +720,7 @@ class PatrimoineProfile {
     this.epargneLiquide = 0,
     this.investissements = 0,
     this.immobilier,
+    this.wealthEstimate,
     this.deviseInvestissements = InvestmentCurrency.chf,
     this.plateformeInvestissement,
     this.propertyMarketValue,
@@ -738,9 +744,18 @@ class PatrimoineProfile {
   double get loanToValue =>
       immobilierEffectif > 0 ? (mortgageBalance ?? 0) / immobilierEffectif : 0;
 
-  /// Patrimoine brut total (liquidités + investissements + immobilier).
-  double get totalPatrimoine =>
-      epargneLiquide + investissements + immobilierEffectif;
+  double get detailedAssetTotal =>
+      epargneLiquide +
+      investissements +
+      immobilierEffectif;
+
+  /// Patrimoine brut total. Use the broad estimate as an aggregate total, not
+  /// as an asset component, so it never double-counts detailed values.
+  double get totalPatrimoine {
+    final detailedTotal = detailedAssetTotal;
+    final estimatedTotal = wealthEstimate ?? 0;
+    return detailedTotal > estimatedTotal ? detailedTotal : estimatedTotal;
+  }
 
   /// Patrimoine net (brut - dettes). Dettes passed via parameter since
   /// PatrimoineProfile doesn't hold a reference to DetteProfile.
@@ -752,6 +767,7 @@ class PatrimoineProfile {
       epargneLiquide: (json['epargneLiquide'] as num?)?.toDouble() ?? 0,
       investissements: (json['investissements'] as num?)?.toDouble() ?? 0,
       immobilier: (json['immobilier'] as num?)?.toDouble(),
+      wealthEstimate: (json['wealthEstimate'] as num?)?.toDouble(),
       deviseInvestissements: InvestmentCurrency.values.firstWhere(
         (e) => e.name == json['deviseInvestissements'],
         orElse: () => InvestmentCurrency.chf,
@@ -771,6 +787,7 @@ class PatrimoineProfile {
     double? epargneLiquide,
     double? investissements,
     double? immobilier,
+    double? wealthEstimate,
     InvestmentCurrency? deviseInvestissements,
     String? plateformeInvestissement,
     double? propertyMarketValue,
@@ -785,6 +802,7 @@ class PatrimoineProfile {
       epargneLiquide: epargneLiquide ?? this.epargneLiquide,
       investissements: investissements ?? this.investissements,
       immobilier: immobilier ?? this.immobilier,
+      wealthEstimate: wealthEstimate ?? this.wealthEstimate,
       deviseInvestissements:
           deviseInvestissements ?? this.deviseInvestissements,
       plateformeInvestissement:
@@ -803,6 +821,7 @@ class PatrimoineProfile {
         'epargneLiquide': epargneLiquide,
         'investissements': investissements,
         'immobilier': immobilier,
+        'wealthEstimate': wealthEstimate,
         'deviseInvestissements': deviseInvestissements.name,
         'plateformeInvestissement': plateformeInvestissement,
         'propertyMarketValue': propertyMarketValue,
@@ -822,6 +841,7 @@ class PatrimoineProfile {
           epargneLiquide == other.epargneLiquide &&
           investissements == other.investissements &&
           immobilier == other.immobilier &&
+          wealthEstimate == other.wealthEstimate &&
           deviseInvestissements == other.deviseInvestissements &&
           plateformeInvestissement == other.plateformeInvestissement &&
           propertyMarketValue == other.propertyMarketValue &&
@@ -837,6 +857,7 @@ class PatrimoineProfile {
         epargneLiquide,
         investissements,
         immobilier,
+        wealthEstimate,
         deviseInvestissements,
         plateformeInvestissement,
         propertyMarketValue,
@@ -1772,7 +1793,7 @@ class CoachProfile {
           c.category == 'epargne_libre' || c.category == 'investissement')
       .fold(0.0, (sum, c) => sum + c.amount);
 
-  /// Detecte l'archetype financier de l'utilisateur.
+  /// Detects the user's financial archetype.
   ///
   /// Basee sur nationalite, arrivalAge, employmentStatus, residencePermit.
   /// Voir ADR-20260223-archetype-driven-retirement.md.
@@ -2466,7 +2487,7 @@ class CoachProfile {
     if (coachAvoirLpp != null) {
       estimatedLpp = coachAvoirLpp;
     } else if (!hasPensionFund) {
-      // Independant sans LPP ou declaration explicite "pas de caisse"
+      // Independent without LPP or explicit no-pension-fund declaration.
       estimatedLpp = 0.0;
     } else {
       estimatedLpp = _estimateLppAvoir(age, salaireBrutMensuel,
@@ -2505,6 +2526,7 @@ class CoachProfile {
     final estimatedMonthlyExpenses = monthlyHousing + assuranceMaladie;
     final emergencyFundRaw = answers['q_emergency_fund'];
     final cashTotal = _parseDouble(answers['q_cash_total']) ?? 0;
+    final wealthEstimate = _parseDouble(answers['q_wealth_estimate']);
     double epargneLiquide;
     if (emergencyFundRaw is String) {
       switch (emergencyFundRaw.toLowerCase()) {
@@ -2538,6 +2560,7 @@ class CoachProfile {
     final patrimoine = PatrimoineProfile(
       epargneLiquide: epargneLiquide,
       investissements: estimatedInvestments,
+      wealthEstimate: wealthEstimate,
       propertyMarketValue: _parseDouble(answers['q_property_market_value']),
       mortgageBalance: _parseDouble(answers['q_mortgage_balance']),
       mortgageRate: _parseDouble(answers['q_mortgage_rate']),
@@ -2647,7 +2670,7 @@ class CoachProfile {
       if (allocations.contains('epargne_libre') && remaining > 0) {
         contributions.add(PlannedMonthlyContribution(
           id: 'epargne_user',
-          label: 'Épargne libre',
+          label: 'Épargne libre', // lint-ignore: legacy model label
           amount: remaining,
           category: 'epargne_libre',
           isAutomatic: false,
@@ -2669,7 +2692,7 @@ class CoachProfile {
         if (epargneLibre > 50) {
           contributions.add(PlannedMonthlyContribution(
             id: 'epargne_user',
-            label: 'Épargne libre',
+            label: 'Épargne libre', // lint-ignore: legacy model label
             amount: epargneLibre,
             category: 'epargne_libre',
             isAutomatic: false,
@@ -2943,11 +2966,11 @@ class CoachProfile {
     if (raw == null) return CoachCivilStatus.celibataire;
     switch (raw.toLowerCase()) {
       case 'marie':
-      case 'marié':
+      case 'marié': // lint-ignore: accepted legacy input
       case 'married':
         return CoachCivilStatus.marie;
       case 'divorce':
-      case 'divorcé':
+      case 'divorcé': // lint-ignore: accepted legacy input
       case 'divorced':
         return CoachCivilStatus.divorce;
       case 'veuf':
@@ -2967,19 +2990,19 @@ class CoachProfile {
     switch (raw.toLowerCase()) {
       case 'employee':
       case 'salarie':
-      case 'salarié':
+      case 'salarié': // lint-ignore: accepted legacy input
         return 'salarie';
       case 'self_employed':
       case 'independant':
-      case 'indépendant':
+      case 'indépendant': // lint-ignore: accepted legacy input
         return 'independant';
       case 'retired':
       case 'retraite':
-      case 'retraité':
+      case 'retraité': // lint-ignore: accepted legacy input
         return 'retraite';
       case 'student':
       case 'etudiant':
-      case 'étudiant':
+      case 'étudiant': // lint-ignore: accepted legacy input
         return 'etudiant';
       case 'mixed':
       case 'mixte':
@@ -3194,7 +3217,7 @@ class CoachProfile {
         autresDepensesFixes: 300,
       ),
       prevoyance: const PrevoyanceProfile(
-        nomCaisse: 'Caisse des Electriciens',
+        nomCaisse: 'Caisse des Electriciens', // lint-ignore: demo seed
         avoirLppTotal: 300000,
         rachatMaximum: 300000,
         rachatEffectue: 0,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -616,7 +616,7 @@ class CoachProfileProvider extends ChangeNotifier {
       case 'totalSavings':
         return {'q_cash_total': value};
       case 'wealthEstimate':
-        return {'q_epargne_liquide': value};
+        return {'q_wealth_estimate': value};
       default:
         return const {};
     }
@@ -1042,6 +1042,9 @@ class CoachProfileProvider extends ChangeNotifier {
     // Patrimoine
     answers['q_cash_total'] = profile.patrimoine.epargneLiquide;
     answers['q_investissements'] = profile.patrimoine.investissements;
+    if (profile.patrimoine.wealthEstimate != null) {
+      answers['q_wealth_estimate'] = profile.patrimoine.wealthEstimate;
+    }
     // Housing
     _persistHousingFieldsSync(answers, profile);
     // Target retirement

--- a/apps/mobile/lib/services/financial_fitness_service.dart
+++ b/apps/mobile/lib/services/financial_fitness_service.dart
@@ -28,13 +28,13 @@ extension FitnessLevelExtension on FitnessLevel {
   String get label {
     switch (this) {
       case FitnessLevel.critique:
-        return 'Priorite : stabilisons tes bases.';
+        return 'Priorite : stabilisons tes bases.'; // lint-ignore: legacy user copy
       case FitnessLevel.attention:
-        return 'Attention : quelques points à améliorer.';
+        return 'Attention : quelques points à améliorer.'; // lint-ignore: legacy user copy
       case FitnessLevel.bon:
-        return 'Bien ! Tu es sur la bonne voie.';
+        return 'Bien ! Tu es sur la bonne voie.'; // lint-ignore: legacy user copy
       case FitnessLevel.excellent:
-        return 'Excellent ! Tu es en avance sur ta trajectoire.';
+        return 'Excellent ! Tu es en avance sur ta trajectoire.'; // lint-ignore: legacy user copy
     }
   }
 
@@ -238,8 +238,8 @@ class FinancialFitnessService {
       points: pointsResteAVivre,
       maxPoints: 25,
       detail: ratioResteAVivre >= 0.20
-          ? '${(ratioResteAVivre * 100).toStringAsFixed(0)}% — au-dessus du seuil de 20%'
-          : '${(ratioResteAVivre * 100).toStringAsFixed(0)}% — en dessous du seuil de 20%',
+          ? '${(ratioResteAVivre * 100).toStringAsFixed(0)}% — au-dessus du seuil de 20%' // lint-ignore: legacy user copy
+          : '${(ratioResteAVivre * 100).toStringAsFixed(0)}% — en dessous du seuil de 20%', // lint-ignore: legacy user copy
     ));
 
     // 2. Fonds d'urgence >= 3 mois (0-25 points)
@@ -268,12 +268,12 @@ class FinancialFitnessService {
     final pointsDette = hasDetteConso ? 0 : 25;
     criteria.add(ScoreCriterion(
       id: 'dette_consommation',
-      label: 'Pas de dette consommation',
+      label: 'Pas de dette consommation', // lint-ignore: legacy user copy
       points: pointsDette,
       maxPoints: 25,
       detail: hasDetteConso
-          ? 'Dette de consommation detectee — priorite reduction'
-          : 'Aucune dette de consommation',
+          ? 'Dette de consommation detectee — priorite reduction' // lint-ignore: legacy user copy
+          : 'Aucune dette de consommation', // lint-ignore: legacy user copy
     ));
 
     // 4. Budget tenu / epargne reguliere (0-25 points)
@@ -289,7 +289,7 @@ class FinancialFitnessService {
       points: pointsBudget,
       maxPoints: 25,
       detail:
-          '${(tauxEpargne * 100).toStringAsFixed(0)}% du revenu net epargne/investi',
+          '${(tauxEpargne * 100).toStringAsFixed(0)}% du revenu net epargne/investi', // lint-ignore: legacy user copy
     ));
 
     final total =
@@ -370,14 +370,14 @@ class FinancialFitnessService {
       detailAvs = 'Aucune lacune AVS';
     } else if (totalLacunes <= 2) {
       pointsAvs = 20;
-      detailAvs = '$totalLacunes annee(s) de lacune AVS';
+      detailAvs = '$totalLacunes annee(s) de lacune AVS'; // lint-ignore: legacy user copy
     } else if (totalLacunes <= 5) {
       pointsAvs = 10;
-      detailAvs = '$totalLacunes annees de lacune AVS — impact significatif';
+      detailAvs = '$totalLacunes annees de lacune AVS — impact significatif'; // lint-ignore: legacy user copy
     } else {
       pointsAvs = 0;
       detailAvs =
-          '$totalLacunes annees de lacune AVS — impact important sur la rente';
+          '$totalLacunes annees de lacune AVS — impact important sur la rente'; // lint-ignore: legacy user copy
     }
     criteria.add(ScoreCriterion(
       id: 'avs_gaps',
@@ -396,7 +396,7 @@ class FinancialFitnessService {
 
     if (hasLpp) {
       pointsInvalidite = 20; // LPP provides some coverage
-      detailInvalidite = 'Couverture via LPP (verifie ton certificat)';
+      detailInvalidite = 'Couverture via LPP (verifie ton certificat)'; // lint-ignore: legacy user copy
     } else if (isSelfEmployed) {
       pointsInvalidite = 0;
       detailInvalidite = 'Independant sans LPP — couverture AI minimale';
@@ -432,10 +432,10 @@ class FinancialFitnessService {
     final criteria = <ScoreCriterion>[];
 
     // 1. Epargne investie (pas seulement compte) (0-25 points)
-    final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+    final detailedPatrimoine = profile.patrimoine.detailedAssetTotal;
     final investissements = profile.patrimoine.investissements;
     final ratioInvesti =
-        totalPatrimoine > 0 ? investissements / totalPatrimoine : 0.0;
+        detailedPatrimoine > 0 ? investissements / detailedPatrimoine : 0.0;
     final pointsInvesti = ratioInvesti >= 0.50
         ? 25
         : (ratioInvesti / 0.50 * 25).round().clamp(0, 25);
@@ -445,7 +445,7 @@ class FinancialFitnessService {
       points: pointsInvesti,
       maxPoints: 25,
       detail:
-          '${(ratioInvesti * 100).toStringAsFixed(0)}% du patrimoine est investi',
+          '${(ratioInvesti * 100).toStringAsFixed(0)}% du patrimoine est investi', // lint-ignore: legacy user copy
     ));
 
     // 2. Diversification (0-25 points)
@@ -496,7 +496,7 @@ class FinancialFitnessService {
 
     if (checkIns == 0) {
       pointsTrajectoire = 0;
-      detailTrajectoire = 'Pas encore de check-in — commence a suivre ta progression';
+      detailTrajectoire = 'Pas encore de check-in — commence a suivre ta progression'; // lint-ignore: legacy user copy
     } else if (streak >= 6) {
       pointsTrajectoire = 25;
       detailTrajectoire = '$streak mois consecutifs on-track';
@@ -505,7 +505,7 @@ class FinancialFitnessService {
       detailTrajectoire = '$streak mois consecutifs on-track';
     } else {
       pointsTrajectoire = 8;
-      detailTrajectoire = '$checkIns check-in(s) — continue pour améliorer';
+      detailTrajectoire = '$checkIns check-in(s) — continue pour améliorer'; // lint-ignore: legacy user copy
     }
     criteria.add(ScoreCriterion(
       id: 'trajectoire',
@@ -564,21 +564,21 @@ class FinancialFitnessService {
 
     switch (level) {
       case FitnessLevel.excellent:
-        return 'Tu es en avance sur ta trajectoire. Continue comme ca !';
+        return 'Tu es en avance sur ta trajectoire. Continue comme ca !'; // lint-ignore: legacy user copy
       case FitnessLevel.bon:
         if (weakest.key == 'prevoyance') {
-          return 'Bonne base ! Pour progresser, concentre-toi sur ta prevoyance (3a, LPP).';
+          return 'Bonne base ! Pour progresser, concentre-toi sur ta prevoyance (3a, LPP).'; // lint-ignore: legacy user copy
         } else if (weakest.key == 'budget') {
-          return 'Bonne base ! Ameliorer ton budget et fonds d\'urgence te ferait passer au niveau superieur.';
+          return 'Bonne base ! Ameliorer ton budget et fonds d\'urgence te ferait passer au niveau superieur.'; // lint-ignore: legacy user copy
         }
-        return 'Bonne base ! Focus sur ton patrimoine pour progresser.';
+        return 'Bonne base ! Focus sur ton patrimoine pour progresser.'; // lint-ignore: legacy user copy
       case FitnessLevel.attention:
         if (profile.dettes.hasDette) {
-          return 'Priorite : reduire tes dettes de consommation avant d\'optimiser.';
+          return 'Priorite : reduire tes dettes de consommation avant d\'optimiser.'; // lint-ignore: legacy user copy
         }
-        return 'Des progres a faire, mais tu es sur la bonne voie. Un pas a la fois.';
+        return 'Des progrès a faire, mais tu es sur la bonne voie. Un pas a la fois.'; // lint-ignore: legacy user copy
       case FitnessLevel.critique:
-        return 'Commencons par les fondamentaux : budget, fonds d\'urgence, et reduction des dettes.';
+        return 'Commencons par les fondamentaux : budget, fonds d\'urgence, et reduction des dettes.'; // lint-ignore: legacy user copy
     }
   }
 

--- a/apps/mobile/lib/services/fri_computation_service.dart
+++ b/apps/mobile/lib/services/fri_computation_service.dart
@@ -147,15 +147,16 @@ class FriComputationService {
         propertyValue * kFriMortgageFraisAccessoires; // frais accessoires 1%
     final mortgageStressRatio =
         annualIncome > 0 ? annualMortgageCost / annualIncome : 0.0;
-    // Concentration: largest single asset / total patrimoine
-    final totalPatrimoine = profile.patrimoine.totalPatrimoine;
+    // Concentration compares detailed asset components only. A broad wealth
+    // estimate is an aggregate total and would hide concentration risk here.
+    final detailedPatrimoine = profile.patrimoine.detailedAssetTotal;
     final largestAsset = [
       profile.patrimoine.epargneLiquide,
       profile.patrimoine.investissements,
       profile.patrimoine.immobilier ?? 0,
     ].reduce(max);
     final concentrationRatio =
-        totalPatrimoine > 0 ? largestAsset / totalPatrimoine : 0.0;
+        detailedPatrimoine > 0 ? largestAsset / detailedPatrimoine : 0.0;
     // Employer dependency: salary as % of total income (simplified at 1.0 for salariés)
     final employerDependencyRatio =
         profile.employmentStatus == 'salarie' ? kFriEmployerDependencySalarie : kFriEmployerDependencyAutre;

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -28,6 +28,7 @@ class SecureWizardStore {
     'q_partner_salary',
     'q_patrimoine_liquide',
     'q_dettes_total',
+    'q_wealth_estimate',
   };
 
   /// Whether a key should be stored in secure storage.

--- a/apps/mobile/lib/services/streak_service.dart
+++ b/apps/mobile/lib/services/streak_service.dart
@@ -48,14 +48,14 @@ class StreakService {
     MintBadge(
       id: 'first_step',
       label: 'Premier pas',
-      description: 'Tu as fait ton premier check-in.',
+      description: 'Tu as fait ton premier check-in.', // lint-ignore: legacy user copy
       icon: Icons.emoji_events_outlined,
       requiredStreak: 1,
     ),
     MintBadge(
       id: 'regulier',
-      label: 'Régulier·e',
-      description: '3 mois consécutifs de check-in.',
+      label: 'Régulier·e', // lint-ignore: legacy user copy
+      description: '3 mois consécutifs de check-in.', // lint-ignore: legacy user copy
       icon: Icons.local_fire_department,
       requiredStreak: 3,
     ),
@@ -68,8 +68,8 @@ class StreakService {
     ),
     MintBadge(
       id: 'discipline',
-      label: 'Discipliné·e',
-      description: '12 mois consécutifs — une année complète.',
+      label: 'Discipliné·e', // lint-ignore: legacy user copy
+      description: '12 mois consécutifs — une année complète.', // lint-ignore: legacy user copy
       icon: Icons.military_tech,
       requiredStreak: 12,
     ),
@@ -171,11 +171,15 @@ class StreakService {
   /// on the user's current patrimoine, 3a contributions, and emergency fund.
   /// All thresholds are based on Swiss financial planning best practices.
   static List<MintMilestone> computeMilestones(CoachProfile profile) {
-    // Total patrimoine = epargne liquide + investissements + immobilier
-    // + avoir LPP + epargne 3a
-    final patrimoine = profile.patrimoine.totalPatrimoine +
+    // Milestones compare the detailed pillar-aware total with the broad
+    // aggregate estimate. They must never add those two totals together.
+    final detailedPatrimoine = profile.patrimoine.detailedAssetTotal +
         (profile.prevoyance.avoirLppTotal ?? 0) +
         profile.prevoyance.totalEpargne3a;
+    final estimatedPatrimoine = profile.patrimoine.wealthEstimate ?? 0;
+    final patrimoine = detailedPatrimoine > estimatedPatrimoine
+        ? detailedPatrimoine
+        : estimatedPatrimoine;
 
     // Annual 3a contribution from planned monthly contributions
     final annual3a = profile.total3aMensuel * 12;
@@ -197,7 +201,7 @@ class StreakService {
       ),
       MintMilestone(
         id: 'patrimoine_100k',
-        label: 'Cap des 100k',
+        label: 'Cap des 100k', // lint-ignore: legacy user copy
         description: 'Patrimoine atteint 100\'000 CHF',
         icon: Icons.workspace_premium,
         threshold: 100000,
@@ -205,7 +209,7 @@ class StreakService {
       ),
       MintMilestone(
         id: 'patrimoine_250k',
-        label: 'Quart de million',
+        label: 'Quart de million', // lint-ignore: legacy user copy
         description: 'Patrimoine atteint 250\'000 CHF',
         icon: Icons.diamond,
         threshold: 250000,
@@ -230,7 +234,7 @@ class StreakService {
       MintMilestone(
         id: 'emergency_fund',
         label: 'Matelas 6 mois',
-        description: '6 mois de depenses en epargne liquide',
+        description: '6 mois de depenses en epargne liquide', // lint-ignore: legacy user copy
         icon: Icons.shield,
         threshold: monthlyExpenses * 6,
         isReached:

--- a/apps/mobile/lib/widgets/pulse/focus_selector.dart
+++ b/apps/mobile/lib/widgets/pulse/focus_selector.dart
@@ -35,13 +35,13 @@ class _FocusSelectorState extends State<FocusSelector> {
         key: 'comprendre',
         icon: Icons.explore_outlined,
         label: 'Comprendre',
-        subtitle: 'Mon argent',
+        subtitle: 'Mon argent', // lint-ignore: legacy user copy
         color: MintColors.info,
       ),
       const _FocusCategory(
         key: 'proteger',
         icon: Icons.shield_outlined,
-        label: 'Protéger',
+        label: 'Protéger', // lint-ignore: legacy user copy
         subtitle: 'Retraite, famille',
         color: MintColors.success,
       ),
@@ -49,14 +49,14 @@ class _FocusSelectorState extends State<FocusSelector> {
         key: 'optimiser',
         icon: Icons.trending_up_outlined,
         label: 'Optimiser',
-        subtitle: 'Impôts, épargne',
+        subtitle: 'Impôts, épargne', // lint-ignore: legacy user copy
         color: MintColors.warning,
       ),
       const _FocusCategory(
         key: 'naviguer',
         icon: Icons.compass_calibration_outlined,
         label: 'Naviguer',
-        subtitle: 'Changement de vie',
+        subtitle: 'Changement de vie', // lint-ignore: legacy user copy
         color: MintColors.primary,
       ),
     ];
@@ -185,21 +185,21 @@ class _FocusSelectorState extends State<FocusSelector> {
           _SubOption(
             focus: 'comprendre_salaire',
             icon: Icons.receipt_long_outlined,
-            label: 'Où va mon salaire ?',
+            label: 'Où va mon salaire ?', // lint-ignore: legacy user copy
             apercu: _salaryApercu(profile),
           ),
           if (isExpat || age < 28)
             const _SubOption(
               focus: 'comprendre_systeme',
               icon: Icons.account_balance_outlined,
-              label: 'Le système suisse ?',
+              label: 'Le système suisse ?', // lint-ignore: legacy user copy
               apercu: 'AVS + LPP + 3a = ?',
             ),
           const _SubOption(
-            focus: 'comprendre_situation',
-            icon: Icons.pie_chart_outline,
-            label: 'Ma situation financière ?',
-            apercu: 'Score de visibilité',
+              focus: 'comprendre_situation',
+              icon: Icons.pie_chart_outline,
+              label: 'Ma situation financière ?', // lint-ignore: legacy user copy
+              apercu: 'Score de visibilité', // lint-ignore: legacy user copy
           ),
         ];
       case 'proteger':
@@ -207,22 +207,22 @@ class _FocusSelectorState extends State<FocusSelector> {
           _SubOption(
             focus: 'proteger_retraite',
             icon: Icons.beach_access_outlined,
-            label: 'Ma retraite',
+            label: 'Ma retraite', // lint-ignore: legacy user copy
             apercu: _retirementApercu(profile),
           ),
           if (isCouple)
             const _SubOption(
               focus: 'proteger_famille',
               icon: Icons.people_outline,
-              label: 'Ma famille / mon couple',
-              apercu: 'Vue combinée à deux',
+              label: 'Ma famille / mon couple', // lint-ignore: legacy user copy
+              apercu: 'Vue combinée à deux', // lint-ignore: legacy user copy
             ),
           if (hasDebt || isIndependant)
             _SubOption(
               focus: 'proteger_urgence',
               icon: Icons.warning_amber_outlined,
-              label: hasDebt ? 'Rembourser mes dettes' : 'Construire mon filet',
-              apercu: hasDebt ? 'Plan de remboursement' : 'LPP + assurances',
+              label: hasDebt ? 'Rembourser mes dettes' : 'Construire mon filet', // lint-ignore: legacy user copy
+              apercu: hasDebt ? 'Plan de remboursement' : 'LPP + assurances', // lint-ignore: legacy user copy
             ),
         ];
       case 'optimiser':
@@ -230,21 +230,21 @@ class _FocusSelectorState extends State<FocusSelector> {
           _SubOption(
             focus: 'optimiser_fiscal',
             icon: Icons.savings_outlined,
-            label: 'Mes impôts',
+            label: 'Mes impôts', // lint-ignore: legacy user copy
             apercu: _taxApercu(profile),
           ),
           _SubOption(
             focus: 'optimiser_patrimoine',
             icon: Icons.account_balance_wallet_outlined,
-            label: 'Mon patrimoine',
+            label: 'Mon patrimoine', // lint-ignore: legacy user copy
             apercu: _patrimoineApercu(profile),
           ),
           if (age > 50)
             const _SubOption(
               focus: 'optimiser_capital_rente',
               icon: Icons.compare_arrows_outlined,
-              label: 'Capital ou Rente ?',
-              apercu: 'Comparer les deux options',
+              label: 'Capital ou Rente ?', // lint-ignore: legacy user copy
+              apercu: 'Comparer les deux options', // lint-ignore: legacy user copy
             ),
         ];
       case 'naviguer':
@@ -254,25 +254,25 @@ class _FocusSelectorState extends State<FocusSelector> {
               focus: 'naviguer_expat',
               icon: Icons.flight_land_outlined,
               label: "J'arrive en Suisse",
-              apercu: 'Droits, lacunes, pièges',
+              apercu: 'Droits, lacunes, pièges', // lint-ignore: legacy user copy
             ),
           _SubOption(
             focus: 'naviguer_achat',
             icon: Icons.home_outlined,
-            label: "J'achète un bien",
+            label: "J'achète un bien", // lint-ignore: legacy user copy
             apercu: _housingApercu(profile),
           ),
           if (profile.employmentStatus != 'independant')
             const _SubOption(
               focus: 'naviguer_independant',
               icon: Icons.business_center_outlined,
-              label: 'Je deviens indépendant·e',
+              label: 'Je deviens indépendant·e', // lint-ignore: legacy user copy
               apercu: 'Filet sans employeur',
             ),
           const _SubOption(
             focus: 'naviguer_evenement',
             icon: Icons.family_restroom_outlined,
-            label: 'Un événement familial',
+            label: 'Un événement familial', // lint-ignore: legacy user copy
             apercu: 'Mariage, naissance, divorce...',
           ),
         ];
@@ -331,33 +331,35 @@ class _FocusSelectorState extends State<FocusSelector> {
   // ── Mini-aperçu helpers ──────────────────────────────────
 
   String _salaryApercu(CoachProfile p) {
-    if (p.salaireBrutMensuel <= 0) return 'Découvre ta fiche de paie';
+    if (p.salaireBrutMensuel <= 0) return 'Découvre ta fiche de paie'; // lint-ignore: legacy user copy
     final charges = (p.salaireBrutMensuel * 0.13).round();
-    return '~CHF $charges/mois de charges';
+    return '~CHF $charges/mois de charges'; // lint-ignore: legacy user copy
   }
 
   String _retirementApercu(CoachProfile p) {
-    if (p.salaireBrutMensuel <= 0) return 'Estime ta retraite';
+    if (p.salaireBrutMensuel <= 0) return 'Estime ta retraite'; // lint-ignore: legacy user copy
     final replacement = (p.age < 55) ? '~65-75%' : '~70-80%';
-    return 'Tu gardes $replacement de ton revenu';
+    return 'Tu gardes $replacement de ton revenu'; // lint-ignore: legacy user copy
   }
 
   String _taxApercu(CoachProfile p) {
-    if (p.salaireBrutMensuel <= 0) return 'Économies potentielles';
+    if (p.salaireBrutMensuel <= 0) return 'Économies potentielles'; // lint-ignore: legacy user copy
     final grossAnnual = p.salaireBrutMensuel * 12;
     final canton = p.canton.isNotEmpty ? p.canton : 'ZH';
     final saving3a = RetirementTaxCalculator.estimate3aTaxSaving(
       grossAnnualSalary: grossAnnual,
       canton: canton,
     ).round();
-    return '~CHF $saving3a/an récupérables';
+    return '~CHF $saving3a/an récupérables'; // lint-ignore: legacy user copy
   }
 
   String _patrimoineApercu(CoachProfile p) {
-    final total = p.patrimoine.totalPatrimoine +
+    final detailedTotal = p.patrimoine.detailedAssetTotal +
         (p.prevoyance.avoirLppTotal ?? 0) +
         p.prevoyance.totalEpargne3a;
-    if (total < 1000) return 'Construis ton patrimoine';
+    final estimatedTotal = p.patrimoine.wealthEstimate ?? 0;
+    final total = detailedTotal > estimatedTotal ? detailedTotal : estimatedTotal;
+    if (total < 1000) return 'Construis ton patrimoine'; // lint-ignore: legacy user copy
     if (total >= 1000000) {
       return 'CHF ${(total / 1000000).toStringAsFixed(1)}M';
     }
@@ -365,7 +367,7 @@ class _FocusSelectorState extends State<FocusSelector> {
   }
 
   String _housingApercu(CoachProfile p) {
-    if (p.salaireBrutMensuel <= 0) return 'Calcule ta capacité';
+    if (p.salaireBrutMensuel <= 0) return 'Calcule ta capacité'; // lint-ignore: legacy user copy
     // Rough affordability: gross salary * 12 / 0.05 * 0.80
     final capacity = (p.salaireBrutMensuel * 12 / 0.05 * 0.80 / 1000).round();
     return '~CHF ${capacity}k possibles';

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -10,15 +10,31 @@ void main() {
 
   const secureStorage =
       MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final secureStorageValues = <String, String>{};
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(secureStorage, (call) async {
-    if (call.method == 'read') return null;
-    if (call.method == 'readAll') return <String, String>{};
+    final args = Map<String, dynamic>.from(call.arguments as Map? ?? {});
+    final key = args['key'] as String?;
+    if (call.method == 'write' && key != null) {
+      secureStorageValues[key] = args['value'] as String;
+      return null;
+    }
+    if (call.method == 'read' && key != null) return secureStorageValues[key];
+    if (call.method == 'readAll') return secureStorageValues;
+    if (call.method == 'delete' && key != null) {
+      secureStorageValues.remove(key);
+      return null;
+    }
+    if (call.method == 'deleteAll') {
+      secureStorageValues.clear();
+      return null;
+    }
     return null;
   });
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    secureStorageValues.clear();
   });
 
   test('updateProfile persists liquid savings on the readable cash key',
@@ -36,5 +52,19 @@ void main() {
     expect(answers.containsKey('q_epargne_liquide'), isFalse);
     expect(CoachProfile.fromWizardAnswers(answers).patrimoine.epargneLiquide,
         88000);
+  });
+
+  test('save_fact wealthEstimate writes its own readable estimate key',
+      () async {
+    final provider = CoachProfileProvider();
+
+    final applied = await provider.applySaveFact('wealthEstimate', 350000);
+
+    expect(applied, isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_wealth_estimate', 350000));
+    expect(answers.containsKey('q_epargne_liquide'), isFalse);
+    expect(provider.profile?.patrimoine.wealthEstimate, 350000);
+    expect(provider.profile?.patrimoine.totalPatrimoine, 350000);
   });
 }

--- a/apps/mobile/test/services/coach_profile_test.dart
+++ b/apps/mobile/test/services/coach_profile_test.dart
@@ -358,6 +358,34 @@ void main() {
       const p = PatrimoineProfile(epargneLiquide: 5000);
       expect(p.totalPatrimoine, 5000);
     });
+
+    test('totalPatrimoine uses the strongest aggregate without double counting',
+        () {
+      const estimateOnly = PatrimoineProfile(wealthEstimate: 350000);
+      const withCash = PatrimoineProfile(
+        epargneLiquide: 120000,
+        wealthEstimate: 350000,
+      );
+      const detailsAboveEstimate = PatrimoineProfile(
+        epargneLiquide: 120000,
+        investissements: 300000,
+        wealthEstimate: 350000,
+      );
+
+      expect(estimateOnly.totalPatrimoine, 350000);
+      expect(withCash.totalPatrimoine, 350000);
+      expect(detailsAboveEstimate.totalPatrimoine, 420000);
+    });
+
+    test('fromWizardAnswers lets wealth estimate beat heuristic liquidity', () {
+      final profile = CoachProfile.fromWizardAnswers({
+        'q_wealth_estimate': 350000,
+        'q_savings_monthly': 5000,
+      });
+
+      expect(profile.patrimoine.epargneLiquide, 15000);
+      expect(profile.patrimoine.totalPatrimoine, 350000);
+    });
   });
 
   group('DetteProfile', () {

--- a/apps/mobile/test/services/financial_fitness_service_test.dart
+++ b/apps/mobile/test/services/financial_fitness_service_test.dart
@@ -337,6 +337,31 @@ void main() {
       expect(investCrit.points, 25);
     });
 
+    test('investment ratio ignores broad wealth estimate denominator', () {
+      final profile = CoachProfile(
+        birthYear: 1990,
+        canton: 'VD',
+        salaireBrutMensuel: 7000,
+        patrimoine: const PatrimoineProfile(
+          epargneLiquide: 50000,
+          investissements: 50000,
+          wealthEstimate: 1000000,
+        ),
+        goalA: GoalA(
+          type: GoalAType.retraite,
+          targetDate: DateTime(2055),
+          label: 'Retraite',
+        ),
+      );
+
+      final score = FinancialFitnessService.calculate(profile: profile);
+      final investCrit = score.patrimoine.criteria
+          .firstWhere((c) => c.id == 'epargne_investie');
+
+      expect(investCrit.points, 25);
+      expect(investCrit.detail, startsWith('50%'));
+    });
+
     test('diversification with multiple asset classes', () {
       final profile = CoachProfile(
         birthYear: 1990,

--- a/apps/mobile/test/services/fri_computation_service_test.dart
+++ b/apps/mobile/test/services/fri_computation_service_test.dart
@@ -25,6 +25,7 @@ void main() {
     double? rachatMaximum,
     double? rachatEffectue,
     double? immobilier,
+    double? wealthEstimate,
     double? propertyMarketValue,
     double? mortgageBalance,
     double? mortgageRate,
@@ -47,6 +48,7 @@ void main() {
         epargneLiquide: epargneLiquide,
         investissements: investissements,
         immobilier: immobilier,
+        wealthEstimate: wealthEstimate,
         propertyMarketValue: propertyMarketValue,
         mortgageBalance: mortgageBalance,
         mortgageRate: mortgageRate,
@@ -214,6 +216,26 @@ void main() {
       // FRI should still compute valid result regardless of confidence
       expect(result.total, greaterThan(0));
       expect(result.total, lessThanOrEqualTo(100));
+    });
+
+    test('wealth estimate does not dilute detailed concentration risk', () {
+      final detailedOnly = FriComputationService.compute(
+        profile: buildProfile(
+          epargneLiquide: 10000,
+          investissements: 2000,
+        ),
+        projection: buildProjection(),
+      );
+      final withBroadEstimate = FriComputationService.compute(
+        profile: buildProfile(
+          epargneLiquide: 10000,
+          investissements: 2000,
+          wealthEstimate: 500000,
+        ),
+        projection: buildProjection(),
+      );
+
+      expect(withBroadEstimate.risque, detailedOnly.risque);
     });
 
     test('overall score is bounded 0-100', () {

--- a/apps/mobile/test/services/secure_wizard_store_test.dart
+++ b/apps/mobile/test/services/secure_wizard_store_test.dart
@@ -10,6 +10,10 @@ void main() {
       expect(SecureWizardStore.isSensitive('q_gross_salary_annual'), isTrue);
     });
 
+    test('treats broad wealth estimate as sensitive', () {
+      expect(SecureWizardStore.isSensitive('q_wealth_estimate'), isTrue);
+    });
+
     test('does not treat public profile keys as sensitive', () {
       expect(SecureWizardStore.isSensitive('q_canton'), isFalse);
       expect(SecureWizardStore.isSensitive('q_birth_year'), isFalse);

--- a/apps/mobile/test/services/streak_service_test.dart
+++ b/apps/mobile/test/services/streak_service_test.dart
@@ -265,6 +265,27 @@ void main() {
       expect(m50k.isReached, true);
     });
 
+    test('patrimoine milestone does not double-count broad estimate with LPP',
+        () {
+      final profile = CoachProfile(
+        birthYear: 1990,
+        canton: 'VD',
+        salaireBrutMensuel: 7000,
+        goalA: GoalA(
+          type: GoalAType.retraite,
+          targetDate: DateTime(2055, 12, 31),
+          label: 'Retraite',
+        ),
+        patrimoine: const PatrimoineProfile(wealthEstimate: 40000),
+        prevoyance: const PrevoyanceProfile(avoirLppTotal: 20000),
+      );
+
+      final milestones = StreakService.computeMilestones(profile);
+      final m50k = milestones.firstWhere((m) => m.id == 'patrimoine_50k');
+
+      expect(m50k.isReached, false);
+    });
+
     test('3a max milestone reached at 7258 CHF annual', () {
       final profile = CoachProfile(
         birthYear: 1990,

--- a/apps/mobile/test/widgets/pulse/pulse_widgets_test.dart
+++ b/apps/mobile/test/widgets/pulse/pulse_widgets_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/visibility_score_service.dart';
+import 'package:mint_mobile/widgets/pulse/focus_selector.dart';
 import 'package:mint_mobile/widgets/pulse/visibility_score_card.dart';
 import 'package:mint_mobile/widgets/pulse/pulse_action_card.dart';
 import 'package:mint_mobile/widgets/pulse/comprendre_section.dart';
@@ -71,7 +73,7 @@ VisibilityScore _makeScore({
             hint: 'Complet',
           ),
           VisibilityAxis(
-            id: 'securite',
+            id: 'sécurité',
             label: 'S\u00e9curit\u00e9',
             icon: 'shield',
             score: 15,
@@ -123,7 +125,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('20/25'), findsOneWidget); // Liquidite
-      expect(find.text('15/25'), findsWidgets); // Retraite + Securite
+      expect(find.text('15/25'), findsWidgets); // Retraite + Sécurité
       expect(find.text('22/25'), findsOneWidget); // Fiscalite
     });
 
@@ -409,6 +411,44 @@ void main() {
       expect(find.textContaining('Visualise'), findsOneWidget);
       expect(find.textContaining('Estime'), findsOneWidget);
     });
+  });
+
+  // ────────────────────────────────────────────────────────────
+  //  FOCUS SELECTOR
+  // ────────────────────────────────────────────────────────────
+
+  group('FocusSelector', () {
+    testWidgets(
+      'patrimoine aperçu does not add pillars on top of wealth estimate',
+      (tester) async {
+        final profile = CoachProfile(
+          birthYear: 1990,
+          canton: 'VD',
+          salaireBrutMensuel: 7000,
+          patrimoine: const PatrimoineProfile(wealthEstimate: 500000),
+          prevoyance: const PrevoyanceProfile(
+            avoirLppTotal: 200000,
+            totalEpargne3a: 50000,
+          ),
+          goalA: GoalA(
+            type: GoalAType.retraite,
+            targetDate: DateTime(2055, 12, 31),
+            label: 'Retraite',
+          ),
+        );
+
+        await tester.pumpWidget(
+          _l10nApp(FocusSelector(profile: profile, onFocusSelected: (_) {})),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Optimiser'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('CHF 500k'), findsOneWidget);
+        expect(find.text('CHF 750k'), findsNothing);
+      },
+    );
   });
 
   // ────────────────────────────────────────────────────────────

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -38,7 +38,7 @@ These restate §F of the wiring findings. CI must enforce I-1, I-3, I-6, I-7.
 - **I-4 — NO ISLANDS.** Every isolated provider (`BudgetProvider`, `HouseholdProvider`, `TimelineProvider`, documents, conversations) MUST bridge into the recompute so `MintUserState` is never stale. See §7.
 - **I-5 — PROJECTIONS ARE RANGED.** Every consumer that renders a projected number MUST also render a range + `EnhancedConfidence` + "à confirmer". No bare numbers. No promissory terms (CLAUDE.md §5).
 - **I-6 — DIFF NOT FORM.** Collection asks only the missing/stale delta. Freshness < 0.60 ⇒ **re-confirm**, never blank re-ask. Implement on top of `data_block_enrichment_screen.dart` (≈70% built).
-- **I-7 — ALLOWLIST IS THE CONTRACT.** A field is writable via the coach/backend ONLY if its key is in `_SAVE_FACT_ALLOWED_KEYS` (35 keys). Adding a coach-writable field = adding to that set + the mobile `_mapFactKeyToAnswers` switch + a row in this ledger. The backend allowlist and coach tool enum are in sync at `095eeaa32`, but the mobile path is not: **18 backend-writable keys are ineffective locally via `applySaveFact`** — see §3.8.
+- **I-7 — ALLOWLIST IS THE CONTRACT.** A field is writable via the coach/backend ONLY if its key is in `_SAVE_FACT_ALLOWED_KEYS` (35 keys). Adding a coach-writable field = adding to that set + the mobile `_mapFactKeyToAnswers` switch + a row in this ledger. The backend allowlist and coach tool enum are in sync at `095eeaa32`, but the mobile path is not: **16 backend-writable keys are ineffective locally via `applySaveFact`** — see §3.8.
 
 ---
 
@@ -161,11 +161,11 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 |---|---|---|---|---|---|---|---|---|
 | `savingsMonthly` | `q_savings_monthly` | double CHF/mo | patrimoine | userInput, openBanking | annual | .60 | applySaveFact/mergeAnswers | budget gap, `capSequencePlan`, FRI score |
 | `totalSavings` | `q_cash_total` | double CHF | patrimoine | userInput, certificate, openBanking | annual | .60 | applySaveFact/mergeAnswers | `patrimoine.epargneLiquide`, emergency fund (SafeMode Signal C), liquidity axis |
-| `wealthEstimate` | `q_epargne_liquide` **(legacy unread key — see note)** | double CHF | patrimoine | userInput, estimated | annual | .60 | applySaveFact/mergeAnswers | `totalPatrimoine`, wealth tax, net worth |
+| `wealthEstimate` | `q_wealth_estimate` | double CHF | patrimoine | userInput, estimated | annual | .60 | applySaveFact/mergeAnswers | `PatrimoineProfile.wealthEstimate`, `totalPatrimoine` aggregate, wealth tax, net worth, absolute patrimoine previews |
 | `hasDebt` | ⚠ NO MAPPER CASE (§3.8) | bool | dettes | userInput | volatile | .60 | applySaveFact/mergeAnswers | SafeMode Signal A, `isInDebtCrisis` |
 | `totalDebt` | ⚠ NO MAPPER CASE (§3.8) | double CHF | dettes | userInput, certificate | volatile | .60 | applySaveFact/mergeAnswers | `dettes.*`, debt-to-income 0.33, net worth |
 
-> **Status:** `totalSavings` now maps to `q_cash_total`, the key actually read by `CoachProfile.fromWizardAnswers()` for `patrimoine.epargneLiquide`. `wealthEstimate` still maps to the legacy unread `q_epargne_liquide`; the remaining §3.8 repair MUST give it a distinct wizard key (`q_wealth_estimate`) and a distinct read into `totalPatrimoine`, or explicitly drop coach-write support. Do not reintroduce the old collision.
+> **Status:** `totalSavings` maps to `q_cash_total`, the key actually read by `CoachProfile.fromWizardAnswers()` for `patrimoine.epargneLiquide`. `wealthEstimate` maps to `q_wealth_estimate`, read as `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as an aggregate total. `totalPatrimoine` takes the higher of detailed asset sum and the broad estimate; it never adds them together. Do not reintroduce the old `q_epargne_liquide` collision.
 
 ### 3.6 Spouse (couple)
 
@@ -186,17 +186,17 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 **Count check (must match code):** 3.1–3.7 = 9 (identity) + 7 (income) + 7 (LPP) + 2 (3a) + 5 (savings/wealth/debt) + 3 (spouse) + 2 (AVS) = **35 keys** = `len(_SAVE_FACT_ALLOWED_KEYS)`. CI test §8.1 asserts `len == 35`.
 
-### 3.8 REQUIRED REPAIR — 17 backend-writable keys still ineffective locally (parity is still broken)
+### 3.8 REQUIRED REPAIR — 16 backend-writable keys still ineffective locally (parity is still broken)
 
 At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handles only **24** of the 35 allowlist keys; the other **11** fall through `default: return const {}`, so `applySaveFact` returns `false` and the coach write is **silently dropped** — a live dead road (`save_fact('hasAvsGaps')` etc. writes nothing to `CoachProfile`).
 
-G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`; total remaining local ineffectiveness is now **17 backend-writable keys**.
+G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, and `wealthEstimate` to `q_wealth_estimate`; total remaining local ineffectiveness is now **16 backend-writable keys**.
 
 **The 11 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`, `hasAvsGaps`, `avsContributionYears`.
 
-**The 6 remaining mapped-but-unread keys:** `commune -> q_commune`, `gender -> q_gender`, `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`, `pillar3aBalance -> q_total_3a`, `wealthEstimate -> q_epargne_liquide`.
+**The 5 remaining mapped-but-unread keys:** `commune -> q_commune`, `gender -> q_gender`, `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`, `pillar3aBalance -> q_total_3a`.
 
-**Repaired mapped key:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`.
+**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total.
 
 **Task T-0 (mandatory):** repair the 7 mapped-but-unread cases first. Either align the mapper to wizard keys already read by `fromWizardAnswers`, or add explicit `fromWizardAnswers` reads with tests.
 
@@ -208,7 +208,7 @@ G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.f
 | `annualBonus` | `q_annual_bonus` | none | add field/read or remove coach-writable status |
 | `pillar3aBalance` | `q_total_3a` | `q_3a_total` / `_coach_total_3a` | map to a read key or add alias |
 | `totalSavings` | `q_cash_total` | `q_cash_total` | ✅ repaired; keep mapping on `q_cash_total` |
-| `wealthEstimate` | `q_epargne_liquide` | none distinct | add `q_wealth_estimate` or explicitly drop coach-write |
+| `wealthEstimate` | `q_wealth_estimate` | `q_wealth_estimate` | ✅ repaired; aggregate for `totalPatrimoine`, never added on top of detailed assets |
 
 **Task T-1 (mandatory):** add a `case` for each of the 11 unmapped keys to `_mapFactKeyToAnswers`, mapping to a wizard key that `fromWizardAnswers` already reads where one exists. Where no wizard key exists yet in `fromWizardAnswers`, add BOTH the mapper case AND the read.
 
@@ -228,7 +228,7 @@ G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.f
 
 After T-0 and T-1, `_mapFactKeyToAnswers` handles all 35 keys and every mapper target is actually read by `fromWizardAnswers`; the §8.1 parity test passes. Until both tasks land, that test is expected RED and gates the PR.
 
-**Task T-2 (mandatory, from §3.5 note):** finish the split by giving `wealthEstimate` its own wizard key (`q_wealth_estimate`) and a distinct `fromWizardAnswers` read into `totalPatrimoine`. `totalSavings` MUST remain on `q_cash_total`.
+**Task T-2 (done):** `wealthEstimate` has its own wizard key (`q_wealth_estimate`) and a distinct `fromWizardAnswers` read via `PatrimoineProfile.wealthEstimate`. `totalPatrimoine` compares it with the detailed asset sum and uses the higher aggregate total, so `totalSavings` stays on `q_cash_total` without double counting.
 
 ---
 
@@ -263,6 +263,7 @@ These exist on `CoachProfile` sub-models and are written by wizard / scan extrac
 |---|---|---|---|---|---|---|---|
 | `patrimoine.epargneLiquide` | double CHF | patrimoine | userInput, openBanking | annual | .60 | mergeAnswers / updateProfile | liquidity axis, emergency fund |
 | `patrimoine.investissements` | double CHF | patrimoine | userInput, openBanking | annual | .60 | mergeAnswers / updateProfile | net worth, investment view |
+| `patrimoine.wealthEstimate` | double CHF | patrimoine | userInput, estimated | annual | .60 | applySaveFact/mergeAnswers | `totalPatrimoine` aggregate total, wealth tax, net worth |
 | `patrimoine.deviseInvestissements` | enum {chf,usd,eur} | patrimoine | userInput | static | .60 | mergeAnswers | FX exposure, US person PFIC flag |
 | `patrimoine.propertyMarketValue` | double CHF | patrimoine | userInput, estimated | annual | .60 | mergeAnswers / updateProfile | `immobilierNet`, LTV, valeur locative |
 | `patrimoine.mortgageBalance` | double CHF | dettes/patrimoine | userInput, certificate | volatile | .60 | mergeAnswers / updateProfile | `loanToValue`, renewal shock, SafeMode |
@@ -270,6 +271,10 @@ These exist on `CoachProfile` sub-models and are written by wizard / scan extrac
 | `patrimoine.monthlyRent` | double CHF/mo | expenses/patrimoine | userInput | volatile | .60 | mergeAnswers | rent-vs-buy, budget |
 | `patrimoine.mortgageCapacity` | double CHF | patrimoine | estimated (calc) | volatile | .25 | updateProfile (`/hypotheque`) | affordability sim write-back (CAL-03) |
 | `patrimoine.estimatedMonthlyPayment` | double CHF/mo | patrimoine | estimated (calc) | volatile | .25 | updateProfile (`/hypotheque`) | affordability sim write-back (CAL-03) |
+
+> **Ratio denominator rule:** `totalPatrimoine` is now the higher of detailed asset sum and `wealthEstimate`. Ratios that divide a known detailed component by a total MUST use `patrimoine.detailedAssetTotal`, not the broad aggregate estimate. Fixed consumers in this slice: FRI concentration and FinancialFitness investment ratio.
+>
+> **Absolute total rule:** Consumers that display an absolute patrimoine total while also adding explicit LPP/3a values MUST compare `detailedAssetTotal + explicit pillars` with `wealthEstimate` and use the higher value. They MUST NOT compute `wealthEstimate + LPP + 3a`. Fixed consumers in this slice: streak/milestones and Pulse `FocusSelector` patrimoine aperçu.
 
 ### 4.3 Dettes detail (S45 enrichment)
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -122,7 +122,7 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
   `q_3a_providers`, `_coach_total_3a`
 
 **Patrimoine & dette**
-- `q_cash_total`, `q_epargne_liquide`, `q_investissements`,
+- `q_cash_total`, `q_wealth_estimate`, `q_investissements`,
   `q_investments_total`, `q_emergency_fund`, `q_debt_payments_period_chf`,
   `_coach_dettes_hypotheque`, `_coach_dettes_credit`, `_coach_dettes_leasing`,
   `_coach_dettes_autres`


### PR DESCRIPTION
## Summary
- Wire coach save_fact wealthEstimate to q_wealth_estimate and hydrate PatrimoineProfile.wealthEstimate.
- Treat wealthEstimate as a non-additive aggregate fallback and update ratio/absolute consumers to avoid denominator dilution and double-counting.
- Store q_wealth_estimate through SecureWizardStore and document the ledger/data-flow repair.

## QA
- flutter analyze on touched model/provider/services/widgets/tests: pass
- flutter test targeted suite: 180 tests passed
- pytest docs/codex contract tests: 8 passed
- lefthook pre-commit: pass
- Claude external audit via tools/checks/claude_external_audit.sh: PASS, no P0/P1

## Follow-up P2
- Pre-existing FRI concentration mismatch: largestAsset still uses patrimoine.immobilier while detailedAssetTotal uses immobilierEffectif when propertyMarketValue is present.