### PR TITLE
fix(fri): use effective property value for concentration

### DIFF
--- a/apps/mobile/lib/services/fri_computation_service.dart
+++ b/apps/mobile/lib/services/fri_computation_service.dart
@@ -100,10 +100,11 @@ class FriComputationService {
     // ── F: Fiscal efficiency ─────────────────────────
     // 3a: sum of planned 3a contributions (annualized)
     final actual3a = profile.total3aMensuel * 12;
-    final isIndependantNoLpp =
-        profile.employmentStatus == 'independant' &&
-            (profile.prevoyance.avoirLppTotal ?? 0) <= 0;
-    final max3a = isIndependantNoLpp ? reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp) : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
+    final isIndependantNoLpp = profile.employmentStatus == 'independant' &&
+        (profile.prevoyance.avoirLppTotal ?? 0) <= 0;
+    final max3a = isIndependantNoLpp
+        ? reg('pillar3a.max_without_lpp', pilier3aPlafondSansLpp)
+        : reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
     // Rachat: use rachatMaximum (total buyback gap) and rachatEffectue
     final potentielRachat = profile.prevoyance.rachatMaximum ?? 0.0;
     final rachatEffectue = profile.prevoyance.rachatEffectue ?? 0.0;
@@ -115,13 +116,11 @@ class FriComputationService {
       isMarried: isMarried,
       children: profile.nombreEnfants,
     );
-    final isPropertyOwner =
-        (profile.patrimoine.immobilier ?? 0) > 0 ||
-            (profile.patrimoine.propertyMarketValue ?? 0) > 0;
+    final isPropertyOwner = (profile.patrimoine.immobilier ?? 0) > 0 ||
+        (profile.patrimoine.propertyMarketValue ?? 0) > 0;
     // Amort indirect: approximated from 3a contributions if property owner
     // (real data would come from mortgage advisor documents)
-    final amortIndirect =
-        isPropertyOwner && actual3a > 0 ? actual3a : 0.0;
+    final amortIndirect = isPropertyOwner && actual3a > 0 ? actual3a : 0.0;
 
     // ── R: Retirement readiness ──────────────────────
     final replacementRatio = projection.tauxRemplacementBase;
@@ -137,11 +136,10 @@ class FriComputationService {
     // Real value would come from LPP certificate parsing.
     const deathProtectionGapRatio = kFriDefaultDeathProtectionGapRatio;
     // Mortgage stress = mortgage payments / gross income
-    final mortgageBalance =
-        profile.patrimoine.mortgageBalance ?? 0;
-    final mortgageRate = profile.patrimoine.mortgageRate ?? kFriMortgageTauxTheorique;
-    final propertyValue =
-        profile.patrimoine.propertyMarketValue ?? 0;
+    final mortgageBalance = profile.patrimoine.mortgageBalance ?? 0;
+    final mortgageRate =
+        profile.patrimoine.mortgageRate ?? kFriMortgageTauxTheorique;
+    final propertyValue = profile.patrimoine.propertyMarketValue ?? 0;
     final annualMortgageCost = mortgageBalance * mortgageRate +
         mortgageBalance * kFriMortgageAmortissementRate + // amortissement 1%
         propertyValue * kFriMortgageFraisAccessoires; // frais accessoires 1%
@@ -153,13 +151,14 @@ class FriComputationService {
     final largestAsset = [
       profile.patrimoine.epargneLiquide,
       profile.patrimoine.investissements,
-      profile.patrimoine.immobilier ?? 0,
+      profile.patrimoine.immobilierEffectif,
     ].reduce(max);
     final concentrationRatio =
         detailedPatrimoine > 0 ? largestAsset / detailedPatrimoine : 0.0;
     // Employer dependency: salary as % of total income (simplified at 1.0 for salariés)
-    final employerDependencyRatio =
-        profile.employmentStatus == 'salarie' ? kFriEmployerDependencySalarie : kFriEmployerDependencyAutre;
+    final employerDependencyRatio = profile.employmentStatus == 'salarie'
+        ? kFriEmployerDependencySalarie
+        : kFriEmployerDependencyAutre;
 
     return FriInput(
       liquidAssets: liquidAssets,
@@ -238,5 +237,4 @@ class FriComputationService {
     // 6. Foreign national arrived young (< 20) → treated as swiss_native
     return 'swiss_native';
   }
-
 }

--- a/apps/mobile/test/services/fri_computation_service_test.dart
+++ b/apps/mobile/test/services/fri_computation_service_test.dart
@@ -163,7 +163,8 @@ void main() {
       expect(indep.total, greaterThan(0));
     });
 
-    test('mortgage stress ratio affects S axis — FINMA 5% theoretical rate', () {
+    test('mortgage stress ratio affects S axis — FINMA 5% theoretical rate',
+        () {
       final noMortgage = FriComputationService.compute(
         profile: buildProfile(),
         projection: buildProjection(),
@@ -178,8 +179,7 @@ void main() {
         projection: buildProjection(),
       );
 
-      expect(noMortgage.risque,
-          greaterThanOrEqualTo(highMortgage.risque),
+      expect(noMortgage.risque, greaterThanOrEqualTo(highMortgage.risque),
           reason: 'Heavy mortgage worsens structural risk');
     });
 
@@ -236,6 +236,30 @@ void main() {
       );
 
       expect(withBroadEstimate.risque, detailedOnly.risque);
+    });
+
+    test(
+        'property market value drives concentration risk without legacy immobilier',
+        () {
+      final marketValueOnly = FriComputationService.compute(
+        profile: buildProfile(
+          epargneLiquide: 50000,
+          investissements: 100000,
+          propertyMarketValue: 500000,
+        ),
+        projection: buildProjection(),
+      );
+      final legacyAndMarketValue = FriComputationService.compute(
+        profile: buildProfile(
+          epargneLiquide: 50000,
+          investissements: 100000,
+          immobilier: 500000,
+          propertyMarketValue: 500000,
+        ),
+        projection: buildProjection(),
+      );
+
+      expect(marketValueOnly.risque, legacyAndMarketValue.risque);
     });
 
     test('overall score is bounded 0-100', () {
@@ -298,7 +322,8 @@ void main() {
         employmentStatus: 'independant',
         avoirLppTotal: 50000,
       );
-      expect(FriComputationService.detectArchetype(profile), 'independent_with_lpp');
+      expect(FriComputationService.detectArchetype(profile),
+          'independent_with_lpp');
     });
 
     test('independent_no_lpp for independant without LPP', () {
@@ -306,7 +331,8 @@ void main() {
         employmentStatus: 'independant',
         avoirLppTotal: 0,
       );
-      expect(FriComputationService.detectArchetype(profile), 'independent_no_lpp');
+      expect(
+          FriComputationService.detectArchetype(profile), 'independent_no_lpp');
     });
 
     test('returning_swiss for CH national arrived late', () {
@@ -336,7 +362,8 @@ void main() {
         employmentStatus: 'independant',
         avoirLppTotal: 0,
       );
-      expect(FriComputationService.detectArchetype(profile), 'independent_no_lpp');
+      expect(
+          FriComputationService.detectArchetype(profile), 'independent_no_lpp');
     });
   });
 }


### PR DESCRIPTION
Summary
- Use PatrimoineProfile.immobilierEffectif for FRI concentration numerator so propertyMarketValue-only profiles get the same real-estate concentration risk as legacy immobilier profiles.
- Add a regression test proving modern property values are not diluted when legacy immobilier is empty.

QA
- RED first: flutter test test/services/fri_computation_service_test.dart --plain-name property market value drives concentration risk without legacy immobilier failed with actual risk 15.0 vs expected 11.0 before the fix.
- flutter test test/services/fri_computation_service_test.dart -> 24 passed.
- flutter analyze lib/services/fri_computation_service.dart test/services/fri_computation_service_test.dart -> no issues.
- python3 tools/checks/financial_core_gate.py --base-ref origin/claude/mint-swiss-coach-eu33i7 -> pass.
- python3 tools/checks/hardcoded_rate_gate.py --base-ref origin/claude/mint-swiss-coach-eu33i7 -> pass.
- lefthook run pre-commit on touched files -> pass.
- External Claude audit via tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 -> PASS, no P0/P1/P2 material.