### PR TITLE
fix(dataquest): hydrate identity save facts

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -2334,6 +2334,8 @@ class CoachProfile {
     final dobRaw = answers['q_date_of_birth'];
     final dateOfBirth = dobRaw is String ? DateTime.tryParse(dobRaw) : null;
     final canton = (answers['q_canton'] as String?) ?? 'ZH';
+    final commune = answers['q_commune'] as String?;
+    final gender = answers['q_gender'] as String?;
     // Use precise age from dateOfBirth if available
     final int age;
     if (dateOfBirth != null) {
@@ -2883,6 +2885,8 @@ class CoachProfile {
       provided.add('age');
     }
     if (answers.containsKey('q_canton')) provided.add('canton');
+    if (answers.containsKey('q_commune')) provided.add('commune');
+    if (answers.containsKey('q_gender')) provided.add('gender');
     if (answers.containsKey('q_net_income_period_chf') ||
         answers.containsKey('q_gross_salary_annual')) {
       provided.add('salary');
@@ -2895,6 +2899,7 @@ class CoachProfile {
       birthYear: birthYear,
       dateOfBirth: dateOfBirth,
       canton: canton,
+      commune: commune,
       nationality: answers['q_nationality'] as String?,
       etatCivil: etatCivil,
       nombreEnfants: nombreEnfants,
@@ -2916,6 +2921,7 @@ class CoachProfile {
       arrivalAge: computedArrivalAge,
       residencePermit: answers['q_residence_permit'] as String?,
       familyChange: familyChange,
+      gender: gender,
       targetRetirementAge: targetRetAge,
       updatedAt:
           savedUpdatedAt != null ? DateTime.tryParse(savedUpdatedAt) : null,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -1022,6 +1022,12 @@ class CoachProfileProvider extends ChangeNotifier {
     final answers = await ReportPersistenceService.loadAnswers();
     // Core fields
     if (profile.canton.isNotEmpty) answers['q_canton'] = profile.canton;
+    if (profile.commune != null && profile.commune!.isNotEmpty) {
+      answers['q_commune'] = profile.commune;
+    }
+    if (profile.gender != null && profile.gender!.isNotEmpty) {
+      answers['q_gender'] = profile.gender;
+    }
     // FIX-096: Persist etatCivil (divorce was lost on restart).
     answers['q_civil_status'] = profile.etatCivil.name;
     answers['q_salaire'] = profile.salaireBrutMensuel;

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -96,4 +96,38 @@ void main() {
     expect(answers.containsKey('q_total_3a'), isFalse);
     expect(provider.profile?.prevoyance.totalEpargne3a, 42000);
   });
+
+  test('save_fact commune and gender hydrate readable identity keys', () async {
+    final provider = CoachProfileProvider();
+
+    final communeApplied = await provider.applySaveFact('commune', 'Lausanne');
+    final genderApplied = await provider.applySaveFact('gender', 'F');
+
+    expect(communeApplied, isTrue);
+    expect(genderApplied, isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_commune', 'Lausanne'));
+    expect(answers, containsPair('q_gender', 'F'));
+    expect(provider.profile?.commune, 'Lausanne');
+    expect(provider.profile?.gender, 'F');
+  });
+
+  test('updateProfile persists commune and gender on readable identity keys',
+      () async {
+    final provider = CoachProfileProvider();
+    final profile = CoachProfile.defaults().copyWith(
+      commune: 'Lausanne',
+      gender: 'F',
+    );
+
+    provider.updateProfile(profile);
+    await Future<void>.delayed(Duration.zero);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_commune', 'Lausanne'));
+    expect(answers, containsPair('q_gender', 'F'));
+    final rehydrated = CoachProfile.fromWizardAnswers(answers);
+    expect(rehydrated.commune, 'Lausanne');
+    expect(rehydrated.gender, 'F');
+  });
 }

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -186,24 +186,24 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 **Count check (must match code):** 3.1–3.7 = 9 (identity) + 7 (income) + 7 (LPP) + 2 (3a) + 5 (savings/wealth/debt) + 3 (spouse) + 2 (AVS) = **35 keys** = `len(_SAVE_FACT_ALLOWED_KEYS)`. CI test §8.1 asserts `len == 35`.
 
-### 3.8 REQUIRED REPAIR — 16 backend-writable keys still ineffective locally (parity is still broken)
+### 3.8 REQUIRED REPAIR — 13 backend-writable keys still ineffective locally (parity is still broken)
 
 At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handles only **24** of the 35 allowlist keys; the other **11** fall through `default: return const {}`, so `applySaveFact` returns `false` and the coach write is **silently dropped** — a live dead road (`save_fact('hasAvsGaps')` etc. writes nothing to `CoachProfile`).
 
-G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, and `pillar3aBalance` to `q_3a_total`; total remaining local ineffectiveness is now **15 backend-writable keys**.
+G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, `pillar3aBalance` to `q_3a_total`, and identity keys `commune`/`gender` to `q_commune`/`q_gender`; total remaining local ineffectiveness is now **13 backend-writable keys**.
 
 **The 11 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`, `hasAvsGaps`, `avsContributionYears`.
 
-**The 4 remaining mapped-but-unread keys:** `commune -> q_commune`, `gender -> q_gender`, `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`.
+**The 2 remaining mapped-but-unread keys:** `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`.
 
-**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`.
+**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`; `commune -> q_commune` and `gender -> q_gender`, which are read into the identity fields on `CoachProfile`.
 
 **Task T-0 (mandatory):** repair the 7 mapped-but-unread cases first. Either align the mapper to wizard keys already read by `fromWizardAnswers`, or add explicit `fromWizardAnswers` reads with tests.
 
 | allowlist key | current mapper | read by `fromWizardAnswers` today | required direction |
 |---|---|---|---|
-| `commune` | `q_commune` | none | add a `commune` field/read or remove coach-writable status |
-| `gender` | `q_gender` | none | add a profile gender read or remove coach-writable status |
+| `commune` | `q_commune` | `q_commune` | ✅ repaired; keep profile identity read/write on `q_commune` |
+| `gender` | `q_gender` | `q_gender` | ✅ repaired; keep profile identity read/write on `q_gender` |
 | `employmentRate` | `q_employment_rate` | none | add field/read or remove coach-writable status |
 | `annualBonus` | `q_annual_bonus` | none | add field/read or remove coach-writable status |
 | `pillar3aBalance` | `q_3a_total` | `q_3a_total` / `_coach_total_3a` | ✅ repaired; keep mapping on `q_3a_total` |


### PR DESCRIPTION
## Summary
- hydrate q_commune and q_gender in CoachProfile.fromWizardAnswers
- persist commune/gender through updateProfile on the same readable wizard keys
- add provider round-trip tests and update DATA_LEDGER remaining mismatch counts

## QA
- flutter test test/providers/coach_profile_provider_test.dart
- flutter test test/providers/
- flutter analyze lib/models/coach_profile.dart lib/providers/coach_profile_provider.dart test/providers/coach_profile_provider_test.dart
- python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q
- lefthook run pre-commit --file apps/mobile/lib/models/coach_profile.dart --file apps/mobile/lib/providers/coach_profile_provider.dart --file apps/mobile/test/providers/coach_profile_provider_test.dart --file docs/codex/DATA_LEDGER.md
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 — PASS, no P0/P1

## Notes
Remaining DataQuest local ineffectiveness is now 13 keys: 11 unmapped and 2 mapped-but-unread (employmentRate, annualBonus).
