### PR TITLE
fix(dataquest): hydrate income save facts

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -13,6 +13,7 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/domain/budget/budget_inputs.dart';
 import 'package:mint_mobile/services/coaching_service.dart';
+import 'package:mint_mobile/services/financial_core/income_conversion_calculator.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/services/voice/voice_cursor_contract.dart'
     show VoicePreference;
@@ -1358,6 +1359,7 @@ class CoachProfile {
   final double salaireBrutMensuel;
   final double nombreDeMois; // 12, 13, 13.5
   final double? bonusPourcentage;
+  final double employmentRate; // 0.0-100.0 (%), default full-time
   final String
       employmentStatus; // 'salarie', 'independant', 'chomage', 'retraite'
 
@@ -1485,6 +1487,8 @@ class CoachProfile {
     required this.salaireBrutMensuel,
     this.nombreDeMois = 12.0,
     this.bonusPourcentage,
+    this.employmentRate =
+        IncomeConversionCalculator.fullTimeEmploymentRatePercent,
     this.employmentStatus = 'salarie',
     this.depenses = const DepensesProfile(),
     this.prevoyance = const PrevoyanceProfile(),
@@ -1614,6 +1618,7 @@ class CoachProfile {
           salaireBrutMensuel == other.salaireBrutMensuel &&
           nombreDeMois == other.nombreDeMois &&
           bonusPourcentage == other.bonusPourcentage &&
+          employmentRate == other.employmentRate &&
           employmentStatus == other.employmentStatus &&
           depenses == other.depenses &&
           prevoyance == other.prevoyance &&
@@ -1643,7 +1648,7 @@ class CoachProfile {
   int get hashCode => Object.hashAll([
         firstName, birthYear, dateOfBirth, canton, commune, nationality,
         etatCivil, nombreEnfants, conjoint, salaireBrutMensuel,
-        nombreDeMois, bonusPourcentage, employmentStatus,
+        nombreDeMois, bonusPourcentage, employmentRate, employmentStatus,
         depenses, prevoyance, patrimoine, dettes, goalA,
         goalsB.length, plannedContributions.length, checkIns.length,
         housingStatus, riskTolerance, realEstateProject,
@@ -1946,6 +1951,7 @@ class CoachProfile {
     double? salaireBrutMensuel,
     double? nombreDeMois,
     double? bonusPourcentage,
+    double? employmentRate,
     String? employmentStatus,
     DepensesProfile? depenses,
     PrevoyanceProfile? prevoyance,
@@ -1997,6 +2003,7 @@ class CoachProfile {
       salaireBrutMensuel: salaireBrutMensuel ?? this.salaireBrutMensuel,
       nombreDeMois: nombreDeMois ?? this.nombreDeMois,
       bonusPourcentage: bonusPourcentage ?? this.bonusPourcentage,
+      employmentRate: employmentRate ?? this.employmentRate,
       employmentStatus: employmentStatus ?? this.employmentStatus,
       depenses: depenses ?? this.depenses,
       prevoyance: prevoyance ?? this.prevoyance,
@@ -2132,7 +2139,7 @@ class CoachProfile {
       hasLpp: (prevoyance.avoirLppTotal ?? 0) > 0,
       avoirLpp: prevoyance.avoirLppTotal ?? 0,
       lacuneLpp: prevoyance.lacuneRachatRestante,
-      tauxActivite: 100,
+      tauxActivite: employmentRate,
       chargesFixesMensuelles: depenses.totalMensuel,
       epargneDispo: patrimoine.epargneLiquide,
       detteTotale: dettes.totalDettes,
@@ -2175,6 +2182,9 @@ class CoachProfile {
       salaireBrutMensuel: (json['salaireBrutMensuel'] as num?)?.toDouble() ?? 0,
       nombreDeMois: (json['nombreDeMois'] as num?)?.toDouble() ?? 12.0,
       bonusPourcentage: (json['bonusPourcentage'] as num?)?.toDouble(),
+      employmentRate: IncomeConversionCalculator.clampEmploymentRatePercent(
+        (json['employmentRate'] as num?)?.toDouble(),
+      ),
       employmentStatus: json['employmentStatus'] ?? 'salarie',
       depenses: json['depenses'] != null
           ? DepensesProfile.fromJson(json['depenses'])
@@ -2282,6 +2292,7 @@ class CoachProfile {
         'salaireBrutMensuel': salaireBrutMensuel,
         'nombreDeMois': nombreDeMois,
         'bonusPourcentage': bonusPourcentage,
+        'employmentRate': employmentRate,
         'employmentStatus': employmentStatus,
         'depenses': depenses.toJson(),
         'prevoyance': prevoyance.toJson(),
@@ -2381,10 +2392,30 @@ class CoachProfile {
     // Source: OFAS barème cotisations 2025. Ceci est une estimation;
     // le taux réel dépend du plan LPP et du canton.
     const double socialChargesRate = 0.13;
+    final nombreDeMois = IncomeConversionCalculator.normalizeAnnualSalaryMonths(
+      _parseDouble(answers['q_nombre_mois']),
+    );
     final grossSalaryDirect = _parseDouble(answers['q_gross_salary_annual']);
     final salaireBrutMensuel = grossSalaryDirect != null
-        ? grossSalaryDirect / 12
+        ? IncomeConversionCalculator.monthlyGrossFromAnnualGross(
+            grossSalaryDirect,
+            months: nombreDeMois,
+          )
         : monthlyNetIncome / (1 - socialChargesRate);
+    final employmentRate = IncomeConversionCalculator.clampEmploymentRatePercent(
+      _parseDouble(answers['q_employment_rate']),
+    );
+    final annualBonus = _parseDouble(answers['q_annual_bonus']);
+    final annualBaseSalary = IncomeConversionCalculator.annualGrossFromMonthly(
+      monthlyGross: salaireBrutMensuel,
+      months: nombreDeMois,
+    );
+    final bonusPourcentage =
+        IncomeConversionCalculator.bonusPercentageFromAnnualBonus(
+              annualBonus: annualBonus,
+              annualBaseSalary: annualBaseSalary,
+            ) ??
+            _parseDouble(answers['q_bonus_percentage']);
 
     // Employment status mapping
     final employmentRaw = answers['q_employment_status'] as String?;
@@ -2891,6 +2922,8 @@ class CoachProfile {
         answers.containsKey('q_gross_salary_annual')) {
       provided.add('salary');
     }
+    if (answers.containsKey('q_employment_rate')) provided.add('employmentRate');
+    if (answers.containsKey('q_annual_bonus')) provided.add('bonusPourcentage');
     if (answers.containsKey('q_civil_status')) provided.add('civilStatus');
     if (answers.containsKey('q_nationality')) provided.add('nationality');
 
@@ -2905,6 +2938,9 @@ class CoachProfile {
       nombreEnfants: nombreEnfants,
       conjoint: conjoint,
       salaireBrutMensuel: salaireBrutMensuel,
+      nombreDeMois: nombreDeMois,
+      bonusPourcentage: bonusPourcentage,
+      employmentRate: employmentRate,
       employmentStatus: employmentStatus,
       depenses: depenses,
       prevoyance: prevoyance,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -7,6 +7,7 @@ import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/services/api_service.dart';
 import 'package:mint_mobile/services/auth_service.dart';
 import 'package:mint_mobile/services/document_parser/document_models.dart';
+import 'package:mint_mobile/services/financial_core/income_conversion_calculator.dart';
 import 'package:mint_mobile/services/financial_core/tax_calculator.dart';
 import 'package:mint_mobile/services/minimal_profile_service.dart';
 import 'package:mint_mobile/services/cap_memory_store.dart';
@@ -1032,6 +1033,26 @@ class CoachProfileProvider extends ChangeNotifier {
     answers['q_civil_status'] = profile.etatCivil.name;
     answers['q_salaire'] = profile.salaireBrutMensuel;
     answers['q_nombre_mois'] = profile.nombreDeMois;
+    final grossAnnual = IncomeConversionCalculator.annualGrossFromMonthly(
+      monthlyGross: profile.salaireBrutMensuel,
+      months: profile.nombreDeMois,
+    );
+    answers['q_gross_salary_annual'] = grossAnnual;
+    if (grossAnnual > 0 && profile.bonusPourcentage != null) {
+      answers['q_annual_bonus'] =
+          IncomeConversionCalculator.annualBonusFromPercentage(
+        annualGross: grossAnnual,
+        bonusPercentage: profile.bonusPourcentage!,
+      );
+    } else {
+      answers.remove('q_annual_bonus');
+    }
+    if (profile.employmentRate !=
+        IncomeConversionCalculator.fullTimeEmploymentRatePercent) {
+      answers['q_employment_rate'] = profile.employmentRate;
+    } else {
+      answers.remove('q_employment_rate');
+    }
     if (profile.employmentStatus.isNotEmpty) {
       answers['q_employment_status'] = profile.employmentStatus;
     }

--- a/apps/mobile/lib/services/financial_core/income_conversion_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/income_conversion_calculator.dart
@@ -1,0 +1,54 @@
+/// Income unit conversions shared by profile hydration and persistence.
+///
+/// Keeps salary/bonus percentage math inside financial_core so profile code
+/// only maps data keys and does not duplicate financial formulas.
+class IncomeConversionCalculator {
+  IncomeConversionCalculator._();
+
+  static const double minimumEmploymentRatePercent = 0.0;
+  static const double fullTimeEmploymentRatePercent = 100.0;
+  static const double defaultAnnualSalaryMonths = 12.0;
+
+  static double clampEmploymentRatePercent(double? value) {
+    return (value ?? fullTimeEmploymentRatePercent)
+        .clamp(minimumEmploymentRatePercent, fullTimeEmploymentRatePercent)
+        .toDouble();
+  }
+
+  static double normalizeAnnualSalaryMonths(double? value) {
+    if (value == null || value <= 0) return defaultAnnualSalaryMonths;
+    return value;
+  }
+
+  static double monthlyGrossFromAnnualGross(
+    double annualGross, {
+    double months = defaultAnnualSalaryMonths,
+  }) {
+    if (annualGross <= 0 || months <= 0) return 0;
+    return annualGross / months;
+  }
+
+  static double annualGrossFromMonthly({
+    required double monthlyGross,
+    required double months,
+  }) {
+    if (monthlyGross <= 0 || months <= 0) return 0;
+    return monthlyGross * months;
+  }
+
+  static double annualBonusFromPercentage({
+    required double annualGross,
+    required double bonusPercentage,
+  }) {
+    if (annualGross <= 0 || bonusPercentage <= 0) return 0;
+    return annualGross * bonusPercentage / fullTimeEmploymentRatePercent;
+  }
+
+  static double? bonusPercentageFromAnnualBonus({
+    required double? annualBonus,
+    required double annualBaseSalary,
+  }) {
+    if (annualBonus == null || annualBaseSalary <= 0) return null;
+    return annualBonus / annualBaseSalary * fullTimeEmploymentRatePercent;
+  }
+}

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -130,4 +130,78 @@ void main() {
     expect(rehydrated.commune, 'Lausanne');
     expect(rehydrated.gender, 'F');
   });
+
+  test('save_fact employmentRate and annualBonus hydrate income keys',
+      () async {
+    final provider = CoachProfileProvider();
+
+    expect(await provider.applySaveFact('incomeGrossYearly', 120000), isTrue);
+    expect(await provider.applySaveFact('employmentRate', 80), isTrue);
+    expect(await provider.applySaveFact('annualBonus', 12000), isTrue);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_employment_rate', 80));
+    expect(answers, containsPair('q_annual_bonus', 12000));
+    expect(provider.profile?.employmentRate, 80);
+    expect(provider.profile?.bonusPourcentage, closeTo(10, 0.001));
+    expect(provider.profile?.revenuBrutAnnuel, closeTo(132000, 0.001));
+    expect(provider.profile?.toCoachingProfile().tauxActivite, 80);
+  });
+
+  test('updateProfile preserves 13-month salary, rate, and bonus shape',
+      () async {
+    final provider = CoachProfileProvider();
+    final profile = CoachProfile.defaults().copyWith(
+      salaireBrutMensuel: 10000,
+      nombreDeMois: 13,
+      bonusPourcentage: 5,
+      employmentRate: 80,
+    );
+
+    provider.updateProfile(profile);
+    await Future<void>.delayed(Duration.zero);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_nombre_mois', 13));
+    expect(answers, containsPair('q_gross_salary_annual', 130000));
+    expect(answers, containsPair('q_employment_rate', 80));
+    expect(answers, containsPair('q_annual_bonus', 6500));
+    final rehydrated = CoachProfile.fromWizardAnswers(answers);
+    expect(rehydrated.salaireBrutMensuel, closeTo(10000, 0.001));
+    expect(rehydrated.nombreDeMois, 13);
+    expect(rehydrated.employmentRate, 80);
+    expect(rehydrated.bonusPourcentage, closeTo(5, 0.001));
+    expect(rehydrated.revenuBrutAnnuel, closeTo(136500, 0.001));
+  });
+
+  test('updateProfile clears stale employment rate and annual bonus keys',
+      () async {
+    final provider = CoachProfileProvider();
+    final partTimeWithBonus = CoachProfile.defaults().copyWith(
+      salaireBrutMensuel: 10000,
+      nombreDeMois: 12,
+      bonusPourcentage: 10,
+      employmentRate: 80,
+    );
+    final fullTimeWithoutBonus = CoachProfile.defaults().copyWith(
+      salaireBrutMensuel: 0,
+      nombreDeMois: 12,
+      employmentRate: 100,
+    );
+
+    provider.updateProfile(partTimeWithBonus);
+    await Future<void>.delayed(Duration.zero);
+    provider.updateProfile(fullTimeWithoutBonus);
+    await Future<void>.delayed(Duration.zero);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers.containsKey('q_employment_rate'), isFalse);
+    expect(answers.containsKey('q_annual_bonus'), isFalse);
+    expect(answers, containsPair('q_gross_salary_annual', 0));
+    final rehydrated = CoachProfile.fromWizardAnswers(answers);
+    expect(rehydrated.employmentRate, 100);
+    expect(rehydrated.bonusPourcentage, isNull);
+    expect(rehydrated.revenuBrutAnnuel, 0);
+    expect(rehydrated.toCoachingProfile().tauxActivite, 100);
+  });
 }

--- a/apps/mobile/test/services/financial_core/income_conversion_calculator_test.dart
+++ b/apps/mobile/test/services/financial_core/income_conversion_calculator_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/services/financial_core/income_conversion_calculator.dart';
+
+void main() {
+  test('normalizes and converts income values', () {
+    expect(IncomeConversionCalculator.clampEmploymentRatePercent(null), 100);
+    expect(IncomeConversionCalculator.clampEmploymentRatePercent(-10), 0);
+    expect(IncomeConversionCalculator.clampEmploymentRatePercent(80), 80);
+    expect(IncomeConversionCalculator.clampEmploymentRatePercent(140), 100);
+    expect(IncomeConversionCalculator.normalizeAnnualSalaryMonths(null), 12);
+    expect(IncomeConversionCalculator.normalizeAnnualSalaryMonths(0), 12);
+    expect(IncomeConversionCalculator.normalizeAnnualSalaryMonths(13), 13);
+
+    final annualGross = IncomeConversionCalculator.annualGrossFromMonthly(
+      monthlyGross: 10000,
+      months: 12,
+    );
+
+    expect(annualGross, 120000);
+    expect(IncomeConversionCalculator.annualBonusFromPercentage(annualGross: annualGross, bonusPercentage: 10), 12000);
+    expect(IncomeConversionCalculator.bonusPercentageFromAnnualBonus(annualBonus: 12000, annualBaseSalary: annualGross), 10);
+    expect(IncomeConversionCalculator.annualGrossFromMonthly(monthlyGross: 10000, months: 0), 0);
+    expect(IncomeConversionCalculator.bonusPercentageFromAnnualBonus(annualBonus: 12000, annualBaseSalary: 0), isNull);
+  });
+}

--- a/docs/calculator-graph.md
+++ b/docs/calculator-graph.md
@@ -78,6 +78,7 @@ Julien + Lauren golden values.
 | **TaxCalculator** | `tax_calculator.dart` | income, canton, marital, 3a | federal + cantonal + marginal | ArbitrageEngine, ProjectionFiscaleScreen |
 | **HousingCostCalculator** | `housing_cost_calculator.dart` | loyer/hyp + canton | monthly housing effective cost | FriCalculator, budget calcs |
 | **FriCalculator** (composite) | `fri_calculator.dart` | CoachProfile | FRI score 0-100 + breakdown | FriComputationService, CoachNarrativeService |
+| **IncomeConversionCalculator** | `income_conversion_calculator.dart` | salary, months, bonus, employment rate | normalized salary/bonus/rate units | CoachProfile.fromWizardAnswers, CoachProfileProvider |
 | **ConfidenceScorer** | `confidence_scorer.dart` | CoachProfile | score 0-100 + per-field confidence | ExtractionReviewScreen, RetirementDashboardScreen, `dataReliability` |
 | **CrossPillarCalculator** | `cross_pillar_calculator.dart` | 3 pillars values | arbitrage opportunities | ArbitrageEngine |
 | **CoupleOptimizer** | `couple_optimizer.dart` | 2 profiles | optimization suggestions | CoupleDashboardScreen |

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -126,7 +126,7 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 | `incomeNetYearly` | `q_net_income_period_chf` + `q_pay_frequency='yearly'` | double CHF/yr | income | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | tax, affordability ~33% |
 | `incomeGrossMonthly` | `q_gross_salary_annual` (= value × 12) | double CHF/mo | income | userInput, certificate, openBanking | annual | .60 | applySaveFact/mergeAnswers | `salaireBrutMensuel`, `revenuBrutAnnuel`, LPP coordination, AVS RAMD |
 | `incomeGrossYearly` | `q_gross_salary_annual` | double CHF/yr | income | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | `revenuBrutAnnuel`, tax tiers, LPP insured salary inference |
-| `employmentRate` | `q_employment_rate` | double % (0–100) | income | userInput | annual | .60 | applySaveFact/mergeAnswers | part-timer LPP pro-rating, coordination deduction |
+| `employmentRate` | `q_employment_rate` | double % (0–100) | income | userInput | annual | .60 | applySaveFact/mergeAnswers | part-time coaching, coordination-deduction alert |
 | `annualBonus` | `q_annual_bonus` | double CHF/yr | income | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | `bonusPourcentage`, `revenuBrutAnnuel` |
 | `selfEmployedNetIncome` | ⚠ NO MAPPER CASE (§3.8) | double CHF/yr | income | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | independant archetype, 3a max 36'288, AVS indep |
 
@@ -186,17 +186,17 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 **Count check (must match code):** 3.1–3.7 = 9 (identity) + 7 (income) + 7 (LPP) + 2 (3a) + 5 (savings/wealth/debt) + 3 (spouse) + 2 (AVS) = **35 keys** = `len(_SAVE_FACT_ALLOWED_KEYS)`. CI test §8.1 asserts `len == 35`.
 
-### 3.8 REQUIRED REPAIR — 13 backend-writable keys still ineffective locally (parity is still broken)
+### 3.8 REQUIRED REPAIR — 11 backend-writable keys still ineffective locally (parity is still broken)
 
 At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handles only **24** of the 35 allowlist keys; the other **11** fall through `default: return const {}`, so `applySaveFact` returns `false` and the coach write is **silently dropped** — a live dead road (`save_fact('hasAvsGaps')` etc. writes nothing to `CoachProfile`).
 
-G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, `pillar3aBalance` to `q_3a_total`, and identity keys `commune`/`gender` to `q_commune`/`q_gender`; total remaining local ineffectiveness is now **13 backend-writable keys**.
+G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, `pillar3aBalance` to `q_3a_total`, identity keys `commune`/`gender` to `q_commune`/`q_gender`, and income keys `employmentRate`/`annualBonus` to `q_employment_rate`/`q_annual_bonus`; total remaining local ineffectiveness is now **11 backend-writable keys**.
 
 **The 11 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`, `hasAvsGaps`, `avsContributionYears`.
 
-**The 2 remaining mapped-but-unread keys:** `employmentRate -> q_employment_rate`, `annualBonus -> q_annual_bonus`.
+**The 0 remaining mapped-but-unread keys:** none. T-0 is complete.
 
-**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`; `commune -> q_commune` and `gender -> q_gender`, which are read into the identity fields on `CoachProfile`.
+**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`; `commune -> q_commune` and `gender -> q_gender`, which are read into the identity fields on `CoachProfile`; `employmentRate -> q_employment_rate`, which is read into `CoachProfile.employmentRate` and forwarded to `CoachingProfile.tauxActivite`; `annualBonus -> q_annual_bonus`, which is converted to `bonusPourcentage` and therefore included in `revenuBrutAnnuel`.
 
 **Task T-0 (mandatory):** repair the 7 mapped-but-unread cases first. Either align the mapper to wizard keys already read by `fromWizardAnswers`, or add explicit `fromWizardAnswers` reads with tests.
 
@@ -204,8 +204,8 @@ G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.f
 |---|---|---|---|
 | `commune` | `q_commune` | `q_commune` | ✅ repaired; keep profile identity read/write on `q_commune` |
 | `gender` | `q_gender` | `q_gender` | ✅ repaired; keep profile identity read/write on `q_gender` |
-| `employmentRate` | `q_employment_rate` | none | add field/read or remove coach-writable status |
-| `annualBonus` | `q_annual_bonus` | none | add field/read or remove coach-writable status |
+| `employmentRate` | `q_employment_rate` | `q_employment_rate` | ✅ repaired; keep profile read/write and `toCoachingProfile().tauxActivite` on this value |
+| `annualBonus` | `q_annual_bonus` | `q_annual_bonus` | ✅ repaired; keep raw CHF/year storage and convert to `bonusPourcentage` for `revenuBrutAnnuel` |
 | `pillar3aBalance` | `q_3a_total` | `q_3a_total` / `_coach_total_3a` | ✅ repaired; keep mapping on `q_3a_total` |
 | `totalSavings` | `q_cash_total` | `q_cash_total` | ✅ repaired; keep mapping on `q_cash_total` |
 | `wealthEstimate` | `q_wealth_estimate` | `q_wealth_estimate` | ✅ repaired; aggregate for `totalPatrimoine`, never added on top of detailed assets |

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -92,6 +92,7 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
 - `q_pay_frequency` (`monthly`|`yearly`|`annuel`),
   `q_net_income_period_chf` (double, amount per period),
   `q_gross_salary_annual` (preferred when known — avoids net↔brut roundtrip),
+  `q_nombre_mois` (salary months, defaults to 12),
   `q_employment_status` (salarie/independant/retraite/etc.),
   `q_employment_rate` (%), `q_annual_bonus` (CHF), `q_partner_net_income_chf`,
   `q_partner_birth_year`, `q_partner_employment_status`


### PR DESCRIPTION
## Summary
- add `IncomeConversionCalculator` in financial_core for salary months, annual gross, annual bonus, and employment-rate normalization
- wire `employmentRate`, `q_nombre_mois`, and `q_annual_bonus` through `CoachProfile`, `toCoachingProfile`, and `CoachProfileProvider`
- update DataQuest/data-flow docs so `employmentRate` and `annualBonus` are no longer mapped-but-unread

## QA
- `flutter test test/services/financial_core/income_conversion_calculator_test.dart test/providers/coach_profile_provider_test.dart`
- `flutter test test/services/coach_profile_test.dart test/services/coaching_service_test.dart`
- `flutter analyze lib/models/coach_profile.dart lib/providers/coach_profile_provider.dart lib/services/financial_core/income_conversion_calculator.dart test/providers/coach_profile_provider_test.dart test/services/financial_core/income_conversion_calculator_test.dart`
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py tools/checks/tests/test_claude_external_audit_contract.py -q`
- `lefthook run pre-commit --file ...`
- `tools/checks/claude_external_audit.sh code HEAD` -> PASS, no P0/P1
- `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code HEAD` -> PASS, no P0/P1

## Notes
- Fixed Claude P2 stale-key hygiene: salary reset to zero now persists `q_gross_salary_annual = 0` and removes stale `q_annual_bonus`.
- No UI surface changed; no Maestro/Patrol runtime proof required for this data hydration slice.