### PR TITLE
fix(dataquest): hydrate avs save facts

### DIFF
--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -546,6 +546,14 @@ class CoachProfileProvider extends ChangeNotifier {
     if (confidence == 'low') return false; // mirror backend skip
     final mapped = _mapFactKeyToAnswers(factKey, factValue);
     if (mapped.isEmpty) return false;
+    if (factKey == 'hasAvsGaps' && _asBool(factValue) == true) {
+      final current = await ReportPersistenceService.loadAnswers();
+      final currentStatus = current['q_avs_lacunes_status'];
+      if (currentStatus == 'arrived_late' || currentStatus == 'lived_abroad') {
+        await mergeAnswers({'q_avs_lacunes_status': currentStatus});
+        return true;
+      }
+    }
     await mergeAnswers(mapped);
     return true;
   }
@@ -618,6 +626,13 @@ class CoachProfileProvider extends ChangeNotifier {
         return {'q_cash_total': value};
       case 'wealthEstimate':
         return {'q_wealth_estimate': value};
+      // AVS
+      case 'avsContributionYears':
+        return {'q_avs_contribution_years': value};
+      case 'hasAvsGaps':
+        final hasGaps = _asBool(value);
+        if (hasGaps == null) return const {};
+        return {'q_avs_lacunes_status': hasGaps ? 'unknown' : 'no_gaps'};
       default:
         return const {};
     }
@@ -626,6 +641,26 @@ class CoachProfileProvider extends ChangeNotifier {
   static num? _asNum(dynamic v) {
     if (v is num) return v;
     if (v is String) return num.tryParse(v);
+    return null;
+  }
+
+  static bool? _asBool(dynamic v) {
+    if (v is bool) return v;
+    if (v is num) return v != 0;
+    if (v is String) {
+      switch (v.toLowerCase()) {
+        case 'true':
+        case 'yes':
+        case 'oui':
+        case '1':
+          return true;
+        case 'false':
+        case 'no':
+        case 'non':
+        case '0':
+          return false;
+      }
+    }
     return null;
   }
 

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -204,4 +204,62 @@ void main() {
     expect(rehydrated.revenuBrutAnnuel, 0);
     expect(rehydrated.toCoachingProfile().tauxActivite, 100);
   });
+
+  test('save_fact AVS gaps and contribution years hydrate AVS keys', () async {
+    final provider = CoachProfileProvider();
+
+    expect(await provider.applySaveFact('birthYear', 1970), isTrue);
+    expect(await provider.applySaveFact('avsContributionYears', 30), isTrue);
+    expect(await provider.applySaveFact('hasAvsGaps', true), isTrue);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_avs_contribution_years', 30));
+    expect(answers, containsPair('q_avs_lacunes_status', 'unknown'));
+    expect(provider.profile?.prevoyance.anneesContribuees, 30);
+    expect(provider.profile?.prevoyance.lacunesAVS, 2);
+  });
+
+  test('save_fact hasAvsGaps false clears AVS gap status', () async {
+    final provider = CoachProfileProvider();
+
+    expect(await provider.applySaveFact('birthYear', 1970), isTrue);
+    expect(await provider.applySaveFact('hasAvsGaps', true), isTrue);
+    expect(await provider.applySaveFact('hasAvsGaps', false), isTrue);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_avs_lacunes_status', 'no_gaps'));
+    expect(provider.profile?.prevoyance.lacunesAVS, isNull);
+  });
+
+  test('save_fact hasAvsGaps true preserves precise AVS status', () async {
+    final provider = CoachProfileProvider();
+    await provider.mergeAnswers({
+      'q_birth_year': 1970,
+      'q_avs_lacunes_status': 'lived_abroad',
+      'q_avs_years_abroad': 4,
+    });
+
+    expect(await provider.applySaveFact('hasAvsGaps', true), isTrue);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_avs_lacunes_status', 'lived_abroad'));
+    expect(provider.profile?.prevoyance.lacunesAVS, 4);
+  });
+
+  test('save_fact hasAvsGaps true preserves arrived-late AVS status',
+      () async {
+    final provider = CoachProfileProvider();
+    await provider.mergeAnswers({
+      'q_birth_year': 1975,
+      'q_avs_lacunes_status': 'arrived_late',
+      'q_avs_arrival_year': 2005,
+    });
+
+    expect(await provider.applySaveFact('hasAvsGaps', true), isTrue);
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_avs_lacunes_status', 'arrived_late'));
+    expect(answers, containsPair('q_avs_arrival_year', 2005));
+    expect(provider.profile?.prevoyance.lacunesAVS, 9);
+  });
 }

--- a/docs/codex/DATA_LEDGER.md
+++ b/docs/codex/DATA_LEDGER.md
@@ -38,7 +38,7 @@ These restate §F of the wiring findings. CI must enforce I-1, I-3, I-6, I-7.
 - **I-4 — NO ISLANDS.** Every isolated provider (`BudgetProvider`, `HouseholdProvider`, `TimelineProvider`, documents, conversations) MUST bridge into the recompute so `MintUserState` is never stale. See §7.
 - **I-5 — PROJECTIONS ARE RANGED.** Every consumer that renders a projected number MUST also render a range + `EnhancedConfidence` + "à confirmer". No bare numbers. No promissory terms (CLAUDE.md §5).
 - **I-6 — DIFF NOT FORM.** Collection asks only the missing/stale delta. Freshness < 0.60 ⇒ **re-confirm**, never blank re-ask. Implement on top of `data_block_enrichment_screen.dart` (≈70% built).
-- **I-7 — ALLOWLIST IS THE CONTRACT.** A field is writable via the coach/backend ONLY if its key is in `_SAVE_FACT_ALLOWED_KEYS` (35 keys). Adding a coach-writable field = adding to that set + the mobile `_mapFactKeyToAnswers` switch + a row in this ledger. The backend allowlist and coach tool enum are in sync at `095eeaa32`, but the mobile path is not: **16 backend-writable keys are ineffective locally via `applySaveFact`** — see §3.8.
+- **I-7 — ALLOWLIST IS THE CONTRACT.** A field is writable via the coach/backend ONLY if its key is in `_SAVE_FACT_ALLOWED_KEYS` (35 keys). Adding a coach-writable field = adding to that set + the mobile `_mapFactKeyToAnswers` switch + a row in this ledger. The backend allowlist and coach tool enum are in sync at `095eeaa32`, but the mobile path is not: **9 backend-writable keys are ineffective locally via `applySaveFact`** — see §3.8.
 
 ---
 
@@ -181,22 +181,22 @@ These **35** keys are the exact contents of `_SAVE_FACT_ALLOWED_KEYS` (`coach_ch
 
 | key | wizard key | type+unit | domain | sources | fresh | wconf | write | consumers |
 |---|---|---|---|---|---|---|---|---|
-| `hasAvsGaps` | ⚠ NO MAPPER CASE (§3.8) | bool | prevoyance | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | `lacunesAVS` flag, AVS rente reduction warning |
-| `avsContributionYears` | ⚠ NO MAPPER CASE (§3.8) | int (yr) | prevoyance | certificate, userInput | annual | .95 / .60 | applySaveFact/mergeAnswers | `anneesContribuees`, AVS full-rente eligibility (44 yr), RAMD |
+| `hasAvsGaps` | `q_avs_lacunes_status` (`true` → `unknown` unless a precise `arrived_late`/`lived_abroad` status already exists; `false` → `no_gaps`) | bool | prevoyance | userInput, certificate | annual | .60 | applySaveFact/mergeAnswers | `lacunesAVS` flag, AVS rente reduction warning |
+| `avsContributionYears` | `q_avs_contribution_years` | int (yr) | prevoyance | certificate, userInput | annual | .95 / .60 | applySaveFact/mergeAnswers | `anneesContribuees`, AVS full-rente eligibility (44 yr), RAMD |
 
 **Count check (must match code):** 3.1–3.7 = 9 (identity) + 7 (income) + 7 (LPP) + 2 (3a) + 5 (savings/wealth/debt) + 3 (spouse) + 2 (AVS) = **35 keys** = `len(_SAVE_FACT_ALLOWED_KEYS)`. CI test §8.1 asserts `len == 35`.
 
-### 3.8 REQUIRED REPAIR — 11 backend-writable keys still ineffective locally (parity is still broken)
+### 3.8 REQUIRED REPAIR — 9 backend-writable keys still ineffective locally (parity is still broken)
 
-At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handles only **24** of the 35 allowlist keys; the other **11** fall through `default: return const {}`, so `applySaveFact` returns `false` and the coach write is **silently dropped** — a live dead road (`save_fact('hasAvsGaps')` etc. writes nothing to `CoachProfile`).
+At `095eeaa32`, the mobile `_mapFactKeyToAnswers` switch handled only **24** of the 35 allowlist keys; the other **11** fell through `default: return const {}`, so `applySaveFact` returned `false` and the coach write was **silently dropped**. After the savings, wealth, 3a, identity, income, and AVS repairs, **9** backend-writable keys still fall through locally.
 
-G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, `pillar3aBalance` to `q_3a_total`, identity keys `commune`/`gender` to `q_commune`/`q_gender`, and income keys `employmentRate`/`annualBonus` to `q_employment_rate`/`q_annual_bonus`; total remaining local ineffectiveness is now **11 backend-writable keys**.
+G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.fromWizardAnswers()` did not read**, so `applySaveFact` returned `true` but the profile still did not reconstruct the intended value. `totalSavings` has since been repaired to `q_cash_total`, `wealthEstimate` to `q_wealth_estimate`, `pillar3aBalance` to `q_3a_total`, identity keys `commune`/`gender` to `q_commune`/`q_gender`, income keys `employmentRate`/`annualBonus` to `q_employment_rate`/`q_annual_bonus`, and AVS keys `hasAvsGaps`/`avsContributionYears` to `q_avs_lacunes_status`/`q_avs_contribution_years` with precise AVS statuses preserved; total remaining local ineffectiveness is now **9 backend-writable keys**.
 
-**The 11 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`, `hasAvsGaps`, `avsContributionYears`.
+**The 9 unmapped keys:** `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, `hasDebt`, `totalDebt`, `spouseBirthYear`, `spouseIncomeNetMonthly`, `spouseAvsContributionYears`.
 
 **The 0 remaining mapped-but-unread keys:** none. T-0 is complete.
 
-**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`; `commune -> q_commune` and `gender -> q_gender`, which are read into the identity fields on `CoachProfile`; `employmentRate -> q_employment_rate`, which is read into `CoachProfile.employmentRate` and forwarded to `CoachingProfile.tauxActivite`; `annualBonus -> q_annual_bonus`, which is converted to `bonusPourcentage` and therefore included in `revenuBrutAnnuel`.
+**Repaired mapped keys:** `totalSavings -> q_cash_total`, which is read by `CoachProfile.fromWizardAnswers()` into `patrimoine.epargneLiquide`; `wealthEstimate -> q_wealth_estimate`, which is read into `PatrimoineProfile.wealthEstimate` and used by `totalPatrimoine` as a non-additive aggregate total; `pillar3aBalance -> q_3a_total`, which is read into `prevoyance.totalEpargne3a`; `commune -> q_commune` and `gender -> q_gender`, which are read into the identity fields on `CoachProfile`; `employmentRate -> q_employment_rate`, which is read into `CoachProfile.employmentRate` and forwarded to `CoachingProfile.tauxActivite`; `annualBonus -> q_annual_bonus`, which is converted to `bonusPourcentage` and therefore included in `revenuBrutAnnuel`; `hasAvsGaps -> q_avs_lacunes_status`, which is read into `prevoyance.lacunesAVS`; `avsContributionYears -> q_avs_contribution_years`, which is read into `prevoyance.anneesContribuees`.
 
 **Task T-0 (mandatory):** repair the 7 mapped-but-unread cases first. Either align the mapper to wizard keys already read by `fromWizardAnswers`, or add explicit `fromWizardAnswers` reads with tests.
 
@@ -210,7 +210,7 @@ G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.f
 | `totalSavings` | `q_cash_total` | `q_cash_total` | ✅ repaired; keep mapping on `q_cash_total` |
 | `wealthEstimate` | `q_wealth_estimate` | `q_wealth_estimate` | ✅ repaired; aggregate for `totalPatrimoine`, never added on top of detailed assets |
 
-**Task T-1 (mandatory):** add a `case` for each of the 11 unmapped keys to `_mapFactKeyToAnswers`, mapping to a wizard key that `fromWizardAnswers` already reads where one exists. Where no wizard key exists yet in `fromWizardAnswers`, add BOTH the mapper case AND the read.
+**Task T-1 (mandatory):** add a `case` for each of the 9 unmapped keys to `_mapFactKeyToAnswers`, mapping to a wizard key that `fromWizardAnswers` already reads where one exists. Where no wizard key exists yet in `fromWizardAnswers`, add BOTH the mapper case AND the read.
 
 | allowlist key | wizard key to add | `fromWizardAnswers` target field |
 |---|---|---|
@@ -223,8 +223,6 @@ G1 found a second gap: **7 mapped keys wrote to wizard keys that `CoachProfile.f
 | `spouseBirthYear` | `q_partner_birth_year` | `conjoint.birthYear` |
 | `spouseIncomeNetMonthly` | `q_partner_net_income_chf` | `conjoint.salaireBrutMensuel` (net->gross handling per existing conjoint logic) |
 | `spouseAvsContributionYears` | add `q_spouse_avs_contribution_years` | `conjoint.prevoyance` AVS years |
-| `hasAvsGaps` | add boolean/status mapping to `q_avs_lacunes_status` or `_coach_avs_lacunes` | `prevoyance.lacunesAVS` flag |
-| `avsContributionYears` | `q_avs_contribution_years` | `prevoyance.anneesContribuees` |
 
 After T-0 and T-1, `_mapFactKeyToAnswers` handles all 35 keys and every mapper target is actually read by `fromWizardAnswers`; the §8.1 parity test passes. Until both tasks land, that test is expected RED and gates the PR.
 


### PR DESCRIPTION
## Summary
- Map `avsContributionYears` to `q_avs_contribution_years` so DataQuest save facts hydrate `prevoyance.anneesContribuees`.
- Map `hasAvsGaps` to `q_avs_lacunes_status`, while preserving already precise `arrived_late` / `lived_abroad` AVS statuses.
- Update `docs/codex/DATA_LEDGER.md` from 11 to 9 remaining unmapped backend-writable keys.

## QA
- `flutter test test/providers/coach_profile_provider_test.dart test/services/coach_profile_wizard_test.dart test/services/avs_logic_test.dart` — 56 tests passed
- `flutter analyze lib/providers/coach_profile_provider.dart test/providers/coach_profile_provider_test.dart` — no issues
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py tools/checks/tests/test_claude_external_audit_contract.py -q` — 31 passed
- `lefthook run pre-commit --file apps/mobile/lib/providers/coach_profile_provider.dart --file apps/mobile/test/providers/coach_profile_provider_test.dart --file docs/codex/DATA_LEDGER.md` — passed
- `tools/checks/claude_external_audit.sh code HEAD` — PASS
- `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code HEAD` — PASS after covering arrived-late guard path

## Runtime
- No UI route or screen changed; Maestro/Patrol runtime proof not applicable for this slice.
