### PR TITLE
tools: guard concurrent Claude audits

### DIFF
--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -12,7 +12,8 @@ CLAUDE_AUDIT_WORKTREE, CLAUDE_AUDIT_BARE, CLAUDE_AUDIT_SETTINGS,
 CLAUDE_AUDIT_SETTING_SOURCES, CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS,
 CLAUDE_AUDIT_MAX_BUDGET_USD, CLAUDE_AUDIT_MAX_DIFF_LINES,
 CLAUDE_AUDIT_ALLOW_LARGE_DIFF, CLAUDE_AUDIT_RERUN,
-CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN, CLAUDE_AUDIT_DRY_RUN.
+CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN, CLAUDE_AUDIT_LOCK_DIR,
+CLAUDE_AUDIT_DRY_RUN.
 EOF
 }
 die() {
@@ -52,6 +53,43 @@ if [[ "$rerun" == "1" && "$model" != *sonnet* && "${CLAUDE_AUDIT_ALLOW_NON_SONNE
 fi
 repo_root="$(git rev-parse --show-toplevel)"
 worktree="${CLAUDE_AUDIT_WORKTREE:-$repo_root}"
+prompt_file=""
+repo_lock_key="$(printf '%s' "$repo_root" | shasum -a 256 | awk '{print $1}')"
+lock_parent="${CLAUDE_AUDIT_LOCK_DIR:-${TMPDIR:-/tmp}}"
+lock_dir="${lock_parent%/}/mint-claude-audit-${repo_lock_key}.lock"
+
+acquire_audit_lock() {
+  if mkdir "$lock_dir" 2>/dev/null; then
+    printf '%s\n' "$$" >"$lock_dir/pid"
+    printf '%s\n' "$mode" >"$lock_dir/mode"
+    return
+  fi
+
+  local existing_pid existing_mode
+  existing_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  existing_mode="$(cat "$lock_dir/mode" 2>/dev/null || true)"
+  if [[ -n "$existing_pid" ]] && ! kill -0 "$existing_pid" 2>/dev/null; then
+    rm -rf "$lock_dir"
+    if mkdir "$lock_dir" 2>/dev/null; then
+      printf '%s\n' "$$" >"$lock_dir/pid"
+      printf '%s\n' "$mode" >"$lock_dir/mode"
+      return
+    fi
+  fi
+
+  die "another Claude audit is already running for this repo${existing_pid:+ (pid ${existing_pid})}${existing_mode:+, mode ${existing_mode}}; let it finish instead of launching a duplicate"
+}
+
+release_audit_lock() {
+  if [[ -f "$lock_dir/pid" ]] && [[ "$(cat "$lock_dir/pid" 2>/dev/null || true)" == "$$" ]]; then
+    rm -rf "$lock_dir"
+  fi
+}
+
+if [[ "${CLAUDE_AUDIT_DRY_RUN:-}" != "1" ]]; then
+  acquire_audit_lock
+  trap 'release_audit_lock; [[ -n "${prompt_file:-}" ]] && rm -f "$prompt_file"' EXIT
+fi
 max_diff_lines="${CLAUDE_AUDIT_MAX_DIFF_LINES:-2500}"
 case "$max_diff_lines" in ""|*[!0-9]*) die "CLAUDE_AUDIT_MAX_DIFF_LINES must be a non-negative integer" ;; esac
 setting_sources="${CLAUDE_AUDIT_SETTING_SOURCES:-user}"
@@ -74,7 +112,9 @@ for setting_source in "${setting_source_parts[@]}"; do
   esac
 done
 prompt_file="$(mktemp "${TMPDIR:-/tmp}/mint-claude-audit.XXXXXX")"
-trap 'rm -f "$prompt_file"' EXIT
+if [[ "${CLAUDE_AUDIT_DRY_RUN:-}" == "1" ]]; then
+  trap 'rm -f "$prompt_file"' EXIT
+fi
 
 count_diff_lines() {
   git -C "$repo_root" diff "$@" | wc -l | tr -d '[:space:]'

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -70,6 +71,74 @@ def test_wrapper_is_syntax_valid_and_executable() -> None:
 
     assert result.returncode == 0, result.stderr
     assert os.access(SCRIPT, os.X_OK)
+
+
+def test_wrapper_rejects_concurrent_live_audits(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    release_file = tmp_path / "release"
+    fake_claude = fake_bin / "claude"
+    fake_claude.write_text(
+        "#!/usr/bin/env bash\n"
+        'while [ ! -f "$CLAUDE_FAKE_RELEASE" ]; do sleep 0.05; done\n'
+        'printf "fake claude done\\n"\n',
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "CLAUDE_AUDIT_LOCK_DIR": str(tmp_path),
+            "CLAUDE_FAKE_RELEASE": str(release_file),
+        }
+    )
+    first = subprocess.Popen(
+        ["bash", str(SCRIPT), "specs"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        lock_paths: list[Path] = []
+        while time.monotonic() < deadline:
+            lock_paths = list(tmp_path.glob("mint-claude-audit-*.lock"))
+            if lock_paths:
+                break
+            if first.poll() is not None:
+                stdout, stderr = first.communicate()
+                pytest.fail(
+                    f"first audit exited before creating lock: {first.returncode}\n"
+                    f"stdout={stdout}\nstderr={stderr}"
+                )
+            time.sleep(0.05)
+
+        assert lock_paths, "first audit did not create a lock"
+        second = subprocess.run(
+            ["bash", str(SCRIPT), "specs"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert second.returncode == 2
+        assert "another Claude audit is already running for this repo" in second.stderr
+        assert "let it finish instead of launching a duplicate" in second.stderr
+    finally:
+        release_file.write_text("ok", encoding="utf-8")
+        try:
+            first.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            first.kill()
+            first.wait(timeout=5)
+
+    assert list(tmp_path.glob("mint-claude-audit-*.lock")) == []
 
 
 def test_wrapper_defaults_are_bounded() -> None:


### PR DESCRIPTION
## Summary
- add a per-repo live-audit lock to tools/checks/claude_external_audit.sh
- reject duplicate concurrent Claude audits with a clear message to let the running audit finish
- cover the behavior with a fake-Claude contract test

## Verification
- bash -n tools/checks/claude_external_audit.sh
- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q
- python3 -m pytest tools/checks/tests/test_instruction_hygiene_contract.py -q
- git diff --check
- lefthook run pre-commit --file tools/checks/claude_external_audit.sh --file tools/checks/tests/test_claude_external_audit_contract.py
- CLAUDE_AUDIT_DRY_RUN=1 tools/checks/claude_external_audit.sh specs | sed -n '1,24p'