### PR TITLE
fix(mobile): hydrate final DataQuest save_fact keys

### DIFF
--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -316,6 +316,8 @@ class PrevoyanceProfile {
   final double? avoirLppSurobligatoire; // part surobligatoire (taux caisse)
   final double? rachatMaximum; // lacune de rachat totale
   final double? rachatEffectue; // déjà racheté (montant CHF cumulé)
+  final bool? hasPensionFund; // user-declared LPP eligibility
+  final bool? hasVoluntaryLpp; // prevoyance facultative for independants
   /// Historique daté des rachats LPP (ordre chronologique, plus récent en
   /// dernier). swiss-brain Q4 2026-04-18 : le blocage 3 ans (LPP art. 79b
   /// al. 3, confirmé par ATF 142 II 399 + ATF 148 II 189) part de la date
@@ -358,6 +360,8 @@ class PrevoyanceProfile {
     this.avoirLppSurobligatoire,
     this.rachatMaximum,
     this.rachatEffectue,
+    this.hasPensionFund,
+    this.hasVoluntaryLpp,
     this.dateRachats = const [],
     this.tauxConversion = lppTauxConversionMinDecimal,
     this.tauxConversionSuroblig,
@@ -431,6 +435,8 @@ class PrevoyanceProfile {
           (json['avoirLppSurobligatoire'] as num?)?.toDouble(),
       rachatMaximum: (json['rachatMaximum'] as num?)?.toDouble(),
       rachatEffectue: (json['rachatEffectue'] as num?)?.toDouble(),
+      hasPensionFund: json['hasPensionFund'] as bool?,
+      hasVoluntaryLpp: json['hasVoluntaryLpp'] as bool?,
       dateRachats: (json['dateRachats'] as List?)
               ?.map((s) => DateTime.parse(s as String))
               .toList() ??
@@ -471,6 +477,8 @@ class PrevoyanceProfile {
     double? avoirLppSurobligatoire,
     double? rachatMaximum,
     double? rachatEffectue,
+    bool? hasPensionFund,
+    bool? hasVoluntaryLpp,
     List<DateTime>? dateRachats,
     double? tauxConversion,
     double? tauxConversionSuroblig,
@@ -499,6 +507,8 @@ class PrevoyanceProfile {
       avoirLppSurobligatoire: avoirLppSurobligatoire ?? this.avoirLppSurobligatoire,
       rachatMaximum: rachatMaximum ?? this.rachatMaximum,
       rachatEffectue: rachatEffectue ?? this.rachatEffectue,
+      hasPensionFund: hasPensionFund ?? this.hasPensionFund,
+      hasVoluntaryLpp: hasVoluntaryLpp ?? this.hasVoluntaryLpp,
       dateRachats: dateRachats ?? this.dateRachats,
       tauxConversion: tauxConversion ?? this.tauxConversion,
       tauxConversionSuroblig: tauxConversionSuroblig ?? this.tauxConversionSuroblig,
@@ -529,6 +539,8 @@ class PrevoyanceProfile {
         'avoirLppSurobligatoire': avoirLppSurobligatoire,
         'rachatMaximum': rachatMaximum,
         'rachatEffectue': rachatEffectue,
+        'hasPensionFund': hasPensionFund,
+        'hasVoluntaryLpp': hasVoluntaryLpp,
         'dateRachats':
             dateRachats.map((d) => d.toIso8601String()).toList(),
         'tauxConversion': tauxConversion,
@@ -563,6 +575,8 @@ class PrevoyanceProfile {
           avoirLppSurobligatoire == other.avoirLppSurobligatoire &&
           rachatMaximum == other.rachatMaximum &&
           rachatEffectue == other.rachatEffectue &&
+          hasPensionFund == other.hasPensionFund &&
+          hasVoluntaryLpp == other.hasVoluntaryLpp &&
           listEquals(dateRachats, other.dateRachats) &&
           tauxConversion == other.tauxConversion &&
           tauxConversionSuroblig == other.tauxConversionSuroblig &&
@@ -592,6 +606,8 @@ class PrevoyanceProfile {
         avoirLppSurobligatoire,
         rachatMaximum,
         rachatEffectue,
+        hasPensionFund,
+        hasVoluntaryLpp,
         Object.hashAll(dateRachats),
         tauxConversion,
         tauxConversionSuroblig,
@@ -1362,6 +1378,7 @@ class CoachProfile {
   final double employmentRate; // 0.0-100.0 (%), default full-time
   final String
       employmentStatus; // 'salarie', 'independant', 'chomage', 'retraite'
+  final double? selfEmployedNetIncome; // CHF/year for independants
 
   // === DEPENSES ===
   final DepensesProfile depenses;
@@ -1490,6 +1507,7 @@ class CoachProfile {
     this.employmentRate =
         IncomeConversionCalculator.fullTimeEmploymentRatePercent,
     this.employmentStatus = 'salarie',
+    this.selfEmployedNetIncome,
     this.depenses = const DepensesProfile(),
     this.prevoyance = const PrevoyanceProfile(),
     this.patrimoine = const PatrimoineProfile(),
@@ -1620,6 +1638,7 @@ class CoachProfile {
           bonusPourcentage == other.bonusPourcentage &&
           employmentRate == other.employmentRate &&
           employmentStatus == other.employmentStatus &&
+          selfEmployedNetIncome == other.selfEmployedNetIncome &&
           depenses == other.depenses &&
           prevoyance == other.prevoyance &&
           patrimoine == other.patrimoine &&
@@ -1649,6 +1668,7 @@ class CoachProfile {
         firstName, birthYear, dateOfBirth, canton, commune, nationality,
         etatCivil, nombreEnfants, conjoint, salaireBrutMensuel,
         nombreDeMois, bonusPourcentage, employmentRate, employmentStatus,
+        selfEmployedNetIncome,
         depenses, prevoyance, patrimoine, dettes, goalA,
         goalsB.length, plannedContributions.length, checkIns.length,
         housingStatus, riskTolerance, realEstateProject,
@@ -1953,6 +1973,7 @@ class CoachProfile {
     double? bonusPourcentage,
     double? employmentRate,
     String? employmentStatus,
+    double? selfEmployedNetIncome,
     DepensesProfile? depenses,
     PrevoyanceProfile? prevoyance,
     PatrimoineProfile? patrimoine,
@@ -2005,6 +2026,8 @@ class CoachProfile {
       bonusPourcentage: bonusPourcentage ?? this.bonusPourcentage,
       employmentRate: employmentRate ?? this.employmentRate,
       employmentStatus: employmentStatus ?? this.employmentStatus,
+      selfEmployedNetIncome:
+          selfEmployedNetIncome ?? this.selfEmployedNetIncome,
       depenses: depenses ?? this.depenses,
       prevoyance: prevoyance ?? this.prevoyance,
       patrimoine: patrimoine ?? this.patrimoine,
@@ -2186,6 +2209,8 @@ class CoachProfile {
         (json['employmentRate'] as num?)?.toDouble(),
       ),
       employmentStatus: json['employmentStatus'] ?? 'salarie',
+      selfEmployedNetIncome:
+          (json['selfEmployedNetIncome'] as num?)?.toDouble(),
       depenses: json['depenses'] != null
           ? DepensesProfile.fromJson(json['depenses'])
           : const DepensesProfile(),
@@ -2294,6 +2319,7 @@ class CoachProfile {
         'bonusPourcentage': bonusPourcentage,
         'employmentRate': employmentRate,
         'employmentStatus': employmentStatus,
+        'selfEmployedNetIncome': selfEmployedNetIncome,
         'depenses': depenses.toJson(),
         'prevoyance': prevoyance.toJson(),
         'patrimoine': patrimoine.toJson(),
@@ -2375,8 +2401,15 @@ class CoachProfile {
     // FIX-P0-2: Normalize to lowercase — "Yearly" (capitalized) was not
     // recognized, causing annual salary to be treated as monthly.
     final payFrequency =
-        (answers['q_pay_frequency'] as String?)?.toLowerCase() ?? 'monthly';
-    final netIncome = _parseDouble(answers['q_net_income_period_chf']) ?? 5000;
+        (answers['q_pay_frequency'] as String?)?.toLowerCase() ??
+            (answers.containsKey('q_self_employed_income')
+                ? 'yearly'
+                : 'monthly');
+    final selfEmployedNetIncome =
+        _parseDouble(answers['q_self_employed_income']);
+    final netIncome = _parseDouble(answers['q_net_income_period_chf']) ??
+        selfEmployedNetIncome ??
+        5000;
 
     // Convert to monthly net income based on pay frequency
     double monthlyNetIncome;
@@ -2419,7 +2452,8 @@ class CoachProfile {
             _parseDouble(answers['q_bonus_percentage']);
 
     // Employment status mapping
-    final employmentRaw = answers['q_employment_status'] as String?;
+    final employmentRaw = (answers['q_employment_status'] as String?) ??
+        (selfEmployedNetIncome != null ? 'independant' : null);
     final employmentStatus = _parseEmploymentStatus(employmentRaw);
 
     // ── Depenses ────────────────────────────────────────────
@@ -2460,7 +2494,12 @@ class CoachProfile {
     );
 
     // ── Prevoyance ──────────────────────────────────────────
-    final hasPensionFund = _parseBool(answers['q_has_pension_fund']);
+    final hasVoluntaryLpp = answers.containsKey('q_has_voluntary_lpp')
+        ? _parseBool(answers['q_has_voluntary_lpp'])
+        : null;
+    final hasPensionFund = answers.containsKey('q_has_pension_fund')
+        ? _parseBool(answers['q_has_pension_fund'])
+        : hasVoluntaryLpp ?? false;
     final lppBuybackAvailable =
         _parseDouble(answers['q_lpp_buyback_available']);
     final has3a = _parseBool(answers['q_has_3a']);
@@ -2543,6 +2582,8 @@ class CoachProfile {
       avoirLppTotal: estimatedLpp,
       avoirLppObligatoire: coachAvoirLppOblig,
       avoirLppSurobligatoire: coachAvoirLppSuroblig,
+      hasPensionFund: hasPensionFund,
+      hasVoluntaryLpp: hasVoluntaryLpp,
       tauxConversion: coachTauxConversion ?? lppTauxConversionMinDecimal,
       tauxConversionSuroblig: coachTauxConvSuroblig,
       rachatMaximum: coachRachatMax ?? lppBuybackAvailable,
@@ -2761,11 +2802,14 @@ class CoachProfile {
     ConjointProfile? conjoint;
     final partnerIncome = _parseDouble(answers['q_partner_net_income_chf']);
     final partnerBirthYear = _parseInt(answers['q_partner_birth_year']);
+    final rawSpouseAvsYears =
+        _parseInt(answers['q_spouse_avs_contribution_years']);
     final conjEmployment = answers['q_partner_employment_status'] as String?;
     final conjNationality = answers['q_partner_nationality'] as String?;
     final partnerChildren = _parseInt(answers['q_partner_enfants']);
     final hasPartnerData = (partnerIncome != null && partnerIncome > 0) ||
         partnerBirthYear != null ||
+        rawSpouseAvsYears != null ||
         (conjEmployment?.isNotEmpty ?? false) ||
         (conjNationality?.isNotEmpty ?? false) ||
         partnerChildren != null;
@@ -2826,7 +2870,13 @@ class CoachProfile {
 
       // === Conjoint prevoyance profile ===
       // FATCA hard block: most providers refuse US persons (LSFin compliance).
+      final spouseAvsYearsMax = partnerBirthYear != null
+          ? (DateTime.now().year - partnerBirthYear - 20).clamp(0, 44)
+          : 44;
+      final spouseAvsYears =
+          rawSpouseAvsYears?.clamp(0, spouseAvsYearsMax).toInt();
       final conjointPrevoyance = PrevoyanceProfile(
+        anneesContribuees: spouseAvsYears,
         lacunesAVS: spouseAvsGaps > 0 ? spouseAvsGaps : null,
         avoirLppTotal: conjLppEstimate,
         canContribute3a: !conjIsFatca,
@@ -2931,6 +2981,15 @@ class CoachProfile {
         answers.containsKey('q_gross_salary_annual')) {
       provided.add('salary');
     }
+    if (answers.containsKey('q_self_employed_income')) {
+      provided.add('selfEmployedNetIncome');
+    }
+    if (answers.containsKey('q_has_pension_fund')) {
+      provided.add('hasPensionFund');
+    }
+    if (answers.containsKey('q_has_voluntary_lpp')) {
+      provided.add('hasVoluntaryLpp');
+    }
     if (answers.containsKey('q_employment_rate')) provided.add('employmentRate');
     if (answers.containsKey('q_annual_bonus')) provided.add('bonusPourcentage');
     if (answers.containsKey('q_civil_status')) provided.add('civilStatus');
@@ -2951,6 +3010,7 @@ class CoachProfile {
       bonusPourcentage: bonusPourcentage,
       employmentRate: employmentRate,
       employmentStatus: employmentStatus,
+      selfEmployedNetIncome: selfEmployedNetIncome,
       depenses: depenses,
       prevoyance: prevoyance,
       patrimoine: patrimoine,

--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -580,6 +580,8 @@ class CoachProfileProvider extends ChangeNotifier {
         return {'q_civil_status': value};
       case 'employmentStatus':
         return {'q_employment_status': value};
+      case 'goal':
+        return {'q_main_goal': value};
       case 'gender':
         return {'q_gender': value};
       case 'targetRetirementAge':
@@ -606,6 +608,16 @@ class CoachProfileProvider extends ChangeNotifier {
         return {'q_employment_rate': value};
       case 'annualBonus':
         return {'q_annual_bonus': value};
+      case 'selfEmployedNetIncome':
+        final income = _asNum(value);
+        if (income == null) return const {};
+        final normalized = income < 0 ? 0 : income;
+        return {
+          'q_self_employed_income': normalized,
+          'q_net_income_period_chf': normalized,
+          'q_pay_frequency': 'yearly',
+          'q_employment_status': 'independant',
+        };
       // LPP — align with keys fromWizardAnswers reads for scan data
       case 'avoirLpp':
         return {'_coach_avoir_lpp': value};
@@ -617,6 +629,18 @@ class CoachProfileProvider extends ChangeNotifier {
         return {'_coach_salaire_assure': value};
       case 'lppBuybackMax':
         return {'_coach_rachat_maximum': value};
+      case 'has2ndPillar':
+        final hasPillar = _asBool(value);
+        if (hasPillar == null) return const {};
+        return {'q_has_pension_fund': hasPillar ? 'yes' : 'no'};
+      case 'hasVoluntaryLpp':
+        final hasVoluntary = _asBool(value);
+        if (hasVoluntary == null) return const {};
+        final answers = {'q_has_voluntary_lpp': hasVoluntary ? 'yes' : 'no'};
+        if (hasVoluntary || _profile?.employmentStatus == 'independant') {
+          answers['q_has_pension_fund'] = hasVoluntary ? 'yes' : 'no';
+        }
+        return answers;
       // 3a
       case 'pillar3aAnnual':
         return {'q_3a_annual_contribution': value};
@@ -670,6 +694,11 @@ class CoachProfileProvider extends ChangeNotifier {
         final income = _asNum(value);
         if (income == null) return const {};
         return {'q_partner_net_income_chf': income < 0 ? 0 : income};
+      case 'spouseAvsContributionYears':
+        if (_profile?.isCouple != true) return const {};
+        final years = _asNum(value)?.toInt();
+        if (years == null) return const {};
+        return {'q_spouse_avs_contribution_years': years.clamp(0, 44)};
       // AVS
       case 'avsContributionYears':
         return {'q_avs_contribution_years': value};
@@ -1155,7 +1184,20 @@ class CoachProfileProvider extends ChangeNotifier {
     if (profile.employmentStatus.isNotEmpty) {
       answers['q_employment_status'] = profile.employmentStatus;
     }
+    if (profile.selfEmployedNetIncome != null) {
+      answers['q_self_employed_income'] = profile.selfEmployedNetIncome;
+      answers['q_net_income_period_chf'] = profile.selfEmployedNetIncome;
+      answers['q_pay_frequency'] = 'yearly';
+    }
     // Prevoyance
+    if (profile.prevoyance.hasPensionFund != null) {
+      answers['q_has_pension_fund'] =
+          profile.prevoyance.hasPensionFund! ? 'yes' : 'no';
+    }
+    if (profile.prevoyance.hasVoluntaryLpp != null) {
+      answers['q_has_voluntary_lpp'] =
+          profile.prevoyance.hasVoluntaryLpp! ? 'yes' : 'no';
+    }
     if (profile.prevoyance.avoirLppTotal != null) {
       answers['q_avoir_lpp'] = profile.prevoyance.avoirLppTotal;
     }
@@ -1210,6 +1252,10 @@ class CoachProfileProvider extends ChangeNotifier {
       }
       if (c.nombreEnfants != null) {
         answers['q_partner_enfants'] = c.nombreEnfants;
+      }
+      if (c.prevoyance?.anneesContribuees != null) {
+        answers['q_spouse_avs_contribution_years'] =
+            c.prevoyance!.anneesContribuees;
       }
     } else {
       _clearPartnerAnswers(answers);

--- a/apps/mobile/test/providers/coach_profile_provider_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_test.dart
@@ -355,6 +355,20 @@ void main() {
     expect(provider.profile?.conjoint, isNull);
   });
 
+  test('save_fact spouse AVS contribution years hydrates conjoint prevoyance',
+      () async {
+    final provider = CoachProfileProvider();
+    provider.updateProfile(
+      CoachProfile.defaults().copyWith(etatCivil: CoachCivilStatus.marie),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(await provider.applySaveFact('spouseAvsContributionYears', 35),
+        isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_spouse_avs_contribution_years', 35));
+    expect(provider.profile?.conjoint?.prevoyance?.anneesContribuees, 35);
+  });
+
   test('updateProfile preserves spouse income through readable keys', () async {
     final provider = CoachProfileProvider();
     final profile = CoachProfile.defaults().copyWith(
@@ -484,5 +498,65 @@ void main() {
     expect(answers['_coach_dettes_autres'], isNull);
     expect(provider.profile?.dettes.creditConsommation, 6000);
     expect(provider.profile?.dettes.totalDettes, 6000);
+  });
+
+  test('save_fact goal writes the readable main goal key', () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('goal', 'house'), isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_main_goal', 'house'));
+    expect(provider.profile?.goalA.type, GoalAType.achatImmo);
+  });
+
+  test('save_fact selfEmployedNetIncome hydrates independent income',
+      () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('selfEmployedNetIncome', 120000),
+        isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_self_employed_income', 120000));
+    expect(answers, containsPair('q_net_income_period_chf', 120000));
+    expect(answers, containsPair('q_pay_frequency', 'yearly'));
+    expect(answers, containsPair('q_employment_status', 'independant'));
+    expect(provider.profile?.employmentStatus, 'independant');
+    expect(provider.profile?.toJson()['selfEmployedNetIncome'], 120000);
+    final restored = CoachProfile.fromJson(provider.profile!.toJson());
+    expect(restored.toJson()['selfEmployedNetIncome'], 120000);
+  });
+
+  test('save_fact has2ndPillar false disables LPP estimation', () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+    expect(await provider.applySaveFact('incomeGrossYearly', 120000), isTrue);
+    expect(await provider.applySaveFact('has2ndPillar', false), isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_has_pension_fund', 'no'));
+    expect(provider.profile?.prevoyance.avoirLppTotal, 0);
+  });
+
+  test('save_fact hasVoluntaryLpp false preserves salaried LPP', () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('incomeGrossYearly', 120000), isTrue);
+    expect(await provider.applySaveFact('has2ndPillar', true), isTrue);
+    expect(await provider.applySaveFact('hasVoluntaryLpp', false), isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_has_voluntary_lpp', 'no'));
+    expect(answers, containsPair('q_has_pension_fund', 'yes'));
+  });
+
+  test('save_fact hasVoluntaryLpp enables independent LPP path', () async {
+    final provider = CoachProfileProvider();
+    expect(await provider.applySaveFact('birthYear', 1980), isTrue);
+    expect(await provider.applySaveFact('incomeGrossYearly', 120000), isTrue);
+    expect(await provider.applySaveFact('employmentStatus', 'independant'),
+        isTrue);
+    expect(await provider.applySaveFact('hasVoluntaryLpp', true), isTrue);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_has_voluntary_lpp', 'yes'));
+    expect(answers, containsPair('q_has_pension_fund', 'yes'));
+    expect(provider.profile?.prevoyance.toJson()['hasVoluntaryLpp'], true);
+    final restored = CoachProfile.fromJson(provider.profile!.toJson());
+    expect(restored.prevoyance.toJson()['hasVoluntaryLpp'], true);
+    expect(provider.profile?.prevoyance.avoirLppTotal, greaterThan(0));
   });
 }


### PR DESCRIPTION
## Summary
- Hydrates the five remaining DataQuest `save_fact` keys into canonical wizard answers: `goal`, `selfEmployedNetIncome`, `has2ndPillar`, `hasVoluntaryLpp`, and `spouseAvsContributionYears`.
- Persists the new profile fields through `CoachProfile` / `PrevoyanceProfile` JSON, equality, hash, and `copyWith`.
- Preserves data chronology and avoids duplicate stores by routing all facts through `ReportPersistenceService` answers, then rebuilding `CoachProfile.fromWizardAnswers`.

## QA
- `cd apps/mobile && flutter test test/providers/coach_profile_provider_test.dart` — 31/31 pass
- `cd apps/mobile && flutter test test/providers/` — 112/112 pass
- `cd apps/mobile && flutter test test/services/coach_profile_wizard_test.dart` — 40/40 pass
- `cd apps/mobile && flutter analyze lib/models/coach_profile.dart lib/providers/coach_profile_provider.dart test/providers/coach_profile_provider_test.dart` — no issues
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q` — 4/4 pass
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q` — 28/28 pass after commit in clean worktree
- `CLAUDE_AUDIT_MAX_DIFF_LINES=4000 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` — PASS, no P0/P1

## External Audit Notes
Claude external audit reported PASS with two P2 follow-ups, both left out of this PR to keep the slice atomic:
- Normalize pre-existing `q_has_pension_fund` bool/string inconsistency in `data_block_enrichment_screen.dart`.
- Review self-employed net/gross approximation consistency between `CoachProfile.fromWizardAnswers` and `budget_living_engine.dart`.
