### PR TITLE
fix(mobile): normalize pension fund answer storage

### DIFF
--- a/apps/mobile/lib/providers/coach_profile_provider.dart
+++ b/apps/mobile/lib/providers/coach_profile_provider.dart
@@ -829,7 +829,9 @@ class CoachProfileProvider extends ChangeNotifier {
       'q_employment_status': effectiveEmployment,
       // LPP access: salary > seuil AND salarié (LPP art. 7 — indépendants: opt.)
       'q_has_pension_fund':
-          clampedGrossSalary >= 22680 && effectiveEmployment != 'independant',
+          clampedGrossSalary >= 22680 && effectiveEmployment != 'independant'
+              ? 'yes'
+              : 'no',
       // AVS years estimated from age and situation (LAVS art. 29)
       'q_avs_contribution_years': avsContributionYears,
       // P2-15: Flag when AVS years were clamped to [0,44] so UI can warn user.

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -424,7 +424,7 @@ class _DataBlockEnrichmentScreenState
       if (capturesBirthYear && birthYear != null) 'q_birth_year': birthYear,
       if (capturesPensionFund &&
           (_hasPensionFundTouched || onlyInputKey == 'q_has_pension_fund'))
-        'q_has_pension_fund': _hasPensionFund,
+        'q_has_pension_fund': _hasPensionFund ? 'yes' : 'no',
     };
 
     if (answers.isNotEmpty) {

--- a/apps/mobile/test/providers/coach_profile_provider_tax_extraction_test.dart
+++ b/apps/mobile/test/providers/coach_profile_provider_tax_extraction_test.dart
@@ -52,6 +52,27 @@ void main() {
       );
     });
 
+    test('smart flow stores pension fund eligibility as yes/no strings',
+        () async {
+      final provider = CoachProfileProvider();
+      await provider.updateFromSmartFlow(
+        age: 35,
+        grossSalary: 120000,
+        canton: 'VD',
+      );
+      var answers = await ReportPersistenceService.loadAnswers();
+      expect(answers, containsPair('q_has_pension_fund', 'yes'));
+
+      await provider.updateFromSmartFlow(
+        age: 35,
+        grossSalary: 120000,
+        canton: 'VD',
+        employmentStatus: 'independant',
+      );
+      answers = await ReportPersistenceService.loadAnswers();
+      expect(answers, containsPair('q_has_pension_fund', 'no'));
+    });
+
     test('persists canonical tax fields and data sources', () async {
       final provider = CoachProfileProvider();
       await provider.updateFromSmartFlow(

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -58,7 +58,7 @@ void main() {
     expect((answers['q_gross_salary_annual'] as num).toDouble(), 96000);
     expect(answers['q_canton'], 'GE');
     expect(answers['q_birth_year'], 2001);
-    expect(answers['q_has_pension_fund'], true);
+    expect(answers['q_has_pension_fund'], 'yes');
     expect(answers.containsKey('q_net_income_period_chf'), isFalse);
     expect(answers.containsKey('q_monthly_gross_salary_chf'), isFalse);
 
@@ -158,7 +158,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final answers = await ReportPersistenceService.loadAnswers();
-    expect(answers, containsPair('q_has_pension_fund', false));
+    expect(answers, containsPair('q_has_pension_fund', 'no'));
     expect(provider.profile, isNotNull);
   });
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -111,7 +111,8 @@ Read by `CoachProfile.fromWizardAnswers`. Sorted by domain.
   `_coach_avs_ramd`, `_coach_avs_source`
 
 **LPP (2nd pillar)**
-- `q_avoir_lpp` (total legacy), `_coach_avoir_lpp` (scanned total),
+- `q_has_pension_fund` (`yes`|`no` string), `q_avoir_lpp` (total legacy),
+  `_coach_avoir_lpp` (scanned total),
   `_coach_avoir_lpp_oblig`, `_coach_avoir_lpp_suroblig`,
   `_coach_taux_conversion`, `_coach_taux_conversion_suroblig`,
   `_coach_salaire_assure`, `_coach_rachat_maximum`,


### PR DESCRIPTION
## Summary
- Normalize `q_has_pension_fund` producers to store canonical `yes`/`no` strings instead of Dart bools.
- Cover both smart-flow and DataQuest revenue block persistence.
- Document the LPP key contract in `docs/data-flow.md`.

## QA
- `cd apps/mobile && flutter test test/screens/data_block_enrichment_screen_test.dart test/providers/coach_profile_provider_tax_extraction_test.dart test/services/educational_insert_service_test.dart` → 60/60 passed
- `cd apps/mobile && flutter test test/providers/` → 107/107 passed earlier in the slice before the final service rollback; no provider-impacting code changed after that
- `cd apps/mobile && flutter analyze lib/screens/onboarding/data_block_enrichment_screen.dart lib/providers/coach_profile_provider.dart test/screens/data_block_enrichment_screen_test.dart test/providers/coach_profile_provider_tax_extraction_test.dart` → No issues
- `python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q` → 4/4 passed
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → PASS, no P0/P1

## Notes
Claude flagged a P2 on `has2ndPillar` Dart mapping that is already addressed by PR #902. It also noted a display-tier legacy bool compatibility issue in `EducationalInsertService`; I attempted the fix, but touching that legacy file correctly triggers `no-hardcoded-fr` due pre-existing hardcoded French strings, so that belongs in a dedicated i18n/refactor slice rather than bypassing hooks.
