### PR TITLE
chore(agents): cap repeated Claude audit loops

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -48,6 +48,8 @@ confirmation. The wrapper rejects non-Sonnet reruns unless
 `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly set for a final
 confirmation or P0 dispute. This avoids paying full startup hooks, MCP servers, memory
 injection, skill inventory, and max reasoning on every tool turn.
+No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
+if still blocked, fix or triage the findings instead of relaunching the same gate.
 
 Do not replace safe mode with ad hoc minimal settings. Do not add
 `--max-turns`: the installed Claude CLI does not expose it, and the wrapper

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -60,6 +60,8 @@ before review. Repeated same-gate re-audits should use Sonnet high first via
 `CLAUDE_AUDIT_RERUN=1`, then one Opus high final. The wrapper rejects
 non-Sonnet reruns unless `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly set for a
 final confirmation or P0 dispute.
+No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
+if still blocked, fix or triage the findings instead of relaunching the same gate.
 
 For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ If a rerun needs Opus for final confirmation or a P0 dispute, set
 project/local settings, set `CLAUDE_AUDIT_ALLOW_PROJECT_SETTINGS=1`. Do not add
 a max-turn cap; this Claude CLI does not expose `--max-turns`, and the wrapper
 rejects `CLAUDE_AUDIT_MAX_TURNS` so agents cannot rely on a fake safety knob.
+No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
+if still blocked, fix or triage the findings instead of relaunching the same gate.
 
 ## 🗺 Before you edit X, read Y, grep Z
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ named final-release/P0 dispute with
 `CLAUDE_AUDIT_ALLOW_MAX=1`. Do not add unsupported `--max-turns`: the installed
 Claude CLI does not expose it, and the wrapper rejects `CLAUDE_AUDIT_MAX_TURNS`
 so agents cannot rely on a fake safety knob.
+No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
+if still blocked, fix or triage the findings instead of relaunching the same gate.
 
 ## 4. ROLE ROUTING
 

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -97,3 +97,5 @@ switches the default model to Sonnet and rejects non-Sonnet reruns unless
 Code audits refuse large diff prompts by default
 (`CLAUDE_AUDIT_MAX_DIFF_LINES`, default 2500); split the PR instead of
 overriding except for a named final-release/P0 dispute.
+No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
+if still blocked, fix or triage the findings instead of relaunching the same gate.

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -343,6 +343,22 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
         assert "CLAUDE_AUDIT_MAX_DIFF_LINES" in text
 
 
+def test_auditor_docs_reject_repeated_same_gate_audit_loops() -> None:
+    for text in (
+        CLAUDE_MD.read_text(encoding="utf-8"),
+        AGENT.read_text(encoding="utf-8"),
+        AGENTS_MD.read_text(encoding="utf-8"),
+        WORKFLOW.read_text(encoding="utf-8"),
+        OPERATING_GATES.read_text(encoding="utf-8"),
+    ):
+        lowered = text.lower()
+        assert "no audit carousel" in lowered
+        assert "one first pass" in lowered
+        assert "one sonnet rerun" in lowered
+        assert "one opus final confirmation" in lowered
+        assert "fix or triage" in lowered
+
+
 def test_claude_md_anchors_external_audit_latency_policy() -> None:
     text = CLAUDE_MD.read_text(encoding="utf-8")
 
@@ -359,6 +375,7 @@ def test_claude_md_anchors_external_audit_latency_policy() -> None:
         "--no-session-persistence",
         "--effort max",
         "unsupported `--max-turns`",
+        "No audit carousel",
     ):
         assert needle in text
 


### PR DESCRIPTION
## Summary
- add a checked "No audit carousel" policy across the canonical MINT agent/audit docs
- enforce that policy with the Claude external audit contract test

## Verification
- RED: new contract test failed before docs were updated
- python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q
- git diff --check
- CLAUDE_AUDIT_DRY_RUN=1 tools/checks/claude_external_audit.sh code HEAD
- CLAUDE_AUDIT_DRY_RUN=1 CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code HEAD
- lefthook run pre-commit --file CLAUDE.md --file AGENTS.md --file docs/MINT_AGENT_WORKFLOW.md --file .claude/agents/mint-external-auditor.md --file .claude/skills/mint-operating-gates/SKILL.md --file tools/checks/tests/test_claude_external_audit_contract.py
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 -> PASS, P0/P1 none