### PR TITLE
fix(mobile): prefill independent 3a from profile

### DIFF
--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -1,8 +1,10 @@
 import 'dart:math' as math;
+import 'dart:async';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -14,6 +16,7 @@ import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/widgets/common/safe_mode_gate.dart';
+import 'package:provider/provider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  PILLAR 3A INDEPENDANT SCREEN — Sprint S18
@@ -32,24 +35,87 @@ class Pillar3aIndepScreen extends StatefulWidget {
 }
 
 class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
+  static const double _incomeMin = 0;
+  static const double _incomeMax = 300000;
+
   double _revenuNet = 100000;
   bool _affilieLpp = false;
   double _tauxMarginal = 0.30;
   Pillar3aIndepResult? _result;
+  bool _didHydrateFromProfile = false;
 
   @override
   void initState() {
     super.initState();
-    _calculate();
+    _result = _computeResult();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didHydrateFromProfile) return;
+    _didHydrateFromProfile = true;
+    _hydrateFromProfile();
+  }
+
+  Pillar3aIndepResult _computeResult() {
+    return IndependantsService.calculate3aIndependant(
+      _revenuNet,
+      _affilieLpp,
+      _tauxMarginal,
+    );
   }
 
   void _calculate() {
     setState(() {
-      _result = IndependantsService.calculate3aIndependant(
-        _revenuNet,
-        _affilieLpp,
-        _tauxMarginal,
-      );
+      _result = _computeResult();
+    });
+  }
+
+  CoachProfileProvider? _profileProvider() {
+    try {
+      return context.read<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
+    }
+  }
+
+  void _hydrateFromProfile() {
+    final provider = _profileProvider();
+    final profile = provider?.profile;
+    if (profile == null) return;
+
+    final income = profile.selfEmployedNetIncome;
+    if (income != null && income > 0) {
+      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
+    }
+
+    final hasLpp = profile.prevoyance.hasVoluntaryLpp ??
+        (profile.employmentStatus == 'independant'
+            ? profile.prevoyance.hasPensionFund
+            : null);
+    if (hasLpp != null) {
+      _affilieLpp = hasLpp;
+    }
+
+    _result = _computeResult();
+  }
+
+  Future<void> _persistIncome(double value) async {
+    final provider = _profileProvider();
+    await provider?.mergeAnswers({
+      'q_self_employed_income': value,
+      'q_net_income_period_chf': value,
+      'q_pay_frequency': 'yearly',
+      'q_employment_status': 'independant',
+    });
+  }
+
+  Future<void> _persistLppChoice(bool value) async {
+    final provider = _profileProvider();
+    await provider?.mergeAnswers({
+      'q_has_voluntary_lpp': value ? 'yes' : 'no',
+      'q_has_pension_fund': value ? 'yes' : 'no',
     });
   }
 
@@ -181,6 +247,7 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
               onChanged: (v) {
                 _affilieLpp = v;
                 _calculate();
+                unawaited(_persistLppChoice(v));
               },
               activeTrackColor: MintColors.success,
             ),
@@ -205,13 +272,12 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         value: _revenuNet,
         formatValue: (v) => IndependantsService.formatChf(v),
         onChanged: (v) {
-          setState(() {
-            _revenuNet = v;
-            _calculate();
-          });
+          _revenuNet = v;
+          _calculate();
+          unawaited(_persistIncome(v));
         },
-        min: 0,
-        max: 300000,
+        min: _incomeMin,
+        max: _incomeMax,
       ),
     );
   }

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -17,6 +17,7 @@ import 'package:mint_mobile/providers/profile_provider.dart';
 import 'package:mint_mobile/providers/byok_provider.dart';
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 
@@ -27,14 +28,15 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 /// Simple wrapper for screens without provider dependencies.
 Widget buildTestable(Widget child) {
   return MaterialApp(
-locale: const Locale('fr'),
-localizationsDelegates: const [
-  S.delegate,
-  GlobalMaterialLocalizations.delegate,
-  GlobalWidgetsLocalizations.delegate,
-  GlobalCupertinoLocalizations.delegate,
-],
-supportedLocales: S.supportedLocales,home: child);
+      locale: const Locale('fr'),
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: S.supportedLocales,
+      home: child);
 }
 
 /// Wrapper that provides ProfileProvider + ByokProvider (needed by ExploreTab).
@@ -81,6 +83,69 @@ Widget buildWithBudgetProvider(Widget child) {
       child: child,
     ),
   );
+}
+
+Widget buildWithCoachProfileProvider(
+  CoachProfileProvider provider,
+  Widget child,
+) {
+  return MaterialApp(
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    home: ChangeNotifierProvider<CoachProfileProvider>.value(
+      value: provider,
+      child: child,
+    ),
+  );
+}
+
+class RecordingCoachProfileProvider extends CoachProfileProvider {
+  final Map<String, dynamic> _answers;
+  final writes = <Map<String, dynamic>>[];
+  CoachProfile? _profileOverride;
+
+  RecordingCoachProfileProvider(Map<String, dynamic> initialAnswers)
+      : _answers = Map<String, dynamic>.from(initialAnswers) {
+    _profileOverride = CoachProfile.fromWizardAnswers(_answers);
+  }
+
+  @override
+  CoachProfile? get profile => _profileOverride;
+
+  @override
+  bool get hasProfile => _profileOverride != null;
+
+  @override
+  Future<void> mergeAnswers(Map<String, dynamic> partial) async {
+    writes.add(Map<String, dynamic>.from(partial));
+    _answers.addAll(partial);
+    _profileOverride = CoachProfile.fromWizardAnswers(_answers);
+    notifyListeners();
+  }
+}
+
+Map<String, dynamic> independentAnswers({
+  double? selfIncome,
+  double? grossSalary,
+  bool voluntaryLpp = false,
+}) {
+  return {
+    if (selfIncome != null) ...{
+      'q_self_employed_income': selfIncome,
+      'q_net_income_period_chf': selfIncome,
+      'q_pay_frequency': 'yearly',
+    },
+    if (grossSalary != null) 'q_gross_salary_annual': grossSalary,
+    'q_employment_status': 'independant',
+    'q_has_voluntary_lpp': voluntaryLpp ? 'yes' : 'no',
+    'q_has_pension_fund': voluntaryLpp ? 'yes' : 'no',
+  };
 }
 
 void main() {
@@ -250,7 +315,8 @@ void main() {
       );
     });
 
-    testWidgets('has amount field and premium slider (revenu and taux)', (tester) async {
+    testWidgets('has amount field and premium slider (revenu and taux)',
+        (tester) async {
       await tester.pumpWidget(buildTestable(const Pillar3aIndepScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
@@ -276,6 +342,128 @@ void main() {
       expect(
         find.textContaining("Taux marginal"),
         findsOneWidget,
+      );
+    });
+
+    testWidgets('prefills known independent income and LPP choice',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 180000, voluntaryLpp: true),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const Pillar3aIndepScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+      final lppSwitch = tester.widget<Switch>(find.byType(Switch));
+
+      expect(amountField.value, 180000);
+      expect(lppSwitch.value, isTrue);
+    });
+
+    testWidgets('does not prefill net income from a gross salary fallback',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(grossSalary: 240000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const Pillar3aIndepScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+
+      expect(amountField.value, 100000);
+    });
+
+    testWidgets('clamps known independent income to the field maximum',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 450000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const Pillar3aIndepScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+
+      expect(amountField.value, 300000);
+    });
+
+    testWidgets('persists LPP toggle through the profile answer path',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 90000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const Pillar3aIndepScreen(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      expect(provider.writes, isNotEmpty);
+      expect(
+        provider.writes.last,
+        containsPair('q_has_voluntary_lpp', 'yes'),
+      );
+      expect(provider.writes.last, containsPair('q_has_pension_fund', 'yes'));
+    });
+
+    testWidgets('persists edited independent income through the profile path',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 90000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const Pillar3aIndepScreen(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+      amountField.onChanged(123000);
+      await tester.pump();
+
+      expect(provider.writes, isNotEmpty);
+      expect(
+        provider.writes.last,
+        containsPair('q_self_employed_income', 123000),
+      );
+      expect(
+        provider.writes.last,
+        containsPair('q_net_income_period_chf', 123000),
+      );
+      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
+      expect(
+        provider.writes.last,
+        containsPair('q_employment_status', 'independant'),
       );
     });
   });


### PR DESCRIPTION
## Summary
- Hydrate the independent 3a simulator from CoachProfile self-employed net income and voluntary LPP answers when available.
- Persist edited independent net income and voluntary LPP choice back through CoachProfileProvider mergeAnswers.
- Guard against gross salary fallback drift and clamp displayed income to the screen range.

## QA
- flutter analyze lib/screens/independants/pillar_3a_indep_screen.dart test/screens/indep_nav_remaining_smoke_test.dart
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded
- lefthook run pre-commit --file apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
- Maestro on iPhone 17 Pro: deep link mint:///independants/3a, title + LPP block visible
- Prior external Claude audit via tools/checks/claude_external_audit.sh: PASS; remaining notes are non-blocking P2 follow-ups (debounce writes, late hydration policy, fire-and-forget reporting).