### PR TITLE
fix(mobile): prefill voluntary LPP from profile

### DIFF
--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -12,6 +15,7 @@ import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/common/safe_mode_gate.dart';
+import 'package:provider/provider.dart';
 
 // ────────────────────────────────────────────────────────────
 //  LPP VOLONTAIRE SCREEN — Sprint S18 / Independants complet
@@ -31,24 +35,85 @@ class LppVolontaireScreen extends StatefulWidget {
 }
 
 class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
+  static const double _incomeMin = 0;
+  static const double _incomeMax = 250000;
+  static const int _ageMin = 25;
+  static const int _ageMax = 65;
+
   double _revenuNet = 80000;
   int _age = 40;
   double _tauxMarginal = 0.30;
   LppVolontaireResult? _result;
+  bool _didHydrateFromProfile = false;
 
   @override
   void initState() {
     super.initState();
-    _calculate();
+    _result = _computeResult();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didHydrateFromProfile) return;
+    _didHydrateFromProfile = true;
+    _hydrateFromProfile();
+  }
+
+  LppVolontaireResult _computeResult() {
+    return IndependantsService.calculateLppVolontaire(
+      _revenuNet,
+      _age,
+      _tauxMarginal,
+    );
   }
 
   void _calculate() {
     setState(() {
-      _result = IndependantsService.calculateLppVolontaire(
-        _revenuNet,
-        _age,
-        _tauxMarginal,
-      );
+      _result = _computeResult();
+    });
+  }
+
+  CoachProfileProvider? _profileProvider() {
+    try {
+      return context.read<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
+    }
+  }
+
+  void _hydrateFromProfile() {
+    final provider = _profileProvider();
+    final profile = provider?.profile;
+    if (profile == null) return;
+
+    final income = profile.selfEmployedNetIncome;
+    if (income != null && income > 0) {
+      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
+    }
+
+    final age = profile.ageOrNull;
+    if (age != null) {
+      _age = age.clamp(_ageMin, _ageMax).toInt();
+    }
+
+    _result = _computeResult();
+  }
+
+  Future<void> _persistIncome(double value) async {
+    final provider = _profileProvider();
+    await provider?.mergeAnswers({
+      'q_self_employed_income': value,
+      'q_net_income_period_chf': value,
+      'q_pay_frequency': 'yearly',
+      'q_employment_status': 'independant',
+    });
+  }
+
+  Future<void> _persistAge(int value) async {
+    final provider = _profileProvider();
+    await provider?.mergeAnswers({
+      'q_birth_year': DateTime.now().year - value,
     });
   }
 
@@ -153,13 +218,12 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
         value: _revenuNet,
         formatValue: (v) => IndependantsService.formatChf(v),
         onChanged: (v) {
-          setState(() {
-            _revenuNet = v;
-            _calculate();
-          });
+          _revenuNet = v;
+          _calculate();
+          unawaited(_persistIncome(v));
         },
-        min: 0,
-        max: 250000,
+        min: _incomeMin,
+        max: _incomeMax,
       ),
     );
   }
@@ -169,14 +233,13 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
       child: MintPickerTile(
         label: S.of(context)!.lppVolontaireTonAge,
         value: _age,
-        minValue: 25,
-        maxValue: 65,
+        minValue: _ageMin,
+        maxValue: _ageMax,
         formatValue: (v) => '$v ans',
         onChanged: (v) {
-          setState(() {
-            _age = v;
-            _calculate();
-          });
+          _age = v;
+          _calculate();
+          unawaited(_persistAge(v));
         },
       ),
     );

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -133,9 +133,11 @@ class RecordingCoachProfileProvider extends CoachProfileProvider {
 Map<String, dynamic> independentAnswers({
   double? selfIncome,
   double? grossSalary,
+  int? birthYear,
   bool voluntaryLpp = false,
 }) {
   return {
+    if (birthYear != null) 'q_birth_year': birthYear,
     if (selfIncome != null) ...{
       'q_self_employed_income': selfIncome,
       'q_net_income_period_chf': selfIncome,
@@ -280,6 +282,142 @@ void main() {
 
       // Age picker shows formatted value with MintPickerTile
       expect(find.byType(MintPickerTile), findsOneWidget);
+    });
+
+    testWidgets('prefills known independent income and age from profile',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 140000,
+          birthYear: DateTime.now().year - 52,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+      final agePicker =
+          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
+
+      expect(amountField.value, 140000);
+      expect(agePicker.value, 52);
+    });
+
+    testWidgets('does not prefill net income from a gross salary fallback',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(grossSalary: 220000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+
+      expect(amountField.value, 80000);
+    });
+
+    testWidgets('clamps known profile values to the screen ranges',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 450000,
+          birthYear: DateTime.now().year - 80,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+      final agePicker =
+          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
+
+      expect(amountField.value, 250000);
+      expect(agePicker.value, 65);
+    });
+
+    testWidgets('persists edited independent income through the profile path',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 90000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final amountField =
+          tester.widget<MintAmountField>(find.byType(MintAmountField));
+      amountField.onChanged(123000);
+      await tester.pump();
+
+      expect(provider.writes, isNotEmpty);
+      expect(
+        provider.writes.last,
+        containsPair('q_self_employed_income', 123000),
+      );
+      expect(
+        provider.writes.last,
+        containsPair('q_net_income_period_chf', 123000),
+      );
+      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
+      expect(
+        provider.writes.last,
+        containsPair('q_employment_status', 'independant'),
+      );
+    });
+
+    testWidgets('persists edited age as birth year through the profile path',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 90000,
+          birthYear: DateTime.now().year - 39,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final agePicker =
+          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
+      agePicker.onChanged(44);
+      await tester.pump();
+
+      expect(provider.writes, isNotEmpty);
+      expect(
+        provider.writes.last,
+        containsPair('q_birth_year', DateTime.now().year - 44),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Hydrate the voluntary LPP simulator from CoachProfile self-employed net income and age when available.
- Persist edited independent net income and age back through CoachProfileProvider.mergeAnswers using existing DataQuest keys.
- Guard against gross salary fallback drift and clamp displayed profile values to the screen ranges.

## QA
- RED observed first: new LppVolontaireScreen tests failed on profile prefill and persistence before implementation.
- flutter analyze lib/screens/independants/lpp_volontaire_screen.dart test/screens/indep_nav_remaining_smoke_test.dart
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded
- python3 tools/checks/arb_parity.py
- ./tools/mint-routes reconcile
- lefthook run pre-commit --file apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
- flutter build ios --simulator --debug
- Maestro on iPhone 17 Pro: deep link mint:///independants/lpp-volontaire, title + intro + result visible
- External Claude audit via tools/checks/claude_external_audit.sh: PASS

## Follow-ups noted by Claude audit
- DOB-precise profiles keep dateOfBirth as source of truth; age edit writes birth year only.
- Independent-scoped income edit stamps q_employment_status=independant, matching #906 but worth revisiting for mixed-status users.
- Rapid amount edits still use unawaited mergeAnswers; debounce/batched persistence should be a separate shared fix.