### PR TITLE
fix(mobile): prefill independent avs from profile

### DIFF
--- a/apps/mobile/.maestro/indep_avs_cotisations.yaml
+++ b/apps/mobile/.maestro/indep_avs_cotisations.yaml
@@ -1,0 +1,19 @@
+appId: ch.mint.app
+---
+# Independants AVS: the simulator route must render the net-income input and
+# core result blocks on a recent iPhone simulator.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///independants/avs"
+- assertVisible:
+    text: "Cotisations AVS"
+- assertVisible:
+    text: "Ton revenu net annuel"
+- assertVisible:
+    text: ".*CHF.*4'240.*"
+- assertVisible:
+    text: "Comparaison annuelle"

--- a/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
+++ b/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
@@ -18,36 +20,65 @@ class AvsCotisationsScreen extends StatefulWidget {
 }
 
 class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
+  static const double _incomeMin = 0;
+  static const double _incomeMax = 250000;
+
   double _revenuNet = 80000;
   AvsCotisationResult? _result;
+  bool _didHydrateFromProfile = false;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _initializeFromProfile();
-    });
-    _calculate();
+    _result = _computeResult();
   }
 
-  void _initializeFromProfile() {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didHydrateFromProfile) return;
+    _didHydrateFromProfile = true;
+    _hydrateFromProfile();
+  }
+
+  AvsCotisationResult _computeResult() {
+    return IndependantsService.calculateAvsCotisations(_revenuNet);
+  }
+
+  CoachProfileProvider? _profileProvider() {
     try {
-      final profile = context.read<CoachProfileProvider>().profile;
-      if (profile == null) return;
-      bool changed = false;
-      if (profile.revenuBrutAnnuel > 0) {
-        _revenuNet = profile.revenuBrutAnnuel;
-        changed = true;
-      }
-      if (changed) _calculate();
-    } catch (_) {
-      // Provider not available
+      return context.read<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
     }
+  }
+
+  void _hydrateFromProfile() {
+    final provider = _profileProvider();
+    final profile = provider?.profile;
+    if (profile == null) return;
+
+    final income = profile.selfEmployedNetIncome;
+    if (income != null && income > 0) {
+      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
+    }
+
+    _result = _computeResult();
+  }
+
+  Future<void> _persistIncome(double value) async {
+    final provider = _profileProvider();
+    await provider?.mergeAnswers({
+      'q_self_employed_income': value,
+      'q_net_income_period_chf': value,
+      'q_pay_frequency': 'yearly',
+      'q_employment_status': 'independant',
+    });
   }
 
   void _calculate() {
     setState(() {
-      _result = IndependantsService.calculateAvsCotisations(_revenuNet);
+      _result = _computeResult();
     });
   }
 
@@ -120,13 +151,16 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
       child: MintPremiumSlider(
         label: s.avsCotisationsRevenuLabel,
         value: _revenuNet,
-        min: 0,
-        max: 250000,
+        min: _incomeMin,
+        max: _incomeMax,
         divisions: 250,
         formatValue: (v) => IndependantsService.formatChf(v),
         onChanged: (value) {
           _revenuNet = value;
           _calculate();
+        },
+        onChangeEnd: (value) {
+          unawaited(_persistIncome(value));
         },
       ),
     );

--- a/apps/mobile/lib/widgets/premium/mint_premium_slider.dart
+++ b/apps/mobile/lib/widgets/premium/mint_premium_slider.dart
@@ -16,6 +16,7 @@ class MintPremiumSlider extends StatelessWidget {
   final String Function(double)? formatValue;
   final Color? activeColor;
   final ValueChanged<double> onChanged;
+  final ValueChanged<double>? onChangeEnd;
 
   const MintPremiumSlider({
     super.key,
@@ -27,6 +28,7 @@ class MintPremiumSlider extends StatelessWidget {
     this.formatValue,
     this.activeColor,
     required this.onChanged,
+    this.onChangeEnd,
   });
 
   @override
@@ -80,6 +82,7 @@ class MintPremiumSlider extends StatelessWidget {
             max: max,
             divisions: divisions,
             onChanged: onChanged,
+            onChangeEnd: onChangeEnd,
           ),
         ),
       ],

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 // Screens under test
 import 'package:mint_mobile/screens/independant_screen.dart';
+import 'package:mint_mobile/screens/independants/avs_cotisations_screen.dart';
 import 'package:mint_mobile/screens/independants/lpp_volontaire_screen.dart';
 import 'package:mint_mobile/screens/independants/pillar_3a_indep_screen.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
@@ -422,7 +423,93 @@ void main() {
   });
 
   // ===========================================================================
-  // 3. PILLAR 3A INDEPENDANT SCREEN
+  // 3. AVS COTISATIONS SCREEN
+  // ===========================================================================
+
+  group('AvsCotisationsScreen', () {
+    testWidgets('prefills known independent income from profile',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 135000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const AvsCotisationsScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final incomeSlider = tester
+          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
+
+      expect(incomeSlider.value, 135000);
+    });
+
+    testWidgets('does not prefill net income from a gross salary fallback',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(grossSalary: 220000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const AvsCotisationsScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final incomeSlider = tester
+          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
+
+      expect(incomeSlider.value, 80000);
+    });
+
+    testWidgets('persists edited independent income through the profile path',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(selfIncome: 90000),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const AvsCotisationsScreen(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final incomeSlider = tester
+          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
+      incomeSlider.onChanged(123000);
+      await tester.pump();
+
+      expect(provider.writes, isEmpty);
+
+      incomeSlider.onChangeEnd!(123000);
+      await tester.pump();
+
+      expect(provider.writes, isNotEmpty);
+      expect(
+        provider.writes.last,
+        containsPair('q_self_employed_income', 123000),
+      );
+      expect(
+        provider.writes.last,
+        containsPair('q_net_income_period_chf', 123000),
+      );
+      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
+      expect(
+        provider.writes.last,
+        containsPair('q_employment_status', 'independant'),
+      );
+    });
+  });
+
+  // ===========================================================================
+  // 4. PILLAR 3A INDEPENDANT SCREEN
   // ===========================================================================
 
   group('Pillar3aIndepScreen', () {
@@ -609,7 +696,7 @@ void main() {
   // ExploreTab tests removed — screen deleted in S49 Phase 5
 
   // ===========================================================================
-  // 4. TIMELINE SCREEN
+  // 5. TIMELINE SCREEN
   //    Uses a larger surface size to prevent overflow in quick-action cards.
   // ===========================================================================
 


### PR DESCRIPTION
## Summary
- Hydrate AVS cotisations from canonical independent net income instead of derived gross salary
- Persist AVS income edits back to existing DataQuest profile keys on slider release
- Add optional MintPremiumSlider onChangeEnd and a Maestro flow for the AVS independent route

## QA
- RED: AvsCotisationsScreen tests failed before code change: self income became derived gross, gross salary prefilled net field, edits did not persist
- flutter analyze lib/screens/independants/avs_cotisations_screen.dart lib/widgets/premium/mint_premium_slider.dart test/screens/indep_nav_remaining_smoke_test.dart
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --plain-name 'AvsCotisationsScreen' --reporter expanded
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded
- python3 tools/checks/arb_parity.py
- ./tools/mint-routes reconcile
- lefthook run pre-commit
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7: PASS
- flutter build ios --simulator --debug
- maestro check-syntax apps/mobile/.maestro/indep_avs_cotisations.yaml
- maestro test --udid B03E429D-0422-4357-B754-536637D979F9 apps/mobile/.maestro/indep_avs_cotisations.yaml