### PR TITLE
fix(mobile): collect independent income fact

### DIFF
--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -55,6 +55,8 @@ class _DataBlockEnrichmentScreenState
   bool _showCoachMode = false;
   final TextEditingController _cantonController = TextEditingController();
   final TextEditingController _salaryController = TextEditingController();
+  final TextEditingController _selfEmployedIncomeController =
+      TextEditingController();
   final TextEditingController _birthYearController = TextEditingController();
   final TextEditingController _cashController = TextEditingController();
   bool _revenueInputsSeeded = false;
@@ -74,6 +76,7 @@ class _DataBlockEnrichmentScreenState
   void dispose() {
     _cantonController.dispose();
     _salaryController.dispose();
+    _selfEmployedIncomeController.dispose();
     _birthYearController.dispose();
     _cashController.dispose();
     super.dispose();
@@ -241,6 +244,10 @@ class _DataBlockEnrichmentScreenState
     if (profile.revenuBrutAnnuel > 0) {
       _salaryController.text = '${profile.revenuBrutAnnuel.round()}';
     }
+    final selfEmployedIncome = profile.selfEmployedNetIncome;
+    if (selfEmployedIncome != null && selfEmployedIncome > 0) {
+      _selfEmployedIncomeController.text = '${selfEmployedIncome.round()}';
+    }
     if (profile.birthYear >= 1900) _birthYearController.text = '${profile.birthYear}';
     _hasPensionFund = (profile.prevoyance.avoirLppTotal ?? 0) > 0 ||
         profile.prevoyance.isLppFromCertificate;
@@ -269,6 +276,16 @@ class _DataBlockEnrichmentScreenState
         semanticsIdentifier: 'salary_input',
         controller: _salaryController,
         label: l.renteVsCapitalSalary,
+        keyboardType: TextInputType.number,
+        inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+      ));
+    }
+    if (onlyInputKey == 'q_self_employed_income') {
+      addField(_buildRevenueTextField(
+        key: const Key('self_employed_income_input'),
+        semanticsIdentifier: 'self_employed_income_input',
+        controller: _selfEmployedIncomeController,
+        label: l.independantRevenueTitle,
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
       ));
@@ -387,12 +404,16 @@ class _DataBlockEnrichmentScreenState
     final onlyInputKey = _canonicalRevenueInputKey(widget.initialInputKey);
     final capturesSalary =
         _capturesRevenue('q_gross_salary_annual', onlyInputKey);
+    final capturesSelfEmployedIncome =
+        onlyInputKey == 'q_self_employed_income';
     final capturesCanton = _capturesRevenue('q_canton', onlyInputKey);
     final capturesBirthYear = _capturesRevenue('q_birth_year', onlyInputKey);
     final capturesPensionFund =
         _capturesRevenue('q_has_pension_fund', onlyInputKey);
     final canton = _cantonController.text.trim().toUpperCase();
     final salary = int.tryParse(_digitsOnly(_salaryController.text));
+    final selfEmployedIncome =
+        int.tryParse(_digitsOnly(_selfEmployedIncomeController.text));
     final birthText = _birthYearController.text.trim();
     final birthYear = birthText.isEmpty ? null : int.tryParse(birthText);
     final currentYear = DateTime.now().year;
@@ -408,6 +429,8 @@ class _DataBlockEnrichmentScreenState
 
     if ((capturesCanton && !_swissCantonCodes.contains(' $canton ')) ||
         (capturesSalary && (salary == null || salary <= 0)) ||
+        (capturesSelfEmployedIncome &&
+            (selfEmployedIncome == null || selfEmployedIncome <= 0)) ||
         invalidBirthYear) {
       setState(() => _revenueError = l.authErrorInvalid);
       return;
@@ -420,6 +443,12 @@ class _DataBlockEnrichmentScreenState
 
     final answers = <String, dynamic>{
       if (capturesSalary) 'q_gross_salary_annual': salary,
+      if (capturesSelfEmployedIncome) ...{
+        'q_self_employed_income': selfEmployedIncome,
+        'q_net_income_period_chf': selfEmployedIncome,
+        'q_pay_frequency': 'yearly',
+        'q_employment_status': 'independant',
+      },
       if (capturesCanton) 'q_canton': canton,
       if (capturesBirthYear && birthYear != null) 'q_birth_year': birthYear,
       if (capturesPensionFund &&
@@ -537,6 +566,11 @@ class _DataBlockEnrichmentScreenState
       'grosssalaryannual' ||
       'salary' =>
         'q_gross_salary_annual',
+      'qselfemployedincome' ||
+      'selfemployedincome' ||
+      'revenuindependant' ||
+      'revenunetannuelindependant' =>
+        'q_self_employed_income',
       'qcanton' || 'canton' => 'q_canton',
       'qbirthyear' || 'birthyear' => 'q_birth_year',
       'qhaspensionfund' || 'has2ndpillar' || 'haspensionfund' =>

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -97,6 +97,40 @@ void main() {
     expect(provider.profile?.canton, 'GE');
   });
 
+  testWidgets(
+      'revenue block inputKey collects independent income as canonical ledger facts',
+      (tester) async {
+    final provider = CoachProfileProvider();
+
+    await tester.pumpWidget(_wrap(
+      const DataBlockEnrichmentScreen(
+        blockType: 'revenu',
+        initialInputKey: 'q_self_employed_income',
+      ),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('self_employed_income_input')), findsOneWidget);
+    expect(find.byKey(const Key('salary_input')), findsNothing);
+    expect(find.byKey(const Key('canton_picker')), findsNothing);
+
+    await tester.enterText(
+      find.byKey(const Key('self_employed_income_input')),
+      '144000',
+    );
+    await tester.tap(find.byKey(const Key('salary_save_cta')));
+    await tester.pumpAndSettle();
+
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_self_employed_income', 144000));
+    expect(answers, containsPair('q_net_income_period_chf', 144000));
+    expect(answers, containsPair('q_pay_frequency', 'yearly'));
+    expect(answers, containsPair('q_employment_status', 'independant'));
+    expect(answers.containsKey('q_gross_salary_annual'), isFalse);
+    expect(provider.profile?.selfEmployedNetIncome, 144000);
+  });
+
   testWidgets('revenue block does not treat monthly income as annual input',
       (tester) async {
     await tester.pumpWidget(_wrap(


### PR DESCRIPTION
## Summary
- add explicit `q_self_employed_income` capture to the revenue data block
- persist the canonical independent income bundle for downstream simulators
- add regression coverage that the flow does not write gross salary facts

## Verification
- flutter analyze lib/screens/onboarding/data_block_enrichment_screen.dart test/screens/data_block_enrichment_screen_test.dart
- flutter test test/screens/data_block_enrichment_screen_test.dart --reporter expanded
- python3 tools/checks/arb_parity.py
- lefthook run pre-commit --file apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart --file apps/mobile/test/screens/data_block_enrichment_screen_test.dart
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 (PASS)

## Notes
- Claude P2: this field needs a caller. The IJM ledger-first slice is the next PR and provides that caller.