### PR TITLE
fix(mobile): make IJM consume ledger facts

### DIFF
--- a/apps/mobile/.maestro/indep_ijm.yaml
+++ b/apps/mobile/.maestro/indep_ijm.yaml
@@ -1,0 +1,53 @@
+appId: ch.mint.app
+---
+# IJM renders ledger facts, collects missing facts through DataBlock, then shows results.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///independants/ijm"
+- assertVisible:
+    text: "Assurance IJM"
+- assertVisible:
+    id: "ijm_ledger_facts"
+- assertVisible:
+    id: "ijm_income_fact"
+- assertVisible:
+    id: "ijm_age_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- openLink: "mint:///data-block/revenu?inputKey=q_self_employed_income"
+- assertVisible:
+    id: "self_employed_income_input"
+- tapOn:
+    id: "self_employed_income_input"
+- inputText: "144000"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///data-block/revenu?inputKey=q_birth_year"
+- assertVisible:
+    id: "birth_year_input"
+- tapOn:
+    id: "birth_year_input"
+- inputText: "1978"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///independants/ijm"
+- assertVisible:
+    id: "ijm_ledger_facts"
+- scrollUntilVisible:
+    element:
+      id: "ijm_result_cards"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      id: "ijm_coverage_timeline"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true

--- a/apps/mobile/lib/screens/independants/ijm_screen.dart
+++ b/apps/mobile/lib/screens/independants/ijm_screen.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
+import 'package:mint_mobile/services/financial_core/income_conversion_calculator.dart';
 import 'package:mint_mobile/services/independants_service.dart';
-import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
@@ -19,49 +20,50 @@ class IjmScreen extends StatefulWidget {
 }
 
 class _IjmScreenState extends State<IjmScreen> {
-  double _revenuMensuel = 6000;
-  int _age = 40;
+  static const int _ageMin = 18;
+  static const int _ageMax = avsAgeReferenceHomme;
+
   int _delaiCarence = 30;
-  IjmResult? _result;
 
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _initializeFromProfile();
-    });
-    _calculate();
-  }
-
-  void _initializeFromProfile() {
+  CoachProfileProvider? _profileProvider(BuildContext context) {
     try {
-      final profile = context.read<CoachProfileProvider>().profile;
-      if (profile == null) return;
-      bool changed = false;
-      if (profile.salaireBrutMensuel > 0) {
-        _revenuMensuel = profile.salaireBrutMensuel.clamp(0, 20000);
-        changed = true;
-      }
-      final age = profile.age;
-      if (age >= 18 && age <= avsAgeReferenceHomme) {
-        _age = age;
-        changed = true;
-      }
-      if (changed) _calculate();
-    } catch (_) {
-      // Provider not available
+      return context.watch<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
     }
   }
 
-  void _calculate() {
-    setState(() {
-      _result = IndependantsService.calculateIjm(_revenuMensuel, _age, _delaiCarence);
-    });
+  double? _annualIncome(CoachProfileProvider? provider) {
+    final annualIncome = provider?.profile?.selfEmployedNetIncome;
+    if (annualIncome != null && annualIncome > 0) {
+      return annualIncome.toDouble();
+    }
+    return null;
+  }
+
+  int? _age(CoachProfileProvider? provider) {
+    final age = provider?.profile?.ageOrNull;
+    if (age != null && age >= _ageMin && age <= _ageMax) {
+      return age;
+    }
+    return null;
+  }
+
+  IjmResult? _computeResult(double? annualIncome, int? age) {
+    if (annualIncome == null || age == null) return null;
+    // IJM uses declared independent net income; this only periodizes it.
+    final monthlyIncome = IncomeConversionCalculator.monthlyGrossFromAnnualGross(annualIncome);
+    return IndependantsService.calculateIjm(monthlyIncome, age, _delaiCarence);
   }
 
   @override
   Widget build(BuildContext context) {
     final s = S.of(context)!;
+    final provider = _profileProvider(context);
+    final annualIncome = _annualIncome(provider);
+    final age = _age(provider);
+    final result = _computeResult(annualIncome, age);
+
     return Scaffold(
       backgroundColor: MintColors.background,
       appBar: AppBar(
@@ -78,22 +80,20 @@ class _IjmScreenState extends State<IjmScreen> {
           children: [
             MintEntrance(child: _buildHeader(s)),
             const SizedBox(height: MintSpacing.xl),
-            MintEntrance(delay: const Duration(milliseconds: 100), child: _buildSliderCard(title: s.ijmRevenuMensuel, valueLabel: IndependantsService.formatChf(_revenuMensuel), minLabel: s.ijmSliderMinChf0, maxLabel: s.ijmSliderMax20k, value: _revenuMensuel, min: 0, max: 20000, divisions: 200, onChanged: (v) { _revenuMensuel = v; _calculate(); })),
-            const SizedBox(height: MintSpacing.md + 4),
-            MintEntrance(delay: const Duration(milliseconds: 200), child: _buildSliderCard(title: s.ijmTonAge, valueLabel: '$_age ans', minLabel: s.ijmAgeMin, maxLabel: s.ijmAgeMax, value: _age.toDouble(), min: 18, max: 65, divisions: 47, onChanged: (v) { _age = v.toInt(); _calculate(); })),
-            const SizedBox(height: MintSpacing.md + 4),
-            MintEntrance(delay: const Duration(milliseconds: 300), child: _buildCarenceToggle(s)),
-            const SizedBox(height: MintSpacing.lg),
-            if (_result != null) ...[
-              _buildPremierEclairage(s),
+            MintEntrance(delay: const Duration(milliseconds: 100), child: _buildLedgerFactsCard(context, s, annualIncome, age)),
+            if (result != null) ...[
               const SizedBox(height: MintSpacing.lg),
-              if (_result!.isHighRisk) ...[
+              MintEntrance(delay: const Duration(milliseconds: 200), child: _buildCarenceToggle(s)),
+              const SizedBox(height: MintSpacing.lg),
+              _buildPremierEclairage(s, result),
+              const SizedBox(height: MintSpacing.lg),
+              if (result.isHighRisk) ...[
                 _buildHighRiskWarning(s),
                 const SizedBox(height: MintSpacing.md + 4),
               ],
-              _buildResultCards(s),
+              _buildResultCards(s, result),
               const SizedBox(height: MintSpacing.lg),
-              _buildCoverageTimeline(s),
+              _buildCoverageTimeline(s, result),
               const SizedBox(height: MintSpacing.lg),
               _buildEducation(s),
               const SizedBox(height: MintSpacing.lg),
@@ -125,18 +125,85 @@ class _IjmScreenState extends State<IjmScreen> {
     );
   }
 
-  Widget _buildSliderCard({required String title, required String valueLabel, required String minLabel, required String maxLabel, required double value, required double min, required double max, required int divisions, required ValueChanged<double> onChanged}) {
-    return MintSurface(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      radius: 16,
-      child: MintPremiumSlider(
-        label: title,
-        value: value,
-        min: min,
-        max: max,
-        divisions: divisions,
-        formatValue: (_) => valueLabel,
-        onChanged: onChanged,
+  Widget _buildLedgerFactsCard(BuildContext context, S s, double? annualIncome, int? age) {
+    final hasMissing = annualIncome == null || age == null;
+    final editRoute = annualIncome == null
+        ? '/data-block/revenu?inputKey=q_self_employed_income'
+        : '/data-block/revenu?inputKey=q_birth_year';
+
+    return Semantics(
+      key: const Key('ijm_ledger_facts'),
+      identifier: 'ijm_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        padding: const EdgeInsets.all(MintSpacing.md),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasMissing ? Icons.manage_search_outlined : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
+                ),
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
+                  child: Text(
+                    hasMissing ? s.dataQualityMissingSection : s.dataQualityKnownSection,
+                    style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(editRoute),
+                  icon: Icon(hasMissing ? Icons.add_circle_outline : Icons.edit_outlined, size: 18),
+                  label: Text(hasMissing ? s.dataQualityEnrich : s.commonEdit),
+                ),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            _buildFactRow(
+              identifier: 'ijm_income_fact',
+              label: s.independantRevenueTitle,
+              value: annualIncome == null
+                  ? s.dataBlockStatusMissing
+                  : IndependantsService.formatChf(annualIncome),
+              isMissing: annualIncome == null,
+            ),
+            const SizedBox(height: MintSpacing.xs),
+            _buildFactRow(
+              identifier: 'ijm_age_fact',
+              label: s.ijmTonAge,
+              value: age == null ? s.dataBlockStatusMissing : '$age ans',
+              isMissing: age == null,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFactRow({required String identifier, required String label, required String value, required bool isMissing}) {
+    return Semantics(
+      identifier: identifier,
+      label: '$label, $value',
+      container: true,
+      child: Row(
+        children: [
+          Icon(
+            isMissing ? Icons.help_outline : Icons.check_circle_outline,
+            color: isMissing ? MintColors.warning : MintColors.success,
+            size: 16,
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(child: Text(label, style: MintTextStyles.bodySmall(color: MintColors.textSecondary))),
+          Text(
+            value,
+            style: MintTextStyles.bodySmall(color: isMissing ? MintColors.warning : MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
       ),
     );
   }
@@ -174,7 +241,7 @@ class _IjmScreenState extends State<IjmScreen> {
         button: true,
         selected: isSelected,
         child: GestureDetector(
-          onTap: () { _delaiCarence = jours; _calculate(); },
+          onTap: () => setState(() => _delaiCarence = jours),
           child: Container(
             padding: const EdgeInsets.symmetric(vertical: 14),
             decoration: BoxDecoration(
@@ -195,8 +262,7 @@ class _IjmScreenState extends State<IjmScreen> {
     );
   }
 
-  Widget _buildPremierEclairage(S s) {
-    final r = _result!;
+  Widget _buildPremierEclairage(S s, IjmResult r) {
     return Container(
       padding: const EdgeInsets.all(MintSpacing.lg),
       decoration: BoxDecoration(color: MintColors.error, borderRadius: BorderRadius.circular(16)),
@@ -238,22 +304,25 @@ class _IjmScreenState extends State<IjmScreen> {
     );
   }
 
-  Widget _buildResultCards(S s) {
-    final r = _result!;
-    return Column(
-      children: [
-        Row(children: [
-          Expanded(child: _buildResultCard(s.ijmPrimeMois, IndependantsService.formatChf(r.primeMensuelle), Icons.payment_outlined)),
-          const SizedBox(width: MintSpacing.sm + 4),
-          Expanded(child: _buildResultCard(s.ijmPrimeAn, IndependantsService.formatChf(r.primeAnnuelle), Icons.calendar_month_outlined)),
-        ]),
-        const SizedBox(height: MintSpacing.sm + 4),
-        Row(children: [
-          Expanded(child: _buildResultCard(s.ijmIndemniteJour, IndependantsService.formatChf(r.indemniteJournaliere), Icons.today_outlined)),
-          const SizedBox(width: MintSpacing.sm + 4),
-          Expanded(child: _buildResultCard(s.ijmTrancheAge, r.ageBandLabel, Icons.person_outline, small: true)),
-        ]),
-      ],
+  Widget _buildResultCards(S s, IjmResult r) {
+    return Semantics(
+      key: const Key('ijm_result_cards'),
+      identifier: 'ijm_result_cards',
+      child: Column(
+        children: [
+          Row(children: [
+            Expanded(child: _buildResultCard(s.ijmPrimeMois, IndependantsService.formatChf(r.primeMensuelle), Icons.payment_outlined)),
+            const SizedBox(width: MintSpacing.sm + 4),
+            Expanded(child: _buildResultCard(s.ijmPrimeAn, IndependantsService.formatChf(r.primeAnnuelle), Icons.calendar_month_outlined)),
+          ]),
+          const SizedBox(height: MintSpacing.sm + 4),
+          Row(children: [
+            Expanded(child: _buildResultCard(s.ijmIndemniteJour, IndependantsService.formatChf(r.indemniteJournaliere), Icons.today_outlined)),
+            const SizedBox(width: MintSpacing.sm + 4),
+            Expanded(child: _buildResultCard(s.ijmTrancheAge, r.ageBandLabel, Icons.person_outline, small: true)),
+          ]),
+        ],
+      ),
     );
   }
 
@@ -274,45 +343,48 @@ class _IjmScreenState extends State<IjmScreen> {
     );
   }
 
-  Widget _buildCoverageTimeline(S s) {
-    final r = _result!;
+  Widget _buildCoverageTimeline(S s, IjmResult r) {
     const totalDays = 180;
     final carenceRatio = r.delaiCarence / totalDays;
-    return MintSurface(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      radius: 16,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(s.ijmTimelineTitle, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w600)),
-          const SizedBox(height: MintSpacing.md + 4),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(6),
-            child: Row(children: [
-              Expanded(
-                flex: (carenceRatio * 100).toInt().clamp(1, 99),
-                child: Container(height: 32, color: MintColors.error.withValues(alpha: 0.2), alignment: Alignment.center, child: Text('${r.delaiCarence}j', style: MintTextStyles.labelSmall(color: MintColors.error).copyWith(fontWeight: FontWeight.w600))),
-              ),
-              Expanded(
-                flex: (100 - carenceRatio * 100).toInt().clamp(1, 99),
-                child: Container(height: 32, color: MintColors.success.withValues(alpha: 0.2), alignment: Alignment.center, child: Text(s.ijmTimelineCouvert, style: MintTextStyles.labelSmall(color: MintColors.success).copyWith(fontWeight: FontWeight.w600))),
-              ),
+    return Semantics(
+      key: const Key('ijm_coverage_timeline'),
+      identifier: 'ijm_coverage_timeline',
+      child: MintSurface(
+        padding: const EdgeInsets.all(MintSpacing.md + 4),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.ijmTimelineTitle, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w600)),
+            const SizedBox(height: MintSpacing.md + 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: Row(children: [
+                Expanded(
+                  flex: (carenceRatio * 100).toInt().clamp(1, 99),
+                  child: Container(height: 32, color: MintColors.error.withValues(alpha: 0.2), alignment: Alignment.center, child: Text('${r.delaiCarence}j', style: MintTextStyles.labelSmall(color: MintColors.error).copyWith(fontWeight: FontWeight.w600))),
+                ),
+                Expanded(
+                  flex: (100 - carenceRatio * 100).toInt().clamp(1, 99),
+                  child: Container(height: 32, color: MintColors.success.withValues(alpha: 0.2), alignment: Alignment.center, child: Text(s.ijmTimelineCouvert, style: MintTextStyles.labelSmall(color: MintColors.success).copyWith(fontWeight: FontWeight.w600))),
+                ),
+              ]),
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            Row(children: [
+              _buildLegendDot(MintColors.error, s.ijmTimelineNoCoverage),
+              const SizedBox(width: MintSpacing.md),
+              _buildLegendDot(MintColors.success, s.ijmTimelineCoverageIjm),
             ]),
-          ),
-          const SizedBox(height: MintSpacing.sm + 4),
-          Row(children: [
-            _buildLegendDot(MintColors.error, s.ijmTimelineNoCoverage),
-            const SizedBox(width: MintSpacing.md),
-            _buildLegendDot(MintColors.success, s.ijmTimelineCoverageIjm),
-          ]),
-          const SizedBox(height: MintSpacing.md),
-          MintSurface(
-            tone: MintSurfaceTone.porcelaine,
-            padding: const EdgeInsets.all(MintSpacing.sm + 4),
-            radius: 12,
-            child: Text(s.ijmTimelineSummary(r.delaiCarence, IndependantsService.formatChf(r.indemniteJournaliere)), style: MintTextStyles.bodySmall(color: MintColors.textSecondary)),
-          ),
-        ],
+            const SizedBox(height: MintSpacing.md),
+            MintSurface(
+              tone: MintSurfaceTone.porcelaine,
+              padding: const EdgeInsets.all(MintSpacing.sm + 4),
+              radius: 12,
+              child: Text(s.ijmTimelineSummary(r.delaiCarence, IndependantsService.formatChf(r.indemniteJournaliere)), style: MintTextStyles.bodySmall(color: MintColors.textSecondary)),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 // Screens under test
 import 'package:mint_mobile/screens/independant_screen.dart';
 import 'package:mint_mobile/screens/independants/avs_cotisations_screen.dart';
+import 'package:mint_mobile/screens/independants/ijm_screen.dart';
 import 'package:mint_mobile/screens/independants/lpp_volontaire_screen.dart';
 import 'package:mint_mobile/screens/independants/pillar_3a_indep_screen.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
@@ -509,7 +510,67 @@ void main() {
   });
 
   // ===========================================================================
-  // 4. PILLAR 3A INDEPENDANT SCREEN
+  // 4. IJM SCREEN
+  // ===========================================================================
+
+  group('IjmScreen', () {
+    Future<void> pumpIjm(
+      WidgetTester tester,
+      Map<String, dynamic> answers,
+    ) async {
+      await tester.pumpWidget(buildWithCoachProfileProvider(
+        RecordingCoachProfileProvider(answers),
+        const IjmScreen(),
+      ));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+    }
+
+    testWidgets('uses ledger facts instead of local income or age sliders',
+        (tester) async {
+      await pumpIjm(
+        tester,
+        independentAnswers(
+          selfIncome: 144000,
+          birthYear: DateTime.now().year - 48,
+        ),
+      );
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.byKey(const Key('ijm_ledger_facts')), findsOneWidget);
+      expect(find.textContaining("144'000"), findsOneWidget);
+      expect(find.text('48 ans'), findsOneWidget);
+      expect(find.byKey(const Key('ijm_result_cards')), findsOneWidget);
+    });
+
+    testWidgets('does not calculate from a gross salary fallback',
+        (tester) async {
+      await pumpIjm(
+        tester,
+        independentAnswers(
+          grossSalary: 240000,
+          birthYear: DateTime.now().year - 48,
+        ),
+      );
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 240'000"), findsNothing);
+      expect(find.byKey(const Key('ijm_result_cards')), findsNothing);
+      expect(find.text('Manquant'), findsOneWidget);
+    });
+
+    testWidgets('shows missing facts instead of defaulting to a monthly value',
+        (tester) async {
+      await pumpIjm(tester, independentAnswers());
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 6'000"), findsNothing);
+      expect(find.text('Manquant'), findsNWidgets(2));
+      expect(find.byKey(const Key('ijm_result_cards')), findsNothing);
+    });
+  });
+
+  // ===========================================================================
+  // 5. PILLAR 3A INDEPENDANT SCREEN
   // ===========================================================================
 
   group('Pillar3aIndepScreen', () {
@@ -696,7 +757,7 @@ void main() {
   // ExploreTab tests removed — screen deleted in S49 Phase 5
 
   // ===========================================================================
-  // 5. TIMELINE SCREEN
+  // 6. TIMELINE SCREEN
   //    Uses a larger surface size to prevent overflow in quick-action cards.
   // ===========================================================================
 
@@ -785,7 +846,7 @@ void main() {
   });
 
   // ===========================================================================
-  // 6. BUDGET CONTAINER SCREEN (needs BudgetProvider)
+  // 7. BUDGET CONTAINER SCREEN (needs BudgetProvider)
   // ===========================================================================
 
   group('BudgetContainerScreen', () {


### PR DESCRIPTION
## Summary
- make `IjmScreen` consume canonical self-employed income and age facts instead of local income/age sliders
- show ledger known/missing fact rows and route missing facts through DataBlock (`q_self_employed_income`, `q_birth_year`)
- add focused widget tests plus a Maestro iPhone flow that fills missing facts and verifies IJM result/timeline rendering

## QA
- `flutter analyze lib/screens/independants/ijm_screen.dart test/screens/indep_nav_remaining_smoke_test.dart`
- `flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded`
- `flutter build ios --simulator --debug`
- `maestro test --udid B03E429D-0422-4357-B754-536637D979F9 apps/mobile/.maestro/indep_ijm.yaml`
- `lefthook run pre-commit --file apps/mobile/lib/screens/independants/ijm_screen.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart --file apps/mobile/.maestro/indep_ijm.yaml`
- `python3 tools/checks/arb_parity.py`
- `./tools/mint-routes reconcile`
- `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → PASS

## Notes
- This intentionally uses declared independent net income as the IJM basis; it is periodized through `IncomeConversionCalculator` so the widget does not own financial math.
- Follow-up debt: LPP volontaire, AVS cotisations, and 3a indépendant still have local controls for canonical facts and should be converted next.
