### PR TITLE
fix(mobile): make AVS consume ledger facts

### DIFF
--- a/apps/mobile/.maestro/indep_avs_cotisations.yaml
+++ b/apps/mobile/.maestro/indep_avs_cotisations.yaml
@@ -1,7 +1,6 @@
 appId: ch.mint.app
 ---
-# Independants AVS: the simulator route must render the net-income input and
-# core result blocks on a recent iPhone simulator.
+# AVS renders ledger facts, collects missing income through DataBlock, then shows results.
 - stopApp
 - launchApp:
     clearState: true
@@ -12,8 +11,40 @@ appId: ch.mint.app
 - assertVisible:
     text: "Cotisations AVS"
 - assertVisible:
-    text: "Ton revenu net annuel"
+    id: "avs_ledger_facts"
 - assertVisible:
-    text: ".*CHF.*4'240.*"
+    id: "avs_income_fact"
 - assertVisible:
-    text: "Comparaison annuelle"
+    text: "Enrichir mon profil"
+- openLink: "mint:///data-block/revenu?inputKey=q_self_employed_income"
+- assertVisible:
+    id: "self_employed_income_input"
+- tapOn:
+    id: "self_employed_income_input"
+- inputText: "135000"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///independants/avs"
+- assertVisible:
+    id: "avs_ledger_facts"
+- scrollUntilVisible:
+    element:
+      id: "avs_result_cards"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      id: "avs_comparison_chart"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      id: "avs_bareme_gauge"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true

--- a/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
+++ b/apps/mobile/lib/screens/independants/avs_cotisations_screen.dart
@@ -1,12 +1,11 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
+import 'package:mint_mobile/services/financial_core/avs_calculator.dart';
 import 'package:mint_mobile/services/independants_service.dart';
-import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
@@ -20,71 +19,32 @@ class AvsCotisationsScreen extends StatefulWidget {
 }
 
 class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
-  static const double _incomeMin = 0;
-  static const double _incomeMax = 250000;
-
-  double _revenuNet = 80000;
-  AvsCotisationResult? _result;
-  bool _didHydrateFromProfile = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _result = _computeResult();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_didHydrateFromProfile) return;
-    _didHydrateFromProfile = true;
-    _hydrateFromProfile();
-  }
-
-  AvsCotisationResult _computeResult() {
-    return IndependantsService.calculateAvsCotisations(_revenuNet);
-  }
-
-  CoachProfileProvider? _profileProvider() {
+  CoachProfileProvider? _profileProvider(BuildContext context) {
     try {
-      return context.read<CoachProfileProvider>();
+      return context.watch<CoachProfileProvider>();
     } on ProviderNotFoundException {
       return null;
     }
   }
 
-  void _hydrateFromProfile() {
-    final provider = _profileProvider();
-    final profile = provider?.profile;
-    if (profile == null) return;
-
-    final income = profile.selfEmployedNetIncome;
-    if (income != null && income > 0) {
-      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
-    }
-
-    _result = _computeResult();
+  double? _annualIncome(CoachProfileProvider? provider) {
+    final income = provider?.profile?.selfEmployedNetIncome;
+    if (income != null && income > 0) return income.toDouble();
+    return null;
   }
 
-  Future<void> _persistIncome(double value) async {
-    final provider = _profileProvider();
-    await provider?.mergeAnswers({
-      'q_self_employed_income': value,
-      'q_net_income_period_chf': value,
-      'q_pay_frequency': 'yearly',
-      'q_employment_status': 'independant',
-    });
-  }
-
-  void _calculate() {
-    setState(() {
-      _result = _computeResult();
-    });
+  AvsCotisationResult? _computeResult(double? annualIncome) {
+    if (annualIncome == null) return null;
+    return IndependantsService.calculateAvsCotisations(annualIncome);
   }
 
   @override
   Widget build(BuildContext context) {
     final s = S.of(context)!;
+    final provider = _profileProvider(context);
+    final annualIncome = _annualIncome(provider);
+    final result = _computeResult(annualIncome);
+
     return Scaffold(
       backgroundColor: MintColors.background,
       appBar: AppBar(
@@ -92,34 +52,43 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
         foregroundColor: MintColors.textPrimary,
         elevation: 0,
         scrolledUnderElevation: 0,
-        title: Text(s.avsCotisationsTitle, style: MintTextStyles.headlineMedium()),
+        title:
+            Text(s.avsCotisationsTitle, style: MintTextStyles.headlineMedium()),
       ),
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: MintSpacing.lg, vertical: MintSpacing.md),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            MintEntrance(child: _buildHeader(s)),
-            const SizedBox(height: MintSpacing.xl),
-            MintEntrance(delay: const Duration(milliseconds: 100), child: _buildIncomeSlider(s)),
-            const SizedBox(height: MintSpacing.lg),
-            if (_result != null) ...[
-              _buildPremierEclairage(s),
-              const SizedBox(height: MintSpacing.lg),
-              _buildResultCards(s),
-              const SizedBox(height: MintSpacing.lg),
-              _buildComparisonChart(s),
-              const SizedBox(height: MintSpacing.lg),
-              _buildBaremeGauge(s),
-              const SizedBox(height: MintSpacing.lg),
-              _buildEducation(s),
-              const SizedBox(height: MintSpacing.lg),
-            ],
-            MintEntrance(delay: const Duration(milliseconds: 200), child: _buildDisclaimer(s)),
-            const SizedBox(height: MintSpacing.xxl),
-          ],
-        ),
-      ))),
+      body: Center(
+          child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: MintSpacing.lg, vertical: MintSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    MintEntrance(child: _buildHeader(s)),
+                    const SizedBox(height: MintSpacing.xl),
+                    MintEntrance(
+                        delay: const Duration(milliseconds: 100),
+                        child: _buildLedgerFactsCard(context, s, annualIncome)),
+                    if (result != null) ...[
+                      const SizedBox(height: MintSpacing.lg),
+                      _buildPremierEclairage(s, result),
+                      const SizedBox(height: MintSpacing.lg),
+                      _buildResultCards(s, result),
+                      const SizedBox(height: MintSpacing.lg),
+                      _buildComparisonChart(s, result),
+                      const SizedBox(height: MintSpacing.lg),
+                      _buildBaremeGauge(s, result),
+                      const SizedBox(height: MintSpacing.lg),
+                      _buildEducation(s),
+                      const SizedBox(height: MintSpacing.lg),
+                    ],
+                    MintEntrance(
+                        delay: const Duration(milliseconds: 200),
+                        child: _buildDisclaimer(s)),
+                    const SizedBox(height: MintSpacing.xxl),
+                  ],
+                ),
+              ))),
     );
   }
 
@@ -137,40 +106,106 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
           const Icon(Icons.info_outline, color: MintColors.info, size: 20),
           const SizedBox(width: MintSpacing.sm + 4),
           Expanded(
-            child: Text(s.avsCotisationsHeaderInfo, style: MintTextStyles.bodySmall(color: MintColors.textSecondary)),
+            child: Text(s.avsCotisationsHeaderInfo,
+                style:
+                    MintTextStyles.bodySmall(color: MintColors.textSecondary)),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildIncomeSlider(S s) {
-    return MintSurface(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      radius: 16,
-      child: MintPremiumSlider(
-        label: s.avsCotisationsRevenuLabel,
-        value: _revenuNet,
-        min: _incomeMin,
-        max: _incomeMax,
-        divisions: 250,
-        formatValue: (v) => IndependantsService.formatChf(v),
-        onChanged: (value) {
-          _revenuNet = value;
-          _calculate();
-        },
-        onChangeEnd: (value) {
-          unawaited(_persistIncome(value));
-        },
+  Widget _buildLedgerFactsCard(
+      BuildContext context, S s, double? annualIncome) {
+    final hasMissing = annualIncome == null;
+    return Semantics(
+      key: const Key('avs_ledger_facts'),
+      identifier: 'avs_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        padding: const EdgeInsets.all(MintSpacing.md),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasMissing
+                      ? Icons.manage_search_outlined
+                      : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
+                ),
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
+                  child: Text(
+                    hasMissing
+                        ? s.dataQualityMissingSection
+                        : s.dataQualityKnownSection,
+                    style:
+                        MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                            .copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(
+                      '/data-block/revenu?inputKey=q_self_employed_income'),
+                  icon: Icon(
+                      hasMissing
+                          ? Icons.add_circle_outline
+                          : Icons.edit_outlined,
+                      size: 18),
+                  label: Text(hasMissing ? s.dataQualityEnrich : s.commonEdit),
+                ),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            Semantics(
+              key: const Key('avs_income_fact'),
+              identifier: 'avs_income_fact',
+              label:
+                  '${s.independantRevenueTitle}, ${annualIncome == null ? s.dataBlockStatusMissing : IndependantsService.formatChf(annualIncome)}',
+              container: true,
+              child: Row(
+                children: [
+                  Icon(
+                    hasMissing
+                        ? Icons.help_outline
+                        : Icons.check_circle_outline,
+                    color: hasMissing ? MintColors.warning : MintColors.success,
+                    size: 16,
+                  ),
+                  const SizedBox(width: MintSpacing.sm),
+                  Expanded(
+                      child: Text(s.independantRevenueTitle,
+                          style: MintTextStyles.bodySmall(
+                              color: MintColors.textSecondary))),
+                  Text(
+                    annualIncome == null
+                        ? s.dataBlockStatusMissing
+                        : IndependantsService.formatChf(annualIncome),
+                    style: MintTextStyles.bodySmall(
+                            color: hasMissing
+                                ? MintColors.warning
+                                : MintColors.textPrimary)
+                        .copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildPremierEclairage(S s) {
-    final r = _result!;
+  Widget _buildPremierEclairage(S s, AvsCotisationResult r) {
     if (r.differenceAnnuelle <= 0) return const SizedBox.shrink();
     return Semantics(
-      label: S.of(context)!.semanticsAvsDifference(IndependantsService.formatChf(r.differenceAnnuelle)),
+      label: S.of(context)!.semanticsAvsDifference(
+          IndependantsService.formatChf(r.differenceAnnuelle)),
       child: Container(
         padding: const EdgeInsets.all(MintSpacing.lg),
         decoration: BoxDecoration(
@@ -185,8 +220,10 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
             ),
             const SizedBox(height: MintSpacing.sm),
             Text(
-              s.avsCotisationsPremierEclairageCaption(IndependantsService.formatChf(r.differenceAnnuelle)),
-              style: MintTextStyles.bodyMedium(color: MintColors.white.withValues(alpha: 0.9)),
+              s.avsCotisationsPremierEclairageCaption(
+                  IndependantsService.formatChf(r.differenceAnnuelle)),
+              style: MintTextStyles.bodyMedium(
+                  color: MintColors.white.withValues(alpha: 0.9)),
               textAlign: TextAlign.center,
             ),
           ],
@@ -195,30 +232,49 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
     );
   }
 
-  Widget _buildResultCards(S s) {
-    final r = _result!;
-    return Column(
-      children: [
-        Row(
-          children: [
-            Expanded(child: _buildMetricCard(s.avsCotisationsTauxEffectif, '${r.tauxEffectif.toStringAsFixed(2)}\u00a0%', Icons.percent)),
-            const SizedBox(width: MintSpacing.sm + 4),
-            Expanded(child: _buildMetricCard(s.avsCotisationsCotisationAn, IndependantsService.formatChf(r.cotisationAnnuelle), Icons.calendar_month_outlined)),
-          ],
-        ),
-        const SizedBox(height: MintSpacing.sm + 4),
-        Row(
-          children: [
-            Expanded(child: _buildMetricCard(s.avsCotisationsCotisationMois, IndependantsService.formatChf(r.cotisationMensuelle), Icons.today_outlined)),
-            const SizedBox(width: MintSpacing.sm + 4),
-            Expanded(child: _buildMetricCard(s.avsCotisationsTranche, r.tranchLabel, Icons.format_list_numbered, small: true)),
-          ],
-        ),
-      ],
+  Widget _buildResultCards(S s, AvsCotisationResult r) {
+    return Semantics(
+      key: const Key('avs_result_cards'),
+      identifier: 'avs_result_cards',
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                  child: _buildMetricCard(
+                      s.avsCotisationsTauxEffectif,
+                      '${r.tauxEffectif.toStringAsFixed(2)}\u00a0%',
+                      Icons.percent)),
+              const SizedBox(width: MintSpacing.sm + 4),
+              Expanded(
+                  child: _buildMetricCard(
+                      s.avsCotisationsCotisationAn,
+                      IndependantsService.formatChf(r.cotisationAnnuelle),
+                      Icons.calendar_month_outlined)),
+            ],
+          ),
+          const SizedBox(height: MintSpacing.sm + 4),
+          Row(
+            children: [
+              Expanded(
+                  child: _buildMetricCard(
+                      s.avsCotisationsCotisationMois,
+                      IndependantsService.formatChf(r.cotisationMensuelle),
+                      Icons.today_outlined)),
+              const SizedBox(width: MintSpacing.sm + 4),
+              Expanded(
+                  child: _buildMetricCard(s.avsCotisationsTranche,
+                      r.tranchLabel, Icons.format_list_numbered,
+                      small: true)),
+            ],
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _buildMetricCard(String label, String value, IconData icon, {bool small = false}) {
+  Widget _buildMetricCard(String label, String value, IconData icon,
+      {bool small = false}) {
     return Semantics(
       label: S.of(context)!.semanticsMetricLabelValue(label, value),
       child: MintSurface(
@@ -227,68 +283,101 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ExcludeSemantics(child: Icon(icon, size: 18, color: MintColors.textMuted)),
+            ExcludeSemantics(
+                child: Icon(icon, size: 18, color: MintColors.textMuted)),
             const SizedBox(height: MintSpacing.sm),
-            Text(value, style: MintTextStyles.titleMedium(color: MintColors.textPrimary).copyWith(fontSize: small ? 13 : 18, fontWeight: FontWeight.w700)),
+            Text(value,
+                style: MintTextStyles.titleMedium(color: MintColors.textPrimary)
+                    .copyWith(
+                        fontSize: small ? 13 : 18,
+                        fontWeight: FontWeight.w700)),
             const SizedBox(height: MintSpacing.xs),
-            Text(label, style: MintTextStyles.labelSmall(color: MintColors.textSecondary)),
+            Text(label,
+                style:
+                    MintTextStyles.labelSmall(color: MintColors.textSecondary)),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildComparisonChart(S s) {
-    final r = _result!;
-    final maxVal = r.cotisationAnnuelle > r.cotisationSalarie ? r.cotisationAnnuelle : r.cotisationSalarie;
+  Widget _buildComparisonChart(S s, AvsCotisationResult r) {
+    final maxVal = r.cotisationAnnuelle > r.cotisationSalarie
+        ? r.cotisationAnnuelle
+        : r.cotisationSalarie;
     if (maxVal <= 0) return const SizedBox.shrink();
     final indepRatio = r.cotisationAnnuelle / maxVal;
     final salarieRatio = r.cotisationSalarie / maxVal;
-    return MintSurface(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      radius: 16,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(s.avsCotisationsComparaisonTitle, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w600)),
-          const SizedBox(height: MintSpacing.md + 4),
-          _buildComparisonBar(label: s.avsCotisationsIndependant, value: r.cotisationAnnuelle, ratio: indepRatio, color: MintColors.error),
-          const SizedBox(height: MintSpacing.md),
-          _buildComparisonBar(label: s.avsCotisationsSalarie, value: r.cotisationSalarie, ratio: salarieRatio, color: MintColors.success),
-          const SizedBox(height: MintSpacing.md),
-          Container(
-            padding: const EdgeInsets.all(MintSpacing.sm + 4),
-            decoration: BoxDecoration(
-              color: MintColors.error.withValues(alpha: 0.06),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Row(
-              children: [
-                const Icon(Icons.arrow_upward, size: 16, color: MintColors.error),
-                const SizedBox(width: MintSpacing.sm),
-                Expanded(
-                  child: Text(
-                    s.avsCotisationsSurcout(IndependantsService.formatChf(r.differenceAnnuelle)),
-                    style: MintTextStyles.bodySmall(color: MintColors.error).copyWith(fontWeight: FontWeight.w600),
+    return Semantics(
+      key: const Key('avs_comparison_chart'),
+      identifier: 'avs_comparison_chart',
+      child: MintSurface(
+        padding: const EdgeInsets.all(MintSpacing.md + 4),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.avsCotisationsComparaisonTitle,
+                style: MintTextStyles.bodySmall(color: MintColors.textMuted)
+                    .copyWith(fontWeight: FontWeight.w600)),
+            const SizedBox(height: MintSpacing.md + 4),
+            _buildComparisonBar(
+                label: s.avsCotisationsIndependant,
+                value: r.cotisationAnnuelle,
+                ratio: indepRatio,
+                color: MintColors.error),
+            const SizedBox(height: MintSpacing.md),
+            _buildComparisonBar(
+                label: s.avsCotisationsSalarie,
+                value: r.cotisationSalarie,
+                ratio: salarieRatio,
+                color: MintColors.success),
+            const SizedBox(height: MintSpacing.md),
+            Container(
+              padding: const EdgeInsets.all(MintSpacing.sm + 4),
+              decoration: BoxDecoration(
+                color: MintColors.error.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Row(
+                children: [
+                  const Icon(Icons.arrow_upward,
+                      size: 16, color: MintColors.error),
+                  const SizedBox(width: MintSpacing.sm),
+                  Expanded(
+                    child: Text(
+                      s.avsCotisationsSurcout(
+                          IndependantsService.formatChf(r.differenceAnnuelle)),
+                      style: MintTextStyles.bodySmall(color: MintColors.error)
+                          .copyWith(fontWeight: FontWeight.w600),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildComparisonBar({required String label, required double value, required double ratio, required Color color}) {
+  Widget _buildComparisonBar(
+      {required String label,
+      required double value,
+      required double ratio,
+      required Color color}) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(label, style: MintTextStyles.bodySmall(color: MintColors.textSecondary)),
-            Text(IndependantsService.formatChf(value), style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600)),
+            Text(label,
+                style:
+                    MintTextStyles.bodySmall(color: MintColors.textSecondary)),
+            Text(IndependantsService.formatChf(value),
+                style: MintTextStyles.bodySmall(color: MintColors.textPrimary)
+                    .copyWith(fontWeight: FontWeight.w600)),
           ],
         ),
         const SizedBox(height: MintSpacing.xs + 2),
@@ -305,62 +394,73 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
     );
   }
 
-  Widget _buildBaremeGauge(S s) {
-    final r = _result!;
-    final position = (_revenuNet / 60500).clamp(0.0, 1.0);
-    return MintSurface(
-      padding: const EdgeInsets.all(MintSpacing.md + 4),
-      radius: 16,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(s.avsCotisationsBaremeTitle, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w600)),
-          const SizedBox(height: MintSpacing.md + 4),
-          Stack(
-            children: [
-              Container(
-                height: 24,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  gradient: LinearGradient(colors: [
-                    MintColors.success.withValues(alpha: 0.5),
-                    MintColors.warning.withValues(alpha: 0.7),
-                    MintColors.error.withValues(alpha: 0.7),
-                  ]),
-                ),
-              ),
-              Positioned(
-                left: (MediaQuery.of(context).size.width - 88) * position.clamp(0.02, 0.95),
-                top: 0,
-                child: Container(
-                  width: 24,
+  Widget _buildBaremeGauge(S s, AvsCotisationResult r) {
+    final position =
+        AvsCalculator.selfEmployedCotisationGaugePosition(r.revenuNet);
+    return Semantics(
+      key: const Key('avs_bareme_gauge'),
+      identifier: 'avs_bareme_gauge',
+      child: MintSurface(
+        padding: const EdgeInsets.all(MintSpacing.md + 4),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.avsCotisationsBaremeTitle,
+                style: MintTextStyles.bodySmall(color: MintColors.textMuted)
+                    .copyWith(fontWeight: FontWeight.w600)),
+            const SizedBox(height: MintSpacing.md + 4),
+            Stack(
+              children: [
+                Container(
                   height: 24,
                   decoration: BoxDecoration(
-                    color: MintColors.white,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: MintColors.primary, width: 3),
+                    borderRadius: BorderRadius.circular(12),
+                    gradient: LinearGradient(colors: [
+                      MintColors.success.withValues(alpha: 0.5),
+                      MintColors.warning.withValues(alpha: 0.7),
+                      MintColors.error.withValues(alpha: 0.7),
+                    ]),
                   ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: MintSpacing.sm),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('5.37\u00a0%', style: MintTextStyles.labelSmall()),
-              Text('10.6\u00a0%', style: MintTextStyles.labelSmall()),
-            ],
-          ),
-          const SizedBox(height: MintSpacing.sm + 4),
-          Semantics(
-            label: S.of(context)!.semanticsAvsTauxEffectif(r.tauxEffectif.toStringAsFixed(2)),
-            child: Text(
-              s.avsCotisationsTauxEffectifLabel(r.tauxEffectif.toStringAsFixed(2)),
-              style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+                Positioned(
+                  left: (MediaQuery.of(context).size.width - 88) *
+                      position.clamp(0.02, 0.95),
+                  top: 0,
+                  child: Container(
+                    width: 24,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      color: MintColors.white,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: MintColors.primary, width: 3),
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
+            const SizedBox(height: MintSpacing.sm),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('5.37\u00a0%', style: MintTextStyles.labelSmall()),
+                Text('10.6\u00a0%', style: MintTextStyles.labelSmall()),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            Semantics(
+              label: S
+                  .of(context)!
+                  .semanticsAvsTauxEffectif(r.tauxEffectif.toStringAsFixed(2)),
+              child: Text(
+                s.avsCotisationsTauxEffectifLabel(
+                    r.tauxEffectif.toStringAsFixed(2)),
+                style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                    .copyWith(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -369,11 +469,18 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(s.avsCotisationsBonASavoir, style: MintTextStyles.bodySmall(color: MintColors.textMuted).copyWith(fontWeight: FontWeight.w600)),
+        Text(s.avsCotisationsBonASavoir,
+            style: MintTextStyles.bodySmall(color: MintColors.textMuted)
+                .copyWith(fontWeight: FontWeight.w600)),
         const SizedBox(height: MintSpacing.sm + 4),
-        _buildEduCard(Icons.trending_down, s.avsCotisationsEduDegressifTitle, s.avsCotisationsEduDegressifBody),
-        _buildEduCard(Icons.people_outline, s.avsCotisationsEduDoubleChargeTitle, s.avsCotisationsEduDoubleChargeBody),
-        _buildEduCard(Icons.calendar_today_outlined, s.avsCotisationsEduMinTitle, s.avsCotisationsEduMinBody),
+        _buildEduCard(Icons.trending_down, s.avsCotisationsEduDegressifTitle,
+            s.avsCotisationsEduDegressifBody),
+        _buildEduCard(
+            Icons.people_outline,
+            s.avsCotisationsEduDoubleChargeTitle,
+            s.avsCotisationsEduDoubleChargeBody),
+        _buildEduCard(Icons.calendar_today_outlined,
+            s.avsCotisationsEduMinTitle, s.avsCotisationsEduMinBody),
       ],
     );
   }
@@ -398,9 +505,14 @@ class _AvsCotisationsScreenState extends State<AvsCotisationsScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(title, style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600)),
+                  Text(title,
+                      style: MintTextStyles.bodyMedium(
+                              color: MintColors.textPrimary)
+                          .copyWith(fontWeight: FontWeight.w600)),
                   const SizedBox(height: MintSpacing.xs),
-                  Text(body, style: MintTextStyles.bodySmall(color: MintColors.textSecondary)),
+                  Text(body,
+                      style: MintTextStyles.bodySmall(
+                          color: MintColors.textSecondary)),
                 ],
               ),
             ),

--- a/apps/mobile/lib/services/financial_core/avs_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/avs_calculator.dart
@@ -124,6 +124,18 @@ class AvsCalculator {
     return (value * 20).roundToDouble() / 20;
   }
 
+  /// Position the self-employed AVS/AI/APG barème gauge.
+  ///
+  /// `1.0` means the income has reached the full-rate bracket for independent
+  /// AVS cotisations. Keep this threshold in financial_core so screens render
+  /// calculator output instead of owning financial constants.
+  static double selfEmployedCotisationGaugePosition(double revenuNet) {
+    final fullRateThreshold =
+        reg('avs.self_employed_full_rate_threshold', 60500.0);
+    if (revenuNet <= 0 || fullRateThreshold <= 0) return 0.0;
+    return (revenuNet / fullRateThreshold).clamp(0.0, 1.0).toDouble();
+  }
+
   /// AVS rente based on RAMD using Echelle 44 (LAVS art. 34).
   ///
   /// Concave lookup + linear interpolation between table points.
@@ -240,26 +252,4 @@ class AvsCalculator {
     return renteMax * gap / fullYears;
   }
 
-  /// Explains why a computed rente is zero or very low.
-  ///
-  /// Use after [computeMonthlyRente] returns 0 or near-zero to provide
-  /// user-facing context instead of a bare "0 CHF".
-  static String? explainZeroRente({
-    required double computedRente,
-    required double grossAnnualSalary,
-    required int currentAge,
-    required int retirementAge,
-  }) {
-    if (computedRente > 0) return null;
-    if (grossAnnualSalary <= 0) {
-      return 'Aucun revenu d\u00e9clar\u00e9 \u2014 renseigne ton salaire pour estimer ta rente AVS.';
-    }
-    if (retirementAge < 63) {
-      return 'Anticipation AVS possible uniquement d\u00e8s 63 ans (LAVS art.\u00a040).';
-    }
-    if (currentAge < 20) {
-      return 'Les cotisations AVS d\u00e9butent \u00e0 20 ans (LAVS art.\u00a03).';
-    }
-    return 'Revenu insuffisant pour g\u00e9n\u00e9rer une rente dans cette configuration.';
-  }
 }

--- a/apps/mobile/test/screens/financial_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/financial_screens_smoke_test.dart
@@ -124,7 +124,8 @@ void main() {
 
       // i18n: avsCotisationsTitle = "Cotisations AVS"
       expect(find.textContaining('Cotisations AVS'), findsOneWidget);
-      expect(find.textContaining('revenu'), findsWidgets);
+      expect(find.byKey(const Key('avs_ledger_facts')), findsOneWidget);
+      expect(find.text('Manquant'), findsOneWidget);
     });
 
     testWidgets('DividendeVsSalaireScreen renders without error',

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -428,84 +428,46 @@ void main() {
   // ===========================================================================
 
   group('AvsCotisationsScreen', () {
-    testWidgets('prefills known independent income from profile',
-        (tester) async {
-      final provider = RecordingCoachProfileProvider(
-        independentAnswers(selfIncome: 135000),
-      );
-
-      await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const AvsCotisationsScreen(),
-        ),
-      );
+    Future<void> pumpAvs(
+      WidgetTester tester,
+      Map<String, dynamic> answers,
+    ) async {
+      await tester.pumpWidget(buildWithCoachProfileProvider(
+        RecordingCoachProfileProvider(answers),
+        const AvsCotisationsScreen(),
+      ));
       await tester.pumpAndSettle(const Duration(seconds: 5));
+    }
 
-      final incomeSlider = tester
-          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
+    testWidgets('uses ledger facts instead of a local income slider',
+        (tester) async {
+      await pumpAvs(tester, independentAnswers(selfIncome: 135000));
 
-      expect(incomeSlider.value, 135000);
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.byKey(const Key('avs_ledger_facts')), findsOneWidget);
+      expect(find.byKey(const Key('avs_income_fact')), findsOneWidget);
+      expect(find.textContaining("135'000"), findsOneWidget);
+      expect(find.byKey(const Key('avs_result_cards')), findsOneWidget);
     });
 
-    testWidgets('does not prefill net income from a gross salary fallback',
+    testWidgets('does not calculate from a gross salary fallback',
         (tester) async {
-      final provider = RecordingCoachProfileProvider(
-        independentAnswers(grossSalary: 220000),
-      );
+      await pumpAvs(tester, independentAnswers(grossSalary: 220000));
 
-      await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const AvsCotisationsScreen(),
-        ),
-      );
-      await tester.pumpAndSettle(const Duration(seconds: 5));
-
-      final incomeSlider = tester
-          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
-
-      expect(incomeSlider.value, 80000);
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 220'000"), findsNothing);
+      expect(find.byKey(const Key('avs_result_cards')), findsNothing);
+      expect(find.text('Manquant'), findsOneWidget);
     });
 
-    testWidgets('persists edited independent income through the profile path',
+    testWidgets('shows missing fact instead of defaulting to 80000',
         (tester) async {
-      final provider = RecordingCoachProfileProvider(
-        independentAnswers(selfIncome: 90000),
-      );
+      await pumpAvs(tester, independentAnswers());
 
-      await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const AvsCotisationsScreen(),
-        ),
-      );
-      await tester.pump(const Duration(milliseconds: 500));
-
-      final incomeSlider = tester
-          .widget<MintPremiumSlider>(find.byType(MintPremiumSlider).first);
-      incomeSlider.onChanged(123000);
-      await tester.pump();
-
-      expect(provider.writes, isEmpty);
-
-      incomeSlider.onChangeEnd!(123000);
-      await tester.pump();
-
-      expect(provider.writes, isNotEmpty);
-      expect(
-        provider.writes.last,
-        containsPair('q_self_employed_income', 123000),
-      );
-      expect(
-        provider.writes.last,
-        containsPair('q_net_income_period_chf', 123000),
-      );
-      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
-      expect(
-        provider.writes.last,
-        containsPair('q_employment_status', 'independant'),
-      );
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 80'000"), findsNothing);
+      expect(find.text('Manquant'), findsOneWidget);
+      expect(find.byKey(const Key('avs_result_cards')), findsNothing);
     });
   });
 

--- a/apps/mobile/test/services/financial_core/calculator_forge_test.dart
+++ b/apps/mobile/test/services/financial_core/calculator_forge_test.dart
@@ -70,6 +70,16 @@ void main() {
       expect(avsNombreRentesParAn, equals(13));
       expect(avs13emeRenteFactor, closeTo(13.0 / 12.0, 0.001));
     });
+
+    test('S1.6 — self-employed AVS gauge caps at full-rate bracket', () {
+      expect(AvsCalculator.selfEmployedCotisationGaugePosition(0), equals(0.0));
+      expect(
+        AvsCalculator.selfEmployedCotisationGaugePosition(30250),
+        closeTo(0.5, 0.001),
+      );
+      expect(AvsCalculator.selfEmployedCotisationGaugePosition(60500), equals(1.0));
+      expect(AvsCalculator.selfEmployedCotisationGaugePosition(135000), equals(1.0));
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Replaces the AVS independent income slider/default with ledger-backed facts from CoachProfileProvider.
- Routes missing self-employed income to DataBlock via /data-block/revenu?inputKey=q_self_employed_income.
- Moves the AVS barème gauge threshold into financial_core and adds a boundary test.
- Updates Maestro to prove missing fact -> DataBlock collection -> AVS result cards.

## QA
- flutter analyze lib/services/financial_core/avs_calculator.dart lib/screens/independants/avs_cotisations_screen.dart test/services/financial_core/calculator_forge_test.dart test/screens/indep_nav_remaining_smoke_test.dart
- flutter test test/services/financial_core/calculator_forge_test.dart --reporter expanded
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded
- maestro check-syntax apps/mobile/.maestro/indep_avs_cotisations.yaml
- python3 tools/checks/arb_parity.py
- ./tools/mint-routes reconcile
- lefthook run pre-commit --file apps/mobile/.maestro/indep_avs_cotisations.yaml --file apps/mobile/lib/screens/independants/avs_cotisations_screen.dart --file apps/mobile/lib/services/financial_core/avs_calculator.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart --file apps/mobile/test/services/financial_core/calculator_forge_test.dart
- flutter build ios --simulator --debug
- maestro test --udid B03E429D-0422-4357-B754-536637D979F9 .maestro/indep_avs_cotisations.yaml
- Claude external audit: PASS (P2: backend override key not registered; route tap covered by Maestro/deep link not widget tap)