### PR TITLE
fix(mobile): use ledger facts for disability self-employed

### DIFF
--- a/apps/mobile/.maestro/disability_self_employed.yaml
+++ b/apps/mobile/.maestro/disability_self_employed.yaml
@@ -1,0 +1,34 @@
+appId: ch.mint.app
+---
+# Disability self-employed renders ledger facts, collects missing income through DataBlock, then shows results.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///disability/self-employed"
+- assertVisible:
+    id: "disability_self_ledger_facts"
+- assertVisible:
+    id: "disability_self_income_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- openLink: "mint:///data-block/revenu?inputKey=q_self_employed_income"
+- assertVisible:
+    id: "self_employed_income_input"
+- tapOn:
+    id: "self_employed_income_input"
+- inputText: "144000"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///disability/self-employed"
+- assertVisible:
+    id: "disability_self_ledger_facts"
+- scrollUntilVisible:
+    element:
+      id: "disability_self_result_cards"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true

--- a/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
+++ b/apps/mobile/lib/screens/disability/disability_self_employed_screen.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/financial_core/income_conversion_calculator.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/widgets/coach/disability_red_screen_widget.dart';
 import 'package:mint_mobile/widgets/coach/disability_countdown_widget.dart';
 import 'package:mint_mobile/widgets/coach/edu_shared_widgets.dart';
-import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 
@@ -28,61 +29,92 @@ class DisabilitySelfEmployedScreen extends StatefulWidget {
 
 class _DisabilitySelfEmployedScreenState
     extends State<DisabilitySelfEmployedScreen> {
-  double _monthlyRevenue = 8000;
   bool _hasPerteDegain = false;
-  bool _seededFromProfile = false;
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_seededFromProfile) return;
-    _seededFromProfile = true;
-    final profile = context.read<CoachProfileProvider>().profile;
-    if (profile == null) return;
-    setState(() {
-      final salary = profile.salaireBrutMensuel;
-      if (salary > 0) _monthlyRevenue = salary.clamp(2000.0, 25000.0);
-    });
+  CoachProfileProvider? _profileProvider(BuildContext context) {
+    try {
+      return context.watch<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
+    }
+  }
+
+  double? _annualIncome(CoachProfileProvider? provider) {
+    final income = provider?.profile?.selfEmployedNetIncome;
+    if (income != null && income > 0) return income.toDouble();
+    return null;
   }
 
   @override
   Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final provider = _profileProvider(context);
+    final annualIncome = _annualIncome(provider);
+    final monthlyRevenue = annualIncome == null
+        ? null
+        : IncomeConversionCalculator.monthlyAmountFromAnnual(annualIncome);
+
     return Scaffold(
       backgroundColor: MintColors.redBgLight, // fond rouge très pale
-      body: Center(child: ConstrainedBox(constraints: const BoxConstraints(maxWidth: 600), child: CustomScrollView(
-        slivers: [
-          _buildAppBar(),
-          SliverPadding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 40),
-            sliver: SliverList(
-              delegate: SliverChildListDelegate([
-                const SizedBox(height: 20),
-                MintEntrance(child: _buildRevenueSlider()),
-                const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 100), child: DisabilityRedScreenWidget(
-                  monthlyExpenses: _monthlyRevenue * 0.70,
-                  hasPerteDegain: _hasPerteDegain,
-                )),
-                const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 200), child: DisabilityCountdownWidget(
-                  monthlyExpenses: _monthlyRevenue * 0.70,
-                  initialSavings: _monthlyRevenue * 3, // hypothèse 3 mois
-                )),
-                const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 300), child: _buildPerteDegainToggle()),
-                const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 400), child: EduDisclaimer(
-                  text: S.of(context)!.disabilitySelfEmployedDisclaimer,
-                )),
-                const SizedBox(height: 8),
-                EduLegalSources(
-                  sources: S.of(context)!.disabilitySelfEmployedSources,
-                ),
-              ]),
-            ),
-          ),
-        ],
-      ))),
+      body: Center(
+          child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600),
+              child: CustomScrollView(
+                slivers: [
+                  _buildAppBar(),
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(20, 0, 20, 40),
+                    sliver: SliverList(
+                      delegate: SliverChildListDelegate([
+                        const SizedBox(height: 20),
+                        MintEntrance(
+                            child: _buildLedgerFactsCard(
+                                context, s, annualIncome)),
+                        const SizedBox(height: 20),
+                        if (monthlyRevenue != null) ...[
+                          Semantics(
+                            key: const Key('disability_self_result_cards'),
+                            identifier: 'disability_self_result_cards',
+                            child: Column(
+                              children: [
+                                MintEntrance(
+                                    delay: const Duration(milliseconds: 100),
+                                    child: DisabilityRedScreenWidget(
+                                      monthlyExpenses: monthlyRevenue * 0.70,
+                                      hasPerteDegain: _hasPerteDegain,
+                                    )),
+                                const SizedBox(height: 20),
+                                MintEntrance(
+                                    delay: const Duration(milliseconds: 200),
+                                    child: DisabilityCountdownWidget(
+                                      monthlyExpenses: monthlyRevenue * 0.70,
+                                      initialSavings: monthlyRevenue * 3,
+                                    )),
+                                const SizedBox(height: 20),
+                                MintEntrance(
+                                    delay: const Duration(milliseconds: 300),
+                                    child: _buildPerteDegainToggle()),
+                                const SizedBox(height: 20),
+                              ],
+                            ),
+                          ),
+                        ],
+                        MintEntrance(
+                            delay: const Duration(milliseconds: 400),
+                            child: EduDisclaimer(
+                              text: S
+                                  .of(context)!
+                                  .disabilitySelfEmployedDisclaimer,
+                            )),
+                        const SizedBox(height: 8),
+                        EduLegalSources(
+                          sources: S.of(context)!.disabilitySelfEmployedSources,
+                        ),
+                      ]),
+                    ),
+                  ),
+                ],
+              ))),
     );
   }
 
@@ -117,7 +149,8 @@ class _DisabilitySelfEmployedScreenState
                     ),
                     child: Text(
                       S.of(context)!.disabilitySelfEmployedAlertLabel,
-                      style: MintTextStyles.labelSmall(color: MintColors.white).copyWith(
+                      style: MintTextStyles.labelSmall(color: MintColors.white)
+                          .copyWith(
                         fontWeight: FontWeight.w700,
                         letterSpacing: 1,
                       ),
@@ -126,7 +159,9 @@ class _DisabilitySelfEmployedScreenState
                   const SizedBox(height: MintSpacing.sm),
                   Text(
                     S.of(context)!.disabilitySelfEmployedTitle,
-                    style: MintTextStyles.headlineMedium(color: MintColors.white).copyWith(fontWeight: FontWeight.w800),
+                    style:
+                        MintTextStyles.headlineMedium(color: MintColors.white)
+                            .copyWith(fontWeight: FontWeight.w800),
                   ),
                 ],
               ),
@@ -136,38 +171,98 @@ class _DisabilitySelfEmployedScreenState
       ),
       title: Text(
         S.of(context)!.disabilitySelfEmployedAppBarTitle,
-        style: MintTextStyles.bodyLarge(color: MintColors.white).copyWith(fontWeight: FontWeight.w700),
+        style: MintTextStyles.bodyLarge(color: MintColors.white)
+            .copyWith(fontWeight: FontWeight.w700),
       ),
     );
   }
 
-  Widget _buildRevenueSlider() {
-    return MintSurface(
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            S.of(context)!.disabilitySelfEmployedRevenueTitle,
-            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
-          ),
-          const SizedBox(height: MintSpacing.xs),
-          Text(
-            S.of(context)!.disabilitySelfEmployedRevenueHint,
-            style: MintTextStyles.labelSmall(),
-          ),
-          const SizedBox(height: 12),
-          MintPremiumSlider(
-            label: S.of(context)!.disabilitySelfEmployedRevenueLabel,
-            value: _monthlyRevenue,
-            min: 2000,
-            max: 25000,
-            divisions: 46,
-            formatValue: (v) => "CHF ${_fmtChf(v)}",
-            activeColor: MintColors.critical,
-            onChanged: (v) => setState(() => _monthlyRevenue = v),
-          ),
-        ],
+  Widget _buildLedgerFactsCard(
+    BuildContext context,
+    S s,
+    double? annualIncome,
+  ) {
+    final hasMissing = annualIncome == null;
+    final incomeLabel =
+        hasMissing ? s.dataBlockStatusMissing : 'CHF ${_fmtChf(annualIncome)}';
+    return Semantics(
+      key: const Key('disability_self_ledger_facts'),
+      identifier: 'disability_self_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasMissing
+                      ? Icons.manage_search_outlined
+                      : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
+                ),
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
+                  child: Text(
+                    hasMissing
+                        ? s.dataQualityMissingSection
+                        : s.dataQualityKnownSection,
+                    style: MintTextStyles.bodyMedium(
+                      color: MintColors.textPrimary,
+                    ).copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(
+                      '/data-block/revenu?inputKey=q_self_employed_income'),
+                  icon: Icon(
+                    hasMissing ? Icons.add_circle_outline : Icons.edit_outlined,
+                    size: 18,
+                  ),
+                  label: Text(hasMissing ? s.dataQualityEnrich : s.commonEdit),
+                ),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            Semantics(
+              key: const Key('disability_self_income_fact'),
+              identifier: 'disability_self_income_fact',
+              label: '${s.independantRevenueTitle}, $incomeLabel',
+              container: true,
+              child: Row(
+                children: [
+                  Icon(
+                    hasMissing
+                        ? Icons.help_outline
+                        : Icons.check_circle_outline,
+                    color: hasMissing ? MintColors.warning : MintColors.success,
+                    size: 16,
+                  ),
+                  const SizedBox(width: MintSpacing.sm),
+                  Expanded(
+                    child: Text(
+                      s.independantRevenueTitle,
+                      style: MintTextStyles.bodySmall(
+                        color: MintColors.textSecondary,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    incomeLabel,
+                    style: MintTextStyles.bodySmall(
+                      color: hasMissing
+                          ? MintColors.warning
+                          : MintColors.textPrimary,
+                    ).copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -180,19 +275,24 @@ class _DisabilitySelfEmployedScreenState
         children: [
           Text(
             S.of(context)!.disabilitySelfEmployedInsuranceQuestion,
-            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w700),
+            style: MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                .copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: 12),
           Row(
             children: [
               Expanded(
-                child: _buildToggleChip(S.of(context)!.disabilitySelfEmployedYes, _hasPerteDegain,
+                child: _buildToggleChip(
+                    S.of(context)!.disabilitySelfEmployedYes,
+                    _hasPerteDegain,
                     () => setState(() => _hasPerteDegain = true),
                     color: MintColors.success),
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: _buildToggleChip(S.of(context)!.disabilitySelfEmployedNo, !_hasPerteDegain,
+                child: _buildToggleChip(
+                    S.of(context)!.disabilitySelfEmployedNo,
+                    !_hasPerteDegain,
                     () => setState(() => _hasPerteDegain = false),
                     color: MintColors.critical),
               ),
@@ -214,7 +314,9 @@ class _DisabilitySelfEmployedScreenState
                   Expanded(
                     child: Text(
                       S.of(context)!.disabilitySelfEmployedApgTip,
-                      style: MintTextStyles.labelSmall(color: MintColors.amberDark).copyWith(height: 1.4),
+                      style:
+                          MintTextStyles.labelSmall(color: MintColors.amberDark)
+                              .copyWith(height: 1.4),
                     ),
                   ),
                 ],
@@ -232,27 +334,30 @@ class _DisabilitySelfEmployedScreenState
       label: label,
       button: true,
       child: GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(vertical: 12),
-        decoration: BoxDecoration(
-          color: selected ? color.withValues(alpha: 0.08) : MintColors.transparent,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: selected ? color : MintColors.border,
-            width: selected ? 2 : 1,
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          decoration: BoxDecoration(
+            color: selected
+                ? color.withValues(alpha: 0.08)
+                : MintColors.transparent,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: selected ? color : MintColors.border,
+              width: selected ? 2 : 1,
+            ),
+          ),
+          child: Center(
+            child: Text(
+              label,
+              style: MintTextStyles.bodySmall(
+                color: selected ? color : MintColors.textSecondary,
+              ).copyWith(
+                  fontWeight: selected ? FontWeight.w700 : FontWeight.w400),
+            ),
           ),
         ),
-        child: Center(
-          child: Text(
-            label,
-            style: MintTextStyles.bodySmall(
-              color: selected ? color : MintColors.textSecondary,
-            ).copyWith(fontWeight: selected ? FontWeight.w700 : FontWeight.w400),
-          ),
-        ),
-      ),
       ),
     );
   }

--- a/apps/mobile/lib/services/financial_core/income_conversion_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/income_conversion_calculator.dart
@@ -25,8 +25,15 @@ class IncomeConversionCalculator {
     double annualGross, {
     double months = defaultAnnualSalaryMonths,
   }) {
-    if (annualGross <= 0 || months <= 0) return 0;
-    return annualGross / months;
+    return monthlyAmountFromAnnual(annualGross, months: months);
+  }
+
+  static double monthlyAmountFromAnnual(
+    double annualAmount, {
+    double months = defaultAnnualSalaryMonths,
+  }) {
+    if (annualAmount <= 0 || months <= 0) return 0;
+    return annualAmount / months;
   }
 
   static double annualGrossFromMonthly({

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -8,6 +8,7 @@ import 'package:mint_mobile/screens/independants/avs_cotisations_screen.dart';
 import 'package:mint_mobile/screens/independants/ijm_screen.dart';
 import 'package:mint_mobile/screens/independants/lpp_volontaire_screen.dart';
 import 'package:mint_mobile/screens/independants/pillar_3a_indep_screen.dart';
+import 'package:mint_mobile/screens/disability/disability_self_employed_screen.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
@@ -532,7 +533,68 @@ void main() {
   });
 
   // ===========================================================================
-  // 5. PILLAR 3A INDEPENDANT SCREEN
+  // 5. DISABILITY SELF-EMPLOYED SCREEN
+  // ===========================================================================
+
+  group('DisabilitySelfEmployedScreen', () {
+    Future<void> pumpDisabilitySelf(
+      WidgetTester tester,
+      Map<String, dynamic> answers,
+    ) async {
+      await tester.pumpWidget(buildWithCoachProfileProvider(
+        RecordingCoachProfileProvider(answers),
+        const DisabilitySelfEmployedScreen(),
+      ));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+    }
+
+    testWidgets('uses ledger income instead of a local revenue slider',
+        (tester) async {
+      await pumpDisabilitySelf(
+        tester,
+        independentAnswers(selfIncome: 144000),
+      );
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(
+        find.byKey(const Key('disability_self_ledger_facts')),
+        findsOneWidget,
+      );
+      expect(
+          find.byKey(const Key('disability_self_income_fact')), findsOneWidget);
+      expect(find.textContaining("144'000"), findsOneWidget);
+      expect(find.byKey(const Key('disability_self_result_cards')),
+          findsOneWidget);
+    });
+
+    testWidgets('does not calculate from a gross salary fallback',
+        (tester) async {
+      await pumpDisabilitySelf(
+        tester,
+        independentAnswers(grossSalary: 240000),
+      );
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 240'000"), findsNothing);
+      expect(
+          find.byKey(const Key('disability_self_result_cards')), findsNothing);
+      expect(find.text('Manquant'), findsOneWidget);
+    });
+
+    testWidgets('shows missing fact instead of defaulting to a monthly value',
+        (tester) async {
+      await pumpDisabilitySelf(tester, independentAnswers());
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(find.text("CHF 8'000"), findsNothing);
+      expect(find.text('Manquant'), findsOneWidget);
+      expect(
+          find.byKey(const Key('disability_self_result_cards')), findsNothing);
+    });
+  });
+
+  // ===========================================================================
+  // 6. PILLAR 3A INDEPENDANT SCREEN
   // ===========================================================================
 
   group('Pillar3aIndepScreen', () {

--- a/apps/mobile/test/services/financial_core/income_conversion_calculator_test.dart
+++ b/apps/mobile/test/services/financial_core/income_conversion_calculator_test.dart
@@ -21,9 +21,26 @@ void main() {
     );
 
     expect(annualGross, 120000);
-    expect(IncomeConversionCalculator.annualBonusFromPercentage(annualGross: annualGross, bonusPercentage: 10), 12000);
-    expect(IncomeConversionCalculator.bonusPercentageFromAnnualBonus(annualBonus: 12000, annualBaseSalary: annualGross), 10);
-    expect(IncomeConversionCalculator.annualGrossFromMonthly(monthlyGross: 10000, months: 0), 0);
-    expect(IncomeConversionCalculator.bonusPercentageFromAnnualBonus(annualBonus: 12000, annualBaseSalary: 0), isNull);
+    expect(IncomeConversionCalculator.monthlyAmountFromAnnual(144000), 12000);
+    expect(
+      IncomeConversionCalculator.monthlyAmountFromAnnual(130000, months: 13),
+      10000,
+    );
+    expect(
+        IncomeConversionCalculator.annualBonusFromPercentage(
+            annualGross: annualGross, bonusPercentage: 10),
+        12000);
+    expect(
+        IncomeConversionCalculator.bonusPercentageFromAnnualBonus(
+            annualBonus: 12000, annualBaseSalary: annualGross),
+        10);
+    expect(
+        IncomeConversionCalculator.annualGrossFromMonthly(
+            monthlyGross: 10000, months: 0),
+        0);
+    expect(
+        IncomeConversionCalculator.bonusPercentageFromAnnualBonus(
+            annualBonus: 12000, annualBaseSalary: 0),
+        isNull);
   });
 }


### PR DESCRIPTION
## Summary
- remove the local revenue slider/default from DisabilitySelfEmployedScreen
- read q_self_employed_income via CoachProfile.selfEmployedNetIncome and show missing/known ledger facts
- route enrichment to /data-block/revenu?inputKey=q_self_employed_income
- add a Maestro flow proving missing fact -> data collection -> result cards
- keep annual/monthly conversion inside financial_core

## QA
- dart format lib/screens/disability/disability_self_employed_screen.dart lib/services/financial_core/income_conversion_calculator.dart test/screens/indep_nav_remaining_smoke_test.dart test/services/financial_core/income_conversion_calculator_test.dart
- flutter test test/screens/indep_nav_remaining_smoke_test.dart test/services/financial_core/income_conversion_calculator_test.dart --reporter expanded
- flutter analyze lib/screens/disability/disability_self_employed_screen.dart lib/services/financial_core/income_conversion_calculator.dart test/screens/indep_nav_remaining_smoke_test.dart test/services/financial_core/income_conversion_calculator_test.dart
- python3 tools/checks/arb_parity.py
- ./tools/mint-routes reconcile
- git diff --check
- lefthook run pre-commit --file apps/mobile/.maestro/disability_self_employed.yaml --file apps/mobile/lib/screens/disability/disability_self_employed_screen.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart --file apps/mobile/lib/services/financial_core/income_conversion_calculator.dart --file apps/mobile/test/services/financial_core/income_conversion_calculator_test.dart
- flutter build ios --simulator --debug
- xcrun simctl install B03E429D-0422-4357-B754-536637D979F9 build/ios/iphonesimulator/Runner.app
- ~/.maestro/bin/maestro --device B03E429D-0422-4357-B754-536637D979F9 test .maestro/disability_self_employed.yaml
- CLAUDE_AUDIT_MODEL=opus CLAUDE_AUDIT_EFFORT=high tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 => PASS, no P0/P1

## Notes
- Patrol is not installed on this Mac (`command -v patrol` returned empty), so runtime proof uses Maestro on iPhone 17 Pro.
- Claude P2 notes left for later: orphaned old slider l10n keys and a redundant `toDouble()`.
