### PR TITLE
fix(mobile): use ledger facts for voluntary lpp

### DIFF
--- a/apps/mobile/.maestro/indep_lpp_volontaire.yaml
+++ b/apps/mobile/.maestro/indep_lpp_volontaire.yaml
@@ -1,0 +1,69 @@
+appId: ch.mint.app
+---
+# LPP volontaire renders ledger facts, collects missing facts through DataBlock,
+# confirms enough liquidity to stay out of SafeMode, then shows results.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///independants/lpp-volontaire"
+- assertVisible:
+    text: "LPP volontaire"
+- assertVisible:
+    id: "lpp_volontaire_ledger_facts"
+- assertVisible:
+    id: "lpp_volontaire_income_fact"
+- assertVisible:
+    id: "lpp_volontaire_age_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- openLink: "mint:///data-block/revenu?inputKey=q_self_employed_income"
+- assertVisible:
+    id: "self_employed_income_input"
+- tapOn:
+    id: "self_employed_income_input"
+- inputText: "144000"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///data-block/revenu?inputKey=q_birth_year"
+- assertVisible:
+    id: "birth_year_input"
+- tapOn:
+    id: "birth_year_input"
+- inputText: "1978"
+- tapOn:
+    id: "salary_save_cta"
+- openLink: "mint:///data-block/patrimoine?inputKey=q_cash_total"
+- assertVisible:
+    id: "savings_input"
+- tapOn:
+    id: "savings_input"
+- inputText: "50000"
+- tapOn:
+    id: "patrimoine_save_cta"
+- openLink: "mint:///independants/lpp-volontaire"
+- assertVisible:
+    id: "lpp_volontaire_ledger_facts"
+- scrollUntilVisible:
+    element:
+      id: "lpp_volontaire_result_cards"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      id: "lpp_volontaire_retirement_comparison"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- scrollUntilVisible:
+    element:
+      id: "lpp_volontaire_age_table"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true

--- a/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
+++ b/apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
@@ -8,10 +7,8 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
-import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
-import 'package:mint_mobile/widgets/premium/mint_picker_tile.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
 import 'package:mint_mobile/widgets/common/safe_mode_gate.dart';
@@ -22,7 +19,7 @@ import 'package:provider/provider.dart';
 // ────────────────────────────────────────────────────────────
 //
 // Voluntary LPP simulator for self-employed workers.
-// Slider: revenu net, age selector.
+// Ledger facts: revenu net, age.
 // Comparison: with vs without LPP volontaire (retirement gap).
 // Chiffre choc: lost capitalization without voluntary LPP.
 // ────────────────────────────────────────────────────────────
@@ -35,90 +32,54 @@ class LppVolontaireScreen extends StatefulWidget {
 }
 
 class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
-  static const double _incomeMin = 0;
-  static const double _incomeMax = 250000;
   static const int _ageMin = 25;
   static const int _ageMax = 65;
 
-  double _revenuNet = 80000;
-  int _age = 40;
   double _tauxMarginal = 0.30;
-  LppVolontaireResult? _result;
-  bool _didHydrateFromProfile = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _result = _computeResult();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_didHydrateFromProfile) return;
-    _didHydrateFromProfile = true;
-    _hydrateFromProfile();
-  }
-
-  LppVolontaireResult _computeResult() {
-    return IndependantsService.calculateLppVolontaire(
-      _revenuNet,
-      _age,
-      _tauxMarginal,
-    );
-  }
-
-  void _calculate() {
-    setState(() {
-      _result = _computeResult();
-    });
-  }
-
-  CoachProfileProvider? _profileProvider() {
+  CoachProfileProvider? _profileProvider(BuildContext context) {
     try {
-      return context.read<CoachProfileProvider>();
+      return context.watch<CoachProfileProvider>();
     } on ProviderNotFoundException {
       return null;
     }
   }
 
-  void _hydrateFromProfile() {
-    final provider = _profileProvider();
+  double? _annualIncome(CoachProfileProvider? provider) {
     final profile = provider?.profile;
-    if (profile == null) return;
-
-    final income = profile.selfEmployedNetIncome;
+    final income = profile?.selfEmployedNetIncome;
     if (income != null && income > 0) {
-      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
+      return income.toDouble();
     }
-
-    final age = profile.ageOrNull;
-    if (age != null) {
-      _age = age.clamp(_ageMin, _ageMax).toInt();
-    }
-
-    _result = _computeResult();
+    return null;
   }
 
-  Future<void> _persistIncome(double value) async {
-    final provider = _profileProvider();
-    await provider?.mergeAnswers({
-      'q_self_employed_income': value,
-      'q_net_income_period_chf': value,
-      'q_pay_frequency': 'yearly',
-      'q_employment_status': 'independant',
-    });
+  int? _age(CoachProfileProvider? provider) {
+    final profile = provider?.profile;
+    final age = profile?.ageOrNull;
+    if (age != null && age >= _ageMin && age <= _ageMax) {
+      return age;
+    }
+    return null;
   }
 
-  Future<void> _persistAge(int value) async {
-    final provider = _profileProvider();
-    await provider?.mergeAnswers({
-      'q_birth_year': DateTime.now().year - value,
-    });
+  LppVolontaireResult? _computeResult(double? annualIncome, int? age) {
+    if (annualIncome == null || age == null) return null;
+    return IndependantsService.calculateLppVolontaire(
+      annualIncome,
+      age,
+      _tauxMarginal,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final provider = _profileProvider(context);
+    final annualIncome = _annualIncome(provider);
+    final age = _age(provider);
+    final result = _computeResult(annualIncome, age);
+
     return Scaffold(
       backgroundColor: MintColors.background,
       body: CustomScrollView(
@@ -130,25 +91,35 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
               delegate: SliverChildListDelegate([
                 MintEntrance(child: _buildHeader()),
                 const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildRevenuSlider()),
-                const SizedBox(height: 20),
-                _buildAgeSlider(),
-                const SizedBox(height: 20),
-                _buildTauxSlider(),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 100),
+                  child: _buildLedgerFactsCard(context, s, annualIncome, age),
+                ),
+                if (result != null) ...[
+                  const SizedBox(height: 20),
+                  _buildTauxSlider(),
+                ],
                 const SizedBox(height: 24),
-                if (_result != null) ...[
-                  // Contribution planning — gated in SafeMode (debt crisis)
+                if (result != null && age != null) ...[
+                  // Contribution planning remains gated in SafeMode: ledger
+                  // facts unlock understanding, but debt crisis blocks action.
                   SafeModeGate(
                     hasDebt: lookupSafeModeFlag(context),
                     child: Column(
                       children: [
-                        MintEntrance(child: _buildPremierEclairage()),
+                        MintEntrance(child: _buildPremierEclairage(result)),
                         const SizedBox(height: 24),
-                        MintEntrance(delay: const Duration(milliseconds: 100), child: _buildResultCards()),
+                        MintEntrance(
+                            delay: const Duration(milliseconds: 100),
+                            child: _buildResultCards(result)),
                         const SizedBox(height: 24),
-                        MintEntrance(delay: const Duration(milliseconds: 150), child: _buildRetirementComparison()),
+                        MintEntrance(
+                            delay: const Duration(milliseconds: 150),
+                            child: _buildRetirementComparison(result)),
                         const SizedBox(height: 24),
-                        MintEntrance(delay: const Duration(milliseconds: 200), child: _buildAgeTable()),
+                        MintEntrance(
+                            delay: const Duration(milliseconds: 200),
+                            child: _buildAgeTable(age)),
                         const SizedBox(height: 24),
                         _buildEducation(),
                         const SizedBox(height: 24),
@@ -179,7 +150,8 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
         icon: const Icon(Icons.arrow_back, color: MintColors.textPrimary),
         onPressed: () => safePop(context),
       ),
-      title: Text(S.of(context)!.lppVolontaireTitle, style: MintTextStyles.headlineMedium()),
+      title: Text(S.of(context)!.lppVolontaireTitle,
+          style: MintTextStyles.headlineMedium()),
     );
   }
 
@@ -209,38 +181,110 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
     );
   }
 
-  // ── Inputs ────────────────────────────────────────────────
+  // ── Ledger facts + scenario levers ─────────────────────────
 
-  Widget _buildRevenuSlider() {
-    return _buildInputCard(
-      child: MintAmountField(
-        label: S.of(context)!.lppVolontaireRevenuLabel,
-        value: _revenuNet,
-        formatValue: (v) => IndependantsService.formatChf(v),
-        onChanged: (v) {
-          _revenuNet = v;
-          _calculate();
-          unawaited(_persistIncome(v));
-        },
-        min: _incomeMin,
-        max: _incomeMax,
+  Widget _buildLedgerFactsCard(
+      BuildContext context, S s, double? annualIncome, int? age) {
+    final hasMissing = annualIncome == null || age == null;
+    final editRoute = annualIncome == null
+        ? '/data-block/revenu?inputKey=q_self_employed_income'
+        : '/data-block/revenu?inputKey=q_birth_year';
+
+    return Semantics(
+      key: const Key('lpp_volontaire_ledger_facts'),
+      identifier: 'lpp_volontaire_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        tone: MintSurfaceTone.blanc,
+        padding: const EdgeInsets.all(MintSpacing.md),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasMissing
+                      ? Icons.manage_search_outlined
+                      : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
+                ),
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
+                  child: Text(
+                    hasMissing
+                        ? s.dataQualityMissingSection
+                        : s.dataQualityKnownSection,
+                    style:
+                        MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                            .copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(editRoute),
+                  icon: Icon(
+                    hasMissing ? Icons.add_circle_outline : Icons.edit_outlined,
+                    size: 18,
+                  ),
+                  label: Text(hasMissing ? s.dataQualityEnrich : s.commonEdit),
+                ),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            _buildFactRow(
+              identifier: 'lpp_volontaire_income_fact',
+              label: s.lppVolontaireRevenuLabel,
+              value: annualIncome == null
+                  ? s.dataBlockStatusMissing
+                  : IndependantsService.formatChf(annualIncome),
+              isMissing: annualIncome == null,
+            ),
+            const SizedBox(height: MintSpacing.xs),
+            _buildFactRow(
+              identifier: 'lpp_volontaire_age_fact',
+              label: s.lppVolontaireTonAge,
+              value: age == null ? s.dataBlockStatusMissing : '$age ans',
+              isMissing: age == null,
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildAgeSlider() {
-    return _buildInputCard(
-      child: MintPickerTile(
-        label: S.of(context)!.lppVolontaireTonAge,
-        value: _age,
-        minValue: _ageMin,
-        maxValue: _ageMax,
-        formatValue: (v) => '$v ans',
-        onChanged: (v) {
-          _age = v;
-          _calculate();
-          unawaited(_persistAge(v));
-        },
+  Widget _buildFactRow({
+    required String identifier,
+    required String label,
+    required String value,
+    required bool isMissing,
+  }) {
+    return Semantics(
+      identifier: identifier,
+      label: '$label, $value',
+      container: true,
+      child: Row(
+        children: [
+          Icon(
+            isMissing ? Icons.help_outline : Icons.check_circle_outline,
+            color: isMissing ? MintColors.warning : MintColors.success,
+            size: 16,
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(
+            child: Text(
+              label,
+              style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+            ),
+          ),
+          Text(
+            value,
+            style: MintTextStyles.bodySmall(
+              color: isMissing ? MintColors.warning : MintColors.textPrimary,
+            ).copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
       ),
     );
   }
@@ -257,7 +301,6 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
         onChanged: (v) {
           setState(() {
             _tauxMarginal = v / 100;
-            _calculate();
           });
         },
       ),
@@ -274,10 +317,10 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
 
   // ── Premier Éclairage ───────────────────────────────────────────
 
-  Widget _buildPremierEclairage() {
-    final r = _result!;
+  Widget _buildPremierEclairage(LppVolontaireResult r) {
     return Semantics(
-      label: S.of(context)!.semanticsLppCapitalisation(IndependantsService.formatChf(r.capitalisationAnnuelle)),
+      label: S.of(context)!.semanticsLppCapitalisation(
+          IndependantsService.formatChf(r.capitalisationAnnuelle)),
       child: MintSurface(
         tone: MintSurfaceTone.peche,
         padding: const EdgeInsets.all(24),
@@ -285,7 +328,8 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
           children: [
             MintHeroNumber(
               value: IndependantsService.formatChf(r.capitalisationAnnuelle),
-              caption: S.of(context)!.lppVolontairePremierEclairageCaption(IndependantsService.formatChf(r.capitalisationAnnuelle)),
+              caption: S.of(context)!.lppVolontairePremierEclairageCaption(
+                  IndependantsService.formatChf(r.capitalisationAnnuelle)),
               color: MintColors.success,
             ),
           ],
@@ -296,59 +340,63 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
 
   // ── Result Cards ───────────────────────────────────────────
 
-  Widget _buildResultCards() {
-    final r = _result!;
-    return Column(
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: _buildMetricCard(
-                S.of(context)!.lppVolontaireSalaireCoordLabel,
-                IndependantsService.formatChf(r.salaireCoordonne),
-                Icons.account_balance_outlined,
+  Widget _buildResultCards(LppVolontaireResult r) {
+    return Semantics(
+      key: const Key('lpp_volontaire_result_cards'),
+      identifier: 'lpp_volontaire_result_cards',
+      container: true,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: _buildMetricCard(
+                  S.of(context)!.lppVolontaireSalaireCoordLabel,
+                  IndependantsService.formatChf(r.salaireCoordonne),
+                  Icons.account_balance_outlined,
+                ),
               ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: _buildMetricCard(
-                S.of(context)!.lppVolontaireTauxBonifLabel,
-                '${(r.tauxBonification * 100).toStringAsFixed(0)}\u00a0%',
-                Icons.trending_up,
+              const SizedBox(width: 12),
+              Expanded(
+                child: _buildMetricCard(
+                  S.of(context)!.lppVolontaireTauxBonifLabel,
+                  '${(r.tauxBonification * 100).toStringAsFixed(0)}\u00a0%',
+                  Icons.trending_up,
+                ),
               ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        Row(
-          children: [
-            Expanded(
-              child: _buildMetricCard(
-                S.of(context)!.lppVolontaireCotisationLabel,
-                IndependantsService.formatChf(r.cotisationAnnuelle),
-                Icons.calendar_month_outlined,
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _buildMetricCard(
+                  S.of(context)!.lppVolontaireCotisationLabel,
+                  IndependantsService.formatChf(r.cotisationAnnuelle),
+                  Icons.calendar_month_outlined,
+                ),
               ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: _buildMetricCard(
-                S.of(context)!.lppVolontaireEconomieFiscaleLabel,
-                IndependantsService.formatChf(r.economieFiscale),
-                Icons.savings_outlined,
-                valueColor: MintColors.success,
+              const SizedBox(width: 12),
+              Expanded(
+                child: _buildMetricCard(
+                  S.of(context)!.lppVolontaireEconomieFiscaleLabel,
+                  IndependantsService.formatChf(r.economieFiscale),
+                  Icons.savings_outlined,
+                  valueColor: MintColors.success,
+                ),
               ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        _buildMetricCard(
-          S.of(context)!.lppVolontaireTrancheAgeLabel,
-          r.ageBracketLabel,
-          Icons.person_outline,
-          small: true,
-          fullWidth: true,
-        ),
-      ],
+            ],
+          ),
+          const SizedBox(height: 12),
+          _buildMetricCard(
+            S.of(context)!.lppVolontaireTrancheAgeLabel,
+            r.ageBracketLabel,
+            Icons.person_outline,
+            small: true,
+            fullWidth: true,
+          ),
+        ],
+      ),
     );
   }
 
@@ -372,11 +420,17 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ExcludeSemantics(child: Icon(icon, size: 18, color: MintColors.textMuted)),
+            ExcludeSemantics(
+                child: Icon(icon, size: 18, color: MintColors.textMuted)),
             const SizedBox(height: 8),
             Text(
               value,
-              style: (small ? MintTextStyles.bodyMedium(color: valueColor ?? MintColors.textPrimary) : MintTextStyles.headlineMedium(color: valueColor ?? MintColors.textPrimary)).copyWith(fontWeight: FontWeight.w700),
+              style: (small
+                      ? MintTextStyles.bodyMedium(
+                          color: valueColor ?? MintColors.textPrimary)
+                      : MintTextStyles.headlineMedium(
+                          color: valueColor ?? MintColors.textPrimary))
+                  .copyWith(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: MintSpacing.xs),
             Text(
@@ -393,8 +447,7 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
 
   // ── Retirement Comparison ──────────────────────────────────
 
-  Widget _buildRetirementComparison() {
-    final r = _result!;
+  Widget _buildRetirementComparison(LppVolontaireResult r) {
     final maxVal = r.projectionAvecLpp > r.projectionSansLpp
         ? r.projectionAvecLpp
         : r.projectionSansLpp;
@@ -404,70 +457,87 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
     final avecRatio = r.projectionAvecLpp / maxVal;
     final gap = r.projectionAvecLpp - r.projectionSansLpp;
 
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.bar_chart, size: 16, color: MintColors.textMuted),
-              const SizedBox(width: 8),
-              Text(
-                S.of(context)!.lppVolontaireProjectionTitle,
-                style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
-              ),
-            ],
-          ),
-          const SizedBox(height: 20),
-
-          // Sans LPP bar
-          _buildProjectionBar(
-            label: S.of(context)!.lppVolontaireSansLpp,
-            value: r.projectionSansLpp,
-            ratio: sansRatio,
-            color: MintColors.success,
-          ),
-          const SizedBox(height: 16),
-
-          // Avec LPP bar
-          _buildProjectionBar(
-            label: S.of(context)!.lppVolontaireAvecLpp,
-            value: r.projectionAvecLpp,
-            ratio: avecRatio,
-            color: MintColors.success,
-          ),
-          const SizedBox(height: 16),
-
-          // Gap highlight
-          Semantics(
-            label: S.of(context)!.semanticsLppGain(IndependantsService.formatChf(gap)),
-            child: Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: MintColors.success.withValues(alpha: 0.08),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Row(
-                children: [
-                  const ExcludeSemantics(child: Icon(Icons.add_circle_outline, size: 16, color: MintColors.success)),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      S.of(context)!.lppVolontaireGapLabel(IndependantsService.formatChf(gap)),
-                      style: MintTextStyles.bodySmall(color: MintColors.success).copyWith(fontWeight: FontWeight.w600),
-                    ),
+    return Semantics(
+      key: const Key('lpp_volontaire_retirement_comparison'),
+      identifier: 'lpp_volontaire_retirement_comparison',
+      container: true,
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.bar_chart,
+                    size: 16, color: MintColors.textMuted),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    S.of(context)!.lppVolontaireProjectionTitle,
+                    style:
+                        MintTextStyles.labelSmall(color: MintColors.textMuted)
+                            .copyWith(fontWeight: FontWeight.w700),
                   ),
-                ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            // Sans LPP bar
+            _buildProjectionBar(
+              label: S.of(context)!.lppVolontaireSansLpp,
+              value: r.projectionSansLpp,
+              ratio: sansRatio,
+              color: MintColors.success,
+            ),
+            const SizedBox(height: 16),
+
+            // Avec LPP bar
+            _buildProjectionBar(
+              label: S.of(context)!.lppVolontaireAvecLpp,
+              value: r.projectionAvecLpp,
+              ratio: avecRatio,
+              color: MintColors.success,
+            ),
+            const SizedBox(height: 16),
+
+            // Gap highlight
+            Semantics(
+              label: S
+                  .of(context)!
+                  .semanticsLppGain(IndependantsService.formatChf(gap)),
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: MintColors.success.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Row(
+                  children: [
+                    const ExcludeSemantics(
+                        child: Icon(Icons.add_circle_outline,
+                            size: 16, color: MintColors.success)),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        S.of(context)!.lppVolontaireGapLabel(
+                            IndependantsService.formatChf(gap)),
+                        style:
+                            MintTextStyles.bodySmall(color: MintColors.success)
+                                .copyWith(fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -487,12 +557,14 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
             Expanded(
               child: Text(
                 label,
-                style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+                style:
+                    MintTextStyles.bodySmall(color: MintColors.textSecondary),
               ),
             ),
             Text(
               '${IndependantsService.formatChf(value)}/an',
-              style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+              style: MintTextStyles.bodySmall(color: MintColors.textPrimary)
+                  .copyWith(fontWeight: FontWeight.w600),
             ),
           ],
         ),
@@ -512,37 +584,47 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
 
   // ── Age Bonification Table ─────────────────────────────────
 
-  Widget _buildAgeTable() {
+  Widget _buildAgeTable(int age) {
     final brackets = [
-      ('25-34 ans', '7%', _age >= 25 && _age <= 34),
-      ('35-44 ans', '10%', _age >= 35 && _age <= 44),
-      ('45-54 ans', '15%', _age >= 45 && _age <= 54),
-      ('55-65 ans', '18%', _age >= 55 && _age <= 65),
+      ('25-34 ans', '7%', age >= 25 && age <= 34),
+      ('35-44 ans', '10%', age >= 35 && age <= 44),
+      ('45-54 ans', '15%', age >= 45 && age <= 54),
+      ('55-65 ans', '18%', age >= 55 && age <= 65),
     ];
 
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(Icons.table_chart_outlined, size: 16, color: MintColors.textMuted),
-              const SizedBox(width: 8),
-              Text(
-                S.of(context)!.lppVolontaireBonificationTitle,
-                style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          ...brackets.map((b) => _buildBracketRow(b.$1, b.$2, b.$3)),
-        ],
+    return Semantics(
+      key: const Key('lpp_volontaire_age_table'),
+      identifier: 'lpp_volontaire_age_table',
+      container: true,
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.table_chart_outlined,
+                    size: 16, color: MintColors.textMuted),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    S.of(context)!.lppVolontaireBonificationTitle,
+                    style:
+                        MintTextStyles.labelSmall(color: MintColors.textMuted)
+                            .copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            ...brackets.map((b) => _buildBracketRow(b.$1, b.$2, b.$3)),
+          ],
+        ),
       ),
     );
   }
@@ -552,7 +634,9 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
-        color: isCurrent ? MintColors.primary.withValues(alpha: 0.06) : MintColors.transparent,
+        color: isCurrent
+            ? MintColors.primary.withValues(alpha: 0.06)
+            : MintColors.transparent,
         borderRadius: BorderRadius.circular(10),
         border: isCurrent
             ? Border.all(color: MintColors.primary.withValues(alpha: 0.3))
@@ -566,25 +650,35 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
               if (isCurrent)
                 Container(
                   margin: const EdgeInsets.only(right: 8),
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                   decoration: BoxDecoration(
                     color: MintColors.primary,
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Text(
                     S.of(context)!.lppVolontaireToi,
-                    style: MintTextStyles.micro(color: MintColors.white).copyWith(fontWeight: FontWeight.w700),
+                    style: MintTextStyles.micro(color: MintColors.white)
+                        .copyWith(fontWeight: FontWeight.w700),
                   ),
                 ),
               Text(
                 age,
-                style: MintTextStyles.bodyMedium(color: isCurrent ? MintColors.textPrimary : MintColors.textSecondary).copyWith(fontWeight: isCurrent ? FontWeight.w600 : FontWeight.w400),
+                style: MintTextStyles.bodyMedium(
+                        color: isCurrent
+                            ? MintColors.textPrimary
+                            : MintColors.textSecondary)
+                    .copyWith(
+                        fontWeight:
+                            isCurrent ? FontWeight.w600 : FontWeight.w400),
               ),
             ],
           ),
           Text(
             taux,
-            style: MintTextStyles.titleMedium(color: isCurrent ? MintColors.primary : MintColors.textSecondary),
+            style: MintTextStyles.titleMedium(
+                color:
+                    isCurrent ? MintColors.primary : MintColors.textSecondary),
           ),
         ],
       ),
@@ -599,11 +693,13 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
       children: [
         Row(
           children: [
-            const Icon(Icons.lightbulb_outline, size: 16, color: MintColors.textMuted),
+            const Icon(Icons.lightbulb_outline,
+                size: 16, color: MintColors.textMuted),
             const SizedBox(width: 8),
             Text(
               S.of(context)!.lppVolontaireBonASavoir,
-              style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
+              style: MintTextStyles.labelSmall(color: MintColors.textMuted)
+                  .copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
             ),
           ],
         ),
@@ -654,12 +750,15 @@ class _LppVolontaireScreenState extends State<LppVolontaireScreen> {
                 children: [
                   Text(
                     title,
-                    style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+                    style:
+                        MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                            .copyWith(fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: MintSpacing.xs),
                   Text(
                     body,
-                    style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+                    style: MintTextStyles.bodySmall(
+                        color: MintColors.textSecondary),
                   ),
                 ],
               ),

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -137,10 +137,14 @@ Map<String, dynamic> independentAnswers({
   double? selfIncome,
   double? grossSalary,
   int? birthYear,
+  double? cashTotal,
+  bool hasConsumerDebt = false,
   bool voluntaryLpp = false,
 }) {
   return {
     if (birthYear != null) 'q_birth_year': birthYear,
+    if (cashTotal != null) 'q_cash_total': cashTotal,
+    if (hasConsumerDebt) 'q_has_consumer_debt': true,
     if (selfIncome != null) ...{
       'q_self_employed_income': selfIncome,
       'q_net_income_period_chf': selfIncome,
@@ -250,15 +254,19 @@ void main() {
       expect(find.text('LPP volontaire'), findsOneWidget);
     });
 
-    testWidgets('has revenu and age sliders visible', (tester) async {
+    testWidgets('shows missing ledger facts instead of local inputs',
+        (tester) async {
       await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      // In the default test viewport, only the first 2 sliders are visible
-      // (revenu net annuel and Ton age). The taux marginal slider is offscreen.
-      expect(find.byType(Slider), findsWidgets);
+      expect(
+          find.byKey(const Key('lpp_volontaire_ledger_facts')), findsOneWidget);
       expect(find.text('Revenu net annuel'), findsOneWidget);
-      expect(find.textContaining('Ton âge'), findsOneWidget);
+      expect(find.text('Ton âge'), findsOneWidget);
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(find.byType(MintPickerTile), findsNothing);
+      expect(find.byType(Slider), findsNothing);
     });
 
     testWidgets('shows intro info text about LPP', (tester) async {
@@ -267,32 +275,38 @@ void main() {
 
       expect(
         find.textContaining('caisse de pension'),
-        findsOneWidget,
+        findsWidgets,
       );
     });
 
-    testWidgets('shows CHF value labels on sliders', (tester) async {
-      await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
-      await tester.pumpAndSettle(const Duration(seconds: 5));
-
-      // The revenu slider shows CHF formatted value and range labels
-      expect(find.textContaining('CHF'), findsWidgets);
-    });
-
-    testWidgets('shows age picker tile', (tester) async {
-      await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
-      await tester.pumpAndSettle(const Duration(seconds: 5));
-
-      // Age picker shows formatted value with MintPickerTile
-      expect(find.byType(MintPickerTile), findsOneWidget);
-    });
-
-    testWidgets('prefills known independent income and age from profile',
+    testWidgets('shows missing status when ledger facts are absent',
         (tester) async {
+      await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text('Manquant'), findsNWidgets(2));
+    });
+
+    testWidgets('hides scenario slider until ledger facts are complete',
+        (tester) async {
+      await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.byType(MintPremiumSlider), findsNothing);
+    });
+
+    testWidgets('uses known independent income and age from profile facts',
+        (tester) async {
+      tester.view.physicalSize = const Size(390, 4000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
       final provider = RecordingCoachProfileProvider(
         independentAnswers(
           selfIncome: 140000,
           birthYear: DateTime.now().year - 52,
+          cashTotal: 50000,
         ),
       );
 
@@ -304,16 +318,47 @@ void main() {
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-      final agePicker =
-          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
-
-      expect(amountField.value, 140000);
-      expect(agePicker.value, 52);
+      expect(find.text('Données connues'), findsOneWidget);
+      expect(find.textContaining("CHF\u00A0140'000"), findsWidgets);
+      expect(find.text('52 ans'), findsWidgets);
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(find.byType(MintPickerTile), findsNothing);
+      expect(find.byType(MintPremiumSlider), findsOneWidget);
+      expect(
+          find.byKey(const Key('lpp_volontaire_result_cards')), findsOneWidget);
+      expect(find.byKey(const Key('lpp_volontaire_retirement_comparison')),
+          findsOneWidget);
+      expect(find.byKey(const Key('lpp_volontaire_age_table')), findsOneWidget);
     });
 
-    testWidgets('does not prefill net income from a gross salary fallback',
+    testWidgets('keeps contribution planning locked in SafeMode',
+        (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 140000,
+          birthYear: DateTime.now().year - 52,
+          cashTotal: 50000,
+          hasConsumerDebt: true,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          provider,
+          const LppVolontaireScreen(),
+        ),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text('Concentration Prioritaire'), findsOneWidget);
+      expect(
+          find.byKey(const Key('lpp_volontaire_result_cards')), findsNothing);
+      expect(find.byKey(const Key('lpp_volontaire_retirement_comparison')),
+          findsNothing);
+      expect(find.byKey(const Key('lpp_volontaire_age_table')), findsNothing);
+    });
+
+    testWidgets('does not use gross salary fallback as independent income',
         (tester) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(grossSalary: 220000),
@@ -327,13 +372,15 @@ void main() {
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-
-      expect(amountField.value, 80000);
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.text('Manquant'), findsWidgets);
+      expect(find.text("CHF\u00A0220'000"), findsNothing);
+      expect(find.text("CHF\u00A080'000"), findsNothing);
+      expect(find.byType(MintAmountField), findsNothing);
     });
 
-    testWidgets('clamps known profile values to the screen ranges',
+    testWidgets(
+        'does not clamp ledger income and treats invalid age as missing',
         (tester) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(
@@ -350,16 +397,12 @@ void main() {
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-      final agePicker =
-          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
-
-      expect(amountField.value, 250000);
-      expect(agePicker.value, 65);
+      expect(find.text("CHF\u00A0450'000"), findsOneWidget);
+      expect(find.text('Manquant'), findsWidgets);
+      expect(find.byType(MintPremiumSlider), findsNothing);
     });
 
-    testWidgets('persists edited independent income through the profile path',
+    testWidgets('does not expose an income editor inside the simulator',
         (tester) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(selfIncome: 90000),
@@ -373,28 +416,11 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 500));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-      amountField.onChanged(123000);
-      await tester.pump();
-
-      expect(provider.writes, isNotEmpty);
-      expect(
-        provider.writes.last,
-        containsPair('q_self_employed_income', 123000),
-      );
-      expect(
-        provider.writes.last,
-        containsPair('q_net_income_period_chf', 123000),
-      );
-      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
-      expect(
-        provider.writes.last,
-        containsPair('q_employment_status', 'independant'),
-      );
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(provider.writes, isEmpty);
     });
 
-    testWidgets('persists edited age as birth year through the profile path',
+    testWidgets('does not expose an age editor inside the simulator',
         (tester) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(
@@ -411,16 +437,8 @@ void main() {
       );
       await tester.pump(const Duration(milliseconds: 500));
 
-      final agePicker =
-          tester.widget<MintPickerTile>(find.byType(MintPickerTile));
-      agePicker.onChanged(44);
-      await tester.pump();
-
-      expect(provider.writes, isNotEmpty);
-      expect(
-        provider.writes.last,
-        containsPair('q_birth_year', DateTime.now().year - 44),
-      );
+      expect(find.byType(MintPickerTile), findsNothing);
+      expect(provider.writes, isEmpty);
     });
   });
 


### PR DESCRIPTION
## Summary
- Convert LPP volontaire from local income/age editors to canonical CoachProfile ledger facts.
- Route missing facts through DataBlock (`q_self_employed_income`, `q_birth_year`) and keep marginal tax rate as the only local scenario lever.
- Preserve SafeMode debt-crisis gating for contribution planning and add a regression test.
- Add Maestro runtime flow covering DataBlock enrichment and result cards on iPhone simulator.

## QA
- `flutter analyze lib/screens/independants/lpp_volontaire_screen.dart test/screens/indep_nav_remaining_smoke_test.dart`
- `flutter test test/screens/indep_nav_remaining_smoke_test.dart --plain-name LppVolontaireScreen --reporter expanded`
- `flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded`
- `flutter test test/screens/data_block_enrichment_screen_test.dart --reporter expanded`
- `flutter test test/navigation_route_integrity_test.dart --plain-name "FIX-191: all static context.push targets match a GoRoute path" --reporter expanded`
- `~/.maestro/bin/maestro check-syntax apps/mobile/.maestro/indep_lpp_volontaire.yaml`
- `flutter build ios --simulator --debug`
- `~/.maestro/bin/maestro --udid B03E429D-0422-4357-B754-536637D979F9 test apps/mobile/.maestro/indep_lpp_volontaire.yaml`
- `lefthook run pre-commit --file apps/mobile/lib/screens/independants/lpp_volontaire_screen.dart --file apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart --file apps/mobile/.maestro/indep_lpp_volontaire.yaml`
- `tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` → initial NO-GO on SafeMode removal, fixed; final audit PASS.

## Notes
- Diff exceeds 300 lines because the coherent unit is one screen + its smoke tests + runtime proof. This follows the repo rule that 300 lines is a reviewability heuristic, not a hard gate.
- Runtime evidence screenshot captured locally at `.planning/runtime-evidence/lpp-volontaire-ledger-20260710.png` (ignored evidence artifact).
