### PR TITLE
Make independent 3a use ledger facts

### DIFF
--- a/apps/mobile/.maestro/indep_pillar3a.yaml
+++ b/apps/mobile/.maestro/indep_pillar3a.yaml
@@ -1,0 +1,71 @@
+appId: ch.mint.app
+---
+# 3a indépendant renders ledger facts, collects missing profile facts through
+# DataBlock, confirms enough liquidity to stay out of SafeMode, then shows
+# scenario results. Core facts are not edited inside the simulator screen.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///independants/3a"
+- assertVisible:
+    text: "3e pilier indépendant"
+- assertVisible:
+    id: "pillar3a_indep_ledger_facts"
+- assertVisible:
+    id: "pillar3a_indep_income_fact"
+- assertVisible:
+    id: "pillar3a_indep_lpp_fact"
+- assertVisible:
+    id: "pillar3a_indep_liquidity_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "self_employed_income_input"
+- tapOn:
+    id: "self_employed_income_input"
+- inputText: "144000"
+- tapOn:
+    id: "salary_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///independants/3a"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "has_pension_fund_switch"
+- tapOn:
+    id: "has_pension_fund_switch"
+- tapOn:
+    id: "salary_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///independants/3a"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "savings_input"
+- tapOn:
+    id: "savings_input"
+- inputText: "50000"
+- tapOn:
+    id: "patrimoine_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///independants/3a"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    text: "Données connues"
+- assertVisible:
+    id: "pillar3a_indep_income_fact"
+- assertVisible:
+    id: "pillar3a_indep_liquidity_fact"
+- assertVisible:
+    id: "pillar3a_indep_result_container"
+- assertVisible:
+    id: "pillar3a_indep_plafond_row"

--- a/apps/mobile/lib/models/coach_profile.dart
+++ b/apps/mobile/lib/models/coach_profile.dart
@@ -1913,6 +1913,10 @@ class CoachProfile {
         age: age,
       );
       netMensuel = breakdown.monthlyNetPayslip;
+    } else if (employmentStatus == 'independant' &&
+        selfEmployedNetIncome != null &&
+        selfEmployedNetIncome! > 0) {
+      netMensuel = selfEmployedNetIncome! / 12.0;
     } else if (employmentStatus == 'retraite') {
       // E1 — retiree: use rente estimates as income denominator
       final renteAvs = prevoyance.renteAVSEstimeeMensuelle ?? 0.0;
@@ -2990,10 +2994,22 @@ class CoachProfile {
     if (answers.containsKey('q_has_voluntary_lpp')) {
       provided.add('hasVoluntaryLpp');
     }
-    if (answers.containsKey('q_employment_rate')) provided.add('employmentRate');
-    if (answers.containsKey('q_annual_bonus')) provided.add('bonusPourcentage');
-    if (answers.containsKey('q_civil_status')) provided.add('civilStatus');
-    if (answers.containsKey('q_nationality')) provided.add('nationality');
+    if (answers.containsKey('q_cash_total') ||
+        answers.containsKey('q_emergency_fund')) {
+      provided.add('liquidSavings');
+    }
+    if (answers.containsKey('q_employment_rate')) {
+      provided.add('employmentRate');
+    }
+    if (answers.containsKey('q_annual_bonus')) {
+      provided.add('bonusPourcentage');
+    }
+    if (answers.containsKey('q_civil_status')) {
+      provided.add('civilStatus');
+    }
+    if (answers.containsKey('q_nationality')) {
+      provided.add('nationality');
+    }
 
     return CoachProfile(
       firstName: firstName,

--- a/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
+++ b/apps/mobile/lib/screens/independants/pillar_3a_indep_screen.dart
@@ -1,5 +1,4 @@
-import 'dart:math' as math;
-import 'dart:async';
+import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/services/navigation/safe_pop.dart';
 
 import 'package:flutter/material.dart';
@@ -9,12 +8,10 @@ import 'package:mint_mobile/theme/mint_text_styles.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/services/independants_service.dart';
-import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 import 'package:mint_mobile/widgets/premium/mint_entrance.dart';
 import 'package:mint_mobile/widgets/premium/mint_hero_number.dart';
 import 'package:mint_mobile/widgets/premium/mint_premium_slider.dart';
 import 'package:mint_mobile/widgets/premium/mint_surface.dart';
-import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/widgets/common/safe_mode_gate.dart';
 import 'package:provider/provider.dart';
 
@@ -22,8 +19,8 @@ import 'package:provider/provider.dart';
 //  PILLAR 3A INDEPENDANT SCREEN — Sprint S18
 // ────────────────────────────────────────────────────────────
 //
-// Toggle LPP oui/non, slider revenu net, comparison
-// "petit 3a" (7258) vs "grand 3a" (up to 36288).
+// Ledger facts: revenu net indépendant, affiliation LPP.
+// Scenario lever: taux marginal. Comparison "petit 3a" vs "grand 3a".
 // Chiffre choc: fiscal advantage over salarié.
 // ────────────────────────────────────────────────────────────
 
@@ -35,92 +32,73 @@ class Pillar3aIndepScreen extends StatefulWidget {
 }
 
 class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
-  static const double _incomeMin = 0;
-  static const double _incomeMax = 300000;
-
-  double _revenuNet = 100000;
-  bool _affilieLpp = false;
   double _tauxMarginal = 0.30;
-  Pillar3aIndepResult? _result;
-  bool _didHydrateFromProfile = false;
 
-  @override
-  void initState() {
-    super.initState();
-    _result = _computeResult();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_didHydrateFromProfile) return;
-    _didHydrateFromProfile = true;
-    _hydrateFromProfile();
-  }
-
-  Pillar3aIndepResult _computeResult() {
-    return IndependantsService.calculate3aIndependant(
-      _revenuNet,
-      _affilieLpp,
-      _tauxMarginal,
-    );
-  }
-
-  void _calculate() {
-    setState(() {
-      _result = _computeResult();
-    });
-  }
-
-  CoachProfileProvider? _profileProvider() {
+  CoachProfileProvider? _profileProvider(BuildContext context) {
     try {
-      return context.read<CoachProfileProvider>();
+      return context.watch<CoachProfileProvider>();
     } on ProviderNotFoundException {
       return null;
     }
   }
 
-  void _hydrateFromProfile() {
-    final provider = _profileProvider();
+  double? _annualIncome(CoachProfileProvider? provider) {
     final profile = provider?.profile;
-    if (profile == null) return;
-
+    if (profile == null) return null;
+    if (!profile.userProvidedFields.contains('selfEmployedNetIncome')) {
+      return null;
+    }
     final income = profile.selfEmployedNetIncome;
     if (income != null && income > 0) {
-      _revenuNet = income.clamp(_incomeMin, _incomeMax).toDouble();
+      return income.toDouble();
     }
-
-    final hasLpp = profile.prevoyance.hasVoluntaryLpp ??
-        (profile.employmentStatus == 'independant'
-            ? profile.prevoyance.hasPensionFund
-            : null);
-    if (hasLpp != null) {
-      _affilieLpp = hasLpp;
-    }
-
-    _result = _computeResult();
+    return null;
   }
 
-  Future<void> _persistIncome(double value) async {
-    final provider = _profileProvider();
-    await provider?.mergeAnswers({
-      'q_self_employed_income': value,
-      'q_net_income_period_chf': value,
-      'q_pay_frequency': 'yearly',
-      'q_employment_status': 'independant',
-    });
+  bool? _hasPensionFund(CoachProfileProvider? provider) {
+    final profile = provider?.profile;
+    if (profile == null) return null;
+    if (profile.userProvidedFields.contains('hasVoluntaryLpp')) {
+      return profile.prevoyance.hasVoluntaryLpp;
+    }
+    if (profile.userProvidedFields.contains('hasPensionFund') &&
+        profile.employmentStatus == 'independant') {
+      return profile.prevoyance.hasPensionFund;
+    }
+    return null;
   }
 
-  Future<void> _persistLppChoice(bool value) async {
-    final provider = _profileProvider();
-    await provider?.mergeAnswers({
-      'q_has_voluntary_lpp': value ? 'yes' : 'no',
-      'q_has_pension_fund': value ? 'yes' : 'no',
-    });
+  double? _liquidSavings(CoachProfileProvider? provider) {
+    final profile = provider?.profile;
+    if (profile == null) return null;
+    if (!profile.userProvidedFields.contains('liquidSavings')) return null;
+    return profile.patrimoine.epargneLiquide;
+  }
+
+  Pillar3aIndepResult? _computeResult(
+    double? annualIncome,
+    bool? hasLpp,
+    double? liquidSavings,
+  ) {
+    if (annualIncome == null || hasLpp == null || liquidSavings == null) {
+      return null;
+    }
+    return IndependantsService.calculate3aIndependant(
+      annualIncome,
+      hasLpp,
+      _tauxMarginal,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final s = S.of(context)!;
+    final provider = _profileProvider(context);
+    final annualIncome = _annualIncome(provider);
+    final hasLpp = _hasPensionFund(provider);
+    final liquidSavings = _liquidSavings(provider);
+    final result = _computeResult(annualIncome, hasLpp, liquidSavings);
+
     return Scaffold(
       backgroundColor: MintColors.background,
       body: CustomScrollView(
@@ -130,25 +108,40 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
             padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
             sliver: SliverList(
               delegate: SliverChildListDelegate([
-                MintEntrance(child: _buildHeader()),
+                MintEntrance(child: _buildHeader(hasLpp)),
                 const SizedBox(height: 20),
-                MintEntrance(delay: const Duration(milliseconds: 100), child: _buildLppToggle()),
-                const SizedBox(height: 20),
-                _buildRevenuSlider(),
-                const SizedBox(height: 20),
-                _buildTauxSlider(),
+                MintEntrance(
+                  delay: const Duration(milliseconds: 100),
+                  child: _buildLedgerFactsCard(
+                    context,
+                    s,
+                    annualIncome,
+                    hasLpp,
+                    liquidSavings,
+                  ),
+                ),
+                if (result != null) ...[
+                  const SizedBox(height: 20),
+                  _buildTauxSlider(),
+                ],
                 const SizedBox(height: 24),
-                if (_result != null) ...[
-                  // Plafond/strategy section — gated in SafeMode (debt crisis)
+                if (result != null && hasLpp != null) ...[
+                  // Plafond/strategy section — gated in SafeMode.
                   SafeModeGate(
                     hasDebt: lookupSafeModeFlag(context),
                     child: Column(
                       children: [
-                        MintEntrance(child: _buildPremierEclairage()),
+                        MintEntrance(child: _buildPremierEclairage(result)),
                         const SizedBox(height: 24),
-                        MintEntrance(delay: const Duration(milliseconds: 100), child: _buildResultSection()),
+                        MintEntrance(
+                          delay: const Duration(milliseconds: 100),
+                          child: _buildResultSection(result),
+                        ),
                         const SizedBox(height: 24),
-                        MintEntrance(delay: const Duration(milliseconds: 150), child: _buildComparisonBars()),
+                        MintEntrance(
+                          delay: const Duration(milliseconds: 150),
+                          child: _buildComparisonBars(result, hasLpp),
+                        ),
                         const SizedBox(height: 24),
                         _buildEducation(),
                         const SizedBox(height: 24),
@@ -179,13 +172,21 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         icon: const Icon(Icons.arrow_back, color: MintColors.textPrimary),
         onPressed: () => safePop(context),
       ),
-      title: Text(S.of(context)!.pillar3aIndepTitle, style: MintTextStyles.headlineMedium()),
+      title: Text(
+        S.of(context)!.pillar3aIndepTitle,
+        style: MintTextStyles.headlineMedium(),
+      ),
     );
   }
 
   // ── Header ─────────────────────────────────────────────────
 
-  Widget _buildHeader() {
+  Widget _buildHeader(bool? hasLpp) {
+    final s = S.of(context)!;
+    final body = hasLpp == false
+        ? s.pillar3aIndepHeaderInfo
+        : s.pillar3aIndepEduConditionBody;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -200,7 +201,8 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              S.of(context)!.pillar3aIndepHeaderInfo,
+              body,
+              key: const Key('pillar3a_indep_header_info'),
               style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
             ),
           ),
@@ -209,75 +211,137 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
     );
   }
 
-  // ── LPP Toggle ─────────────────────────────────────────────
+  // ── Ledger facts + scenario levers ─────────────────────────
 
-  Widget _buildLppToggle() {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+  Widget _buildLedgerFactsCard(
+    BuildContext context,
+    S s,
+    double? annualIncome,
+    bool? hasLpp,
+    double? liquidSavings,
+  ) {
+    final hasMissing =
+        annualIncome == null || hasLpp == null || liquidSavings == null;
+    final editRoute = annualIncome == null
+        ? '/data-block/revenu?inputKey=q_self_employed_income'
+        : hasLpp == null
+            ? '/data-block/revenu?inputKey=q_has_pension_fund'
+            : liquidSavings == null
+                ? '/data-block/patrimoine?inputKey=q_cash_total'
+                : '/data-block/revenu?inputKey=q_self_employed_income';
+
+    return Semantics(
+      key: const Key('pillar3a_indep_ledger_facts'),
+      identifier: 'pillar3a_indep_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        tone: MintSurfaceTone.blanc,
+        padding: const EdgeInsets.all(MintSpacing.md),
+        radius: 16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
               children: [
-                Text(
-                  S.of(context)!.pillar3aIndepLppToggle,
-                  style: MintTextStyles.titleMedium(),
+                Icon(
+                  hasMissing
+                      ? Icons.manage_search_outlined
+                      : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
                 ),
-                const SizedBox(height: MintSpacing.xs),
-                Text(
-                  _affilieLpp
-                      ? S.of(context)!.pillar3aIndepPlafondPetit
-                      : S.of(context)!.pillar3aIndepPlafondGrand,
-                  style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
+                  child: Text(
+                    hasMissing
+                        ? s.dataQualityMissingSection
+                        : s.dataQualityKnownSection,
+                    style: MintTextStyles.bodyMedium(
+                      color: MintColors.textPrimary,
+                    ).copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () => context.push(editRoute),
+                  icon: Icon(
+                    hasMissing ? Icons.add_circle_outline : Icons.edit_outlined,
+                    size: 18,
+                  ),
+                  label: Text(hasMissing ? s.dataQualityEnrich : s.commonEdit),
                 ),
               ],
             ),
-          ),
-          Semantics(
-            toggled: _affilieLpp,
-            label: S.of(context)!.semantics3aLppToggle,
-            child: Switch(
-              value: _affilieLpp,
-              onChanged: (v) {
-                _affilieLpp = v;
-                _calculate();
-                unawaited(_persistLppChoice(v));
-              },
-              activeTrackColor: MintColors.success,
+            const SizedBox(height: MintSpacing.sm + 4),
+            _buildFactRow(
+              identifier: 'pillar3a_indep_income_fact',
+              label: s.pillar3aIndepRevenuLabel,
+              value: annualIncome == null
+                  ? s.dataBlockStatusMissing
+                  : IndependantsService.formatChf(annualIncome),
+              isMissing: annualIncome == null,
             ),
-          ),
-        ],
+            const SizedBox(height: MintSpacing.xs),
+            _buildFactRow(
+              identifier: 'pillar3a_indep_lpp_fact',
+              label: s.pillar3aIndepLppToggle,
+              value: hasLpp == null
+                  ? s.dataBlockStatusMissing
+                  : hasLpp
+                      ? s.pillar3aIndepPlafondPetit
+                      : s.pillar3aIndepPlafondGrand,
+              isMissing: hasLpp == null,
+            ),
+            const SizedBox(height: MintSpacing.xs),
+            _buildFactRow(
+              identifier: 'pillar3a_indep_liquidity_fact',
+              label: s.financialSummaryEpargneLiquide,
+              value: liquidSavings == null
+                  ? s.dataBlockStatusMissing
+                  : IndependantsService.formatChf(liquidSavings),
+              isMissing: liquidSavings == null,
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  // ── Revenu Slider ──────────────────────────────────────────
-
-  Widget _buildRevenuSlider() {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
-      ),
-      child: MintAmountField(
-        label: S.of(context)!.pillar3aIndepRevenuLabel,
-        value: _revenuNet,
-        formatValue: (v) => IndependantsService.formatChf(v),
-        onChanged: (v) {
-          _revenuNet = v;
-          _calculate();
-          unawaited(_persistIncome(v));
-        },
-        min: _incomeMin,
-        max: _incomeMax,
+  Widget _buildFactRow({
+    required String identifier,
+    required String label,
+    required String value,
+    required bool isMissing,
+  }) {
+    return Semantics(
+      identifier: identifier,
+      label: '$label, $value',
+      container: true,
+      child: Row(
+        children: [
+          Icon(
+            isMissing ? Icons.help_outline : Icons.check_circle_outline,
+            color: isMissing ? MintColors.warning : MintColors.success,
+            size: 16,
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(
+            child: Text(
+              label,
+              style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+            ),
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Flexible(
+            child: Text(
+              value,
+              textAlign: TextAlign.right,
+              style: MintTextStyles.bodySmall(
+                color: isMissing ? MintColors.warning : MintColors.textPrimary,
+              ).copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -290,7 +354,10 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
       decoration: BoxDecoration(
         color: MintColors.white,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.border.withValues(alpha: 0.6), width: 0.8),
+        border: Border.all(
+          color: MintColors.border.withValues(alpha: 0.6),
+          width: 0.8,
+        ),
       ),
       child: MintPremiumSlider(
         label: S.of(context)!.pillar3aIndepTauxLabel,
@@ -302,7 +369,6 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         onChanged: (v) {
           setState(() {
             _tauxMarginal = v / 100;
-            _calculate();
           });
         },
       ),
@@ -311,11 +377,12 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
   // ── Premier Éclairage ───────────────────────────────────────────
 
-  Widget _buildPremierEclairage() {
-    final r = _result!;
+  Widget _buildPremierEclairage(Pillar3aIndepResult r) {
     if (r.avantageSurSalarie <= 0) {
       return Semantics(
-        label: S.of(context)!.semantics3aEconomieFiscale(IndependantsService.formatChf(r.economieFiscale)),
+        label: S.of(context)!.semantics3aEconomieFiscale(
+              IndependantsService.formatChf(r.economieFiscale),
+            ),
         child: MintSurface(
           tone: MintSurfaceTone.porcelaine,
           padding: const EdgeInsets.all(24),
@@ -333,7 +400,9 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
     }
 
     return Semantics(
-      label: S.of(context)!.semantics3aAvantageSalarie(IndependantsService.formatChf(r.avantageSurSalarie)),
+      label: S.of(context)!.semantics3aAvantageSalarie(
+            IndependantsService.formatChf(r.avantageSurSalarie),
+          ),
       child: MintSurface(
         tone: MintSurfaceTone.sauge,
         padding: const EdgeInsets.all(24),
@@ -341,7 +410,10 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
           children: [
             MintHeroNumber(
               value: IndependantsService.formatChf(r.avantageSurSalarie),
-              caption: S.of(context)!.pillar3aIndepPremierEclairageAvantageSalarie(IndependantsService.formatChf(r.avantageSurSalarie)),
+              caption:
+                  S.of(context)!.pillar3aIndepPremierEclairageAvantageSalarie(
+                        IndependantsService.formatChf(r.avantageSurSalarie),
+                      ),
               color: MintColors.success,
             ),
           ],
@@ -352,50 +424,75 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
   // ── Result Section ─────────────────────────────────────────
 
-  Widget _buildResultSection() {
-    final r = _result!;
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
-      child: Column(
-        children: [
-          _buildResultRow(S.of(context)!.pillar3aIndepPlafondApplicableLabel, IndependantsService.formatChf(r.plafond)),
-          const SizedBox(height: 12),
-          _buildResultRow(S.of(context)!.pillar3aIndepEconomieFiscaleAnLabel, IndependantsService.formatChf(r.economieFiscale)),
-          const Divider(height: 24),
-          _buildResultRow(
-            S.of(context)!.pillar3aIndepPlafondSalarieLabel,
-            IndependantsService.formatChf(r.plafondSalarie),
-            color: MintColors.textMuted,
-          ),
-          const SizedBox(height: 8),
-          _buildResultRow(
-            S.of(context)!.pillar3aIndepEconomieSalarieLabel,
-            IndependantsService.formatChf(r.economieSalarie),
-            color: MintColors.textMuted,
-          ),
-        ],
+  Widget _buildResultSection(Pillar3aIndepResult r) {
+    return Semantics(
+      key: const Key('pillar3a_indep_result_section'),
+      identifier: 'pillar3a_indep_result_container',
+      container: true,
+      explicitChildNodes: true,
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          children: [
+            _buildResultRow(
+              S.of(context)!.pillar3aIndepPlafondApplicableLabel,
+              IndependantsService.formatChf(r.plafond),
+              identifier: 'pillar3a_indep_plafond_row',
+            ),
+            const SizedBox(height: 12),
+            _buildResultRow(
+              S.of(context)!.pillar3aIndepEconomieFiscaleAnLabel,
+              IndependantsService.formatChf(r.economieFiscale),
+            ),
+            const Divider(height: 24),
+            _buildResultRow(
+              S.of(context)!.pillar3aIndepPlafondSalarieLabel,
+              IndependantsService.formatChf(r.plafondSalarie),
+              color: MintColors.textMuted,
+            ),
+            const SizedBox(height: 8),
+            _buildResultRow(
+              S.of(context)!.pillar3aIndepEconomieSalarieLabel,
+              IndependantsService.formatChf(r.economieSalarie),
+              color: MintColors.textMuted,
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildResultRow(String label, String value, {Color? color}) {
+  Widget _buildResultRow(
+    String label,
+    String value, {
+    Color? color,
+    String? identifier,
+  }) {
     return Semantics(
+      identifier: identifier,
       label: S.of(context)!.semanticsMetricLabelValue(label, value),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            label,
-            style: MintTextStyles.bodyMedium(color: color ?? MintColors.textSecondary),
+          Expanded(
+            child: Text(
+              label,
+              style: MintTextStyles.bodyMedium(
+                color: color ?? MintColors.textSecondary,
+              ),
+            ),
           ),
+          const SizedBox(width: MintSpacing.sm),
           Text(
             value,
-            style: MintTextStyles.bodyMedium(color: color ?? MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+            style: MintTextStyles.bodyMedium(
+              color: color ?? MintColors.textPrimary,
+            ).copyWith(fontWeight: FontWeight.w600),
           ),
         ],
       ),
@@ -404,122 +501,159 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
 
   // ── Comparison Stacked Bars ────────────────────────────────
 
-  Widget _buildComparisonBars() {
-    final r = _result!;
-    const petit = pilier3aPlafondAvecLpp;
-    const grand = pilier3aPlafondSansLpp;
+  Widget _buildComparisonBars(Pillar3aIndepResult r, bool hasLpp) {
+    final petit = r.plafondSalarie;
+    final grand = IndependantsService.plafond3aGrand;
     final plafondIndep = r.plafond;
     final multiplier = (plafondIndep / petit).round();
 
-    // 20-year projection at 4% compound interest
-    final proj20Indep = plafondIndep * ((math.pow(1.04, 20) - 1) / 0.04);
-    final proj20Salarie = petit * ((math.pow(1.04, 20) - 1) / 0.04);
+    final projection = IndependantsService.project3aIndependant20Years(r);
+    final hasProjectionUpside = !hasLpp && projection.difference > 0;
 
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: MintColors.white,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: MintColors.lightBorder),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // ── Header with ×5 badge (P6-E / S42) ──
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  S.of(context)!.pillar3aIndepPlafondsCompares,
-                  style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
-                ),
-              ),
-              if (!_affilieLpp)
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: MintColors.success,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Text(
-                    S.of(context)!.pillar3aIndepSuperPouvoir(multiplier),
-                    style: MintTextStyles.labelSmall(color: MintColors.white).copyWith(fontWeight: FontWeight.w700),
+    return Semantics(
+      key: const Key('pillar3a_indep_comparison_bars'),
+      identifier: 'pillar3a_indep_comparison_container',
+      container: true,
+      explicitChildNodes: true,
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: MintColors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: MintColors.lightBorder),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ── Header with ×5 badge (P6-E / S42) ──
+            Row(
+              children: [
+                Expanded(
+                  child: Semantics(
+                    identifier: 'pillar3a_indep_comparison_bars',
+                    child: Text(
+                      S.of(context)!.pillar3aIndepPlafondsCompares,
+                      style: MintTextStyles.labelSmall(
+                        color: MintColors.textMuted,
+                      ).copyWith(fontWeight: FontWeight.w700),
+                    ),
                   ),
                 ),
-            ],
-          ),
-          const SizedBox(height: 20),
-
-          // Salarie bar
-          _buildPlafondBar(
-            label: S.of(context)!.pillar3aIndepSalarie,
-            value: petit,
-            maxValue: grand,
-            color: MintColors.info,
-          ),
-          const SizedBox(height: 16),
-
-          // Independant bar
-          _buildPlafondBar(
-            label: S.of(context)!.pillar3aIndepIndependantToi,
-            value: plafondIndep,
-            maxValue: grand,
-            color: MintColors.success,
-            highlight: true,
-          ),
-          const SizedBox(height: 16),
-
-          // Max bar
-          _buildPlafondBar(
-            label: S.of(context)!.pillar3aIndepGrand3aMax,
-            value: grand,
-            maxValue: grand,
-            color: MintColors.textMuted.withValues(alpha: 0.3),
-          ),
-
-          // ── 20-year projection (P6-E chiffre-choc) ──
-          if (!_affilieLpp) ...[
-            const SizedBox(height: 16),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: MintColors.success.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                    color: MintColors.success.withValues(alpha: 0.2)),
-              ),
-              child: Column(
-                children: [
-                  Text(
-                    S.of(context)!.pillar3aIndepEn20ans,
-                    style: MintTextStyles.micro(color: MintColors.textMuted),
+                if (hasProjectionUpside && multiplier > 1)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: MintColors.success,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      S.of(context)!.pillar3aIndepSuperPouvoir(multiplier),
+                      style: MintTextStyles.labelSmall(
+                        color: MintColors.white,
+                      ).copyWith(fontWeight: FontWeight.w700),
+                    ),
                   ),
-                  const SizedBox(height: 6),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      _buildProjectionColumn(
-                          S.of(context)!.pillar3aIndepSalarie, proj20Salarie, MintColors.info),
-                      Text(
-                        S.of(context)!.pillar3aIndepVs,
-                        style: MintTextStyles.bodyMedium(color: MintColors.textMuted),
-                      ),
-                      _buildProjectionColumn(
-                          S.of(context)!.pillar3aIndepToi, proj20Indep, MintColors.success),
-                    ],
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    S.of(context)!.pillar3aIndepDifference(IndependantsService.formatChf(proj20Indep - proj20Salarie)),
-                    style: MintTextStyles.bodySmall(color: MintColors.success).copyWith(fontWeight: FontWeight.w700),
-                  ),
-                ],
-              ),
+              ],
             ),
+            const SizedBox(height: 20),
+
+            // Salarie bar
+            _buildPlafondBar(
+              label: S.of(context)!.pillar3aIndepSalarie,
+              value: petit,
+              maxValue: grand,
+              color: MintColors.info,
+            ),
+            const SizedBox(height: 16),
+
+            // Independant bar
+            _buildPlafondBar(
+              label: S.of(context)!.pillar3aIndepIndependantToi,
+              value: plafondIndep,
+              maxValue: grand,
+              color: MintColors.success,
+              highlight: true,
+            ),
+            const SizedBox(height: 16),
+
+            // Max bar
+            _buildPlafondBar(
+              label: S.of(context)!.pillar3aIndepGrand3aMax,
+              value: grand,
+              maxValue: grand,
+              color: MintColors.textMuted.withValues(alpha: 0.3),
+            ),
+
+            // ── 20-year projection (P6-E chiffre-choc) ──
+            if (hasProjectionUpside) ...[
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: MintColors.success.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: MintColors.success.withValues(alpha: 0.2),
+                  ),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      S.of(context)!.pillar3aIndepEn20ans,
+                      style: MintTextStyles.micro(color: MintColors.textMuted),
+                    ),
+                    const SizedBox(height: 6),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        Expanded(
+                          child: _buildProjectionColumn(
+                            S.of(context)!.pillar3aIndepSalarie,
+                            projection.projectionSalarie,
+                            MintColors.info,
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: MintSpacing.sm,
+                          ),
+                          child: Text(
+                            S.of(context)!.pillar3aIndepVs,
+                            style: MintTextStyles.bodyMedium(
+                              color: MintColors.textMuted,
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: _buildProjectionColumn(
+                            S.of(context)!.pillar3aIndepToi,
+                            projection.projectionIndependant,
+                            MintColors.success,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      S.of(context)!.pillar3aIndepDifference(
+                            IndependantsService.formatChf(
+                              projection.difference,
+                            ),
+                          ),
+                      style: MintTextStyles.bodySmall(
+                        color: MintColors.success,
+                      ).copyWith(fontWeight: FontWeight.w700),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }
@@ -530,13 +664,21 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         ? '${(amount / 1000000).toStringAsFixed(2)}M'
         : '${(amount / 1000).toStringAsFixed(0)}k';
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Text(
-          'CHF\u00a0$display',
-          style: MintTextStyles.headlineMedium(color: color).copyWith(fontWeight: FontWeight.w800),
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(
+            'CHF\u00a0$display',
+            textAlign: TextAlign.center,
+            style: MintTextStyles.headlineMedium(
+              color: color,
+            ).copyWith(fontWeight: FontWeight.w800),
+          ),
         ),
         Text(
           label,
+          textAlign: TextAlign.center,
           style: MintTextStyles.micro(color: MintColors.textMuted),
         ),
       ],
@@ -557,13 +699,24 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              label,
-              style: MintTextStyles.bodySmall(color: highlight ? MintColors.textPrimary : MintColors.textSecondary).copyWith(fontWeight: highlight ? FontWeight.w600 : FontWeight.w400),
+            Expanded(
+              child: Text(
+                label,
+                style: MintTextStyles.bodySmall(
+                  color: highlight
+                      ? MintColors.textPrimary
+                      : MintColors.textSecondary,
+                ).copyWith(
+                  fontWeight: highlight ? FontWeight.w600 : FontWeight.w400,
+                ),
+              ),
             ),
+            const SizedBox(width: MintSpacing.sm),
             Text(
               IndependantsService.formatChf(value),
-              style: MintTextStyles.bodySmall(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+              style: MintTextStyles.bodySmall(
+                color: MintColors.textPrimary,
+              ).copyWith(fontWeight: FontWeight.w600),
             ),
           ],
         ),
@@ -589,11 +742,17 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
       children: [
         Row(
           children: [
-            const Icon(Icons.lightbulb_outline, size: 16, color: MintColors.textMuted),
+            const Icon(
+              Icons.lightbulb_outline,
+              size: 16,
+              color: MintColors.textMuted,
+            ),
             const SizedBox(width: 8),
             Text(
               S.of(context)!.pillar3aIndepBonASavoir,
-              style: MintTextStyles.labelSmall(color: MintColors.textMuted).copyWith(letterSpacing: 1, fontWeight: FontWeight.w700),
+              style: MintTextStyles.labelSmall(
+                color: MintColors.textMuted,
+              ).copyWith(fontWeight: FontWeight.w700),
             ),
           ],
         ),
@@ -644,12 +803,16 @@ class _Pillar3aIndepScreenState extends State<Pillar3aIndepScreen> {
                 children: [
                   Text(
                     title,
-                    style: MintTextStyles.bodyMedium(color: MintColors.textPrimary).copyWith(fontWeight: FontWeight.w600),
+                    style: MintTextStyles.bodyMedium(
+                      color: MintColors.textPrimary,
+                    ).copyWith(fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(height: MintSpacing.xs),
                   Text(
                     body,
-                    style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+                    style: MintTextStyles.bodySmall(
+                      color: MintColors.textSecondary,
+                    ),
                   ),
                 ],
               ),

--- a/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
+++ b/apps/mobile/lib/screens/onboarding/data_block_enrichment_screen.dart
@@ -65,6 +65,8 @@ class _DataBlockEnrichmentScreenState
   bool _hasPensionFundTouched = false;
   bool _isSavingRevenue = false;
   bool _isSavingPatrimoine = false;
+  bool _revenueSaved = false;
+  bool _patrimoineSaved = false;
   String? _revenueError;
   String? _patrimoineError;
 
@@ -280,6 +282,7 @@ class _DataBlockEnrichmentScreenState
         label: l.renteVsCapitalSalary,
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+        onChanged: (_) => setState(() => _revenueSaved = false),
       ));
     }
     if (onlyInputKey == 'q_self_employed_income') {
@@ -290,6 +293,7 @@ class _DataBlockEnrichmentScreenState
         label: l.independantRevenueTitle,
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+        onChanged: (_) => setState(() => _revenueSaved = false),
       ));
     }
     if (_capturesRevenue('q_canton', onlyInputKey)) {
@@ -300,6 +304,7 @@ class _DataBlockEnrichmentScreenState
         label: l.affordabilityCanton,
         textCapitalization: TextCapitalization.characters,
         inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z]')), LengthLimitingTextInputFormatter(2)],
+        onChanged: (_) => setState(() => _revenueSaved = false),
       ));
     }
     if (_capturesRevenue('q_birth_year', onlyInputKey)) {
@@ -310,6 +315,7 @@ class _DataBlockEnrichmentScreenState
         label: l.landingBirthYear,
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.digitsOnly, LengthLimitingTextInputFormatter(4)],
+        onChanged: (_) => setState(() => _revenueSaved = false),
       ));
     }
     if (_capturesRevenue('q_has_pension_fund', onlyInputKey)) {
@@ -327,6 +333,7 @@ class _DataBlockEnrichmentScreenState
           onChanged: (value) => setState(() {
             _hasPensionFund = value;
             _hasPensionFundTouched = true;
+            _revenueSaved = false;
           }),
         ),
       ));
@@ -346,6 +353,10 @@ class _DataBlockEnrichmentScreenState
               style: MintTextStyles.labelMedium(color: MintColors.error),
             ),
           ],
+          if (_revenueSaved) ...[
+            const SizedBox(height: 8),
+            _buildSaveSuccess(l),
+          ],
           const SizedBox(height: 12),
           Semantics(
             identifier: 'salary_save_cta',
@@ -362,11 +373,20 @@ class _DataBlockEnrichmentScreenState
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              child: Text(
-                l.financialSummaryEnregistrer,
-                style: MintTextStyles.titleMedium()
-                    .copyWith(fontWeight: FontWeight.w600),
-              ),
+              child: _isSavingRevenue
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: MintColors.white,
+                      ),
+                    )
+                  : Text(
+                      l.financialSummaryEnregistrer,
+                      style: MintTextStyles.titleMedium()
+                          .copyWith(fontWeight: FontWeight.w600),
+                    ),
             ),
           ),
         ],
@@ -382,6 +402,7 @@ class _DataBlockEnrichmentScreenState
     TextInputType? keyboardType,
     TextCapitalization textCapitalization = TextCapitalization.none,
     List<TextInputFormatter>? inputFormatters,
+    ValueChanged<String>? onChanged,
   }) {
     return Semantics(
       identifier: semanticsIdentifier,
@@ -391,6 +412,7 @@ class _DataBlockEnrichmentScreenState
         keyboardType: keyboardType,
         textCapitalization: textCapitalization,
         inputFormatters: inputFormatters,
+        onChanged: onChanged,
         decoration: InputDecoration(
           labelText: label,
           border: OutlineInputBorder(
@@ -441,6 +463,7 @@ class _DataBlockEnrichmentScreenState
     setState(() {
       _isSavingRevenue = true;
       _revenueError = null;
+      _revenueSaved = false;
     });
 
     final answers = <String, dynamic>{
@@ -463,7 +486,10 @@ class _DataBlockEnrichmentScreenState
     }
     if (!mounted) return;
     HapticFeedback.lightImpact();
-    setState(() => _isSavingRevenue = false);
+    setState(() {
+      _isSavingRevenue = false;
+      _revenueSaved = true;
+    });
   }
 
   bool _shouldShowPatrimoineCollector(String canonicalBlockType) {
@@ -485,6 +511,7 @@ class _DataBlockEnrichmentScreenState
             label: l.financialSummaryEditEpargneLiquide,
             keyboardType: TextInputType.number,
             inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]"))],
+            onChanged: (_) => setState(() => _patrimoineSaved = false),
           ),
           if (_patrimoineError != null) ...[
             const SizedBox(height: 8),
@@ -492,6 +519,10 @@ class _DataBlockEnrichmentScreenState
               _patrimoineError!,
               style: MintTextStyles.labelMedium(color: MintColors.error),
             ),
+          ],
+          if (_patrimoineSaved) ...[
+            const SizedBox(height: 8),
+            _buildSaveSuccess(l),
           ],
           const SizedBox(height: 12),
           Semantics(
@@ -509,11 +540,20 @@ class _DataBlockEnrichmentScreenState
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              child: Text(
-                l.financialSummaryEnregistrer,
-                style: MintTextStyles.titleMedium()
-                    .copyWith(fontWeight: FontWeight.w600),
-              ),
+              child: _isSavingPatrimoine
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: MintColors.white,
+                      ),
+                    )
+                  : Text(
+                      l.financialSummaryEnregistrer,
+                      style: MintTextStyles.titleMedium()
+                          .copyWith(fontWeight: FontWeight.w600),
+                    ),
             ),
           ),
         ],
@@ -531,13 +571,39 @@ class _DataBlockEnrichmentScreenState
     setState(() {
       _isSavingPatrimoine = true;
       _patrimoineError = null;
+      _patrimoineSaved = false;
     });
     await context.read<CoachProfileProvider>().mergeAnswers({
       'q_cash_total': cash,
     });
     if (!mounted) return;
     HapticFeedback.lightImpact();
-    setState(() => _isSavingPatrimoine = false);
+    setState(() {
+      _isSavingPatrimoine = false;
+      _patrimoineSaved = true;
+    });
+  }
+
+  Widget _buildSaveSuccess(S l) {
+    return Semantics(
+      key: const Key('data_block_save_success'),
+      identifier: 'data_block_save_success',
+      container: true,
+      child: Row(
+        children: [
+          const Icon(Icons.check_circle_outline,
+              color: MintColors.success, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l.documentDetailProfileUpdated,
+              style: MintTextStyles.labelMedium(color: MintColors.success)
+                  .copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   String _digitsOnly(String value) => value.replaceAll(RegExp(r'[^0-9]'), '');

--- a/apps/mobile/lib/services/financial_core/compound_contribution_projection_calculator.dart
+++ b/apps/mobile/lib/services/financial_core/compound_contribution_projection_calculator.dart
@@ -1,0 +1,27 @@
+import 'dart:math' as math;
+
+/// Compound future value for repeated annual contributions.
+///
+/// This is intentionally small and generic: product screens choose the
+/// scenario, but compound-interest math stays in financial_core.
+class CompoundContributionProjectionCalculator {
+  CompoundContributionProjectionCalculator._();
+
+  static const int defaultHorizonYears = 20;
+  static const double defaultAnnualReturnRate = 0.04;
+
+  static double futureValueOfAnnualContributions(
+    double annualContribution, {
+    int horizonYears = defaultHorizonYears,
+    double annualReturnRate = defaultAnnualReturnRate,
+  }) {
+    if (annualContribution <= 0 || horizonYears <= 0) return 0;
+    if (annualReturnRate <= 0) {
+      return annualContribution * horizonYears;
+    }
+
+    final compoundFactor =
+        (math.pow(1 + annualReturnRate, horizonYears) - 1) / annualReturnRate;
+    return annualContribution * compoundFactor;
+  }
+}

--- a/apps/mobile/lib/services/independants_service.dart
+++ b/apps/mobile/lib/services/independants_service.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:mint_mobile/constants/social_insurance.dart';
 import 'package:mint_mobile/services/financial_core/avs_calculator.dart';
+import 'package:mint_mobile/services/financial_core/compound_contribution_projection_calculator.dart';
 
 // ────────────────────────────────────────────────────────────
 //  INDEPENDANTS SERVICE — Sprint S18 / Indépendants complet
@@ -15,7 +16,6 @@ import 'package:mint_mobile/services/financial_core/avs_calculator.dart';
 //   5. calculateLppVolontaire   — Voluntary LPP
 //
 // All constants match the backend exactly.
-// No banned terms ("garanti", "certain", "assuré", "sans risque").
 // ────────────────────────────────────────────────────────────
 
 /// Result of AVS cotisation calculation.
@@ -88,6 +88,19 @@ class Pillar3aIndepResult {
     required this.economieSalarie,
     required this.avantageSurSalarie,
     required this.tauxMarginal,
+  });
+}
+
+/// 20-year projection comparison for repeated 3a contributions.
+class Pillar3aIndepProjectionResult {
+  final double projectionIndependant;
+  final double projectionSalarie;
+  final double difference;
+
+  const Pillar3aIndepProjectionResult({
+    required this.projectionIndependant,
+    required this.projectionSalarie,
+    required this.difference,
   });
 }
 
@@ -212,6 +225,10 @@ class IndependantsService {
 
   /// 3a ceiling for self-employed with LPP (same as salaried).
   static double get _plafond3aPetit => reg('pillar3a.max_with_lpp', pilier3aPlafondAvecLpp);
+
+  static double get plafond3aGrand => _plafond3aGrand;
+
+  static double get plafond3aPetit => _plafond3aPetit;
 
   /// LPP coordination deduction (2025).
   static double get _deductionCoordination => reg('lpp.coordination_deduction', lppDeductionCoordination);
@@ -430,6 +447,24 @@ class IndependantsService {
     );
   }
 
+  static Pillar3aIndepProjectionResult project3aIndependant20Years(
+    Pillar3aIndepResult result,
+  ) {
+    final projectionIndependant =
+        CompoundContributionProjectionCalculator.futureValueOfAnnualContributions(
+      result.plafond,
+    );
+    final projectionSalarie =
+        CompoundContributionProjectionCalculator.futureValueOfAnnualContributions(
+      result.plafondSalarie,
+    );
+    return Pillar3aIndepProjectionResult(
+      projectionIndependant: projectionIndependant,
+      projectionSalarie: projectionSalarie,
+      difference: projectionIndependant - projectionSalarie,
+    );
+  }
+
   // ════════════════════════════════════════════════════════════
   //  4. DIVIDENDE VS SALAIRE
   // ════════════════════════════════════════════════════════════
@@ -572,7 +607,7 @@ class IndependantsService {
     } else if (age >= 25) {
       ageBracketLabel = '25-34 ans';
     } else {
-      ageBracketLabel = 'Moins de 25 ans';
+      ageBracketLabel = '< 25 ans';
     }
 
     final cotisationAnnuelle = salaireCoordonne * tauxBonification;

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -9,12 +9,16 @@
 ///   - FINMA circular 2023/1 (operational risk)
 library;
 
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kReleaseMode;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class SecureWizardStore {
   static const _storage = FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
   );
+  static const _operationTimeout = Duration(seconds: 2);
 
   /// Keys containing sensitive financial PII that must not be stored
   /// in plain SharedPreferences.
@@ -22,6 +26,7 @@ class SecureWizardStore {
     // Legacy key retained so old secure placeholders do not leak as plain JSON.
     'q_gross_salary',
     'q_gross_salary_annual',
+    'q_self_employed_income',
     'q_net_income_period_chf',
     'q_lpp_avoir',
     'q_3a_capital',
@@ -34,6 +39,7 @@ class SecureWizardStore {
     '_coach_dettes_credit',
     '_coach_dettes_leasing',
     '_coach_dettes_autres',
+    'q_cash_total',
     'q_wealth_estimate',
   };
 
@@ -41,9 +47,17 @@ class SecureWizardStore {
   static bool isSensitive(String key) => _sensitiveKeys.contains(key);
 
   /// Write a sensitive value to encrypted storage.
-  static Future<void> write(String key, String value) async {
-    if (_sensitiveKeys.contains(key)) {
-      await _storage.write(key: key, value: value);
+  ///
+  /// Returns false when platform secure storage is unavailable or does not
+  /// answer. Dev/local iOS simulators can hit Keychain entitlement failures;
+  /// those must never leave the profile save button spinning forever.
+  static Future<bool> write(String key, String value) async {
+    if (!_sensitiveKeys.contains(key)) return true;
+    try {
+      await _storage.write(key: key, value: value).timeout(_operationTimeout);
+      return true;
+    } on Object {
+      return false;
     }
   }
 
@@ -60,21 +74,34 @@ class SecureWizardStore {
   static Future<String?> read(String key) async {
     if (!_sensitiveKeys.contains(key)) return null;
     try {
-      return await _storage.read(key: key);
-    } on Exception {
+      return await _storage.read(key: key).timeout(_operationTimeout);
+    } on Object {
       return null;
+    }
+  }
+
+  static Future<void> _delete(String key) async {
+    try {
+      await _storage.delete(key: key).timeout(_operationTimeout);
+    } on Object {
+      // Best effort: callers still remove the plain placeholder from local
+      // answers so stale secure storage cannot block the visible profile.
     }
   }
 
   /// Delete all sensitive keys from encrypted storage.
   static Future<void> deleteAll() async {
     for (final key in _sensitiveKeys) {
-      await _storage.delete(key: key);
+      await _delete(key);
     }
   }
 
   /// Extract sensitive values from an answers map and store them securely.
   /// Returns the map with sensitive values replaced by a placeholder.
+  ///
+  /// Local simulator/dev builds keep the plain value when secure storage is
+  /// unavailable so product QA can continue. Release builds fail closed: the
+  /// sensitive key is not persisted in plain SharedPreferences.
   static Future<Map<String, dynamic>> secureSensitiveKeys(
     Map<String, dynamic> answers,
   ) async {
@@ -82,13 +109,17 @@ class SecureWizardStore {
     for (final key in _sensitiveKeys) {
       if (cleaned.containsKey(key)) {
         if (cleaned[key] == null) {
-          await _storage.delete(key: key);
+          await _delete(key);
           cleaned.remove(key);
           continue;
         }
         if (cleaned[key] == '__secure__') continue;
-        await write(key, cleaned[key].toString());
-        cleaned[key] = '__secure__';
+        final stored = await write(key, cleaned[key].toString());
+        if (stored) {
+          cleaned[key] = '__secure__';
+        } else if (kReleaseMode) {
+          cleaned.remove(key);
+        }
       }
     }
     return cleaned;

--- a/apps/mobile/test/models/coach_profile_safe_mode_test.dart
+++ b/apps/mobile/test/models/coach_profile_safe_mode_test.dart
@@ -22,6 +22,7 @@ void main() {
     double? mensualiteCreditConso,
     double? mensualiteLeasing,
     double? mensualiteHypotheque,
+    double? selfEmployedNetIncome,
     double epargneLiquide = 20000,
     double totalMensuelDepenses = 3000,
   }) {
@@ -31,6 +32,7 @@ void main() {
       salaireBrutMensuel: salaire,
       nombreDeMois: nombreDeMois,
       employmentStatus: employmentStatus,
+      selfEmployedNetIncome: selfEmployedNetIncome,
       depenses: DepensesProfile(
         loyer: totalMensuelDepenses,
         assuranceMaladie: 0,
@@ -114,6 +116,17 @@ void main() {
       // Expenses 3000/month, liquid 15000 → 5 months
       final p = makeProfile(epargneLiquide: 15000, totalMensuelDepenses: 3000);
       expect(p.isInDebtCrisis, isFalse);
+    });
+
+    test('independent income also feeds liquidity SafeMode', () {
+      final p = makeProfile(
+        salaire: 0,
+        employmentStatus: 'independant',
+        selfEmployedNetIncome: 144000,
+        epargneLiquide: 5000,
+        totalMensuelDepenses: 3000,
+      );
+      expect(p.isInDebtCrisis, isTrue);
     });
   });
 

--- a/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
+++ b/apps/mobile/test/screens/data_block_enrichment_screen_test.dart
@@ -18,12 +18,16 @@ Widget _wrap(Widget child, {CoachProfileProvider? coachProfileProvider}) {
       ),
       ChangeNotifierProvider(create: (_) => SlmProvider()),
     ],
-    child: MaterialApp(locale: const Locale('fr'), localizationsDelegates: const [
-      S.delegate,
-      GlobalMaterialLocalizations.delegate,
-      GlobalWidgetsLocalizations.delegate,
-      GlobalCupertinoLocalizations.delegate,
-    ], supportedLocales: S.supportedLocales, home: child),
+    child: MaterialApp(
+        locale: const Locale('fr'),
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.supportedLocales,
+        home: child),
   );
 }
 
@@ -122,6 +126,7 @@ void main() {
     await tester.tap(find.byKey(const Key('salary_save_cta')));
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('data_block_save_success')), findsOneWidget);
     final answers = await ReportPersistenceService.loadAnswers();
     expect(answers, containsPair('q_self_employed_income', 144000));
     expect(answers, containsPair('q_net_income_period_chf', 144000));
@@ -169,7 +174,8 @@ void main() {
     final answers = await ReportPersistenceService.loadAnswers();
     expect(answers.containsKey('q_birth_year'), isFalse);
     expect(provider.profile, isNull);
-    expect(find.text('Les informations saisies sont invalides.'), findsOneWidget);
+    expect(
+        find.text('Les informations saisies sont invalides.'), findsOneWidget);
   });
 
   testWidgets('revenue block pension inputKey can persist default false',
@@ -191,6 +197,7 @@ void main() {
     await tester.tap(find.byKey(const Key('salary_save_cta')));
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('data_block_save_success')), findsOneWidget);
     final answers = await ReportPersistenceService.loadAnswers();
     expect(answers, containsPair('q_has_pension_fund', 'no'));
     expect(provider.profile, isNotNull);
@@ -216,10 +223,12 @@ void main() {
     await tester.tap(find.byKey(const Key('patrimoine_save_cta')));
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('data_block_save_success')), findsOneWidget);
     final answers = await ReportPersistenceService.loadAnswers();
     expect(answers, containsPair('q_cash_total', 120000));
     expect(answers.containsKey('q_epargne_liquide'), isFalse);
     expect(provider.profile?.patrimoine.epargneLiquide, 120000);
+    expect(provider.profile?.userProvidedFields, contains('liquidSavings'));
   });
 
   testWidgets('revenue block seeds pension switch from existing profile',

--- a/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
+++ b/apps/mobile/test/screens/indep_nav_remaining_smoke_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 // Screens under test
@@ -31,15 +32,16 @@ import 'package:mint_mobile/l10n/app_localizations.dart';
 /// Simple wrapper for screens without provider dependencies.
 Widget buildTestable(Widget child) {
   return MaterialApp(
-      locale: const Locale('fr'),
-      localizationsDelegates: const [
-        S.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: S.supportedLocales,
-      home: child);
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    home: child,
+  );
 }
 
 /// Wrapper that provides ProfileProvider + ByokProvider (needed by ExploreTab).
@@ -58,9 +60,7 @@ Widget buildWithExploreProviders(Widget child) {
         ChangeNotifierProvider<ProfileProvider>(
           create: (_) => ProfileProvider(),
         ),
-        ChangeNotifierProvider<ByokProvider>(
-          create: (_) => ByokProvider(),
-        ),
+        ChangeNotifierProvider<ByokProvider>(create: (_) => ByokProvider()),
         ChangeNotifierProvider<CoachProfileProvider>(
           create: (_) => CoachProfileProvider(),
         ),
@@ -108,6 +108,39 @@ Widget buildWithCoachProfileProvider(
   );
 }
 
+Widget buildWithCoachProfileRouter(CoachProfileProvider provider) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => ChangeNotifierProvider<CoachProfileProvider>.value(
+          value: provider,
+          child: const Pillar3aIndepScreen(),
+        ),
+      ),
+      GoRoute(
+        path: '/data-block/:type',
+        builder: (_, state) => Text(
+          'data-block:${state.pathParameters['type']}:${state.uri.queryParameters['inputKey']}',
+          key: const Key('data_block_route_probe'),
+        ),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    locale: const Locale('fr'),
+    localizationsDelegates: const [
+      S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: S.supportedLocales,
+    routerConfig: router,
+  );
+}
+
 class RecordingCoachProfileProvider extends CoachProfileProvider {
   final Map<String, dynamic> _answers;
   final writes = <Map<String, dynamic>>[];
@@ -139,7 +172,7 @@ Map<String, dynamic> independentAnswers({
   int? birthYear,
   double? cashTotal,
   bool hasConsumerDebt = false,
-  bool voluntaryLpp = false,
+  bool? voluntaryLpp,
 }) {
   return {
     if (birthYear != null) 'q_birth_year': birthYear,
@@ -152,8 +185,10 @@ Map<String, dynamic> independentAnswers({
     },
     if (grossSalary != null) 'q_gross_salary_annual': grossSalary,
     'q_employment_status': 'independant',
-    'q_has_voluntary_lpp': voluntaryLpp ? 'yes' : 'no',
-    'q_has_pension_fund': voluntaryLpp ? 'yes' : 'no',
+    if (voluntaryLpp != null) ...{
+      'q_has_voluntary_lpp': voluntaryLpp ? 'yes' : 'no',
+      'q_has_pension_fund': voluntaryLpp ? 'yes' : 'no',
+    },
   };
 }
 
@@ -198,10 +233,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(find.text('Indépendant'), findsOneWidget);
-      expect(
-        find.textContaining('Analyse de couverture'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Analyse de couverture'), findsOneWidget);
     });
 
     testWidgets('shows coverage toggles section', (tester) async {
@@ -218,20 +250,14 @@ void main() {
       await tester.pumpWidget(buildTestable(const IndependantScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(
-        find.text('PARCOURS INDÉPENDANT'),
-        findsOneWidget,
-      );
+      expect(find.text('PARCOURS INDÉPENDANT'), findsOneWidget);
     });
 
     testWidgets('shows intro info text', (tester) async {
       await tester.pumpWidget(buildTestable(const IndependantScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(
-        find.textContaining('indépendant'),
-        findsWidgets,
-      );
+      expect(find.textContaining('indépendant'), findsWidgets);
     });
   });
 
@@ -254,13 +280,16 @@ void main() {
       expect(find.text('LPP volontaire'), findsOneWidget);
     });
 
-    testWidgets('shows missing ledger facts instead of local inputs',
-        (tester) async {
+    testWidgets('shows missing ledger facts instead of local inputs', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(
-          find.byKey(const Key('lpp_volontaire_ledger_facts')), findsOneWidget);
+        find.byKey(const Key('lpp_volontaire_ledger_facts')),
+        findsOneWidget,
+      );
       expect(find.text('Revenu net annuel'), findsOneWidget);
       expect(find.text('Ton âge'), findsOneWidget);
       expect(find.text('Données manquantes'), findsOneWidget);
@@ -273,30 +302,30 @@ void main() {
       await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(
-        find.textContaining('caisse de pension'),
-        findsWidgets,
-      );
+      expect(find.textContaining('caisse de pension'), findsWidgets);
     });
 
-    testWidgets('shows missing status when ledger facts are absent',
-        (tester) async {
+    testWidgets('shows missing status when ledger facts are absent', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(find.text('Manquant'), findsNWidgets(2));
     });
 
-    testWidgets('hides scenario slider until ledger facts are complete',
-        (tester) async {
+    testWidgets('hides scenario slider until ledger facts are complete', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestable(const LppVolontaireScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(find.byType(MintPremiumSlider), findsNothing);
     });
 
-    testWidgets('uses known independent income and age from profile facts',
-        (tester) async {
+    testWidgets('uses known independent income and age from profile facts', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(390, 4000);
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetPhysicalSize);
@@ -311,10 +340,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
@@ -325,14 +351,19 @@ void main() {
       expect(find.byType(MintPickerTile), findsNothing);
       expect(find.byType(MintPremiumSlider), findsOneWidget);
       expect(
-          find.byKey(const Key('lpp_volontaire_result_cards')), findsOneWidget);
-      expect(find.byKey(const Key('lpp_volontaire_retirement_comparison')),
-          findsOneWidget);
+        find.byKey(const Key('lpp_volontaire_result_cards')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('lpp_volontaire_retirement_comparison')),
+        findsOneWidget,
+      );
       expect(find.byKey(const Key('lpp_volontaire_age_table')), findsOneWidget);
     });
 
-    testWidgets('keeps contribution planning locked in SafeMode',
-        (tester) async {
+    testWidgets('keeps contribution planning locked in SafeMode', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(
           selfIncome: 140000,
@@ -343,32 +374,31 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(find.text('Concentration Prioritaire'), findsOneWidget);
       expect(
-          find.byKey(const Key('lpp_volontaire_result_cards')), findsNothing);
-      expect(find.byKey(const Key('lpp_volontaire_retirement_comparison')),
-          findsNothing);
+        find.byKey(const Key('lpp_volontaire_result_cards')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('lpp_volontaire_retirement_comparison')),
+        findsNothing,
+      );
       expect(find.byKey(const Key('lpp_volontaire_age_table')), findsNothing);
     });
 
-    testWidgets('does not use gross salary fallback as independent income',
-        (tester) async {
+    testWidgets('does not use gross salary fallback as independent income', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(grossSalary: 220000),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
@@ -380,39 +410,35 @@ void main() {
     });
 
     testWidgets(
-        'does not clamp ledger income and treats invalid age as missing',
-        (tester) async {
-      final provider = RecordingCoachProfileProvider(
-        independentAnswers(
-          selfIncome: 450000,
-          birthYear: DateTime.now().year - 80,
-        ),
-      );
+      'does not clamp ledger income and treats invalid age as missing',
+      (tester) async {
+        final provider = RecordingCoachProfileProvider(
+          independentAnswers(
+            selfIncome: 450000,
+            birthYear: DateTime.now().year - 80,
+          ),
+        );
 
-      await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
-      );
-      await tester.pumpAndSettle(const Duration(seconds: 5));
+        await tester.pumpWidget(
+          buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
+        );
+        await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(find.text("CHF\u00A0450'000"), findsOneWidget);
-      expect(find.text('Manquant'), findsWidgets);
-      expect(find.byType(MintPremiumSlider), findsNothing);
-    });
+        expect(find.text("CHF\u00A0450'000"), findsOneWidget);
+        expect(find.text('Manquant'), findsWidgets);
+        expect(find.byType(MintPremiumSlider), findsNothing);
+      },
+    );
 
-    testWidgets('does not expose an income editor inside the simulator',
-        (tester) async {
+    testWidgets('does not expose an income editor inside the simulator', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(selfIncome: 90000),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
       );
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -420,8 +446,9 @@ void main() {
       expect(provider.writes, isEmpty);
     });
 
-    testWidgets('does not expose an age editor inside the simulator',
-        (tester) async {
+    testWidgets('does not expose an age editor inside the simulator', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(
           selfIncome: 90000,
@@ -430,10 +457,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const LppVolontaireScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const LppVolontaireScreen()),
       );
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -451,15 +475,18 @@ void main() {
       WidgetTester tester,
       Map<String, dynamic> answers,
     ) async {
-      await tester.pumpWidget(buildWithCoachProfileProvider(
-        RecordingCoachProfileProvider(answers),
-        const AvsCotisationsScreen(),
-      ));
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          RecordingCoachProfileProvider(answers),
+          const AvsCotisationsScreen(),
+        ),
+      );
       await tester.pumpAndSettle(const Duration(seconds: 5));
     }
 
-    testWidgets('uses ledger facts instead of a local income slider',
-        (tester) async {
+    testWidgets('uses ledger facts instead of a local income slider', (
+      tester,
+    ) async {
       await pumpAvs(tester, independentAnswers(selfIncome: 135000));
 
       expect(find.byType(MintPremiumSlider), findsNothing);
@@ -469,8 +496,9 @@ void main() {
       expect(find.byKey(const Key('avs_result_cards')), findsOneWidget);
     });
 
-    testWidgets('does not calculate from a gross salary fallback',
-        (tester) async {
+    testWidgets('does not calculate from a gross salary fallback', (
+      tester,
+    ) async {
       await pumpAvs(tester, independentAnswers(grossSalary: 220000));
 
       expect(find.byType(MintPremiumSlider), findsNothing);
@@ -479,8 +507,9 @@ void main() {
       expect(find.text('Manquant'), findsOneWidget);
     });
 
-    testWidgets('shows missing fact instead of defaulting to 80000',
-        (tester) async {
+    testWidgets('shows missing fact instead of defaulting to 80000', (
+      tester,
+    ) async {
       await pumpAvs(tester, independentAnswers());
 
       expect(find.byType(MintPremiumSlider), findsNothing);
@@ -499,15 +528,18 @@ void main() {
       WidgetTester tester,
       Map<String, dynamic> answers,
     ) async {
-      await tester.pumpWidget(buildWithCoachProfileProvider(
-        RecordingCoachProfileProvider(answers),
-        const IjmScreen(),
-      ));
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          RecordingCoachProfileProvider(answers),
+          const IjmScreen(),
+        ),
+      );
       await tester.pumpAndSettle(const Duration(seconds: 5));
     }
 
-    testWidgets('uses ledger facts instead of local income or age sliders',
-        (tester) async {
+    testWidgets('uses ledger facts instead of local income or age sliders', (
+      tester,
+    ) async {
       await pumpIjm(
         tester,
         independentAnswers(
@@ -523,8 +555,9 @@ void main() {
       expect(find.byKey(const Key('ijm_result_cards')), findsOneWidget);
     });
 
-    testWidgets('does not calculate from a gross salary fallback',
-        (tester) async {
+    testWidgets('does not calculate from a gross salary fallback', (
+      tester,
+    ) async {
       await pumpIjm(
         tester,
         independentAnswers(
@@ -539,15 +572,17 @@ void main() {
       expect(find.text('Manquant'), findsOneWidget);
     });
 
-    testWidgets('shows missing facts instead of defaulting to a monthly value',
-        (tester) async {
-      await pumpIjm(tester, independentAnswers());
+    testWidgets(
+      'shows missing facts instead of defaulting to a monthly value',
+      (tester) async {
+        await pumpIjm(tester, independentAnswers());
 
-      expect(find.byType(MintPremiumSlider), findsNothing);
-      expect(find.text("CHF 6'000"), findsNothing);
-      expect(find.text('Manquant'), findsNWidgets(2));
-      expect(find.byKey(const Key('ijm_result_cards')), findsNothing);
-    });
+        expect(find.byType(MintPremiumSlider), findsNothing);
+        expect(find.text("CHF 6'000"), findsNothing);
+        expect(find.text('Manquant'), findsNWidgets(2));
+        expect(find.byKey(const Key('ijm_result_cards')), findsNothing);
+      },
+    );
   });
 
   // ===========================================================================
@@ -559,19 +594,19 @@ void main() {
       WidgetTester tester,
       Map<String, dynamic> answers,
     ) async {
-      await tester.pumpWidget(buildWithCoachProfileProvider(
-        RecordingCoachProfileProvider(answers),
-        const DisabilitySelfEmployedScreen(),
-      ));
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(
+          RecordingCoachProfileProvider(answers),
+          const DisabilitySelfEmployedScreen(),
+        ),
+      );
       await tester.pumpAndSettle(const Duration(seconds: 5));
     }
 
-    testWidgets('uses ledger income instead of a local revenue slider',
-        (tester) async {
-      await pumpDisabilitySelf(
-        tester,
-        independentAnswers(selfIncome: 144000),
-      );
+    testWidgets('uses ledger income instead of a local revenue slider', (
+      tester,
+    ) async {
+      await pumpDisabilitySelf(tester, independentAnswers(selfIncome: 144000));
 
       expect(find.byType(MintPremiumSlider), findsNothing);
       expect(
@@ -579,35 +614,42 @@ void main() {
         findsOneWidget,
       );
       expect(
-          find.byKey(const Key('disability_self_income_fact')), findsOneWidget);
+        find.byKey(const Key('disability_self_income_fact')),
+        findsOneWidget,
+      );
       expect(find.textContaining("144'000"), findsOneWidget);
-      expect(find.byKey(const Key('disability_self_result_cards')),
-          findsOneWidget);
+      expect(
+        find.byKey(const Key('disability_self_result_cards')),
+        findsOneWidget,
+      );
     });
 
-    testWidgets('does not calculate from a gross salary fallback',
-        (tester) async {
-      await pumpDisabilitySelf(
-        tester,
-        independentAnswers(grossSalary: 240000),
-      );
+    testWidgets('does not calculate from a gross salary fallback', (
+      tester,
+    ) async {
+      await pumpDisabilitySelf(tester, independentAnswers(grossSalary: 240000));
 
       expect(find.byType(MintPremiumSlider), findsNothing);
       expect(find.text("CHF 240'000"), findsNothing);
       expect(
-          find.byKey(const Key('disability_self_result_cards')), findsNothing);
+        find.byKey(const Key('disability_self_result_cards')),
+        findsNothing,
+      );
       expect(find.text('Manquant'), findsOneWidget);
     });
 
-    testWidgets('shows missing fact instead of defaulting to a monthly value',
-        (tester) async {
+    testWidgets('shows missing fact instead of defaulting to a monthly value', (
+      tester,
+    ) async {
       await pumpDisabilitySelf(tester, independentAnswers());
 
       expect(find.byType(MintPremiumSlider), findsNothing);
       expect(find.text("CHF 8'000"), findsNothing);
       expect(find.text('Manquant'), findsOneWidget);
       expect(
-          find.byKey(const Key('disability_self_result_cards')), findsNothing);
+        find.byKey(const Key('disability_self_result_cards')),
+        findsNothing,
+      );
     });
   });
 
@@ -630,169 +672,358 @@ void main() {
       expect(find.text('3e pilier indépendant'), findsOneWidget);
     });
 
-    testWidgets('has LPP toggle switch', (tester) async {
+    testWidgets('shows ledger facts instead of local LPP/income editors', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestable(const Pillar3aIndepScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(find.byType(Switch), findsOneWidget);
-      // The phrase "LPP volontaire" appears in both the toggle label AND the
-      // 3a explanation paragraph that references it. Expect at least one match.
       expect(
-        find.textContaining('LPP volontaire'),
-        findsWidgets,
+        find.byKey(const Key('pillar3a_indep_ledger_facts')),
+        findsOneWidget,
       );
+      expect(find.byType(Switch), findsNothing);
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(find.text('Manquant'), findsNWidgets(3));
     });
 
-    testWidgets('has amount field and premium slider (revenu and taux)',
-        (tester) async {
+    testWidgets('hides scenario slider until ledger facts are complete', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildTestable(const Pillar3aIndepScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      // Revenu uses MintAmountField, taux uses MintPremiumSlider
-      expect(find.byType(MintAmountField), findsOneWidget);
-      expect(find.byType(MintPremiumSlider), findsOneWidget);
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('pillar3a_indep_comparison_bars')),
+        findsNothing,
+      );
     });
 
     testWidgets('shows intro about grand 3a', (tester) async {
       await tester.pumpWidget(buildTestable(const Pillar3aIndepScreen()));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      expect(
-        find.textContaining('grand 3a'),
-        findsWidgets,
-      );
+      expect(find.textContaining('grand 3a'), findsWidgets);
     });
 
-    testWidgets('shows taux marginal slider', (tester) async {
-      await tester.pumpWidget(buildTestable(const Pillar3aIndepScreen()));
+    testWidgets(
+      'uses known independent income and LPP choice from ledger facts',
+      (tester) async {
+        tester.view.physicalSize = const Size(390, 4000);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final provider = RecordingCoachProfileProvider(
+          independentAnswers(
+            selfIncome: 180000,
+            cashTotal: 50000,
+            voluntaryLpp: true,
+          ),
+        );
+
+        await tester.pumpWidget(
+          buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+        );
+        await tester.pumpAndSettle(const Duration(seconds: 5));
+
+        final header = tester.widget<Text>(
+          find.byKey(const Key('pillar3a_indep_header_info')),
+        );
+        expect(header.data, contains('Avec LPP'));
+        expect(header.data, isNot(contains('sans LPP')));
+        expect(find.text('Données connues'), findsOneWidget);
+        expect(find.textContaining("CHF\u00A0180'000"), findsWidgets);
+        expect(find.text('Épargne liquide'), findsOneWidget);
+        expect(find.textContaining("CHF\u00A050'000"), findsWidgets);
+        expect(find.textContaining('petit 3a'), findsWidgets);
+        expect(find.byType(MintAmountField), findsNothing);
+        expect(find.byType(Switch), findsNothing);
+        expect(find.byType(MintPremiumSlider), findsOneWidget);
+        expect(
+          find.byKey(const Key('pillar3a_indep_result_section')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('pillar3a_indep_comparison_bars')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('edit known facts opens the independent income collector', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 4000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 180000,
+          cashTotal: 50000,
+          voluntaryLpp: true,
+        ),
+      );
+
+      await tester.pumpWidget(buildWithCoachProfileRouter(provider));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      await tester.tap(find.text('Modifier'));
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
       expect(
-        find.textContaining("Taux marginal"),
+        find.text('data-block:revenu:q_self_employed_income'),
         findsOneWidget,
       );
     });
 
-    testWidgets('prefills known independent income and LPP choice',
-        (tester) async {
+    testWidgets('shows taux marginal slider only as a scenario lever', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
-        independentAnswers(selfIncome: 180000, voluntaryLpp: true),
+        independentAnswers(
+          selfIncome: 90000,
+          cashTotal: 50000,
+          voluntaryLpp: false,
+        ),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const Pillar3aIndepScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-      final lppSwitch = tester.widget<Switch>(find.byType(Switch));
-
-      expect(amountField.value, 180000);
-      expect(lppSwitch.value, isTrue);
+      expect(find.textContaining("Taux marginal"), findsOneWidget);
+      expect(find.byType(MintPremiumSlider), findsOneWidget);
     });
 
-    testWidgets('does not prefill net income from a gross salary fallback',
-        (tester) async {
+    testWidgets('does not prefill net income from a gross salary fallback', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
-        independentAnswers(grossSalary: 240000),
+        independentAnswers(grossSalary: 240000, voluntaryLpp: false),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const Pillar3aIndepScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-
-      expect(amountField.value, 100000);
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.text('Manquant'), findsWidgets);
+      expect(find.text("CHF\u00A0240'000"), findsNothing);
+      expect(find.text("CHF\u00A0100'000"), findsNothing);
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(find.byType(MintPremiumSlider), findsNothing);
     });
 
-    testWidgets('clamps known independent income to the field maximum',
-        (tester) async {
+    testWidgets('does not treat unprovided independent income as known', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
-        independentAnswers(selfIncome: 450000),
+        independentAnswers(cashTotal: 50000, voluntaryLpp: false),
+      );
+      provider._profileOverride = provider.profile!.copyWith(
+        selfEmployedNetIncome: 180000,
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const Pillar3aIndepScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
       );
       await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-
-      expect(amountField.value, 300000);
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.textContaining("CHF\u00A0180'000"), findsNothing);
+      expect(find.byType(MintPremiumSlider), findsNothing);
     });
 
-    testWidgets('persists LPP toggle through the profile answer path',
-        (tester) async {
+    testWidgets('does not clamp known independent income from the ledger', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 4000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 450000,
+          cashTotal: 50000,
+          voluntaryLpp: false,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.textContaining("CHF\u00A0450'000"), findsWidgets);
+      expect(find.byType(MintAmountField), findsNothing);
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides upside framing when grand 3a is below salaried ceiling', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 5000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 30000,
+          cashTotal: 50000,
+          voluntaryLpp: false,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('pillar3a_indep_comparison_bars')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('super-pouvoir'), findsNothing);
+      expect(find.textContaining('Différence'), findsNothing);
+    });
+
+    testWidgets('treats missing LPP affiliation as a missing ledger fact', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
         independentAnswers(selfIncome: 90000),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const Pillar3aIndepScreen(),
-        ),
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
       );
-      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle(const Duration(seconds: 5));
 
-      await tester.tap(find.byType(Switch));
-      await tester.pump();
-
-      expect(provider.writes, isNotEmpty);
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.text('Manquant'), findsWidgets);
+      expect(find.byType(Switch), findsNothing);
+      expect(find.byType(MintPremiumSlider), findsNothing);
       expect(
-        provider.writes.last,
-        containsPair('q_has_voluntary_lpp', 'yes'),
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsNothing,
       );
-      expect(provider.writes.last, containsPair('q_has_pension_fund', 'yes'));
     });
 
-    testWidgets('persists edited independent income through the profile path',
-        (tester) async {
+    testWidgets('treats missing liquidity as a missing guardrail fact', (
+      tester,
+    ) async {
       final provider = RecordingCoachProfileProvider(
-        independentAnswers(selfIncome: 90000),
+        independentAnswers(selfIncome: 90000, voluntaryLpp: false),
       );
 
       await tester.pumpWidget(
-        buildWithCoachProfileProvider(
-          provider,
-          const Pillar3aIndepScreen(),
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text('Données manquantes'), findsOneWidget);
+      expect(find.text('Épargne liquide'), findsOneWidget);
+      expect(find.text('Manquant'), findsOneWidget);
+      expect(find.byType(MintPremiumSlider), findsNothing);
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsNothing,
+      );
+      expect(find.text('Concentration Prioritaire'), findsNothing);
+    });
+
+    testWidgets('keeps result planning locked in SafeMode', (tester) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 90000,
+          cashTotal: 50000,
+          hasConsumerDebt: true,
+          voluntaryLpp: false,
         ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text('Concentration Prioritaire'), findsOneWidget);
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const Key('pillar3a_indep_comparison_bars')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('keeps result planning locked when liquidity is too low', (
+      tester,
+    ) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 90000,
+          cashTotal: 1000,
+          voluntaryLpp: false,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
+      );
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      expect(find.text('Données connues'), findsOneWidget);
+      expect(find.text('Concentration Prioritaire'), findsOneWidget);
+      expect(
+        find.byKey(const Key('pillar3a_indep_result_section')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('does not write profile facts from local scenario changes', (
+      tester,
+    ) async {
+      final provider = RecordingCoachProfileProvider(
+        independentAnswers(
+          selfIncome: 90000,
+          cashTotal: 50000,
+          voluntaryLpp: false,
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildWithCoachProfileProvider(provider, const Pillar3aIndepScreen()),
       );
       await tester.pump(const Duration(milliseconds: 500));
 
-      final amountField =
-          tester.widget<MintAmountField>(find.byType(MintAmountField));
-      amountField.onChanged(123000);
+      final slider = tester.widget<MintPremiumSlider>(
+        find.byType(MintPremiumSlider),
+      );
+      slider.onChanged(35);
       await tester.pump();
 
-      expect(provider.writes, isNotEmpty);
-      expect(
-        provider.writes.last,
-        containsPair('q_self_employed_income', 123000),
-      );
-      expect(
-        provider.writes.last,
-        containsPair('q_net_income_period_chf', 123000),
-      );
-      expect(provider.writes.last, containsPair('q_pay_frequency', 'yearly'));
-      expect(
-        provider.writes.last,
-        containsPair('q_employment_status', 'independant'),
-      );
+      expect(provider.writes, isEmpty);
     });
   });
 
@@ -841,10 +1072,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 5));
       FlutterError.onError = handler;
 
-      expect(
-        find.textContaining('Ta vie financière'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Ta vie financière'), findsOneWidget);
     });
 
     testWidgets('shows description subtitle', (tester) async {
@@ -855,10 +1083,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 5));
       FlutterError.onError = handler;
 
-      expect(
-        find.textContaining('Outils essentiels'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Outils essentiels'), findsOneWidget);
     });
 
     testWidgets('shows life events section title', (tester) async {
@@ -869,10 +1094,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 5));
       FlutterError.onError = handler;
 
-      expect(
-        find.textContaining('ÉVÉNEMENTS DE VIE'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('ÉVÉNEMENTS DE VIE'), findsOneWidget);
     });
 
     testWidgets('shows event category FAMILLE', (tester) async {

--- a/apps/mobile/test/services/chat/fact_extraction_fallback_test.dart
+++ b/apps/mobile/test/services/chat/fact_extraction_fallback_test.dart
@@ -13,14 +13,36 @@ void main() {
   // blow up on a MissingPluginException during unit tests.
   const secureStorage =
       MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final secureStorageValues = <String, String>{};
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(secureStorage, (call) async {
-    if (call.method == 'read') return null;
-    if (call.method == 'readAll') return <String, String>{};
+    final args = Map<String, dynamic>.from(call.arguments as Map? ?? {});
+    final key = args['key'] as String?;
+    if (call.method == 'write' && key != null) {
+      secureStorageValues[key] = args['value'] as String;
+      return null;
+    }
+    if (call.method == 'read' && key != null) {
+      return secureStorageValues[key];
+    }
+    if (call.method == 'readAll') {
+      return Map<String, String>.from(
+        secureStorageValues,
+      );
+    }
+    if (call.method == 'delete' && key != null) {
+      secureStorageValues.remove(key);
+      return null;
+    }
+    if (call.method == 'deleteAll') {
+      secureStorageValues.clear();
+      return null;
+    }
     return null;
   });
 
   setUp(() {
+    secureStorageValues.clear();
     SharedPreferences.setMockInitialValues({});
   });
 

--- a/apps/mobile/test/services/independants_3a_projection_test.dart
+++ b/apps/mobile/test/services/independants_3a_projection_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/services/independants_service.dart';
+
+void main() {
+  group('IndependantsService - 3a projection bridge', () {
+    test('compares petit and grand 3a through financial_core projection', () {
+      final withoutLpp = IndependantsService.calculate3aIndependant(
+        100000,
+        false,
+        0.30,
+      );
+      final withoutLppProjection =
+          IndependantsService.project3aIndependant20Years(withoutLpp);
+
+      expect(
+        withoutLppProjection.projectionIndependant,
+        greaterThan(withoutLppProjection.projectionSalarie),
+      );
+      expect(
+        withoutLppProjection.difference,
+        closeTo(
+          withoutLppProjection.projectionIndependant -
+              withoutLppProjection.projectionSalarie,
+          0.01,
+        ),
+      );
+
+      final withLpp = IndependantsService.calculate3aIndependant(
+        100000,
+        true,
+        0.30,
+      );
+      final withLppProjection =
+          IndependantsService.project3aIndependant20Years(withLpp);
+      expect(withLppProjection.difference, closeTo(0, 0.01));
+    });
+  });
+}

--- a/apps/mobile/test/services/independants_service_test.dart
+++ b/apps/mobile/test/services/independants_service_test.dart
@@ -374,7 +374,7 @@ void main() {
         0.30,
       );
       expect(result.tauxBonification, 0.0);
-      expect(result.ageBracketLabel, 'Moins de 25 ans');
+      expect(result.ageBracketLabel, '< 25 ans');
       expect(result.cotisationAnnuelle, 0);
     });
 

--- a/apps/mobile/test/services/secure_wizard_store_test.dart
+++ b/apps/mobile/test/services/secure_wizard_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mint_mobile/services/secure_wizard_store.dart';
@@ -8,11 +10,15 @@ void main() {
   const secureStorage =
       MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
   final secureStorageValues = <String, String>{};
+  var failWrites = false;
+  var hangWrites = false;
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(secureStorage, (call) async {
     final args = Map<String, dynamic>.from(call.arguments as Map? ?? {});
     final key = args['key'] as String?;
     if (call.method == 'write' && key != null) {
+      if (failWrites) throw PlatformException(code: '-34018');
+      if (hangWrites) return Completer<Object?>().future;
       secureStorageValues[key] = args['value'] as String;
       return null;
     }
@@ -24,16 +30,23 @@ void main() {
     return null;
   });
 
-  setUp(secureStorageValues.clear);
+  setUp(() {
+    secureStorageValues.clear();
+    failWrites = false;
+    hangWrites = false;
+  });
 
   group('SecureWizardStore', () {
     test('treats gross salary ledger keys as sensitive', () {
       expect(SecureWizardStore.isSensitive('q_gross_salary'), isTrue);
       expect(SecureWizardStore.isSensitive('q_gross_salary_annual'), isTrue);
+      expect(SecureWizardStore.isSensitive('q_self_employed_income'), isTrue);
+      expect(SecureWizardStore.isSensitive('q_net_income_period_chf'), isTrue);
     });
 
     test('treats broad wealth estimate as sensitive', () {
       expect(SecureWizardStore.isSensitive('q_wealth_estimate'), isTrue);
+      expect(SecureWizardStore.isSensitive('q_cash_total'), isTrue);
     });
 
     test('treats partner income as sensitive but not partner birth year', () {
@@ -71,6 +84,28 @@ void main() {
 
       expect(cleaned['q_has_consumer_debt'], '__secure__');
       expect(restored['q_has_consumer_debt'], true);
+    });
+
+    test('keeps local dev value when secure write throws', () async {
+      failWrites = true;
+
+      final cleaned = await SecureWizardStore.secureSensitiveKeys({
+        'q_net_income_period_chf': 144000,
+      });
+
+      expect(cleaned['q_net_income_period_chf'], 144000);
+      expect(secureStorageValues, isEmpty);
+    });
+
+    test('keeps local dev value when secure write times out', () async {
+      hangWrites = true;
+
+      final cleaned = await SecureWizardStore.secureSensitiveKeys({
+        'q_net_income_period_chf': 144000,
+      });
+
+      expect(cleaned['q_net_income_period_chf'], 144000);
+      expect(secureStorageValues, isEmpty);
     });
 
     test('deletes stale secure debt amount when value is null', () async {

--- a/docs/calculator-graph.md
+++ b/docs/calculator-graph.md
@@ -56,6 +56,7 @@ flowchart LR
 
     MC[MonteCarloService]:::calc --> ARB
     WITHDRAW[WithdrawalSequencingService]:::calc --> ARB
+    COMPOUND[CompoundContributionProjectionCalculator]:::calc --> INDEP[IndependantsService]:::composer
 
     classDef profile fill:#E0F2F1,stroke:#00382E
     classDef calc fill:#FFF,stroke:#1D1D1F
@@ -87,6 +88,7 @@ Julien + Lauren golden values.
 | **MonteCarloService** | `monte_carlo_service.dart` | profile + scenarios | probability distributions | RetirementDashboard scenarios (Prudent/Base/Optimiste) |
 | **WithdrawalSequencingService** | `withdrawal_sequencing_service.dart` | retirement params | sequencing plan | DecaissementScreen |
 | **TornadoSensitivityService** | `tornado_sensitivity_service.dart` | FRI inputs | sensitivity chart data | FinancialSummaryScreen tornado chart |
+| **CompoundContributionProjectionCalculator** | `compound_contribution_projection_calculator.dart` | annual contribution, years, annual return | future value of repeated contributions | IndependantsService 3a projection bridge |
 | **CoachReasoner** | `coach_reasoner.dart` | CoachContext | reasoning chain | CoachNarrativeService advanced narratives |
 
 ---


### PR DESCRIPTION
## Summary
- Migrates the independent 3a screen from local income/LPP editors to read-only ledger facts with DataBlock enrichment routes.
- Moves 20-year compound projection math into financial_core via IndependantsService.
- Wires independent net income into SafeMode liquidity checks and adds Maestro coverage for the full CTA-driven flow.

## QA
- flutter analyze targeted changed production/test files
- flutter test test/models/coach_profile_safe_mode_test.dart --reporter expanded
- flutter test test/screens/indep_nav_remaining_smoke_test.dart --reporter expanded
- flutter test test/screens/data_block_enrichment_screen_test.dart --reporter expanded
- flutter test test/providers/coach_profile_provider_test.dart --plain-name "updateProfile persists liquid savings on the readable cash key" --reporter expanded
- flutter test test/services/independants_3a_projection_test.dart --reporter expanded
- flutter test test/services/independants_service_test.dart --plain-name "moins de 25 ans : taux 0%" --reporter expanded
- flutter test test/navigation_route_integrity_test.dart --plain-name "FIX-191: all static context.push targets match a GoRoute path" --reporter expanded
- python3 tools/checks/financial_core_gate.py && python3 tools/checks/hardcoded_rate_gate.py
- lefthook run pre-commit (targeted files)
- flutter build ios --simulator --debug
- Maestro iPhone 17 Pro: apps/mobile/.maestro/indep_pillar3a.yaml
- Claude external audit: PASS