### PR TITLE
chore: restore Mint runtime tooling

### DIFF
--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -16,11 +16,14 @@ privacy, persisted profile data, runtime proof, or Swiss financial scenario.
 
 Read, in order:
 
-1. `CLAUDE.md`
-2. `AGENTS.md`
-3. `docs/MINT_AGENT_WORKFLOW.md` when present
-4. the docs named by the relevant `AGENTS.md` pre-flight row
-5. `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json` when present
+1. Run `python3 tools/checks/mint_os_doctor.py --repo-only`; for runtime proof,
+   run full `python3 tools/checks/mint_os_doctor.py` before claiming any tool is
+   unavailable.
+2. `CLAUDE.md`
+3. `AGENTS.md`
+4. `docs/MINT_AGENT_WORKFLOW.md` when present
+5. the docs named by the relevant `AGENTS.md` pre-flight row
+6. `.planning/ACTIVE_CONTEXT.md` and `.planning/ACTIVE_CONTEXT.json` when present
 
 If a required file is missing, record it as a workflow gap and continue only
 when the task can still be verified from checked-in code and tests.
@@ -31,9 +34,14 @@ Run the smallest relevant set:
 
 ```bash
 python3 tools/checks/arb_parity.py
+python3 tools/checks/mint_os_doctor.py --repo-only
 ./tools/mint-routes reconcile
 lefthook run pre-commit --file <touched-file>
 ```
+
+If `bd`/Beads is initialized for this repository, start work with `bd prime`
+and claim durable tasks with `bd update <id> --claim`. Do not initialize
+`.beads/` opportunistically inside an unrelated product PR.
 
 For external Claude review, use the checked-in wrapper instead of raw
 `claude -p` commands:

--- a/.github/workflows/patrol.md
+++ b/.github/workflows/patrol.md
@@ -2,16 +2,14 @@
 
 ## Status
 
-Patrol integration tests are **NOT** included in CI. They require emulator infrastructure
-(iOS 17 simulator + Android API 34 emulator) that is not available on GitHub Actions
-ubuntu runners.
+Patrol integration tests are **NOT** included in the main Linux CI. They require
+local simulator infrastructure, and the default MINT runtime gate is iOS.
 
 ## Test Location
 
 ```
 apps/mobile/test/patrol/
-  onboarding_patrol_test.dart   — Full onboarding flow (7 steps)
-  document_patrol_test.dart     — Document capture flow (7 steps, screenshots)
+  mint_runtime_smoke_test.dart  — Minimal Patrol bootstrap and app launch proof
 ```
 
 ## When to Run
@@ -28,43 +26,52 @@ Patrol tests are a **manual gate** required before promotion PRs:
 
 ### Prerequisites
 
-- macOS with Xcode 15+ (iOS 17 simulator)
-- Android Studio with API 34 emulator image
+- macOS with Xcode and an iPhone 15+ simulator
 - Flutter 3.27.4+ with patrol_cli installed
+- Patrol CLI may live at `$HOME/.pub-cache/bin/patrol` even when `patrol` is
+  not exported in `PATH`. Do not claim Patrol is unavailable before running
+  `python3 tools/checks/patrol_tooling_guard.py`.
 
 ### Commands
 
 ```bash
 cd apps/mobile
 
-# iOS (iPhone 15 simulator)
-flutter test test/patrol/ --device-id "iPhone 15"
+# iOS, preferred local simulator. Replace the device name with the currently
+# booted iPhone 15+ simulator when needed.
+$HOME/.pub-cache/bin/patrol test \
+  -t test/patrol/mint_runtime_smoke_test.dart \
+  -d "iPhone 17 Pro" \
+  --dart-define=MINT_PATROL_CLI=true
 
-# Android (Pixel 7 API 34 emulator)
-flutter test test/patrol/ --device-id "emulator-5554"
+# Static/config preflight from repo root.
+python3 tools/checks/patrol_tooling_guard.py
+
+# If the Patrol console summary is ambiguous, verify the xcresult directly.
+xcrun xcresulttool get test-results tests --path build/ios_results_<id>.xcresult --compact
 ```
 
 ### Expected Results
 
-- All 7 onboarding steps complete without crash
-- All 7 document capture steps complete with screenshots captured
+- Patrol builds and launches MINT through the native runner
+- `mint_runtime_smoke_test.dart` finds the root `MaterialApp`
+- `xcresulttool get test-results tests` reports the test case as `Passed`
 - No unhandled exceptions in console output
 
 ## Future: CI Integration
 
 When GitHub Actions macOS runners with iOS simulator support are configured
-(or self-hosted runners with emulator access), add a dedicated `patrol` CI job:
+(or self-hosted runners with simulator access), add a dedicated `patrol` CI job:
 
 1. Create `.github/workflows/patrol.yml` with macOS runner
-2. Configure iOS 17 simulator boot
-3. Add Android API 34 emulator via `reactivecircus/android-emulator-runner`
-4. Move `test/patrol/` into the new workflow
-5. Remove this manual gate policy document
+2. Configure an iPhone 15+ simulator boot
+3. Run `python3 tools/checks/patrol_tooling_guard.py`
+4. Run `$HOME/.pub-cache/bin/patrol test -t test/patrol/mint_runtime_smoke_test.dart -d "<device>" --dart-define=MINT_PATROL_CLI=true`
+5. Keep this document as the local/manual fallback
 
 ## Why Not CI Today
 
 - GitHub Actions ubuntu runners have no iOS simulator support
-- macOS runners are 10x more expensive and have limited availability
-- Android emulator setup on CI adds 3-5 minutes of boot time per run
+- macOS runners are more expensive and have limited availability
 - Patrol tests are slow by nature (real navigation, screenshots) — better suited
   for a dedicated workflow than the main CI pipeline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,20 +138,35 @@ Use what exists, and record missing tools instead of pretending they ran.
 - **Daily loop roadmap** → morning sim walk + Sentry pull + auto-PR
   on P0/P1. **The mechanism that catches « an agent broke something
   overnight ».** Mandatory for solo-dev + AI workflow.
-- **Future MCP/tools** → Swiss constants / banned-terms / Patrol / Beads /
-  Mermaid gates once installed and wired in this checkout
+- **Patrol** → available through Dart global tooling on this Mac. Use
+  `$HOME/.pub-cache/bin/patrol` and `python3 tools/checks/patrol_tooling_guard.py`;
+  do not claim Patrol is unavailable from `command -v patrol` alone.
+- **Mermaid** → render with `python3 tools/checks/mermaid_render_guard.py`
+  (`npx @mermaid-js/mermaid-cli` under the hood). Keep interaction maps
+  layered: system wiring in `docs/codex/WIRING_GRAPH.mmd`, product journey
+  flows in focused `.mmd` files, fine-grained button contracts in
+  `SCREEN_CONTRACTS.md` / interaction registries, and runtime proof in
+  Maestro/Patrol.
+- **Beads** → CLI is `bd` (Homebrew formula `beads`). Use it for an agent issue
+  graph after a dedicated `.beads/` init PR; do not run `bd init` as an
+  incidental side effect because it creates a Dolt-backed repo artifact.
+- **Future MCP/tools** → Swiss constants / banned-terms gates once installed and
+  wired in this checkout.
 
 ## 🤝 Session handshake — run these in order, every time
 
-1. Read curator memory when present; otherwise use Engram context plus checked-in docs.
-2. Read [`CLAUDE.md`](CLAUDE.md) (auto-loaded).
-3. Read this file.
-4. Read [`docs/MINT_AGENT_WORKFLOW.md`](docs/MINT_AGENT_WORKFLOW.md).
-5. Read [`.claude/skills/mint-operating-gates/SKILL.md`](.claude/skills/mint-operating-gates/SKILL.md).
-6. When the user names a subsystem, read the matching `docs/*.md` **before
+1. Run `python3 tools/checks/mint_os_doctor.py --repo-only`; for runtime work
+   run the full `python3 tools/checks/mint_os_doctor.py` before claiming a tool
+   is missing.
+2. Read curator memory when present; otherwise use Engram context plus checked-in docs.
+3. Read [`CLAUDE.md`](CLAUDE.md) (auto-loaded).
+4. Read this file.
+5. Read [`docs/MINT_AGENT_WORKFLOW.md`](docs/MINT_AGENT_WORKFLOW.md).
+6. Read [`.claude/skills/mint-operating-gates/SKILL.md`](.claude/skills/mint-operating-gates/SKILL.md).
+7. When the user names a subsystem, read the matching `docs/*.md` **before
    the first code change**.
-7. Run the grep verification from the table.
-8. *Only then* propose code.
+8. Run the grep verification from the table.
+9. *Only then* propose code.
 
 If a step was skipped, revert and redo. That's cheaper than debugging
 the ghost in prod.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ cd services/backend && python3 -m pytest tests/ -q && uvicorn app.main:app --rel
 
 # Mobile
 cd apps/mobile && flutter analyze && flutter test && flutter gen-l10n
+
+# MINT OS tooling preflight
+python3 tools/checks/mint_os_doctor.py          # local/runtime session
+python3 tools/checks/mint_os_doctor.py --repo-only  # CI/repo contract
 ```
 
 ### 3.1 EXTERNAL CLAUDE AUDIT (latency policy)

--- a/apps/mobile/ios/Podfile
+++ b/apps/mobile/ios/Podfile
@@ -34,6 +34,9 @@ target 'Runner' do
   target 'RunnerTests' do
     inherit! :search_paths
   end
+  target 'RunnerUITests' do
+    inherit! :complete
+  end
 end
 
 post_install do |installer|
@@ -41,6 +44,10 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
+
+      if target.name == 'patrol'
+        config.build_settings['ENABLE_TESTING_SEARCH_PATHS'] = 'YES'
+      end
 
       # macOS Sequoia/Tahoe propagates `com.apple.provenance` xattr to copied
       # framework sources, breaking ad-hoc codesign on simulator builds
@@ -62,7 +69,7 @@ post_install do |installer|
   # -lc++abi into the Pods-Runner aggregate xcconfig so the final link picks
   # them up. Safe on device and simulator; both ship with every iOS SDK.
   require 'pathname'
-  Pathname.glob("#{installer.sandbox.root}/Target Support Files/Pods-Runner/*.xcconfig").each do |xcconfig|
+  Pathname.glob("#{installer.sandbox.root}/Target Support Files/{Pods-Runner,Pods-Runner-RunnerUITests}/*.xcconfig").each do |xcconfig|
     contents = xcconfig.read
     next unless contents =~ /^OTHER_LDFLAGS = (.+)$/
     existing = Regexp.last_match(1)

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - CocoaAsyncSocket (7.6.5)
   - CwlCatchException (2.2.1):
     - CwlCatchExceptionSupport (~> 2.2.1)
   - CwlCatchExceptionSupport (2.2.1)
@@ -61,6 +62,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - patrol (0.0.1):
+    - CocoaAsyncSocket (~> 7.6)
+    - Flutter
+    - FlutterMacOS
   - printing (1.0.0):
     - Flutter
   - SDWebImage (5.21.7):
@@ -105,6 +110,7 @@ DEPENDENCIES:
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - patrol (from `.symlinks/plugins/patrol/darwin`)
   - printing (from `.symlinks/plugins/printing/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -115,6 +121,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - CocoaAsyncSocket
     - CwlCatchException
     - CwlCatchExceptionSupport
     - DKImagePickerController
@@ -148,6 +155,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  patrol:
+    :path: ".symlinks/plugins/patrol/darwin"
   printing:
     :path: ".symlinks/plugins/printing/ios"
   sentry_flutter:
@@ -164,6 +173,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CwlCatchException: 7acc161b299a6de7f0a46a6ed741eae2c8b4d75a
   CwlCatchExceptionSupport: 54ccab8d8c78907b57f99717fb19d4cc3bce02dc
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
@@ -180,6 +190,7 @@ SPEC CHECKSUMS:
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  patrol: cea8074f183a2a4232d0ebd10569ae05149ada42
   printing: 54ff03f28fe9ba3aa93358afb80a8595a071dd07
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
@@ -192,6 +203,6 @@ SPEC CHECKSUMS:
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
-PODFILE CHECKSUM: 6d63677042f1242a318dccea4a4047ca4e6c4733
+PODFILE CHECKSUM: 6446c74255a8ab2646b9ef29fa3709f45c2f426a
 
 COCOAPODS: 1.16.2

--- a/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		4C9E4D82AC42C46CD18016F6 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8036909F1F536355E2727D0 /* Pods_Runner.framework */; };
+		72A2363663A42A057A1AB869 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0514E700B68238EC6B1DD80 /* Pods_Runner_RunnerUITests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		949673023551B76B006E7A81 /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A9609ED81F5B5151CBBF19B /* RunnerUITests.m */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -21,6 +23,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
+		C547FC789B47C363C67DD2AB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
 			proxyType = 1;
@@ -43,6 +52,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		11AEC0A23169AA6638C2034A /* RunnerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		1E94BD3134DADB9F43C2D4A3 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
@@ -51,6 +61,7 @@
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		5897EDE0707519B0D285ECCC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		5A9609ED81F5B5151CBBF19B /* RunnerUITests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RunnerUITests.m; sourceTree = "<group>"; };
 		5B243E1BD520090C147F014E /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		691053B0EBC5FAB22792A7DE /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -63,10 +74,15 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9936019BFD8C128AA692214B /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
+		9C6CA13322F5DD1CCEB90941 /* Pods-Runner-RunnerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.release.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		A1B2C3D42026041700000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C5CFCE119F126781A87C3738 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CAC53C3D3E037E683D2B112B /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		CDBFEA38689144B08F0EF469 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		D8036909F1F536355E2727D0 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3D1A0012D0A000100000001 /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
+		F0514E700B68238EC6B1DD80 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,6 +102,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EC843620C1F31470182AAE43 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				72A2363663A42A057A1AB869 /* Pods_Runner_RunnerUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -98,6 +122,9 @@
 				28BFA3573856A7723583E256 /* Pods-RunnerTests.debug.xcconfig */,
 				691053B0EBC5FAB22792A7DE /* Pods-RunnerTests.release.xcconfig */,
 				C5CFCE119F126781A87C3738 /* Pods-RunnerTests.profile.xcconfig */,
+				9C6CA13322F5DD1CCEB90941 /* Pods-Runner-RunnerUITests.release.xcconfig */,
+				CAC53C3D3E037E683D2B112B /* Pods-Runner-RunnerUITests.debug.xcconfig */,
+				9936019BFD8C128AA692214B /* Pods-Runner-RunnerUITests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -115,6 +142,7 @@
 			children = (
 				D8036909F1F536355E2727D0 /* Pods_Runner.framework */,
 				5B243E1BD520090C147F014E /* Pods_RunnerTests.framework */,
+				F0514E700B68238EC6B1DD80 /* Pods_Runner_RunnerUITests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -139,6 +167,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				0F5776853A7B1AB9F954316B /* Pods */,
 				7B4C3703B08A851998214BE2 /* Frameworks */,
+				A3E519F1D34AD98437890158 /* RunnerUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -147,6 +176,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				11AEC0A23169AA6638C2034A /* RunnerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -158,6 +188,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				E3D1A0012D0A000100000001 /* Info-Debug.plist */,
 				A1B2C3D42026041700000001 /* PrivacyInfo.xcprivacy */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
@@ -165,6 +196,14 @@
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
+			sourceTree = "<group>";
+		};
+		A3E519F1D34AD98437890158 /* RunnerUITests */ = {
+			isa = PBXGroup;
+			children = (
+				5A9609ED81F5B5151CBBF19B /* RunnerUITests.m */,
+			);
+			path = RunnerUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -189,6 +228,27 @@
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		498668805E82EB6E1E931EC7 /* RunnerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6BCEB468DC42333F32112EF0 /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
+			buildPhases = (
+				F861E6251D24ACDEF1D43496 /* [CP] Check Pods Manifest.lock */,
+				E3667FD77B5596934CAB9CA7 /* Sources */,
+				EC843620C1F31470182AAE43 /* Frameworks */,
+				265303002FC00A4AA35BDB94 /* Resources */,
+				7B8F89AC66FF1E6055254ECA /* [CP] Copy Pods Resources */,
+				EBDAB82AEB75F5D06717D52A /* Embed Flutter framework for Patrol */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				006A2AF93E4363C51D9C5E2F /* PBXTargetDependency */,
+			);
+			name = RunnerUITests;
+			productName = RunnerUITests;
+			productReference = 11AEC0A23169AA6638C2034A /* RunnerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -199,9 +259,9 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				E30884E87B8637E245C49191 /* Strip xattrs before codesign */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				6A100A9142CE6905C2652591 /* [CP] Copy Pods Resources */,
-				E30884E87B8637E245C49191 /* Strip xattrs before codesign */,
 			);
 			buildRules = (
 			);
@@ -247,11 +307,19 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				498668805E82EB6E1E931EC7 /* RunnerUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		265303002FC00A4AA35BDB94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807F294A63A400263BE5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -351,6 +419,23 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		7B8F89AC66FF1E6055254ECA /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -383,7 +468,47 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Strip xattrs from the app bundle at both possible codesign locations.\n# On macOS Sequoia/Tahoe, com.apple.provenance xattr propagates from\n# flutter engine cache to embedded frameworks and breaks ad-hoc codesign.\nfor path in \"${CODESIGNING_FOLDER_PATH}\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}\" \"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"; do\n  if [ -n \"$path\" ] && [ -e \"$path\" ]; then\n    /usr/bin/xattr -cr \"$path\" 2>/dev/null || true\n  fi\ndone\n";
+			shellScript = "/bin/sh \"${SRCROOT}/scripts/strip_xattrs_before_codesign.sh\"";
+		};
+		EBDAB82AEB75F5D06717D52A /* Embed Flutter framework for Patrol */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Flutter framework for Patrol";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\ncase \"${SDK_NAME:-}\" in\n  iphonesimulator*) ;;\n  *) exit 0 ;;\nesac\n\nstrip_bundle() {\n  path=\"$1\"\n  [ -d \"$path\" ] || return 0\n  /usr/bin/xattr -cr \"$path\" 2>/dev/null || true\n  parent_dir=\"$(cd \"$(dirname \"$path\")\" && pwd -P)\"\n  base_name=\"$(basename \"$path\")\"\n  tmp_path=\"$parent_dir/.${base_name}.norsrc.$$\"\n  backup_path=\"$parent_dir/.${base_name}.pre-xattr-strip.$$\"\n  rm -rf \"$tmp_path\" \"$backup_path\"\n  /usr/bin/ditto --norsrc \"$path\" \"$tmp_path\"\n  test -d \"$tmp_path\"\n  mv \"$path\" \"$backup_path\"\n  if mv \"$tmp_path\" \"$path\"; then\n    rm -rf \"$backup_path\"\n  else\n    rm -rf \"$path\"\n    mv \"$backup_path\" \"$path\"\n    rm -rf \"$tmp_path\"\n    exit 1\n  fi\n}\n\nflutter_framework=\"${BUILT_PRODUCTS_DIR}/Flutter.framework\"\nstrip_bundle \"$flutter_framework\"\n\nrunner_app=\"$(cd \"${TARGET_BUILD_DIR}/..\" && pwd -P)\"\ncase \"$(basename \"$runner_app\")\" in\n  *.app) ;;\n  *) exit 1 ;;\nesac\n\nframeworks_dir=\"$runner_app/Frameworks\"\nmkdir -p \"$frameworks_dir\"\nrm -rf \"$frameworks_dir/Flutter.framework\"\n/usr/bin/ditto --norsrc \"$flutter_framework\" \"$frameworks_dir/Flutter.framework\"\nstrip_bundle \"$frameworks_dir/Flutter.framework\"\n";
+		};
+		F861E6251D24ACDEF1D43496 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-RunnerUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -405,9 +530,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E3667FD77B5596934CAB9CA7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				949673023551B76B006E7A81 /* RunnerUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		006A2AF93E4363C51D9C5E2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Runner;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = C547FC789B47C363C67DD2AB /* PBXContainerItemProxy */;
+		};
 		331C8086294A63A400263BE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
@@ -493,6 +632,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
@@ -557,6 +697,45 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+			};
+			name = Profile;
+		};
+		48640CEDE168444847E71203 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAC53C3D3E037E683D2B112B /* Pods-Runner-RunnerUITests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ch.mint.app.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+			};
+			name = Debug;
+		};
+		7DFAC2F6A7E558CDC8F88BC0 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9936019BFD8C128AA692214B /* Pods-Runner-RunnerUITests.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ch.mint.app.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
 		};
@@ -677,11 +856,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 7F5UDGYS5H;
 				ENABLE_BITCODE = NO;
-				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_FILE = "Runner/Info-Debug.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -702,6 +882,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 7F5UDGYS5H;
@@ -720,6 +901,26 @@
 			};
 			name = Release;
 		};
+		FBC2CF7740554D74A9D140C3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9C6CA13322F5DD1CCEB90941 /* Pods-Runner-RunnerUITests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGNING_ALLOWED[sdk=iphonesimulator*]" = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ch.mint.app.RunnerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_TARGET_NAME = Runner;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -729,6 +930,16 @@
 				331C8088294A63A400263BE5 /* Debug */,
 				331C8089294A63A400263BE5 /* Release */,
 				331C808A294A63A400263BE5 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6BCEB468DC42333F32112EF0 /* Build configuration list for PBXNativeTarget "RunnerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FBC2CF7740554D74A9D140C3 /* Release */,
+				48640CEDE168444847E71203 /* Debug */,
+				7DFAC2F6A7E558CDC8F88BC0 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -49,6 +49,17 @@
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "498668805E82EB6E1E931EC7"
+               BuildableName = "RunnerUITests.xctest"
+               BlueprintName = "RunnerUITests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/mobile/ios/Runner/Info-Debug.plist
+++ b/apps/mobile/ios/Runner/Info-Debug.plist
@@ -18,6 +18,12 @@
 	<string>MINT</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -29,18 +35,22 @@
 			</array>
 		</dict>
 	</array>
-	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_dartobservatory._tcp</string>
+		<string>_dartVmService._tcp</string>
+		<string>_flutter-devtools._tcp</string>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>MINT utilise l'appareil photo pour scanner tes documents financiers, jamais sans ton accord.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>MINT utilise le réseau local en mode debug pour se connecter aux outils de développement Flutter.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>MINT utilise le micro pour la dictée vocale avec le coach.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/apps/mobile/ios/RunnerUITests/RunnerUITests.m
+++ b/apps/mobile/ios/RunnerUITests/RunnerUITests.m
@@ -1,0 +1,5 @@
+@import XCTest;
+@import patrol;
+@import ObjectiveC.runtime;
+
+PATROL_INTEGRATION_TEST_IOS_RUNNER(RunnerUITests)

--- a/apps/mobile/ios/scripts/strip_xattrs_before_codesign.sh
+++ b/apps/mobile/ios/scripts/strip_xattrs_before_codesign.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -e
+
+# Strip resource forks / Finder metadata before Flutter's embed_and_thin
+# codesigns generated app/framework bundles. FileProvider-backed worktrees on
+# macOS can attach provenance xattrs that make ad-hoc codesign fail.
+case "${SDK_NAME:-}" in
+  iphoneos*|iphonesimulator*) ;;
+  *) exit 0 ;;
+esac
+
+strip_bundle() {
+  path="$1"
+  [ -n "$path" ] || return 0
+  [ -d "$path" ] || return 0
+
+  base_name="$(basename "$path")"
+  case "$base_name" in
+    *.app|*.framework) ;;
+    *) exit 1 ;;
+  esac
+
+  parent_dir="$(cd "$(dirname "$path")" && pwd -P)"
+  resolved_path="$parent_dir/$base_name"
+  tmp_path="$parent_dir/.${base_name}.norsrc.$$"
+  backup_path="$parent_dir/.${base_name}.pre-xattr-strip.$$"
+
+  /usr/bin/xattr -dr com.apple.provenance "$resolved_path" 2>/dev/null || true
+  /usr/bin/xattr -dr com.apple.FinderInfo "$resolved_path" 2>/dev/null || true
+  /usr/bin/xattr -dr com.apple.ResourceFork "$resolved_path" 2>/dev/null || true
+  /usr/bin/xattr -cr "$resolved_path" 2>/dev/null || true
+
+  rm -rf "$tmp_path" "$backup_path"
+  /usr/bin/ditto --norsrc "$resolved_path" "$tmp_path"
+  test -d "$tmp_path"
+  mv "$resolved_path" "$backup_path"
+  if mv "$tmp_path" "$resolved_path"; then
+    rm -rf "$backup_path"
+  else
+    rm -rf "$resolved_path"
+    mv "$backup_path" "$resolved_path"
+    rm -rf "$tmp_path"
+    exit 1
+  fi
+}
+
+seen_paths=""
+for path in \
+  "${BUILT_PRODUCTS_DIR:-}/Flutter.framework" \
+  "${BUILT_PRODUCTS_DIR:-}/App.framework" \
+  "${CODESIGNING_FOLDER_PATH:-}" \
+  "${BUILT_PRODUCTS_DIR:-}/${WRAPPER_NAME:-}" \
+  "${TARGET_BUILD_DIR:-}/${WRAPPER_NAME:-}" \
+  "${TARGET_BUILD_DIR:-}/${FRAMEWORKS_FOLDER_PATH:-}/Flutter.framework" \
+  "${TARGET_BUILD_DIR:-}/${FRAMEWORKS_FOLDER_PATH:-}/App.framework"; do
+  [ -n "$path" ] || continue
+  [ -d "$path" ] || continue
+  parent_dir="$(cd "$(dirname "$path")" && pwd -P)"
+  resolved_path="$parent_dir/$(basename "$path")"
+  case " $seen_paths " in
+    *" $resolved_path "*) continue ;;
+  esac
+  seen_paths="$seen_paths $resolved_path"
+  strip_bundle "$resolved_path"
+done

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  dispose_scope:
+    dependency: transitive
+    description:
+      name: dispose_scope
+      sha256: "48ec38ca2631c53c4f8fa96b294c801e55c335db5e3fb9f82cede150cfe5a2af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   equatable:
     dependency: transitive
     description:
@@ -692,6 +700,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  patrol:
+    dependency: "direct dev"
+    description:
+      name: patrol
+      sha256: f43fda9425e90c0e69d2dac9e495e3a3036a22a550466365b4720fa4dd53d6ae
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.1"
+  patrol_finders:
+    dependency: transitive
+    description:
+      name: patrol_finders
+      sha256: "34e75a59df653dc9e6fc6c0caa469b950b18aaa538aaf859f756b52f937f0da8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.0"
+  patrol_log:
+    dependency: transitive
+    description:
+      name: patrol_log
+      sha256: "080608c3402480e18f7dce5a7ee17bf2e23fc191eedffb73a8a635506ce6d4bf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   pdf:
     dependency: "direct main"
     description:
@@ -852,6 +884,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.2"
   sign_in_with_apple:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -61,7 +61,14 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  patrol: ^4.6.1
   flutter_lints: ^3.0.0
+
+patrol:
+  app_name: Mint
+  test_directory: test/patrol
+  ios:
+    bundle_id: ch.mint.app
 
 flutter:
   generate: true

--- a/apps/mobile/test/patrol/mint_runtime_smoke_test.dart
+++ b/apps/mobile/test/patrol/mint_runtime_smoke_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/app.dart';
+import 'package:patrol/patrol.dart';
+
+const _runningFromPatrolCli = bool.fromEnvironment('MINT_PATROL_CLI');
+
+void main() {
+  patrolTest(
+    'launches Mint through the Patrol runner',
+    skip: !_runningFromPatrolCli,
+    timeout: const Timeout(Duration(minutes: 3)),
+    ($) async {
+      await $.pumpWidgetAndSettle(const MintApp());
+
+      expect(find.byType(MaterialApp), findsOneWidget);
+    },
+  );
+}

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -52,22 +52,52 @@ Every product PR must list:
   dossier/PDF artifacts are touched.
 - Design review for new or materially changed product screens.
 - Maestro runtime proof for touched P0 mobile UI; Patrol is required for real
-  P0 input proof once the Patrol CLI is available in the environment.
+  P0 input proof. The CLI may be at `$HOME/.pub-cache/bin/patrol` even when
+  `patrol` is not exported in `PATH`.
 - Claude CLI audit for architecture, compliance, and pre-merge code review when
   possible.
 - Engram memory after merge.
 
 ## Current Tool Matrix
 
+Run `python3 tools/checks/mint_os_doctor.py --repo-only` to verify checked-in
+MINT OS contracts, and full `python3 tools/checks/mint_os_doctor.py` before any
+runtime claim about a local tool.
+
 | Tool | Status in clean checkout | Gate use |
 |---|---|---|
 | Claude CLI | Available after local login | External audit via `tools/checks/claude_external_audit.sh`; use bounded audits (`opus high`, safe mode, strict empty MCP, `--setting-sources user`) by default |
 | Engram MCP | Available | Memory |
 | Maestro | Available at `~/.maestro/bin/maestro` | Runtime UI proof |
-| Patrol CLI | Not in PATH at G0 base restore | Required gap before Patrol-only gates |
-| Mermaid CLI | Not in PATH at G0 base restore | Optional graph rendering until installed |
-| Beads/bug CLI | Not in PATH at G0 base restore | Use checked-in bug ledger fallback |
+| Patrol CLI | Installed by Dart global tooling; canonical path is `$HOME/.pub-cache/bin/patrol` when not exported in `PATH` | Real mobile input proof for P0 flows; verify with `python3 tools/checks/patrol_tooling_guard.py` before claiming unavailable |
+| Mermaid CLI | Executable through `npx --yes @mermaid-js/mermaid-cli` | Graph render proof via `python3 tools/checks/mermaid_render_guard.py` |
+| Beads/bug CLI | Installed as `bd` via Homebrew | Agent issue graph; initialize `.beads/` only in a dedicated PR because `bd init` adds a Dolt-backed repo artifact |
 | ARB parity | `tools/checks/arb_parity.py` | i18n key parity |
+
+## Interaction Cartography
+
+Mermaid is an executable map, not a decorative diagram and not one giant
+screen-by-screen encyclopedia.
+
+- `docs/codex/WIRING_GRAPH.mmd` owns system wiring: routes, providers, source
+  of truth, live gaps, and machine-checkable invariants.
+- Product journeys own their own Mermaid flow when they become P0/P1: data
+  collection, decisions, branches, degraded states, PDF handoff, and runtime
+  proof links.
+- `SCREEN_CONTRACTS.md` owns per-screen interaction contracts: visible controls,
+  CTA routes, known/estimated/missing states, recovery states, and required
+  ledger facts.
+- Interaction registries own fine-grained control metadata:
+  `screen_id -> control_id -> action -> route/data read/write -> Maestro/Patrol
+  proof`.
+
+Every important button, click, and navigation edge must be traceable through one
+of these layers. Do not stuff every micro-interaction into `WIRING_GRAPH.mmd`;
+that makes the graph unreadable and guarantees drift. Use established mobile
+flow archetypes before inventing a new flow: progressive data collection,
+known-fact review/edit, scenario comparison, document extraction, permission or
+consent, dossier export, specialist handoff, error recovery, and return to the
+ledger.
 
 ## Product Spine
 

--- a/tools/checks/mermaid_render_guard.py
+++ b/tools/checks/mermaid_render_guard.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Render checked-in MINT Mermaid diagrams to catch syntax drift."""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REQUIRED_DIAGRAMS = (Path("docs/codex/WIRING_GRAPH.mmd"),)
+OPTIONAL_DIAGRAM_DIRS = (Path(".planning/journeys/diagrams"),)
+MERMAID_CLI = "@mermaid-js/mermaid-cli@11.4.2"
+
+
+def _render(root: Path, diagram: Path, out_dir: Path, puppeteer_config: Path) -> str | None:
+    output = out_dir / f"{diagram.stem}.svg"
+    proc = subprocess.run(
+        ["npx", "-y", MERMAID_CLI, "-p", str(puppeteer_config), "-i", str(diagram), "-o", str(output)],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        timeout=120,
+    )
+    if proc.returncode:
+        return f"{diagram.relative_to(root)} failed to render: {proc.stderr.strip() or proc.stdout.strip()}"
+    try:
+        svg = output.read_text(encoding="utf-8", errors="ignore")
+    except OSError as exc:
+        return f"{diagram.relative_to(root)} did not produce an SVG: {exc}"
+    if "<svg" not in svg or len(svg.strip()) < 100:
+        return f"{diagram.relative_to(root)} produced an empty or invalid SVG"
+    return None
+
+
+def check(root: Path) -> list[str]:
+    root = root.resolve()
+    if shutil.which("npx") is None:
+        return ["npx is required to render MINT Mermaid diagrams"]
+    missing = [path for path in REQUIRED_DIAGRAMS if not (root / path).is_file()]
+    if missing:
+        return [f"missing required MINT Mermaid diagram: {path}" for path in missing]
+    diagrams = [root / path for path in REQUIRED_DIAGRAMS]
+    for diagram_dir in OPTIONAL_DIAGRAM_DIRS:
+        diagrams.extend(sorted((root / diagram_dir).glob("*.mmd")))
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="mint-mermaid-render-") as tmp:
+        out_dir = Path(tmp)
+        puppeteer_config = out_dir / "puppeteer-config.json"
+        puppeteer_config.write_text(
+            json.dumps({"args": ["--no-sandbox", "--disable-setuid-sandbox"]}),
+            encoding="utf-8",
+        )
+        for diagram in diagrams:
+            error = _render(root, diagram, out_dir, puppeteer_config)
+            if error:
+                errors.append(error)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    errors = check(args.root)
+    if not errors:
+        print("OK mermaid_render_guard: MINT Mermaid diagrams render.")
+        return 0
+    print("FAIL mermaid_render_guard: MINT Mermaid diagrams do not render.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/mint_os_doctor.py
+++ b/tools/checks/mint_os_doctor.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""MINT OS preflight: make runtime tooling explicit and non-implicit."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.checks import patrol_tooling_guard
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    status: str
+    detail: str
+
+
+def _executable(path: Path) -> bool:
+    return path.exists() and os.access(path, os.X_OK)
+
+
+def _which_or_path(binary: str, fallback: Path | None = None) -> Path | None:
+    if found := shutil.which(binary):
+        return Path(found)
+    if fallback is not None and _executable(fallback):
+        return fallback
+    return None
+
+
+def _run_version(args: list[str], cwd: Path, timeout: int = 20) -> str:
+    proc = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    output = (proc.stdout or proc.stderr).strip().splitlines()
+    if proc.returncode != 0:
+        return f"exit {proc.returncode}: {output[0] if output else 'no output'}"
+    return output[0] if output else "ok"
+
+
+def _read_plist(path: Path) -> dict:
+    try:
+        with path.open("rb") as plist:
+            data = plistlib.load(plist)
+    except (OSError, plistlib.InvalidFileException):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _url_schemes(plist: dict) -> set[str]:
+    schemes: set[str] = set()
+    for entry in plist.get("CFBundleURLTypes", []):
+        if not isinstance(entry, dict):
+            continue
+        for scheme in entry.get("CFBundleURLSchemes", []):
+            if isinstance(scheme, str):
+                schemes.add(scheme)
+    return schemes
+
+
+def _ios_plist_split_errors(root: Path) -> list[str]:
+    release = _read_plist(root / "apps" / "mobile" / "ios" / "Runner" / "Info.plist")
+    debug = _read_plist(root / "apps" / "mobile" / "ios" / "Runner" / "Info-Debug.plist")
+    errors: list[str] = []
+    if not release:
+        errors.append("missing or invalid apps/mobile/ios/Runner/Info.plist")
+    if not debug:
+        errors.append("missing or invalid apps/mobile/ios/Runner/Info-Debug.plist")
+    if errors:
+        return errors
+
+    debug_only_keys = ("NSBonjourServices", "NSLocalNetworkUsageDescription")
+    for key in debug_only_keys:
+        if key in release:
+            errors.append(f"release Info.plist must not contain debug-only {key}")
+        if key not in debug:
+            errors.append(f"Info-Debug.plist must contain {key}")
+
+    release_schemes = _url_schemes(release)
+    debug_schemes = _url_schemes(debug)
+    if not release_schemes:
+        errors.append("release Info.plist must define at least one CFBundleURLScheme")
+    elif release_schemes != debug_schemes:
+        errors.append(f"Info-Debug.plist URL schemes {sorted(debug_schemes)} must match release {sorted(release_schemes)}")
+    return errors
+
+
+def check_repo(root: Path) -> list[CheckResult]:
+    root = root.resolve()
+    results: list[CheckResult] = []
+
+    patrol_errors = patrol_tooling_guard.check(root, require_cli=False)
+    results.append(
+        CheckResult(
+            "repo.patrol",
+            "pass" if not patrol_errors else "fail",
+            "Patrol dependency/config/test directory wired"
+            if not patrol_errors
+            else "; ".join(patrol_errors),
+        )
+    )
+
+    repo_files = {
+        "repo.maestro_env": root / "tools" / "simulator" / "maestro_env.sh",
+        "repo.maestro_watchdog": root / "tools" / "simulator" / "maestro_with_watchdog.sh",
+        "repo.mermaid_guard": root / "tools" / "checks" / "mermaid_render_guard.py",
+        "repo.claude_audit_wrapper": root / "tools" / "checks" / "claude_external_audit.sh",
+        "repo.agent_workflow": root / "docs" / "MINT_AGENT_WORKFLOW.md",
+    }
+    for name, path in repo_files.items():
+        results.append(
+            CheckResult(
+                name,
+                "pass" if path.exists() else "fail",
+                str(path.relative_to(root)) if path.exists() else f"missing {path.relative_to(root)}",
+            )
+        )
+    plist_errors = _ios_plist_split_errors(root)
+    results.append(
+        CheckResult(
+            "repo.ios_plist_split",
+            "pass" if not plist_errors else "fail",
+            "Debug-only Flutter VM network keys stay out of release Info.plist"
+            if not plist_errors
+            else "; ".join(plist_errors),
+        )
+    )
+    return results
+
+
+def check_host(root: Path) -> list[CheckResult]:
+    home = Path.home()
+    results: list[CheckResult] = []
+
+    patrol = _which_or_path("patrol", home / ".pub-cache" / "bin" / "patrol")
+    results.append(
+        CheckResult(
+            "host.patrol_cli",
+            "pass" if patrol else "fail",
+            str(patrol) if patrol else "missing patrol CLI; expected $HOME/.pub-cache/bin/patrol",
+        )
+    )
+
+    maestro = _which_or_path("maestro", home / ".maestro" / "bin" / "maestro")
+    results.append(
+        CheckResult(
+            "host.maestro_cli",
+            "pass" if maestro else "fail",
+            str(maestro) if maestro else "missing Maestro CLI; expected $HOME/.maestro/bin/maestro",
+        )
+    )
+
+    npx = _which_or_path("npx")
+    results.append(
+        CheckResult(
+            "host.mermaid_cli",
+            "pass" if npx else "fail",
+            _run_version(["npx", "--yes", "@mermaid-js/mermaid-cli", "--version"], root)
+            if npx
+            else "missing npx for @mermaid-js/mermaid-cli",
+        )
+    )
+
+    claude = _which_or_path("claude")
+    results.append(
+        CheckResult(
+            "host.claude_cli",
+            "pass" if claude else "fail",
+            str(claude) if claude else "missing Claude CLI",
+        )
+    )
+
+    beads = _which_or_path("bd")
+    results.append(
+        CheckResult(
+            "host.beads_cli",
+            "pass" if beads else "warn",
+            _run_version([str(beads), "--version"], root) if beads else "not found; install with `brew install beads`",
+        )
+    )
+    return results
+
+
+def render(results: list[CheckResult], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps([asdict(result) for result in results], indent=2, ensure_ascii=False))
+        return
+    width = max(len(result.name) for result in results)
+    for result in results:
+        print(f"{result.status.upper():4} {result.name.ljust(width)}  {result.detail}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--repo-only", action="store_true", help="Skip host-specific binary checks.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    results = check_repo(root)
+    if not args.repo_only:
+        results.extend(check_host(root))
+    render(results, as_json=args.json)
+
+    return 1 if any(result.status == "fail" for result in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/patrol_tooling_guard.py
+++ b/tools/checks/patrol_tooling_guard.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Verify that MINT's Patrol gate is wired and discoverable."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _section(text: str, name: str) -> str:
+    match = re.search(rf"^{re.escape(name)}:\s*$", text, re.MULTILINE)
+    if not match:
+        return ""
+    start = match.end()
+    next_top = re.search(r"^\S[^:\n]*:\s*$", text[start:], re.MULTILINE)
+    end = start + next_top.start() if next_top else len(text)
+    return text[start:end]
+
+
+def _has_dev_dependency(pubspec: str, dependency: str) -> bool:
+    section = _section(pubspec, "dev_dependencies")
+    return re.search(rf"^\s{{2}}{re.escape(dependency)}:\s*\S+", section, re.MULTILINE) is not None
+
+
+def _has_patrol_config(pubspec: str) -> bool:
+    section = _section(pubspec, "patrol")
+    required = (
+        r"^\s{2}app_name:\s*Mint\s*$",
+        r"^\s{2}test_directory:\s*test/patrol\s*$",
+        r"^\s{4}bundle_id:\s*ch\.mint\.app\s*$",
+    )
+    return bool(section) and all(re.search(pattern, section, re.MULTILINE) for pattern in required)
+
+
+def _patrol_cli_paths() -> list[Path]:
+    candidates: list[Path] = []
+    if path := shutil.which("patrol"):
+        candidates.append(Path(path))
+    candidates.append(Path.home() / ".pub-cache" / "bin" / "patrol")
+    return [path for path in candidates if path.exists() and os.access(path, os.X_OK)]
+
+
+def _dart_global_has_patrol_cli() -> bool:
+    dart = shutil.which("dart")
+    if dart is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [dart, "pub", "global", "list"],
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0 and "patrol_cli" in proc.stdout
+
+
+def check(root: Path, *, require_cli: bool = True) -> list[str]:
+    root = root.resolve()
+    errors: list[str] = []
+    mobile = root / "apps" / "mobile"
+    pubspec = _read(mobile / "pubspec.yaml")
+
+    if not pubspec:
+        errors.append("apps/mobile/pubspec.yaml is missing or unreadable")
+        return errors
+    if not _has_dev_dependency(pubspec, "patrol"):
+        errors.append("apps/mobile/pubspec.yaml must declare dev_dependencies.patrol")
+    if not _has_patrol_config(pubspec):
+        errors.append("apps/mobile/pubspec.yaml must define patrol app_name, test_directory, and iOS bundle_id")
+
+    patrol_tests = mobile / "test" / "patrol"
+    if not patrol_tests.is_dir() or not any(patrol_tests.glob("*_test.dart")):
+        errors.append("apps/mobile/test/patrol must contain at least one *_test.dart")
+    else:
+        test_text = "\n".join(_read(path) for path in patrol_tests.glob("*_test.dart"))
+        if "bool.fromEnvironment('MINT_PATROL_CLI')" not in test_text:
+            errors.append("Patrol smoke tests must gate native-only patrolTest with MINT_PATROL_CLI")
+
+    patrol_doc = _read(root / ".github" / "workflows" / "patrol.md")
+    if "--dart-define=MINT_PATROL_CLI=true" not in patrol_doc:
+        errors.append("Patrol runbook must pass --dart-define=MINT_PATROL_CLI=true")
+
+    if require_cli and not _patrol_cli_paths() and not _dart_global_has_patrol_cli():
+        errors.append(
+            "patrol CLI not found; add $HOME/.pub-cache/bin to PATH or run "
+            "`dart pub global activate patrol_cli`"
+        )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--no-cli", action="store_true", help="Skip host CLI availability checks.")
+    args = parser.parse_args(argv)
+
+    errors = check(args.root, require_cli=not args.no_cli)
+    if not errors:
+        print("OK patrol_tooling_guard: Patrol config, tests, and CLI discovery are wired.")
+        for path in _patrol_cli_paths():
+            print(f"  patrol_cli: {path}")
+        return 0
+    print("FAIL patrol_tooling_guard: Patrol gate is not wired.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/conftest.py
+++ b/tools/checks/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tools/checks/tests/test_mermaid_render_guard.py
+++ b/tools/checks/tests/test_mermaid_render_guard.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from tools.checks import mermaid_render_guard
+
+
+def _root(tmp_path: Path) -> Path:
+    diagrams = tmp_path / "docs/codex"
+    diagrams.mkdir(parents=True)
+    (diagrams / "WIRING_GRAPH.mmd").write_text("flowchart LR\n  A-->B\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_mermaid_render_guard_writes_sandbox_config_and_checks_svg(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    def fake_run(args, cwd, text, capture_output, timeout):  # noqa: ANN001
+        calls.append(args)
+        puppeteer_config = Path(args[args.index("-p") + 1])
+        output = Path(args[args.index("-o") + 1])
+        assert cwd == root.resolve()
+        assert text is True
+        assert capture_output is True
+        assert timeout == 120
+        assert json.loads(puppeteer_config.read_text(encoding="utf-8")) == {
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+        }
+        output.write_text("<svg>" + ("x" * 120) + "</svg>", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mermaid_render_guard.subprocess, "run", fake_run)
+
+    assert mermaid_render_guard.check(root) == []
+    assert calls
+    assert calls[0][:4] == ["npx", "-y", mermaid_render_guard.MERMAID_CLI, "-p"]
+
+
+def test_mermaid_render_guard_requires_npx(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: None)
+
+    assert mermaid_render_guard.check(root) == ["npx is required to render MINT Mermaid diagrams"]
+
+
+def test_mermaid_render_guard_reports_render_failure(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    def fake_run(args, cwd, text, capture_output, timeout):  # noqa: ANN001
+        return subprocess.CompletedProcess(args, 1, "", "syntax error")
+
+    monkeypatch.setattr(mermaid_render_guard.subprocess, "run", fake_run)
+
+    errors = mermaid_render_guard.check(root)
+
+    assert len(errors) == 1
+    assert "WIRING_GRAPH.mmd failed to render: syntax error" in errors[0]
+
+
+def test_mermaid_render_guard_rejects_empty_svg(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    def fake_run(args, cwd, text, capture_output, timeout):  # noqa: ANN001
+        output = Path(args[args.index("-o") + 1])
+        output.write_text("<svg></svg>", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mermaid_render_guard.subprocess, "run", fake_run)
+
+    errors = mermaid_render_guard.check(root)
+
+    assert len(errors) == 1
+    assert "produced an empty or invalid SVG" in errors[0]
+
+
+def test_mermaid_render_guard_includes_optional_journey_diagrams(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    optional = root / ".planning/journeys/diagrams"
+    optional.mkdir(parents=True)
+    (optional / "system_map.mmd").write_text("flowchart LR\n  B-->C\n", encoding="utf-8")
+    rendered: list[str] = []
+
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    def fake_run(args, cwd, text, capture_output, timeout):  # noqa: ANN001
+        diagram = Path(args[args.index("-i") + 1])
+        output = Path(args[args.index("-o") + 1])
+        rendered.append(str(diagram.relative_to(root)))
+        output.write_text("<svg>" + ("x" * 120) + "</svg>", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mermaid_render_guard.subprocess, "run", fake_run)
+
+    assert mermaid_render_guard.check(root) == []
+    assert rendered == [
+        "docs/codex/WIRING_GRAPH.mmd",
+        ".planning/journeys/diagrams/system_map.mmd",
+    ]
+
+
+def test_mermaid_render_guard_requires_wiring_graph(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    assert mermaid_render_guard.check(tmp_path) == [
+        "missing required MINT Mermaid diagram: docs/codex/WIRING_GRAPH.mmd"
+    ]

--- a/tools/checks/tests/test_mint_os_doctor.py
+++ b/tools/checks/tests/test_mint_os_doctor.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from tools.checks import mint_os_doctor
+
+
+def _write_plist(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as plist:
+        plistlib.dump(data, plist)
+
+
+def _write_repo(root: Path) -> None:
+    mobile = root / "apps" / "mobile"
+    (mobile / "test" / "patrol").mkdir(parents=True)
+    (mobile / "test" / "patrol" / "mint_runtime_smoke_test.dart").write_text(
+        "const _runningFromPatrolCli = bool.fromEnvironment('MINT_PATROL_CLI');\nvoid main() {}\n",
+        encoding="utf-8",
+    )
+    (mobile / "pubspec.yaml").write_text(
+        """
+name: mint_mobile
+dev_dependencies:
+  patrol: ^4.6.1
+
+patrol:
+  app_name: Mint
+  test_directory: test/patrol
+  ios:
+    bundle_id: ch.mint.app
+""",
+        encoding="utf-8",
+    )
+    for rel in (
+        "tools/simulator/maestro_env.sh",
+        "tools/simulator/maestro_with_watchdog.sh",
+        "tools/checks/mermaid_render_guard.py",
+        "tools/checks/claude_external_audit.sh",
+        "docs/MINT_AGENT_WORKFLOW.md",
+    ):
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    runbook = root / ".github" / "workflows" / "patrol.md"
+    runbook.parent.mkdir(parents=True, exist_ok=True)
+    runbook.write_text("--dart-define=MINT_PATROL_CLI=true\n", encoding="utf-8")
+    release_plist = {
+        "CFBundleURLTypes": [{"CFBundleURLSchemes": ["mint"]}],
+        "NSCameraUsageDescription": "camera",
+    }
+    debug_plist = {
+        **release_plist,
+        "NSBonjourServices": ["_dartobservatory._tcp", "_dartVmService._tcp", "_flutter-devtools._tcp"],
+        "NSLocalNetworkUsageDescription": "debug local network",
+    }
+    _write_plist(root / "apps/mobile/ios/Runner/Info.plist", release_plist)
+    _write_plist(root / "apps/mobile/ios/Runner/Info-Debug.plist", debug_plist)
+
+
+def test_repo_only_doctor_passes_when_os_contract_files_exist(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+
+    results = mint_os_doctor.check_repo(tmp_path)
+
+    assert {result.status for result in results} == {"pass"}
+
+
+def test_repo_only_doctor_fails_when_patrol_contract_is_missing(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    (tmp_path / "apps" / "mobile" / "pubspec.yaml").write_text(
+        "name: mint_mobile\n",
+        encoding="utf-8",
+    )
+
+    results = mint_os_doctor.check_repo(tmp_path)
+
+    assert any(result.name == "repo.patrol" and result.status == "fail" for result in results)
+
+
+def test_repo_only_doctor_fails_when_release_plist_contains_debug_network_keys(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    _write_plist(
+        tmp_path / "apps/mobile/ios/Runner/Info.plist",
+        {
+            "CFBundleURLTypes": [{"CFBundleURLSchemes": ["mint"]}],
+            "NSBonjourServices": ["_dartVmService._tcp"],
+            "NSLocalNetworkUsageDescription": "debug only",
+        },
+    )
+
+    results = mint_os_doctor.check_repo(tmp_path)
+
+    assert any(result.name == "repo.ios_plist_split" and result.status == "fail" for result in results)
+
+
+def test_host_doctor_accepts_pub_cache_patrol_and_beads(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    for rel in (
+        ".pub-cache/bin/patrol",
+        ".maestro/bin/maestro",
+        ".local/bin/claude",
+        "bin/npx",
+        "bin/bd",
+    ):
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    def fake_which(binary: str) -> str | None:
+        if binary == "npx":
+            return str(tmp_path / "bin" / "npx")
+        if binary == "bd":
+            return str(tmp_path / "bin" / "bd")
+        if binary == "claude":
+            return str(tmp_path / ".local" / "bin" / "claude")
+        return None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(mint_os_doctor.shutil, "which", fake_which)
+    monkeypatch.setattr(mint_os_doctor, "_run_version", lambda *args, **kwargs: "tool-version")
+
+    results = mint_os_doctor.check_host(tmp_path)
+
+    by_name = {result.name: result for result in results}
+    assert by_name["host.patrol_cli"].status == "pass"
+    assert by_name["host.maestro_cli"].status == "pass"
+    assert by_name["host.mermaid_cli"].status == "pass"
+    assert by_name["host.claude_cli"].status == "pass"
+    assert by_name["host.beads_cli"].status == "pass"
+
+
+def test_host_doctor_warns_when_beads_is_missing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    for rel in (
+        ".pub-cache/bin/patrol",
+        ".maestro/bin/maestro",
+        ".local/bin/claude",
+        "bin/npx",
+    ):
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        path.chmod(0o755)
+
+    def fake_which(binary: str) -> str | None:
+        if binary == "npx":
+            return str(tmp_path / "bin" / "npx")
+        if binary == "claude":
+            return str(tmp_path / ".local" / "bin" / "claude")
+        return None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(mint_os_doctor.shutil, "which", fake_which)
+    monkeypatch.setattr(mint_os_doctor, "_run_version", lambda *args, **kwargs: "tool-version")
+
+    results = mint_os_doctor.check_host(tmp_path)
+
+    by_name = {result.name: result for result in results}
+    assert by_name["host.beads_cli"].status == "warn"

--- a/tools/checks/tests/test_patrol_tooling_guard.py
+++ b/tools/checks/tests/test_patrol_tooling_guard.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.checks import patrol_tooling_guard
+
+
+def _write_project(root: Path, pubspec: str) -> None:
+    mobile = root / "apps" / "mobile"
+    (mobile / "test" / "patrol").mkdir(parents=True)
+    (mobile / "test" / "patrol" / "mint_runtime_smoke_test.dart").write_text(
+        "const _runningFromPatrolCli = bool.fromEnvironment('MINT_PATROL_CLI');\nvoid main() {}\n",
+        encoding="utf-8",
+    )
+    (mobile / "pubspec.yaml").write_text(pubspec, encoding="utf-8")
+    runbook = root / ".github" / "workflows"
+    runbook.mkdir(parents=True)
+    (runbook / "patrol.md").write_text("--dart-define=MINT_PATROL_CLI=true\n", encoding="utf-8")
+
+
+def _valid_pubspec() -> str:
+    return """
+name: mint_mobile
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  patrol: ^4.6.1
+  flutter_lints: ^3.0.0
+
+patrol:
+  app_name: Mint
+  test_directory: test/patrol
+  ios:
+    bundle_id: ch.mint.app
+"""
+
+
+def test_guard_accepts_pub_cache_patrol_even_when_not_on_path(monkeypatch, tmp_path: Path) -> None:
+    _write_project(tmp_path, _valid_pubspec())
+    patrol = tmp_path / ".pub-cache" / "bin" / "patrol"
+    patrol.parent.mkdir(parents=True)
+    patrol.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    patrol.chmod(0o755)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(patrol_tooling_guard.shutil, "which", lambda binary: None)
+
+    assert patrol_tooling_guard.check(tmp_path) == []
+
+
+def test_guard_rejects_missing_patrol_dependency(tmp_path: Path) -> None:
+    _write_project(
+        tmp_path,
+        """
+name: mint_mobile
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+patrol:
+  app_name: Mint
+  test_directory: test/patrol
+  ios:
+    bundle_id: ch.mint.app
+""",
+    )
+
+    errors = patrol_tooling_guard.check(tmp_path, require_cli=False)
+
+    assert "apps/mobile/pubspec.yaml must declare dev_dependencies.patrol" in errors
+
+
+def test_guard_rejects_missing_patrol_config(tmp_path: Path) -> None:
+    _write_project(
+        tmp_path,
+        """
+name: mint_mobile
+dev_dependencies:
+  patrol: ^4.6.1
+""",
+    )
+
+    errors = patrol_tooling_guard.check(tmp_path, require_cli=False)
+
+    assert "apps/mobile/pubspec.yaml must define patrol app_name, test_directory, and iOS bundle_id" in errors
+
+
+def test_guard_rejects_missing_patrol_tests(tmp_path: Path) -> None:
+    mobile = tmp_path / "apps" / "mobile"
+    mobile.mkdir(parents=True)
+    (mobile / "pubspec.yaml").write_text(_valid_pubspec(), encoding="utf-8")
+
+    errors = patrol_tooling_guard.check(tmp_path, require_cli=False)
+
+    assert "apps/mobile/test/patrol must contain at least one *_test.dart" in errors
+
+
+def test_guard_rejects_missing_patrol_define_in_test(tmp_path: Path) -> None:
+    _write_project(tmp_path, _valid_pubspec())
+    test_file = tmp_path / "apps" / "mobile" / "test" / "patrol" / "mint_runtime_smoke_test.dart"
+    test_file.write_text("void main() {}\n", encoding="utf-8")
+
+    errors = patrol_tooling_guard.check(tmp_path, require_cli=False)
+
+    assert "Patrol smoke tests must gate native-only patrolTest with MINT_PATROL_CLI" in errors
+
+
+def test_guard_rejects_missing_patrol_define_in_runbook(tmp_path: Path) -> None:
+    _write_project(tmp_path, _valid_pubspec())
+    (tmp_path / ".github" / "workflows" / "patrol.md").write_text("patrol test\n", encoding="utf-8")
+
+    errors = patrol_tooling_guard.check(tmp_path, require_cli=False)
+
+    assert "Patrol runbook must pass --dart-define=MINT_PATROL_CLI=true" in errors

--- a/tools/simulator/maestro_env.sh
+++ b/tools/simulator/maestro_env.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# tools/simulator/maestro_env.sh
+#
+# Phase 90 PERS-01 (v2.13) — Maestro CLI environment helper.
+#
+# Maestro CLI on macOS requires Java 17+. brew installs `maestro` as a
+# Cask (the Studio GUI app at /Applications/Maestro.app), NOT the CLI.
+# Per https://docs.maestro.dev/getting-started/installation, the CLI is
+# installed via :
+#   curl -fsSL "https://get.maestro.mobile.dev" | bash
+# which lands at ~/.maestro/bin/maestro and needs a JAVA_HOME on PATH.
+#
+# This script sets JAVA_HOME + PATH from brew's openjdk and then exec's
+# the requested maestro command. Reproducible across machines that have
+# brew + openjdk installed (no sudo required ; brew openjdk lives in the
+# user-writable /opt/homebrew/opt/openjdk).
+#
+# Usage :
+#   bash tools/simulator/maestro_env.sh test flows/julien_swiss.yaml
+#   bash tools/simulator/maestro_env.sh --version
+#
+# Why not just `eval $(brew shellenv)` ? — brew shellenv doesn't add
+# openjdk to PATH ; it's a keg-only formula. We must set JAVA_HOME
+# explicitly to its libexec path.
+
+set -euo pipefail
+
+if [ ! -d "/opt/homebrew/opt/openjdk" ]; then
+  echo "ERROR: brew openjdk not installed. Run: brew install openjdk" >&2
+  exit 1
+fi
+if [ ! -x "$HOME/.maestro/bin/maestro" ]; then
+  echo "ERROR: Maestro CLI not installed. Run: curl -fsSL https://get.maestro.mobile.dev | bash" >&2
+  exit 1
+fi
+
+export JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home
+export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
+export MAESTRO_CLI_NO_ANALYTICS=1
+
+exec "$HOME/.maestro/bin/maestro" "$@"

--- a/tools/simulator/maestro_with_watchdog.sh
+++ b/tools/simulator/maestro_with_watchdog.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# tools/simulator/maestro_with_watchdog.sh — S98 Phase 3
+#
+# Wraps a Maestro flow run with a stall-detector watchdog. Maestro on
+# iOS sim is known-flaky: documented silent hangs (mobile-dev-inc
+# issues #1252 #2628 #3254) sit with no output for 10-30 minutes and
+# never auto-kill. Session 2026-05-13 lost 30 min on task `bo1o442ww`
+# which stalled and never returned.
+#
+# This wrapper:
+#   1. Tees maestro stdout/stderr to a log file with a per-line mtime.
+#   2. A background watchdog probes the log's mtime every
+#      MAESTRO_STALL_PROBE_INTERVAL seconds (default 30s). If the log
+#      hasn't been touched in MAESTRO_STALL_THRESHOLD seconds (default
+#      90s), maestro is considered stalled.
+#   3. On stall: dump artifacts (last screenshot, /debug/state snapshot
+#      if endpoint reachable, OSLog tail) and SIGTERM maestro.
+#   4. Hard ceiling at MAESTRO_HARD_LIMIT seconds (default 900s = 15
+#      min). Past that, SIGKILL.
+#
+# Usage:
+#   bash tools/simulator/maestro_with_watchdog.sh test <flow.yaml> [...args]
+#
+# Forwards all args to `tools/simulator/maestro_env.sh`. The first arg
+# must be the maestro subcommand (`test`, `studio`, etc.) — same shape
+# as direct `maestro` invocation.
+#
+# Env:
+#   MAESTRO_STALL_PROBE_INTERVAL   default 30
+#   MAESTRO_STALL_THRESHOLD        default 90
+#   MAESTRO_HARD_LIMIT             default 900
+#   MINT_WALKER_ARTIFACTS          default $REPO/.planning/_walker/<ts>
+#   MINT_DEBUG_PORT                default 8181
+#   MINT_DEBUG_TOKEN_PATH          default <auto-resolved from simctl>
+#
+# Exit codes:
+#   0    — maestro succeeded
+#   124  — stall detected, maestro killed
+#   137  — hard limit hit (SIGKILL)
+#   other — maestro's own non-zero exit
+set -euo pipefail
+
+# ── Resolve paths + defaults ───────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MAESTRO_ENV="$SCRIPT_DIR/maestro_env.sh"
+# Many .sh files in this repo are committed `100644` (non-executable).
+# Rather than depend on the exec bit, we invoke via `bash` explicitly —
+# matches walker_persona.sh's historical pattern + survives a fresh
+# clone where `chmod +x` wasn't run.
+[ -r "$MAESTRO_ENV" ] || {
+  echo "ERROR: $MAESTRO_ENV not found / not readable" >&2
+  exit 2
+}
+
+STALL_PROBE_INTERVAL="${MAESTRO_STALL_PROBE_INTERVAL:-30}"
+STALL_THRESHOLD="${MAESTRO_STALL_THRESHOLD:-90}"
+HARD_LIMIT="${MAESTRO_HARD_LIMIT:-900}"
+
+TS="$(date +%Y%m%dT%H%M%S)"
+ARTIFACT_DIR="${MINT_WALKER_ARTIFACTS:-$REPO_ROOT/.planning/_walker/$TS}"
+mkdir -p "$ARTIFACT_DIR"
+
+LOG_FILE="$ARTIFACT_DIR/maestro.log"
+STALL_MARKER="$ARTIFACT_DIR/STALLED"
+
+DEBUG_PORT="${MINT_DEBUG_PORT:-8181}"
+BUNDLE="${MINT_BUNDLE_ID:-ch.mint.app}"
+
+echo "[watchdog] artifacts → $ARTIFACT_DIR"
+echo "[watchdog] hard limit ${HARD_LIMIT}s ; stall threshold ${STALL_THRESHOLD}s ; probe ${STALL_PROBE_INTERVAL}s"
+
+# ── Dump function (called on stall OR caller-side trap) ────────────────
+dump_state() {
+  local reason="$1"
+  echo "[watchdog] DUMPING STATE — reason: $reason"
+  {
+    echo "reason: $reason"
+    echo "timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "maestro_log: $LOG_FILE ($(wc -l < "$LOG_FILE" 2>/dev/null || echo 0) lines)"
+    echo "last_log_lines:"
+    tail -n 30 "$LOG_FILE" 2>/dev/null | sed 's/^/  /'
+  } > "$ARTIFACT_DIR/stall-summary.txt"
+
+  # 1. Last sim screenshot (best-effort, doesn't matter if booted-state
+  # is gone).
+  xcrun simctl io booted screenshot "$ARTIFACT_DIR/last-screen.png" 2>/dev/null \
+    || echo "[watchdog] simctl screenshot failed (sim may not be booted)"
+
+  # 2. OSLog tail filtered to ch.mint.* (the same tag MintHttpClient
+  # uses) — 5-minute window pre-stall.
+  xcrun simctl spawn booted log show --last 5m \
+    --predicate 'subsystem CONTAINS "mint" OR category CONTAINS "mint"' \
+    --style compact > "$ARTIFACT_DIR/oslog-mint.txt" 2>/dev/null \
+    || echo "[watchdog] simctl log show failed"
+
+  # 3. /debug/state snapshot if reachable. Token discovery via
+  # `simctl get_app_container booted <bundle> data` then tmp/mint_debug.token
+  # (matches Tier 2 spec — see lib/debug/debug_server.dart file-header).
+  if app_data=$(xcrun simctl get_app_container booted "$BUNDLE" data 2>/dev/null); then
+    token_file="$app_data/tmp/mint_debug.token"
+    if [ -f "$token_file" ]; then
+      token=$(cat "$token_file")
+      curl -fsS --max-time 5 \
+        -H "Authorization: Bearer $token" \
+        "http://127.0.0.1:${DEBUG_PORT}/debug/state" \
+        -o "$ARTIFACT_DIR/debug-state.json" \
+        || echo "[watchdog] /debug/state fetch failed (endpoint not running?)"
+    else
+      echo "[watchdog] token file not found at $token_file — Tier 2 endpoint not enabled?"
+    fi
+  fi
+
+  # 4. Maestro driver logs ~/.maestro/tests/<latest>/ (Maestro internal
+  # trace).
+  if [ -d "$HOME/.maestro/tests" ]; then
+    latest_trace=$(ls -t "$HOME/.maestro/tests" 2>/dev/null | head -1)
+    if [ -n "$latest_trace" ]; then
+      cp -R "$HOME/.maestro/tests/$latest_trace" "$ARTIFACT_DIR/maestro-trace/" 2>/dev/null \
+        || true
+    fi
+  fi
+
+  # 5. Auto-invoke Phase 4 cassure classifier on the dumped state (per
+  # code-review I3 — was previously a manual operator step despite the
+  # spec claiming « auto-runs on stall dump »). Best-effort: if the
+  # classifier is missing or jq is unavailable, the watchdog still
+  # completes its core dump.
+  classifier="$REPO_ROOT/tools/debug/cassure-classifier.sh"
+  if [ -x "$classifier" ] && [ -f "$ARTIFACT_DIR/debug-state.json" ]; then
+    "$classifier" \
+      --state "$ARTIFACT_DIR/debug-state.json" \
+      --oslog "$ARTIFACT_DIR/oslog-mint.txt" \
+      --out   "$ARTIFACT_DIR/cassure-report.json" \
+      >> "$ARTIFACT_DIR/classifier.log" 2>&1 \
+      || echo "[watchdog] classifier returned non-zero — see classifier.log"
+  fi
+
+  echo "[watchdog] dump complete → $ARTIFACT_DIR/"
+}
+
+# ── Spawn Maestro in its own process group ─────────────────────────────
+# Per code-review C1+C2 (PR #596) : the original `( cmd ) | tee &`
+# pipeline made the maestro subshell a SIBLING of tee, not its child.
+# `pkill -P TEE_PID` found zero processes and `kill TEE_PID` alone left
+# the maestro subshell orphan'd to init. Worse, `wait TEE_PID` waited
+# for the whole pipeline job, so the watchdog itself hung indefinitely
+# on a real stall.
+#
+# Fix : `set -m` enables job control so each background launch gets its
+# own process group. `kill -SIGNAL -PGID` then signals the whole group
+# in one shot. tee runs as a sibling reading from a process-substitution
+# pipe ; on group SIGKILL, tee detects EOF and exits cleanly.
+set -m
+bash "$MAESTRO_ENV" "$@" > >(tee "$LOG_FILE") 2>&1 &
+MAESTRO_PID=$!
+set +m
+echo "[watchdog] maestro pid=$MAESTRO_PID (running in own process group)"
+
+# Helper — kill the whole maestro process group with escalation.
+kill_maestro_group() {
+  kill -TERM "-$MAESTRO_PID" 2>/dev/null || true
+  # Brief grace period to allow JVM shutdown hooks ; 3s is enough on
+  # macOS for SIGTERM to reach Java's signal handler before SIGKILL.
+  sleep 3
+  kill -KILL "-$MAESTRO_PID" 2>/dev/null || true
+}
+
+# ── Spawn the watchdog ─────────────────────────────────────────────────
+START_TS=$(date +%s)
+(
+  while true; do
+    sleep "$STALL_PROBE_INTERVAL"
+    # Has maestro exited?
+    if ! kill -0 "$MAESTRO_PID" 2>/dev/null; then
+      exit 0
+    fi
+    # Hard limit check.
+    now=$(date +%s)
+    elapsed=$(( now - START_TS ))
+    if [ "$elapsed" -gt "$HARD_LIMIT" ]; then
+      echo "[watchdog] HARD LIMIT ${HARD_LIMIT}s exceeded — killing"
+      echo "hard_limit" > "$STALL_MARKER"
+      dump_state "hard_limit_${elapsed}s"
+      kill_maestro_group
+      exit 137
+    fi
+    # Stall check via log mtime.
+    if [ -f "$LOG_FILE" ]; then
+      log_mtime=$(stat -f %m "$LOG_FILE" 2>/dev/null || echo 0)
+      idle=$(( now - log_mtime ))
+      if [ "$idle" -gt "$STALL_THRESHOLD" ]; then
+        echo "[watchdog] STALL — no log output for ${idle}s (> ${STALL_THRESHOLD}s)"
+        echo "stall_${idle}s" > "$STALL_MARKER"
+        dump_state "stall_${idle}s"
+        kill_maestro_group
+        exit 124
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+# Operator Ctrl-C cleanup (per code-review I4). Without this, SIGINT
+# leaks the maestro process group and the watchdog subshell as orphans.
+cleanup() {
+  trap - EXIT INT TERM
+  kill "$WATCHDOG_PID" 2>/dev/null || true
+  kill -KILL "-$MAESTRO_PID" 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+# ── Wait for maestro to finish ─────────────────────────────────────────
+# `wait` returns the child's exit status (or 128+signal if killed). Under
+# `set -e`, a non-zero return would abort BEFORE we can capture $?.
+# Disable `errexit` just around this call so the watchdog's signal of
+# the maestro group is observable as a normal exit code.
+set +e
+wait "$MAESTRO_PID" 2>/dev/null
+MAESTRO_EXIT=$?
+set -e
+
+# Stop the watchdog (whether by stall or normal completion).
+kill "$WATCHDOG_PID" 2>/dev/null || true
+wait "$WATCHDOG_PID" 2>/dev/null || true
+trap - INT TERM
+
+if [ -f "$STALL_MARKER" ]; then
+  reason=$(cat "$STALL_MARKER")
+  echo "[watchdog] EXIT — STALLED ($reason). Artifacts: $ARTIFACT_DIR"
+  if [ "$reason" = "hard_limit" ] || [[ "$reason" == "hard_limit_"* ]]; then
+    exit 137
+  fi
+  exit 124
+fi
+
+echo "[watchdog] EXIT — maestro returned $MAESTRO_EXIT"
+exit "$MAESTRO_EXIT"

--- a/tools/simulator/maestro_with_watchdog_test.sh
+++ b/tools/simulator/maestro_with_watchdog_test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Self-test for tools/simulator/maestro_with_watchdog.sh
+#
+# Verifies the stall-detector watchdog actually fires when the child
+# process goes silent. Uses a deliberate-hang fake-maestro stub
+# (sleep loop with no stdout) so the test runs offline without a real
+# iOS sim.
+#
+# Three scenarios:
+#   1. Fast-clean exit: stub prints lines fast → watchdog never fires →
+#      exit 0.
+#   2. Stall: stub silent for > MAESTRO_STALL_THRESHOLD seconds →
+#      watchdog kills with exit 124, artifact dir contains STALLED.
+#   3. Hard limit: stub keeps printing but exceeds hard limit →
+#      exit 137 + STALLED hard_limit marker.
+#
+# Run:
+#   tools/simulator/maestro_with_watchdog_test.sh
+#
+# Exit:
+#   0 — all assertions passed
+#   1 — at least one assertion failed
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WD="$SCRIPT_DIR/maestro_with_watchdog.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAIL=0
+
+assert_exit() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "  FAIL  $label — expected exit $expected, got $actual"
+    FAIL=1
+  else
+    echo "  PASS  $label (exit $actual)"
+  fi
+}
+
+assert_file_exists() {
+  local path="$1" label="$2"
+  if [[ -f "$path" ]]; then
+    echo "  PASS  $label — file exists"
+  else
+    echo "  FAIL  $label — does not exist: $path"
+    FAIL=1
+  fi
+}
+
+# ── Scenario 1 — fast-clean exit ───────────────────────────────────────
+echo "=== Scenario 1 — fast-clean exit ==="
+mkdir -p "$TMP/scenario1"
+cp "$WD" "$TMP/scenario1/maestro_with_watchdog.sh"
+cat > "$TMP/scenario1/maestro_env.sh" <<'EOF'
+#!/usr/bin/env bash
+for i in 1 2 3 4 5; do echo "[stub] line $i"; sleep 0.2; done
+exit 0
+EOF
+chmod +x "$TMP/scenario1/maestro_with_watchdog.sh" "$TMP/scenario1/maestro_env.sh"
+
+set +e
+MAESTRO_STALL_THRESHOLD=10 \
+  MAESTRO_STALL_PROBE_INTERVAL=5 \
+  MAESTRO_HARD_LIMIT=20 \
+  MINT_WALKER_ARTIFACTS="$TMP/scenario1/artifacts" \
+  "$TMP/scenario1/maestro_with_watchdog.sh" test fake-flow.yaml >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit 0 "$rc" "scenario 1 fast-clean exit"
+if [[ -f "$TMP/scenario1/artifacts/STALLED" ]]; then
+  echo "  FAIL  scenario 1 — STALLED marker present on clean exit"
+  FAIL=1
+else
+  echo "  PASS  scenario 1 — no STALLED marker on clean exit"
+fi
+
+# ── Scenario 2 — stall ─────────────────────────────────────────────────
+echo "=== Scenario 2 — stall (silent stub) ==="
+mkdir -p "$TMP/scenario2"
+cp "$WD" "$TMP/scenario2/maestro_with_watchdog.sh"
+cat > "$TMP/scenario2/maestro_env.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "[stub] starting"
+sleep 30
+echo "[stub] would have completed"
+EOF
+chmod +x "$TMP/scenario2/maestro_with_watchdog.sh" "$TMP/scenario2/maestro_env.sh"
+
+set +e
+MAESTRO_STALL_THRESHOLD=4 \
+  MAESTRO_STALL_PROBE_INTERVAL=2 \
+  MAESTRO_HARD_LIMIT=60 \
+  MINT_WALKER_ARTIFACTS="$TMP/scenario2/artifacts" \
+  "$TMP/scenario2/maestro_with_watchdog.sh" test fake-flow.yaml >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit 124 "$rc" "scenario 2 stall detected"
+assert_file_exists "$TMP/scenario2/artifacts/STALLED" "scenario 2 STALLED marker"
+assert_file_exists "$TMP/scenario2/artifacts/stall-summary.txt" "scenario 2 stall-summary.txt"
+if [[ -f "$TMP/scenario2/artifacts/STALLED" ]]; then
+  reason=$(cat "$TMP/scenario2/artifacts/STALLED")
+  if [[ "$reason" == stall_* ]]; then
+    echo "  PASS  scenario 2 — STALLED reason starts with 'stall_' ($reason)"
+  else
+    echo "  FAIL  scenario 2 — STALLED reason is '$reason', expected stall_*"
+    FAIL=1
+  fi
+fi
+
+# ── Scenario 3 — hard limit ────────────────────────────────────────────
+echo "=== Scenario 3 — hard limit ==="
+mkdir -p "$TMP/scenario3"
+cp "$WD" "$TMP/scenario3/maestro_with_watchdog.sh"
+cat > "$TMP/scenario3/maestro_env.sh" <<'EOF'
+#!/usr/bin/env bash
+for i in $(seq 1 30); do echo "[stub] tick $i"; sleep 1; done
+EOF
+chmod +x "$TMP/scenario3/maestro_with_watchdog.sh" "$TMP/scenario3/maestro_env.sh"
+
+set +e
+MAESTRO_STALL_THRESHOLD=999 \
+  MAESTRO_STALL_PROBE_INTERVAL=2 \
+  MAESTRO_HARD_LIMIT=6 \
+  MINT_WALKER_ARTIFACTS="$TMP/scenario3/artifacts" \
+  "$TMP/scenario3/maestro_with_watchdog.sh" test fake-flow.yaml >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit 137 "$rc" "scenario 3 hard limit"
+assert_file_exists "$TMP/scenario3/artifacts/STALLED" "scenario 3 STALLED marker"
+if [[ -f "$TMP/scenario3/artifacts/STALLED" ]]; then
+  reason=$(cat "$TMP/scenario3/artifacts/STALLED")
+  if [[ "$reason" == hard_limit* ]]; then
+    echo "  PASS  scenario 3 — STALLED reason starts with 'hard_limit' ($reason)"
+  else
+    echo "  FAIL  scenario 3 — STALLED reason is '$reason', expected hard_limit*"
+    FAIL=1
+  fi
+fi
+
+# ── Scenario 4 — maestro fails fast (non-stall failure, per code-review I3) ──
+echo "=== Scenario 4 — maestro fails fast (non-zero exit, no stall) ==="
+mkdir -p "$TMP/scenario4"
+cp "$WD" "$TMP/scenario4/maestro_with_watchdog.sh"
+cat > "$TMP/scenario4/maestro_env.sh" <<'EOF'
+#!/usr/bin/env bash
+# Real Maestro flow-failure shape: prints an error message and exits
+# with a non-zero code BEFORE any stall threshold could possibly fire.
+# Watchdog MUST propagate the exact exit code (7 here) — NOT treat as
+# stall and NOT swap to 124 / 137.
+echo "[stub] element not found: 'foo'"
+echo "[stub] flow failed"
+exit 7
+EOF
+chmod +x "$TMP/scenario4/maestro_with_watchdog.sh" "$TMP/scenario4/maestro_env.sh"
+
+set +e
+MAESTRO_STALL_THRESHOLD=10 \
+  MAESTRO_STALL_PROBE_INTERVAL=5 \
+  MAESTRO_HARD_LIMIT=60 \
+  MINT_WALKER_ARTIFACTS="$TMP/scenario4/artifacts" \
+  "$TMP/scenario4/maestro_with_watchdog.sh" test fake-flow.yaml >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit 7 "$rc" "scenario 4 fast non-zero exit (rc=7 propagated)"
+if [[ -f "$TMP/scenario4/artifacts/STALLED" ]]; then
+  echo "  FAIL  scenario 4 — STALLED marker present (should not be)"
+  FAIL=1
+else
+  echo "  PASS  scenario 4 — no STALLED marker on non-stall failure"
+fi
+
+# ── Result ─────────────────────────────────────────────────────────────
+if [[ $FAIL -ne 0 ]]; then
+  echo ""
+  echo "::error::Watchdog self-test failed"
+  exit 1
+fi
+echo ""
+echo "[maestro_with_watchdog_test] all 4 scenarios passed"


### PR DESCRIPTION
## Summary
- Restores the checked-in Mint runtime OS gates for Patrol, Maestro, Mermaid, Claude audit, and Beads discovery.
- Adds iOS Patrol native RunnerUITests wiring plus a gated smoke test for MintApp.
- Adds mint_os_doctor, patrol_tooling_guard, mermaid_render_guard, and tests.
- Documents layered Mermaid interaction cartography and keeps release/debug iOS plist separation enforced.

## QA
- python3 -m pytest tools/checks/tests/test_patrol_tooling_guard.py tools/checks/tests/test_mint_os_doctor.py tools/checks/tests/test_mermaid_render_guard.py -q -> 17 passed
- python3 tools/checks/mint_os_doctor.py -> all PASS, including Patrol/Maestro/Mermaid/Claude/Beads
- python3 tools/checks/mermaid_render_guard.py -> OK, WIRING_GRAPH renders
- bash tools/simulator/maestro_with_watchdog_test.sh -> all 4 scenarios passed
- flutter analyze test/patrol/mint_runtime_smoke_test.dart -> no issues
- flutter test test/patrol/mint_runtime_smoke_test.dart --reporter expanded -> clean skip outside Patrol runner
- patrol test on iPhone 17 Pro with MINT_PATROL_CLI=true -> exit 0; xcresult test case Passed
- plutil -lint Info.plist Info-Debug.plist project.pbxproj -> OK
- Claude Opus 4.8 external audit -> PASS, no P0/P1

## Notes
- Full flutter analyze still reports pre-existing warnings/infos outside this infra slice; not introduced here.
- Beads is installed/discovered as bd, but .beads initialization is intentionally left for a dedicated PR because bd init creates a Dolt-backed artifact.
