### PR TITLE
feat(interactions): add registry lint bootstrap

### DIFF
--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -55,6 +55,22 @@ les edges). Décision à prendre au moment de l'étape 1, pas avant.
 | D10 | Index généré **une-ligne-par-edge** (`interactions/INDEX.md`) pour la lecture agents ; les YAML par flux restent la source. |
 | D11 | **(v1.1)** Relation aux specs existantes : `SCREEN_CONTRACTS.md` tables par route et `WIRING_GRAPH` deviennent des **artefacts générés** dès qu'un flux est migré ; un flux non migré reste gouverné par les docs actuels. Lint `contract_double_authority` : une route ne peut pas être déclarée à la fois dans un flux migré et éditée à la main dans les docs générés. |
 
+## 0.d Première tranche exécutable, sans executor
+
+Le registre reste `Status: Proposed` et ne génère pas encore de navigation
+Flutter. La première tranche active est volontairement bornée :
+
+- source : `interactions/revenu_to_mortgage.yaml`;
+- vue agents : `interactions/INDEX.md`;
+- vérification : `python3 tools/checks/interaction_registry_lint.py`;
+- preuve runtime référencée : `apps/mobile/.maestro/f2_datablock_to_mortgage.yaml`.
+
+Le lint vérifie uniquement que les edges déclarées pointent vers des routes,
+widgets, clés ARB, events analytics et preuves de test existants, et que
+`payload.extra` ne transporte pas d'objet domaine. Cette tranche ne remplace pas
+encore `SCREEN_CONTRACTS.md` ni `WIRING_GRAPH.mmd`; elle matérialise l'étape 1
+("Photo") et prépare le ratchet flux par flux.
+
 ## 1. Modèle
 
 Trois entités : **node** (écran ou scène), **edge** (interaction), **flow**

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -1,0 +1,8 @@
+# Interaction Registry Index
+
+> Generated view. Source of truth: `interactions/*.yaml`.
+
+| flow | edge | from | to | trigger | transition | proof |
+|---|---|---|---|---|---|---|
+| revenu_to_mortgage | `db.edge.revenu.save_facts` | `db.route.revenu` | `db.route.revenu` | submit | in_shell | `apps/mobile/.maestro/f2_datablock_to_mortgage.yaml` |
+| revenu_to_mortgage | `db.edge.revenu.open_mortgage_deeplink` | `db.route.revenu` | `mortgage.route.hypotheque` | system | reset_stack | `apps/mobile/.maestro/f2_datablock_to_mortgage.yaml` |

--- a/interactions/revenu_to_mortgage.yaml
+++ b/interactions/revenu_to_mortgage.yaml
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "flow": {
+    "id": "revenu_to_mortgage",
+    "title": "Faits de revenu canoniques vers capacité d'achat immobilier",
+    "exits": ["mortgage.route.hypotheque"],
+    "invariants": {
+      "max_depth": 4,
+      "back_never_loses_input": true,
+      "every_scene_has_exit": true
+    }
+  },
+  "nodes": [
+    {
+      "id": "db.route.revenu",
+      "kind": "route",
+      "route": "/data-block/:type",
+      "widget": "screens/onboarding/data_block_enrichment_screen.dart",
+      "platforms": ["mobile"],
+      "entries": [
+        {"via": "flow", "back": "pop"},
+        {"via": "deeplink", "back": "reset_to(home.route.dashboard)"}
+      ],
+      "states": ["content", "loading", "error.compute"]
+    },
+    {
+      "id": "mortgage.route.hypotheque",
+      "kind": "route",
+      "route": "/hypotheque",
+      "widget": "screens/mortgage/affordability_screen.dart",
+      "platforms": ["mobile"],
+      "entries": [
+        {"via": "flow", "back": "pop"},
+        {"via": "tab", "back": "pop_to(home.route.dashboard)"}
+      ],
+      "states": ["content", "partial", "loading", "error.compute"]
+    }
+  ],
+  "edges": [
+    {
+      "id": "db.edge.revenu.save_facts",
+      "from": "db.route.revenu",
+      "to": "db.route.revenu",
+      "trigger": "submit",
+      "intent": "Enregistrer mes faits de revenu dans le ledger",
+      "payload": {},
+      "transition": "in_shell",
+      "back": "pop",
+      "analytics": "cta_clicked",
+      "a11y_label": "financialSummaryEnregistrer",
+      "test_ref": "apps/mobile/.maestro/f2_datablock_to_mortgage.yaml"
+    },
+    {
+      "id": "db.edge.revenu.open_mortgage_deeplink",
+      "from": "db.route.revenu",
+      "to": "mortgage.route.hypotheque",
+      "trigger": "system",
+      "intent": "Ouvrir l'écran hypothèque et vérifier qu'il lit les faits de revenu persistés",
+      "payload": {},
+      "transition": "reset_stack",
+      "back": "pop",
+      "test_ref": "apps/mobile/.maestro/f2_datablock_to_mortgage.yaml"
+    }
+  ]
+}

--- a/tools/checks/interaction_registry_lint.py
+++ b/tools/checks/interaction_registry_lint.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Validate proposed MINT interaction registry flow files.
+
+The registry is intentionally non-codegen for now: this lint only proves that
+declared interactions reference live routes, widgets, ARB keys, analytics
+events, and test artifacts. Source files are YAML; today they are kept
+JSON-compatible so repository contract tests do not need PyYAML.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+INTERACTIONS_DIR = ROOT / "interactions"
+
+ID_RE = re.compile(r"^[a-z]+\.(route|scene)\.[a-z0-9_]+$")
+FLOW_REF_RE = re.compile(r"^[a-z][a-z0-9_]*\.flow\.[a-z0-9_]+$")
+FLOW_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+ROUTE_KEY_RE = re.compile(
+    r"""^\s*(?P<q>['"])(?P<path>[^'"]+?)(?P=q)\s*:\s*RouteMeta\(""",
+    re.MULTILINE,
+)
+ANALYTICS_RE = re.compile(r"const\s+String\s+\w+\s*=\s*'([^']+)';")
+DOMAIN_EXTRA_RE = re.compile(
+    r"CoachProfile|MintUserState|ExtractionResult|ConfidenceResult|"
+    r"wizardAnswers|BudgetSnapshot|ProfileModel|Map<|List<",
+)
+ALLOWED_PAYLOAD_KEYS = {"path_params", "extra"}
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"{path}: unreadable: {exc}") from exc
+
+
+def _load_flow(path: Path) -> dict[str, Any]:
+    text = _read_text(path)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as json_exc:
+        try:
+            import yaml  # type: ignore
+        except Exception as yaml_exc:
+            raise ValueError(
+                f"{path}: not JSON-compatible YAML and PyYAML is unavailable "
+                f"({json_exc.msg})"
+            ) from yaml_exc
+        loaded = yaml.safe_load(text)
+        if not isinstance(loaded, dict):
+            raise ValueError(f"{path}: top-level YAML must be a mapping")
+        data = loaded
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: top-level registry document must be a mapping")
+    return data
+
+
+def _registry_routes(root: Path) -> set[str]:
+    path = root / "apps/mobile/lib/routes/route_metadata.dart"
+    return {m.group("path") for m in ROUTE_KEY_RE.finditer(_read_text(path))}
+
+
+def _arb_keys(root: Path) -> set[str]:
+    data = json.loads(_read_text(root / "apps/mobile/lib/l10n/app_fr.arb"))
+    return {key for key in data if not key.startswith("@")}
+
+
+def _analytics_events(root: Path) -> set[str]:
+    path = root / "apps/mobile/lib/services/analytics_events.dart"
+    return set(ANALYTICS_RE.findall(_read_text(path)))
+
+
+def _widget_exists(root: Path, widget: str) -> bool:
+    return (root / "apps/mobile/lib" / widget).is_file()
+
+
+def _test_ref_exists(root: Path, test_ref: str, edge_id: str) -> bool:
+    path_text, _, anchor = test_ref.partition("#")
+    path = root / path_text
+    if not path.is_file():
+        return False
+    if anchor and path.suffix != ".yaml":
+        text = _read_text(path)
+        return edge_id in text or anchor in text
+    return True
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _validate_node(
+    node: Any,
+    *,
+    root: Path,
+    path: Path,
+    routes: set[str],
+    node_ids: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(node, dict):
+        return [f"{path}: node entries must be mappings"]
+    node_id = node.get("id")
+    kind = node.get("kind")
+    if not isinstance(node_id, str) or not ID_RE.match(node_id):
+        errors.append(f"{path}: node id must match {ID_RE.pattern}: {node_id!r}")
+    if kind not in {"route", "scene"}:
+        errors.append(f"{path}:{node_id}: kind must be route or scene")
+    if kind == "route":
+        route = node.get("route")
+        if not isinstance(route, str) or route not in routes:
+            errors.append(f"{path}:{node_id}: unknown route {route!r}")
+    if kind == "scene":
+        parent = node.get("parent")
+        if not isinstance(parent, str) or parent not in node_ids:
+            errors.append(f"{path}:{node_id}: scene parent must reference a node")
+    widget = node.get("widget")
+    if not isinstance(widget, str) or not _widget_exists(root, widget):
+        errors.append(f"{path}:{node_id}: widget path not found: {widget!r}")
+    entries = _list(node.get("entries"))
+    for entry in entries:
+        if not isinstance(entry, dict) or "via" not in entry or "back" not in entry:
+            errors.append(f"{path}:{node_id}: entries require via and back")
+    states = _list(node.get("states"))
+    if not states and "states_waived" not in node:
+        errors.append(f"{path}:{node_id}: states required or explicitly waived")
+    return errors
+
+
+def _validate_payload_extra(path: Path, edge_id: str, payload: dict[str, Any]) -> list[str]:
+    unknown = sorted(set(payload) - ALLOWED_PAYLOAD_KEYS)
+    if unknown:
+        return [f"{path}:{edge_id}: unknown payload key(s): {', '.join(unknown)}"]
+    extra = payload.get("extra")
+    if extra is None:
+        return []
+    extra_text = json.dumps(extra, sort_keys=True)
+    if DOMAIN_EXTRA_RE.search(extra_text):
+        return [
+            f"{path}:{edge_id}: payload.extra must not carry domain data "
+            f"({extra_text})"
+        ]
+    return []
+
+
+def _validate_edge(
+    edge: Any,
+    *,
+    root: Path,
+    path: Path,
+    node_ids: set[str],
+    action_ids: set[str],
+    exits: set[str],
+    arb_keys: set[str],
+    analytics_events: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(edge, dict):
+        return [f"{path}: edge entries must be mappings"]
+    edge_id = edge.get("id")
+    if not isinstance(edge_id, str) or ".edge." not in edge_id:
+        errors.append(f"{path}: edge id must include .edge.: {edge_id!r}")
+        edge_id = str(edge_id)
+    if edge.get("from") not in node_ids:
+        errors.append(f"{path}:{edge_id}: from references unknown node")
+    target = edge.get("to")
+    if (
+        target not in node_ids
+        and target not in action_ids
+        and target not in exits
+        and not (isinstance(target, str) and FLOW_REF_RE.match(target))
+    ):
+        errors.append(f"{path}:{edge_id}: to references unknown target {target!r}")
+    if edge.get("trigger") not in {"tap", "swipe", "long_press", "submit", "system"}:
+        errors.append(f"{path}:{edge_id}: trigger is invalid")
+    if edge.get("transition") not in {
+        "push",
+        "replace",
+        "reset_stack",
+        "sheet",
+        "dialog",
+        "in_shell",
+    }:
+        errors.append(f"{path}:{edge_id}: transition is invalid")
+    payload = _dict(edge.get("payload"))
+    errors.extend(_validate_payload_extra(path, edge_id, payload))
+    analytics = edge.get("analytics")
+    if analytics is not None and analytics not in analytics_events:
+        errors.append(f"{path}:{edge_id}: unknown analytics event {analytics!r}")
+    a11y_label = edge.get("a11y_label")
+    if a11y_label is not None and a11y_label not in arb_keys:
+        errors.append(f"{path}:{edge_id}: a11y_label is not an ARB key: {a11y_label!r}")
+    test_ref = edge.get("test_ref")
+    if not isinstance(test_ref, str) or not _test_ref_exists(root, test_ref, edge_id):
+        errors.append(f"{path}:{edge_id}: test_ref not found or unanchored: {test_ref!r}")
+    return errors
+
+
+def _reachable_depth(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    exits: set[str],
+) -> tuple[set[str], int, set[str]]:
+    node_ids = {node["id"] for node in nodes if isinstance(node.get("id"), str)}
+    entry_nodes = {
+        node["id"]
+        for node in nodes
+        if isinstance(node.get("id"), str) and _list(node.get("entries"))
+    }
+    adjacency: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+    incoming: set[str] = set()
+    for edge in edges:
+        source = edge.get("from")
+        target = edge.get("to")
+        if source in adjacency and target in node_ids:
+            adjacency[source].add(target)
+            if target != source:
+                incoming.add(target)
+    roots = (node_ids - incoming) or set(node_ids)
+    seen: set[str] = set()
+    max_depth = 0
+    queue: deque[tuple[str, int]] = deque((root, 0) for root in roots)
+    while queue:
+        node_id, depth = queue.popleft()
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        max_depth = max(max_depth, depth)
+        for target in adjacency.get(node_id, set()):
+            queue.append((target, depth + 1))
+    dead_ends = {
+        node_id
+        for node_id in node_ids
+        if not adjacency.get(node_id) and node_id not in exits
+    }
+    orphaned = {
+        node_id
+        for node_id in node_ids
+        if node_id not in entry_nodes and node_id not in incoming
+    }
+    return orphaned, max_depth, dead_ends
+
+
+def validate_file(
+    path: Path,
+    *,
+    root: Path = ROOT,
+    routes: set[str],
+    arb_keys: set[str],
+    analytics_events: set[str],
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        data = _load_flow(path)
+    except ValueError as exc:
+        return [str(exc)]
+    if data.get("schema_version") != 1:
+        errors.append(f"{path}: schema_version must be 1")
+    flow = _dict(data.get("flow"))
+    flow_id = flow.get("id")
+    if not isinstance(flow_id, str) or not FLOW_ID_RE.match(flow_id):
+        errors.append(f"{path}: flow.id must be snake_case")
+    elif path.stem != flow_id:
+        errors.append(f"{path}: file stem must match flow.id {flow_id!r}")
+    if not isinstance(flow.get("title"), str) or not flow["title"].strip():
+        errors.append(f"{path}: flow.title is required")
+    exits = set(str(item) for item in _list(flow.get("exits")))
+    invariants = _dict(flow.get("invariants"))
+    nodes = [node for node in _list(data.get("nodes")) if isinstance(node, dict)]
+    edges = [edge for edge in _list(data.get("edges")) if isinstance(edge, dict)]
+    if not nodes:
+        errors.append(f"{path}: at least one node is required")
+    if not edges:
+        errors.append(f"{path}: at least one edge is required")
+    node_ids = {str(node.get("id")) for node in nodes if isinstance(node.get("id"), str)}
+    action_ids = {
+        str(action.get("id"))
+        for action in _list(data.get("actions"))
+        if isinstance(action, dict) and isinstance(action.get("id"), str)
+    }
+    for exit_id in sorted(exits):
+        if exit_id not in node_ids and not FLOW_REF_RE.match(exit_id):
+            errors.append(f"{path}: exit references unknown node or flow ref {exit_id!r}")
+    for node in nodes:
+        errors.extend(
+            _validate_node(
+                node,
+                root=root,
+                path=path,
+                routes=routes,
+                node_ids=node_ids,
+            )
+        )
+    for edge in edges:
+        errors.extend(
+            _validate_edge(
+                edge,
+                root=root,
+                path=path,
+                node_ids=node_ids,
+                action_ids=action_ids,
+                exits=exits,
+                arb_keys=arb_keys,
+                analytics_events=analytics_events,
+            )
+        )
+    orphaned, max_depth, dead_ends = _reachable_depth(nodes, edges, exits)
+    for node_id in sorted(orphaned):
+        errors.append(f"{path}:{node_id}: orphan node")
+    for node_id in sorted(dead_ends):
+        errors.append(f"{path}:{node_id}: dead end without flow exit")
+    declared_depth = invariants.get("max_depth")
+    if isinstance(declared_depth, int) and max_depth > declared_depth:
+        errors.append(f"{path}: max depth {max_depth} exceeds {declared_depth}")
+    return errors
+
+
+def emit_index(files: list[Path]) -> str:
+    lines = [
+        "# Interaction Registry Index",
+        "",
+        "> Generated view. Source of truth: `interactions/*.yaml`.",
+        "",
+        "| flow | edge | from | to | trigger | transition | proof |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for path in files:
+        data = _load_flow(path)
+        flow = _dict(data.get("flow"))
+        flow_id = str(flow.get("id", path.stem))
+        for edge in _list(data.get("edges")):
+            if not isinstance(edge, dict):
+                continue
+            lines.append(
+                "| {flow} | `{edge}` | `{source}` | `{target}` | {trigger} | "
+                "{transition} | `{proof}` |".format(
+                    flow=flow_id,
+                    edge=edge.get("id", ""),
+                    source=edge.get("from", ""),
+                    target=edge.get("to", ""),
+                    trigger=edge.get("trigger", ""),
+                    transition=edge.get("transition", ""),
+                    proof=edge.get("test_ref", ""),
+                )
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _flow_files(root: Path) -> list[Path]:
+    directory = root / "interactions"
+    if not directory.is_dir():
+        return []
+    return sorted(directory.glob("*.yaml"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--file", type=Path, action="append")
+    parser.add_argument("--emit-index", action="store_true")
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    files = [path if path.is_absolute() else root / path for path in args.file or []]
+    if not files:
+        files = _flow_files(root)
+    routes = _registry_routes(root)
+    arb_keys = _arb_keys(root)
+    analytics_events = _analytics_events(root)
+    errors: list[str] = []
+    for path in files:
+        errors.extend(
+            validate_file(
+                path,
+                root=root,
+                routes=routes,
+                arb_keys=arb_keys,
+                analytics_events=analytics_events,
+            )
+        )
+    if errors:
+        print("FAIL interaction_registry_lint:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    if args.emit_index:
+        print(emit_index(files), end="")
+        return 0
+    print(f"OK interaction_registry_lint: {len(files)} flow file(s) validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/checks/tests/test_interaction_registry_lint.py
+++ b/tools/checks/tests/test_interaction_registry_lint.py
@@ -1,0 +1,182 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "tools/checks/interaction_registry_lint.py"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_live_interaction_registry_validates() -> None:
+    result = _run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1 flow file(s) validated" in result.stdout
+
+
+def test_interaction_index_is_generated_from_registry() -> None:
+    result = _run("--emit-index")
+    index = (ROOT / "interactions/INDEX.md").read_text(encoding="utf-8")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == index
+
+
+def test_root_option_resolves_references_inside_target_repo(tmp_path: Path) -> None:
+    (tmp_path / "interactions").mkdir()
+    (tmp_path / "apps/mobile/lib/routes").mkdir(parents=True)
+    (tmp_path / "apps/mobile/lib/l10n").mkdir(parents=True)
+    (tmp_path / "apps/mobile/lib/services").mkdir(parents=True)
+    (tmp_path / "apps/mobile/lib/screens").mkdir(parents=True)
+    (tmp_path / "apps/mobile/lib/routes/route_metadata.dart").write_text(
+        "const routes = {\n  '/custom': RouteMeta(path: '/custom'),\n};\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "apps/mobile/lib/l10n/app_fr.arb").write_text(
+        json.dumps({"ctaKey": "Continuer"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "apps/mobile/lib/services/analytics_events.dart").write_text(
+        "const String kEventCustom = 'event_clicked';\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "apps/mobile/lib/screens/custom.dart").write_text(
+        "class CustomScreen {}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "proof.yaml").write_text("appId: test\n---\n", encoding="utf-8")
+    (tmp_path / "interactions/custom.yaml").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "flow": {
+                    "id": "custom",
+                    "title": "Custom flow",
+                    "exits": ["custom.route.screen"],
+                    "invariants": {"max_depth": 1, "every_scene_has_exit": True},
+                },
+                "nodes": [
+                    {
+                        "id": "custom.route.screen",
+                        "kind": "route",
+                        "route": "/custom",
+                        "widget": "screens/custom.dart",
+                        "entries": [{"via": "flow", "back": "pop"}],
+                        "states": ["content"],
+                    }
+                ],
+                "edges": [
+                    {
+                        "id": "custom.edge.submit",
+                        "from": "custom.route.screen",
+                        "to": "custom.route.screen",
+                        "trigger": "submit",
+                        "payload": {},
+                        "transition": "push",
+                        "analytics": "event_clicked",
+                        "a11y_label": "ctaKey",
+                        "test_ref": "proof.yaml",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run("--root", str(tmp_path))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_lint_rejects_unknown_route(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["nodes"][1]["route"] = "/ghost-route"
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "unknown route '/ghost-route'" in result.stderr
+
+
+def test_lint_enforces_declared_max_depth(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["flow"]["invariants"]["max_depth"] = 0
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "max depth 1 exceeds 0" in result.stderr
+
+
+def test_lint_rejects_dead_end_without_flow_exit(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["flow"]["exits"] = ["home.route.dashboard"]
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "mortgage.route.hypotheque: dead end without flow exit" in result.stderr
+
+
+def test_lint_rejects_unknown_exit_identifier(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["flow"]["exits"] = ["home.route.typo"]
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "exit references unknown node or flow ref 'home.route.typo'" in result.stderr
+
+
+def test_lint_allows_cross_flow_edge_targets(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["edges"][1]["to"] = "mortgage.flow.next"
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_lint_rejects_unknown_payload_keys(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["edges"][1]["payload"] = {"deeplink": "mint:///hypotheque"}
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "unknown payload key(s): deeplink" in result.stderr
+
+
+def test_lint_rejects_domain_data_in_extra(tmp_path: Path) -> None:
+    flow = json.loads((ROOT / "interactions/revenu_to_mortgage.yaml").read_text())
+    flow["edges"][0]["payload"] = {"extra": "CoachProfile"}
+    fixture = tmp_path / "revenu_to_mortgage.yaml"
+    fixture.write_text(json.dumps(flow), encoding="utf-8")
+
+    result = _run("--file", str(fixture))
+
+    assert result.returncode == 1
+    assert "payload.extra must not carry domain data" in result.stderr


### PR DESCRIPTION
## Summary
- Adds the first non-codegen Interaction Registry slice for `revenu_to_mortgage`.
- Adds generated `interactions/INDEX.md` and a stdlib-friendly lint that validates routes, widgets, ARB labels, analytics events, flow exits, payload schema, and test refs.
- Documents the slice as `Status: Proposed`: no executor, no generated navigation, no replacement of `SCREEN_CONTRACTS.md` or `WIRING_GRAPH.mmd` yet.

## QA
- `python3 tools/checks/interaction_registry_lint.py`
- `python3 tools/checks/interaction_registry_lint.py --emit-index >/tmp/mint_interaction_index_check.md && diff -u interactions/INDEX.md /tmp/mint_interaction_index_check.md`
- `python3 -m pytest tools/checks/tests/test_interaction_registry_lint.py -q`
- `python3 -m pytest tools/checks/tests tests/checks -q --tb=short`
- `python3 tools/checks/mermaid_render_guard.py`
- `python3 tools/checks/mint_os_doctor.py --repo-only`
- `python3 tools/checks/accent_lint_fr.py --file docs/codex/INTERACTION_REGISTRY.md && python3 tools/checks/accent_lint_fr.py --file interactions/INDEX.md && python3 tools/checks/accent_lint_fr.py --file interactions/revenu_to_mortgage.yaml`
- `git diff --check`
- `lefthook run pre-commit`
- Claude external audit via `CLAUDE_AUDIT_MODEL=claude-opus-4-8 CLAUDE_AUDIT_EFFORT=high tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7` -> PASS; non-blocking P2 items on payload schema/dead constants were fixed before commit.

## Notes
- The flow is intentionally honest about current proof: save facts in `/data-block/revenu`, then system/deeplink opens `/hypotheque` and verifies ledger fact reuse. It does not claim a direct submit-to-hypotheque push.
