### PR TITLE
fix(mortgage): require ledger revenue facts

### DIFF
--- a/apps/mobile/lib/screens/mortgage/affordability_screen.dart
+++ b/apps/mobile/lib/screens/mortgage/affordability_screen.dart
@@ -11,6 +11,7 @@ import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:mint_mobile/models/screen_return.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
 import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/widgets/coach/mortgage_journey_widget.dart';
@@ -34,64 +35,110 @@ class AffordabilityScreen extends StatefulWidget {
   State<AffordabilityScreen> createState() => _AffordabilityScreenState();
 }
 
+class _MortgageLedgerFacts {
+  const _MortgageLedgerFacts({
+    required this.grossIncomeAnnual,
+    required this.canton,
+  });
+
+  const _MortgageLedgerFacts.empty()
+      : grossIncomeAnnual = null,
+        canton = null;
+
+  final double? grossIncomeAnnual;
+  final String? canton;
+
+  bool get hasRequired => grossIncomeAnnual != null && canton != null;
+
+  bool hasSameValuesAs(_MortgageLedgerFacts other) {
+    return grossIncomeAnnual == other.grossIncomeAnnual &&
+        canton == other.canton;
+  }
+}
+
 class _AffordabilityScreenState extends State<AffordabilityScreen> {
   bool _hasUserInteracted = false;
   String? _seqRunId;
   String? _seqStepId;
   bool _finalReturnEmitted = false;
   final Set<String> _prefilledFields = {};
+  final Set<String> _userEditedFields = {};
+  _MortgageLedgerFacts _facts = const _MortgageLedgerFacts.empty();
 
   @override
   void initState() {
     super.initState();
     ReportPersistenceService.markSimulatorExplored('mortgage');
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _initializeFromProfile();
       _readSequenceContext();
     });
   }
 
-  /// Auto-fill from CoachProfile — replaces hardcoded defaults (120000, 200000).
-  void _initializeFromProfile() {
-    try {
-      final provider = context.read<CoachProfileProvider>();
-      final profile = provider.profile;
-      if (profile == null) return;
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final profile = _profileProvider(context)?.profile;
+    final facts = _ledgerFactsFromProfile(profile);
+    if (_facts.hasSameValuesAs(facts)) return;
+    _facts = facts;
+    _syncInputsFromLedgerFacts(profile);
+  }
 
-      bool changed = false;
-      // Use household income if married/concubinage (both salaries count
-      // for mortgage capacity per ASB directive).
-      var revenuAnnuel = profile.salaireBrutMensuel * profile.nombreDeMois;
-      final conjointRevenu = profile.conjoint?.salaireBrutMensuel ?? 0;
-      if (conjointRevenu > 0) {
-        revenuAnnuel += conjointRevenu * profile.nombreDeMois;
-      }
-      if (revenuAnnuel > 0) {
-        _revenuBrut = revenuAnnuel;
-        _prefilledFields.add('revenu_brut');
-        changed = true;
-      }
+  CoachProfileProvider? _profileProvider(BuildContext context) {
+    try {
+      return context.watch<CoachProfileProvider>();
+    } on ProviderNotFoundException {
+      return null;
+    }
+  }
+
+  _MortgageLedgerFacts _ledgerFactsFromProfile(CoachProfile? profile) {
+    if (profile == null) return const _MortgageLedgerFacts.empty();
+    final provided = profile.userProvidedFields;
+    final hasIncome = provided.contains('salary') &&
+        profile.salaireBrutMensuel > 0 &&
+        profile.nombreDeMois > 0;
+    final hasCanton = provided.contains('canton') && profile.canton.isNotEmpty;
+    return _MortgageLedgerFacts(
+      grossIncomeAnnual: hasIncome ? profile.revenuBrutAnnuelCouple : null,
+      canton: hasCanton ? profile.canton.toUpperCase() : null,
+    );
+  }
+
+  void _syncInputsFromLedgerFacts(CoachProfile? profile) {
+    _prefilledFields.remove('revenu_brut');
+    if (_facts.grossIncomeAnnual != null &&
+        !_userEditedFields.contains('revenu_brut')) {
+      _revenuBrut = _facts.grossIncomeAnnual!;
+    }
+    if (_facts.canton != null) {
+      _canton = _facts.canton!;
+    }
+    if (profile == null) return;
+    if (!_userEditedFields.contains('avoir_lpp')) {
       final avoirLpp = profile.prevoyance.avoirLppTotal;
       if (avoirLpp != null && avoirLpp > 0) {
         _avoirLpp = avoirLpp;
         _prefilledFields.add('avoir_lpp');
-        changed = true;
+      } else {
+        _prefilledFields.remove('avoir_lpp');
       }
+    }
+    if (!_userEditedFields.contains('epargne_dispo')) {
       final epargne = profile.patrimoine.epargneLiquide;
       if (epargne > 0) {
         _epargneDispo = epargne;
         _prefilledFields.add('epargne_dispo');
-        changed = true;
+      } else {
+        _prefilledFields.remove('epargne_dispo');
       }
-      final canton = profile.canton;
-      if (canton.isNotEmpty) {
-        _canton = canton.toUpperCase();
-        changed = true;
-      }
-      if (changed) setState(() {});
-    } catch (_) {
-      // CoachProfileProvider not available — keep hardcoded defaults.
     }
+  }
+
+  void _markUserEdited(String fieldKey) {
+    _hasUserInteracted = true;
+    _userEditedFields.add(fieldKey);
+    _prefilledFields.remove(fieldKey);
   }
 
   void _readSequenceContext() {
@@ -108,17 +155,9 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
     }
   }
 
-  /// Apply prefill from GoRouter coach suggestion (overrides profile auto-fill).
+  /// Apply scenario prefill from GoRouter coach suggestion.
   void _applyPrefill(Map<String, dynamic> prefill) {
     bool changed = false;
-
-    final salaireBrut = prefill['salaireBrut'];
-    if (salaireBrut is num && salaireBrut > 0) {
-      // Monthly value — multiply by 13 for annual
-      _revenuBrut = salaireBrut.toDouble() * 13;
-      _prefilledFields.add('revenu_brut');
-      changed = true;
-    }
 
     final epargne = prefill['epargne'];
     if (epargne is num && epargne >= 0) {
@@ -146,11 +185,11 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
 
     try {
       final result = _result;
+      if (result == null) return;
       final updated = profile.copyWith(
         patrimoine: profile.patrimoine.copyWith(
-          mortgageCapacity: result.prixMaxAccessible > 0
-              ? result.prixMaxAccessible
-              : null,
+          mortgageCapacity:
+              result.prixMaxAccessible > 0 ? result.prixMaxAccessible : null,
           estimatedMonthlyPayment: result.chargesTheoriquesMensuelles > 0
               ? result.chargesTheoriquesMensuelles
               : null,
@@ -187,18 +226,19 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
     if (_seqRunId == null || _seqStepId == null) return;
     _finalReturnEmitted = true;
 
-    if (!_hasUserInteracted) {
+    final result = _result;
+    if (!_hasUserInteracted || result == null) {
       final screenReturn = ScreenReturn.abandoned(
         route: '/hypotheque',
         runId: _seqRunId,
         stepId: _seqStepId,
         eventId: 'evt_${_seqRunId}_${DateTime.now().millisecondsSinceEpoch}',
       );
-      ScreenCompletionTracker.markCompletedWithReturn('affordability', screenReturn);
+      ScreenCompletionTracker.markCompletedWithReturn(
+          'affordability', screenReturn);
       return;
     }
 
-    final result = _result;
     final screenReturn = ScreenReturn.completed(
       route: '/hypotheque',
       stepOutputs: {
@@ -209,7 +249,8 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
       stepId: _seqStepId,
       eventId: 'evt_${_seqRunId}_${DateTime.now().millisecondsSinceEpoch}',
     );
-    ScreenCompletionTracker.markCompletedWithReturn('affordability', screenReturn);
+    ScreenCompletionTracker.markCompletedWithReturn(
+        'affordability', screenReturn);
   }
 
   double _revenuBrut = 120000;
@@ -221,19 +262,45 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
   bool _showAdvancedParams = false;
 
   static const _cantons = [
-    'AG', 'AI', 'AR', 'BE', 'BL', 'BS', 'FR', 'GE', 'GL', 'GR',
-    'JU', 'LU', 'NE', 'NW', 'OW', 'SG', 'SH', 'SO', 'SZ', 'TG',
-    'TI', 'UR', 'VD', 'VS', 'ZG', 'ZH',
+    'AG',
+    'AI',
+    'AR',
+    'BE',
+    'BL',
+    'BS',
+    'FR',
+    'GE',
+    'GL',
+    'GR',
+    'JU',
+    'LU',
+    'NE',
+    'NW',
+    'OW',
+    'SG',
+    'SH',
+    'SO',
+    'SZ',
+    'TG',
+    'TI',
+    'UR',
+    'VD',
+    'VS',
+    'ZG',
+    'ZH',
   ];
 
-  AffordabilityResult get _result => AffordabilityCalculator.calculate(
-        revenuBrutAnnuel: _revenuBrut,
-        epargneDispo: _epargneDispo,
-        avoir3a: _avoir3a,
-        avoirLpp: _avoirLpp,
-        prixAchat: _prixAchat,
-        canton: _canton,
-      );
+  AffordabilityResult? get _result {
+    if (!_facts.hasRequired) return null;
+    return AffordabilityCalculator.calculate(
+      revenuBrutAnnuel: _revenuBrut,
+      epargneDispo: _epargneDispo,
+      avoir3a: _avoir3a,
+      avoirLpp: _avoirLpp,
+      prixAchat: _prixAchat,
+      canton: _canton,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -241,332 +308,509 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
     final l = S.of(context)!;
 
     return PopScope(
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop) _emitFinalReturn();
-      },
-      child: Scaffold(
-      backgroundColor: MintColors.porcelaine,
-      body: CustomScrollView(
-        slivers: [
-          // ── White standard AppBar (Design System §4.5) ──
-          SliverAppBar(
-            expandedHeight: 100,
-            pinned: true,
-            backgroundColor: MintColors.white,
-            foregroundColor: MintColors.textPrimary,
-            flexibleSpace: FlexibleSpaceBar(
-              title: Text(
-                l.affordabilityTitle,
-                style: MintTextStyles.headlineMedium(),
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop) _emitFinalReturn();
+        },
+        child: Scaffold(
+          backgroundColor: MintColors.porcelaine,
+          body: CustomScrollView(
+            slivers: [
+              // ── White standard AppBar (Design System §4.5) ──
+              SliverAppBar(
+                expandedHeight: 100,
+                pinned: true,
+                backgroundColor: MintColors.white,
+                foregroundColor: MintColors.textPrimary,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: Text(
+                    l.affordabilityTitle,
+                    style: MintTextStyles.headlineMedium(),
+                  ),
+                ),
               ),
-            ),
-          ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: MintSpacing.lg,
-              vertical: MintSpacing.lg,
-            ),
-            sliver: SliverList(
-              delegate: SliverChildListDelegate([
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 1 — L'ENJEU : la question hero
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                Text(
-                  l.affordabilityEmotionalPositif,
-                  style: MintTextStyles.headlineLarge(
-                    color: MintColors.textPrimary,
-                  ),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: MintSpacing.lg,
+                  vertical: MintSpacing.lg,
                 ),
-                const SizedBox(height: MintSpacing.xl),
-
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 2 — LE RESULTAT : consequence financiere
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                Semantics(
-                  identifier: 'mortgage_afford_result',
-                  child: MintResultHeroCard(
-                    key: const Key('mortgage_afford_result'),
-                    eyebrow: result.premierEclairagePositif
-                        ? l.affordabilityParameters
-                        : l.affordabilityInsightEquityTitle,
-                    primaryValue: result.premierEclairagePositif
-                        ? 'CHF\u00a0${formatChf(result.prixMaxAccessible)}'
-                        : 'CHF\u00a0${formatChf(result.manqueFondsPropres)}',
-                    primaryLabel: result.premierEclairagePositif
-                        ? l.affordabilityCalculationDetail
-                        : l.affordabilityExceeded,
-                    narrative: result.premierEclairageTexte,
-                    accentColor: result.premierEclairagePositif
-                        ? MintColors.success
-                        : MintColors.error,
-                    tone: MintSurfaceTone.porcelaine,
-                  ),
-                ),
-                const SizedBox(height: MintSpacing.xl),
-
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 3 — INDICATEURS : signaux, pas jauges
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                MintSurface(
-                  tone: MintSurfaceTone.blanc,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l.affordabilityIndicators,
-                        style: MintTextStyles.labelSmall(
-                          color: MintColors.textMuted,
-                        ),
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate([
+                    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                    // SECTION 1 — L'ENJEU : la question hero
+                    // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                    Text(
+                      l.affordabilityEmotionalPositif,
+                      style: MintTextStyles.headlineLarge(
+                        color: MintColors.textPrimary,
                       ),
-                      MintSignalRow(
-                        label: l.affordabilityChargesRatio,
-                        value: '${(result.ratioCharges * 100).toStringAsFixed(1)}\u00a0%',
-                        valueColor: result.capaciteOk
-                            ? MintColors.success
-                            : MintColors.error,
-                      ),
-                      MintSignalRow(
-                        label: l.affordabilityEquityRatio,
-                        value:
-                            'CHF\u00a0${formatChf(result.fondsPropresTotal)} / ${formatChf(result.fondsPropresRequis)}',
-                        valueColor: result.fondsPropresOk
-                            ? MintColors.success
-                            : MintColors.error,
-                      ),
-                      MintSignalRow(
-                        label: l.affordabilityMonthlyCharges,
-                        value:
-                            'CHF\u00a0${formatChf(result.chargesTheoriquesMensuelles)}',
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: MintSpacing.lg),
+                    ),
+                    const SizedBox(height: MintSpacing.lg),
+                    _buildLedgerFactsCard(context, l),
+                    const SizedBox(height: MintSpacing.xl),
 
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 4 — INSIGHT pedagogique
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                _buildInsightCard(result, l),
-                const SizedBox(height: MintSpacing.lg),
-
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 5 — CONFIDENCE NOTICE (donnees estimees)
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                MintConfidenceNotice(
-                  percent: 45,
-                  message: l.affordabilityCalculationNote,
-                ),
-                const SizedBox(height: MintSpacing.xl),
-
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 6 — CONTROLES : sliders SOUS le resultat
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                MintSurface(
-                  tone: MintSurfaceTone.craie,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l.affordabilityParameters,
-                        style: MintTextStyles.labelSmall(
-                          color: MintColors.textMuted,
-                        ),
-                      ),
-                      const SizedBox(height: MintSpacing.md),
-
-                      // Canton
+                    if (result == null) ...[
+                      _buildMissingFactsNotice(l),
+                      const SizedBox(height: MintSpacing.xl),
+                    ] else ...[
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 2 — LE RESULTAT : consequence financiere
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                       Semantics(
-                        label: l.affordabilityCanton,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        identifier: 'mortgage_afford_result',
+                        child: MintResultHeroCard(
+                          key: const Key('mortgage_afford_result'),
+                          eyebrow: result.premierEclairagePositif
+                              ? l.affordabilityParameters
+                              : l.affordabilityInsightEquityTitle,
+                          primaryValue: result.premierEclairagePositif
+                              ? 'CHF\u00a0${formatChf(result.prixMaxAccessible)}'
+                              : 'CHF\u00a0${formatChf(result.manqueFondsPropres)}',
+                          primaryLabel: result.premierEclairagePositif
+                              ? l.affordabilityCalculationDetail
+                              : l.affordabilityExceeded,
+                          narrative: result.premierEclairageTexte,
+                          accentColor: result.premierEclairagePositif
+                              ? MintColors.success
+                              : MintColors.error,
+                          tone: MintSurfaceTone.porcelaine,
+                        ),
+                      ),
+                      const SizedBox(height: MintSpacing.xl),
+
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 3 — INDICATEURS : signaux, pas jauges
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      MintSurface(
+                        tone: MintSurfaceTone.blanc,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              l.affordabilityCanton,
-                              style: MintTextStyles.bodySmall(
-                                color: MintColors.textSecondary,
+                              l.affordabilityIndicators,
+                              style: MintTextStyles.labelSmall(
+                                color: MintColors.textMuted,
                               ),
                             ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: MintSpacing.sm + MintSpacing.xs,
-                              ),
-                              decoration: BoxDecoration(
-                                border: Border.all(color: MintColors.border),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: DropdownButtonHideUnderline(
-                                child: DropdownButton<String>(
-                                  value: _canton,
-                                  items: _cantons
-                                      .map((c) => DropdownMenuItem(
-                                            value: c,
-                                            child: Text(c,
-                                                style: MintTextStyles.bodySmall(
-                                                    color: MintColors
-                                                        .textPrimary)),
-                                          ))
-                                      .toList(),
-                                  onChanged: (v) {
-                                    if (v != null) {
-                                      setState(() { _hasUserInteracted = true; _canton = v; });
-                                      WidgetsBinding.instance.addPostFrameCallback((_) => _writeBackResult());
-                                    }
-                                  },
-                                ),
-                              ),
+                            MintSignalRow(
+                              label: l.affordabilityChargesRatio,
+                              value:
+                                  '${(result.ratioCharges * 100).toStringAsFixed(1)}\u00a0%',
+                              valueColor: result.capaciteOk
+                                  ? MintColors.success
+                                  : MintColors.error,
+                            ),
+                            MintSignalRow(
+                              label: l.affordabilityEquityRatio,
+                              value:
+                                  'CHF\u00a0${formatChf(result.fondsPropresTotal)} / ${formatChf(result.fondsPropresRequis)}',
+                              valueColor: result.fondsPropresOk
+                                  ? MintColors.success
+                                  : MintColors.error,
+                            ),
+                            MintSignalRow(
+                              label: l.affordabilityMonthlyCharges,
+                              value:
+                                  'CHF\u00a0${formatChf(result.chargesTheoriquesMensuelles)}',
                             ),
                           ],
                         ),
                       ),
                       const SizedBox(height: MintSpacing.lg),
 
-                      // Revenu brut annuel
-                      Semantics(
-                        identifier: 'mortgage_income_amount',
-                        child: _buildAmountFieldWithBadge(
-                          key: const Key('mortgage_income_amount'),
-                          label: l.affordabilityGrossIncome,
-                          value: _revenuBrut,
-                          fieldKey: 'revenu_brut',
-                          onChanged: (v) {
-                            setState(() { _hasUserInteracted = true; _revenuBrut = v; });
-                            WidgetsBinding.instance.addPostFrameCallback((_) => _writeBackResult());
-                          },
-                          min: 50000,
-                          max: 300000,
-                        ),
-                      ),
-                      const SizedBox(height: MintSpacing.md),
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 4 — INSIGHT pedagogique
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      _buildInsightCard(result, l),
+                      const SizedBox(height: MintSpacing.lg),
 
-                      // Prix d'achat
-                      Semantics(
-                        identifier: 'mortgage_price_amount',
-                        child: MintAmountField(
-                          key: const Key('mortgage_price_amount'),
-                          label: l.affordabilityTargetPrice,
-                          value: _prixAchat,
-                          formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                          onChanged: (v) => setState(() { _hasUserInteracted = true; _prixAchat = v; }),
-                          min: 200000,
-                          max: 3000000,
-                        ),
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 5 — CONFIDENCE NOTICE (donnees estimees)
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      MintConfidenceNotice(
+                        percent: 45,
+                        message: l.affordabilityCalculationNote,
                       ),
-                      const SizedBox(height: MintSpacing.md),
+                      const SizedBox(height: MintSpacing.xl),
 
-                      // Epargne disponible
-                      Semantics(
-                        identifier: 'mortgage_savings_amount',
-                        child: MintAmountField(
-                          key: const Key('mortgage_savings_amount'),
-                          label: l.affordabilityAvailableSavings,
-                          value: _epargneDispo,
-                          formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                          onChanged: (v) => setState(() { _hasUserInteracted = true; _epargneDispo = v; }),
-                          min: 0,
-                          max: 500000,
-                        ),
-                      ),
-
-                      // Progressive disclosure: 3a + LPP behind toggle
-                      const SizedBox(height: MintSpacing.md),
-                      Semantics(
-                        button: true,
-                        label: l.affordabilityAdvancedParams,
-                        child: GestureDetector(
-                          onTap: () => setState(
-                              () => _showAdvancedParams = !_showAdvancedParams),
-                          child: Row(
-                            children: [
-                              Icon(
-                                _showAdvancedParams
-                                    ? Icons.expand_less
-                                    : Icons.expand_more,
-                                color: MintColors.info,
-                                size: 20,
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 6 — CONTROLES : sliders SOUS le resultat
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      MintSurface(
+                        tone: MintSurfaceTone.craie,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              l.affordabilityParameters,
+                              style: MintTextStyles.labelSmall(
+                                color: MintColors.textMuted,
                               ),
-                              const SizedBox(width: MintSpacing.xs),
-                              Text(
-                                l.affordabilityAdvancedParams,
-                                style: MintTextStyles.bodySmall(
-                                    color: MintColors.info),
+                            ),
+                            const SizedBox(height: MintSpacing.md),
+
+                            // Canton
+                            Semantics(
+                              label: l.affordabilityCanton,
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(
+                                    l.affordabilityCanton,
+                                    style: MintTextStyles.bodySmall(
+                                      color: MintColors.textSecondary,
+                                    ),
+                                  ),
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal:
+                                          MintSpacing.sm + MintSpacing.xs,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      border:
+                                          Border.all(color: MintColors.border),
+                                      borderRadius: BorderRadius.circular(8),
+                                    ),
+                                    child: DropdownButtonHideUnderline(
+                                      child: DropdownButton<String>(
+                                        value: _canton,
+                                        items: _cantons
+                                            .map((c) => DropdownMenuItem(
+                                                  value: c,
+                                                  child: Text(c,
+                                                      style: MintTextStyles
+                                                          .bodySmall(
+                                                              color: MintColors
+                                                                  .textPrimary)),
+                                                ))
+                                            .toList(),
+                                        onChanged: (v) {
+                                          if (v != null) {
+                                            setState(() {
+                                              _markUserEdited('canton');
+                                              _canton = v;
+                                            });
+                                            WidgetsBinding.instance
+                                                .addPostFrameCallback(
+                                                    (_) => _writeBackResult());
+                                          }
+                                        },
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: MintSpacing.lg),
+
+                            // Revenu brut annuel
+                            Semantics(
+                              identifier: 'mortgage_income_amount',
+                              child: _buildAmountFieldWithBadge(
+                                key: const Key('mortgage_income_amount'),
+                                label: l.affordabilityGrossIncome,
+                                value: _revenuBrut,
+                                fieldKey: 'revenu_brut',
+                                onChanged: (v) {
+                                  setState(() {
+                                    _markUserEdited('revenu_brut');
+                                    _revenuBrut = v;
+                                  });
+                                  WidgetsBinding.instance.addPostFrameCallback(
+                                      (_) => _writeBackResult());
+                                },
+                                min: 50000,
+                                max: 300000,
+                              ),
+                            ),
+                            const SizedBox(height: MintSpacing.md),
+
+                            // Prix d'achat
+                            Semantics(
+                              identifier: 'mortgage_price_amount',
+                              child: MintAmountField(
+                                key: const Key('mortgage_price_amount'),
+                                label: l.affordabilityTargetPrice,
+                                value: _prixAchat,
+                                formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
+                                onChanged: (v) => setState(() {
+                                  _markUserEdited('prix_achat');
+                                  _prixAchat = v;
+                                }),
+                                min: 200000,
+                                max: 3000000,
+                              ),
+                            ),
+                            const SizedBox(height: MintSpacing.md),
+
+                            // Epargne disponible
+                            Semantics(
+                              identifier: 'mortgage_savings_amount',
+                              child: MintAmountField(
+                                key: const Key('mortgage_savings_amount'),
+                                label: l.affordabilityAvailableSavings,
+                                value: _epargneDispo,
+                                formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
+                                onChanged: (v) => setState(() {
+                                  _markUserEdited('epargne_dispo');
+                                  _epargneDispo = v;
+                                }),
+                                min: 0,
+                                max: 500000,
+                              ),
+                            ),
+
+                            // Progressive disclosure: 3a + LPP behind toggle
+                            const SizedBox(height: MintSpacing.md),
+                            Semantics(
+                              button: true,
+                              label: l.affordabilityAdvancedParams,
+                              child: GestureDetector(
+                                onTap: () => setState(() =>
+                                    _showAdvancedParams = !_showAdvancedParams),
+                                child: Row(
+                                  children: [
+                                    Icon(
+                                      _showAdvancedParams
+                                          ? Icons.expand_less
+                                          : Icons.expand_more,
+                                      color: MintColors.info,
+                                      size: 20,
+                                    ),
+                                    const SizedBox(width: MintSpacing.xs),
+                                    Text(
+                                      l.affordabilityAdvancedParams,
+                                      style: MintTextStyles.bodySmall(
+                                          color: MintColors.info),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            if (_showAdvancedParams) ...[
+                              const SizedBox(height: MintSpacing.md),
+                              Semantics(
+                                identifier: 'mortgage_pillar3a_amount',
+                                child: MintAmountField(
+                                  key: const Key('mortgage_pillar3a_amount'),
+                                  label: l.affordabilityPillar3a,
+                                  value: _avoir3a,
+                                  formatValue: (v) =>
+                                      'CHF\u00a0${formatChf(v)}',
+                                  onChanged: (v) => setState(() {
+                                    _markUserEdited('avoir_3a');
+                                    _avoir3a = v;
+                                  }),
+                                  min: 0,
+                                  max: 300000,
+                                ),
+                              ),
+                              const SizedBox(height: MintSpacing.md),
+                              Semantics(
+                                identifier: 'mortgage_lpp_amount',
+                                child: _buildAmountFieldWithBadge(
+                                  key: const Key('mortgage_lpp_amount'),
+                                  label: l.affordabilityPillarLpp,
+                                  value: _avoirLpp,
+                                  fieldKey: 'avoir_lpp',
+                                  onChanged: (v) => setState(() {
+                                    _markUserEdited('avoir_lpp');
+                                    _avoirLpp = v;
+                                  }),
+                                  min: 0,
+                                  max: 500000,
+                                ),
                               ),
                             ],
-                          ),
+                          ],
                         ),
                       ),
-                      if (_showAdvancedParams) ...[
-                        const SizedBox(height: MintSpacing.md),
-                        Semantics(
-                          identifier: 'mortgage_pillar3a_amount',
-                          child: MintAmountField(
-                            key: const Key('mortgage_pillar3a_amount'),
-                            label: l.affordabilityPillar3a,
-                            value: _avoir3a,
-                            formatValue: (v) => 'CHF\u00a0${formatChf(v)}',
-                            onChanged: (v) => setState(() { _hasUserInteracted = true; _avoir3a = v; }),
-                            min: 0,
-                            max: 300000,
-                          ),
-                        ),
-                        const SizedBox(height: MintSpacing.md),
-                        Semantics(
-                          identifier: 'mortgage_lpp_amount',
-                          child: _buildAmountFieldWithBadge(
-                            key: const Key('mortgage_lpp_amount'),
-                            label: l.affordabilityPillarLpp,
-                            value: _avoirLpp,
-                            fieldKey: 'avoir_lpp',
-                            onChanged: (v) => setState(() { _hasUserInteracted = true; _avoirLpp = v; }),
-                            min: 0,
-                            max: 500000,
-                          ),
-                        ),
-                      ],
+                      const SizedBox(height: MintSpacing.xl),
+
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 7 — DETAIL calcul (progressive disclosure)
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      _buildDetailSection(result, l),
+                      const SizedBox(height: MintSpacing.lg),
+
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 8 — EXPLORER AUSSI
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      _buildRelatedSections(l),
+                      const SizedBox(height: MintSpacing.lg),
+
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      // SECTION 9 — DISCLAIMER (micro)
+                      // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                      Text(
+                        result.disclaimer,
+                        style: MintTextStyles.micro(),
+                      ),
+                      const SizedBox(height: MintSpacing.lg),
                     ],
-                  ),
+
+                    // ── P3-E : Parcours achat immobilier ──
+                    const MortgageJourneyWidget(),
+                    const SizedBox(height: MintSpacing.sm),
+
+                    // ── Source legale ──
+                    Semantics(
+                      label: l.affordabilitySource,
+                      child: Text(
+                        l.affordabilitySource,
+                        style: MintTextStyles.micro(),
+                      ),
+                    ),
+                    const SizedBox(height: MintSpacing.xl),
+                  ]),
                 ),
-                const SizedBox(height: MintSpacing.xl),
+              ),
+            ],
+          ),
+        ));
+  }
 
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 7 — DETAIL calcul (progressive disclosure)
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                _buildDetailSection(result, l),
-                const SizedBox(height: MintSpacing.lg),
+  String _revenueDataBlockRoute() {
+    final inputKey =
+        _facts.grossIncomeAnnual == null ? 'q_gross_salary_annual' : 'q_canton';
+    return Uri(
+      path: '/data-block/revenu',
+      queryParameters: {'inputKey': inputKey},
+    ).toString();
+  }
 
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 8 — EXPLORER AUSSI
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                _buildRelatedSections(l),
-                const SizedBox(height: MintSpacing.lg),
-
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                // SECTION 9 — DISCLAIMER (micro)
-                // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                Text(
-                  result.disclaimer,
-                  style: MintTextStyles.micro(),
+  Widget _buildLedgerFactsCard(BuildContext context, S l) {
+    final hasMissing = !_facts.hasRequired;
+    return Semantics(
+      key: const Key('mortgage_ledger_facts'),
+      identifier: 'mortgage_ledger_facts',
+      container: true,
+      explicitChildNodes: true,
+      child: MintSurface(
+        tone: MintSurfaceTone.blanc,
+        padding: const EdgeInsets.all(MintSpacing.md + 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  hasMissing
+                      ? Icons.manage_search_outlined
+                      : Icons.check_circle_outline,
+                  color: hasMissing ? MintColors.warning : MintColors.success,
+                  size: 20,
                 ),
-                const SizedBox(height: MintSpacing.lg),
-
-                // ── P3-E : Parcours achat immobilier ──
-                const MortgageJourneyWidget(),
-                const SizedBox(height: MintSpacing.sm),
-
-                // ── Source legale ──
-                Semantics(
-                  label: l.affordabilitySource,
+                const SizedBox(width: MintSpacing.sm),
+                Expanded(
                   child: Text(
-                    l.affordabilitySource,
-                    style: MintTextStyles.micro(),
+                    hasMissing
+                        ? l.dataQualityMissingSection
+                        : l.dataQualityKnownSection,
+                    style:
+                        MintTextStyles.bodyMedium(color: MintColors.textPrimary)
+                            .copyWith(fontWeight: FontWeight.w700),
                   ),
                 ),
-                const SizedBox(height: MintSpacing.xl),
-              ]),
+                Semantics(
+                  key: const Key('mortgage_revenue_enrich_cta'),
+                  identifier: 'mortgage_revenue_enrich_cta',
+                  button: true,
+                  child: TextButton.icon(
+                    onPressed: () {
+                      _hasUserInteracted = true;
+                      context.push(_revenueDataBlockRoute());
+                    },
+                    icon: Icon(
+                      hasMissing
+                          ? Icons.add_circle_outline
+                          : Icons.edit_outlined,
+                      size: 18,
+                    ),
+                    label:
+                        Text(hasMissing ? l.dataQualityEnrich : l.commonEdit),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: MintSpacing.sm + 4),
+            _buildFactRow(
+              identifier: 'mortgage_income_fact',
+              label: l.affordabilityGrossIncome,
+              value: _facts.grossIncomeAnnual == null
+                  ? l.dataBlockStatusMissing
+                  : 'CHF\u00a0${formatChf(_facts.grossIncomeAnnual!)}',
+              isMissing: _facts.grossIncomeAnnual == null,
+            ),
+            const SizedBox(height: MintSpacing.xs),
+            _buildFactRow(
+              identifier: 'mortgage_canton_fact',
+              label: l.affordabilityCanton,
+              value: _facts.canton ?? l.dataBlockStatusMissing,
+              isMissing: _facts.canton == null,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFactRow({
+    required String identifier,
+    required String label,
+    required String value,
+    required bool isMissing,
+  }) {
+    return Semantics(
+      key: Key(identifier),
+      identifier: identifier,
+      label: '$label, $value',
+      container: true,
+      child: Row(
+        children: [
+          Icon(
+            isMissing ? Icons.help_outline : Icons.check_circle_outline,
+            color: isMissing ? MintColors.warning : MintColors.success,
+            size: 16,
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(
+            child: Text(
+              label,
+              style: MintTextStyles.bodySmall(color: MintColors.textSecondary),
+            ),
+          ),
+          Text(
+            value,
+            style: MintTextStyles.bodySmall(
+              color: isMissing ? MintColors.warning : MintColors.textPrimary,
+            ).copyWith(fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMissingFactsNotice(S l) {
+    return MintSurface(
+      tone: MintSurfaceTone.sauge,
+      child: Row(
+        children: [
+          const Icon(
+            Icons.info_outline,
+            color: MintColors.info,
+            size: 20,
+          ),
+          const SizedBox(width: MintSpacing.sm),
+          Expanded(
+            child: Text(
+              l.dataQualityMissingSection,
+              style: MintTextStyles.bodyMedium(color: MintColors.textPrimary),
             ),
           ),
         ],
       ),
-    ));
+    );
   }
 
   /// Builds a MintAmountField with an optional SmartDefaultIndicator badge
@@ -591,8 +835,8 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
               Text(label,
                   style: MintTextStyles.bodySmall(
                       color: MintColors.textSecondary)),
-              const SmartDefaultIndicator(
-                source: 'Depuis ton profil MINT',
+              SmartDefaultIndicator(
+                source: S.of(context)!.prefillSourceEstimated,
                 confidence: 0.60,
               ),
             ],
@@ -699,15 +943,13 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
           ),
           MintSignalRow(
             label: l.affordabilityLppMax10,
-            value:
-                'CHF\u00a0${formatChf(min(_avoirLpp, _prixAchat * 0.10))}',
+            value: 'CHF\u00a0${formatChf(min(_avoirLpp, _prixAchat * 0.10))}',
           ),
           MintSignalRow(
             label: l.affordabilityTotalEquity,
             value: 'CHF\u00a0${formatChf(result.fondsPropresTotal)}',
-            valueColor: result.fondsPropresOk
-                ? MintColors.success
-                : MintColors.error,
+            valueColor:
+                result.fondsPropresOk ? MintColors.success : MintColors.error,
           ),
           Divider(
             color: MintColors.border.withValues(alpha: 0.3),
@@ -726,11 +968,9 @@ class _AffordabilityScreenState extends State<AffordabilityScreen> {
           }(),
           MintSignalRow(
             label: l.affordabilityChargesRatio,
-            value:
-                '${(result.ratioCharges * 100).toStringAsFixed(1)}\u00a0%',
-            valueColor: result.capaciteOk
-                ? MintColors.success
-                : MintColors.error,
+            value: '${(result.ratioCharges * 100).toStringAsFixed(1)}\u00a0%',
+            valueColor:
+                result.capaciteOk ? MintColors.success : MintColors.error,
           ),
         ],
       ),

--- a/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
+++ b/apps/mobile/test/screens/mortgage_screens_smoke_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 // Screens under test
@@ -10,7 +13,10 @@ import 'package:mint_mobile/screens/mortgage/amortization_screen.dart';
 import 'package:mint_mobile/screens/mortgage/epl_combined_screen.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/models/coach_profile.dart';
+import 'package:mint_mobile/models/screen_return.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/screen_completion_tracker.dart';
 import 'package:mint_mobile/widgets/premium/mint_amount_field.dart';
 
 // =============================================================================
@@ -33,7 +39,20 @@ void main() {
   // ===========================================================================
 
   group('AffordabilityScreen', () {
-    Widget buildScreen({CoachProfileProvider? coachProvider}) {
+    CoachProfileProvider mortgageFactsProvider() {
+      return CoachProfileProvider()
+        ..updateFromAnswers({
+          'q_gross_salary_annual': 96000,
+          'q_canton': 'GE',
+          'q_birth_year': 2001,
+          'q_has_pension_fund': false,
+        });
+    }
+
+    Widget buildScreen({
+      CoachProfileProvider? coachProvider,
+      bool withLedgerFacts = true,
+    }) {
       const app = MaterialApp(
         locale: Locale('fr'),
         localizationsDelegates: [
@@ -45,14 +64,10 @@ void main() {
         supportedLocales: S.supportedLocales,
         home: AffordabilityScreen(),
       );
-      if (coachProvider != null) {
-        return ChangeNotifierProvider<CoachProfileProvider>.value(
-          value: coachProvider,
-          child: app,
-        );
-      }
-      return ChangeNotifierProvider<CoachProfileProvider>(
-        create: (_) => CoachProfileProvider(),
+      final provider = coachProvider ??
+          (withLedgerFacts ? mortgageFactsProvider() : CoachProfileProvider());
+      return ChangeNotifierProvider<CoachProfileProvider>.value(
+        value: provider,
         child: app,
       );
     }
@@ -64,6 +79,111 @@ void main() {
       expect(find.byType(Scaffold), findsOneWidget);
     });
 
+    testWidgets('requires revenue ledger facts before calculating capacity',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(withLedgerFacts: false));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('mortgage_ledger_facts')), findsOneWidget);
+      expect(find.byKey(const Key('mortgage_afford_result')), findsNothing);
+      expect(find.byKey(const Key('mortgage_income_amount')), findsNothing);
+    });
+
+    testWidgets('uses household income when spouse ledger data exists',
+        (tester) async {
+      final coachProvider = mortgageFactsProvider();
+      final profile = coachProvider.profile!;
+      coachProvider.updateProfile(
+        profile.copyWith(
+          conjoint: const ConjointProfile(
+            salaireBrutMensuel: 4000,
+            nombreDeMois: 13,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildScreen(coachProvider: coachProvider));
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('mortgage_income_amount')),
+        300,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining("148'000"), findsWidgets);
+    });
+
+    testWidgets(
+        'emits abandoned sequence return when facts stay missing after enrichment',
+        (tester) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, __) => const Scaffold(body: Text('Home')),
+          ),
+          GoRoute(
+            path: '/hypotheque',
+            builder: (_, __) => const AffordabilityScreen(),
+          ),
+          GoRoute(
+            path: '/data-block/revenu',
+            builder: (_, __) => const Scaffold(body: Text('Data block')),
+          ),
+        ],
+      );
+      final eventFuture = ScreenCompletionTracker.stream
+          .firstWhere(
+            (event) =>
+                event.route == '/hypotheque' &&
+                event.runId == 'run_missing_facts',
+          )
+          .timeout(const Duration(seconds: 2));
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<CoachProfileProvider>.value(
+          value: CoachProfileProvider(),
+          child: MaterialApp.router(
+            locale: const Locale('fr'),
+            localizationsDelegates: const [
+              S.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: S.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+
+      unawaited(
+        router.push<void>(
+          '/hypotheque',
+          extra: {
+            'runId': 'run_missing_facts',
+            'stepId': 'hou_03_capacity',
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('mortgage_revenue_enrich_cta')));
+      await tester.pumpAndSettle();
+      expect(find.text('Data block'), findsOneWidget);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      router.pop();
+      await tester.pumpAndSettle();
+
+      final event = await eventFuture;
+      expect(event.outcome, ScreenOutcome.abandoned);
+      expect(event.stepId, 'hou_03_capacity');
+    });
+
     testWidgets('displays i18n title in SliverAppBar', (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
@@ -72,7 +192,8 @@ void main() {
       expect(find.textContaining('achat'), findsWidgets);
     });
 
-    testWidgets('displays premier éclairage card with CHF amount', (tester) async {
+    testWidgets('displays premier éclairage card with CHF amount',
+        (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
@@ -117,14 +238,18 @@ void main() {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
-      await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
-      await tester.pump();
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('mortgage_price_amount')),
+        300,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
 
-      // i18n: affordabilityParameters = "Tes hypotheses"
-      expect(find.textContaining('hypoth'), findsWidgets);
+      expect(find.byKey(const Key('mortgage_price_amount')), findsOneWidget);
     });
 
-    testWidgets('has MintAmountField widgets for input parameters', (tester) async {
+    testWidgets('has MintAmountField widgets for input parameters',
+        (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
@@ -174,13 +299,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('mortgage_income_amount')), findsOneWidget);
-      expect(find.text('Estime'), findsWidgets);
       expect(find.textContaining("96'000"), findsWidgets);
       expect(find.text('GE'), findsWidgets);
-
-      await tester.tap(find.text('Estime').first);
-      await tester.pumpAndSettle();
-      expect(find.text('Depuis ton profil MINT'), findsOneWidget);
+      expect(find.text('Estime'), findsNothing);
     });
 
     testWidgets('displays detail section after scrolling', (tester) async {
@@ -194,7 +315,8 @@ void main() {
       expect(find.textContaining('calcul'), findsWidgets);
     });
 
-    testWidgets('builds without overflow or crash at various scroll depths', (tester) async {
+    testWidgets('builds without overflow or crash at various scroll depths',
+        (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
@@ -381,7 +503,8 @@ void main() {
       expect(find.textContaining('locative'), findsWidgets);
     });
 
-    testWidgets('displays premier éclairage with fiscal impact', (tester) async {
+    testWidgets('displays premier éclairage with fiscal impact',
+        (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 
@@ -491,7 +614,8 @@ void main() {
       expect(find.textContaining('direct'), findsWidgets);
     });
 
-    testWidgets('displays two method cards (Direct / Indirect)', (tester) async {
+    testWidgets('displays two method cards (Direct / Indirect)',
+        (tester) async {
       await tester.pumpWidget(buildScreen());
       await tester.pump();
 


### PR DESCRIPTION
## Summary
- Gate /hypotheque affordability results behind canonical ledger facts for annual income + canton.
- Route missing facts to /data-block/revenu instead of computing from local defaults.
- Use household income when conjoint ledger data exists.
- Preserve sequence return semantics by emitting abandoned when enrichment leaves required facts missing.
- Remove estimated badge from declared ledger income.

## QA
- flutter analyze lib/screens/mortgage/affordability_screen.dart test/screens/mortgage_screens_smoke_test.dart
- flutter test test/screens/mortgage_screens_smoke_test.dart --reporter expanded (56/56)
- flutter build ios --simulator --debug
- Maestro iPhone 17 Pro: apps/mobile/.maestro/f2_datablock_to_mortgage.yaml PASS (data-block/revenu -> /hypotheque shows CHF 96'000 + Canton GE)
- lefthook pre-commit targeted PASS
- python3 tools/checks/mint_os_doctor.py --repo-only PASS
- python3 tools/checks/patrol_tooling_guard.py PASS
- python3 tools/checks/mermaid_render_guard.py PASS
- ./tools/mint-routes reconcile PASS
- tools/checks/claude_external_audit.sh code origin/claude/mint-swiss-coach-eu33i7 PASS (no P0/P1)