### PR TITLE
docs(interactions): require journey Mermaid maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,8 +681,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/puppeteer
+          key: ${{ runner.os }}-mermaid-cli-11.4.2
       - name: Install pytest
         run: pip install pytest
+      - name: Render Mermaid diagrams
+        run: python3 tools/checks/mermaid_render_guard.py
       - name: Run repository contract tests
         run: pytest tools/checks/tests tests/checks -q --tb=short
 

--- a/.planning/journeys/diagrams/data_quest_loop.mmd
+++ b/.planning/journeys/diagrams/data_quest_loop.mmd
@@ -1,0 +1,65 @@
+%% ============================================================================
+%% data_quest_loop.mmd — MINT progressive data collection loop
+%% ----------------------------------------------------------------------------
+%% Purpose: route every missing/stale fact through DATA_QUEST + DATA_LEDGER,
+%% not through screen-local sliders or GoRouter.extra domain payloads.
+%% Sources: docs/codex/DATA_QUEST.md, DATA_LEDGER.md, SCREEN_CONTRACTS.md.
+%% ============================================================================
+
+flowchart TB
+  classDef route fill:#eaf6f0,stroke:#166b4a,color:#10261d,stroke-width:1px;
+  classDef ledger fill:#f6f1e7,stroke:#b48a3b,color:#21180a,stroke-width:1px;
+  classDef guard fill:#fff5e6,stroke:#c26f00,color:#201307,stroke-width:1px;
+  classDef proof fill:#eef1ff,stroke:#4f62c6,color:#111836,stroke-width:1px;
+  classDef no fill:#fff0f0,stroke:#c83d3d,color:#2c0f0f,stroke-width:1px;
+
+  Start["User intent<br/>CTA, hub card, coach topic, deep link"]:::route
+  Screen["Target route<br/>SCREEN_CONTRACTS reads[]"]:::route
+  Contract["Route contract<br/>required ledger keys + states"]:::proof
+  Profile["CoachProfileProvider.profile<br/>single read/write spine"]:::ledger
+  Facts["BiographyRepository<br/>source, date, freshness"]:::ledger
+  Fresh{"All required facts<br/>fresh enough?"}:::guard
+
+  Partial["Render partialState now<br/>range + confidence + missing facts"]:::route
+  DataQuest["DataQuest.planQuest<br/>missing + stale delta only"]:::proof
+  Heavy{"Heavy life event?"}:::guard
+  CoachAsk["Coach gentle ask<br/>one question per turn"]:::route
+  DataBlock["/data-block/:type<br/>optional inputKey"]:::route
+  Reconfirm["AskMode.reconfirm<br/>yes / update / rescan"]:::route
+
+  Write["mergeAnswers / applySaveFact / updateProfile<br/>no direct persistence"]:::ledger
+  Recompute["MintStateProvider recompute<br/>derived state refresh"]:::ledger
+  Result["Personalized screen state<br/>known / estimated / missing / error"]:::route
+  Dossier["PDF / specialist handoff<br/>facts + assumptions + open questions"]:::proof
+  Runtime["Maestro / Patrol proof<br/>stable ids, route, persisted values"]:::proof
+
+  ExtraBan["Forbidden<br/>domain data in GoRouter.extra"]:::no
+  LocalBan["Forbidden<br/>screen-local fact sliders"]:::no
+
+  Start --> Screen --> Contract
+  Contract --> Profile
+  Contract --> Facts
+  Profile --> Fresh
+  Facts --> Fresh
+  Fresh -- "yes" --> Result
+  Fresh -- "no" --> Partial --> DataQuest
+  DataQuest --> Heavy
+  Heavy -- "yes" --> CoachAsk
+  Heavy -- "no" --> DataBlock
+  DataQuest --> Reconfirm
+  CoachAsk --> Write
+  DataBlock --> Write
+  Reconfirm --> Write
+  Write --> Profile --> Recompute --> Result
+  Result --> Dossier --> Runtime
+
+  ExtraBan -. "blocked by SCREEN_CONTRACTS hard rule" .-> Contract
+  LocalBan -. "replace with ledger fact or scenario lever" .-> DataQuest
+
+  %% Invariants:
+  %% DQ-1 fresh facts trigger zero asks.
+  %% DQ-2 missing facts trigger only the missing delta, never a form wall.
+  %% DQ-3 stale facts trigger reconfirm, never blank re-entry.
+  %% DQ-4 all writes pass through CoachProfileProvider.
+  %% DQ-5 heavy cases ask gently in the coach.
+  %% DQ-6 every projection carries range + confidence.

--- a/.planning/journeys/diagrams/independent_protection.mmd
+++ b/.planning/journeys/diagrams/independent_protection.mmd
@@ -1,0 +1,96 @@
+%% ============================================================================
+%% independent_protection.mmd — independent worker protection journey
+%% ----------------------------------------------------------------------------
+%% Purpose: keep independent screens ledger-first while preserving scenario
+%% levers. This map covers the current P0 independent chain:
+%% AVS, IJM, independent 3a, dividend-vs-salary, voluntary LPP.
+%% Sources: DATA_LEDGER.md §3.2/3.3/3.5, SCREEN_CONTRACTS.md §4,
+%% MAESTRO_FLOWS.md M-0b/F independent stable ids.
+%% ============================================================================
+
+flowchart LR
+  classDef route fill:#eaf6f0,stroke:#166b4a,color:#10261d,stroke-width:1px;
+  classDef fact fill:#f6f1e7,stroke:#b48a3b,color:#21180a,stroke-width:1px;
+  classDef lever fill:#eef1ff,stroke:#4f62c6,color:#111836,stroke-width:1px;
+  classDef missing fill:#fff5e6,stroke:#c26f00,color:#201307,stroke-width:1px;
+  classDef proof fill:#f2edf8,stroke:#7b4eb2,color:#1d102a,stroke-width:1px;
+
+  Hub["/segments/independant"]:::route
+  Avs["/independants/avs<br/>AVS cotisations"]:::route
+  Ijm["/independants/ijm<br/>daily allowance gap"]:::route
+  P3a["/independants/3a<br/>3a independent"]:::route
+  Div["/independants/dividende-salaire<br/>SA/Sarl split"]:::route
+  Lpp["/independants/lpp-volontaire<br/>voluntary LPP"]:::route
+
+  SelfIncome["q_self_employed_income<br/>self-employed annual net income"]:::fact
+  BirthYear["q_birth_year<br/>age fact"]:::fact
+  PensionFund["q_has_pension_fund<br/>2nd pillar status"]:::fact
+  Cash["q_cash_total<br/>liquid savings"]:::fact
+  CompanyProfit["q_company_profit_annual_chf<br/>SA/Sarl annual profit"]:::fact
+  VoluntaryLpp["q_has_voluntary_lpp<br/>voluntary LPP status"]:::fact
+
+  DBIncome["/data-block/revenu<br/>?inputKey=q_self_employed_income"]:::missing
+  DBAge["/data-block/revenu<br/>?inputKey=q_birth_year"]:::missing
+  DBPension["/data-block/revenu<br/>?inputKey=q_has_pension_fund"]:::missing
+  DBCash["/data-block/patrimoine<br/>?inputKey=q_cash_total"]:::missing
+  DBProfit["/data-block/revenu<br/>?inputKey=q_company_profit_annual_chf"]:::missing
+
+  Delay["Scenario lever<br/>IJM waiting period"]:::lever
+  TaxRate["Scenario lever<br/>marginal tax rate"]:::lever
+  SalarySplit["Scenario lever<br/>salary/dividend split"]:::lever
+
+  Provider["CoachProfileProvider<br/>mergeAnswers/applySaveFact"]:::fact
+  Recompute["MintStateProvider<br/>recompute"]:::fact
+  Evidence["Widget tests + Maestro/Patrol ids<br/>result unlocked only with facts"]:::proof
+
+  Hub --> Avs
+  Hub --> Ijm
+  Hub --> P3a
+  Hub --> Div
+  Hub --> Lpp
+
+  Avs --> SelfIncome
+  Ijm --> SelfIncome
+  Ijm --> BirthYear
+  P3a --> SelfIncome
+  P3a --> PensionFund
+  P3a --> Cash
+  Div --> CompanyProfit
+  Lpp --> SelfIncome
+  Lpp --> BirthYear
+  Lpp --> VoluntaryLpp
+
+  SelfIncome -- "missing" --> DBIncome
+  BirthYear -- "missing" --> DBAge
+  PensionFund -- "missing" --> DBPension
+  Cash -- "missing" --> DBCash
+  CompanyProfit -- "missing" --> DBProfit
+
+  DBIncome --> Provider
+  DBAge --> Provider
+  DBPension --> Provider
+  DBCash --> Provider
+  DBProfit --> Provider
+  Provider --> Recompute
+  Recompute --> Avs
+  Recompute --> Ijm
+  Recompute --> P3a
+  Recompute --> Div
+  Recompute --> Lpp
+
+  Ijm --> Delay
+  P3a --> TaxRate
+  Div --> TaxRate
+  Div --> SalarySplit
+  Lpp --> TaxRate
+
+  Avs --> Evidence
+  Ijm --> Evidence
+  P3a --> Evidence
+  Div --> Evidence
+  Lpp --> Evidence
+
+  %% Fact/lever separation:
+  %% - Facts are user ledger values and must not be represented as local sliders.
+  %% - Levers are scenario assumptions and may remain local when clearly labeled.
+  %% - Dividend-vs-salary uses q_company_profit_annual_chf, never q_self_employed_income.

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -81,6 +81,12 @@ screen-by-screen encyclopedia.
 
 - `docs/codex/WIRING_GRAPH.mmd` owns system wiring: routes, providers, source
   of truth, live gaps, and machine-checkable invariants.
+- `.planning/journeys/diagrams/data_quest_loop.mmd` owns the progressive
+  collection loop: route contract, ledger freshness, DataQuest asks, write-back,
+  recompute, and runtime proof.
+- `.planning/journeys/diagrams/independent_protection.mmd` owns the current
+  independent-worker protection chain: AVS, IJM, independent 3a,
+  dividend-vs-salary, voluntary LPP, and the fact-vs-scenario-lever boundary.
 - Product journeys own their own Mermaid flow when they become P0/P1: data
   collection, decisions, branches, degraded states, PDF handoff, and runtime
   proof links.
@@ -98,6 +104,12 @@ flow archetypes before inventing a new flow: progressive data collection,
 known-fact review/edit, scenario comparison, document extraction, permission or
 consent, dossier export, specialist handoff, error recovery, and return to the
 ledger.
+
+`python3 tools/checks/mermaid_render_guard.py` renders the wiring graph and the
+canonical journey diagrams above. A new P0/P1 product path should add or update
+a focused `.mmd` diagram before changing the screen, but the
+`INTERACTION_REGISTRY.md` executor remains Proposed until its own go/no-go
+threshold is met.
 
 ## Product Spine
 

--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -55,6 +55,25 @@ les edges). Décision à prendre au moment de l'étape 1, pas avant.
 | D10 | Index généré **une-ligne-par-edge** (`interactions/INDEX.md`) pour la lecture agents ; les YAML par flux restent la source. |
 | D11 | **(v1.1)** Relation aux specs existantes : `SCREEN_CONTRACTS.md` tables par route et `WIRING_GRAPH` deviennent des **artefacts générés** dès qu'un flux est migré ; un flux non migré reste gouverné par les docs actuels. Lint `contract_double_authority` : une route ne peut pas être déclarée à la fois dans un flux migré et éditée à la main dans les docs générés. |
 
+## 0.d Cartographie Mermaid active sans executor
+
+Ce registre reste `Status: Proposed`; il ne génère pas encore de routes,
+guards, tables `SCREEN_CONTRACTS.md`, ni `WIRING_GRAPH`. En revanche, la
+cartographie de parcours est active et vérifiée par
+`tools/checks/mermaid_render_guard.py` :
+
+- `docs/codex/WIRING_GRAPH.mmd` : graphe système global.
+- `.planning/journeys/diagrams/data_quest_loop.mmd` : boucle
+  `SCREEN_CONTRACTS.reads[] -> ledger -> DataQuest -> write-back -> recompute`.
+- `.planning/journeys/diagrams/independent_protection.mmd` : chaîne
+  indépendants et frontière stricte faits utilisateur vs leviers de scénario.
+
+La règle opérationnelle immédiate est donc : une interaction critique nouvelle
+est d'abord représentée dans un diagramme de parcours focalisé, puis reliée à
+`SCREEN_CONTRACTS.md`, `DATA_LEDGER.md` et à une preuve Maestro/Patrol. La règle
+plus forte « pas d'edge YAML, pas de bouton » reste réservée à l'étape 4 du
+séquencement, après le go/no-go D1.
+
 ## 1. Modèle
 
 Trois entités : **node** (écran ou scène), **edge** (interaction), **flow**

--- a/tools/checks/mermaid_render_guard.py
+++ b/tools/checks/mermaid_render_guard.py
@@ -10,13 +10,21 @@ import sys
 import tempfile
 from pathlib import Path
 
-REQUIRED_DIAGRAMS = (Path("docs/codex/WIRING_GRAPH.mmd"),)
+REQUIRED_DIAGRAMS = (
+    Path("docs/codex/WIRING_GRAPH.mmd"),
+    Path(".planning/journeys/diagrams/data_quest_loop.mmd"),
+    Path(".planning/journeys/diagrams/independent_protection.mmd"),
+)
 OPTIONAL_DIAGRAM_DIRS = (Path(".planning/journeys/diagrams"),)
 MERMAID_CLI = "@mermaid-js/mermaid-cli@11.4.2"
 
 
 def _render(root: Path, diagram: Path, out_dir: Path, puppeteer_config: Path) -> str | None:
-    output = out_dir / f"{diagram.stem}.svg"
+    output_stem = "__".join(
+        f"dot_{part[1:]}" if part.startswith(".") else part
+        for part in diagram.relative_to(root).with_suffix("").parts
+    )
+    output = out_dir / f"{output_stem}.svg"
     proc = subprocess.run(
         ["npx", "-y", MERMAID_CLI, "-p", str(puppeteer_config), "-i", str(diagram), "-o", str(output)],
         cwd=root,
@@ -45,6 +53,7 @@ def check(root: Path) -> list[str]:
     diagrams = [root / path for path in REQUIRED_DIAGRAMS]
     for diagram_dir in OPTIONAL_DIAGRAM_DIRS:
         diagrams.extend(sorted((root / diagram_dir).glob("*.mmd")))
+    diagrams = list(dict.fromkeys(diagrams))
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="mint-mermaid-render-") as tmp:
         out_dir = Path(tmp)

--- a/tools/checks/tests/test_interaction_journey_diagrams_contract.py
+++ b/tools/checks/tests/test_interaction_journey_diagrams_contract.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DIAGRAM_DIR = ROOT / ".planning/journeys/diagrams"
+WORKFLOW = ROOT / "docs/MINT_AGENT_WORKFLOW.md"
+REGISTRY = ROOT / "docs/codex/INTERACTION_REGISTRY.md"
+CI = ROOT / ".github/workflows/ci.yml"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_data_quest_loop_diagram_pins_ledger_first_collection() -> None:
+    diagram = _text(DIAGRAM_DIR / "data_quest_loop.mmd")
+
+    required = (
+        "SCREEN_CONTRACTS reads[]",
+        "CoachProfileProvider.profile",
+        "BiographyRepository",
+        "DataQuest.planQuest",
+        "/data-block/:type",
+        "AskMode.reconfirm",
+        "mergeAnswers / applySaveFact / updateProfile",
+        "MintStateProvider recompute",
+        "Maestro / Patrol proof",
+        "Forbidden<br/>domain data in GoRouter.extra",
+        "Forbidden<br/>screen-local fact sliders",
+    )
+    for phrase in required:
+        assert phrase in diagram
+
+
+def test_independent_protection_diagram_pins_fact_vs_lever_boundary() -> None:
+    diagram = _text(DIAGRAM_DIR / "independent_protection.mmd")
+
+    required = (
+        "/segments/independant",
+        "/independants/avs",
+        "/independants/ijm",
+        "/independants/3a",
+        "/independants/dividende-salaire",
+        "/independants/lpp-volontaire",
+        "q_self_employed_income",
+        "q_company_profit_annual_chf",
+        "q_birth_year",
+        "q_has_pension_fund",
+        "q_cash_total",
+        "Scenario lever",
+        "Dividend-vs-salary uses q_company_profit_annual_chf",
+    )
+    for phrase in required:
+        assert phrase in diagram
+
+
+def test_workflow_and_registry_reference_active_mermaid_layers() -> None:
+    workflow = _text(WORKFLOW)
+    registry = _text(REGISTRY)
+
+    for doc in (workflow, registry):
+        assert ".planning/journeys/diagrams/data_quest_loop.mmd" in doc
+        assert ".planning/journeys/diagrams/independent_protection.mmd" in doc
+        assert "tools/checks/mermaid_render_guard.py" in doc
+
+    assert "INTERACTION_REGISTRY.md` executor remains Proposed" in workflow
+    assert "Ce registre reste `Status: Proposed`" in registry
+
+
+def test_ci_renders_mermaid_diagrams_before_contract_tests() -> None:
+    ci = _text(CI)
+    repository_header = "\n  repository-contract-tests:\n"
+    admin_header = "\n  admin-build-sanity:\n"
+    repository_start = ci.index(repository_header)
+    admin_start = ci.index(
+        admin_header,
+        repository_start,
+    )
+    repository_job = ci[repository_start:admin_start]
+
+    assert "repository-contract-tests:" not in ci[:repository_start]
+    assert "admin-build-sanity:" not in ci[
+        repository_start + len(repository_header) : admin_start
+    ]
+
+    assert "actions/setup-node@v4" in repository_job
+    assert "actions/cache@v4" in repository_job
+    assert "~/.npm" in repository_job
+    assert "~/.cache/puppeteer" in repository_job
+    assert "python3 tools/checks/mermaid_render_guard.py" in repository_job
+    assert "pytest tools/checks/tests tests/checks" in repository_job
+    assert repository_job.index("python3 tools/checks/mermaid_render_guard.py") < (
+        repository_job.index("pytest tools/checks/tests tests/checks")
+    )

--- a/tools/checks/tests/test_mermaid_render_guard.py
+++ b/tools/checks/tests/test_mermaid_render_guard.py
@@ -11,6 +11,16 @@ def _root(tmp_path: Path) -> Path:
     diagrams = tmp_path / "docs/codex"
     diagrams.mkdir(parents=True)
     (diagrams / "WIRING_GRAPH.mmd").write_text("flowchart LR\n  A-->B\n", encoding="utf-8")
+    journey_diagrams = tmp_path / ".planning/journeys/diagrams"
+    journey_diagrams.mkdir(parents=True)
+    (journey_diagrams / "data_quest_loop.mmd").write_text(
+        "flowchart LR\n  DataQuest-->Ledger\n",
+        encoding="utf-8",
+    )
+    (journey_diagrams / "independent_protection.mmd").write_text(
+        "flowchart LR\n  Independant-->Ledger\n",
+        encoding="utf-8",
+    )
     return tmp_path
 
 
@@ -59,7 +69,7 @@ def test_mermaid_render_guard_reports_render_failure(monkeypatch, tmp_path: Path
 
     errors = mermaid_render_guard.check(root)
 
-    assert len(errors) == 1
+    assert len(errors) == len(mermaid_render_guard.REQUIRED_DIAGRAMS)
     assert "WIRING_GRAPH.mmd failed to render: syntax error" in errors[0]
 
 
@@ -76,14 +86,14 @@ def test_mermaid_render_guard_rejects_empty_svg(monkeypatch, tmp_path: Path) -> 
 
     errors = mermaid_render_guard.check(root)
 
-    assert len(errors) == 1
+    assert len(errors) == len(mermaid_render_guard.REQUIRED_DIAGRAMS)
     assert "produced an empty or invalid SVG" in errors[0]
 
 
 def test_mermaid_render_guard_includes_optional_journey_diagrams(monkeypatch, tmp_path: Path) -> None:
     root = _root(tmp_path)
     optional = root / ".planning/journeys/diagrams"
-    optional.mkdir(parents=True)
+    optional.mkdir(parents=True, exist_ok=True)
     (optional / "system_map.mmd").write_text("flowchart LR\n  B-->C\n", encoding="utf-8")
     rendered: list[str] = []
 
@@ -101,13 +111,60 @@ def test_mermaid_render_guard_includes_optional_journey_diagrams(monkeypatch, tm
     assert mermaid_render_guard.check(root) == []
     assert rendered == [
         "docs/codex/WIRING_GRAPH.mmd",
+        ".planning/journeys/diagrams/data_quest_loop.mmd",
+        ".planning/journeys/diagrams/independent_protection.mmd",
         ".planning/journeys/diagrams/system_map.mmd",
     ]
+
+
+def test_mermaid_render_guard_uses_path_safe_output_names(monkeypatch, tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    optional = root / ".planning/journeys/diagrams"
+    (optional / "WIRING_GRAPH.mmd").write_text("flowchart LR\n  Z-->Y\n", encoding="utf-8")
+    outputs: list[str] = []
+
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    def fake_run(args, cwd, text, capture_output, timeout):  # noqa: ANN001
+        output = Path(args[args.index("-o") + 1])
+        outputs.append(output.name)
+        output.write_text("<svg>" + ("x" * 120) + "</svg>", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mermaid_render_guard.subprocess, "run", fake_run)
+
+    assert mermaid_render_guard.check(root) == []
+    assert len(outputs) == len(set(outputs))
+    assert "docs__codex__WIRING_GRAPH.svg" in outputs
+    assert "dot_planning__journeys__diagrams__WIRING_GRAPH.svg" in outputs
 
 
 def test_mermaid_render_guard_requires_wiring_graph(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
 
-    assert mermaid_render_guard.check(tmp_path) == [
-        "missing required MINT Mermaid diagram: docs/codex/WIRING_GRAPH.mmd"
-    ]
+    assert "missing required MINT Mermaid diagram: docs/codex/WIRING_GRAPH.mmd" in (
+        mermaid_render_guard.check(tmp_path)
+    )
+
+
+def test_mermaid_render_guard_requires_canonical_journey_diagrams(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docs/codex").mkdir(parents=True)
+    (tmp_path / "docs/codex/WIRING_GRAPH.mmd").write_text(
+        "flowchart LR\n  A-->B\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mermaid_render_guard.shutil, "which", lambda binary: "/usr/bin/npx")
+
+    errors = mermaid_render_guard.check(tmp_path)
+
+    assert (
+        "missing required MINT Mermaid diagram: .planning/journeys/diagrams/data_quest_loop.mmd"
+        in errors
+    )
+    assert (
+        "missing required MINT Mermaid diagram: .planning/journeys/diagrams/independent_protection.mmd"
+        in errors
+    )


### PR DESCRIPTION
## Summary
- promote two focused journey Mermaid maps as required artifacts: DataQuest loop and independent protection
- extend mermaid_render_guard to render required journey diagrams with path-safe SVG outputs
- wire Mermaid rendering into repository-contract-tests CI before pytest
- document that Interaction Registry remains Proposed while focused journey maps are active

## Verification
- python3 tools/checks/mermaid_render_guard.py
- python3 -m pytest tools/checks/tests tests/checks -q --tb=short
- python3 -m ruff check tools/checks/mermaid_render_guard.py tools/checks/tests/test_mermaid_render_guard.py tools/checks/tests/test_interaction_journey_diagrams_contract.py
- python3 tools/checks/mint_os_doctor.py --repo-only
- lefthook run pre-commit --file .github/workflows/ci.yml --file docs/MINT_AGENT_WORKFLOW.md --file docs/codex/INTERACTION_REGISTRY.md --file tools/checks/mermaid_render_guard.py --file tools/checks/tests/test_mermaid_render_guard.py --file tools/checks/tests/test_interaction_journey_diagrams_contract.py --file .planning/journeys/diagrams/data_quest_loop.mmd --file .planning/journeys/diagrams/independent_protection.mmd
- CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code codex/dividend-salary-ledger-facts-20260710 → PASS

## Notes
- No Flutter/backend/API runtime surface changed.
- Beads not initialized here because AGENTS.md requires a dedicated .beads init PR.