### PR TITLE
Map independent missing-fact interactions

### DIFF
--- a/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
+++ b/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
@@ -6,15 +6,20 @@
 
 - Extracted Flutter route references: 350
 - Distinct known route templates referenced: 92
-- Covered by declared Interaction Registry edge targets: 1
-- Known route templates not yet declared as edge targets: 91
+- Covered by declared Interaction Registry route nodes: 5
+- Known route templates not yet declared as route nodes: 87
+- Declared edge target route templates: 2
 - Unknown route literals/templates: 0
 
-## Covered Routes
+## Covered Registry Route Nodes
 
 | Status | Route | References |
 |---|---|---|
-| covered by declared edge target | `/hypotheque` | apps/mobile/lib/app.dart:588, apps/mobile/lib/screens/mortgage/affordability_screen.dart:192, apps/mobile/lib/screens/mortgage/affordability_screen.dart:203, apps/mobile/lib/screens/timeline_screen.dart:148 (+5 more) |
+| covered by declared route node | `/data-block/:type` | apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:1325, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:801, apps/mobile/lib/widgets/coach/confidence_blocks_bar.dart:82, apps/mobile/lib/widgets/coach/indicatif_banner.dart:99 |
+| covered by declared route node | `/home` | apps/mobile/lib/services/navigation/mint_nav.dart:19 |
+| covered by declared route node | `/hypotheque` | apps/mobile/lib/app.dart:588, apps/mobile/lib/screens/mortgage/affordability_screen.dart:192, apps/mobile/lib/screens/mortgage/affordability_screen.dart:203, apps/mobile/lib/screens/timeline_screen.dart:148 (+5 more) |
+| covered by declared route node | `/independants/avs` | apps/mobile/lib/widgets/coach/smart_shortcuts.dart:183 |
+| covered by declared route node | `/independants/dividende-salaire` | apps/mobile/lib/services/response_card_service.dart:403 |
 
 ## Uncovered Known Routes
 
@@ -45,7 +50,6 @@
 | uncovered literal route | `/coach/cockpit` | apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:507, apps/mobile/lib/widgets/coach/early_retirement_comparison.dart:202, apps/mobile/lib/widgets/coach/smart_shortcuts.dart:48, apps/mobile/lib/widgets/coach/trajectory_card.dart:54 |
 | uncovered literal route | `/concubinage` | apps/mobile/lib/app.dart:561, apps/mobile/lib/screens/timeline_screen.dart:71, apps/mobile/lib/services/cap_engine.dart:835, apps/mobile/lib/services/response_card_service.dart:301 (+1 more) |
 | uncovered literal route | `/couple` | apps/mobile/lib/screens/household/accept_invitation_screen.dart:187, apps/mobile/lib/services/response_card_service.dart:806 |
-| uncovered literal route | `/data-block/:type` | apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:1325, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:801, apps/mobile/lib/widgets/coach/confidence_blocks_bar.dart:82, apps/mobile/lib/widgets/coach/indicatif_banner.dart:99 |
 | uncovered literal route | `/debt/help` | apps/mobile/lib/widgets/common/debt_tools_nav.dart:40 |
 | uncovered literal route | `/debt/ratio` | apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart:67, apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart:78, apps/mobile/lib/services/response_card_service.dart:481, apps/mobile/lib/widgets/common/debt_tools_nav.dart:16 |
 | uncovered literal route | `/debt/repayment` | apps/mobile/lib/screens/debt_prevention/debt_ratio_screen.dart:944, apps/mobile/lib/screens/debt_prevention/repayment_screen.dart:63, apps/mobile/lib/screens/debt_prevention/repayment_screen.dart:74, apps/mobile/lib/services/cap_engine.dart:889 (+1 more) |
@@ -69,10 +73,7 @@
 | uncovered literal route | `/explore/travail` | apps/mobile/lib/screens/explore/explorer_screen.dart:53 |
 | uncovered literal route | `/first-job` | apps/mobile/lib/app.dart:573, apps/mobile/lib/screens/first_job_screen.dart:111, apps/mobile/lib/screens/first_job_screen.dart:122, apps/mobile/lib/screens/timeline_screen.dart:106 (+2 more) |
 | uncovered literal route | `/fiscal` | apps/mobile/lib/app.dart:609, apps/mobile/lib/data/educational_themes.dart:195, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:564, apps/mobile/lib/screens/fiscal_comparator_screen.dart:170 (+8 more) |
-| uncovered literal route | `/home` | apps/mobile/lib/services/navigation/mint_nav.dart:19 |
 | uncovered literal route | `/household/accept` | apps/mobile/lib/screens/household/household_screen.dart:509 |
-| uncovered literal route | `/independants/avs` | apps/mobile/lib/widgets/coach/smart_shortcuts.dart:183 |
-| uncovered literal route | `/independants/dividende-salaire` | apps/mobile/lib/services/response_card_service.dart:403 |
 | uncovered literal route | `/invalidite` | apps/mobile/lib/app.dart:633, apps/mobile/lib/screens/disability/disability_gap_screen.dart:94, apps/mobile/lib/screens/timeline_screen.dart:183, apps/mobile/lib/services/cap_engine.dart:871 (+2 more) |
 | uncovered literal route | `/libre-passage` | apps/mobile/lib/app.dart:549, apps/mobile/lib/services/response_card_service.dart:113 |
 | uncovered literal route | `/life-event/deces-proche` | apps/mobile/lib/app.dart:622, apps/mobile/lib/services/cap_engine.dart:841 |
@@ -118,8 +119,22 @@
 |---|---|---|
 | unknown route literal | _none_ |  |
 
+## Declared Route Node Routes
+
+| Route |
+|---|
+| `/data-block/:type` |
+| `/home` |
+| `/hypotheque` |
+| `/independants/3a` |
+| `/independants/avs` |
+| `/independants/dividende-salaire` |
+| `/independants/ijm` |
+| `/independants/lpp-volontaire` |
+
 ## Declared Edge Target Routes
 
 | Route |
 |---|
+| `/data-block/:type` |
 | `/hypotheque` |

--- a/.planning/journeys/diagrams/interaction_graph.mmd
+++ b/.planning/journeys/diagrams/interaction_graph.mmd
@@ -3,10 +3,22 @@ flowchart LR
   classDef route fill:#eef7f2,stroke:#0d7c66,stroke-width:1px,color:#10231f;
   classDef scene fill:#fff7e8,stroke:#b7791f,stroke-width:1px,color:#2b2112;
 
+  db_route_patrimoine["db.route.patrimoine<br/>/data-block/:type"]:::route
   db_route_revenu["db.route.revenu<br/>/data-block/:type"]:::route
   home_route_dashboard["home.route.dashboard<br/>/home"]:::route
+  indep_route_avs["indep.route.avs<br/>/independants/avs"]:::route
+  indep_route_divsalary["indep.route.divsalary<br/>/independants/dividende-salaire"]:::route
+  indep_route_ijm["indep.route.ijm<br/>/independants/ijm"]:::route
+  indep_route_lpp["indep.route.lpp<br/>/independants/lpp-volontaire"]:::route
+  indep_route_pillar3a["indep.route.pillar3a<br/>/independants/3a"]:::route
   mortgage_route_hypotheque["mortgage.route.hypotheque<br/>/hypotheque"]:::route
 
+  indep_route_avs -->|"tap / push"| db_route_revenu
+  indep_route_divsalary -->|"tap / push"| db_route_revenu
+  indep_route_ijm -->|"tap / push"| db_route_revenu
+  indep_route_lpp -->|"tap / push"| db_route_revenu
+  indep_route_pillar3a -->|"tap / push"| db_route_patrimoine
+  indep_route_pillar3a -->|"tap / push"| db_route_revenu
   db_route_revenu -->|"submit / push"| mortgage_route_hypotheque
 
   db_route_revenu -. "back" .-> home_route_dashboard

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -118,9 +118,9 @@ a focused `.mmd` diagram before changing the screen.
 `interactions/INDEX.md` and
 `.planning/journeys/diagrams/interaction_graph.mmd`. The executor/codegen
 remains Proposed until its own go/no-go threshold is met.
-`python3 tools/checks/interaction_coverage_audit.py --write` snapshots real
+`python3 tools/checks/interaction_coverage_audit.py --write` snapshots literal
 Flutter navigation references and compares them with declared Interaction
-Registry edge targets in
+Registry route nodes in
 `.planning/journeys/INTERACTION_COVERAGE_AUDIT.md`. It is intentionally a
 coverage backlog, not a product-failure gate: use it to choose the next journey
 to migrate, and keep it current whenever screens, CTA routes, or registry YAML

--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -66,8 +66,8 @@ La cartographie de parcours est active et vérifiée par
 régénère `interactions/INDEX.md` plus
 `.planning/journeys/diagrams/interaction_graph.mmd`.
 `tools/checks/interaction_coverage_audit.py --write` photographie les
-références de navigation Flutter réelles et les compare aux routes cibles déjà
-déclarées dans les edges YAML. Son rapport généré
+références de navigation Flutter littérales et les compare aux routes déjà
+déclarées comme nodes dans les YAML. Son rapport généré
 `.planning/journeys/INTERACTION_COVERAGE_AUDIT.md` sert de backlog objectif pour
 prioriser les prochains flux à migrer ; il ne remplace pas le registry et ne
 bloque pas encore les routes non migrées.
@@ -83,6 +83,11 @@ bloque pas encore les routes non migrées.
 - `interactions/revenu_to_mortgage.yaml` : premier flux piloté, reliant
   `/data-block/:type` à `/hypotheque` avec preuve Maestro
   `apps/mobile/.maestro/f2_datablock_to_mortgage.yaml`.
+- `interactions/independent_missing_facts.yaml` : flux indépendant réel,
+  limité aux CTA prouvées des écrans AVS/IJM/3a/dividende-salaire/LPP vers
+  DataBlock revenu/patrimoine. Il ne déclare pas de hub
+  `/segments/independant -> outils` tant que le code et Maestro ne prouvent pas
+  ces taps.
 - `interactions/INDEX.md` et
   `.planning/journeys/diagrams/interaction_graph.mmd` : artefacts générés par le
   linter depuis les YAML, jamais édités à la main.

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -4,4 +4,10 @@
 
 | Flow | Edge | From -> To | Trigger | Transition | Runtime proof |
 |---|---|---|---|---|---|
+| independent_missing_facts | `indep.edge.avs.enrich_income` | `indep.route.avs -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_avs_cotisations.yaml` |
+| independent_missing_facts | `indep.edge.divsalary.enrich_profit` | `indep.route.divsalary -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_dividende_salaire.yaml` |
+| independent_missing_facts | `indep.edge.ijm.enrich_income_or_age` | `indep.route.ijm -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_ijm.yaml` |
+| independent_missing_facts | `indep.edge.lpp.enrich_income_or_age` | `indep.route.lpp -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_lpp_volontaire.yaml` |
+| independent_missing_facts | `indep.edge.pillar3a.enrich_cash` | `indep.route.pillar3a -> db.route.patrimoine` | `tap` | `push` | `apps/mobile/.maestro/indep_pillar3a.yaml` |
+| independent_missing_facts | `indep.edge.pillar3a.enrich_income_or_pension` | `indep.route.pillar3a -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_pillar3a.yaml` |
 | revenu_to_mortgage | `db.edge.revenu.submit` | `db.route.revenu -> mortgage.route.hypotheque` | `submit` | `push` | `apps/mobile/.maestro/f2_datablock_to_mortgage.yaml` |

--- a/interactions/independent_missing_facts.yaml
+++ b/interactions/independent_missing_facts.yaml
@@ -1,0 +1,138 @@
+schema_version: 1
+flow:
+  id: independent_missing_facts
+  title: "Independent protection screens to missing ledger facts"
+  exits: [db.route.revenu, db.route.patrimoine]
+  invariants:
+    max_depth: 3
+    back_never_loses_input: true
+    every_scene_has_exit: true
+
+nodes:
+  - id: indep.route.avs
+    kind: route
+    route: /independants/avs
+    widget: screens/independants/avs_cotisations_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: indep.route.ijm
+    kind: route
+    route: /independants/ijm
+    widget: screens/independants/ijm_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: indep.route.pillar3a
+    kind: route
+    route: /independants/3a
+    widget: screens/independants/pillar_3a_indep_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: indep.route.divsalary
+    kind: route
+    route: /independants/dividende-salaire
+    widget: screens/independants/dividende_vs_salaire_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: indep.route.lpp
+    kind: route
+    route: /independants/lpp-volontaire
+    widget: screens/independants/lpp_volontaire_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: db.route.revenu
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+  - id: db.route.patrimoine
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+edges:
+  - id: indep.edge.avs.enrich_income
+    from: indep.route.avs
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect self-employed income before calculating AVS contributions"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_avs_cotisations.yaml
+
+  - id: indep.edge.ijm.enrich_income_or_age
+    from: indep.route.ijm
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect independent income or birth year before estimating IJM cover"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_ijm.yaml
+
+  - id: indep.edge.pillar3a.enrich_income_or_pension
+    from: indep.route.pillar3a
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect independent income or pension-fund status before calculating 3a room"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_pillar3a.yaml
+
+  - id: indep.edge.pillar3a.enrich_cash
+    from: indep.route.pillar3a
+    to: db.route.patrimoine
+    trigger: tap
+    intent: "Collect liquid savings before showing independent 3a safe-mode result"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_pillar3a.yaml
+
+  - id: indep.edge.divsalary.enrich_profit
+    from: indep.route.divsalary
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect company profit envelope before comparing salary and dividend"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_dividende_salaire.yaml
+
+  - id: indep.edge.lpp.enrich_income_or_age
+    from: indep.route.lpp
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect independent income or birth year before estimating voluntary LPP"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_lpp_volontaire.yaml

--- a/tools/checks/interaction_coverage_audit.py
+++ b/tools/checks/interaction_coverage_audit.py
@@ -212,6 +212,17 @@ def declared_edge_target_routes(root: Path) -> set[str]:
     return routes
 
 
+def declared_route_node_routes(root: Path) -> set[str]:
+    routes: set[str] = set()
+    for doc in _load_interactions(root):
+        for node in doc.get("nodes", []):
+            if isinstance(node, dict) and node.get("kind") == "route":
+                route = node.get("route")
+                if isinstance(route, str):
+                    routes.add(route)
+    return routes
+
+
 def _group_locations(refs: list[RouteReference], root: Path, limit: int = 4) -> str:
     locations = [ref.location(root) for ref in refs[:limit]]
     extra = len(refs) - len(locations)
@@ -223,15 +234,16 @@ def generate_report(root: Path) -> str:
     root = root.resolve()
     route_registry = _route_registry(root)
     refs = extract_references(root)
-    declared = declared_edge_target_routes(root)
+    declared_nodes = declared_route_node_routes(root)
+    declared_targets = declared_edge_target_routes(root)
     refs_by_route: dict[str, list[RouteReference]] = {}
     for ref in refs:
         refs_by_route.setdefault(ref.canonical_route, []).append(ref)
 
     known_routes = set(refs_by_route).intersection(route_registry)
     unknown_routes = set(refs_by_route).difference(route_registry)
-    covered_routes = known_routes.intersection(declared)
-    uncovered_routes = known_routes.difference(declared)
+    covered_routes = known_routes.intersection(declared_nodes)
+    uncovered_routes = known_routes.difference(declared_nodes)
 
     lines = [
         "# Interaction Coverage Audit",
@@ -242,21 +254,22 @@ def generate_report(root: Path) -> str:
         "",
         f"- Extracted Flutter route references: {len(refs)}",
         f"- Distinct known route templates referenced: {len(known_routes)}",
-        f"- Covered by declared Interaction Registry edge targets: {len(covered_routes)}",
-        f"- Known route templates not yet declared as edge targets: {len(uncovered_routes)}",
+        f"- Covered by declared Interaction Registry route nodes: {len(covered_routes)}",
+        f"- Known route templates not yet declared as route nodes: {len(uncovered_routes)}",
+        f"- Declared edge target route templates: {len(declared_targets)}",
         f"- Unknown route literals/templates: {len(unknown_routes)}",
         "",
-        "## Covered Routes",
+        "## Covered Registry Route Nodes",
         "",
         "| Status | Route | References |",
         "|---|---|---|",
     ]
     for route in sorted(covered_routes):
         lines.append(
-            f"| covered by declared edge target | `{route}` | {_group_locations(refs_by_route[route], root)} |",
+            f"| covered by declared route node | `{route}` | {_group_locations(refs_by_route[route], root)} |",
         )
     if not covered_routes:
-        lines.append("| covered by declared edge target | _none_ |  |")
+        lines.append("| covered by declared route node | _none_ |  |")
 
     lines.extend(
         [
@@ -288,15 +301,28 @@ def generate_report(root: Path) -> str:
     lines.extend(
         [
             "",
+            "## Declared Route Node Routes",
+            "",
+            "| Route |",
+            "|---|",
+        ],
+    )
+    for route in sorted(declared_nodes):
+        lines.append(f"| `{route}` |")
+    if not declared_nodes:
+        lines.append("| _none_ |")
+    lines.extend(
+        [
+            "",
             "## Declared Edge Target Routes",
             "",
             "| Route |",
             "|---|",
         ],
     )
-    for route in sorted(declared):
+    for route in sorted(declared_targets):
         lines.append(f"| `{route}` |")
-    if not declared:
+    if not declared_targets:
         lines.append("| _none_ |")
     return "\n".join(lines) + "\n"
 

--- a/tools/checks/interaction_registry_lint.py
+++ b/tools/checks/interaction_registry_lint.py
@@ -36,6 +36,7 @@ EXTRA_ALLOWLIST_RE = re.compile(
     r"^[A-Z][A-Za-z0-9_]*(Id|Ids|Key|Code|Token|Enum|Type|Selection|Slug)$",
 )
 BACK_TARGET_RE = re.compile(r"^(?:pop_to|reset_to)\(([^)]+)\)$")
+DATA_BLOCK_NODE_RE = re.compile(r"^db\.route\.([a-z0-9_]+)$")
 
 
 @dataclass(frozen=True)
@@ -120,6 +121,43 @@ def _arb_keys(root: Path) -> set[str]:
     return {key for key in data if not key.startswith("@")}
 
 
+def _data_block_instance_for_node(node: dict[str, Any]) -> str | None:
+    if node.get("route") != "/data-block/:type":
+        return None
+    node_id = node.get("id")
+    if not isinstance(node_id, str):
+        return None
+    match = DATA_BLOCK_NODE_RE.match(node_id)
+    if not match:
+        return None
+    return f"/data-block/{match.group(1)}"
+
+
+def _validate_data_block_edge_reference(
+    root: Path,
+    rel_path: str,
+    edge_id: str,
+    from_node: dict[str, Any],
+    to_node: dict[str, Any],
+    errors: list[str],
+) -> None:
+    expected_literal = _data_block_instance_for_node(to_node)
+    if expected_literal is None:
+        return
+    widget = from_node.get("widget")
+    if not isinstance(widget, str):
+        return
+    widget_path = root / "apps/mobile/lib" / widget
+    if not widget_path.is_file():
+        return
+    text = widget_path.read_text(encoding="utf-8", errors="ignore")
+    if expected_literal not in text:
+        errors.append(
+            f"{rel_path}: edge {edge_id} target instance {expected_literal} "
+            f"is not referenced in source widget {widget}",
+        )
+
+
 def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
     routes = _route_registry(root)
     analytics = _analytics_events(root)
@@ -153,6 +191,7 @@ def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
             errors.append(f"{rel_path}: edges must contain at least one edge")
 
         node_ids: set[str] = set()
+        nodes_by_id: dict[str, dict[str, Any]] = {}
         incoming: dict[str, int] = {}
         outgoing: dict[str, int] = {}
         exits = flow.get("exits") or []
@@ -170,6 +209,7 @@ def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
             if node_id in node_ids:
                 errors.append(f"{rel_path}: duplicate node id {node_id}")
             node_ids.add(node_id)
+            nodes_by_id[node_id] = node
             if node_kind not in ("route", "scene"):
                 errors.append(f"{rel_path}: node {node_id} kind must be route or scene")
             if node_kind == "route":
@@ -178,6 +218,10 @@ def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
                     errors.append(f"{rel_path}: node {node_id} route is required")
                 elif route not in routes:
                     errors.append(f"{rel_path}: unknown route {route}")
+                elif route == "/data-block/:type" and _data_block_instance_for_node(node) is None:
+                    errors.append(
+                        f"{rel_path}: data-block node {node_id} must use id format db.route.<type>",
+                    )
             if node_kind == "scene" and not node.get("parent"):
                 errors.append(f"{rel_path}: scene {node_id} must declare parent")
             widget = node.get("widget")
@@ -226,6 +270,11 @@ def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
                 outgoing[from_node] = outgoing.get(from_node, 0) + 1
             if isinstance(to_node, str):
                 incoming[to_node] = incoming.get(to_node, 0) + 1
+            if isinstance(from_node, str) and isinstance(to_node, str):
+                source_node = nodes_by_id.get(from_node)
+                target_node = nodes_by_id.get(to_node)
+                if source_node is not None and target_node is not None:
+                    _validate_data_block_edge_reference(root, rel_path, edge_id, source_node, target_node, errors)
             if edge.get("trigger") not in ("tap", "swipe", "long_press", "submit", "system"):
                 errors.append(f"{rel_path}: edge {edge_id} trigger is invalid")
             if edge.get("transition") not in ("push", "replace", "reset_stack", "sheet", "dialog", "in_shell"):

--- a/tools/checks/tests/test_interaction_coverage_audit.py
+++ b/tools/checks/tests/test_interaction_coverage_audit.py
@@ -72,6 +72,7 @@ void wire(context, doc) {
   context.go('/coach/chat?topic=budget');
   context.push('/missing');
   final item = LinkItem(route: '/documents/${doc.id}'); // context.push('/inline-commented');
+  final enrichment = LinkItem(route: '/data-block/${type}');
   /*
    context.push('/block-commented');
    */
@@ -94,7 +95,8 @@ def test_interaction_coverage_audit_generates_current_report(tmp_path: Path) -> 
     report = (tmp_path / ".planning/journeys/INTERACTION_COVERAGE_AUDIT.md").read_text(
         encoding="utf-8",
     )
-    assert "covered by declared edge target | `/hypotheque`" in report
+    assert "covered by declared route node | `/hypotheque`" in report
+    assert "covered by declared route node | `/data-block/:type`" in report
     assert "uncovered literal route | `/coach/chat`" in report
     assert "uncovered literal route | `/documents/:id`" in report
     assert "unknown route literal | `/missing`" in report
@@ -109,6 +111,7 @@ def test_interaction_coverage_extracts_query_and_dynamic_route_templates(tmp_pat
 
     assert by_raw["/coach/chat?topic=budget"].canonical_route == "/coach/chat"
     assert by_raw["/documents/${doc.id}"].canonical_route == "/documents/:id"
+    assert by_raw["/data-block/${type}"].canonical_route == "/data-block/:type"
     assert "/commented" not in by_raw
     assert "/inline-commented" not in by_raw
     assert "/block-commented" not in by_raw

--- a/tools/checks/tests/test_interaction_registry_lint.py
+++ b/tools/checks/tests/test_interaction_registry_lint.py
@@ -11,6 +11,7 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
   '/data-block/:type': RouteMeta(path: '/data-block/:type'),
   '/hypotheque': RouteMeta(path: '/hypotheque'),
   '/home': RouteMeta(path: '/home'),
+  '/independants/avs': RouteMeta(path: '/independants/avs'),
 };
 """,
         encoding="utf-8",
@@ -30,6 +31,11 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
         "class AffordabilityScreen {}\n",
         encoding="utf-8",
     )
+    (root / "apps/mobile/lib/screens/independants").mkdir(parents=True)
+    (root / "apps/mobile/lib/screens/independants/avs_cotisations_screen.dart").write_text(
+        "void cta(context) => context.push('/data-block/revenu?inputKey=q_self_employed_income');\n",
+        encoding="utf-8",
+    )
     (root / "apps/mobile/lib/services").mkdir(parents=True)
     (root / "apps/mobile/lib/services/analytics_events.dart").write_text(
         "const String kEventCtaClicked = 'cta_clicked';\n",
@@ -43,6 +49,10 @@ const Map<String, RouteMeta> kRouteRegistry = <String, RouteMeta>{
     (root / "apps/mobile/.maestro").mkdir(parents=True)
     (root / "apps/mobile/.maestro/f2_datablock_to_mortgage.yaml").write_text(
         "appId: ch.mint.app\n---\n- assertVisible: {text: Revenu}\n",
+        encoding="utf-8",
+    )
+    (root / "apps/mobile/.maestro/indep_avs_cotisations.yaml").write_text(
+        "appId: ch.mint.app\n---\n- assertVisible: {text: AVS}\n",
         encoding="utf-8",
     )
     (root / ".planning/journeys/diagrams").mkdir(parents=True)
@@ -224,6 +234,67 @@ def test_interaction_registry_lint_rejects_undeclared_back_target(tmp_path: Path
     assert (
         "interactions/revenu_to_mortgage.yaml: node db.route.revenu back target "
         "is undeclared: home.route.dashbord"
+    ) in interaction_registry_lint.check(tmp_path)
+
+
+def test_interaction_registry_lint_rejects_unreferenced_data_block_instance(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+    interactions = tmp_path / "interactions"
+    interactions.mkdir()
+    (interactions / "independent_missing_facts.yaml").write_text(
+        """
+schema_version: 1
+flow:
+  id: independent_missing_facts
+  title: "Independent missing facts"
+  exits: [db.route.patrimoine]
+nodes:
+  - id: indep.route.avs
+    kind: route
+    route: /independants/avs
+    widget: screens/independants/avs_cotisations_screen.dart
+    entries: [{via: deeplink, back: pop}]
+    states: [content]
+  - id: db.route.patrimoine
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries: [{via: flow, back: pop}]
+    states: [content]
+edges:
+  - id: indep.edge.avs.enrich_cash
+    from: indep.route.avs
+    to: db.route.patrimoine
+    trigger: tap
+    intent: "Collect cash"
+    payload: {path_params: {type: EnrichmentType}, extra: InputKey}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/indep_avs_cotisations.yaml
+""",
+        encoding="utf-8",
+    )
+
+    assert (
+        "interactions/independent_missing_facts.yaml: edge indep.edge.avs.enrich_cash "
+        "target instance /data-block/patrimoine is not referenced in source widget "
+        "screens/independants/avs_cotisations_screen.dart"
+    ) in interaction_registry_lint.check(tmp_path)
+
+
+def test_interaction_registry_lint_rejects_unenforced_data_block_node_name(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+    _write_registry(tmp_path)
+    registry = tmp_path / "interactions/revenu_to_mortgage.yaml"
+    registry.write_text(
+        registry.read_text(encoding="utf-8").replace("db.route.revenu", "data.route.revenu"),
+        encoding="utf-8",
+    )
+
+    assert (
+        "interactions/revenu_to_mortgage.yaml: data-block node data.route.revenu "
+        "must use id format db.route.<type>"
     ) in interaction_registry_lint.check(tmp_path)
 
 


### PR DESCRIPTION
## Summary
- add independent_missing_facts.yaml for real independent-screen CTA edges into DataBlock revenue/patrimoine
- regenerate Interaction Registry index, generated Mermaid graph, and coverage audit
- harden the registry lint so DataBlock edge instances must be referenced by the source widget and DataBlock node ids keep the enforced db.route.<type> shape
- reframe coverage audit around declared route nodes while retaining edge-target counts

## QA
- python3 tools/checks/interaction_registry_lint.py
- python3 tools/checks/interaction_coverage_audit.py
- python3 tools/checks/mermaid_render_guard.py
- python3 -m pytest tools/checks/tests tests/checks -q --tb=short
- python3 tools/checks/mint_os_doctor.py --repo-only
- python3 tools/checks/patrol_tooling_guard.py
- lefthook run pre-commit
- MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=60 MAESTRO_STALL_PROBE_INTERVAL=20 bash tools/simulator/maestro_with_watchdog.sh test apps/mobile/.maestro/indep_ijm.yaml
- Claude external audit: PASS, no P0/P1