### PR TITLE
Map first-job missing-fact interaction

### DIFF
--- a/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
+++ b/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
@@ -6,8 +6,8 @@
 
 - Extracted Flutter route references: 350
 - Distinct known route templates referenced: 92
-- Covered by declared Interaction Registry route nodes: 5
-- Known route templates not yet declared as route nodes: 87
+- Covered by declared Interaction Registry route nodes: 6
+- Known route templates not yet declared as route nodes: 86
 - Declared edge target route templates: 2
 - Unknown route literals/templates: 0
 
@@ -16,6 +16,7 @@
 | Status | Route | References |
 |---|---|---|
 | covered by declared route node | `/data-block/:type` | apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:1325, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:801, apps/mobile/lib/widgets/coach/confidence_blocks_bar.dart:82, apps/mobile/lib/widgets/coach/indicatif_banner.dart:99 |
+| covered by declared route node | `/first-job` | apps/mobile/lib/app.dart:573, apps/mobile/lib/screens/first_job_screen.dart:111, apps/mobile/lib/screens/first_job_screen.dart:122, apps/mobile/lib/screens/timeline_screen.dart:106 (+2 more) |
 | covered by declared route node | `/home` | apps/mobile/lib/services/navigation/mint_nav.dart:19 |
 | covered by declared route node | `/hypotheque` | apps/mobile/lib/app.dart:588, apps/mobile/lib/screens/mortgage/affordability_screen.dart:192, apps/mobile/lib/screens/mortgage/affordability_screen.dart:203, apps/mobile/lib/screens/timeline_screen.dart:148 (+5 more) |
 | covered by declared route node | `/independants/avs` | apps/mobile/lib/widgets/coach/smart_shortcuts.dart:183 |
@@ -71,7 +72,6 @@
 | uncovered literal route | `/explore/retraite` | apps/mobile/lib/screens/explore/explorer_screen.dart:41 |
 | uncovered literal route | `/explore/sante` | apps/mobile/lib/screens/explore/explorer_screen.dart:77 |
 | uncovered literal route | `/explore/travail` | apps/mobile/lib/screens/explore/explorer_screen.dart:53 |
-| uncovered literal route | `/first-job` | apps/mobile/lib/app.dart:573, apps/mobile/lib/screens/first_job_screen.dart:111, apps/mobile/lib/screens/first_job_screen.dart:122, apps/mobile/lib/screens/timeline_screen.dart:106 (+2 more) |
 | uncovered literal route | `/fiscal` | apps/mobile/lib/app.dart:609, apps/mobile/lib/data/educational_themes.dart:195, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:564, apps/mobile/lib/screens/fiscal_comparator_screen.dart:170 (+8 more) |
 | uncovered literal route | `/household/accept` | apps/mobile/lib/screens/household/household_screen.dart:509 |
 | uncovered literal route | `/invalidite` | apps/mobile/lib/app.dart:633, apps/mobile/lib/screens/disability/disability_gap_screen.dart:94, apps/mobile/lib/screens/timeline_screen.dart:183, apps/mobile/lib/services/cap_engine.dart:871 (+2 more) |
@@ -124,6 +124,7 @@
 | Route |
 |---|
 | `/data-block/:type` |
+| `/first-job` |
 | `/home` |
 | `/hypotheque` |
 | `/independants/3a` |

--- a/.planning/journeys/diagrams/interaction_graph.mmd
+++ b/.planning/journeys/diagrams/interaction_graph.mmd
@@ -5,6 +5,7 @@ flowchart LR
 
   db_route_patrimoine["db.route.patrimoine<br/>/data-block/:type"]:::route
   db_route_revenu["db.route.revenu<br/>/data-block/:type"]:::route
+  firstjob_route_first_job["firstjob.route.first_job<br/>/first-job"]:::route
   home_route_dashboard["home.route.dashboard<br/>/home"]:::route
   indep_route_avs["indep.route.avs<br/>/independants/avs"]:::route
   indep_route_divsalary["indep.route.divsalary<br/>/independants/dividende-salaire"]:::route
@@ -13,6 +14,7 @@ flowchart LR
   indep_route_pillar3a["indep.route.pillar3a<br/>/independants/3a"]:::route
   mortgage_route_hypotheque["mortgage.route.hypotheque<br/>/hypotheque"]:::route
 
+  firstjob_route_first_job -->|"tap / push"| db_route_revenu
   indep_route_avs -->|"tap / push"| db_route_revenu
   indep_route_divsalary -->|"tap / push"| db_route_revenu
   indep_route_ijm -->|"tap / push"| db_route_revenu

--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -88,6 +88,10 @@ bloque pas encore les routes non migrées.
   DataBlock revenu/patrimoine. Il ne déclare pas de hub
   `/segments/independant -> outils` tant que le code et Maestro ne prouvent pas
   ces taps.
+- `interactions/first_job_missing_facts.yaml` : flux premier emploi réel,
+  limité à la CTA `first_job_enrich_profile_cta` vers DataBlock revenu. Il ne
+  déclare pas de sortie vers 3a/fiscalité tant que ces transitions ne sont pas
+  des interactions produit prouvées dans l'écran.
 - `interactions/INDEX.md` et
   `.planning/journeys/diagrams/interaction_graph.mmd` : artefacts générés par le
   linter depuis les YAML, jamais édités à la main.

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -4,6 +4,7 @@
 
 | Flow | Edge | From -> To | Trigger | Transition | Runtime proof |
 |---|---|---|---|---|---|
+| first_job_missing_facts | `firstjob.edge.first_job.enrich_revenue` | `firstjob.route.first_job -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/first_job_ledger.yaml` |
 | independent_missing_facts | `indep.edge.avs.enrich_income` | `indep.route.avs -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_avs_cotisations.yaml` |
 | independent_missing_facts | `indep.edge.divsalary.enrich_profit` | `indep.route.divsalary -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_dividende_salaire.yaml` |
 | independent_missing_facts | `indep.edge.ijm.enrich_income_or_age` | `indep.route.ijm -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_ijm.yaml` |

--- a/interactions/first_job_missing_facts.yaml
+++ b/interactions/first_job_missing_facts.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+flow:
+  id: first_job_missing_facts
+  title: "First job screen to canonical revenue facts"
+  exits: [db.route.revenu]
+  invariants:
+    max_depth: 2
+    back_never_loses_input: true
+    every_scene_has_exit: true
+
+nodes:
+  - id: firstjob.route.first_job
+    kind: route
+    route: /first-job
+    widget: screens/first_job_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: db.route.revenu
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+edges:
+  - id: firstjob.edge.first_job.enrich_revenue
+    from: firstjob.route.first_job
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect salary, age, and canton before analyzing a first job"
+    payload: {path_params: {type: EnrichmentType}}
+    transition: push
+    back: pop
+    analytics: cta_clicked
+    test_ref: apps/mobile/.maestro/first_job_ledger.yaml


### PR DESCRIPTION
## Summary
- add first_job_missing_facts.yaml for the real first-job enrichment CTA into DataBlock revenue
- regenerate Interaction Registry index, generated Mermaid graph, and coverage audit
- document that first-job only maps the proven DataBlock CTA, not unproven 3a/fiscal transitions

## QA
- python3 tools/checks/interaction_registry_lint.py
- python3 tools/checks/interaction_coverage_audit.py
- python3 tools/checks/mermaid_render_guard.py
- python3 -m pytest tools/checks/tests tests/checks -q --tb=short
- python3 tools/checks/mint_os_doctor.py --repo-only
- python3 tools/checks/patrol_tooling_guard.py
- lefthook run pre-commit
- MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=60 MAESTRO_STALL_PROBE_INTERVAL=20 bash tools/simulator/maestro_with_watchdog.sh test apps/mobile/.maestro/first_job_ledger.yaml
- Claude external audit: PASS, no P0/P1; P2 payload note addressed before commit