### PR TITLE
Map scan recovery interactions

### DIFF
--- a/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
+++ b/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
@@ -6,9 +6,9 @@
 
 - Extracted Flutter route references: 350
 - Distinct known route templates referenced: 92
-- Covered by declared Interaction Registry route nodes: 6
-- Known route templates not yet declared as route nodes: 86
-- Declared edge target route templates: 2
+- Covered by declared Interaction Registry route nodes: 9
+- Known route templates not yet declared as route nodes: 83
+- Declared edge target route templates: 4
 - Unknown route literals/templates: 0
 
 ## Covered Registry Route Nodes
@@ -21,6 +21,9 @@
 | covered by declared route node | `/hypotheque` | apps/mobile/lib/app.dart:588, apps/mobile/lib/screens/mortgage/affordability_screen.dart:192, apps/mobile/lib/screens/mortgage/affordability_screen.dart:203, apps/mobile/lib/screens/timeline_screen.dart:148 (+5 more) |
 | covered by declared route node | `/independants/avs` | apps/mobile/lib/widgets/coach/smart_shortcuts.dart:183 |
 | covered by declared route node | `/independants/dividende-salaire` | apps/mobile/lib/services/response_card_service.dart:403 |
+| covered by declared route node | `/scan` | apps/mobile/lib/screens/coach/coach_chat_screen.dart:1940, apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:465, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:126, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:160 (+9 more) |
+| covered by declared route node | `/scan/impact` | apps/mobile/lib/screens/document_scan/document_impact_screen.dart:721, apps/mobile/lib/screens/document_scan/extraction_review_screen.dart:745 |
+| covered by declared route node | `/scan/review` | apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:485, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1397, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1617, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:645 (+2 more) |
 
 ## Uncovered Known Routes
 
@@ -98,9 +101,6 @@
 | uncovered literal route | `/rapport` | apps/mobile/lib/widgets/mentor_fab.dart:69 |
 | uncovered literal route | `/rente-vs-capital` | apps/mobile/lib/app.dart:545, apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart:146, apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart:157, apps/mobile/lib/screens/arbitrage/rente_vs_capital_screen.dart:533 (+11 more) |
 | uncovered literal route | `/retraite` | apps/mobile/lib/app.dart:544, apps/mobile/lib/data/educational_themes.dart:133, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:335, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:350 (+5 more) |
-| uncovered literal route | `/scan` | apps/mobile/lib/screens/coach/coach_chat_screen.dart:1940, apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:465, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:126, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:160 (+9 more) |
-| uncovered literal route | `/scan/impact` | apps/mobile/lib/screens/document_scan/document_impact_screen.dart:721, apps/mobile/lib/screens/document_scan/extraction_review_screen.dart:745 |
-| uncovered literal route | `/scan/review` | apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:485, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1397, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1617, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:645 (+2 more) |
 | uncovered literal route | `/segments/frontalier` | apps/mobile/lib/app.dart:578, apps/mobile/lib/services/response_card_service.dart:380 |
 | uncovered literal route | `/segments/gender-gap` | apps/mobile/lib/services/response_card_service.dart:452 |
 | uncovered literal route | `/segments/independant` | apps/mobile/lib/app.dart:576, apps/mobile/lib/screens/timeline_screen.dart:120, apps/mobile/lib/services/cap_engine.dart:823, apps/mobile/lib/widgets/life_event_suggestions.dart:128 |
@@ -132,10 +132,15 @@
 | `/independants/dividende-salaire` |
 | `/independants/ijm` |
 | `/independants/lpp-volontaire` |
+| `/scan` |
+| `/scan/impact` |
+| `/scan/review` |
 
 ## Declared Edge Target Routes
 
 | Route |
 |---|
 | `/data-block/:type` |
+| `/home` |
 | `/hypotheque` |
+| `/scan` |

--- a/.planning/journeys/diagrams/interaction_graph.mmd
+++ b/.planning/journeys/diagrams/interaction_graph.mmd
@@ -13,7 +13,12 @@ flowchart LR
   indep_route_lpp["indep.route.lpp<br/>/independants/lpp-volontaire"]:::route
   indep_route_pillar3a["indep.route.pillar3a<br/>/independants/3a"]:::route
   mortgage_route_hypotheque["mortgage.route.hypotheque<br/>/hypotheque"]:::route
+  scan_route_capture["scan.route.capture<br/>/scan"]:::route
+  scan_route_impact_recovery["scan.route.impact_recovery<br/>/scan/impact"]:::route
+  scan_route_review_recovery["scan.route.review_recovery<br/>/scan/review"]:::route
 
+  scan_route_impact_recovery -->|"tap / go"| home_route_dashboard
+  scan_route_review_recovery -->|"tap / go"| scan_route_capture
   firstjob_route_first_job -->|"tap / push"| db_route_revenu
   indep_route_avs -->|"tap / push"| db_route_revenu
   indep_route_divsalary -->|"tap / push"| db_route_revenu
@@ -25,3 +30,5 @@ flowchart LR
 
   db_route_revenu -. "back" .-> home_route_dashboard
   mortgage_route_hypotheque -. "back" .-> home_route_dashboard
+  scan_route_impact_recovery -. "back" .-> home_route_dashboard
+  scan_route_review_recovery -. "back" .-> scan_route_capture

--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -92,6 +92,12 @@ bloque pas encore les routes non migrées.
   limité à la CTA `first_job_enrich_profile_cta` vers DataBlock revenu. Il ne
   déclare pas de sortie vers 3a/fiscalité tant que ces transitions ne sont pas
   des interactions produit prouvées dans l'écran.
+- `interactions/document_scan_recovery.yaml` : flux scan documentaire réel,
+  limité aux routes dégradées `/scan/review` et `/scan/impact` quand le
+  payload GoRouter manque. Il déclare seulement les CTA de récupération
+  prouvées par Maestro (`r1_scan_review`, `r2_scan_impact`) et ne déclare pas
+  encore le pipeline OCR réussi tant que le contrat `extra` domaine
+  `ExtractionResult` / `Map` n'est pas remplacé ou explicitement testé.
 - `interactions/INDEX.md` et
   `.planning/journeys/diagrams/interaction_graph.mmd` : artefacts générés par le
   linter depuis les YAML, jamais édités à la main.
@@ -157,7 +163,7 @@ edges:
       extra: dart_type?                  # ids / enums / codes / tokens /
                                          # sélection éphémère UNIQUEMENT (A4)
       # Le codegen vérifie que la cible consomme exactement ce contrat.
-    transition: push | replace | reset_stack | sheet | dialog | in_shell
+    transition: push | go | replace | reset_stack | sheet | dialog | in_shell
     back: ...                # v1 : enforcement walker (D2)
     guards: [guard_id]?
     variant: string?

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -4,6 +4,8 @@
 
 | Flow | Edge | From -> To | Trigger | Transition | Runtime proof |
 |---|---|---|---|---|---|
+| document_scan_recovery | `scan.edge.impact_recovery.home` | `scan.route.impact_recovery -> home.route.dashboard` | `tap` | `go` | `apps/mobile/.maestro/r2_scan_impact.yaml` |
+| document_scan_recovery | `scan.edge.review_recovery.rescan` | `scan.route.review_recovery -> scan.route.capture` | `tap` | `go` | `apps/mobile/.maestro/r1_scan_review.yaml` |
 | first_job_missing_facts | `firstjob.edge.first_job.enrich_revenue` | `firstjob.route.first_job -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/first_job_ledger.yaml` |
 | independent_missing_facts | `indep.edge.avs.enrich_income` | `indep.route.avs -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_avs_cotisations.yaml` |
 | independent_missing_facts | `indep.edge.divsalary.enrich_profit` | `indep.route.divsalary -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/indep_dividende_salaire.yaml` |

--- a/interactions/document_scan_recovery.yaml
+++ b/interactions/document_scan_recovery.yaml
@@ -1,0 +1,69 @@
+schema_version: 1
+flow:
+  id: document_scan_recovery
+  title: "Document scan degraded routes to safe recovery targets"
+  exits: [scan.route.capture, home.route.dashboard]
+  invariants:
+    max_depth: 2
+    back_never_loses_input: true
+    every_scene_has_exit: true
+
+nodes:
+  - id: scan.route.review_recovery
+    kind: route
+    route: /scan/review
+    widget: app.dart
+    entries:
+      - {via: deeplink, back: reset_to(scan.route.capture)}
+      - {via: system, back: reset_to(scan.route.capture)}
+    states: [error.guard]
+
+  - id: scan.route.impact_recovery
+    kind: route
+    route: /scan/impact
+    widget: app.dart
+    entries:
+      - {via: deeplink, back: reset_to(home.route.dashboard)}
+      - {via: system, back: reset_to(home.route.dashboard)}
+    states: [error.guard]
+
+  - id: scan.route.capture
+    kind: route
+    route: /scan
+    widget: screens/document_scan/document_scan_screen.dart
+    entries:
+      - {via: flow, back: pop}
+      - {via: deeplink, back: pop}
+    states: [content, loading, error.network, error.compute]
+
+  - id: home.route.dashboard
+    kind: route
+    route: /home
+    widget: screens/aujourdhui/aujourdhui_screen.dart
+    entries:
+      - {via: tab, back: exits_app}
+      - {via: deeplink, back: reset_to(home.route.dashboard)}
+    states: [content, loading]
+
+edges:
+  - id: scan.edge.review_recovery.rescan
+    from: scan.route.review_recovery
+    to: scan.route.capture
+    trigger: tap
+    intent: "Recover a missing scan review payload by returning to document capture"
+    payload: {}
+    transition: go
+    back: reset_to(scan.route.capture)
+    a11y_label: scanReviewRescan
+    test_ref: apps/mobile/.maestro/r1_scan_review.yaml
+
+  - id: scan.edge.impact_recovery.home
+    from: scan.route.impact_recovery
+    to: home.route.dashboard
+    trigger: tap
+    intent: "Recover a missing scan impact payload by returning to the home overview"
+    payload: {}
+    transition: go
+    back: reset_to(home.route.dashboard)
+    a11y_label: scanImpactBackHome
+    test_ref: apps/mobile/.maestro/r2_scan_impact.yaml

--- a/tools/checks/interaction_registry_lint.py
+++ b/tools/checks/interaction_registry_lint.py
@@ -277,7 +277,15 @@ def _validate_documents(root: Path, docs: list[RegistryDocument]) -> list[str]:
                     _validate_data_block_edge_reference(root, rel_path, edge_id, source_node, target_node, errors)
             if edge.get("trigger") not in ("tap", "swipe", "long_press", "submit", "system"):
                 errors.append(f"{rel_path}: edge {edge_id} trigger is invalid")
-            if edge.get("transition") not in ("push", "replace", "reset_stack", "sheet", "dialog", "in_shell"):
+            if edge.get("transition") not in (
+                "push",
+                "go",
+                "replace",
+                "reset_stack",
+                "sheet",
+                "dialog",
+                "in_shell",
+            ):
                 errors.append(f"{rel_path}: edge {edge_id} transition is invalid")
             payload = edge.get("payload")
             if payload is not None and not isinstance(payload, dict):

--- a/tools/checks/tests/test_interaction_registry_lint.py
+++ b/tools/checks/tests/test_interaction_registry_lint.py
@@ -183,6 +183,20 @@ def test_interaction_registry_lint_allows_result_code_extra(tmp_path: Path) -> N
     assert not any("payload.extra" in error for error in errors)
 
 
+def test_interaction_registry_lint_allows_gorouter_go_transition(tmp_path: Path) -> None:
+    _write_minimal_repo(tmp_path)
+    _write_registry(tmp_path)
+    registry = tmp_path / "interactions/revenu_to_mortgage.yaml"
+    registry.write_text(
+        registry.read_text(encoding="utf-8").replace("transition: push", "transition: go"),
+        encoding="utf-8",
+    )
+
+    errors = interaction_registry_lint.check(tmp_path)
+
+    assert not any("transition is invalid" in error for error in errors)
+
+
 def test_interaction_registry_lint_rejects_unapproved_extra_type(tmp_path: Path) -> None:
     _write_minimal_repo(tmp_path)
     _write_registry(tmp_path)


### PR DESCRIPTION
## Summary
- Add an Interaction Registry flow for the degraded document scan routes: /scan/review -> /scan and /scan/impact -> /home.
- Extend the registry transition enum with GoRouter's context.go primitive and cover it with a lint unit test.
- Regenerate the interaction index, Mermaid graph, and coverage audit so /scan, /scan/review, and /scan/impact are covered route nodes.

## QA
- python3 tools/checks/mint_os_doctor.py --repo-only
- python3 tools/checks/mint_os_doctor.py
- python3 tools/checks/interaction_registry_lint.py
- python3 tools/checks/interaction_coverage_audit.py
- python3 tools/checks/mermaid_render_guard.py
- python3 tools/checks/patrol_tooling_guard.py
- python3 -m pytest tools/checks/tests/test_interaction_registry_lint.py tools/checks/tests/test_interaction_coverage_audit.py -q
- python3 -m pytest tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py -q
- python3 -m pytest tools/checks/tests/test_screen_contracts_route_contract.py -q
- MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=60 MAESTRO_STALL_PROBE_INTERVAL=20 bash tools/simulator/maestro_with_watchdog.sh test apps/mobile/.maestro/r1_scan_review.yaml
- MAESTRO_HARD_LIMIT=240 MAESTRO_STALL_THRESHOLD=60 MAESTRO_STALL_PROBE_INTERVAL=20 bash tools/simulator/maestro_with_watchdog.sh test apps/mobile/.maestro/r2_scan_impact.yaml
- lefthook run pre-commit
- CLAUDE_AUDIT_MODEL=claude-opus-4-8 CLAUDE_AUDIT_EFFORT=high CLAUDE_AUDIT_MAX_BUDGET_USD=3 tools/checks/claude_external_audit.sh code codex/first-job-interactions-20260710 => PASS, no P0/P1

## Notes
This intentionally does not declare the successful OCR pipeline yet: /scan -> /scan/review and /scan/review -> /scan/impact still move domain payloads via GoRouter extra and do not have a runtime proof in this slice.