### PR TITLE
Map remaining self-employed disability facts

### DIFF
--- a/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
+++ b/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
@@ -6,15 +6,16 @@
 
 - Extracted Flutter route references: 350
 - Distinct known route templates referenced: 92
-- Covered by declared Interaction Registry route nodes: 10
-- Known route templates not yet declared as route nodes: 82
-- Declared edge target route templates: 4
+- Covered by declared Interaction Registry route nodes: 11
+- Known route templates not yet declared as route nodes: 81
+- Declared edge target route templates: 5
 - Unknown route literals/templates: 0
 
 ## Covered Registry Route Nodes
 
 | Status | Route | References |
 |---|---|---|
+| covered by declared route node | `/budget/setup` | apps/mobile/lib/screens/budget/budget_container_screen.dart:61, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:115 |
 | covered by declared route node | `/data-block/:type` | apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:1325, apps/mobile/lib/screens/coach/retirement_dashboard_screen.dart:801, apps/mobile/lib/widgets/coach/confidence_blocks_bar.dart:82, apps/mobile/lib/widgets/coach/indicatif_banner.dart:99 |
 | covered by declared route node | `/disability/self-employed` | apps/mobile/lib/app.dart:635 |
 | covered by declared route node | `/first-job` | apps/mobile/lib/app.dart:573, apps/mobile/lib/screens/first_job_screen.dart:111, apps/mobile/lib/screens/first_job_screen.dart:122, apps/mobile/lib/screens/timeline_screen.dart:106 (+2 more) |
@@ -48,7 +49,6 @@
 | uncovered literal route | `/auth/verify-email` | apps/mobile/lib/screens/auth/login_screen.dart:537, apps/mobile/lib/screens/auth/register_screen.dart:109, apps/mobile/lib/screens/auth/register_screen.dart:111 |
 | uncovered literal route | `/bank-import` | apps/mobile/lib/screens/documents_screen.dart:935 |
 | uncovered literal route | `/budget` | apps/mobile/lib/data/educational_themes.dart:143, apps/mobile/lib/data/educational_themes.dart:174, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:348, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:441 (+10 more) |
-| uncovered literal route | `/budget/setup` | apps/mobile/lib/screens/budget/budget_container_screen.dart:61, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:115 |
 | uncovered literal route | `/check/debt` | apps/mobile/lib/screens/timeline_screen.dart:218, apps/mobile/lib/widgets/common/debt_tools_nav.dart:28 |
 | uncovered literal route | `/coach/chat` | apps/mobile/lib/app.dart:1809, apps/mobile/lib/app.dart:1812, apps/mobile/lib/app.dart:1901, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:70 (+27 more) |
 | uncovered literal route | `/coach/checkin` | apps/mobile/lib/widgets/coach/explore_hub.dart:54 |
@@ -123,6 +123,7 @@
 
 | Route |
 |---|
+| `/budget/setup` |
 | `/data-block/:type` |
 | `/disability/self-employed` |
 | `/first-job` |
@@ -141,6 +142,7 @@
 
 | Route |
 |---|
+| `/budget/setup` |
 | `/data-block/:type` |
 | `/home` |
 | `/hypotheque` |

--- a/.planning/journeys/diagrams/interaction_graph.mmd
+++ b/.planning/journeys/diagrams/interaction_graph.mmd
@@ -3,6 +3,7 @@ flowchart LR
   classDef route fill:#eef7f2,stroke:#0d7c66,stroke-width:1px,color:#10231f;
   classDef scene fill:#fff7e8,stroke:#b7791f,stroke-width:1px,color:#2b2112;
 
+  budget_route_setup["budget.route.setup<br/>/budget/setup"]:::route
   db_route_patrimoine["db.route.patrimoine<br/>/data-block/:type"]:::route
   db_route_revenu["db.route.revenu<br/>/data-block/:type"]:::route
   disability_route_self_employed["disability.route.self_employed<br/>/disability/self-employed"]:::route
@@ -18,7 +19,9 @@ flowchart LR
   scan_route_impact_recovery["scan.route.impact_recovery<br/>/scan/impact"]:::route
   scan_route_review_recovery["scan.route.review_recovery<br/>/scan/review"]:::route
 
+  disability_route_self_employed -->|"tap / push"| budget_route_setup
   disability_route_self_employed -->|"tap / push"| db_route_revenu
+  disability_route_self_employed -->|"tap / push"| db_route_patrimoine
   scan_route_impact_recovery -->|"tap / go"| home_route_dashboard
   scan_route_review_recovery -->|"tap / go"| scan_route_capture
   firstjob_route_first_job -->|"tap / push"| db_route_revenu

--- a/apps/mobile/.maestro/disability_self_employed.yaml
+++ b/apps/mobile/.maestro/disability_self_employed.yaml
@@ -1,7 +1,7 @@
 appId: ch.mint.app
 ---
-# Disability self-employed renders ledger facts, collects missing income through
-# the screen CTA, then returns with the canonical income fact filled.
+# Disability self-employed renders ledger facts, then collects the missing facts
+# in the same order as the source screen routes them: income, savings, expenses.
 - stopApp
 - launchApp:
     clearState: true
@@ -31,3 +31,46 @@ appId: ch.mint.app
     id: "disability_self_ledger_facts"
 - assertVisible:
     id: "disability_self_income_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "savings_input"
+- tapOn:
+    id: "savings_input"
+- inputText: "36000"
+- tapOn:
+    id: "patrimoine_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///disability/self-employed"
+- assertVisible:
+    id: "disability_self_ledger_facts"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "budget_setup_housing_input"
+- tapOn:
+    id: "budget_setup_housing_input"
+- inputText: "2400"
+- tapOn:
+    id: "budget_setup_lamal_input"
+- inputText: "380"
+- scrollUntilVisible:
+    element:
+      id: "budget_setup_save_cta"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- tapOn:
+    id: "budget_setup_save_cta"
+- assertVisible:
+    id: "disability_self_ledger_facts"
+- assertVisible:
+    id: "disability_self_expenses_fact"
+- assertVisible:
+    id: "disability_self_result_cards"

--- a/apps/mobile/lib/screens/budget/budget_setup_screen.dart
+++ b/apps/mobile/lib/screens/budget/budget_setup_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mint_mobile/l10n/app_localizations.dart';
 import 'package:mint_mobile/providers/budget/budget_provider.dart';
 import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
 import 'package:mint_mobile/theme/colors.dart';
 import 'package:mint_mobile/theme/mint_spacing.dart';
 import 'package:mint_mobile/theme/mint_text_styles.dart';
@@ -24,10 +25,9 @@ import 'package:provider/provider.dart';
 /// `TextField` + numeric keyboard, per `feedback_no_sliders_ux` and
 /// `feedback_modern_inputs_no_sliders`.
 ///
-/// Pre-fills each field from `ReportPersistenceService.loadAnswers`
-/// via the current `CoachProfile` so previously captured values
-/// (scan, wizard, coach-chat inline) stay visible and editable
-/// (`feedback_profile_prefill_architecture`).
+/// Pre-fills each field from persisted canonical answers only, so previously
+/// captured values (scan, wizard, coach-chat inline) stay visible and editable
+/// without promoting `CoachProfile` defaults/estimates to user facts.
 ///
 /// The chat remains available as an explicit fallback link at the
 /// bottom — doctrine `chat_is_everything` is respected ("all data
@@ -67,21 +67,23 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
   @override
   void initState() {
     super.initState();
-    // Pre-fill from current profile. mounted guard unnecessary here — widget
-    // is just built. We intentionally use `read` because this is a one-shot
-    // hydration, not a subscription.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    // Pre-fill from the ledger answers, not from CoachProfile.depenses:
+    // CoachProfile may contain derived/default amounts for calculations, while
+    // this screen must only display facts the user has actually supplied.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
-      final profile = context.read<CoachProfileProvider>().profile;
-      if (profile == null) return;
-      final d = profile.depenses;
-      _housing.text = _formatAmount(d.loyer);
-      _lamal.text = _formatAmount(d.assuranceMaladie);
-      _transport.text = _formatAmount(d.transport);
-      _telecom.text = _formatAmount(d.telecom);
-      _electricity.text = _formatAmount(d.electricite);
-      _medical.text = _formatAmount(d.fraisMedicaux);
-      _other.text = _formatAmount(d.autresDepensesFixes);
+      final answers = await ReportPersistenceService.loadAnswers();
+      if (!mounted) return;
+      _housing.text = _formatAnswerAmount(answers['q_housing_cost_period_chf']);
+      _lamal.text = _formatAnswerAmount(answers['q_lamal_premium_monthly_chf']);
+      _transport.text =
+          _formatAnswerAmount(answers['_coach_depenses_transport']);
+      _telecom.text = _formatAnswerAmount(answers['_coach_depenses_telecom']);
+      _electricity.text =
+          _formatAnswerAmount(answers['_coach_depenses_electricite']);
+      _medical.text =
+          _formatAnswerAmount(answers['_coach_depenses_frais_medicaux']);
+      _other.text = _formatAnswerAmount(answers['_coach_depenses_autres']);
     });
 
     // Live total ticker — rebuild on every field change so the user sees
@@ -139,6 +141,15 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
   String _formatAmount(double? value) =>
       (value == null || value == 0) ? '' : value.toStringAsFixed(0);
 
+  String _formatAnswerAmount(dynamic value) =>
+      _formatAmount(_coerceAmount(value));
+
+  double? _coerceAmount(dynamic value) {
+    if (value is num) return value.toDouble();
+    if (value is String) return _parseAmount(value);
+    return null;
+  }
+
   double? _parseAmount(String raw) {
     final cleaned = raw.trim().replaceAll(RegExp(r"[' ]"), '');
     if (cleaned.isEmpty) return null;
@@ -180,7 +191,7 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
     if (!mounted) return;
     // Refresh BudgetProvider so the Mon argent « Ton budget ce mois »
     // card re-derives inputs from the updated CoachProfile.depenses and
-    // swaps from the empty "Définis ton budget" state to the computed
+    // swaps from the empty budget-definition state to the computed
     // plan (revenu / charges fixes / reste). Without this the user
     // enters their charges and the card still shows « Commencer » —
     // silent failure, identical to the save_fact bug.
@@ -206,14 +217,26 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
             children: [
               Text(
                 s.budgetSetupSubtitle,
-                style: MintTextStyles.bodyMedium(
-                    color: MintColors.textSecondary),
+                style:
+                    MintTextStyles.bodyMedium(color: MintColors.textSecondary),
               ),
               const SizedBox(height: MintSpacing.lg),
-              _field(s.budgetSetupHousing, _housing,
-                  required: true, placeholder: _placeholderHousing),
-              _field(s.budgetSetupLamal, _lamal,
-                  required: true, placeholder: _placeholderLamal),
+              _field(
+                s.budgetSetupHousing,
+                _housing,
+                required: true,
+                placeholder: _placeholderHousing,
+                fieldKey: const Key('budget_setup_housing_input'),
+                semanticsIdentifier: 'budget_setup_housing_input',
+              ),
+              _field(
+                s.budgetSetupLamal,
+                _lamal,
+                required: true,
+                placeholder: _placeholderLamal,
+                fieldKey: const Key('budget_setup_lamal_input'),
+                semanticsIdentifier: 'budget_setup_lamal_input',
+              ),
               if (_showOptional) ...[
                 _field(s.budgetSetupTransport, _transport,
                     placeholder: _placeholderTransport),
@@ -234,8 +257,8 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
               if (_liveTotal > 0) ...[
                 const SizedBox(height: MintSpacing.md),
                 Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 14, vertical: 10),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                   decoration: BoxDecoration(
                     color: MintColors.craie,
                     borderRadius: BorderRadius.circular(10),
@@ -248,28 +271,32 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
                 ),
               ],
               const SizedBox(height: MintSpacing.lg),
-              FilledButton(
-                onPressed: _saving ? null : _save,
-                style: FilledButton.styleFrom(
-                  backgroundColor: MintColors.primary,
-                  minimumSize: const Size.fromHeight(48),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12)),
+              Semantics(
+                identifier: 'budget_setup_save_cta',
+                button: true,
+                child: FilledButton(
+                  key: const Key('budget_setup_save_cta'),
+                  onPressed: _saving ? null : _save,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: MintColors.primary,
+                    minimumSize: const Size.fromHeight(48),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12)),
+                  ),
+                  child: _saving
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: Colors.white),
+                        )
+                      : Text(s.budgetSetupSave),
                 ),
-                child: _saving
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(
-                            strokeWidth: 2, color: Colors.white),
-                      )
-                    : Text(s.budgetSetupSave),
               ),
               const SizedBox(height: MintSpacing.md),
               Center(
                 child: TextButton(
-                  onPressed: () =>
-                      context.push('/coach/chat?topic=budget'),
+                  onPressed: () => context.push('/coach/chat?topic=budget'),
                   child: Text(
                     s.budgetSetupChatFallback,
                     style: MintTextStyles.bodyMedium(
@@ -289,6 +316,8 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
     TextEditingController c, {
     bool required = false,
     String? placeholder,
+    Key? fieldKey,
+    String? semanticsIdentifier,
   }) {
     final s = S.of(context)!;
     return Padding(
@@ -299,8 +328,8 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
           Row(
             children: [
               Text(label,
-                  style: MintTextStyles.labelLarge(
-                      color: MintColors.textPrimary)),
+                  style:
+                      MintTextStyles.labelLarge(color: MintColors.textPrimary)),
               if (required) ...[
                 const SizedBox(width: 6),
                 Text('*',
@@ -309,18 +338,23 @@ class _BudgetSetupScreenState extends State<BudgetSetupScreen> {
             ],
           ),
           const SizedBox(height: 6),
-          TextField(
-            controller: c,
-            keyboardType: const TextInputType.numberWithOptions(decimal: false),
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]")),
-            ],
-            decoration: InputDecoration(
-              hintText: placeholder ?? s.budgetSetupFieldPlaceholder,
-              border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(10)),
-              contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 12, vertical: 12),
+          Semantics(
+            identifier: semanticsIdentifier,
+            child: TextField(
+              key: fieldKey,
+              controller: c,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: false),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r"[0-9' ]")),
+              ],
+              decoration: InputDecoration(
+                hintText: placeholder ?? s.budgetSetupFieldPlaceholder,
+                border:
+                    OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              ),
             ),
           ),
         ],

--- a/apps/mobile/lib/services/secure_wizard_store.dart
+++ b/apps/mobile/lib/services/secure_wizard_store.dart
@@ -132,6 +132,7 @@ class SecureWizardStore {
   ) async {
     final restored = Map<String, dynamic>.from(answers);
     for (final key in _sensitiveKeys) {
+      if (restored[key] != '__secure__') continue;
       final value = await read(key);
       if (value != null) {
         if (value == 'true') {

--- a/apps/mobile/test/screens/budget_setup_screen_test.dart
+++ b/apps/mobile/test/screens/budget_setup_screen_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/l10n/app_localizations.dart';
+import 'package:mint_mobile/providers/budget/budget_provider.dart';
+import 'package:mint_mobile/providers/coach_profile_provider.dart';
+import 'package:mint_mobile/screens/budget/budget_setup_screen.dart';
+import 'package:mint_mobile/services/report_persistence_service.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Widget _wrap(
+  Widget child, {
+  CoachProfileProvider? coachProfileProvider,
+}) {
+  return MultiProvider(
+    providers: [
+      if (coachProfileProvider == null)
+        ChangeNotifierProvider(create: (_) => CoachProfileProvider())
+      else
+        ChangeNotifierProvider.value(value: coachProfileProvider),
+      ChangeNotifierProvider(create: (_) => BudgetProvider()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('fr'),
+      localizationsDelegates: const [
+        S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: S.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('budget setup exposes runtime ids and saves fixed charges',
+      (tester) async {
+    await tester.pumpWidget(_wrap(const BudgetSetupScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('budget_setup_housing_input')), findsOneWidget);
+    expect(find.byKey(const Key('budget_setup_lamal_input')), findsOneWidget);
+    expect(find.byKey(const Key('budget_setup_save_cta')), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('budget_setup_housing_input')),
+      '2400',
+    );
+    await tester.enterText(
+      find.byKey(const Key('budget_setup_lamal_input')),
+      '380',
+    );
+    await tester.tap(find.byKey(const Key('budget_setup_save_cta')));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    final answers = await ReportPersistenceService.loadAnswers();
+    expect(answers, containsPair('q_housing_cost_period_chf', 2400.0));
+    expect(answers, containsPair('q_lamal_premium_monthly_chf', 380.0));
+    expect(answers, containsPair('q_pay_frequency', 'monthly'));
+  });
+
+  testWidgets('budget setup does not prefill derived expense defaults',
+      (tester) async {
+    const answersWithoutExpenses = <String, dynamic>{
+      'q_canton': 'VD',
+      'q_salaire': 6000,
+    };
+    await ReportPersistenceService.saveAnswers(answersWithoutExpenses);
+
+    final provider = CoachProfileProvider()
+      ..updateFromAnswers(answersWithoutExpenses);
+
+    await tester.pumpWidget(_wrap(
+      const BudgetSetupScreen(),
+      coachProfileProvider: provider,
+    ));
+    await tester.pumpAndSettle();
+
+    final housing = tester.widget<TextField>(
+      find.byKey(const Key('budget_setup_housing_input')),
+    );
+    final lamal = tester.widget<TextField>(
+      find.byKey(const Key('budget_setup_lamal_input')),
+    );
+
+    expect(housing.controller!.text, isEmpty);
+    expect(lamal.controller!.text, isEmpty);
+  });
+
+  testWidgets('budget setup hydrates persisted canonical answers',
+      (tester) async {
+    await ReportPersistenceService.saveAnswers(const {
+      'q_housing_cost_period_chf': 2100,
+      'q_lamal_premium_monthly_chf': 390,
+    });
+
+    await tester.pumpWidget(_wrap(const BudgetSetupScreen()));
+    await tester.pumpAndSettle();
+
+    final housing = tester.widget<TextField>(
+      find.byKey(const Key('budget_setup_housing_input')),
+    );
+    final lamal = tester.widget<TextField>(
+      find.byKey(const Key('budget_setup_lamal_input')),
+    );
+
+    expect(housing.controller!.text, '2100');
+    expect(lamal.controller!.text, '390');
+  });
+}

--- a/apps/mobile/test/services/secure_wizard_store_test.dart
+++ b/apps/mobile/test/services/secure_wizard_store_test.dart
@@ -90,6 +90,19 @@ void main() {
       expect(restored['q_has_consumer_debt'], true);
     });
 
+    test('does not restore stale secure values absent from answers', () async {
+      await SecureWizardStore.secureSensitiveKeys({
+        'q_cash_total': 36000,
+      });
+
+      final restored = await SecureWizardStore.restoreSensitiveKeys({
+        'q_self_employed_income': 144000,
+      });
+
+      expect(restored, containsPair('q_self_employed_income', 144000));
+      expect(restored.containsKey('q_cash_total'), isFalse);
+    });
+
     test('keeps local dev value when secure write throws', () async {
       failWrites = true;
 

--- a/docs/codex/INTERACTION_REGISTRY.md
+++ b/docs/codex/INTERACTION_REGISTRY.md
@@ -99,10 +99,10 @@ bloque pas encore les routes non migrées.
   encore le pipeline OCR réussi tant que le contrat `extra` domaine
   `ExtractionResult` / `Map` n'est pas remplacé ou explicitement testé.
 - `interactions/disability_self_employed_missing_facts.yaml` : flux invalidité
-  indépendant réel, limité à la CTA prouvée vers DataBlock revenu pour
-  `q_self_employed_income`. Les branches patrimoine/budget restent hors
-  registre tant qu'elles n'ont pas une preuve runtime déclenchée depuis l'écran
-  source.
+  indépendant réel, couvrant la collecte progressive déclenchée depuis l'écran
+  source pour `q_self_employed_income`, `q_cash_total`, puis les charges fixes
+  `q_housing_cost_period_chf` et `q_lamal_premium_monthly_chf` via Budget
+  Setup.
 - `interactions/INDEX.md` et
   `.planning/journeys/diagrams/interaction_graph.mmd` : artefacts générés par le
   linter depuis les YAML, jamais édités à la main.

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -4,7 +4,9 @@
 
 | Flow | Edge | From -> To | Trigger | Transition | Runtime proof |
 |---|---|---|---|---|---|
+| disability_self_employed_missing_facts | `disability.edge.self_employed.enrich_expenses` | `disability.route.self_employed -> budget.route.setup` | `tap` | `push` | `apps/mobile/.maestro/disability_self_employed.yaml` |
 | disability_self_employed_missing_facts | `disability.edge.self_employed.enrich_income` | `disability.route.self_employed -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/disability_self_employed.yaml` |
+| disability_self_employed_missing_facts | `disability.edge.self_employed.enrich_savings` | `disability.route.self_employed -> db.route.patrimoine` | `tap` | `push` | `apps/mobile/.maestro/disability_self_employed.yaml` |
 | document_scan_recovery | `scan.edge.impact_recovery.home` | `scan.route.impact_recovery -> home.route.dashboard` | `tap` | `go` | `apps/mobile/.maestro/r2_scan_impact.yaml` |
 | document_scan_recovery | `scan.edge.review_recovery.rescan` | `scan.route.review_recovery -> scan.route.capture` | `tap` | `go` | `apps/mobile/.maestro/r1_scan_review.yaml` |
 | first_job_missing_facts | `firstjob.edge.first_job.enrich_revenue` | `firstjob.route.first_job -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/first_job_ledger.yaml` |

--- a/interactions/disability_self_employed_missing_facts.yaml
+++ b/interactions/disability_self_employed_missing_facts.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 flow:
   id: disability_self_employed_missing_facts
   title: "Self-employed disability screen to missing ledger facts"
-  exits: [db.route.revenu]
+  exits: [db.route.revenu, db.route.patrimoine, budget.route.setup]
   invariants:
     max_depth: 2
     back_never_loses_input: true
@@ -26,6 +26,22 @@ nodes:
       - {via: flow, back: pop}
     states: [content, loading, error.compute]
 
+  - id: db.route.patrimoine
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+  - id: budget.route.setup
+    kind: route
+    route: /budget/setup
+    widget: screens/budget/budget_setup_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
 edges:
   - id: disability.edge.self_employed.enrich_income
     from: disability.route.self_employed
@@ -35,6 +51,28 @@ edges:
     payload:
       path_params: {type: EnrichmentType}
       query_params: {inputKey: InputKey}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_self_employed.yaml
+
+  - id: disability.edge.self_employed.enrich_savings
+    from: disability.route.self_employed
+    to: db.route.patrimoine
+    trigger: tap
+    intent: "Collect liquid savings before estimating self-employed disability runway"
+    payload:
+      path_params: {type: EnrichmentType}
+      query_params: {inputKey: InputKey}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_self_employed.yaml
+
+  - id: disability.edge.self_employed.enrich_expenses
+    from: disability.route.self_employed
+    to: budget.route.setup
+    trigger: tap
+    intent: "Collect fixed monthly charges before showing disability protection results"
+    payload: {}
     transition: push
     back: pop
     test_ref: apps/mobile/.maestro/disability_self_employed.yaml


### PR DESCRIPTION
## Summary
- Extend the self-employed disability Interaction Registry flow from income-only to income, liquid savings, and fixed expenses.
- Instrument Budget Setup with stable runtime IDs and hydrate it from canonical persisted answers only, not derived profile defaults.
- Fix SecureWizardStore stale secure-value restoration so Keychain values only hydrate declared `__secure__` placeholders.

## QA
- flutter test test/services/secure_wizard_store_test.dart test/screens/budget_setup_screen_test.dart test/screens/disability_self_employed_ledger_test.dart test/screens/data_block_enrichment_screen_test.dart
- flutter build ios --simulator --debug
- Maestro iPhone 17 Pro: apps/mobile/.maestro/disability_self_employed.yaml
- python3 tools/checks/interaction_registry_lint.py
- python3 tools/checks/interaction_coverage_audit.py
- python3 tools/checks/mermaid_render_guard.py
- python3 tools/checks/patrol_tooling_guard.py
- python3 -m pytest tools/checks/tests/test_interaction_registry_lint.py tools/checks/tests/test_interaction_coverage_audit.py tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py -q
- lefthook run pre-commit
- Claude Opus 4.8 external audit: PASS, no P0/P1

## Notes
- `flutter analyze` still fails on existing repo-wide warnings outside this slice; no new analyzer issue was introduced in touched files.