### PR TITLE
Map disability gap interactions

### DIFF
--- a/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
+++ b/.planning/journeys/INTERACTION_COVERAGE_AUDIT.md
@@ -6,8 +6,8 @@
 
 - Extracted Flutter route references: 350
 - Distinct known route templates referenced: 92
-- Covered by declared Interaction Registry route nodes: 12
-- Known route templates not yet declared as route nodes: 80
+- Covered by declared Interaction Registry route nodes: 13
+- Known route templates not yet declared as route nodes: 79
 - Declared edge target route templates: 5
 - Unknown route literals/templates: 0
 
@@ -24,6 +24,7 @@
 | covered by declared route node | `/hypotheque` | apps/mobile/lib/app.dart:588, apps/mobile/lib/screens/mortgage/affordability_screen.dart:192, apps/mobile/lib/screens/mortgage/affordability_screen.dart:203, apps/mobile/lib/screens/timeline_screen.dart:148 (+5 more) |
 | covered by declared route node | `/independants/avs` | apps/mobile/lib/widgets/coach/smart_shortcuts.dart:183 |
 | covered by declared route node | `/independants/dividende-salaire` | apps/mobile/lib/services/response_card_service.dart:403 |
+| covered by declared route node | `/invalidite` | apps/mobile/lib/app.dart:633, apps/mobile/lib/screens/disability/disability_gap_screen.dart:94, apps/mobile/lib/screens/timeline_screen.dart:183, apps/mobile/lib/services/cap_engine.dart:871 (+2 more) |
 | covered by declared route node | `/scan` | apps/mobile/lib/screens/coach/coach_chat_screen.dart:1940, apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:465, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:126, apps/mobile/lib/screens/mon_argent/mon_argent_screen.dart:160 (+9 more) |
 | covered by declared route node | `/scan/impact` | apps/mobile/lib/screens/document_scan/document_impact_screen.dart:721, apps/mobile/lib/screens/document_scan/extraction_review_screen.dart:745 |
 | covered by declared route node | `/scan/review` | apps/mobile/lib/screens/document_scan/avs_guide_screen.dart:485, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1397, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:1617, apps/mobile/lib/screens/document_scan/document_scan_screen.dart:645 (+2 more) |
@@ -77,7 +78,6 @@
 | uncovered literal route | `/explore/travail` | apps/mobile/lib/screens/explore/explorer_screen.dart:53 |
 | uncovered literal route | `/fiscal` | apps/mobile/lib/app.dart:609, apps/mobile/lib/data/educational_themes.dart:195, apps/mobile/lib/screens/advisor/financial_report_screen_v2.dart:564, apps/mobile/lib/screens/fiscal_comparator_screen.dart:170 (+8 more) |
 | uncovered literal route | `/household/accept` | apps/mobile/lib/screens/household/household_screen.dart:509 |
-| uncovered literal route | `/invalidite` | apps/mobile/lib/app.dart:633, apps/mobile/lib/screens/disability/disability_gap_screen.dart:94, apps/mobile/lib/screens/timeline_screen.dart:183, apps/mobile/lib/services/cap_engine.dart:871 (+2 more) |
 | uncovered literal route | `/libre-passage` | apps/mobile/lib/app.dart:549, apps/mobile/lib/services/response_card_service.dart:113 |
 | uncovered literal route | `/life-event/deces-proche` | apps/mobile/lib/app.dart:622, apps/mobile/lib/services/cap_engine.dart:841 |
 | uncovered literal route | `/life-event/demenagement-cantonal` | apps/mobile/lib/app.dart:623, apps/mobile/lib/services/cap_engine.dart:877 |
@@ -135,6 +135,7 @@
 | `/independants/dividende-salaire` |
 | `/independants/ijm` |
 | `/independants/lpp-volontaire` |
+| `/invalidite` |
 | `/scan` |
 | `/scan/impact` |
 | `/scan/review` |

--- a/.planning/journeys/diagrams/interaction_graph.mmd
+++ b/.planning/journeys/diagrams/interaction_graph.mmd
@@ -6,6 +6,7 @@ flowchart LR
   budget_route_setup["budget.route.setup<br/>/budget/setup"]:::route
   db_route_patrimoine["db.route.patrimoine<br/>/data-block/:type"]:::route
   db_route_revenu["db.route.revenu<br/>/data-block/:type"]:::route
+  disability_route_gap["disability.route.gap<br/>/invalidite"]:::route
   disability_route_insurance["disability.route.insurance<br/>/disability/insurance"]:::route
   disability_route_self_employed["disability.route.self_employed<br/>/disability/self-employed"]:::route
   firstjob_route_first_job["firstjob.route.first_job<br/>/first-job"]:::route
@@ -20,22 +21,26 @@ flowchart LR
   scan_route_impact_recovery["scan.route.impact_recovery<br/>/scan/impact"]:::route
   scan_route_review_recovery["scan.route.review_recovery<br/>/scan/review"]:::route
 
-  disability_route_insurance -->|"tap / push"| budget_route_setup
-  disability_route_insurance -->|"tap / push"| db_route_revenu
-  disability_route_insurance -->|"tap / push"| db_route_patrimoine
-  disability_route_self_employed -->|"tap / push"| budget_route_setup
-  disability_route_self_employed -->|"tap / push"| db_route_revenu
-  disability_route_self_employed -->|"tap / push"| db_route_patrimoine
-  scan_route_impact_recovery -->|"tap / go"| home_route_dashboard
-  scan_route_review_recovery -->|"tap / go"| scan_route_capture
-  firstjob_route_first_job -->|"tap / push"| db_route_revenu
-  indep_route_avs -->|"tap / push"| db_route_revenu
-  indep_route_divsalary -->|"tap / push"| db_route_revenu
-  indep_route_ijm -->|"tap / push"| db_route_revenu
-  indep_route_lpp -->|"tap / push"| db_route_revenu
-  indep_route_pillar3a -->|"tap / push"| db_route_patrimoine
-  indep_route_pillar3a -->|"tap / push"| db_route_revenu
-  db_route_revenu -->|"submit / push"| mortgage_route_hypotheque
+  disability_route_gap -->|"disability.edge.gap.enrich_age<br/>tap / push"| db_route_revenu
+  disability_route_gap -->|"disability.edge.gap.enrich_expenses<br/>tap / push"| budget_route_setup
+  disability_route_gap -->|"disability.edge.gap.enrich_salary<br/>tap / push"| db_route_revenu
+  disability_route_gap -->|"disability.edge.gap.enrich_savings<br/>tap / push"| db_route_patrimoine
+  disability_route_insurance -->|"disability.edge.insurance.enrich_expenses<br/>tap / push"| budget_route_setup
+  disability_route_insurance -->|"disability.edge.insurance.enrich_salary<br/>tap / push"| db_route_revenu
+  disability_route_insurance -->|"disability.edge.insurance.enrich_savings<br/>tap / push"| db_route_patrimoine
+  disability_route_self_employed -->|"disability.edge.self_employed.enrich_expenses<br/>tap / push"| budget_route_setup
+  disability_route_self_employed -->|"disability.edge.self_employed.enrich_income<br/>tap / push"| db_route_revenu
+  disability_route_self_employed -->|"disability.edge.self_employed.enrich_savings<br/>tap / push"| db_route_patrimoine
+  scan_route_impact_recovery -->|"scan.edge.impact_recovery.home<br/>tap / go"| home_route_dashboard
+  scan_route_review_recovery -->|"scan.edge.review_recovery.rescan<br/>tap / go"| scan_route_capture
+  firstjob_route_first_job -->|"firstjob.edge.first_job.enrich_revenue<br/>tap / push"| db_route_revenu
+  indep_route_avs -->|"indep.edge.avs.enrich_income<br/>tap / push"| db_route_revenu
+  indep_route_divsalary -->|"indep.edge.divsalary.enrich_profit<br/>tap / push"| db_route_revenu
+  indep_route_ijm -->|"indep.edge.ijm.enrich_income_or_age<br/>tap / push"| db_route_revenu
+  indep_route_lpp -->|"indep.edge.lpp.enrich_income_or_age<br/>tap / push"| db_route_revenu
+  indep_route_pillar3a -->|"indep.edge.pillar3a.enrich_cash<br/>tap / push"| db_route_patrimoine
+  indep_route_pillar3a -->|"indep.edge.pillar3a.enrich_income_or_pension<br/>tap / push"| db_route_revenu
+  db_route_revenu -->|"db.edge.revenu.submit<br/>submit / push"| mortgage_route_hypotheque
 
   db_route_revenu -. "back" .-> home_route_dashboard
   mortgage_route_hypotheque -. "back" .-> home_route_dashboard

--- a/apps/mobile/.maestro/disability_gap.yaml
+++ b/apps/mobile/.maestro/disability_gap.yaml
@@ -1,0 +1,108 @@
+appId: ch.mint.app
+---
+# Disability gap collects missing ledger facts in the same order as the source
+# screen routes them: salary, birth year, savings, expenses.
+- stopApp
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "Cancel"
+    optional: true
+- openLink: "mint:///invalidite"
+- assertVisible:
+    id: "disability_gap_ledger_facts"
+- assertVisible:
+    id: "disability_gap_salary_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "salary_input"
+- tapOn:
+    id: "salary_input"
+- inputText: "96000"
+- scrollUntilVisible:
+    element:
+      id: "salary_save_cta"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- tapOn:
+    id: "salary_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///invalidite"
+- assertVisible:
+    id: "disability_gap_ledger_facts"
+- assertVisible:
+    id: "disability_gap_salary_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "birth_year_input"
+- tapOn:
+    id: "birth_year_input"
+- inputText: "1981"
+- scrollUntilVisible:
+    element:
+      id: "salary_save_cta"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- tapOn:
+    id: "salary_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///invalidite"
+- assertVisible:
+    id: "disability_gap_ledger_facts"
+- assertVisible:
+    id: "disability_gap_age_fact"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "savings_input"
+- tapOn:
+    id: "savings_input"
+- inputText: "42000"
+- tapOn:
+    id: "patrimoine_save_cta"
+- assertVisible:
+    id: "data_block_save_success"
+- openLink: "mint:///invalidite"
+- assertVisible:
+    id: "disability_gap_ledger_facts"
+- assertVisible:
+    text: "Enrichir mon profil"
+- tapOn:
+    text: "Enrichir mon profil"
+- assertVisible:
+    id: "budget_setup_housing_input"
+- tapOn:
+    id: "budget_setup_housing_input"
+- inputText: "2200"
+- tapOn:
+    id: "budget_setup_lamal_input"
+- inputText: "420"
+- scrollUntilVisible:
+    element:
+      id: "budget_setup_save_cta"
+    direction: DOWN
+    speed: 5
+    visibilityPercentage: 20
+    centerElement: true
+- tapOn:
+    id: "budget_setup_save_cta"
+- assertVisible:
+    id: "disability_gap_ledger_facts"
+- assertVisible:
+    id: "disability_gap_expenses_fact"
+- assertVisible:
+    id: "disability_gap_result_section"

--- a/apps/mobile/test/patrol/disability_gap_runtime_test.dart
+++ b/apps/mobile/test/patrol/disability_gap_runtime_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mint_mobile/app.dart';
+import 'package:patrol/patrol.dart';
+
+const _runningFromPatrolCli = bool.fromEnvironment('MINT_PATROL_CLI');
+
+void main() {
+  patrolTest(
+    'opens disability gap by deeplink and collects missing facts',
+    skip: !_runningFromPatrolCli,
+    timeout: const Timeout(Duration(minutes: 5)),
+    ($) async {
+      await $.pumpWidgetAndSettle(const MintApp());
+
+      await $.platformAutomator.mobile.openUrl('mint:///invalidite');
+      await $.pumpAndSettle();
+
+      await $(#disability_gap_ledger_facts).waitUntilVisible();
+      await $(#disability_gap_enrich_cta).tap();
+
+      await $(#salary_input).waitUntilVisible();
+      await $(#salary_input).enterText('96000');
+      await $(#salary_save_cta).scrollTo().tap();
+      await $(#data_block_save_success).waitUntilVisible();
+
+      await $.platformAutomator.mobile.openUrl('mint:///invalidite');
+      await $.pumpAndSettle();
+
+      await $(#disability_gap_ledger_facts).waitUntilVisible();
+      await $(#disability_gap_salary_fact).waitUntilVisible();
+      await $(#disability_gap_enrich_cta).tap();
+
+      await $(#birth_year_input).waitUntilVisible();
+      await $(#birth_year_input).enterText('1981');
+      await $(#salary_save_cta).scrollTo().tap();
+      await $(#data_block_save_success).waitUntilVisible();
+
+      await $.platformAutomator.mobile.openUrl('mint:///invalidite');
+      await $.pumpAndSettle();
+
+      await $(#disability_gap_ledger_facts).waitUntilVisible();
+      await $(#disability_gap_age_fact).waitUntilVisible();
+      await $(#disability_gap_enrich_cta).tap();
+
+      await $(#savings_input).waitUntilVisible();
+      await $(#savings_input).enterText('42000');
+      await $(#patrimoine_save_cta).tap();
+      await $(#data_block_save_success).waitUntilVisible();
+
+      await $.platformAutomator.mobile.openUrl('mint:///invalidite');
+      await $.pumpAndSettle();
+
+      await $(#disability_gap_ledger_facts).waitUntilVisible();
+      await $(#disability_gap_enrich_cta).tap();
+
+      await $(#budget_setup_housing_input).waitUntilVisible();
+      await $(#budget_setup_housing_input).enterText('2200');
+      await $(#budget_setup_lamal_input).enterText('420');
+      await $(#budget_setup_save_cta).scrollTo().tap();
+
+      await $(#disability_gap_ledger_facts).waitUntilVisible();
+      await $(#disability_gap_expenses_fact).waitUntilVisible();
+      await $(#disability_gap_result_section).scrollTo();
+      await $(#disability_gap_result_section).waitUntilVisible();
+    },
+  );
+}

--- a/interactions/INDEX.md
+++ b/interactions/INDEX.md
@@ -4,6 +4,10 @@
 
 | Flow | Edge | From -> To | Trigger | Transition | Runtime proof |
 |---|---|---|---|---|---|
+| disability_gap_missing_facts | `disability.edge.gap.enrich_age` | `disability.route.gap -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/disability_gap.yaml` |
+| disability_gap_missing_facts | `disability.edge.gap.enrich_expenses` | `disability.route.gap -> budget.route.setup` | `tap` | `push` | `apps/mobile/.maestro/disability_gap.yaml` |
+| disability_gap_missing_facts | `disability.edge.gap.enrich_salary` | `disability.route.gap -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/disability_gap.yaml` |
+| disability_gap_missing_facts | `disability.edge.gap.enrich_savings` | `disability.route.gap -> db.route.patrimoine` | `tap` | `push` | `apps/mobile/.maestro/disability_gap.yaml` |
 | disability_insurance_missing_facts | `disability.edge.insurance.enrich_expenses` | `disability.route.insurance -> budget.route.setup` | `tap` | `push` | `apps/mobile/.maestro/disability_insurance.yaml` |
 | disability_insurance_missing_facts | `disability.edge.insurance.enrich_salary` | `disability.route.insurance -> db.route.revenu` | `tap` | `push` | `apps/mobile/.maestro/disability_insurance.yaml` |
 | disability_insurance_missing_facts | `disability.edge.insurance.enrich_savings` | `disability.route.insurance -> db.route.patrimoine` | `tap` | `push` | `apps/mobile/.maestro/disability_insurance.yaml` |

--- a/interactions/disability_gap_missing_facts.yaml
+++ b/interactions/disability_gap_missing_facts.yaml
@@ -1,0 +1,90 @@
+schema_version: 1
+flow:
+  id: disability_gap_missing_facts
+  title: "Disability gap screen to missing ledger facts"
+  exits: [db.route.revenu, db.route.patrimoine, budget.route.setup]
+  invariants:
+    max_depth: 2
+    back_never_loses_input: true
+    every_scene_has_exit: true
+
+nodes:
+  - id: disability.route.gap
+    kind: route
+    route: /invalidite
+    widget: screens/disability/disability_gap_screen.dart
+    entries:
+      - {via: deeplink, back: pop}
+      - {via: flow, back: pop}
+    states: [content, partial, loading, error.compute]
+
+  - id: db.route.revenu
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+  - id: db.route.patrimoine
+    kind: route
+    route: /data-block/:type
+    widget: screens/onboarding/data_block_enrichment_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+  - id: budget.route.setup
+    kind: route
+    route: /budget/setup
+    widget: screens/budget/budget_setup_screen.dart
+    entries:
+      - {via: flow, back: pop}
+    states: [content, loading, error.compute]
+
+edges:
+  - id: disability.edge.gap.enrich_salary
+    from: disability.route.gap
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect annual salary before showing the disability gap"
+    payload:
+      path_params: {type: EnrichmentType}
+      query_params: {inputKey: InputKey}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_gap.yaml
+
+  - id: disability.edge.gap.enrich_age
+    from: disability.route.gap
+    to: db.route.revenu
+    trigger: tap
+    intent: "Collect birth year before projecting disability retirement effects"
+    payload:
+      path_params: {type: EnrichmentType}
+      query_params: {inputKey: InputKey}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_gap.yaml
+
+  - id: disability.edge.gap.enrich_savings
+    from: disability.route.gap
+    to: db.route.patrimoine
+    trigger: tap
+    intent: "Collect liquid savings before showing the disability runway"
+    payload:
+      path_params: {type: EnrichmentType}
+      query_params: {inputKey: InputKey}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_gap.yaml
+
+  - id: disability.edge.gap.enrich_expenses
+    from: disability.route.gap
+    to: budget.route.setup
+    trigger: tap
+    intent: "Collect fixed monthly charges before unlocking the disability scorecard"
+    payload: {}
+    transition: push
+    back: pop
+    test_ref: apps/mobile/.maestro/disability_gap.yaml

--- a/tools/checks/interaction_registry_lint.py
+++ b/tools/checks/interaction_registry_lint.py
@@ -413,7 +413,10 @@ def generate_mermaid(docs: list[RegistryDocument]) -> str:
         lines.append(f'  {_mermaid_id(node_id)}["{node_id}<br/>{label_suffix}"]:::{node.get("kind", "route")}')
     lines.append("")
     for _, edge in _sorted_edges(docs):
-        edge_label = f'{edge.get("trigger", "")} / {edge.get("transition", "")}'
+        edge_label = (
+            f'{edge.get("id", "")}<br/>'
+            f'{edge.get("trigger", "")} / {edge.get("transition", "")}'
+        )
         lines.append(
             f'  {_mermaid_id(str(edge.get("from", "")))} -->|"{edge_label}"| '
             f'{_mermaid_id(str(edge.get("to", "")))}',

--- a/tools/checks/tests/test_interaction_registry_lint.py
+++ b/tools/checks/tests/test_interaction_registry_lint.py
@@ -130,7 +130,7 @@ def test_interaction_registry_lint_accepts_a_real_flow_and_writes_artifacts(tmp_
     assert "db.edge.revenu.submit" in index
     assert "db.route.revenu -> mortgage.route.hypotheque" in index
     assert '"db.route.revenu<br/>/data-block/:type"' in graph
-    assert '"submit / push"' in graph
+    assert '"db.edge.revenu.submit<br/>submit / push"' in graph
     assert 'db_route_revenu -. "back" .-> home_route_dashboard' in graph
 
 


### PR DESCRIPTION
## Summary

- Adds the `/invalidite` disability-gap Interaction Registry flow with four missing-fact edges: salary, birth year, liquid savings, and fixed monthly charges.
- Adds Maestro and Patrol runtime coverage for the progressive ledger collection path.
- Updates generated interaction index, Mermaid graph, and coverage audit; Mermaid edge labels now include stable edge ids so duplicate route pairs stay distinguishable.

## QA

- `python3 tools/checks/mint_os_doctor.py`
- `python3 tools/checks/interaction_registry_lint.py`
- `python3 tools/checks/interaction_coverage_audit.py`
- `python3 tools/checks/mermaid_render_guard.py`
- `python3 tools/checks/patrol_tooling_guard.py`
- `python3 -m pytest tools/checks/tests/test_interaction_registry_lint.py tools/checks/tests/test_interaction_coverage_audit.py tools/checks/tests/test_data_quest_goal_aware_ranking_contract.py tools/checks/tests/test_screen_contracts_route_contract.py tools/checks/tests/test_patrol_tooling_guard.py tools/checks/tests/test_mint_os_doctor.py -q`
- `flutter test test/screens/disability_gap_ledger_test.dart test/screens/disability_insurance_ledger_test.dart test/screens/disability_self_employed_ledger_test.dart test/screens/data_block_enrichment_screen_test.dart test/screens/budget_setup_screen_test.dart test/services/secure_wizard_store_test.dart test/patrol/disability_gap_runtime_test.dart test/patrol/disability_insurance_runtime_test.dart`
- `dart format --set-exit-if-changed test/patrol/disability_gap_runtime_test.dart`
- `flutter analyze test/patrol/disability_gap_runtime_test.dart`
- XcodeBuildMCP `build_run_sim` on iPhone 17 Pro `B03E429D-0422-4357-B754-536637D979F9`
- `tools/simulator/maestro_with_watchdog.sh test apps/mobile/.maestro/disability_gap.yaml`
- `$HOME/.pub-cache/bin/patrol test -t test/patrol/disability_gap_runtime_test.dart -d B03E429D-0422-4357-B754-536637D979F9 --dart-define=MINT_PATROL_CLI=true --no-label`
- `xcrun xcresulttool get test-results summary --path build/ios_results_1783727655787.xcresult --format json` -> `totalTestCount=1`, `passedTests=1`
- `CLAUDE_AUDIT_MODEL=claude-opus-4-8 CLAUDE_AUDIT_EFFORT=high CLAUDE_AUDIT_MAX_BUDGET_USD=5 tools/checks/claude_external_audit.sh code codex/disability-insurance-interactions-20260711` -> PASS

## Notes

- Patrol CLI still prints `Total: 0`; the authoritative `.xcresult` reports one passed UI test.
- Lefthook passed; memory-retention warning remains non-blocking and pre-existing.
