### PR TITLE
Add Claude product-domain audit gate

### DIFF
--- a/.claude/agents/mint-external-auditor.md
+++ b/.claude/agents/mint-external-auditor.md
@@ -29,6 +29,9 @@ Spec drift audit:
 Code audit against a base branch:
 `tools/checks/claude_external_audit.sh code <base-branch>`.
 
+Product/domain audit against a base branch:
+`tools/checks/claude_external_audit.sh product-domain <base-branch>`.
+
 Same-gate rerun after a first finding pass:
 `CLAUDE_AUDIT_RERUN=1 tools/checks/claude_external_audit.sh code <base-branch>`.
 
@@ -51,6 +54,16 @@ injection, skill inventory, and max reasoning on every tool turn.
 No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
 if still blocked, fix or triage the findings instead of relaunching the same gate.
 
+For any PR that touches a Swiss financial user journey, scenario, data
+collection, PDF/dossier handoff, or compliance-sensitive copy, run both:
+
+1. `code <base-branch>` for implementation, routing, privacy, tests, and
+   facade-without-wiring risks.
+2. `product-domain <base-branch>` for MINT product logic plus Swiss domain
+   correctness: AVS/LPP/3a/tax/mortgage/insurance/succession fit, missing or
+   duplicated variables, no-advice compliance, specialist handoff, and whether
+   the flow actually improves user lucidity.
+
 Do not replace safe mode with ad hoc minimal settings. Do not add
 `--max-turns`: the installed Claude CLI does not expose it, and the wrapper
 rejects `CLAUDE_AUDIT_MAX_TURNS` to prevent fake safety knobs. Do not use
@@ -65,6 +78,9 @@ default: they can reload repo hooks. The wrapper rejects them unless
 - Critical/high findings are hard blockers until fixed or downgraded with
   concrete code/spec evidence. `mint-lead` cannot accept a phase while this
   agent reports unresolved critical/high findings.
+- Product/domain P0/P1 findings block acceptance even when the code audit
+  passes. A technically correct change can still be a MINT NO-GO if it is
+  Swiss-domain wrong, advice-shaped, or product-stupid.
 - If Claude CLI is unavailable, `mint-lead` must log the command, failure mode,
   and retry plan in the scorecard. That exception can defer one phase gate at
   most and cannot be used for final acceptance.

--- a/.claude/agents/mint-swiss-brain.md
+++ b/.claude/agents/mint-swiss-brain.md
@@ -46,6 +46,14 @@ For every life-event case, produce:
 - privacy/data-protection boundaries for user variables and handoff documents
 </output_contract>
 
+<external_audit_contract>
+Before acceptance of a Swiss financial product change, expect
+`tools/checks/claude_external_audit.sh product-domain <base-ref>` to challenge
+your work as an external product/domain auditor. Treat its P0/P1 findings as
+blockers unless you can downgrade them with code, spec, legal-source, or test
+evidence.
+</external_audit_contract>
+
 <forbidden>
 - Do not use banned words from `CLAUDE.md`.
 - Do not frame MINT as retirement-only.

--- a/.claude/skills/mint-operating-gates/SKILL.md
+++ b/.claude/skills/mint-operating-gates/SKILL.md
@@ -48,6 +48,7 @@ For external Claude review, use the checked-in wrapper instead of raw
 
 ```bash
 tools/checks/claude_external_audit.sh code <base-ref>
+tools/checks/claude_external_audit.sh product-domain <base-ref>
 tools/checks/claude_external_audit.sh specs
 tools/checks/claude_external_audit.sh architecture
 ```
@@ -70,6 +71,13 @@ non-Sonnet reruns unless `CLAUDE_AUDIT_ALLOW_NON_SONNET_RERUN=1` is explicitly s
 final confirmation or P0 dispute.
 No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
 if still blocked, fix or triage the findings instead of relaunching the same gate.
+
+Run `product-domain <base-ref>` for any Swiss financial journey, Data Ledger/
+Data Quest collection change, scenario result, PDF/dossier handoff, or
+compliance-sensitive product copy. Treat it as the external MINT product lead
+plus Swiss domain audit: it must catch flows that are technically wired but
+business-wrong, law-ambiguous, advice-shaped, missing mandatory variables,
+duplicating user facts, or not increasing user lucidity.
 
 For `docs/codex/` contract work, run the contract tests that exist in this
 checkout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,16 @@ rejects `CLAUDE_AUDIT_MAX_TURNS` so agents cannot rely on a fake safety knob.
 No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
 if still blocked, fix or triage the findings instead of relaunching the same gate.
 
+Use two Claude audit lenses when a PR changes a financial product path:
+
+- `code <base-ref>`: implementation correctness, privacy, routing, tests, and
+  facade-without-wiring risks.
+- `product-domain <base-ref>`: MINT product logic plus Swiss financial/legal
+  correctness. This audit must challenge life-event fit, Swiss law/tax/
+  insurance/prevention assumptions, missing variables, duplicated Data Ledger
+  facts, no-advice compliance, specialist handoff, and whether the flow actually
+  increases user lucidity.
+
 ## 🗺 Before you edit X, read Y, grep Z
 
 Pre-flight for any code change. If the agent can't state which row applies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Use the checked-in wrapper, never raw `claude -p`, for external reviews:
 
 ```bash
 tools/checks/claude_external_audit.sh code <base-ref>
+tools/checks/claude_external_audit.sh product-domain <base-ref>
 tools/checks/claude_external_audit.sh specs
 tools/checks/claude_external_audit.sh architecture
 ```
@@ -69,6 +70,13 @@ Claude CLI does not expose it, and the wrapper rejects `CLAUDE_AUDIT_MAX_TURNS`
 so agents cannot rely on a fake safety knob.
 No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
 if still blocked, fix or triage the findings instead of relaunching the same gate.
+For any change touching a Swiss financial journey, user data collection,
+scenario output, PDF/dossier handoff, or compliance-sensitive copy, run
+`product-domain <base-ref>` as well as code review. That mode asks Claude to
+act as MINT product lead plus Swiss finance/legal domain auditor: it must hunt
+for illogical flows, duplicated sources of truth, wrong Swiss-system
+assumptions, missing variables, advice/compliance violations, and user-value
+dead ends.
 
 ## 4. ROLE ROUTING
 

--- a/docs/MINT_AGENT_WORKFLOW.md
+++ b/docs/MINT_AGENT_WORKFLOW.md
@@ -54,8 +54,14 @@ Every product PR must list:
 - Maestro runtime proof for touched P0 mobile UI; Patrol is required for real
   P0 input proof. The CLI may be at `$HOME/.pub-cache/bin/patrol` even when
   `patrol` is not exported in `PATH`.
-- Claude CLI audit for architecture, compliance, and pre-merge code review when
+- Claude CLI `code <base-ref>` audit for pre-merge implementation review when
   possible.
+- Claude CLI `product-domain <base-ref>` audit for every Swiss financial
+  journey, data-collection, scenario, PDF/dossier, or compliance-sensitive
+  product change. It is the independent product-lead + Swiss domain lens:
+  life-event fit, law/tax/insurance/prevention assumptions, no-advice framing,
+  missing variables, duplicated ledger facts, specialist handoff, and user
+  lucidity.
 - Engram memory after merge.
 
 ## Current Tool Matrix
@@ -156,3 +162,10 @@ Code audits refuse large diff prompts by default
 overriding except for a named final-release/P0 dispute.
 No audit carousel: one first pass, one Sonnet rerun, one Opus final confirmation;
 if still blocked, fix or triage the findings instead of relaunching the same gate.
+
+`product-domain <base-ref>` is not a replacement for `mint-swiss-brain`; it is
+the external adversarial pass. It must reject work that is technically wired but
+product-stupid: a screen that asks for already-known facts, a Swiss scenario
+that misses mandatory variables, a result that hides legal uncertainty, a
+comparison that becomes advice/ranking, or a flow that cannot produce a useful
+specialist-ready dossier.

--- a/tools/checks/claude_external_audit.sh
+++ b/tools/checks/claude_external_audit.sh
@@ -4,6 +4,7 @@ usage() {
   cat <<'EOF'
 Usage:
   tools/checks/claude_external_audit.sh code <base-ref>
+  tools/checks/claude_external_audit.sh product-domain <base-ref>
   tools/checks/claude_external_audit.sh specs
   tools/checks/claude_external_audit.sh architecture
 
@@ -26,7 +27,7 @@ case "$mode" in
     usage
     exit 0
     ;;
-  code|specs|architecture)
+  code|product-domain|specs|architecture)
     ;;
   *)
     usage >&2
@@ -135,6 +136,10 @@ enforce_code_diff_budget() {
 
 write_header() {
   local audit_mode="$1"
+  local verdict_rule="- Return exactly one verdict: PASS or NO-GO."
+  if [[ "$audit_mode" == "product-domain" ]]; then
+    verdict_rule="- Return exactly one verdict line: Product/domain verdict: PASS or Product/domain verdict: NO-GO."
+  fi
   cat >"$prompt_file" <<EOF
 You are the MINT external auditor.
 
@@ -143,7 +148,7 @@ Repo root: ${repo_root}
 
 Hard rules:
 - Treat checked-in code and tests as source of truth; do not trust docs blindly.
-- Return exactly one verdict: PASS or NO-GO.
+${verdict_rule}
 - Findings must be grouped as P0/P1/P2 with file:line evidence when possible.
 - P0/P1 findings must include a concrete reproduction or code path.
 - Ignore speculative rewrites; focus on correctness, privacy, compliance, routing, tests, and facade-without-wiring risks.
@@ -163,6 +168,92 @@ case "$mode" in
       echo "Base ref: ${base_ref}"
       echo "Diff line budget: ${max_diff_lines} lines (override requires CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1)."
       echo
+      echo "Current branch/status:"
+      echo '```text'
+      git -C "$repo_root" status --short --branch
+      echo '```'
+      echo
+      echo "Diff stat:"
+      echo '```text'
+      git -C "$repo_root" diff --stat "${base_ref}...HEAD"
+      echo '```'
+      echo
+      echo "Full diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --no-ext-diff --unified=80 "${base_ref}...HEAD"
+      echo '```'
+      echo
+      echo "Staged worktree diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --cached --no-ext-diff --unified=80
+      echo '```'
+      echo
+      echo "Unstaged worktree diff:"
+      echo '```diff'
+      git -C "$repo_root" diff --no-ext-diff --unified=80
+      echo '```'
+    } >>"$prompt_file"
+    ;;
+  product-domain)
+    base_ref="${2:-}"
+    [[ -n "$base_ref" ]] || die "product-domain mode requires a base ref"
+    git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null || die "unknown base ref '$base_ref'"
+    enforce_code_diff_budget "$base_ref"
+    write_header "product-domain"
+    {
+      echo "Base ref: ${base_ref}"
+      echo "Diff line budget: ${max_diff_lines} lines (override requires CLAUDE_AUDIT_ALLOW_LARGE_DIFF=1)."
+      cat <<'EOF'
+
+You are the MINT Product + Swiss Domain Lead auditor, not only a code reviewer.
+
+Read the diff against the live repo and challenge it against:
+- MINT product identity: Swiss financial lucidity, not a chatbot, not retirement-only.
+- Data Ledger / Data Quest: one source of truth, no duplicated user variables,
+  progressive data collection, no asking again for fresh known facts.
+- Swiss financial domain correctness: AVS, LPP, 3a, tax, mortgage, insurance,
+  inheritance/donation/succession, disability, family status, canton differences.
+- Swiss legal/compliance boundaries: no personalized legal/tax/financial advice,
+  no product recommendations, no banned promise language, clear uncertainty and
+  specialist handoff.
+- User value: every screen/route/button should unlock understanding, a decision
+  frame, a missing-data question, or a dossier/PDF handoff.
+
+Required checks:
+1. Identify the user life event(s) touched and the Swiss decision the flow is
+   supposed to clarify.
+2. Verify whether the collected variables are the right minimum variables for
+   that life event; flag missing, premature, duplicated, stale, or irrelevant
+   variables.
+3. Verify whether results distinguish known / missing / estimated / stale /
+   specialist-only facts, and whether confidence is justified.
+4. Challenge business logic against Swiss rules and legal boundaries. If a rule
+   or constant could be current-law sensitive and the diff does not prove a
+   source, mark it unverified instead of assuming it is correct.
+5. Check that compliance language avoids advice, ranking, guarantees, product
+   recommendations, and hidden legal/tax conclusions.
+6. Check the interaction model: route, CTA, back behavior, degraded state,
+   write-back to ledger, and return to the originating scenario.
+7. Check whether a specialist-ready PDF/dossier would receive the facts,
+   assumptions, caveats, and open questions it needs.
+
+Severity:
+- P0: illegal/misleading advice, confident wrong Swiss law/tax/insurance logic,
+  privacy exposure, or a flow that can drive a harmful decision.
+- P1: product/domain incoherence, wrong or duplicated source of truth, missing
+  mandatory Swiss variables, no missing-data state, no specialist handoff for a
+  specialist-only decision, or a route that does not deliver user value.
+- P2: polish, naming, documentation, or useful next-step improvements.
+
+Output contract:
+- Start with "Product/domain verdict: PASS" or "Product/domain verdict: NO-GO".
+- Then list P0/P1/P2 findings with file:line evidence when possible.
+- Include a short "Swiss domain review" section: AVS/LPP/3a/tax/mortgage/
+  insurance/succession items that are affected or explicitly not affected.
+- Include a short "Mint product logic review" section: whether the change moves
+  Mint toward the ledger -> DataQuest -> scenario -> dossier spine.
+
+EOF
       echo "Current branch/status:"
       echo '```text'
       git -C "$repo_root" status --short --branch

--- a/tools/checks/tests/test_claude_external_audit_contract.py
+++ b/tools/checks/tests/test_claude_external_audit_contract.py
@@ -33,7 +33,11 @@ RAW_CLAUDE_PRINT_ALLOWLIST = {
 
 
 def _run(*args: str, **env_overrides: str) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("CLAUDE_AUDIT_")
+    }
     env.update(env_overrides)
     return subprocess.run(
         ["bash", str(SCRIPT), *args],
@@ -165,7 +169,43 @@ def test_wrapper_defaults_are_bounded() -> None:
         assert needle in result.stdout
 
 
+def test_product_domain_prompt_is_wired() -> None:
+    result = _run("product-domain", "HEAD", CLAUDE_AUDIT_DRY_RUN="1")
+
+    assert result.returncode == 0, result.stderr
+    for needle in (
+        "Audit mode: product-domain",
+        "MINT Product + Swiss Domain Lead auditor",
+        "Swiss financial lucidity",
+        "Data Ledger / Data Quest",
+        "AVS, LPP, 3a, tax, mortgage, insurance",
+        "inheritance/donation/succession",
+        "no personalized legal/tax/financial advice",
+        "known / missing / estimated / stale",
+        "Product/domain verdict: PASS",
+        "Product/domain verdict: NO-GO",
+        "Swiss domain review",
+        "Mint product logic review",
+        "Staged worktree diff:",
+        "Unstaged worktree diff:",
+    ):
+        assert needle in result.stdout
+    prompt_header = result.stdout.split("Base ref:", maxsplit=1)[0]
+    assert "Return exactly one verdict line: Product/domain verdict: PASS" in prompt_header
+    assert "Return exactly one verdict: PASS or NO-GO." not in prompt_header
+
+
 def test_rerun_mode_defaults_to_sonnet_high() -> None:
+    result = _run("code", "HEAD", CLAUDE_AUDIT_DRY_RUN="1", CLAUDE_AUDIT_RERUN="1")
+
+    assert result.returncode == 0, result.stderr
+    assert "--model sonnet" in result.stdout
+    assert "--effort high" in result.stdout
+
+
+def test_run_helper_scrubs_shell_audit_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLAUDE_AUDIT_MODEL", "opus")
+
     result = _run("code", "HEAD", CLAUDE_AUDIT_DRY_RUN="1", CLAUDE_AUDIT_RERUN="1")
 
     assert result.returncode == 0, result.stderr
@@ -177,8 +217,18 @@ def test_rerun_mode_defaults_to_sonnet_high() -> None:
     ("args", "env", "stderr"),
     (
         (("code",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "code mode requires a base ref"),
+        (
+            ("product-domain",),
+            {"CLAUDE_AUDIT_DRY_RUN": "1"},
+            "product-domain mode requires a base ref",
+        ),
         (("unknown",), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "unknown mode"),
         (("code", "no-such-ref-xyz"), {"CLAUDE_AUDIT_DRY_RUN": "1"}, "unknown base ref"),
+        (
+            ("product-domain", "no-such-ref-xyz"),
+            {"CLAUDE_AUDIT_DRY_RUN": "1"},
+            "unknown base ref",
+        ),
         (
             ("code", "HEAD"),
             {"CLAUDE_AUDIT_DRY_RUN": "1", "CLAUDE_AUDIT_EFFORT": "max"},
@@ -330,6 +380,13 @@ def test_auditor_docs_point_to_wrapper_policy() -> None:
     ):
         lowered = text.lower()
         assert "tools/checks/claude_external_audit.sh" in text
+        assert "product-domain" in text
+        assert (
+            "Swiss domain" in text
+            or "swiss domain" in lowered
+            or "Swiss financial" in text
+            or "swiss financial" in lowered
+        )
         assert "opus high" in lowered
         assert "Sonnet high" in text
         assert "CLAUDE_AUDIT_RERUN=1" in text
@@ -364,6 +421,7 @@ def test_claude_md_anchors_external_audit_latency_policy() -> None:
 
     for needle in (
         "tools/checks/claude_external_audit.sh",
+        "product-domain <base-ref>",
         "Opus high",
         "Sonnet high",
         "CLAUDE_AUDIT_RERUN=1",


### PR DESCRIPTION
## Scope
Adds an executable Claude `product-domain` external audit mode so MINT can gate Swiss product/domain coherence separately from pure code wiring.

This mode challenges future PRs on:
- Swiss financial domain correctness: AVS, LPP, 3a, tax, mortgage, insurance, succession/donation, disability, canton differences.
- MINT product logic: ledger -> DataQuest -> scenario -> dossier/PDF, one source of truth, no duplicate known facts, progressive data collection.
- Compliance: no personalized legal/tax/financial advice, no product recommendation/ranking/guarantee language, explicit uncertainty and specialist handoff.

Also hardens the audit contract tests by scrubbing inherited `CLAUDE_AUDIT_*` env vars.

## QA
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py -q` -> 33 passed.
- `CLAUDE_AUDIT_MODEL=opus python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py::test_rerun_mode_defaults_to_sonnet_high tools/checks/tests/test_claude_external_audit_contract.py::test_run_helper_scrubs_shell_audit_environment -q` -> 2 passed.
- `python3 -m pytest tools/checks/tests/test_claude_external_audit_contract.py tools/checks/tests/test_mint_os_doctor.py tools/checks/tests/test_governance_docs_contract.py tools/checks/tests/test_instruction_hygiene_contract.py -q` -> 47 passed.
- `python3 tools/checks/mint_os_doctor.py --repo-only` -> PASS for Patrol, Maestro, Mermaid, Claude audit wrapper, workflow, iOS plist split.
- `git diff --check` -> pass.
- `lefthook run pre-commit` -> pass, gitleaks no leaks; memory retention warning only.
- Claude code audit: PASS, P0/P1 none.
- Claude product-domain audit: PASS, P0/P1 none.

## Stack
Base: #946 / `codex/coverage-mortgage-fact-collector-20260711`.
